### PR TITLE
ci(benchmarks): estree benchmark use `black_box` on result of `to_estree_ts_json`

### DIFF
--- a/tasks/benchmark/benches/parser.rs
+++ b/tasks/benchmark/benches/parser.rs
@@ -1,6 +1,6 @@
 use oxc_allocator::Allocator;
 use oxc_ast_visit::utf8_to_utf16::Utf8ToUtf16;
-use oxc_benchmark::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use oxc_benchmark::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use oxc_parser::{ParseOptions, Parser};
 use oxc_span::SourceType;
 use oxc_tasks_common::TestFiles;
@@ -52,7 +52,7 @@ fn bench_estree(criterion: &mut Criterion) {
                     span_converter.convert_program(&mut program);
                     span_converter.convert_comments(&mut program.comments);
 
-                    program.to_estree_ts_json();
+                    black_box(program.to_estree_ts_json());
                     program
                 });
             });


### PR DESCRIPTION
In benchmark for ESTree conversion, pass result of `program.to_estree_ts_json()` to `black_box`. Without it, if compiler was sufficiently clever, it could remove the entire call to `to_estree_ts_json` because the result is never used.
