### PR TITLE
fix(napi/parser): expose visitor keys files in NPM package

### DIFF
--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -43,7 +43,8 @@
     "wasm.mjs",
     "bindings.js",
     "webcontainer-fallback.js",
-    "generated/visitor-keys.js",
+    "generated/visitor-keys.cjs",
+    "generated/visitor-keys.mjs",
     "generated/deserialize/js.js",
     "generated/deserialize/ts.js"
   ],


### PR DESCRIPTION
#10791 added 2 files `generated/visitor-keys.cjs` and `visitor-keys.mjs` to the NAPI package. When I amended the original PR, I forgot to update `package.json` to include them both in NPM package.
