### PR TITLE
refactor(allocator/vec2): move `len` field from `Vec` to `RawVec`

### DIFF
--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -25,8 +25,7 @@ use crate::{
 use super::define_generator;
 
 // Offsets of `Vec`'s fields.
-// These are based on observation, and are not stable.
-// They will be fully reliable once we implement our own `Vec` type and make it `#[repr(C)]`.
+// `Vec` is `#[repr(transparent)]` and `RawVec` is `#[repr(C)]`, so these offsets are fixed.
 const VEC_PTR_FIELD_OFFSET: usize = 0;
 const VEC_LEN_FIELD_OFFSET: usize = 24;
 


### PR DESCRIPTION
Prepare for #9706.

Move `len` field from `Vec` to `RawVec` to adapt upcoming change that reduces `len` and `cap` fields from `usize` to `u32` so that the `Vec` size can reduce from `32` to `24` without padding.

Marked `Vec` as `#[repr(transparent)]` and `RawVec` as `#[repr(C)]` to easier to solve raw transfer test failures because the fields are no longer reordered, we can statically determine the offsets, as mentioned in that comment.
