### PR TITLE
perf(semantic): reuse `Atom`

### DIFF
--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -800,19 +800,16 @@ impl Scoping {
     /// Panics in debug mode if either of the above are not satisfied.
     pub fn rename_symbol(&mut self, symbol_id: SymbolId, scope_id: ScopeId, new_name: &str) {
         self.cell.with_dependent_mut(|allocator, cell| {
-            // Rename symbol name.
-            let old_name = mem::replace(
-                &mut cell.symbol_names[symbol_id.index()],
-                Atom::from_in(new_name, allocator),
-            );
+            // Rename symbol
+            let new_name = Atom::from_in(new_name, allocator);
+            let old_name = mem::replace(&mut cell.symbol_names[symbol_id.index()], new_name);
 
             // Rename binding, same as `Self::rename_binding`, we cannot call it directly
             // because the `old_name` borrowed `cell`.
             let bindings = &mut cell.bindings[scope_id];
             let old_symbol_id = bindings.remove(old_name.as_str());
             debug_assert_eq!(old_symbol_id, Some(symbol_id));
-            let new_name = allocator.alloc_str(new_name);
-            let existing_symbol_id = bindings.insert(new_name, symbol_id);
+            let existing_symbol_id = bindings.insert(new_name.as_str(), symbol_id);
             debug_assert!(existing_symbol_id.is_none());
         });
     }


### PR DESCRIPTION
Follow-on after #10612. Small optimization. We already allocate `new_name` into `SemanticInner`'s arena. No need to allocate it again - just use the same string.