### PR TITLE
feat(linter/no-extraneous-class): add conditional fixer

### DIFF
--- a/crates/oxc_linter/src/snapshots/typescript_no_extraneous_class.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_extraneous_class.snap
@@ -6,6 +6,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ class Foo {}
    · ────────────
    ╰────
+  help: Delete this class
 
   ⚠ typescript-eslint(no-extraneous-class): Unexpected class with only static properties.
    ╭─[no_extraneous_class.tsx:5:14]
@@ -39,6 +40,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ────────────────────
  9 │               }
    ╰────
+  help: Delete this class
 
   ⚠ typescript-eslint(no-extraneous-class): Unexpected class with only static properties.
    ╭─[no_extraneous_class.tsx:1:16]
@@ -79,6 +81,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ abstract class Foo {}
    · ─────────────────────
    ╰────
+  help: Delete this class
 
   ⚠ typescript-eslint(no-extraneous-class): Unexpected class with only static properties.
    ╭─[no_extraneous_class.tsx:1:16]


### PR DESCRIPTION
## What This PR Does
Adds a `suggestion`-level auto-fixer to remove empty classes. Empty classes with decorators are not removed.