### PR TITLE
fix(linter): fix panic when doing code gen on regexp

### DIFF
--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -262,6 +262,7 @@ impl<'a> Codegen<'a> {
     /// NOTE: you must call [`Codegen::with_source_text`] before calling this method
     #[inline]
     pub fn print_expression(&mut self, expr: &Expression<'_>) {
+        debug_assert!(!self.source_text.is_empty());
         expr.print_expr(self, Precedence::Lowest, Context::empty());
     }
 }

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -184,10 +184,10 @@ impl<'c, 'a: 'c> RuleFixer<'c, 'a> {
         self.new_fix(CompositeFix::Single(fix), message)
     }
 
-    #[expect(clippy::unused_self)]
     #[must_use]
     pub fn codegen(self) -> Codegen<'a> {
         Codegen::new()
+            .with_source_text(self.source_text())
             .with_options(CodegenOptions { single_quote: true, ..CodegenOptions::default() })
     }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
@@ -553,6 +553,11 @@ fn test() {
         // `string.split()`
         (r#""🦄".split("")"#, r#"[..."🦄"]"#, None),
         (r#""foo bar baz".split("")"#, r#"[..."foo bar baz"]"#, None),
+        (
+            r"Array.from(path.matchAll(/\{([^{}?]+\??)\}/g))",
+            "[...path.matchAll(/\\{([^{}?]+\\??)\\}/g)]",
+            None,
+        ),
     ];
 
     Tester::new(PreferSpread::NAME, PreferSpread::PLUGIN, pass, fail)


### PR DESCRIPTION
fixes the panic in https://github.com/oxc-project/oxc/pull/10765 by providing the source text of the program to the code generator