### PR TITLE
fix(linter/no-unused-vars): Recognize parameters used in await/yield expressions within comma expressions

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -236,6 +236,15 @@ fn test_vars_discarded_reads() {
         }
         foo(1)
         ",
+        // https://github.com/oxc-project/oxc/issues/10806
+        "export function f1(fn: () => Promise<void>) {
+            return async () => (await fn(), 1)
+        }",
+        "export function f2(fn: () => Promise<void>) {
+            return function* () {
+                return (yield fn(), 1);
+            }
+        }",
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
@@ -610,6 +610,9 @@ impl<'a> Symbol<'_, 'a> {
                     if matches!(parent, AstKind::CallExpression(_)) {
                         continue;
                     }
+                    if matches!(parent, AstKind::AwaitExpression(_) | AstKind::YieldExpression(_)) {
+                        continue;
+                    }
                     debug_assert!(
                         !seq.expressions.is_empty(),
                         "empty SequenceExpressions should be a parse error."

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
@@ -607,12 +607,15 @@ impl<'a> Symbol<'_, 'a> {
                     }
                 }
                 (parent, AstKind::SequenceExpression(seq)) => {
-                    if matches!(parent, AstKind::CallExpression(_)) {
+                    if matches!(
+                        parent,
+                        AstKind::CallExpression(_)
+                            | AstKind::AwaitExpression(_)
+                            | AstKind::YieldExpression(_)
+                    ) {
                         continue;
                     }
-                    if matches!(parent, AstKind::AwaitExpression(_) | AstKind::YieldExpression(_)) {
-                        continue;
-                    }
+
                     debug_assert!(
                         !seq.expressions.is_empty(),
                         "empty SequenceExpressions should be a parse error."


### PR DESCRIPTION
- Closes: #10806 