### PR TITLE
fix(ast/estree): reorder fields for TS `Identifier` types in TS-ESTree AST

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -34,7 +34,7 @@ use super::{inherit_variants, js::*, literal::*};
 #[estree(
     rename = "Identifier",
     add_fields(name = This, decorators = EmptyArray, optional = False),
-    field_order(span, name, type_annotation, decorators, optional),
+    field_order(span, name, decorators, optional, type_annotation),
 )]
 pub struct TSThisParameter<'a> {
     pub span: Span,
@@ -1080,7 +1080,11 @@ pub struct TSConstructSignatureDeclaration<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "Identifier", add_fields(decorators = EmptyArray, optional = False))]
+#[estree(
+    rename = "Identifier",
+    add_fields(decorators = EmptyArray, optional = False),
+    field_order(span, name, decorators, optional, type_annotation),
+)]
 pub struct TSIndexSignatureName<'a> {
     pub span: Span,
     #[estree(json_safe)]

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -2281,9 +2281,9 @@ impl ESTree for TSThisParameter<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &crate::serialize::This(self));
-        state.serialize_field("typeAnnotation", &self.type_annotation);
         state.serialize_field("decorators", &crate::serialize::EmptyArray(self));
         state.serialize_field("optional", &crate::serialize::False(self));
+        state.serialize_field("typeAnnotation", &self.type_annotation);
         state.end();
     }
 }
@@ -2985,9 +2985,9 @@ impl ESTree for TSIndexSignatureName<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &JsonSafeString(self.name.as_str()));
-        state.serialize_field("typeAnnotation", &self.type_annotation);
         state.serialize_field("decorators", &crate::serialize::EmptyArray(self));
         state.serialize_field("optional", &crate::serialize::False(self));
+        state.serialize_field("typeAnnotation", &self.type_annotation);
         state.end();
     }
 }

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -1289,9 +1289,9 @@ function deserializeTSThisParameter(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     name: 'this',
-    typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 16),
     decorators: [],
     optional: false,
+    typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 16),
   };
 }
 
@@ -1764,9 +1764,9 @@ function deserializeTSIndexSignatureName(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     name: deserializeStr(pos + 8),
-    typeAnnotation: deserializeBoxTSTypeAnnotation(pos + 24),
     decorators: [],
     optional: false,
+    typeAnnotation: deserializeBoxTSTypeAnnotation(pos + 24),
   };
 }
 

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -1441,9 +1441,9 @@ function deserializeTSThisParameter(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     name: 'this',
-    typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 16),
     decorators: [],
     optional: false,
+    typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 16),
   };
 }
 
@@ -1916,9 +1916,9 @@ function deserializeTSIndexSignatureName(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     name: deserializeStr(pos + 8),
-    typeAnnotation: deserializeBoxTSTypeAnnotation(pos + 24),
     decorators: [],
     optional: false,
+    typeAnnotation: deserializeBoxTSTypeAnnotation(pos + 24),
   };
 }
 

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -964,9 +964,9 @@ export interface JSXText extends Span {
 export interface TSThisParameter extends Span {
   type: 'Identifier';
   name: 'this';
-  typeAnnotation: TSTypeAnnotation | null;
   decorators: [];
   optional: false;
+  typeAnnotation: TSTypeAnnotation | null;
 }
 
 export interface TSEnumDeclaration extends Span {
@@ -1294,9 +1294,9 @@ export interface TSConstructSignatureDeclaration extends Span {
 export interface TSIndexSignatureName extends Span {
   type: 'Identifier';
   name: string;
-  typeAnnotation: TSTypeAnnotation;
   decorators: [];
   optional: false;
+  typeAnnotation: TSTypeAnnotation;
 }
 
 export interface TSInterfaceHeritage extends Span {


### PR DESCRIPTION
Change field order of TS types which are converted to `Identifier`s in TS-ESTree AST, to be consistent with other `Identifier`s.
