### PR TITLE
fix(language_server): return server version `initialize` response

### DIFF
--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -83,6 +83,7 @@ impl Options {
 impl LanguageServer for Backend {
     #[expect(deprecated)] // TODO: FIXME
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
+        let server_version = env!("CARGO_PKG_VERSION");
         let options = params.initialization_options.and_then(|mut value| {
             let settings = value.get_mut("settings")?.take();
             serde_json::from_value::<Options>(settings).ok()
@@ -97,7 +98,7 @@ impl LanguageServer for Backend {
 
         if let Some(value) = options {
             info!("initialize: {value:?}");
-            info!("language server version: {:?}", env!("CARGO_PKG_VERSION"));
+            info!("language server version: {server_version}");
         }
 
         let capabilities = Capabilities::from(params.capabilities);
@@ -113,7 +114,10 @@ impl LanguageServer for Backend {
         })?;
 
         Ok(InitializeResult {
-            server_info: Some(ServerInfo { name: "oxc".into(), version: None }),
+            server_info: Some(ServerInfo {
+                name: "oxc".into(),
+                version: Some(server_version.to_string()),
+            }),
             offset_encoding: None,
             capabilities: capabilities.into(),
         })


### PR DESCRIPTION
closes #10799

```
2025-05-05 12:38:19.243 [info] [Trace - 12:38:19 PM] Received response 'initialize - (0)' in 331ms.
2025-05-05 12:38:19.243 [info] Result: {
    "capabilities": {
        "textDocumentSync": 1,
        "codeActionProvider": {
            "codeActionKinds": [
                "quickfix",
                "source.fixAll.oxc"
            ]
        },
        "executeCommandProvider": {
            "commands": [
                "oxc.fixAll"
            ]
        },
        "workspace": {
            "workspaceFolders": {
                "supported": true,
                "changeNotifications": true
            }
        }
    },
    "serverInfo": {
        "name": "oxc",
        "version": "0.16.9"
    }
}
```