### PR TITLE
refactor(ast/estree): add `regex` and `bigint` fields to all `Literal` nodes in ESTree AST

### DIFF
--- a/.github/actions/clone-submodules/action.yml
+++ b/.github/actions/clone-submodules/action.yml
@@ -38,4 +38,4 @@ runs:
         show-progress: false
         repository: oxc-project/acorn-test262
         path: tasks/coverage/acorn-test262
-        ref: 4e88e3a36b29e72a4d9b7b77b9bf721915a609aa # Latest main at 7/5/25
+        ref: 362e539c91751239c3a5d876919e50cb7fbc150a # Latest main at 7/5/25

--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -20,7 +20,7 @@ use oxc_syntax::number::{BigintBase, NumberBase};
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "Literal", add_fields(raw = BooleanLiteralRaw))]
+#[estree(rename = "Literal", add_fields(raw = BooleanLiteralRaw, regex = Null, bigint = Null))]
 pub struct BooleanLiteral {
     /// Node location in source code
     pub span: Span,
@@ -34,7 +34,7 @@ pub struct BooleanLiteral {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "Literal", add_fields(value = Null, raw = NullLiteralRaw))]
+#[estree(rename = "Literal", add_fields(value = Null, raw = NullLiteralRaw, regex = Null, bigint = Null))]
 pub struct NullLiteral {
     /// Node location in source code
     pub span: Span,
@@ -46,7 +46,7 @@ pub struct NullLiteral {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, Dummy, TakeIn, ContentEq, GetSpan, GetSpanMut, ESTree)]
-#[estree(rename = "Literal")]
+#[estree(rename = "Literal", add_fields(regex = Null, bigint = Null))]
 pub struct NumericLiteral<'a> {
     /// Node location in source code
     pub span: Span,
@@ -69,7 +69,7 @@ pub struct NumericLiteral<'a> {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, Dummy, TakeIn, ContentEq, GetSpan, GetSpanMut, ESTree)]
-#[estree(rename = "Literal")]
+#[estree(rename = "Literal", add_fields(regex = Null, bigint = Null))]
 pub struct StringLiteral<'a> {
     /// Node location in source code
     pub span: Span,
@@ -101,8 +101,8 @@ pub struct StringLiteral<'a> {
 #[generate_derive(CloneIn, Dummy, TakeIn, ContentEq, GetSpan, GetSpanMut, ESTree)]
 #[estree(
     rename = "Literal",
-    add_fields(value = BigIntLiteralValue, bigint = BigIntLiteralBigint),
-    field_order(span, value, raw, bigint),
+    add_fields(value = BigIntLiteralValue, regex = Null, bigint = BigIntLiteralBigint),
+    field_order(span, value, raw, regex, bigint),
 )]
 pub struct BigIntLiteral<'a> {
     /// Node location in source code
@@ -124,8 +124,8 @@ pub struct BigIntLiteral<'a> {
 #[generate_derive(CloneIn, Dummy, TakeIn, ContentEq, GetSpan, GetSpanMut, ESTree)]
 #[estree(
     rename = "Literal",
-    add_fields(value = RegExpLiteralValue),
-    field_order(span, value, raw, regex),
+    add_fields(value = RegExpLiteralValue, bigint = Null),
+    field_order(span, value, raw, regex, bigint),
 )]
 pub struct RegExpLiteral<'a> {
     /// Node location in source code

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1894,6 +1894,8 @@ impl ESTree for BooleanLiteral {
         state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &self.value);
         state.serialize_field("raw", &crate::serialize::BooleanLiteralRaw(self));
+        state.serialize_field("regex", &crate::serialize::Null(self));
+        state.serialize_field("bigint", &crate::serialize::Null(self));
         state.end();
     }
 }
@@ -1906,6 +1908,8 @@ impl ESTree for NullLiteral {
         state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &crate::serialize::Null(self));
         state.serialize_field("raw", &crate::serialize::NullLiteralRaw(self));
+        state.serialize_field("regex", &crate::serialize::Null(self));
+        state.serialize_field("bigint", &crate::serialize::Null(self));
         state.end();
     }
 }
@@ -1918,6 +1922,8 @@ impl ESTree for NumericLiteral<'_> {
         state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &self.value);
         state.serialize_field("raw", &self.raw);
+        state.serialize_field("regex", &crate::serialize::Null(self));
+        state.serialize_field("bigint", &crate::serialize::Null(self));
         state.end();
     }
 }
@@ -1930,6 +1936,8 @@ impl ESTree for StringLiteral<'_> {
         state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &crate::serialize::StringLiteralValue(self));
         state.serialize_field("raw", &self.raw);
+        state.serialize_field("regex", &crate::serialize::Null(self));
+        state.serialize_field("bigint", &crate::serialize::Null(self));
         state.end();
     }
 }
@@ -1942,6 +1950,7 @@ impl ESTree for BigIntLiteral<'_> {
         state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &crate::serialize::BigIntLiteralValue(self));
         state.serialize_field("raw", &self.raw);
+        state.serialize_field("regex", &crate::serialize::Null(self));
         state.serialize_field("bigint", &crate::serialize::BigIntLiteralBigint(self));
         state.end();
     }
@@ -1956,6 +1965,7 @@ impl ESTree for RegExpLiteral<'_> {
         state.serialize_field("value", &crate::serialize::RegExpLiteralValue(self));
         state.serialize_field("raw", &self.raw);
         state.serialize_field("regex", &self.regex);
+        state.serialize_field("bigint", &crate::serialize::Null(self));
         state.end();
     }
 }

--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ submodules:
   just clone-submodule tasks/coverage/babel https://github.com/babel/babel.git 578ac4df1c8a05f01350553950dbfbbeaac013c2
   just clone-submodule tasks/coverage/typescript https://github.com/microsoft/TypeScript.git 15392346d05045742e653eab5c87538ff2a3c863
   just clone-submodule tasks/prettier_conformance/prettier https://github.com/prettier/prettier.git 7584432401a47a26943dd7a9ca9a8e032ead7285
-  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 4e88e3a36b29e72a4d9b7b77b9bf721915a609aa
+  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 362e539c91751239c3a5d876919e50cb7fbc150a
   just update-transformer-fixtures
 
 # Install git pre-commit to format files

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -1039,6 +1039,8 @@ function deserializeBooleanLiteral(pos) {
     end,
     value,
     raw: (start === 0 && end === 0) ? null : value + '',
+    regex: null,
+    bigint: null,
   };
 }
 
@@ -1051,6 +1053,8 @@ function deserializeNullLiteral(pos) {
     end,
     value: null,
     raw: (start === 0 && end === 0) ? null : 'null',
+    regex: null,
+    bigint: null,
   };
 }
 
@@ -1061,6 +1065,8 @@ function deserializeNumericLiteral(pos) {
     end: deserializeU32(pos + 4),
     value: deserializeF64(pos + 8),
     raw: deserializeOptionStr(pos + 16),
+    regex: null,
+    bigint: null,
   };
 }
 
@@ -1075,6 +1081,8 @@ function deserializeStringLiteral(pos) {
     end: deserializeU32(pos + 4),
     value,
     raw: deserializeOptionStr(pos + 24),
+    regex: null,
+    bigint: null,
   };
 }
 
@@ -1087,6 +1095,7 @@ function deserializeBigIntLiteral(pos) {
     end: deserializeU32(pos + 4),
     value: BigInt(bigint),
     raw,
+    regex: null,
     bigint,
   };
 }
@@ -1104,6 +1113,7 @@ function deserializeRegExpLiteral(pos) {
     value,
     raw: deserializeOptionStr(pos + 40),
     regex,
+    bigint: null,
   };
 }
 

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -1192,6 +1192,8 @@ function deserializeBooleanLiteral(pos) {
     end,
     value,
     raw: (start === 0 && end === 0) ? null : value + '',
+    regex: null,
+    bigint: null,
   };
 }
 
@@ -1204,6 +1206,8 @@ function deserializeNullLiteral(pos) {
     end,
     value: null,
     raw: (start === 0 && end === 0) ? null : 'null',
+    regex: null,
+    bigint: null,
   };
 }
 
@@ -1214,6 +1218,8 @@ function deserializeNumericLiteral(pos) {
     end: deserializeU32(pos + 4),
     value: deserializeF64(pos + 8),
     raw: deserializeOptionStr(pos + 16),
+    regex: null,
+    bigint: null,
   };
 }
 
@@ -1228,6 +1234,8 @@ function deserializeStringLiteral(pos) {
     end: deserializeU32(pos + 4),
     value,
     raw: deserializeOptionStr(pos + 24),
+    regex: null,
+    bigint: null,
   };
 }
 
@@ -1240,6 +1248,7 @@ function deserializeBigIntLiteral(pos) {
     end: deserializeU32(pos + 4),
     value: BigInt(bigint),
     raw,
+    regex: null,
     bigint,
   };
 }
@@ -1257,6 +1266,7 @@ function deserializeRegExpLiteral(pos) {
     value,
     raw: deserializeOptionStr(pos + 40),
     regex,
+    bigint: null,
   };
 }
 

--- a/napi/parser/test/parse.test.ts
+++ b/napi/parser/test/parse.test.ts
@@ -157,6 +157,8 @@ describe('parse', () => {
         end: 6,
         value: Infinity,
         raw: '1e+350',
+        regex: null,
+        bigint: null,
       },
     });
   });
@@ -175,6 +177,7 @@ describe('parse', () => {
         end: 8,
         value: 123456n,
         raw: '123_456n',
+        regex: null,
         bigint: '123456',
       },
     });
@@ -195,6 +198,8 @@ describe('parse', () => {
           end: 15,
           value: '\ud800\udbff',
           raw: '"\\uD800\\uDBFF"',
+          regex: null,
+          bigint: null,
         },
       });
     });
@@ -213,6 +218,8 @@ describe('parse', () => {
           end: 12,
           value: '��',
           raw: '"�\\u{FFFD}"',
+          regex: null,
+          bigint: null,
         },
       });
     });
@@ -231,6 +238,8 @@ describe('parse', () => {
           end: 33,
           value: '��\ud800\udbff��',
           raw: '"�\\u{FFFD}\\uD800\\uDBFF�\\u{FFFD}"',
+          regex: null,
+          bigint: null,
         },
       });
     });
@@ -255,6 +264,7 @@ describe('parse', () => {
             pattern: 'abc',
             flags: 'gu',
           },
+          bigint: null,
         },
       });
     });
@@ -277,6 +287,7 @@ describe('parse', () => {
             pattern: '+',
             flags: '',
           },
+          bigint: null,
         },
       });
     });

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -823,30 +823,39 @@ export interface BooleanLiteral extends Span {
   type: 'Literal';
   value: boolean;
   raw: string | null;
+  regex: null;
+  bigint: null;
 }
 
 export interface NullLiteral extends Span {
   type: 'Literal';
   value: null;
   raw: 'null' | null;
+  regex: null;
+  bigint: null;
 }
 
 export interface NumericLiteral extends Span {
   type: 'Literal';
   value: number;
   raw: string | null;
+  regex: null;
+  bigint: null;
 }
 
 export interface StringLiteral extends Span {
   type: 'Literal';
   value: string;
   raw: string | null;
+  regex: null;
+  bigint: null;
 }
 
 export interface BigIntLiteral extends Span {
   type: 'Literal';
   value: bigint;
   raw: string | null;
+  regex: null;
   bigint: string;
 }
 
@@ -855,6 +864,7 @@ export interface RegExpLiteral extends Span {
   value: RegExp | null;
   raw: string | null;
   regex: { pattern: string; flags: string };
+  bigint: null;
 }
 
 export interface JSXElement extends Span {

--- a/tasks/coverage/snapshots/estree_acorn_jsx.snap
+++ b/tasks/coverage/snapshots/estree_acorn_jsx.snap
@@ -1,4 +1,4 @@
-commit: 4e88e3a3
+commit: 362e539c
 
 estree_acorn_jsx Summary:
 AST Parsed     : 39/39 (100.00%)


### PR DESCRIPTION
Add `regex` and `bigint` fields to all `Literal` nodes, so all `Literal`s have a consistent object shape.

Bump `acorn-test262`, which performs the some alterations to AST in the test fixtures in https://github.com/oxc-project/acorn-test262/pull/28.

This is a divergence from both Acorn and TS-ESLint, but in my opinion it's likely a good idea regardless.