### PR TITLE
fix(ast/estree): fix TS type def for `RegExpLiteral`

### DIFF
--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -146,7 +146,7 @@ pub struct RegExpLiteral<'a> {
 #[ast]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, ContentEq, ESTree)]
-#[estree(no_type)]
+#[estree(no_type, ts_alias = "{ pattern: string; flags: string; }")]
 pub struct RegExp<'a> {
     /// The regex pattern between the slashes
     pub pattern: RegExpPattern<'a>,

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -854,12 +854,7 @@ export interface RegExpLiteral extends Span {
   type: 'Literal';
   value: RegExp | null;
   raw: string | null;
-  regex: RegExp;
-}
-
-export interface RegExp {
-  pattern: string;
-  flags: string;
+  regex: { pattern: string; flags: string };
 }
 
 export interface JSXElement extends Span {


### PR DESCRIPTION
Fix TS type def for `RegExpLiteral`.

Problem is that we were defining `interface RegExp`. This name clashes with the native JS type `RegExp` which is used for the `value` field of `RegExpLiteral`. Get rid of this interface to remove the naming clash.
