### PR TITLE
perf(napi/parser): simplify recursion and avoid function calls in fixup visitor

### DIFF
--- a/napi/parser/wrap.cjs
+++ b/napi/parser/wrap.cjs
@@ -27,41 +27,41 @@ module.exports.wrap = function wrap(result) {
 
 function jsonParseAst(programJson) {
   const program = JSON.parse(programJson);
-  visitNode(program, transform);
+  transformNode(program);
   return program;
 }
 
-function transform(node) {
-  // Set `value` field of `Literal`s for `BigInt`s and `RegExp`s.
-  // This is not possible to do on Rust side, as neither can be represented correctly in JSON.
-  if (node.type === 'Literal') {
-    if (node.bigint) {
-      node.value = BigInt(node.bigint);
-    }
-    if (node.regex) {
-      try {
-        node.value = RegExp(node.regex.pattern, node.regex.flags);
-      } catch (_err) {
-        // Invalid regexp, or valid regexp using syntax not supported by this version of NodeJS
-      }
-    }
-  }
-}
-
-function visitNode(node, fn) {
+function transformNode(node) {
   if (!node) return;
   if (Array.isArray(node)) {
     for (const el of node) {
-      visitNode(el, fn);
+      transformNode(el);
     }
     return;
   }
 
-  fn(node);
+  if (node.type === 'Literal') {
+    transformLiteral(node);
+    return;
+  }
 
   const keys = visitorKeys[node.type];
   if (!keys) return;
   for (const key of keys) {
-    visitNode(node[key], fn);
+    transformNode(node[key]);
+  }
+}
+
+function transformLiteral(node) {
+  // Set `value` field of `Literal`s for `BigInt`s and `RegExp`s.
+  // This is not possible to do on Rust side, as neither can be represented correctly in JSON.
+  if (node.bigint) {
+    node.value = BigInt(node.bigint);
+  } else if (node.regex) {
+    try {
+      node.value = RegExp(node.regex.pattern, node.regex.flags);
+    } catch (_err) {
+      // Invalid regexp, or valid regexp using syntax not supported by this version of NodeJS
+    }
   }
 }

--- a/napi/parser/wrap.mjs
+++ b/napi/parser/wrap.mjs
@@ -28,41 +28,41 @@ export function wrap(result) {
 // Used by napi/playground/patch.mjs
 export function jsonParseAst(programJson) {
   const program = JSON.parse(programJson);
-  visitNode(program, transform);
+  transformNode(program);
   return program;
 }
 
-function transform(node) {
-  // Set `value` field of `Literal`s for `BigInt`s and `RegExp`s.
-  // This is not possible to do on Rust side, as neither can be represented correctly in JSON.
-  if (node.type === 'Literal') {
-    if (node.bigint) {
-      node.value = BigInt(node.bigint);
-    }
-    if (node.regex) {
-      try {
-        node.value = RegExp(node.regex.pattern, node.regex.flags);
-      } catch (_err) {
-        // Invalid regexp, or valid regexp using syntax not supported by this version of NodeJS
-      }
-    }
-  }
-}
-
-function visitNode(node, fn) {
+function transformNode(node) {
   if (!node) return;
   if (Array.isArray(node)) {
     for (const el of node) {
-      visitNode(el, fn);
+      transformNode(el);
     }
     return;
   }
 
-  fn(node);
+  if (node.type === 'Literal') {
+    transformLiteral(node);
+    return;
+  }
 
   const keys = visitorKeys[node.type];
   if (!keys) return;
   for (const key of keys) {
-    visitNode(node[key], fn);
+    transformNode(node[key]);
+  }
+}
+
+function transformLiteral(node) {
+  // Set `value` field of `Literal`s for `BigInt`s and `RegExp`s.
+  // This is not possible to do on Rust side, as neither can be represented correctly in JSON.
+  if (node.bigint) {
+    node.value = BigInt(node.bigint);
+  } else if (node.regex) {
+    try {
+      node.value = RegExp(node.regex.pattern, node.regex.flags);
+    } catch (_err) {
+      // Invalid regexp, or valid regexp using syntax not supported by this version of NodeJS
+    }
   }
 }


### PR DESCRIPTION
Follow-on after #10791, part of #10783.

In the fixup visitor, replace `visitNode` with a more specialized `transformNode` function. The difference is that `transformNode` doesn't need to be passed `fn` as 2nd param.

Also, move the check for whether a node is a `Literal` into `transformNode` to avoid the cost of a function call for every node (most of which are not `Literal`s).

Running benchmarks locally (`pnpm run bench` in `napi/parser`), I'm seeing a 2%-3% speed-up.
