### PR TITLE
fix(ast)!: fix field order for `JSXElement` and `JSXFragment`

### DIFF
--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -33,18 +33,19 @@ use super::{inherit_variants, js::*, literal::*, ts::*};
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[estree(field_order(span, opening_element, closing_element, children))]
 pub struct JSXElement<'a> {
     /// Node location in source code
     pub span: Span,
     /// Opening tag of the element.
     #[estree(via = JSXElementOpening)]
     pub opening_element: Box<'a, JSXOpeningElement<'a>>,
-    /// Closing tag of the element.
-    /// [`None`] for self-closing tags.
-    pub closing_element: Option<Box<'a, JSXClosingElement<'a>>>,
     /// Children of the element.
     /// This can be text, other elements, or expressions.
     pub children: Vec<'a, JSXChild<'a>>,
+    /// Closing tag of the element.
+    /// [`None`] for self-closing tags.
+    pub closing_element: Option<Box<'a, JSXClosingElement<'a>>>,
 }
 
 /// JSX Opening Element
@@ -113,15 +114,16 @@ pub struct JSXClosingElement<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[estree(field_order(span, opening_fragment, closing_fragment, children))]
 pub struct JSXFragment<'a> {
     /// Node location in source code
     pub span: Span,
     /// `<>`
     pub opening_fragment: JSXOpeningFragment,
-    /// `</>`
-    pub closing_fragment: JSXClosingFragment,
     /// Elements inside the fragment.
     pub children: Vec<'a, JSXChild<'a>>,
+    /// `</>`
+    pub closing_fragment: JSXClosingFragment,
 }
 
 /// JSX Opening Fragment (`<>`)

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -806,8 +806,8 @@ const _: () = {
     assert!(align_of::<JSXElement>() == 8);
     assert!(offset_of!(JSXElement, span) == 0);
     assert!(offset_of!(JSXElement, opening_element) == 8);
-    assert!(offset_of!(JSXElement, closing_element) == 16);
-    assert!(offset_of!(JSXElement, children) == 24);
+    assert!(offset_of!(JSXElement, children) == 16);
+    assert!(offset_of!(JSXElement, closing_element) == 48);
 
     assert!(size_of::<JSXOpeningElement>() == 64);
     assert!(align_of::<JSXOpeningElement>() == 8);
@@ -825,8 +825,8 @@ const _: () = {
     assert!(align_of::<JSXFragment>() == 8);
     assert!(offset_of!(JSXFragment, span) == 0);
     assert!(offset_of!(JSXFragment, opening_fragment) == 8);
-    assert!(offset_of!(JSXFragment, closing_fragment) == 16);
-    assert!(offset_of!(JSXFragment, children) == 24);
+    assert!(offset_of!(JSXFragment, children) == 16);
+    assert!(offset_of!(JSXFragment, closing_fragment) == 48);
 
     assert!(size_of::<JSXOpeningFragment>() == 8);
     assert!(align_of::<JSXOpeningFragment>() == 8);
@@ -2201,8 +2201,8 @@ const _: () = {
     assert!(align_of::<JSXElement>() == 4);
     assert!(offset_of!(JSXElement, span) == 0);
     assert!(offset_of!(JSXElement, opening_element) == 8);
-    assert!(offset_of!(JSXElement, closing_element) == 12);
-    assert!(offset_of!(JSXElement, children) == 16);
+    assert!(offset_of!(JSXElement, children) == 12);
+    assert!(offset_of!(JSXElement, closing_element) == 28);
 
     assert!(size_of::<JSXOpeningElement>() == 36);
     assert!(align_of::<JSXOpeningElement>() == 4);
@@ -2220,8 +2220,8 @@ const _: () = {
     assert!(align_of::<JSXFragment>() == 4);
     assert!(offset_of!(JSXFragment, span) == 0);
     assert!(offset_of!(JSXFragment, opening_fragment) == 8);
-    assert!(offset_of!(JSXFragment, closing_fragment) == 16);
-    assert!(offset_of!(JSXFragment, children) == 24);
+    assert!(offset_of!(JSXFragment, children) == 16);
+    assert!(offset_of!(JSXFragment, closing_fragment) == 32);
 
     assert!(size_of::<JSXOpeningFragment>() == 8);
     assert!(align_of::<JSXOpeningFragment>() == 4);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -1047,15 +1047,15 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     /// * `opening_element`: Opening tag of the element.
-    /// * `closing_element`: Closing tag of the element.
     /// * `children`: Children of the element.
+    /// * `closing_element`: Closing tag of the element.
     #[inline]
     pub fn expression_jsx_element<T1, T2>(
         self,
         span: Span,
         opening_element: T1,
-        closing_element: T2,
         children: Vec<'a, JSXChild<'a>>,
+        closing_element: T2,
     ) -> Expression<'a>
     where
         T1: IntoIn<'a, Box<'a, JSXOpeningElement<'a>>>,
@@ -1064,8 +1064,8 @@ impl<'a> AstBuilder<'a> {
         Expression::JSXElement(self.alloc_jsx_element(
             span,
             opening_element,
-            closing_element,
             children,
+            closing_element,
         ))
     }
 
@@ -1076,21 +1076,21 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     /// * `opening_fragment`: `<>`
-    /// * `closing_fragment`: `</>`
     /// * `children`: Elements inside the fragment.
+    /// * `closing_fragment`: `</>`
     #[inline]
     pub fn expression_jsx_fragment(
         self,
         span: Span,
         opening_fragment: JSXOpeningFragment,
-        closing_fragment: JSXClosingFragment,
         children: Vec<'a, JSXChild<'a>>,
+        closing_fragment: JSXClosingFragment,
     ) -> Expression<'a> {
         Expression::JSXFragment(self.alloc_jsx_fragment(
             span,
             opening_fragment,
-            closing_fragment,
             children,
+            closing_fragment,
         ))
     }
 
@@ -8598,15 +8598,15 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     /// * `opening_element`: Opening tag of the element.
-    /// * `closing_element`: Closing tag of the element.
     /// * `children`: Children of the element.
+    /// * `closing_element`: Closing tag of the element.
     #[inline]
     pub fn jsx_element<T1, T2>(
         self,
         span: Span,
         opening_element: T1,
-        closing_element: T2,
         children: Vec<'a, JSXChild<'a>>,
+        closing_element: T2,
     ) -> JSXElement<'a>
     where
         T1: IntoIn<'a, Box<'a, JSXOpeningElement<'a>>>,
@@ -8615,8 +8615,8 @@ impl<'a> AstBuilder<'a> {
         JSXElement {
             span,
             opening_element: opening_element.into_in(self.allocator),
-            closing_element: closing_element.into_in(self.allocator),
             children,
+            closing_element: closing_element.into_in(self.allocator),
         }
     }
 
@@ -8628,22 +8628,22 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     /// * `opening_element`: Opening tag of the element.
-    /// * `closing_element`: Closing tag of the element.
     /// * `children`: Children of the element.
+    /// * `closing_element`: Closing tag of the element.
     #[inline]
     pub fn alloc_jsx_element<T1, T2>(
         self,
         span: Span,
         opening_element: T1,
-        closing_element: T2,
         children: Vec<'a, JSXChild<'a>>,
+        closing_element: T2,
     ) -> Box<'a, JSXElement<'a>>
     where
         T1: IntoIn<'a, Box<'a, JSXOpeningElement<'a>>>,
         T2: IntoIn<'a, Option<Box<'a, JSXClosingElement<'a>>>>,
     {
         Box::new_in(
-            self.jsx_element(span, opening_element, closing_element, children),
+            self.jsx_element(span, opening_element, children, closing_element),
             self.allocator,
         )
     }
@@ -8746,17 +8746,17 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     /// * `opening_fragment`: `<>`
-    /// * `closing_fragment`: `</>`
     /// * `children`: Elements inside the fragment.
+    /// * `closing_fragment`: `</>`
     #[inline]
     pub fn jsx_fragment(
         self,
         span: Span,
         opening_fragment: JSXOpeningFragment,
-        closing_fragment: JSXClosingFragment,
         children: Vec<'a, JSXChild<'a>>,
+        closing_fragment: JSXClosingFragment,
     ) -> JSXFragment<'a> {
-        JSXFragment { span, opening_fragment, closing_fragment, children }
+        JSXFragment { span, opening_fragment, children, closing_fragment }
     }
 
     /// Build a [`JSXFragment`], and store it in the memory arena.
@@ -8767,18 +8767,18 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     /// * `opening_fragment`: `<>`
-    /// * `closing_fragment`: `</>`
     /// * `children`: Elements inside the fragment.
+    /// * `closing_fragment`: `</>`
     #[inline]
     pub fn alloc_jsx_fragment(
         self,
         span: Span,
         opening_fragment: JSXOpeningFragment,
-        closing_fragment: JSXClosingFragment,
         children: Vec<'a, JSXChild<'a>>,
+        closing_fragment: JSXClosingFragment,
     ) -> Box<'a, JSXFragment<'a>> {
         Box::new_in(
-            self.jsx_fragment(span, opening_fragment, closing_fragment, children),
+            self.jsx_fragment(span, opening_fragment, children, closing_fragment),
             self.allocator,
         )
     }
@@ -9324,15 +9324,15 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     /// * `opening_element`: Opening tag of the element.
-    /// * `closing_element`: Closing tag of the element.
     /// * `children`: Children of the element.
+    /// * `closing_element`: Closing tag of the element.
     #[inline]
     pub fn jsx_attribute_value_element<T1, T2>(
         self,
         span: Span,
         opening_element: T1,
-        closing_element: T2,
         children: Vec<'a, JSXChild<'a>>,
+        closing_element: T2,
     ) -> JSXAttributeValue<'a>
     where
         T1: IntoIn<'a, Box<'a, JSXOpeningElement<'a>>>,
@@ -9341,8 +9341,8 @@ impl<'a> AstBuilder<'a> {
         JSXAttributeValue::Element(self.alloc_jsx_element(
             span,
             opening_element,
-            closing_element,
             children,
+            closing_element,
         ))
     }
 
@@ -9353,21 +9353,21 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     /// * `opening_fragment`: `<>`
-    /// * `closing_fragment`: `</>`
     /// * `children`: Elements inside the fragment.
+    /// * `closing_fragment`: `</>`
     #[inline]
     pub fn jsx_attribute_value_fragment(
         self,
         span: Span,
         opening_fragment: JSXOpeningFragment,
-        closing_fragment: JSXClosingFragment,
         children: Vec<'a, JSXChild<'a>>,
+        closing_fragment: JSXClosingFragment,
     ) -> JSXAttributeValue<'a> {
         JSXAttributeValue::Fragment(self.alloc_jsx_fragment(
             span,
             opening_fragment,
-            closing_fragment,
             children,
+            closing_fragment,
         ))
     }
 
@@ -9426,21 +9426,21 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     /// * `opening_element`: Opening tag of the element.
-    /// * `closing_element`: Closing tag of the element.
     /// * `children`: Children of the element.
+    /// * `closing_element`: Closing tag of the element.
     #[inline]
     pub fn jsx_child_element<T1, T2>(
         self,
         span: Span,
         opening_element: T1,
-        closing_element: T2,
         children: Vec<'a, JSXChild<'a>>,
+        closing_element: T2,
     ) -> JSXChild<'a>
     where
         T1: IntoIn<'a, Box<'a, JSXOpeningElement<'a>>>,
         T2: IntoIn<'a, Option<Box<'a, JSXClosingElement<'a>>>>,
     {
-        JSXChild::Element(self.alloc_jsx_element(span, opening_element, closing_element, children))
+        JSXChild::Element(self.alloc_jsx_element(span, opening_element, children, closing_element))
     }
 
     /// Build a [`JSXChild::Fragment`].
@@ -9450,21 +9450,21 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     /// * `opening_fragment`: `<>`
-    /// * `closing_fragment`: `</>`
     /// * `children`: Elements inside the fragment.
+    /// * `closing_fragment`: `</>`
     #[inline]
     pub fn jsx_child_fragment(
         self,
         span: Span,
         opening_fragment: JSXOpeningFragment,
-        closing_fragment: JSXClosingFragment,
         children: Vec<'a, JSXChild<'a>>,
+        closing_fragment: JSXClosingFragment,
     ) -> JSXChild<'a> {
         JSXChild::Fragment(self.alloc_jsx_fragment(
             span,
             opening_fragment,
-            closing_fragment,
             children,
+            closing_fragment,
         ))
     }
 

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -4938,8 +4938,8 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXElement<'_> {
         JSXElement {
             span: CloneIn::clone_in(&self.span, allocator),
             opening_element: CloneIn::clone_in(&self.opening_element, allocator),
-            closing_element: CloneIn::clone_in(&self.closing_element, allocator),
             children: CloneIn::clone_in(&self.children, allocator),
+            closing_element: CloneIn::clone_in(&self.closing_element, allocator),
         }
     }
 
@@ -4947,8 +4947,8 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXElement<'_> {
         JSXElement {
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             opening_element: CloneIn::clone_in_with_semantic_ids(&self.opening_element, allocator),
-            closing_element: CloneIn::clone_in_with_semantic_ids(&self.closing_element, allocator),
             children: CloneIn::clone_in_with_semantic_ids(&self.children, allocator),
+            closing_element: CloneIn::clone_in_with_semantic_ids(&self.closing_element, allocator),
         }
     }
 }
@@ -5000,8 +5000,8 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXFragment<'_> {
         JSXFragment {
             span: CloneIn::clone_in(&self.span, allocator),
             opening_fragment: CloneIn::clone_in(&self.opening_fragment, allocator),
-            closing_fragment: CloneIn::clone_in(&self.closing_fragment, allocator),
             children: CloneIn::clone_in(&self.children, allocator),
+            closing_fragment: CloneIn::clone_in(&self.closing_fragment, allocator),
         }
     }
 
@@ -5012,11 +5012,11 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXFragment<'_> {
                 &self.opening_fragment,
                 allocator,
             ),
+            children: CloneIn::clone_in_with_semantic_ids(&self.children, allocator),
             closing_fragment: CloneIn::clone_in_with_semantic_ids(
                 &self.closing_fragment,
                 allocator,
             ),
-            children: CloneIn::clone_in_with_semantic_ids(&self.children, allocator),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -1505,8 +1505,8 @@ impl ContentEq for RegExpPattern<'_> {
 impl ContentEq for JSXElement<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.opening_element, &other.opening_element)
-            && ContentEq::content_eq(&self.closing_element, &other.closing_element)
             && ContentEq::content_eq(&self.children, &other.children)
+            && ContentEq::content_eq(&self.closing_element, &other.closing_element)
     }
 }
 
@@ -1527,8 +1527,8 @@ impl ContentEq for JSXClosingElement<'_> {
 impl ContentEq for JSXFragment<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.opening_fragment, &other.opening_fragment)
-            && ContentEq::content_eq(&self.closing_fragment, &other.closing_fragment)
             && ContentEq::content_eq(&self.children, &other.children)
+            && ContentEq::content_eq(&self.closing_fragment, &other.closing_fragment)
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_dummy.rs
+++ b/crates/oxc_ast/src/generated/derive_dummy.rs
@@ -1647,8 +1647,8 @@ impl<'a> Dummy<'a> for JSXElement<'a> {
         Self {
             span: Dummy::dummy(allocator),
             opening_element: Dummy::dummy(allocator),
-            closing_element: Dummy::dummy(allocator),
             children: Dummy::dummy(allocator),
+            closing_element: Dummy::dummy(allocator),
         }
     }
 }
@@ -1684,8 +1684,8 @@ impl<'a> Dummy<'a> for JSXFragment<'a> {
         Self {
             span: Dummy::dummy(allocator),
             opening_fragment: Dummy::dummy(allocator),
-            closing_fragment: Dummy::dummy(allocator),
             children: Dummy::dummy(allocator),
+            closing_fragment: Dummy::dummy(allocator),
         }
     }
 }

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -2926,10 +2926,10 @@ pub mod walk {
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
         visitor.visit_jsx_opening_element(&it.opening_element);
+        visitor.visit_jsx_children(&it.children);
         if let Some(closing_element) = &it.closing_element {
             visitor.visit_jsx_closing_element(closing_element);
         }
-        visitor.visit_jsx_children(&it.children);
         visitor.leave_node(kind);
     }
 
@@ -2961,8 +2961,8 @@ pub mod walk {
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
         visitor.visit_jsx_opening_fragment(&it.opening_fragment);
-        visitor.visit_jsx_closing_fragment(&it.closing_fragment);
         visitor.visit_jsx_children(&it.children);
+        visitor.visit_jsx_closing_fragment(&it.closing_fragment);
         visitor.leave_node(kind);
     }
 

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -3042,10 +3042,10 @@ pub mod walk_mut {
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
         visitor.visit_jsx_opening_element(&mut it.opening_element);
+        visitor.visit_jsx_children(&mut it.children);
         if let Some(closing_element) = &mut it.closing_element {
             visitor.visit_jsx_closing_element(closing_element);
         }
-        visitor.visit_jsx_children(&mut it.children);
         visitor.leave_node(kind);
     }
 
@@ -3083,8 +3083,8 @@ pub mod walk_mut {
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
         visitor.visit_jsx_opening_fragment(&mut it.opening_fragment);
-        visitor.visit_jsx_closing_fragment(&mut it.closing_fragment);
         visitor.visit_jsx_children(&mut it.children);
+        visitor.visit_jsx_closing_fragment(&mut it.closing_fragment);
         visitor.leave_node(kind);
     }
 

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -25,8 +25,8 @@ impl<'a> ParserImpl<'a> {
         self.ast.alloc_jsx_fragment(
             self.end_span(span),
             opening_fragment,
-            closing_fragment,
             children,
+            closing_fragment,
         )
     }
 
@@ -73,7 +73,7 @@ impl<'a> ParserImpl<'a> {
             }
             Some(closing_element)
         };
-        self.ast.alloc_jsx_element(self.end_span(span), opening_element, closing_element, children)
+        self.ast.alloc_jsx_element(self.end_span(span), opening_element, children, closing_element)
     }
 
     /// `JSXOpeningElement` :

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/children.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/children.snap
@@ -17,9 +17,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/children.ts
         "references": [
           {
             "flags": "ReferenceFlags(Read)",
-            "id": 2,
+            "id": 1,
             "name": "child",
-            "node_id": 14
+            "node_id": 11
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-attribute.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-attribute.snap
@@ -28,7 +28,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-
                 "flags": "ReferenceFlags(Read)",
                 "id": 3,
                 "name": "props",
-                "node_id": 57
+                "node_id": 54
               }
             ]
           }

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -192,15 +192,15 @@ pub(crate) enum AncestorType {
     V8IntrinsicExpressionName = 169,
     V8IntrinsicExpressionArguments = 170,
     JSXElementOpeningElement = 171,
-    JSXElementClosingElement = 172,
-    JSXElementChildren = 173,
+    JSXElementChildren = 172,
+    JSXElementClosingElement = 173,
     JSXOpeningElementName = 174,
     JSXOpeningElementAttributes = 175,
     JSXOpeningElementTypeArguments = 176,
     JSXClosingElementName = 177,
     JSXFragmentOpeningFragment = 178,
-    JSXFragmentClosingFragment = 179,
-    JSXFragmentChildren = 180,
+    JSXFragmentChildren = 179,
+    JSXFragmentClosingFragment = 180,
     JSXNamespacedNameNamespace = 181,
     JSXNamespacedNameName = 182,
     JSXMemberExpressionObject = 183,
@@ -643,9 +643,9 @@ pub enum Ancestor<'a, 't> {
         AncestorType::V8IntrinsicExpressionArguments as u16,
     JSXElementOpeningElement(JSXElementWithoutOpeningElement<'a, 't>) =
         AncestorType::JSXElementOpeningElement as u16,
+    JSXElementChildren(JSXElementWithoutChildren<'a, 't>) = AncestorType::JSXElementChildren as u16,
     JSXElementClosingElement(JSXElementWithoutClosingElement<'a, 't>) =
         AncestorType::JSXElementClosingElement as u16,
-    JSXElementChildren(JSXElementWithoutChildren<'a, 't>) = AncestorType::JSXElementChildren as u16,
     JSXOpeningElementName(JSXOpeningElementWithoutName<'a, 't>) =
         AncestorType::JSXOpeningElementName as u16,
     JSXOpeningElementAttributes(JSXOpeningElementWithoutAttributes<'a, 't>) =
@@ -656,10 +656,10 @@ pub enum Ancestor<'a, 't> {
         AncestorType::JSXClosingElementName as u16,
     JSXFragmentOpeningFragment(JSXFragmentWithoutOpeningFragment<'a, 't>) =
         AncestorType::JSXFragmentOpeningFragment as u16,
-    JSXFragmentClosingFragment(JSXFragmentWithoutClosingFragment<'a, 't>) =
-        AncestorType::JSXFragmentClosingFragment as u16,
     JSXFragmentChildren(JSXFragmentWithoutChildren<'a, 't>) =
         AncestorType::JSXFragmentChildren as u16,
+    JSXFragmentClosingFragment(JSXFragmentWithoutClosingFragment<'a, 't>) =
+        AncestorType::JSXFragmentClosingFragment as u16,
     JSXNamespacedNameNamespace(JSXNamespacedNameWithoutNamespace<'a, 't>) =
         AncestorType::JSXNamespacedNameNamespace as u16,
     JSXNamespacedNameName(JSXNamespacedNameWithoutName<'a, 't>) =
@@ -1430,8 +1430,8 @@ impl<'a, 't> Ancestor<'a, 't> {
         matches!(
             self,
             Self::JSXElementOpeningElement(_)
-                | Self::JSXElementClosingElement(_)
                 | Self::JSXElementChildren(_)
+                | Self::JSXElementClosingElement(_)
         )
     }
 
@@ -1455,8 +1455,8 @@ impl<'a, 't> Ancestor<'a, 't> {
         matches!(
             self,
             Self::JSXFragmentOpeningFragment(_)
-                | Self::JSXFragmentClosingFragment(_)
                 | Self::JSXFragmentChildren(_)
+                | Self::JSXFragmentClosingFragment(_)
         )
     }
 
@@ -2369,15 +2369,15 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::V8IntrinsicExpressionName(a) => a.address(),
             Self::V8IntrinsicExpressionArguments(a) => a.address(),
             Self::JSXElementOpeningElement(a) => a.address(),
-            Self::JSXElementClosingElement(a) => a.address(),
             Self::JSXElementChildren(a) => a.address(),
+            Self::JSXElementClosingElement(a) => a.address(),
             Self::JSXOpeningElementName(a) => a.address(),
             Self::JSXOpeningElementAttributes(a) => a.address(),
             Self::JSXOpeningElementTypeArguments(a) => a.address(),
             Self::JSXClosingElementName(a) => a.address(),
             Self::JSXFragmentOpeningFragment(a) => a.address(),
-            Self::JSXFragmentClosingFragment(a) => a.address(),
             Self::JSXFragmentChildren(a) => a.address(),
+            Self::JSXFragmentClosingFragment(a) => a.address(),
             Self::JSXNamespacedNameNamespace(a) => a.address(),
             Self::JSXNamespacedNameName(a) => a.address(),
             Self::JSXMemberExpressionObject(a) => a.address(),
@@ -10435,9 +10435,9 @@ impl<'a, 't> GetAddress for V8IntrinsicExpressionWithoutArguments<'a, 't> {
 pub(crate) const OFFSET_JSX_ELEMENT_SPAN: usize = offset_of!(JSXElement, span);
 pub(crate) const OFFSET_JSX_ELEMENT_OPENING_ELEMENT: usize =
     offset_of!(JSXElement, opening_element);
+pub(crate) const OFFSET_JSX_ELEMENT_CHILDREN: usize = offset_of!(JSXElement, children);
 pub(crate) const OFFSET_JSX_ELEMENT_CLOSING_ELEMENT: usize =
     offset_of!(JSXElement, closing_element);
-pub(crate) const OFFSET_JSX_ELEMENT_CHILDREN: usize = offset_of!(JSXElement, children);
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -10453,60 +10453,23 @@ impl<'a, 't> JSXElementWithoutOpeningElement<'a, 't> {
     }
 
     #[inline]
+    pub fn children(self) -> &'t Vec<'a, JSXChild<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_JSX_ELEMENT_CHILDREN)
+                as *const Vec<'a, JSXChild<'a>>)
+        }
+    }
+
+    #[inline]
     pub fn closing_element(self) -> &'t Option<Box<'a, JSXClosingElement<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_ELEMENT_CLOSING_ELEMENT)
                 as *const Option<Box<'a, JSXClosingElement<'a>>>)
         }
     }
-
-    #[inline]
-    pub fn children(self) -> &'t Vec<'a, JSXChild<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_JSX_ELEMENT_CHILDREN)
-                as *const Vec<'a, JSXChild<'a>>)
-        }
-    }
 }
 
 impl<'a, 't> GetAddress for JSXElementWithoutOpeningElement<'a, 't> {
-    #[inline]
-    fn address(&self) -> Address {
-        Address::from_ptr(self.0)
-    }
-}
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct JSXElementWithoutClosingElement<'a, 't>(
-    pub(crate) *const JSXElement<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> JSXElementWithoutClosingElement<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_JSX_ELEMENT_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn opening_element(self) -> &'t Box<'a, JSXOpeningElement<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_JSX_ELEMENT_OPENING_ELEMENT)
-                as *const Box<'a, JSXOpeningElement<'a>>)
-        }
-    }
-
-    #[inline]
-    pub fn children(self) -> &'t Vec<'a, JSXChild<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_JSX_ELEMENT_CHILDREN)
-                as *const Vec<'a, JSXChild<'a>>)
-        }
-    }
-}
-
-impl<'a, 't> GetAddress for JSXElementWithoutClosingElement<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)
@@ -10544,6 +10507,43 @@ impl<'a, 't> JSXElementWithoutChildren<'a, 't> {
 }
 
 impl<'a, 't> GetAddress for JSXElementWithoutChildren<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
+pub struct JSXElementWithoutClosingElement<'a, 't>(
+    pub(crate) *const JSXElement<'a>,
+    pub(crate) PhantomData<&'t ()>,
+);
+
+impl<'a, 't> JSXElementWithoutClosingElement<'a, 't> {
+    #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_JSX_ELEMENT_SPAN) as *const Span) }
+    }
+
+    #[inline]
+    pub fn opening_element(self) -> &'t Box<'a, JSXOpeningElement<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_JSX_ELEMENT_OPENING_ELEMENT)
+                as *const Box<'a, JSXOpeningElement<'a>>)
+        }
+    }
+
+    #[inline]
+    pub fn children(self) -> &'t Vec<'a, JSXChild<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_JSX_ELEMENT_CHILDREN)
+                as *const Vec<'a, JSXChild<'a>>)
+        }
+    }
+}
+
+impl<'a, 't> GetAddress for JSXElementWithoutClosingElement<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)
@@ -10695,9 +10695,9 @@ impl<'a, 't> GetAddress for JSXClosingElementWithoutName<'a, 't> {
 pub(crate) const OFFSET_JSX_FRAGMENT_SPAN: usize = offset_of!(JSXFragment, span);
 pub(crate) const OFFSET_JSX_FRAGMENT_OPENING_FRAGMENT: usize =
     offset_of!(JSXFragment, opening_fragment);
+pub(crate) const OFFSET_JSX_FRAGMENT_CHILDREN: usize = offset_of!(JSXFragment, children);
 pub(crate) const OFFSET_JSX_FRAGMENT_CLOSING_FRAGMENT: usize =
     offset_of!(JSXFragment, closing_fragment);
-pub(crate) const OFFSET_JSX_FRAGMENT_CHILDREN: usize = offset_of!(JSXFragment, children);
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -10713,60 +10713,23 @@ impl<'a, 't> JSXFragmentWithoutOpeningFragment<'a, 't> {
     }
 
     #[inline]
+    pub fn children(self) -> &'t Vec<'a, JSXChild<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_JSX_FRAGMENT_CHILDREN)
+                as *const Vec<'a, JSXChild<'a>>)
+        }
+    }
+
+    #[inline]
     pub fn closing_fragment(self) -> &'t JSXClosingFragment {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_FRAGMENT_CLOSING_FRAGMENT)
                 as *const JSXClosingFragment)
         }
     }
-
-    #[inline]
-    pub fn children(self) -> &'t Vec<'a, JSXChild<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_JSX_FRAGMENT_CHILDREN)
-                as *const Vec<'a, JSXChild<'a>>)
-        }
-    }
 }
 
 impl<'a, 't> GetAddress for JSXFragmentWithoutOpeningFragment<'a, 't> {
-    #[inline]
-    fn address(&self) -> Address {
-        Address::from_ptr(self.0)
-    }
-}
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct JSXFragmentWithoutClosingFragment<'a, 't>(
-    pub(crate) *const JSXFragment<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> JSXFragmentWithoutClosingFragment<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_JSX_FRAGMENT_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn opening_fragment(self) -> &'t JSXOpeningFragment {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_JSX_FRAGMENT_OPENING_FRAGMENT)
-                as *const JSXOpeningFragment)
-        }
-    }
-
-    #[inline]
-    pub fn children(self) -> &'t Vec<'a, JSXChild<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_JSX_FRAGMENT_CHILDREN)
-                as *const Vec<'a, JSXChild<'a>>)
-        }
-    }
-}
-
-impl<'a, 't> GetAddress for JSXFragmentWithoutClosingFragment<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)
@@ -10804,6 +10767,43 @@ impl<'a, 't> JSXFragmentWithoutChildren<'a, 't> {
 }
 
 impl<'a, 't> GetAddress for JSXFragmentWithoutChildren<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
+pub struct JSXFragmentWithoutClosingFragment<'a, 't>(
+    pub(crate) *const JSXFragment<'a>,
+    pub(crate) PhantomData<&'t ()>,
+);
+
+impl<'a, 't> JSXFragmentWithoutClosingFragment<'a, 't> {
+    #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_JSX_FRAGMENT_SPAN) as *const Span) }
+    }
+
+    #[inline]
+    pub fn opening_fragment(self) -> &'t JSXOpeningFragment {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_JSX_FRAGMENT_OPENING_FRAGMENT)
+                as *const JSXOpeningFragment)
+        }
+    }
+
+    #[inline]
+    pub fn children(self) -> &'t Vec<'a, JSXChild<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_JSX_FRAGMENT_CHILDREN)
+                as *const Vec<'a, JSXChild<'a>>)
+        }
+    }
+}
+
+impl<'a, 't> GetAddress for JSXFragmentWithoutClosingFragment<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -3194,17 +3194,17 @@ unsafe fn walk_jsx_element<'a, Tr: Traverse<'a>>(
             as *mut Box<JSXOpeningElement>)) as *mut _,
         ctx,
     );
-    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_ELEMENT_CLOSING_ELEMENT)
-        as *mut Option<Box<JSXClosingElement>>)
-    {
-        ctx.retag_stack(AncestorType::JSXElementClosingElement);
-        walk_jsx_closing_element(traverser, (&mut **field) as *mut _, ctx);
-    }
     ctx.retag_stack(AncestorType::JSXElementChildren);
     for item in
         &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_ELEMENT_CHILDREN) as *mut Vec<JSXChild>)
     {
         walk_jsx_child(traverser, item as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_ELEMENT_CLOSING_ELEMENT)
+        as *mut Option<Box<JSXClosingElement>>)
+    {
+        ctx.retag_stack(AncestorType::JSXElementClosingElement);
+        walk_jsx_closing_element(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_jsx_element(&mut *node, ctx);
@@ -3274,6 +3274,12 @@ unsafe fn walk_jsx_fragment<'a, Tr: Traverse<'a>>(
             as *mut JSXOpeningFragment,
         ctx,
     );
+    ctx.retag_stack(AncestorType::JSXFragmentChildren);
+    for item in
+        &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_FRAGMENT_CHILDREN) as *mut Vec<JSXChild>)
+    {
+        walk_jsx_child(traverser, item as *mut _, ctx);
+    }
     ctx.retag_stack(AncestorType::JSXFragmentClosingFragment);
     walk_jsx_closing_fragment(
         traverser,
@@ -3281,12 +3287,6 @@ unsafe fn walk_jsx_fragment<'a, Tr: Traverse<'a>>(
             as *mut JSXClosingFragment,
         ctx,
     );
-    ctx.retag_stack(AncestorType::JSXFragmentChildren);
-    for item in
-        &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_FRAGMENT_CHILDREN) as *mut Vec<JSXChild>)
-    {
-        walk_jsx_child(traverser, item as *mut _, ctx);
-    }
     ctx.pop_stack(pop_token);
     traverser.exit_jsx_fragment(&mut *node, ctx);
 }

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -1136,7 +1136,7 @@ function deserializeRegExpFlags(pos) {
 }
 
 function deserializeJSXElement(pos) {
-  const closingElement = deserializeOptionBoxJSXClosingElement(pos + 16);
+  const closingElement = deserializeOptionBoxJSXClosingElement(pos + 48);
   const openingElement = deserializeBoxJSXOpeningElement(pos + 8);
   if (closingElement === null) openingElement.selfClosing = true;
   return {
@@ -1145,7 +1145,7 @@ function deserializeJSXElement(pos) {
     end: deserializeU32(pos + 4),
     openingElement,
     closingElement,
-    children: deserializeVecJSXChild(pos + 24),
+    children: deserializeVecJSXChild(pos + 16),
   };
 }
 
@@ -1175,8 +1175,8 @@ function deserializeJSXFragment(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     openingFragment: deserializeJSXOpeningFragment(pos + 8),
-    closingFragment: deserializeJSXClosingFragment(pos + 16),
-    children: deserializeVecJSXChild(pos + 24),
+    closingFragment: deserializeJSXClosingFragment(pos + 48),
+    children: deserializeVecJSXChild(pos + 16),
   };
 }
 
@@ -4871,15 +4871,6 @@ function deserializeBoxJSXOpeningElement(pos) {
   return deserializeJSXOpeningElement(uint32[pos >> 2]);
 }
 
-function deserializeBoxJSXClosingElement(pos) {
-  return deserializeJSXClosingElement(uint32[pos >> 2]);
-}
-
-function deserializeOptionBoxJSXClosingElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxJSXClosingElement(pos);
-}
-
 function deserializeVecJSXChild(pos) {
   const arr = [],
     pos32 = pos >> 2,
@@ -4890,6 +4881,15 @@ function deserializeVecJSXChild(pos) {
     pos += 16;
   }
   return arr;
+}
+
+function deserializeBoxJSXClosingElement(pos) {
+  return deserializeJSXClosingElement(uint32[pos >> 2]);
+}
+
+function deserializeOptionBoxJSXClosingElement(pos) {
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
+  return deserializeBoxJSXClosingElement(pos);
 }
 
 function deserializeVecJSXAttributeItem(pos) {

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -1289,7 +1289,7 @@ function deserializeRegExpFlags(pos) {
 }
 
 function deserializeJSXElement(pos) {
-  const closingElement = deserializeOptionBoxJSXClosingElement(pos + 16);
+  const closingElement = deserializeOptionBoxJSXClosingElement(pos + 48);
   const openingElement = deserializeBoxJSXOpeningElement(pos + 8);
   if (closingElement === null) openingElement.selfClosing = true;
   return {
@@ -1298,7 +1298,7 @@ function deserializeJSXElement(pos) {
     end: deserializeU32(pos + 4),
     openingElement,
     closingElement,
-    children: deserializeVecJSXChild(pos + 24),
+    children: deserializeVecJSXChild(pos + 16),
   };
 }
 
@@ -1329,8 +1329,8 @@ function deserializeJSXFragment(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     openingFragment: deserializeJSXOpeningFragment(pos + 8),
-    closingFragment: deserializeJSXClosingFragment(pos + 16),
-    children: deserializeVecJSXChild(pos + 24),
+    closingFragment: deserializeJSXClosingFragment(pos + 48),
+    children: deserializeVecJSXChild(pos + 16),
   };
 }
 
@@ -5023,15 +5023,6 @@ function deserializeBoxJSXOpeningElement(pos) {
   return deserializeJSXOpeningElement(uint32[pos >> 2]);
 }
 
-function deserializeBoxJSXClosingElement(pos) {
-  return deserializeJSXClosingElement(uint32[pos >> 2]);
-}
-
-function deserializeOptionBoxJSXClosingElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxJSXClosingElement(pos);
-}
-
 function deserializeVecJSXChild(pos) {
   const arr = [],
     pos32 = pos >> 2,
@@ -5042,6 +5033,15 @@ function deserializeVecJSXChild(pos) {
     pos += 16;
   }
   return arr;
+}
+
+function deserializeBoxJSXClosingElement(pos) {
+  return deserializeJSXClosingElement(uint32[pos >> 2]);
+}
+
+function deserializeOptionBoxJSXClosingElement(pos) {
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
+  return deserializeBoxJSXClosingElement(pos);
 }
 
 function deserializeVecJSXAttributeItem(pos) {


### PR DESCRIPTION
Fix field order for `JSXElement` and `JSXFragment`. Move `children` field to before closing field, because `children` comes first in source.
