### PR TITLE
feat(transformer)!: generate shorter UIDs

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -15,6 +15,7 @@ extend-exclude = [
   "crates/oxc_linter/src/rules/react/no_unknown_property.rs",
   "crates/oxc_parser/src/lexer/byte_handlers.rs",
   "crates/oxc_syntax/src/xml_entities.rs",
+  "crates/oxc_traverse/src/context/uid.rs",
   "pnpm-lock.yaml",
   "tasks/coverage/babel",
   "tasks/coverage/test262",

--- a/crates/oxc_transformer/examples/transformer.rs
+++ b/crates/oxc_transformer/examples/transformer.rs
@@ -72,6 +72,7 @@ fn main() {
         TransformOptions::enable_all()
     };
 
+    transform_options.debug = true;
     transform_options.helper_loader.mode = HelperLoaderMode::External;
 
     let ret = Transformer::new(&allocator, path, &transform_options)

--- a/crates/oxc_transformer/src/context.rs
+++ b/crates/oxc_transformer/src/context.rs
@@ -33,6 +33,8 @@ pub struct TransformCtx<'a> {
 
     pub assumptions: CompilerAssumptions,
 
+    pub debug: bool,
+
     // Helpers
     /// Manage helper loading
     pub helper_loader: HelperLoaderStore<'a>,
@@ -60,6 +62,7 @@ impl TransformCtx<'_> {
             source_text: "",
             module: options.env.module,
             assumptions: options.assumptions,
+            debug: options.debug,
             helper_loader: HelperLoaderStore::new(&options.helper_loader),
             module_imports: ModuleImportsStore::new(),
             var_declarations: VarDeclarationsStore::new(),

--- a/crates/oxc_transformer/src/es2022/class_properties/computed_key.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/computed_key.rs
@@ -131,7 +131,7 @@ impl<'a> ClassProperties<'a, '_> {
             let AssignmentTarget::AssignmentTargetIdentifier(ident) = &assign_expr.left else {
                 unreachable!();
             };
-            assert!(ident.name.starts_with('_'));
+            assert!(ident.name.starts_with(if self.ctx.debug { '_' } else { '$' }));
             assert!(ctx.scoping().get_reference(ident.reference_id()).symbol_id().is_some());
             assert!(ident.span.is_empty());
             assert!(prop.value.is_none());

--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -948,7 +948,7 @@ impl<'a> ClassProperties<'a, '_> {
             ..
         } = self.classes_stack.find_get_set_private_prop(&field_expr.field);
 
-        let temp_var_name_base = get_var_name_from_node(field_expr);
+        let temp_var_name_base = get_var_name_from_node(field_expr, self.ctx.debug);
 
         // TODO(improve-on-babel): Could avoid `move_expression` here and replace `update_expr.argument` instead.
         // Only doing this first to match the order Babel creates temp vars.

--- a/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
@@ -373,7 +373,8 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_, '_> {
             unreachable!()
         };
 
-        let temp_var_name_base = get_var_name_from_node(member.as_ref());
+        let temp_var_name_base =
+            get_var_name_from_node(member.as_ref(), self.class_properties.ctx.debug);
 
         let property =
             ctx.ast.expression_string_literal(member.property.span, member.property.name, None);
@@ -436,7 +437,8 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_, '_> {
             unreachable!()
         };
 
-        let temp_var_name_base = get_var_name_from_node(member.as_ref());
+        let temp_var_name_base =
+            get_var_name_from_node(member.as_ref(), self.class_properties.ctx.debug);
 
         let property = member.expression.get_inner_expression_mut().take_in(ctx.ast.allocator);
 

--- a/crates/oxc_transformer/src/options/mod.rs
+++ b/crates/oxc_transformer/src/options/mod.rs
@@ -46,6 +46,9 @@ pub struct TransformOptions {
     /// The working directory that all paths in the programmatic options will be resolved relative to.
     pub cwd: PathBuf,
 
+    /// If `true`, produces code with inserted UIDs in a more easily debuggable form.
+    pub debug: bool,
+
     // Core
     /// Set assumptions in order to produce smaller output.
     /// For more information, check the [assumptions](https://babel.dev/docs/assumptions) documentation page.
@@ -80,6 +83,7 @@ impl TransformOptions {
     pub fn enable_all() -> Self {
         Self {
             cwd: PathBuf::new(),
+            debug: false,
             assumptions: CompilerAssumptions::default(),
             typescript: TypeScriptOptions::default(),
             decorator: DecoratorOptions { legacy: true, emit_decorator_metadata: true },
@@ -260,6 +264,7 @@ impl TryFrom<&BabelOptions> for TransformOptions {
 
         Ok(Self {
             cwd: options.cwd.clone().unwrap_or_default(),
+            debug: false,
             assumptions: options.assumptions,
             typescript,
             decorator,

--- a/crates/oxc_transformer/tests/integrations/es_target.rs
+++ b/crates/oxc_transformer/tests/integrations/es_target.rs
@@ -25,7 +25,8 @@ fn es_target() {
     ];
 
     // Test no transformation for esnext.
-    let options = TransformOptions::from(ESTarget::from_str("esnext").unwrap());
+    let mut options = TransformOptions::from(ESTarget::from_str("esnext").unwrap());
+    options.debug = true;
     for (_, case) in cases {
         assert_eq!(test(case, &options), Ok(codegen(case, SourceType::mjs())));
     }
@@ -33,7 +34,8 @@ fn es_target() {
     #[cfg_attr(miri, expect(unused_variables))]
     let snapshot =
         cases.into_iter().enumerate().fold(String::new(), |mut w, (i, (target, case))| {
-            let options = TransformOptions::from_target(target).unwrap();
+            let mut options = TransformOptions::from_target(target).unwrap();
+            options.debug = true;
             let result = match test(case, &options) {
                 Ok(code) => code,
                 Err(errors) => errors

--- a/crates/oxc_traverse/Cargo.toml
+++ b/crates/oxc_traverse/Cargo.toml
@@ -26,7 +26,7 @@ doctest = true
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
-oxc_data_structures = { workspace = true, features = ["stack"] }
+oxc_data_structures = { workspace = true, features = ["assert_unchecked", "stack"] }
 oxc_ecmascript = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }

--- a/crates/oxc_traverse/src/ast_operations/gather_node_parts.rs
+++ b/crates/oxc_traverse/src/ast_operations/gather_node_parts.rs
@@ -9,7 +9,11 @@ use oxc_ecmascript::BoundNames;
 
 use super::to_identifier;
 
-pub fn get_var_name_from_node<'a, N: GatherNodeParts<'a>>(node: &N) -> String {
+pub fn get_var_name_from_node<'a, N: GatherNodeParts<'a>>(node: &N, debug: bool) -> String {
+    if !debug {
+        return String::new();
+    }
+
     let mut name = String::new();
     node.gather(&mut |mut part| {
         if name.is_empty() {

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -457,7 +457,7 @@ impl<'a> TraverseCtx<'a> {
         scope_id: ScopeId,
         flags: SymbolFlags,
     ) -> BoundIdentifier<'a> {
-        let name = get_var_name_from_node(node);
+        let name = get_var_name_from_node(node, self.scoping.debug);
         self.generate_uid(&name, scope_id, flags)
     }
 
@@ -492,7 +492,7 @@ impl<'a> TraverseCtx<'a> {
         &mut self,
         node: &N,
     ) -> BoundIdentifier<'a> {
-        let name = get_var_name_from_node(node);
+        let name = get_var_name_from_node(node, self.scoping.debug);
         self.generate_uid_in_current_hoist_scope(&name)
     }
 
@@ -649,9 +649,9 @@ impl<'a> TraverseCtx<'a> {
     ///
     /// # SAFETY
     /// This function must not be public to maintain soundness of [`TraverseAncestry`].
-    pub(crate) fn new(scoping: Scoping, allocator: &'a Allocator) -> Self {
+    pub(crate) fn new(scoping: Scoping, allocator: &'a Allocator, debug: bool) -> Self {
         let ancestry = TraverseAncestry::new();
-        let scoping = TraverseScoping::new(scoping);
+        let scoping = TraverseScoping::new(scoping, debug);
         let ast = AstBuilder::new(allocator);
         Self { ancestry, scoping, ast }
     }

--- a/crates/oxc_traverse/src/context/reusable.rs
+++ b/crates/oxc_traverse/src/context/reusable.rs
@@ -21,7 +21,12 @@ pub struct ReusableTraverseCtx<'a>(TraverseCtx<'a>);
 impl<'a> ReusableTraverseCtx<'a> {
     /// Create new [`ReusableTraverseCtx`].
     pub fn new(scoping: Scoping, allocator: &'a Allocator) -> Self {
-        Self(TraverseCtx::new(scoping, allocator))
+        Self(TraverseCtx::new(scoping, allocator, false))
+    }
+
+    /// Create new [`ReusableTraverseCtx`] with `debug` flag.
+    pub fn new_with_debug(scoping: Scoping, allocator: &'a Allocator, debug: bool) -> Self {
+        Self(TraverseCtx::new(scoping, allocator, debug))
     }
 
     /// Consume [`ReusableTraverseCtx`] and return [`Scoping`].

--- a/crates/oxc_traverse/src/context/uid.rs
+++ b/crates/oxc_traverse/src/context/uid.rs
@@ -196,8 +196,8 @@ impl<'a> FastUidGenerator<'a> {
         }
 
         // Increment letter, unless letter is `z` in which case jump to `A`.
-        // Performed with arithmetic to avoid a branch. https://godbolt.org/z/Kq81Kc4xq
-        *last_letter = (*last_letter)
+        // Performed with arithmetic to avoid a branch. https://godbolt.org/z/Kxo9Wc98K
+        *last_letter = last_letter
             .wrapping_add(1 + u8::from(*last_letter == b'z') * (b'A'.wrapping_sub(b'z') - 1));
 
         self.get_active()

--- a/crates/oxc_traverse/src/context/uid.rs
+++ b/crates/oxc_traverse/src/context/uid.rs
@@ -197,6 +197,13 @@ impl<'a> FastUidGenerator<'a> {
     /// This method will never return the same UID twice.
     #[inline] // `#[inline]` to inline into `TraverseCtx::generate_uid_name`
     pub(super) fn create(&mut self) -> Atom<'a> {
+        let allocator = self.allocator;
+        let uid = self.create_str();
+        Atom::from(allocator.alloc_str(uid))
+    }
+
+    /// Create UID as `&str`.
+    fn create_str(&mut self) -> &str {
         // SAFETY: `last_letter_ptr` points to last byte of the buffer.
         // All bytes of the buffer are initialized. No other references to buffer exist.
         let last_letter = unsafe { self.last_letter_ptr.as_mut().unwrap_unchecked() };
@@ -218,7 +225,7 @@ impl<'a> FastUidGenerator<'a> {
     /// Marked `#[cold]` and `#[inline(never)]` as will only happen once every 52 UIDs.
     #[cold]
     #[inline(never)]
-    fn rollover(&mut self) -> Atom<'a> {
+    fn rollover(&mut self) -> &str {
         self.rollover_update();
         self.get_active()
     }
@@ -288,25 +295,24 @@ impl<'a> FastUidGenerator<'a> {
         self.active_ptr = unsafe { self.active_ptr.sub(1) };
     }
 
-    /// Get the active string (current UID) and allocate into arena. Return UID as an [`Atom`].
+    /// Get the active string (UID).
     //
     // `#[inline(always)]` to inline into `create`, to keep the path for no rollover as fast as possible
     #[expect(clippy::inline_always)]
     #[inline(always)]
-    fn get_active(&self) -> Atom<'a> {
+    fn get_active(&self) -> &str {
         // SAFETY: `active_ptr` points within buffer. `last_letter_ptr + 1` is end of buffer.
         // The distance between the two is at least 2 bytes.
         // All bytes in buffer are initialized.
         // Buffer contains only ASCII bytes, so any slice of it is a valid UTF-8 string.
-        let uid = unsafe {
+        unsafe {
             let end_ptr = self.last_letter_ptr.add(1).cast_const();
             assert_unchecked!(end_ptr > self.active_ptr);
             #[expect(clippy::cast_sign_loss)]
             let len = end_ptr.offset_from(self.active_ptr) as usize;
             let slice = slice::from_raw_parts(self.active_ptr, len);
             str::from_utf8_unchecked(slice)
-        };
-        Atom::from(self.allocator.alloc_str(uid))
+        }
     }
 }
 

--- a/crates/oxc_traverse/src/context/uid.rs
+++ b/crates/oxc_traverse/src/context/uid.rs
@@ -8,11 +8,11 @@ use oxc_data_structures::assert_unchecked;
 use oxc_semantic::Scoping;
 use oxc_span::Atom;
 
-/// Number of characters in range `a-z` required to produce at least `u32::MAX` unique combinations
-const POSTFIX_BYTES: usize = 7;
+/// Number of characters in range `a-z` or `A-Z` required to produce at least `u32::MAX` unique combinations
+const POSTFIX_BYTES: usize = 6;
 const _: () = {
     #[expect(clippy::cast_possible_truncation)]
-    let max_combinations = 26u64.pow(POSTFIX_BYTES as u32);
+    let max_combinations = 52u64.pow(POSTFIX_BYTES as u32);
     assert!(max_combinations >= u32::MAX as u64);
 };
 
@@ -65,7 +65,7 @@ impl<'a> UidGenerator<'a> {
 /// [`FastUidGenerator::create`] uses that information to generate a unique identifier which does not
 /// clash with any existing name.
 ///
-/// Generated UIDs are `$a`, `$b`, ... `$z`, `$aa`, `$ab`, ...
+/// Generated UIDs are `$a`, `$b`, ... `$z`, `$A`, `$B`, ... `$Z`, `$aa`, `$ab`, ...
 ///
 /// If AST already contains a symbol that begins with `$`, generated UIDs are `$$a`, `$$b`, etc.
 /// If AST contains a symbol with a longer `$` prefix, generated UIDs are prefixed with 1 more `$`
@@ -80,30 +80,30 @@ impl<'a> UidGenerator<'a> {
 ///
 /// `FastUidGenerator` owns a small string buffer.
 ///
-/// Buffer starts as "$$$$$$$`".
+/// Buffer starts as "$$$$$$`".
 /// When generating a UID, the last byte is incremented.
-/// i.e. "$$$$$$$`" -> `$$$$$$$a` -> `$$$$$$$b` -> `$$$$$$$c`.
+/// i.e. "$$$$$$`" -> `$$$$$$a` -> `$$$$$$b` -> `$$$$$$c`.
 ///
 /// All the pointers stored in the type point to different places in that buffer:
 ///
 /// ```no_compile
-/// $$$$$abc
-/// ^        `buffer_start_ptr`
-///     ^    `active_ptr`
-///        ^ `last_letter_ptr`
+/// $$$$abc
+/// ^       `buffer_start_ptr`
+///    ^    `active_ptr`
+///       ^ `last_letter_ptr`
 /// ```
 ///
 /// "Active" part of the buffer is the section which is used as UID:
 /// ```no_compile
-/// Buffer: $$$$$$$a
-/// Active:       ^^
+/// Buffer: $$$$$$a
+/// Active:      ^^
 /// ```
 ///
-/// 26th UID is `$z`, after which the UID grows in length to `$aa` ("rollover").
+/// 52nd UID is `$Z`, after which the UID grows in length to `$aa` ("rollover").
 /// The active part of the buffer expands in place:
 /// ```no_compile
-/// Buffer: $$$$$$aa
-/// Active:      ^^^
+/// Buffer: $$$$$aa
+/// Active:     ^^^
 /// ```
 ///
 /// This in place expansion means the buffer never has to reallocate.
@@ -112,7 +112,7 @@ impl<'a> UidGenerator<'a> {
 /// is more efficient than a `u32` counter which is converted to a string on each call to
 /// [`FastUidGenerator::create`].
 ///
-/// Using pointers to access the buffer makes the fast path for generating a UID (last byte is not `z`,
+/// Using pointers to access the buffer makes the fast path for generating a UID (last byte is not `Z`,
 /// so no "rollover" required) as cheap as possible - only a handful of instructions.
 pub struct FastUidGenerator<'a> {
     /// Pointer to start of buffer
@@ -149,11 +149,11 @@ impl<'a> FastUidGenerator<'a> {
         // Create a buffer large enough to contain all possible UID names.
         // Fill it with `$`s and a final "`".
         // If `dollar_count` is 1 (no symbols found starting with a `$`),
-        // buffer contains "$$$$$$$`" (8 bytes).
+        // buffer contains "$$$$$$`" (7 bytes).
         // If the maximum number of UIDs are created, buffer will end up containing
-        // `$zzzzzzz` (also 8 bytes).
+        // `$ZZZZZZ` (also 7 bytes).
         // If an existing symbol was found which starts with `$$`, buffer needs to be longer.
-        // Buffer will contain "$$$$$$$$$`" (10 bytes). Maximum UID is `$$$zzzzzzz` (also 10 bytes).
+        // Buffer will contain "$$$$$$$$`" (9 bytes). Maximum UID is `$$$ZZZZZZ` (also 9 bytes).
         let len = dollar_count + POSTFIX_BYTES;
         let mut buffer = String::with_capacity(len);
         buffer.extend(iter::repeat_n('$', len - 1));
@@ -191,19 +191,22 @@ impl<'a> FastUidGenerator<'a> {
         // SAFETY: `last_letter_ptr` points to last byte of the buffer.
         // All bytes of the buffer are initialized. No other references to buffer exist.
         let last_letter = unsafe { self.last_letter_ptr.as_mut().unwrap_unchecked() };
-        if *last_letter == b'z' {
+        if (*last_letter | 32) < b'z' {
+            // `| 32` converts `A-Z` to lower case, so this matches `a-y` or `A-Y` or "`"
+            *last_letter += 1;
+        } else if *last_letter == b'z' {
+            *last_letter = b'A';
+        } else {
+            debug_assert_eq!(*last_letter, b'Z');
             return self.rollover();
         }
-
-        // Increment last letter i.e. `a` -> `b`
-        *last_letter += 1;
 
         self.get_active()
     }
 
-    /// Create UID when last letter is `z`, so the previous letter needs to be incremented.
+    /// Create UID when last letter is `Z`, so the previous letter needs to be incremented.
     ///
-    /// Marked `#[cold]` and `#[inline(never)]` as will only happen once every 26 UIDs.
+    /// Marked `#[cold]` and `#[inline(never)]` as will only happen once every 52 UIDs.
     #[cold]
     #[inline(never)]
     fn rollover(&mut self) -> Atom<'a> {
@@ -234,12 +237,18 @@ impl<'a> FastUidGenerator<'a> {
                 }
 
                 // Increment letter
-                if *letter != b'z' {
+                if (*letter | 32) < b'z' {
+                    // `| 32` converts `A-Z` to lower case, so this matches `a-y` or `A-Y`
                     *letter += 1;
                     return;
                 }
+                if *letter == b'z' {
+                    *letter = b'A';
+                    return;
+                }
 
-                // Letter is `z`. Need to change it to `a` and increment previous letter
+                // Letter is `Z`. Need to change it to `a` and increment previous letter
+                debug_assert_eq!(*letter, b'Z');
             }
         }
 
@@ -251,7 +260,7 @@ impl<'a> FastUidGenerator<'a> {
         assert!(letter_ptr.cast_const() >= earliest_letter_ptr, "Created too many UIDs");
 
         // Add another `a` on start (loop above has already converted all existing letters to `a`).
-        // So we started with `$zz` and now end up with `$aaa`.
+        // So we started with `$ZZ` and now end up with `$aaa`.
         // SAFETY: `letter_ptr` is in bounds of buffer. All bytes of buffer are initialized.
         let letter = unsafe { letter_ptr.as_mut().unwrap_unchecked() };
         *letter = b'a';
@@ -577,10 +586,16 @@ fn fast_uids() {
             &[
                 "$a", "$b", "$c", "$d", "$e", "$f", "$g", "$h", "$i", "$j", "$k", "$l", "$m",
                 "$n", "$o", "$p", "$q", "$r", "$s", "$t", "$u", "$v", "$w", "$x", "$y", "$z",
+                "$A", "$B", "$C", "$D", "$E", "$F", "$G", "$H", "$I", "$J", "$K", "$L", "$M",
+                "$N", "$O", "$P", "$Q", "$R", "$S", "$T", "$U", "$V", "$W", "$X", "$Y", "$Z",
                 "$aa", "$ab", "$ac", "$ad", "$ae", "$af", "$ag", "$ah", "$ai", "$aj", "$ak", "$al", "$am",
                 "$an", "$ao", "$ap", "$aq", "$ar", "$as", "$at", "$au", "$av", "$aw", "$ax", "$ay", "$az",
+                "$aA", "$aB", "$aC", "$aD", "$aE", "$aF", "$aG", "$aH", "$aI", "$aJ", "$aK", "$aL", "$aM",
+                "$aN", "$aO", "$aP", "$aQ", "$aR", "$aS", "$aT", "$aU", "$aV", "$aW", "$aX", "$aY", "$aZ",
                 "$ba", "$bb", "$bc", "$bd", "$be", "$bf", "$bg", "$bh", "$bi", "$bj", "$bk", "$bl", "$bm",
                 "$bn", "$bo", "$bp", "$bq", "$br", "$bs", "$bt", "$bu", "$bv", "$bw", "$bx", "$by", "$bz",
+                "$bA", "$bB", "$bC", "$bD", "$bE", "$bF", "$bG", "$bH", "$bI", "$bJ", "$bK", "$bL", "$bM",
+                "$bN", "$bO", "$bP", "$bQ", "$bR", "$bS", "$bT", "$bU", "$bV", "$bW", "$bX", "$bY", "$bZ",
                 "$ca",
             ],
         ),
@@ -589,10 +604,16 @@ fn fast_uids() {
             &[
                 "$a", "$b", "$c", "$d", "$e", "$f", "$g", "$h", "$i", "$j", "$k", "$l", "$m",
                 "$n", "$o", "$p", "$q", "$r", "$s", "$t", "$u", "$v", "$w", "$x", "$y", "$z",
+                "$A", "$B", "$C", "$D", "$E", "$F", "$G", "$H", "$I", "$J", "$K", "$L", "$M",
+                "$N", "$O", "$P", "$Q", "$R", "$S", "$T", "$U", "$V", "$W", "$X", "$Y", "$Z",
                 "$aa", "$ab", "$ac", "$ad", "$ae", "$af", "$ag", "$ah", "$ai", "$aj", "$ak", "$al", "$am",
                 "$an", "$ao", "$ap", "$aq", "$ar", "$as", "$at", "$au", "$av", "$aw", "$ax", "$ay", "$az",
+                "$aA", "$aB", "$aC", "$aD", "$aE", "$aF", "$aG", "$aH", "$aI", "$aJ", "$aK", "$aL", "$aM",
+                "$aN", "$aO", "$aP", "$aQ", "$aR", "$aS", "$aT", "$aU", "$aV", "$aW", "$aX", "$aY", "$aZ",
                 "$ba", "$bb", "$bc", "$bd", "$be", "$bf", "$bg", "$bh", "$bi", "$bj", "$bk", "$bl", "$bm",
                 "$bn", "$bo", "$bp", "$bq", "$br", "$bs", "$bt", "$bu", "$bv", "$bw", "$bx", "$by", "$bz",
+                "$bA", "$bB", "$bC", "$bD", "$bE", "$bF", "$bG", "$bH", "$bI", "$bJ", "$bK", "$bL", "$bM",
+                "$bN", "$bO", "$bP", "$bQ", "$bR", "$bS", "$bT", "$bU", "$bV", "$bW", "$bX", "$bY", "$bZ",
                 "$ca",
             ],
         ),
@@ -601,10 +622,16 @@ fn fast_uids() {
             &[
                 "$$a", "$$b", "$$c", "$$d", "$$e", "$$f", "$$g", "$$h", "$$i", "$$j", "$$k", "$$l", "$$m",
                 "$$n", "$$o", "$$p", "$$q", "$$r", "$$s", "$$t", "$$u", "$$v", "$$w", "$$x", "$$y", "$$z",
+                "$$A", "$$B", "$$C", "$$D", "$$E", "$$F", "$$G", "$$H", "$$I", "$$J", "$$K", "$$L", "$$M",
+                "$$N", "$$O", "$$P", "$$Q", "$$R", "$$S", "$$T", "$$U", "$$V", "$$W", "$$X", "$$Y", "$$Z",
                 "$$aa", "$$ab", "$$ac", "$$ad", "$$ae", "$$af", "$$ag", "$$ah", "$$ai", "$$aj", "$$ak", "$$al", "$$am",
                 "$$an", "$$ao", "$$ap", "$$aq", "$$ar", "$$as", "$$at", "$$au", "$$av", "$$aw", "$$ax", "$$ay", "$$az",
+                "$$aA", "$$aB", "$$aC", "$$aD", "$$aE", "$$aF", "$$aG", "$$aH", "$$aI", "$$aJ", "$$aK", "$$aL", "$$aM",
+                "$$aN", "$$aO", "$$aP", "$$aQ", "$$aR", "$$aS", "$$aT", "$$aU", "$$aV", "$$aW", "$$aX", "$$aY", "$$aZ",
                 "$$ba", "$$bb", "$$bc", "$$bd", "$$be", "$$bf", "$$bg", "$$bh", "$$bi", "$$bj", "$$bk", "$$bl", "$$bm",
                 "$$bn", "$$bo", "$$bp", "$$bq", "$$br", "$$bs", "$$bt", "$$bu", "$$bv", "$$bw", "$$bx", "$$by", "$$bz",
+                "$$bA", "$$bB", "$$bC", "$$bD", "$$bE", "$$bF", "$$bG", "$$bH", "$$bI", "$$bJ", "$$bK", "$$bL", "$$bM",
+                "$$bN", "$$bO", "$$bP", "$$bQ", "$$bR", "$$bS", "$$bT", "$$bU", "$$bV", "$$bW", "$$bX", "$$bY", "$$bZ",
                 "$$ca",
             ],
         ),
@@ -613,10 +640,16 @@ fn fast_uids() {
             &[
                 "$$a", "$$b", "$$c", "$$d", "$$e", "$$f", "$$g", "$$h", "$$i", "$$j", "$$k", "$$l", "$$m",
                 "$$n", "$$o", "$$p", "$$q", "$$r", "$$s", "$$t", "$$u", "$$v", "$$w", "$$x", "$$y", "$$z",
+                "$$A", "$$B", "$$C", "$$D", "$$E", "$$F", "$$G", "$$H", "$$I", "$$J", "$$K", "$$L", "$$M",
+                "$$N", "$$O", "$$P", "$$Q", "$$R", "$$S", "$$T", "$$U", "$$V", "$$W", "$$X", "$$Y", "$$Z",
                 "$$aa", "$$ab", "$$ac", "$$ad", "$$ae", "$$af", "$$ag", "$$ah", "$$ai", "$$aj", "$$ak", "$$al", "$$am",
                 "$$an", "$$ao", "$$ap", "$$aq", "$$ar", "$$as", "$$at", "$$au", "$$av", "$$aw", "$$ax", "$$ay", "$$az",
+                "$$aA", "$$aB", "$$aC", "$$aD", "$$aE", "$$aF", "$$aG", "$$aH", "$$aI", "$$aJ", "$$aK", "$$aL", "$$aM",
+                "$$aN", "$$aO", "$$aP", "$$aQ", "$$aR", "$$aS", "$$aT", "$$aU", "$$aV", "$$aW", "$$aX", "$$aY", "$$aZ",
                 "$$ba", "$$bb", "$$bc", "$$bd", "$$be", "$$bf", "$$bg", "$$bh", "$$bi", "$$bj", "$$bk", "$$bl", "$$bm",
                 "$$bn", "$$bo", "$$bp", "$$bq", "$$br", "$$bs", "$$bt", "$$bu", "$$bv", "$$bw", "$$bx", "$$by", "$$bz",
+                "$$bA", "$$bB", "$$bC", "$$bD", "$$bE", "$$bF", "$$bG", "$$bH", "$$bI", "$$bJ", "$$bK", "$$bL", "$$bM",
+                "$$bN", "$$bO", "$$bP", "$$bQ", "$$bR", "$$bS", "$$bT", "$$bU", "$$bV", "$$bW", "$$bX", "$$bY", "$$bZ",
                 "$$ca",
             ],
         ),
@@ -625,10 +658,16 @@ fn fast_uids() {
             &[
                 "$$$$a", "$$$$b", "$$$$c", "$$$$d", "$$$$e", "$$$$f", "$$$$g", "$$$$h", "$$$$i", "$$$$j", "$$$$k", "$$$$l", "$$$$m",
                 "$$$$n", "$$$$o", "$$$$p", "$$$$q", "$$$$r", "$$$$s", "$$$$t", "$$$$u", "$$$$v", "$$$$w", "$$$$x", "$$$$y", "$$$$z",
+                "$$$$A", "$$$$B", "$$$$C", "$$$$D", "$$$$E", "$$$$F", "$$$$G", "$$$$H", "$$$$I", "$$$$J", "$$$$K", "$$$$L", "$$$$M",
+                "$$$$N", "$$$$O", "$$$$P", "$$$$Q", "$$$$R", "$$$$S", "$$$$T", "$$$$U", "$$$$V", "$$$$W", "$$$$X", "$$$$Y", "$$$$Z",
                 "$$$$aa", "$$$$ab", "$$$$ac", "$$$$ad", "$$$$ae", "$$$$af", "$$$$ag", "$$$$ah", "$$$$ai", "$$$$aj", "$$$$ak", "$$$$al", "$$$$am",
                 "$$$$an", "$$$$ao", "$$$$ap", "$$$$aq", "$$$$ar", "$$$$as", "$$$$at", "$$$$au", "$$$$av", "$$$$aw", "$$$$ax", "$$$$ay", "$$$$az",
+                "$$$$aA", "$$$$aB", "$$$$aC", "$$$$aD", "$$$$aE", "$$$$aF", "$$$$aG", "$$$$aH", "$$$$aI", "$$$$aJ", "$$$$aK", "$$$$aL", "$$$$aM",
+                "$$$$aN", "$$$$aO", "$$$$aP", "$$$$aQ", "$$$$aR", "$$$$aS", "$$$$aT", "$$$$aU", "$$$$aV", "$$$$aW", "$$$$aX", "$$$$aY", "$$$$aZ",
                 "$$$$ba", "$$$$bb", "$$$$bc", "$$$$bd", "$$$$be", "$$$$bf", "$$$$bg", "$$$$bh", "$$$$bi", "$$$$bj", "$$$$bk", "$$$$bl", "$$$$bm",
                 "$$$$bn", "$$$$bo", "$$$$bp", "$$$$bq", "$$$$br", "$$$$bs", "$$$$bt", "$$$$bu", "$$$$bv", "$$$$bw", "$$$$bx", "$$$$by", "$$$$bz",
+                "$$$$bA", "$$$$bB", "$$$$bC", "$$$$bD", "$$$$bE", "$$$$bF", "$$$$bG", "$$$$bH", "$$$$bI", "$$$$bJ", "$$$$bK", "$$$$bL", "$$$$bM",
+                "$$$$bN", "$$$$bO", "$$$$bP", "$$$$bQ", "$$$$bR", "$$$$bS", "$$$$bT", "$$$$bU", "$$$$bV", "$$$$bW", "$$$$bX", "$$$$bY", "$$$$bZ",
                 "$$$$ca",
             ],
         ),
@@ -637,10 +676,16 @@ fn fast_uids() {
             &[
                 "$$$$a", "$$$$b", "$$$$c", "$$$$d", "$$$$e", "$$$$f", "$$$$g", "$$$$h", "$$$$i", "$$$$j", "$$$$k", "$$$$l", "$$$$m",
                 "$$$$n", "$$$$o", "$$$$p", "$$$$q", "$$$$r", "$$$$s", "$$$$t", "$$$$u", "$$$$v", "$$$$w", "$$$$x", "$$$$y", "$$$$z",
+                "$$$$A", "$$$$B", "$$$$C", "$$$$D", "$$$$E", "$$$$F", "$$$$G", "$$$$H", "$$$$I", "$$$$J", "$$$$K", "$$$$L", "$$$$M",
+                "$$$$N", "$$$$O", "$$$$P", "$$$$Q", "$$$$R", "$$$$S", "$$$$T", "$$$$U", "$$$$V", "$$$$W", "$$$$X", "$$$$Y", "$$$$Z",
                 "$$$$aa", "$$$$ab", "$$$$ac", "$$$$ad", "$$$$ae", "$$$$af", "$$$$ag", "$$$$ah", "$$$$ai", "$$$$aj", "$$$$ak", "$$$$al", "$$$$am",
                 "$$$$an", "$$$$ao", "$$$$ap", "$$$$aq", "$$$$ar", "$$$$as", "$$$$at", "$$$$au", "$$$$av", "$$$$aw", "$$$$ax", "$$$$ay", "$$$$az",
+                "$$$$aA", "$$$$aB", "$$$$aC", "$$$$aD", "$$$$aE", "$$$$aF", "$$$$aG", "$$$$aH", "$$$$aI", "$$$$aJ", "$$$$aK", "$$$$aL", "$$$$aM",
+                "$$$$aN", "$$$$aO", "$$$$aP", "$$$$aQ", "$$$$aR", "$$$$aS", "$$$$aT", "$$$$aU", "$$$$aV", "$$$$aW", "$$$$aX", "$$$$aY", "$$$$aZ",
                 "$$$$ba", "$$$$bb", "$$$$bc", "$$$$bd", "$$$$be", "$$$$bf", "$$$$bg", "$$$$bh", "$$$$bi", "$$$$bj", "$$$$bk", "$$$$bl", "$$$$bm",
                 "$$$$bn", "$$$$bo", "$$$$bp", "$$$$bq", "$$$$br", "$$$$bs", "$$$$bt", "$$$$bu", "$$$$bv", "$$$$bw", "$$$$bx", "$$$$by", "$$$$bz",
+                "$$$$bA", "$$$$bB", "$$$$bC", "$$$$bD", "$$$$bE", "$$$$bF", "$$$$bG", "$$$$bH", "$$$$bI", "$$$$bJ", "$$$$bK", "$$$$bL", "$$$$bM",
+                "$$$$bN", "$$$$bO", "$$$$bP", "$$$$bQ", "$$$$bR", "$$$$bS", "$$$$bT", "$$$$bU", "$$$$bV", "$$$$bW", "$$$$bX", "$$$$bY", "$$$$bZ",
                 "$$$$ca",
             ],
         ),
@@ -649,10 +694,16 @@ fn fast_uids() {
             &[
                 "$$$$a", "$$$$b", "$$$$c", "$$$$d", "$$$$e", "$$$$f", "$$$$g", "$$$$h", "$$$$i", "$$$$j", "$$$$k", "$$$$l", "$$$$m",
                 "$$$$n", "$$$$o", "$$$$p", "$$$$q", "$$$$r", "$$$$s", "$$$$t", "$$$$u", "$$$$v", "$$$$w", "$$$$x", "$$$$y", "$$$$z",
+                "$$$$A", "$$$$B", "$$$$C", "$$$$D", "$$$$E", "$$$$F", "$$$$G", "$$$$H", "$$$$I", "$$$$J", "$$$$K", "$$$$L", "$$$$M",
+                "$$$$N", "$$$$O", "$$$$P", "$$$$Q", "$$$$R", "$$$$S", "$$$$T", "$$$$U", "$$$$V", "$$$$W", "$$$$X", "$$$$Y", "$$$$Z",
                 "$$$$aa", "$$$$ab", "$$$$ac", "$$$$ad", "$$$$ae", "$$$$af", "$$$$ag", "$$$$ah", "$$$$ai", "$$$$aj", "$$$$ak", "$$$$al", "$$$$am",
                 "$$$$an", "$$$$ao", "$$$$ap", "$$$$aq", "$$$$ar", "$$$$as", "$$$$at", "$$$$au", "$$$$av", "$$$$aw", "$$$$ax", "$$$$ay", "$$$$az",
+                "$$$$aA", "$$$$aB", "$$$$aC", "$$$$aD", "$$$$aE", "$$$$aF", "$$$$aG", "$$$$aH", "$$$$aI", "$$$$aJ", "$$$$aK", "$$$$aL", "$$$$aM",
+                "$$$$aN", "$$$$aO", "$$$$aP", "$$$$aQ", "$$$$aR", "$$$$aS", "$$$$aT", "$$$$aU", "$$$$aV", "$$$$aW", "$$$$aX", "$$$$aY", "$$$$aZ",
                 "$$$$ba", "$$$$bb", "$$$$bc", "$$$$bd", "$$$$be", "$$$$bf", "$$$$bg", "$$$$bh", "$$$$bi", "$$$$bj", "$$$$bk", "$$$$bl", "$$$$bm",
                 "$$$$bn", "$$$$bo", "$$$$bp", "$$$$bq", "$$$$br", "$$$$bs", "$$$$bt", "$$$$bu", "$$$$bv", "$$$$bw", "$$$$bx", "$$$$by", "$$$$bz",
+                "$$$$bA", "$$$$bB", "$$$$bC", "$$$$bD", "$$$$bE", "$$$$bF", "$$$$bG", "$$$$bH", "$$$$bI", "$$$$bJ", "$$$$bK", "$$$$bL", "$$$$bM",
+                "$$$$bN", "$$$$bO", "$$$$bP", "$$$$bQ", "$$$$bR", "$$$$bS", "$$$$bT", "$$$$bU", "$$$$bV", "$$$$bW", "$$$$bX", "$$$$bY", "$$$$bZ",
                 "$$$$ca",
             ],
         ),

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -189,7 +189,7 @@ impl Oxc {
                 return Ok(());
             }
 
-            let options = transform_options
+            let mut options = transform_options
                 .target
                 .as_ref()
                 .and_then(|target| {
@@ -200,6 +200,7 @@ impl Oxc {
                         .ok()
                 })
                 .unwrap_or_default();
+            options.debug = true;
             let result = Transformer::new(&allocator, &path, &options)
                 .build_with_scoping(scoping, &mut program);
             if !result.errors.is_empty() {

--- a/napi/transform/index.d.ts
+++ b/napi/transform/index.d.ts
@@ -369,6 +369,8 @@ export interface TransformOptions {
    * options.
    */
   cwd?: string
+  /** If `true` produces more debuggable output */
+  debug?: boolean
   /**
    * Enable source map generation.
    *

--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -97,6 +97,9 @@ pub struct TransformOptions {
     /// options.
     pub cwd: Option<String>,
 
+    /// If `true` produces more debuggable output
+    pub debug: Option<bool>,
+
     /// Enable source map generation.
     ///
     /// When `true`, the `sourceMap` field of transform result objects will be populated.
@@ -156,6 +159,7 @@ impl TryFrom<TransformOptions> for oxc::transformer::TransformOptions {
         };
         Ok(Self {
             cwd: options.cwd.map(PathBuf::from).unwrap_or_default(),
+            debug: options.debug.is_some_and(|debug| debug),
             assumptions: options.assumptions.map(Into::into).unwrap_or_default(),
             typescript: options
                 .typescript

--- a/napi/transform/test/transform.test.ts
+++ b/napi/transform/test/transform.test.ts
@@ -1,7 +1,12 @@
 import { Worker } from 'node:worker_threads';
 import { describe, expect, it, test } from 'vitest';
 
-import { HelperMode, transform } from '../index';
+import { HelperMode, transform as transformOriginal } from '../index';
+
+function transform(filename, code, ...args) {
+  const options = { debug: true, ...args[0] };
+  return transformOriginal(filename, code, options);
+}
 
 describe('simple', () => {
   const code = 'export class A<T> {}';

--- a/tasks/coverage/src/tools/semantic.rs
+++ b/tasks/coverage/src/tools/semantic.rs
@@ -16,6 +16,7 @@ use crate::{
 
 fn get_default_transformer_options() -> TransformOptions {
     TransformOptions {
+        debug: true,
         jsx: JsxOptions {
             jsx_plugin: true,
             jsx_self_plugin: true,

--- a/tasks/transform_conformance/src/test_case.rs
+++ b/tasks/transform_conformance/src/test_case.rs
@@ -52,7 +52,10 @@ impl TestCase {
 
         let mut options = BabelOptions::from_test_path(options_directory_path.as_path());
         options.cwd.replace(cwd.to_path_buf());
-        let transform_options = TransformOptions::try_from(&options);
+        let transform_options = TransformOptions::try_from(&options).map(|mut options| {
+            options.debug = true;
+            options
+        });
         let path = path.to_path_buf();
         let errors = vec![];
 


### PR DESCRIPTION
Transformer produce more compact output by generating shorter UIDs. Producing these shorter UIDs is also faster.

Previously UIDs would depend on the base name passed to `generate_uid_name` e.g. `foo` -> `_foo`, `_foo2`, `_foo3` etc. This requires maintaining a `HashMap` of used names and a hashmap lookup for every UID.

New scheme in this PR is much simpler. UIDs are `$a`, `$b`, `$c`, `$d` etc. The name passed to `generate_uid_name` is ignored. If the AST contains existing identifiers starting with `$`, UIDs will be `$$a`, `$$b` etc, to avoid naming clashes. This does not require a hashmap, so is much cheaper.

The rationale is that when building for production, there isn't much point spending cycles producing lengthy and descriptive `_foo_bar_qux2` UIDs in the transformer, when the mangler will blow them all away anyway.

Introduce a `debug` option to use the old lengthy UID style. We need this option for transformer conformance tests, and it can be useful for debugging. But set `debug: false` as the default.
