### PR TITLE
fix(linter/no-extraneous-class): improve docs, reporting and code refactor

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
@@ -5,10 +5,12 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
+use schemars::JsonSchema;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone, Default, JsonSchema)]
+#[serde(renameAll = "camelCase", default)]
 pub struct NoExtraneousClass {
     allow_constructor_only: bool,
     allow_empty: bool,
@@ -19,26 +21,33 @@ pub struct NoExtraneousClass {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule reports when a class has no non-static members,
-    /// such as for a class used exclusively as a static namespace.
-    /// This rule also reports classes that have only a constructor and no fields.
-    /// Those classes can generally be replaced with a standalone function.
+    /// This rule reports when a class has no non-static members, such as for a
+    /// class used exclusively as a static namespace.  This rule also reports
+    /// classes that have only a constructor and no fields.  Those classes can
+    /// generally be replaced with a standalone function.
     ///
     /// ### Why is this bad?
     ///
-    /// Users who come from a OOP paradigm may wrap their utility functions in an extra class,
-    /// instead of putting them at the top level of an ECMAScript module.
-    /// Doing so is generally unnecessary in JavaScript and TypeScript projects.
+    /// Users who come from a OOP paradigm may wrap their utility functions in
+    /// an extra class, instead of putting them at the top level of an
+    /// ECMAScript module.  Doing so is generally unnecessary in JavaScript and
+    /// TypeScript projects.
     ///
-    /// Wrapper classes add extra cognitive complexity to code without adding any structural improvements
+    /// * Wrapper classes add extra cognitive complexity to code without adding
+    ///   any structural improvements
+    ///   * Whatever would be put on them, such as utility functions, are already
+    ///     organized by virtue of being in a module.
+    ///   * As an alternative, you can `import * as ...` the module to get all of them
+    ///     in a single object.
+    /// * IDEs can't provide as good suggestions for static class or namespace
+    ///   imported properties when you start typing property names
+    /// * It's more difficult to statically analyze code for unused variables,
+    ///   etc.  when they're all on the class (see: [Finding dead code (and dead
+    ///   types) in TypeScript](https://effectivetypescript.com/2020/10/20/tsprune/)).
     ///
-    /// Whatever would be put on them, such as utility functions, are already organized by virtue of being in a module.
-    ///
-    /// As an alternative, you can import * as ... the module to get all of them in a single object.
-    /// IDEs can't provide as good suggestions for static class or namespace imported properties when you start typing property names
-    ///
-    /// It's more difficult to statically analyze code for unused variables, etc.
-    /// when they're all on the class (see: Finding dead code (and dead types) in TypeScript).
+    /// This rule also reports classes that have only a constructor and no
+    /// fields. Those classes can generally be replaced with a standalone
+    /// function.
     ///
     /// ### Example
     /// ```ts
@@ -63,16 +72,27 @@ declare_oxc_lint!(
     suspicious
 );
 
-fn empty_no_extraneous_class_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected empty class.").with_label(span)
+fn empty_class_diagnostic(span: Span, has_decorators: bool) -> OxcDiagnostic {
+    let diagnostic = OxcDiagnostic::warn("Unexpected empty class.").with_label(span);
+    if has_decorators {
+        diagnostic.with_help(
+            r#"Set "allowWithDecorator": true in your config to allow empty decorated classes"#,
+        )
+    } else {
+        diagnostic
+    }
 }
 
 fn only_static_no_extraneous_class_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected class with only static properties.").with_label(span)
+    OxcDiagnostic::warn("Unexpected class with only static properties.")
+        .with_label(span)
+        .with_help("Try using standalone functions instead of static methods")
 }
 
 fn only_constructor_no_extraneous_class_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected class with only a constructor.").with_label(span)
+    OxcDiagnostic::warn("Unexpected class with only a constructor.")
+        .with_label(span)
+        .with_help("Try replacing this class with a standalone function or deleting it entirely")
 }
 
 impl Rule for NoExtraneousClass {
@@ -115,7 +135,19 @@ impl Rule for NoExtraneousClass {
         match body.as_slice() {
             [] => {
                 if !self.allow_empty {
-                    ctx.diagnostic(empty_no_extraneous_class_diagnostic(class.span));
+                    let mut span = class.span;
+                    #[expect(clippy::checked_conversions, clippy::cast_possible_truncation)]
+                    if let Some(decorator) = class.decorators.last() {
+                        span = Span::new(decorator.span.end, span.end);
+                        // NOTE: there will always be a 'c' because of 'class' keyword.
+                        let start = ctx.source_range(span).find('c').unwrap();
+                        // SAFETY: source files are guaranteed to be less than
+                        // 2^32 characters, so conversion will never fail. Using
+                        // unchecked assert here removes a useless bounds check.
+                        unsafe { std::hint::assert_unchecked(start <= u32::MAX as usize) };
+                        span = span.shrink_left(start as u32);
+                    }
+                    ctx.diagnostic(empty_class_diagnostic(span, !class.decorators.is_empty()));
                 }
             }
             [ClassElement::MethodDefinition(constructor)] if constructor.kind.is_constructor() => {
@@ -138,6 +170,7 @@ impl Rule for NoExtraneousClass {
 #[test]
 fn test() {
     use crate::tester::Tester;
+    use serde_json::json;
 
     let pass = vec![
         (
@@ -146,7 +179,7 @@ fn test() {
 			  public prop = 1;
 			  constructor() {}
 			}
-			    ",
+            ",
             None,
         ),
         (
@@ -158,26 +191,12 @@ fn test() {
 			  }
 			  constructor() {}
 			}
-			    ",
+            ",
             None,
         ),
-        (
-            "
-			class Foo {
-			  constructor(public bar: string) {}
-			}
-			    ",
-            None,
-        ),
-        ("class Foo {}", Some(serde_json::json!([{ "allowEmpty": true }]))),
-        (
-            "
-			class Foo {
-			  constructor() {}
-			}
-			      ",
-            Some(serde_json::json!([{ "allowConstructorOnly": true }])),
-        ),
+        ("class Foo { constructor(public bar: string) {} }", None),
+        ("class Foo {}", Some(json!([{ "allowEmpty": true }]))),
+        ("class Foo { constructor() {} }", Some(json!([{ "allowConstructorOnly": true }]))),
         (
             "
 			export class Bar {
@@ -187,7 +206,7 @@ fn test() {
 			  }
 			}
 			      ",
-            Some(serde_json::json!([{ "allowStaticOnly": true }])),
+            Some(json!([{ "allowStaticOnly": true }])),
         ),
         (
             "
@@ -196,16 +215,10 @@ fn test() {
 			    return 'I am foo!';
 			  }
 			}
-			    ",
+		    ",
             None,
         ),
-        (
-            "
-			@FooDecorator
-			class Foo {}
-			      ",
-            Some(serde_json::json!([{ "allowWithDecorator": true }])),
-        ),
+        ("@FooDecorator class Foo {} ", Some(json!([{ "allowWithDecorator": true }]))),
         (
             "
 			@FooDecorator
@@ -216,25 +229,11 @@ fn test() {
 			    });
 			  }
 			}
-			      ",
-            Some(serde_json::json!([{ "allowWithDecorator": true }])),
+            ",
+            Some(json!([{ "allowWithDecorator": true }])),
         ),
-        (
-            "
-			abstract class Foo {
-			  abstract property: string;
-			}
-			    ",
-            None,
-        ),
-        (
-            "
-			abstract class Foo {
-			  abstract method(): string;
-			}
-			    ",
-            None,
-        ),
+        ("abstract class Foo { abstract property: string; }", None),
+        ("abstract class Foo { abstract method(): string; }", None),
     ];
 
     let fail = vec![
@@ -258,14 +257,7 @@ fn test() {
 			      ",
             None,
         ),
-        (
-            "
-			class Foo {
-			  constructor() {}
-			}
-			      ",
-            None,
-        ),
+        ("class Foo { constructor() {} }", None),
         (
             "
 			export class AClass {
@@ -280,20 +272,23 @@ fn test() {
 			      ",
             None,
         ),
-        (
-            "
-			export default class {
-			  static hello() {}
-			}
-			      ",
-            None,
-        ),
+        ("export default class { static hello() {} }", None),
         (
             "
 			@FooDecorator
 			class Foo {}
-			      ",
-            Some(serde_json::json!([{ "allowWithDecorator": false }])),
+            ",
+            Some(json!([{ "allowWithDecorator": false }])),
+        ),
+        (
+            "
+			@FooDecorator({
+              wowThisDecoratorIsQuiteLarge: true,
+              itShouldNotBeIncludedIn: 'the diagnostic span',
+            })
+			class Foo {}
+            ",
+            Some(json!([{ "allowWithDecorator": false }])),
         ),
         (
             "
@@ -305,31 +300,12 @@ fn test() {
 			    });
 			  }
 			}
-			      ",
-            Some(serde_json::json!([{ "allowWithDecorator": false }])),
+			",
+            Some(json!([{ "allowWithDecorator": false }])),
         ),
-        (
-            "
-			abstract class Foo {}
-			      ",
-            None,
-        ),
-        (
-            "
-			abstract class Foo {
-			  static property: string;
-			}
-			      ",
-            None,
-        ),
-        (
-            "
-			abstract class Foo {
-			  constructor() {}
-			}
-			      ",
-            None,
-        ),
+        ("abstract class Foo {}", None),
+        ("abstract class Foo { static property: string; }", None),
+        ("abstract class Foo { constructor() {} }", None),
     ];
 
     Tester::new(NoExtraneousClass::NAME, NoExtraneousClass::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/typescript_no_extraneous_class.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_extraneous_class.snap
@@ -14,6 +14,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ───
  6 │                   static PROP = 2;
    ╰────
+  help: Try using standalone functions instead of static methods
 
   ⚠ typescript-eslint(no-extraneous-class): Unexpected class with only static properties.
     ╭─[no_extraneous_class.tsx:10:17]
@@ -22,14 +23,14 @@ source: crates/oxc_linter/src/tester.rs
     ·                          ───
  11 │               public static helper(): void {}
     ╰────
+  help: Try using standalone functions instead of static methods
 
   ⚠ typescript-eslint(no-extraneous-class): Unexpected class with only a constructor.
-   ╭─[no_extraneous_class.tsx:2:10]
- 1 │ 
- 2 │             class Foo {
-   ·                   ───
- 3 │               constructor() {}
+   ╭─[no_extraneous_class.tsx:1:7]
+ 1 │ class Foo { constructor() {} }
+   ·       ───
    ╰────
+  help: Try replacing this class with a standalone function or deleting it entirely
 
   ⚠ typescript-eslint(no-extraneous-class): Unexpected empty class.
    ╭─[no_extraneous_class.tsx:8:8]
@@ -40,21 +41,29 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(no-extraneous-class): Unexpected class with only static properties.
-   ╭─[no_extraneous_class.tsx:2:19]
- 1 │     
- 2 │ ╭─▶             export default class {
- 3 │ │                 static hello() {}
- 4 │ ╰─▶             }
- 5 │                       
+   ╭─[no_extraneous_class.tsx:1:16]
+ 1 │ export default class { static hello() {} }
+   ·                ───────────────────────────
    ╰────
+  help: Try using standalone functions instead of static methods
 
   ⚠ typescript-eslint(no-extraneous-class): Unexpected empty class.
-   ╭─[no_extraneous_class.tsx:2:4]
- 1 │     
- 2 │ ╭─▶             @FooDecorator
- 3 │ ╰─▶             class Foo {}
- 4 │                       
+   ╭─[no_extraneous_class.tsx:3:4]
+ 2 │             @FooDecorator
+ 3 │             class Foo {}
+   ·             ────────────
+ 4 │             
    ╰────
+  help: Set "allowWithDecorator": true in your config to allow empty decorated classes
+
+  ⚠ typescript-eslint(no-extraneous-class): Unexpected empty class.
+   ╭─[no_extraneous_class.tsx:6:4]
+ 5 │             })
+ 6 │             class Foo {}
+   ·             ────────────
+ 7 │             
+   ╰────
+  help: Set "allowWithDecorator": true in your config to allow empty decorated classes
 
   ⚠ typescript-eslint(no-extraneous-class): Unexpected class with only a constructor.
    ╭─[no_extraneous_class.tsx:3:10]
@@ -63,27 +72,24 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ───
  4 │               constructor(foo: Foo) {
    ╰────
+  help: Try replacing this class with a standalone function or deleting it entirely
 
   ⚠ typescript-eslint(no-extraneous-class): Unexpected empty class.
-   ╭─[no_extraneous_class.tsx:2:4]
- 1 │ 
- 2 │             abstract class Foo {}
-   ·             ─────────────────────
- 3 │                   
+   ╭─[no_extraneous_class.tsx:1:1]
+ 1 │ abstract class Foo {}
+   · ─────────────────────
    ╰────
 
   ⚠ typescript-eslint(no-extraneous-class): Unexpected class with only static properties.
-   ╭─[no_extraneous_class.tsx:2:19]
- 1 │ 
- 2 │             abstract class Foo {
-   ·                            ───
- 3 │               static property: string;
+   ╭─[no_extraneous_class.tsx:1:16]
+ 1 │ abstract class Foo { static property: string; }
+   ·                ───
    ╰────
+  help: Try using standalone functions instead of static methods
 
   ⚠ typescript-eslint(no-extraneous-class): Unexpected class with only a constructor.
-   ╭─[no_extraneous_class.tsx:2:19]
- 1 │ 
- 2 │             abstract class Foo {
-   ·                            ───
- 3 │               constructor() {}
+   ╭─[no_extraneous_class.tsx:1:16]
+ 1 │ abstract class Foo { constructor() {} }
+   ·                ───
    ╰────
+  help: Try replacing this class with a standalone function or deleting it entirely


### PR DESCRIPTION
## What This PR Does
Deviates from `@typescript-eslint/no-extraneous-class` by allowing empty, decorated classes by default.

This provides a better experience for NestJS user using Oxlint without a config file. In NestJS, [`Module`s are often empty but use decorators to declaratively state their contents](https://docs.nestjs.com/modules#feature-modules). Other similar frameworks (TSeD, maybe Angular) will also benefit.

### Other Changes
- Fix span on empty class diagnostics to not cover decorators.
- Provide help messages on all diagnostics
- Add missing links and rich text stuff to docs