### PR TITLE
feat(data_structures): add `InlineString::as_mut_str` method

### DIFF
--- a/crates/oxc_data_structures/src/inline_string.rs
+++ b/crates/oxc_data_structures/src/inline_string.rs
@@ -128,6 +128,18 @@ impl<const CAPACITY: usize, Len: UnsignedInt> InlineString<CAPACITY, Len> {
             std::str::from_utf8_unchecked(slice)
         }
     }
+
+    /// Get string as `&mut str` slice.
+    #[inline]
+    pub fn as_mut_str(&mut self) -> &mut str {
+        // SAFETY: If safety conditions of `push_unchecked` have been upheld,
+        // `self.len <= CAPACITY`, and contents of slice of `bytes` is a valid UTF-8 string
+        unsafe {
+            assert_unchecked!(self.len.to_usize() <= CAPACITY);
+            let slice = &mut self.bytes[..self.len.to_usize()];
+            std::str::from_utf8_unchecked_mut(slice)
+        }
+    }
 }
 
 impl<const CAPACITY: usize, Len: UnsignedInt> Default for InlineString<CAPACITY, Len> {


### PR DESCRIPTION
Add `InlineString::as_mut_str` method, to accompany `as_str`. Not including this method was an oversight when I wrote `InlineString`.