### PR TITLE
refactor(ast/estree): use `#[estree(prepend_to)]`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -30,7 +30,7 @@ use super::{macros::inherit_variants, *};
 )]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(field_order(span, directives, source_type, hashbang), via = ProgramConverter)]
+#[estree(field_order(span, body, source_type, hashbang), via = ProgramConverter)]
 pub struct Program<'a> {
     pub span: Span,
     pub source_type: SourceType,
@@ -40,9 +40,8 @@ pub struct Program<'a> {
     #[estree(skip)]
     pub comments: Vec<'a, Comment>,
     pub hashbang: Option<Hashbang<'a>>,
-    #[estree(rename = "body")]
+    #[estree(prepend_to = "body")]
     pub directives: Vec<'a, Directive<'a>>,
-    #[estree(append_to = "directives")]
     pub body: Vec<'a, Statement<'a>>,
     pub scope_id: Cell<Option<ScopeId>>,
 }
@@ -1852,9 +1851,9 @@ pub enum FormalParameterKind {
 #[estree(rename = "BlockStatement")]
 pub struct FunctionBody<'a> {
     pub span: Span,
-    #[estree(rename = "body")]
+    #[estree(prepend_to = "statements")]
     pub directives: Vec<'a, Directive<'a>>,
-    #[estree(append_to = "directives")]
+    #[estree(rename = "body")]
     pub statements: Vec<'a, Statement<'a>>,
 }
 

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1262,9 +1262,8 @@ pub enum TSModuleDeclarationBody<'a> {
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSModuleBlock<'a> {
     pub span: Span,
-    #[estree(rename = "body")]
+    #[estree(prepend_to = "body")]
     pub directives: Vec<'a, Directive<'a>>,
-    #[estree(append_to = "directives")]
     pub body: Vec<'a, Statement<'a>>,
 }
 


### PR DESCRIPTION
Pure refactor. Use `#[estree(prepend_to = ...)]` (introduced in #10849) to concatenate directives and statements in ESTree AST.

Previously we had hacks like this:

```rs
pub struct Program<'a> {
    #[estree(rename = "body")]
    pub directives: Vec<'a, Directive<'a>>,
    #[estree(append_to = "directives")]
    pub body: Vec<'a, Statement<'a>>,
}
```

Instead we can do this which is easier to read, and simpler for `oxc_ast_tools` to generate code for:

```rs
pub struct Program<'a> {
    #[estree(prepend_to = "body")]
    pub directives: Vec<'a, Directive<'a>>,
    pub body: Vec<'a, Statement<'a>>,
}
```
