### PR TITLE
fix(parser): fix rhs precedence while parsing `PrivateInExpression`

### DIFF
--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -11,6 +11,9 @@ fn cases() {
     test_same("interface I<in out T,> {}\n");
     test_same("function F<const in out T,>() {}\n");
     test_same("class C {\n\tp = await(0);\n}\n");
+    test_same(
+        "class Foo {\n\t#name: string;\n\tf() {\n\t\t#name in other && this.#name === other.#name;\n\t}\n}\n",
+    );
 }
 
 #[test]

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -1040,10 +1040,11 @@ impl<'a> ParserImpl<'a> {
     ) -> Expression<'a> {
         let lhs_span = self.start_span();
 
+        // [+In] PrivateIdentifier in ShiftExpression[?Yield, ?Await]
         let lhs = if self.ctx.has_in() && self.at(Kind::PrivateIdentifier) {
             let left = self.parse_private_identifier();
             self.expect(Kind::In);
-            let right = self.parse_binary_expression_or_higher(Precedence::Lowest);
+            let right = self.parse_binary_expression_or_higher(Precedence::Compare);
             if let Expression::PrivateInExpression(private_in_expr) = right {
                 let error = diagnostics::private_in_private(private_in_expr.span);
                 return self.fatal_error(error);

--- a/tasks/transform_conformance/snapshots/babel_exec.snap.md
+++ b/tasks/transform_conformance/snapshots/babel_exec.snap.md
@@ -420,29 +420,20 @@ AssertionError: expected [Function] to throw error including 'right-hand side of
     at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-private-loose-rhs-not-object-exec.test.js:176:5
 
 ./fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-private-loose-static-shadow-exec.test.js
-TypeError: right-hand side of 'in' should be an object, got number
-    at _checkInRHS (./npm/runtime/src/helpers/checkInRHS.js:3:30)
-    at func (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-private-loose-static-shadow-exec.test.js:10:12)
-    at Test.method (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-private-loose-static-shadow-exec.test.js:12:11)
-    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-private-loose-static-shadow-exec.test.js:18:11
+AssertionError: expected 2 to be 5 // Object.is equality
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-private-loose-static-shadow-exec.test.js:18:25
 
 ./fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-private-static-shadow-exec.test.js
-TypeError: right-hand side of 'in' should be an object, got number
-    at _checkInRHS (./npm/runtime/src/helpers/checkInRHS.js:3:30)
-    at func (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-private-static-shadow-exec.test.js:10:12)
-    at Test.method (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-private-static-shadow-exec.test.js:12:11)
-    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-private-static-shadow-exec.test.js:18:11
+AssertionError: expected 2 to be 5 // Object.is equality
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-private-static-shadow-exec.test.js:18:25
 
 ./fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-to-native-fields-half-constructed-static-exec.test.js
 AssertionError: expected true to be false // Object.is equality
     at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-to-native-fields-half-constructed-static-exec.test.js:29:15
 
 ./fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-to-native-fields-static-shadow-exec.test.js
-TypeError: right-hand side of 'in' should be an object, got number
-    at _checkInRHS (./npm/runtime/src/helpers/checkInRHS.js:3:30)
-    at func (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-to-native-fields-static-shadow-exec.test.js:10:12)
-    at Test.method (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-to-native-fields-static-shadow-exec.test.js:12:11)
-    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-to-native-fields-static-shadow-exec.test.js:18:11
+AssertionError: expected 2 to be 5 // Object.is equality
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-to-native-fields-static-shadow-exec.test.js:18:25
 
 ./fixtures/babel/babel-plugin-transform-react-jsx-source-test-fixtures-react-source-basic-sample-exec.test.js
 ReferenceError: transformAsync is not defined


### PR DESCRIPTION
fixes #10839

```
class Foo {
  #name: string;
  f() { #name in other && this.#name === other.#name }
                 ^^^^^ rhs is only this part
}

RelationalExpression[In, Yield, Await] :
  [+In] PrivateIdentifier in ShiftExpression[?Yield, ?Await]
```