### PR TITLE
feat(language_server): provide commands / code actions for unopened files

### DIFF
--- a/editors/vscode/client/extension.spec.ts
+++ b/editors/vscode/client/extension.spec.ts
@@ -99,7 +99,7 @@ suite('code actions', () => {
     });
 
     await workspace.applyEdit(edit);
-    await window.showTextDocument(fileUri);
+    // await window.showTextDocument(fileUri); -- should also work without opening the file
 
     const codeActions: ProviderResult<Array<CodeAction>> = await commands.executeCommand(
       'vscode.executeCodeActionProvider',


### PR DESCRIPTION
Related https://github.com/oxc-project/oxc-intellij-plugin/pull/177

When the client request code actions or commands for a file. This file must not be open to be requested.
In the main, we are just looking into our `diagnostics_map`, which will be filled only on open/change/close of the text document.

When the client request now a code action or command for a file, we will lint them only (if not already done) and avoid filling the `diagnostic_map`.