### PR TITLE
fix(playground): fix display of ESTree AST

### DIFF
--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -262,9 +262,9 @@ impl Oxc {
                 );
             }
 
-            program.to_pretty_estree_js_json()
+            program.to_pretty_estree_js_json_with_fixes()
         } else {
-            program.to_pretty_estree_ts_json()
+            program.to_pretty_estree_ts_json_with_fixes()
         };
         self.comments = comments;
 


### PR DESCRIPTION
Display of ESTree AST in Playground is currently broken. Fix it. Problem was that calls `jsonParseAst` from `wrap.mjs` to convert AST JSON to an object, which uses the `fixes` property. So it needs to use `Program::to_pretty_estree_js_json_with_fixes` on Rust side.

fixes https://github.com/oxc-project/playground/issues/100
