### PR TITLE
fix(napi): Use latest parser API for playground

### DIFF
--- a/napi/parser/src/lib.rs
+++ b/napi/parser/src/lib.rs
@@ -100,6 +100,7 @@ fn parse_with_return(filename: &str, source_text: String, options: &ParserOption
 
     let mut errors = OxcError::from_diagnostics(filename, &source_text, diagnostics);
 
+    // NOTE: These lines are almost the same as in `napi/playground`, so keep them in sync
     let mut comments =
         convert_utf8_to_utf16(&source_text, &mut program, &mut module_record, &mut errors);
 

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -248,6 +248,7 @@ impl Oxc {
         let mut comments =
             convert_utf8_to_utf16(&source_text, &mut program, &mut module_record, &mut []);
 
+        // NOTE: These lines are almost the same as in `napi/parser`, so keep them in sync
         self.ast_json = if source_type.is_javascript() {
             // Add hashbang to start of comments
             if let Some(hashbang) = &program.hashbang {
@@ -262,9 +263,13 @@ impl Oxc {
                 );
             }
 
-            program.to_pretty_estree_js_json()
+            program.to_pretty_estree_js_json_with_fixes()
         } else {
-            program.to_pretty_estree_ts_json()
+            // Note: `@typescript-eslint/parser` ignores hashbangs,
+            // despite appearances to the contrary in AST explorers.
+            // So we ignore them too.
+            // See: https://github.com/typescript-eslint/typescript-eslint/issues/6500
+            program.to_pretty_estree_ts_json_with_fixes()
         };
         self.comments = comments;
 


### PR DESCRIPTION
Follow up #10820 and fixes https://discord.com/channels/1079625926024900739/1114213284766294149/1369346152335409333

(= This PR fixes broken playground 🔨)