### PR TITLE
refactor(ast/estree): print header and footer on JSON AST with fixes on separate lines

### DIFF
--- a/crates/oxc_estree/src/serialize/mod.rs
+++ b/crates/oxc_estree/src/serialize/mod.rs
@@ -142,14 +142,14 @@ impl<C: Config, F: Formatter> ESTreeSerializer<C, F> {
             );
         }
 
-        self.buffer.print_str(r#"{"node":"#);
+        self.buffer.print_str("{\"node\":\n");
 
         node.serialize(&mut self);
 
         debug_assert_eq!(self.trace_path.len(), 1);
         debug_assert_eq!(self.trace_path[0], TracePathPart::DUMMY);
 
-        self.buffer.print_str(r#","fixes":["#);
+        self.buffer.print_str("\n,\"fixes\":[");
         if !self.fixes_buffer.is_empty() {
             let traces_buffer = mem::take(&mut self.fixes_buffer).into_string();
             self.buffer.print_str(&traces_buffer[1..]);


### PR DESCRIPTION
#10820 changed how `BigInt`s and `RegExp`s are fixed in ESTree AST on JS side. It adds a list of fix paths to the end of the JSON.

Add line breaks after the inserted header, and before the inserted footer. This will allow playground to easily trim off the header and footer and display the raw JSON instead of converting the AST Object back to JSON with `JSON.stringify`. https://github.com/oxc-project/playground/pull/101
