### PR TITLE
fix(ast)!: fix field order for `JSXOpeningElement`

### DIFF
--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -75,11 +75,11 @@ pub struct JSXOpeningElement<'a> {
     pub span: Span,
     /// The possibly-namespaced tag name, e.g. `Foo` in `<Foo />`.
     pub name: JSXElementName<'a>,
-    /// List of JSX attributes. In React-like applications, these become props.
-    pub attributes: Vec<'a, JSXAttributeItem<'a>>,
     /// Type parameters for generic JSX elements.
     #[ts]
     pub type_arguments: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
+    /// List of JSX attributes. In React-like applications, these become props.
+    pub attributes: Vec<'a, JSXAttributeItem<'a>>,
 }
 
 /// JSX Closing Element

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -813,8 +813,8 @@ const _: () = {
     assert!(align_of::<JSXOpeningElement>() == 8);
     assert!(offset_of!(JSXOpeningElement, span) == 0);
     assert!(offset_of!(JSXOpeningElement, name) == 8);
-    assert!(offset_of!(JSXOpeningElement, attributes) == 24);
-    assert!(offset_of!(JSXOpeningElement, type_arguments) == 56);
+    assert!(offset_of!(JSXOpeningElement, type_arguments) == 24);
+    assert!(offset_of!(JSXOpeningElement, attributes) == 32);
 
     assert!(size_of::<JSXClosingElement>() == 24);
     assert!(align_of::<JSXClosingElement>() == 8);
@@ -2208,8 +2208,8 @@ const _: () = {
     assert!(align_of::<JSXOpeningElement>() == 4);
     assert!(offset_of!(JSXOpeningElement, span) == 0);
     assert!(offset_of!(JSXOpeningElement, name) == 8);
-    assert!(offset_of!(JSXOpeningElement, attributes) == 16);
-    assert!(offset_of!(JSXOpeningElement, type_arguments) == 32);
+    assert!(offset_of!(JSXOpeningElement, type_arguments) == 16);
+    assert!(offset_of!(JSXOpeningElement, attributes) == 20);
 
     assert!(size_of::<JSXClosingElement>() == 16);
     assert!(align_of::<JSXClosingElement>() == 4);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -8656,15 +8656,15 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     /// * `name`: The possibly-namespaced tag name, e.g. `Foo` in `<Foo />`.
-    /// * `attributes`: List of JSX attributes. In React-like applications, these become props.
     /// * `type_arguments`: Type parameters for generic JSX elements.
+    /// * `attributes`: List of JSX attributes. In React-like applications, these become props.
     #[inline]
     pub fn jsx_opening_element<T1>(
         self,
         span: Span,
         name: JSXElementName<'a>,
-        attributes: Vec<'a, JSXAttributeItem<'a>>,
         type_arguments: T1,
+        attributes: Vec<'a, JSXAttributeItem<'a>>,
     ) -> JSXOpeningElement<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
@@ -8672,8 +8672,8 @@ impl<'a> AstBuilder<'a> {
         JSXOpeningElement {
             span,
             name,
-            attributes,
             type_arguments: type_arguments.into_in(self.allocator),
+            attributes,
         }
     }
 
@@ -8685,21 +8685,21 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     /// * `name`: The possibly-namespaced tag name, e.g. `Foo` in `<Foo />`.
-    /// * `attributes`: List of JSX attributes. In React-like applications, these become props.
     /// * `type_arguments`: Type parameters for generic JSX elements.
+    /// * `attributes`: List of JSX attributes. In React-like applications, these become props.
     #[inline]
     pub fn alloc_jsx_opening_element<T1>(
         self,
         span: Span,
         name: JSXElementName<'a>,
-        attributes: Vec<'a, JSXAttributeItem<'a>>,
         type_arguments: T1,
+        attributes: Vec<'a, JSXAttributeItem<'a>>,
     ) -> Box<'a, JSXOpeningElement<'a>>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         Box::new_in(
-            self.jsx_opening_element(span, name, attributes, type_arguments),
+            self.jsx_opening_element(span, name, type_arguments, attributes),
             self.allocator,
         )
     }

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -4960,8 +4960,8 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXOpeningElement<'_> {
         JSXOpeningElement {
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
-            attributes: CloneIn::clone_in(&self.attributes, allocator),
             type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
+            attributes: CloneIn::clone_in(&self.attributes, allocator),
         }
     }
 
@@ -4969,8 +4969,8 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXOpeningElement<'_> {
         JSXOpeningElement {
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
-            attributes: CloneIn::clone_in_with_semantic_ids(&self.attributes, allocator),
             type_arguments: CloneIn::clone_in_with_semantic_ids(&self.type_arguments, allocator),
+            attributes: CloneIn::clone_in_with_semantic_ids(&self.attributes, allocator),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -1513,8 +1513,8 @@ impl ContentEq for JSXElement<'_> {
 impl ContentEq for JSXOpeningElement<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.name, &other.name)
-            && ContentEq::content_eq(&self.attributes, &other.attributes)
             && ContentEq::content_eq(&self.type_arguments, &other.type_arguments)
+            && ContentEq::content_eq(&self.attributes, &other.attributes)
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_dummy.rs
+++ b/crates/oxc_ast/src/generated/derive_dummy.rs
@@ -1661,8 +1661,8 @@ impl<'a> Dummy<'a> for JSXOpeningElement<'a> {
         Self {
             span: Dummy::dummy(allocator),
             name: Dummy::dummy(allocator),
-            attributes: Dummy::dummy(allocator),
             type_arguments: Dummy::dummy(allocator),
+            attributes: Dummy::dummy(allocator),
         }
     }
 }

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -2939,10 +2939,10 @@ pub mod walk {
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
         visitor.visit_jsx_element_name(&it.name);
-        visitor.visit_jsx_attribute_items(&it.attributes);
         if let Some(type_arguments) = &it.type_arguments {
             visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
+        visitor.visit_jsx_attribute_items(&it.attributes);
         visitor.leave_node(kind);
     }
 

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -3058,10 +3058,10 @@ pub mod walk_mut {
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
         visitor.visit_jsx_element_name(&mut it.name);
-        visitor.visit_jsx_attribute_items(&mut it.attributes);
         if let Some(type_arguments) = &mut it.type_arguments {
             visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
+        visitor.visit_jsx_attribute_items(&mut it.attributes);
         visitor.leave_node(kind);
     }
 

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -89,7 +89,7 @@ impl<'a> ParserImpl<'a> {
         self.expect(Kind::LAngle);
         let name = self.parse_jsx_element_name();
         // <Component<TsType> for tsx
-        let type_parameters = if self.is_ts { self.try_parse_type_arguments() } else { None };
+        let type_arguments = if self.is_ts { self.try_parse_type_arguments() } else { None };
         let attributes = self.parse_jsx_attributes();
         let self_closing = self.eat(Kind::Slash);
         if !self_closing || in_jsx_child {
@@ -100,8 +100,8 @@ impl<'a> ParserImpl<'a> {
         let elem = self.ast.alloc_jsx_opening_element(
             self.end_span(span),
             name,
+            type_arguments,
             attributes,
-            type_parameters,
         );
         (elem, self_closing)
     }

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -195,8 +195,8 @@ pub(crate) enum AncestorType {
     JSXElementChildren = 172,
     JSXElementClosingElement = 173,
     JSXOpeningElementName = 174,
-    JSXOpeningElementAttributes = 175,
-    JSXOpeningElementTypeArguments = 176,
+    JSXOpeningElementTypeArguments = 175,
+    JSXOpeningElementAttributes = 176,
     JSXClosingElementName = 177,
     JSXFragmentOpeningFragment = 178,
     JSXFragmentChildren = 179,
@@ -648,10 +648,10 @@ pub enum Ancestor<'a, 't> {
         AncestorType::JSXElementClosingElement as u16,
     JSXOpeningElementName(JSXOpeningElementWithoutName<'a, 't>) =
         AncestorType::JSXOpeningElementName as u16,
-    JSXOpeningElementAttributes(JSXOpeningElementWithoutAttributes<'a, 't>) =
-        AncestorType::JSXOpeningElementAttributes as u16,
     JSXOpeningElementTypeArguments(JSXOpeningElementWithoutTypeArguments<'a, 't>) =
         AncestorType::JSXOpeningElementTypeArguments as u16,
+    JSXOpeningElementAttributes(JSXOpeningElementWithoutAttributes<'a, 't>) =
+        AncestorType::JSXOpeningElementAttributes as u16,
     JSXClosingElementName(JSXClosingElementWithoutName<'a, 't>) =
         AncestorType::JSXClosingElementName as u16,
     JSXFragmentOpeningFragment(JSXFragmentWithoutOpeningFragment<'a, 't>) =
@@ -1440,8 +1440,8 @@ impl<'a, 't> Ancestor<'a, 't> {
         matches!(
             self,
             Self::JSXOpeningElementName(_)
-                | Self::JSXOpeningElementAttributes(_)
                 | Self::JSXOpeningElementTypeArguments(_)
+                | Self::JSXOpeningElementAttributes(_)
         )
     }
 
@@ -2372,8 +2372,8 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::JSXElementChildren(a) => a.address(),
             Self::JSXElementClosingElement(a) => a.address(),
             Self::JSXOpeningElementName(a) => a.address(),
-            Self::JSXOpeningElementAttributes(a) => a.address(),
             Self::JSXOpeningElementTypeArguments(a) => a.address(),
+            Self::JSXOpeningElementAttributes(a) => a.address(),
             Self::JSXClosingElementName(a) => a.address(),
             Self::JSXFragmentOpeningFragment(a) => a.address(),
             Self::JSXFragmentChildren(a) => a.address(),
@@ -10552,10 +10552,10 @@ impl<'a, 't> GetAddress for JSXElementWithoutClosingElement<'a, 't> {
 
 pub(crate) const OFFSET_JSX_OPENING_ELEMENT_SPAN: usize = offset_of!(JSXOpeningElement, span);
 pub(crate) const OFFSET_JSX_OPENING_ELEMENT_NAME: usize = offset_of!(JSXOpeningElement, name);
-pub(crate) const OFFSET_JSX_OPENING_ELEMENT_ATTRIBUTES: usize =
-    offset_of!(JSXOpeningElement, attributes);
 pub(crate) const OFFSET_JSX_OPENING_ELEMENT_TYPE_ARGUMENTS: usize =
     offset_of!(JSXOpeningElement, type_arguments);
+pub(crate) const OFFSET_JSX_OPENING_ELEMENT_ATTRIBUTES: usize =
+    offset_of!(JSXOpeningElement, attributes);
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -10571,60 +10571,23 @@ impl<'a, 't> JSXOpeningElementWithoutName<'a, 't> {
     }
 
     #[inline]
+    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_TYPE_ARGUMENTS)
+                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+        }
+    }
+
+    #[inline]
     pub fn attributes(self) -> &'t Vec<'a, JSXAttributeItem<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_ATTRIBUTES)
                 as *const Vec<'a, JSXAttributeItem<'a>>)
         }
     }
-
-    #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
-        }
-    }
 }
 
 impl<'a, 't> GetAddress for JSXOpeningElementWithoutName<'a, 't> {
-    #[inline]
-    fn address(&self) -> Address {
-        Address::from_ptr(self.0)
-    }
-}
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct JSXOpeningElementWithoutAttributes<'a, 't>(
-    pub(crate) *const JSXOpeningElement<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> JSXOpeningElementWithoutAttributes<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn name(self) -> &'t JSXElementName<'a> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_NAME)
-                as *const JSXElementName<'a>)
-        }
-    }
-
-    #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
-        }
-    }
-}
-
-impl<'a, 't> GetAddress for JSXOpeningElementWithoutAttributes<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)
@@ -10662,6 +10625,43 @@ impl<'a, 't> JSXOpeningElementWithoutTypeArguments<'a, 't> {
 }
 
 impl<'a, 't> GetAddress for JSXOpeningElementWithoutTypeArguments<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
+pub struct JSXOpeningElementWithoutAttributes<'a, 't>(
+    pub(crate) *const JSXOpeningElement<'a>,
+    pub(crate) PhantomData<&'t ()>,
+);
+
+impl<'a, 't> JSXOpeningElementWithoutAttributes<'a, 't> {
+    #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_SPAN) as *const Span) }
+    }
+
+    #[inline]
+    pub fn name(self) -> &'t JSXElementName<'a> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_NAME)
+                as *const JSXElementName<'a>)
+        }
+    }
+
+    #[inline]
+    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_TYPE_ARGUMENTS)
+                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+        }
+    }
+}
+
+impl<'a, 't> GetAddress for JSXOpeningElementWithoutAttributes<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)

--- a/crates/oxc_traverse/src/generated/scopes_collector.rs
+++ b/crates/oxc_traverse/src/generated/scopes_collector.rs
@@ -1265,10 +1265,10 @@ impl<'a> Visit<'a> for ChildScopeCollector {
 
     #[inline]
     fn visit_jsx_opening_element(&mut self, it: &JSXOpeningElement<'a>) {
-        self.visit_jsx_attribute_items(&it.attributes);
         if let Some(type_arguments) = &it.type_arguments {
             self.visit_ts_type_parameter_instantiation(type_arguments);
         }
+        self.visit_jsx_attribute_items(&it.attributes);
     }
 
     #[inline(always)]

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -3224,18 +3224,18 @@ unsafe fn walk_jsx_opening_element<'a, Tr: Traverse<'a>>(
         (node as *mut u8).add(ancestor::OFFSET_JSX_OPENING_ELEMENT_NAME) as *mut JSXElementName,
         ctx,
     );
-    ctx.retag_stack(AncestorType::JSXOpeningElementAttributes);
-    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_OPENING_ELEMENT_ATTRIBUTES)
-        as *mut Vec<JSXAttributeItem>)
-    {
-        walk_jsx_attribute_item(traverser, item as *mut _, ctx);
-    }
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_JSX_OPENING_ELEMENT_TYPE_ARGUMENTS)
         as *mut Option<Box<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::JSXOpeningElementTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::JSXOpeningElementAttributes);
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_OPENING_ELEMENT_ATTRIBUTES)
+        as *mut Vec<JSXAttributeItem>)
+    {
+        walk_jsx_attribute_item(traverser, item as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_jsx_opening_element(&mut *node, ctx);

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -1154,7 +1154,7 @@ function deserializeJSXOpeningElement(pos) {
     type: 'JSXOpeningElement',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    attributes: deserializeVecJSXAttributeItem(pos + 24),
+    attributes: deserializeVecJSXAttributeItem(pos + 32),
     name: deserializeJSXElementName(pos + 8),
     selfClosing: false,
   };

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -1307,10 +1307,10 @@ function deserializeJSXOpeningElement(pos) {
     type: 'JSXOpeningElement',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    attributes: deserializeVecJSXAttributeItem(pos + 24),
+    attributes: deserializeVecJSXAttributeItem(pos + 32),
     name: deserializeJSXElementName(pos + 8),
     selfClosing: false,
-    typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 56),
+    typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
   };
 }
 

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -19030,7 +19030,7 @@ Scope children mismatch:
 after transform: ScopeId(4): [ScopeId(6), ScopeId(9)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
 Symbol reference IDs mismatch for "TestObject":
-after transform: SymbolId(4): [ReferenceId(11), ReferenceId(16)]
+after transform: SymbolId(4): [ReferenceId(11), ReferenceId(15)]
 rebuilt        : SymbolId(2): [ReferenceId(5)]
 Unresolved references mismatch:
 after transform: ["Function", "React"]


### PR DESCRIPTION
Fix field order for `JSXOpeningElement`. Move `type_arguments` to before `attributes`, because they come first in source:

```tsx
<Component<T> foo={123} />
```
