### PR TITLE
feat(parser): `accessor` modifier cannot be used with `readonly` and `declare` modifier.

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -570,6 +570,15 @@ pub fn cannot_appear_on_an_index_signature(modifier: &Modifier) -> OxcDiagnostic
         .with_label(modifier.span)
 }
 
+/// TS(1243)
+pub fn accessor_modifier(modifier: &Modifier) -> OxcDiagnostic {
+    ts_error(
+        "1243",
+        format!("'accessor' modifier cannot be used with '{}' modifier.", modifier.kind),
+    )
+    .with_label(modifier.span)
+}
+
 /// TS(1354)
 #[cold]
 pub fn readonly_in_array_or_tuple_type(span: Span) -> OxcDiagnostic {

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -11886,6 +11886,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  7 │ }
    ╰────
 
+  × TS(1243): 'accessor' modifier cannot be used with 'declare' modifier.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/accessor-invalid/input.ts:2:3]
+ 1 │ abstract class Foo {
+ 2 │   declare accessor prop7: number;
+   ·   ───────
+ 3 │   private accessor #p: any;
+   ╰────
+
   × TS(18010): An accessibility modifier cannot be used with a private identifier.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/accessor-invalid/input.ts:3:3]
  2 │   declare accessor prop7: number;
@@ -11901,6 +11909,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·              ─
  8 │   abstract accessor f = 1;
    ╰────
+
+  × TS(1243): 'accessor' modifier cannot be used with 'readonly' modifier.
+    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/accessor-invalid/input.ts:9:3]
+  8 │   abstract accessor f = 1;
+  9 │   readonly accessor g;
+    ·   ────────
+ 10 │ }
+    ╰────
 
   × TS(1092): Type parameters cannot appear on a constructor declaration
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/constructor-with-type-parameters/input.ts:2:14]

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -20327,6 +20327,22 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╰────
   help: Remove the duplicate modifier.
 
+  × TS(1243): 'accessor' modifier cannot be used with 'readonly' modifier.
+   ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorDisallowedModifiers.ts:3:5]
+ 2 │     accessor accessor a: any;
+ 3 │     readonly accessor b: any;
+   ·     ────────
+ 4 │     declare accessor c: any;
+   ╰────
+
+  × TS(1243): 'accessor' modifier cannot be used with 'declare' modifier.
+   ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorDisallowedModifiers.ts:4:5]
+ 3 │     readonly accessor b: any;
+ 4 │     declare accessor c: any;
+   ·     ───────
+ 5 │     accessor public d: any;
+   ╰────
+
   × Expected a semicolon or an implicit semicolon after a statement, but found none
     ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorDisallowedModifiers.ts:10:15]
   9 │     accessor static h: any;

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1377,6 +1377,15 @@ rebuilt        : ["x"]
    `----
 
 
+  x TS(1243): 'accessor' modifier cannot be used with 'readonly' modifier.
+    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/class/accessor-allowDeclareFields-false/input.ts:14:3]
+ 13 |   abstract accessor f = 1;
+ 14 |   readonly accessor g;
+    :   ^^^^^^^^
+ 15 | }
+    `----
+
+
 * class/accessor-allowDeclareFields-true/input.ts
 
   x TS(18010): An accessibility modifier cannot be used with a private
@@ -1387,6 +1396,15 @@ rebuilt        : ["x"]
    :   ^^^^^^^
  9 | 
    `----
+
+
+  x TS(1243): 'accessor' modifier cannot be used with 'readonly' modifier.
+    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/class/accessor-allowDeclareFields-true/input.ts:14:3]
+ 13 |   abstract accessor f = 1;
+ 14 |   readonly accessor g;
+    :   ^^^^^^^^
+ 15 | }
+    `----
 
 
 * class/head/input.ts


### PR DESCRIPTION
closes #10837

These are syntax errors:

```ts
class Foo {
    readonly accessor a: any;
    declare accessor b: any;
}
```