### PR TITLE
feat(allocator/vec2): change `len` and `cap` fields from `usize` to `u32`

### DIFF
--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -78,7 +78,7 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// minimum *capacity* specified, the vector will have a zero *length*.
     ///
     /// For `Vec<T>` where `T` is a zero-sized type, there will be no allocation
-    /// and the capacity will always be `usize::MAX`.
+    /// and the capacity will always be `u32::MAX`.
     ///
     /// # Panics
     ///

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -10,16 +10,16 @@ use crate::ast::*;
 #[cfg(target_pointer_width = "64")]
 const _: () = {
     // Padding: 9 bytes
-    assert!(size_of::<Program>() == 160);
+    assert!(size_of::<Program>() == 136);
     assert!(align_of::<Program>() == 8);
     assert!(offset_of!(Program, span) == 0);
     assert!(offset_of!(Program, source_type) == 8);
     assert!(offset_of!(Program, source_text) == 16);
     assert!(offset_of!(Program, comments) == 32);
-    assert!(offset_of!(Program, hashbang) == 64);
-    assert!(offset_of!(Program, directives) == 88);
-    assert!(offset_of!(Program, body) == 120);
-    assert!(offset_of!(Program, scope_id) == 152);
+    assert!(offset_of!(Program, hashbang) == 56);
+    assert!(offset_of!(Program, directives) == 80);
+    assert!(offset_of!(Program, body) == 104);
+    assert!(offset_of!(Program, scope_id) == 128);
 
     assert!(size_of::<Expression>() == 16);
     assert!(align_of::<Expression>() == 8);
@@ -56,7 +56,7 @@ const _: () = {
     assert!(offset_of!(ThisExpression, span) == 0);
 
     // Padding: 0 bytes
-    assert!(size_of::<ArrayExpression>() == 40);
+    assert!(size_of::<ArrayExpression>() == 32);
     assert!(align_of::<ArrayExpression>() == 8);
     assert!(offset_of!(ArrayExpression, span) == 0);
     assert!(offset_of!(ArrayExpression, elements) == 8);
@@ -70,7 +70,7 @@ const _: () = {
     assert!(offset_of!(Elision, span) == 0);
 
     // Padding: 0 bytes
-    assert!(size_of::<ObjectExpression>() == 40);
+    assert!(size_of::<ObjectExpression>() == 32);
     assert!(align_of::<ObjectExpression>() == 8);
     assert!(offset_of!(ObjectExpression, span) == 0);
     assert!(offset_of!(ObjectExpression, properties) == 8);
@@ -96,14 +96,14 @@ const _: () = {
     assert!(align_of::<PropertyKind>() == 1);
 
     // Padding: 0 bytes
-    assert!(size_of::<TemplateLiteral>() == 72);
+    assert!(size_of::<TemplateLiteral>() == 56);
     assert!(align_of::<TemplateLiteral>() == 8);
     assert!(offset_of!(TemplateLiteral, span) == 0);
     assert!(offset_of!(TemplateLiteral, quasis) == 8);
-    assert!(offset_of!(TemplateLiteral, expressions) == 40);
+    assert!(offset_of!(TemplateLiteral, expressions) == 32);
 
     // Padding: 0 bytes
-    assert!(size_of::<TaggedTemplateExpression>() == 104);
+    assert!(size_of::<TaggedTemplateExpression>() == 88);
     assert!(align_of::<TaggedTemplateExpression>() == 8);
     assert!(offset_of!(TaggedTemplateExpression, span) == 0);
     assert!(offset_of!(TaggedTemplateExpression, tag) == 8);
@@ -152,23 +152,23 @@ const _: () = {
     assert!(offset_of!(PrivateFieldExpression, optional) == 48);
 
     // Padding: 6 bytes
-    assert!(size_of::<CallExpression>() == 72);
+    assert!(size_of::<CallExpression>() == 64);
     assert!(align_of::<CallExpression>() == 8);
     assert!(offset_of!(CallExpression, span) == 0);
     assert!(offset_of!(CallExpression, callee) == 8);
     assert!(offset_of!(CallExpression, type_arguments) == 24);
     assert!(offset_of!(CallExpression, arguments) == 32);
-    assert!(offset_of!(CallExpression, optional) == 64);
-    assert!(offset_of!(CallExpression, pure) == 65);
+    assert!(offset_of!(CallExpression, optional) == 56);
+    assert!(offset_of!(CallExpression, pure) == 57);
 
     // Padding: 7 bytes
-    assert!(size_of::<NewExpression>() == 72);
+    assert!(size_of::<NewExpression>() == 64);
     assert!(align_of::<NewExpression>() == 8);
     assert!(offset_of!(NewExpression, span) == 0);
     assert!(offset_of!(NewExpression, callee) == 8);
     assert!(offset_of!(NewExpression, type_arguments) == 24);
     assert!(offset_of!(NewExpression, arguments) == 32);
-    assert!(offset_of!(NewExpression, pure) == 64);
+    assert!(offset_of!(NewExpression, pure) == 56);
 
     // Padding: 0 bytes
     assert!(size_of::<MetaProperty>() == 56);
@@ -250,18 +250,18 @@ const _: () = {
     assert!(align_of::<AssignmentTargetPattern>() == 8);
 
     // Padding: 0 bytes
-    assert!(size_of::<ArrayAssignmentTarget>() == 64);
+    assert!(size_of::<ArrayAssignmentTarget>() == 56);
     assert!(align_of::<ArrayAssignmentTarget>() == 8);
     assert!(offset_of!(ArrayAssignmentTarget, span) == 0);
     assert!(offset_of!(ArrayAssignmentTarget, elements) == 8);
-    assert!(offset_of!(ArrayAssignmentTarget, rest) == 40);
+    assert!(offset_of!(ArrayAssignmentTarget, rest) == 32);
 
     // Padding: 0 bytes
-    assert!(size_of::<ObjectAssignmentTarget>() == 64);
+    assert!(size_of::<ObjectAssignmentTarget>() == 56);
     assert!(align_of::<ObjectAssignmentTarget>() == 8);
     assert!(offset_of!(ObjectAssignmentTarget, span) == 0);
     assert!(offset_of!(ObjectAssignmentTarget, properties) == 8);
-    assert!(offset_of!(ObjectAssignmentTarget, rest) == 40);
+    assert!(offset_of!(ObjectAssignmentTarget, rest) == 32);
 
     // Padding: 0 bytes
     assert!(size_of::<AssignmentTargetRest>() == 24);
@@ -298,7 +298,7 @@ const _: () = {
     assert!(offset_of!(AssignmentTargetPropertyProperty, computed) == 40);
 
     // Padding: 0 bytes
-    assert!(size_of::<SequenceExpression>() == 40);
+    assert!(size_of::<SequenceExpression>() == 32);
     assert!(align_of::<SequenceExpression>() == 8);
     assert!(offset_of!(SequenceExpression, span) == 0);
     assert!(offset_of!(SequenceExpression, expressions) == 8);
@@ -346,22 +346,22 @@ const _: () = {
     assert!(offset_of!(Hashbang, value) == 8);
 
     // Padding: 4 bytes
-    assert!(size_of::<BlockStatement>() == 48);
+    assert!(size_of::<BlockStatement>() == 40);
     assert!(align_of::<BlockStatement>() == 8);
     assert!(offset_of!(BlockStatement, span) == 0);
     assert!(offset_of!(BlockStatement, body) == 8);
-    assert!(offset_of!(BlockStatement, scope_id) == 40);
+    assert!(offset_of!(BlockStatement, scope_id) == 32);
 
     assert!(size_of::<Declaration>() == 16);
     assert!(align_of::<Declaration>() == 8);
 
     // Padding: 14 bytes
-    assert!(size_of::<VariableDeclaration>() == 56);
+    assert!(size_of::<VariableDeclaration>() == 48);
     assert!(align_of::<VariableDeclaration>() == 8);
     assert!(offset_of!(VariableDeclaration, span) == 0);
     assert!(offset_of!(VariableDeclaration, kind) == 8);
     assert!(offset_of!(VariableDeclaration, declarations) == 16);
-    assert!(offset_of!(VariableDeclaration, declare) == 48);
+    assert!(offset_of!(VariableDeclaration, declare) == 40);
 
     assert!(size_of::<VariableDeclarationKind>() == 1);
     assert!(align_of::<VariableDeclarationKind>() == 1);
@@ -469,15 +469,15 @@ const _: () = {
     assert!(offset_of!(WithStatement, body) == 24);
 
     // Padding: 4 bytes
-    assert!(size_of::<SwitchStatement>() == 64);
+    assert!(size_of::<SwitchStatement>() == 56);
     assert!(align_of::<SwitchStatement>() == 8);
     assert!(offset_of!(SwitchStatement, span) == 0);
     assert!(offset_of!(SwitchStatement, discriminant) == 8);
     assert!(offset_of!(SwitchStatement, cases) == 24);
-    assert!(offset_of!(SwitchStatement, scope_id) == 56);
+    assert!(offset_of!(SwitchStatement, scope_id) == 48);
 
     // Padding: 0 bytes
-    assert!(size_of::<SwitchCase>() == 56);
+    assert!(size_of::<SwitchCase>() == 48);
     assert!(align_of::<SwitchCase>() == 8);
     assert!(offset_of!(SwitchCase, span) == 0);
     assert!(offset_of!(SwitchCase, test) == 8);
@@ -541,11 +541,11 @@ const _: () = {
     assert!(offset_of!(AssignmentPattern, right) == 40);
 
     // Padding: 0 bytes
-    assert!(size_of::<ObjectPattern>() == 48);
+    assert!(size_of::<ObjectPattern>() == 40);
     assert!(align_of::<ObjectPattern>() == 8);
     assert!(offset_of!(ObjectPattern, span) == 0);
     assert!(offset_of!(ObjectPattern, properties) == 8);
-    assert!(offset_of!(ObjectPattern, rest) == 40);
+    assert!(offset_of!(ObjectPattern, rest) == 32);
 
     // Padding: 6 bytes
     assert!(size_of::<BindingProperty>() == 64);
@@ -557,11 +557,11 @@ const _: () = {
     assert!(offset_of!(BindingProperty, computed) == 57);
 
     // Padding: 0 bytes
-    assert!(size_of::<ArrayPattern>() == 48);
+    assert!(size_of::<ArrayPattern>() == 40);
     assert!(align_of::<ArrayPattern>() == 8);
     assert!(offset_of!(ArrayPattern, span) == 0);
     assert!(offset_of!(ArrayPattern, elements) == 8);
-    assert!(offset_of!(ArrayPattern, rest) == 40);
+    assert!(offset_of!(ArrayPattern, rest) == 32);
 
     // Padding: 0 bytes
     assert!(size_of::<BindingRestElement>() == 40);
@@ -590,32 +590,32 @@ const _: () = {
     assert!(align_of::<FunctionType>() == 1);
 
     // Padding: 7 bytes
-    assert!(size_of::<FormalParameters>() == 56);
+    assert!(size_of::<FormalParameters>() == 48);
     assert!(align_of::<FormalParameters>() == 8);
     assert!(offset_of!(FormalParameters, span) == 0);
     assert!(offset_of!(FormalParameters, kind) == 8);
     assert!(offset_of!(FormalParameters, items) == 16);
-    assert!(offset_of!(FormalParameters, rest) == 48);
+    assert!(offset_of!(FormalParameters, rest) == 40);
 
     // Padding: 5 bytes
-    assert!(size_of::<FormalParameter>() == 80);
+    assert!(size_of::<FormalParameter>() == 72);
     assert!(align_of::<FormalParameter>() == 8);
     assert!(offset_of!(FormalParameter, span) == 0);
     assert!(offset_of!(FormalParameter, decorators) == 8);
-    assert!(offset_of!(FormalParameter, pattern) == 40);
-    assert!(offset_of!(FormalParameter, accessibility) == 72);
-    assert!(offset_of!(FormalParameter, readonly) == 73);
-    assert!(offset_of!(FormalParameter, r#override) == 74);
+    assert!(offset_of!(FormalParameter, pattern) == 32);
+    assert!(offset_of!(FormalParameter, accessibility) == 64);
+    assert!(offset_of!(FormalParameter, readonly) == 65);
+    assert!(offset_of!(FormalParameter, r#override) == 66);
 
     assert!(size_of::<FormalParameterKind>() == 1);
     assert!(align_of::<FormalParameterKind>() == 1);
 
     // Padding: 0 bytes
-    assert!(size_of::<FunctionBody>() == 72);
+    assert!(size_of::<FunctionBody>() == 56);
     assert!(align_of::<FunctionBody>() == 8);
     assert!(offset_of!(FunctionBody, span) == 0);
     assert!(offset_of!(FunctionBody, directives) == 8);
-    assert!(offset_of!(FunctionBody, statements) == 40);
+    assert!(offset_of!(FunctionBody, statements) == 32);
 
     // Padding: 9 bytes
     assert!(size_of::<ArrowFunctionExpression>() == 56);
@@ -638,26 +638,26 @@ const _: () = {
     assert!(offset_of!(YieldExpression, argument) == 16);
 
     // Padding: 9 bytes
-    assert!(size_of::<Class>() == 160);
+    assert!(size_of::<Class>() == 144);
     assert!(align_of::<Class>() == 8);
     assert!(offset_of!(Class, span) == 0);
     assert!(offset_of!(Class, r#type) == 8);
     assert!(offset_of!(Class, decorators) == 16);
-    assert!(offset_of!(Class, id) == 48);
-    assert!(offset_of!(Class, type_parameters) == 80);
-    assert!(offset_of!(Class, super_class) == 88);
-    assert!(offset_of!(Class, super_type_arguments) == 104);
-    assert!(offset_of!(Class, implements) == 112);
-    assert!(offset_of!(Class, body) == 144);
-    assert!(offset_of!(Class, r#abstract) == 152);
-    assert!(offset_of!(Class, declare) == 153);
-    assert!(offset_of!(Class, scope_id) == 156);
+    assert!(offset_of!(Class, id) == 40);
+    assert!(offset_of!(Class, type_parameters) == 72);
+    assert!(offset_of!(Class, super_class) == 80);
+    assert!(offset_of!(Class, super_type_arguments) == 96);
+    assert!(offset_of!(Class, implements) == 104);
+    assert!(offset_of!(Class, body) == 128);
+    assert!(offset_of!(Class, r#abstract) == 136);
+    assert!(offset_of!(Class, declare) == 137);
+    assert!(offset_of!(Class, scope_id) == 140);
 
     assert!(size_of::<ClassType>() == 1);
     assert!(align_of::<ClassType>() == 1);
 
     // Padding: 0 bytes
-    assert!(size_of::<ClassBody>() == 40);
+    assert!(size_of::<ClassBody>() == 32);
     assert!(align_of::<ClassBody>() == 8);
     assert!(offset_of!(ClassBody, span) == 0);
     assert!(offset_of!(ClassBody, body) == 8);
@@ -666,40 +666,40 @@ const _: () = {
     assert!(align_of::<ClassElement>() == 8);
 
     // Padding: 9 bytes
-    assert!(size_of::<MethodDefinition>() == 80);
+    assert!(size_of::<MethodDefinition>() == 72);
     assert!(align_of::<MethodDefinition>() == 8);
     assert!(offset_of!(MethodDefinition, span) == 0);
     assert!(offset_of!(MethodDefinition, r#type) == 8);
     assert!(offset_of!(MethodDefinition, decorators) == 16);
-    assert!(offset_of!(MethodDefinition, key) == 48);
-    assert!(offset_of!(MethodDefinition, value) == 64);
-    assert!(offset_of!(MethodDefinition, kind) == 72);
-    assert!(offset_of!(MethodDefinition, computed) == 73);
-    assert!(offset_of!(MethodDefinition, r#static) == 74);
-    assert!(offset_of!(MethodDefinition, r#override) == 75);
-    assert!(offset_of!(MethodDefinition, optional) == 76);
-    assert!(offset_of!(MethodDefinition, accessibility) == 77);
+    assert!(offset_of!(MethodDefinition, key) == 40);
+    assert!(offset_of!(MethodDefinition, value) == 56);
+    assert!(offset_of!(MethodDefinition, kind) == 64);
+    assert!(offset_of!(MethodDefinition, computed) == 65);
+    assert!(offset_of!(MethodDefinition, r#static) == 66);
+    assert!(offset_of!(MethodDefinition, r#override) == 67);
+    assert!(offset_of!(MethodDefinition, optional) == 68);
+    assert!(offset_of!(MethodDefinition, accessibility) == 69);
 
     assert!(size_of::<MethodDefinitionType>() == 1);
     assert!(align_of::<MethodDefinitionType>() == 1);
 
     // Padding: 7 bytes
-    assert!(size_of::<PropertyDefinition>() == 96);
+    assert!(size_of::<PropertyDefinition>() == 88);
     assert!(align_of::<PropertyDefinition>() == 8);
     assert!(offset_of!(PropertyDefinition, span) == 0);
     assert!(offset_of!(PropertyDefinition, r#type) == 8);
     assert!(offset_of!(PropertyDefinition, decorators) == 16);
-    assert!(offset_of!(PropertyDefinition, key) == 48);
-    assert!(offset_of!(PropertyDefinition, type_annotation) == 64);
-    assert!(offset_of!(PropertyDefinition, value) == 72);
-    assert!(offset_of!(PropertyDefinition, computed) == 88);
-    assert!(offset_of!(PropertyDefinition, r#static) == 89);
-    assert!(offset_of!(PropertyDefinition, declare) == 90);
-    assert!(offset_of!(PropertyDefinition, r#override) == 91);
-    assert!(offset_of!(PropertyDefinition, optional) == 92);
-    assert!(offset_of!(PropertyDefinition, definite) == 93);
-    assert!(offset_of!(PropertyDefinition, readonly) == 94);
-    assert!(offset_of!(PropertyDefinition, accessibility) == 95);
+    assert!(offset_of!(PropertyDefinition, key) == 40);
+    assert!(offset_of!(PropertyDefinition, type_annotation) == 56);
+    assert!(offset_of!(PropertyDefinition, value) == 64);
+    assert!(offset_of!(PropertyDefinition, computed) == 80);
+    assert!(offset_of!(PropertyDefinition, r#static) == 81);
+    assert!(offset_of!(PropertyDefinition, declare) == 82);
+    assert!(offset_of!(PropertyDefinition, r#override) == 83);
+    assert!(offset_of!(PropertyDefinition, optional) == 84);
+    assert!(offset_of!(PropertyDefinition, definite) == 85);
+    assert!(offset_of!(PropertyDefinition, readonly) == 86);
+    assert!(offset_of!(PropertyDefinition, accessibility) == 87);
 
     assert!(size_of::<PropertyDefinitionType>() == 1);
     assert!(align_of::<PropertyDefinitionType>() == 1);
@@ -714,11 +714,11 @@ const _: () = {
     assert!(offset_of!(PrivateIdentifier, name) == 8);
 
     // Padding: 4 bytes
-    assert!(size_of::<StaticBlock>() == 48);
+    assert!(size_of::<StaticBlock>() == 40);
     assert!(align_of::<StaticBlock>() == 8);
     assert!(offset_of!(StaticBlock, span) == 0);
     assert!(offset_of!(StaticBlock, body) == 8);
-    assert!(offset_of!(StaticBlock, scope_id) == 40);
+    assert!(offset_of!(StaticBlock, scope_id) == 32);
 
     assert!(size_of::<ModuleDeclaration>() == 16);
     assert!(align_of::<ModuleDeclaration>() == 8);
@@ -727,19 +727,19 @@ const _: () = {
     assert!(align_of::<AccessorPropertyType>() == 1);
 
     // Padding: 10 bytes
-    assert!(size_of::<AccessorProperty>() == 96);
+    assert!(size_of::<AccessorProperty>() == 88);
     assert!(align_of::<AccessorProperty>() == 8);
     assert!(offset_of!(AccessorProperty, span) == 0);
     assert!(offset_of!(AccessorProperty, r#type) == 8);
     assert!(offset_of!(AccessorProperty, decorators) == 16);
-    assert!(offset_of!(AccessorProperty, key) == 48);
-    assert!(offset_of!(AccessorProperty, type_annotation) == 64);
-    assert!(offset_of!(AccessorProperty, value) == 72);
-    assert!(offset_of!(AccessorProperty, computed) == 88);
-    assert!(offset_of!(AccessorProperty, r#static) == 89);
-    assert!(offset_of!(AccessorProperty, r#override) == 90);
-    assert!(offset_of!(AccessorProperty, definite) == 91);
-    assert!(offset_of!(AccessorProperty, accessibility) == 92);
+    assert!(offset_of!(AccessorProperty, key) == 40);
+    assert!(offset_of!(AccessorProperty, type_annotation) == 56);
+    assert!(offset_of!(AccessorProperty, value) == 64);
+    assert!(offset_of!(AccessorProperty, computed) == 80);
+    assert!(offset_of!(AccessorProperty, r#static) == 81);
+    assert!(offset_of!(AccessorProperty, r#override) == 82);
+    assert!(offset_of!(AccessorProperty, definite) == 83);
+    assert!(offset_of!(AccessorProperty, accessibility) == 84);
 
     // Padding: 7 bytes
     assert!(size_of::<ImportExpression>() == 48);
@@ -750,14 +750,14 @@ const _: () = {
     assert!(offset_of!(ImportExpression, phase) == 40);
 
     // Padding: 14 bytes
-    assert!(size_of::<ImportDeclaration>() == 112);
+    assert!(size_of::<ImportDeclaration>() == 104);
     assert!(align_of::<ImportDeclaration>() == 8);
     assert!(offset_of!(ImportDeclaration, span) == 0);
     assert!(offset_of!(ImportDeclaration, specifiers) == 8);
-    assert!(offset_of!(ImportDeclaration, source) == 40);
-    assert!(offset_of!(ImportDeclaration, phase) == 88);
-    assert!(offset_of!(ImportDeclaration, with_clause) == 96);
-    assert!(offset_of!(ImportDeclaration, import_kind) == 104);
+    assert!(offset_of!(ImportDeclaration, source) == 32);
+    assert!(offset_of!(ImportDeclaration, phase) == 80);
+    assert!(offset_of!(ImportDeclaration, with_clause) == 88);
+    assert!(offset_of!(ImportDeclaration, import_kind) == 96);
 
     assert!(size_of::<ImportPhase>() == 1);
     assert!(align_of::<ImportPhase>() == 1);
@@ -786,7 +786,7 @@ const _: () = {
     assert!(offset_of!(ImportNamespaceSpecifier, local) == 8);
 
     // Padding: 0 bytes
-    assert!(size_of::<WithClause>() == 64);
+    assert!(size_of::<WithClause>() == 56);
     assert!(align_of::<WithClause>() == 8);
     assert!(offset_of!(WithClause, span) == 0);
     assert!(offset_of!(WithClause, attributes_keyword) == 8);
@@ -803,14 +803,14 @@ const _: () = {
     assert!(align_of::<ImportAttributeKey>() == 8);
 
     // Padding: 7 bytes
-    assert!(size_of::<ExportNamedDeclaration>() == 120);
+    assert!(size_of::<ExportNamedDeclaration>() == 112);
     assert!(align_of::<ExportNamedDeclaration>() == 8);
     assert!(offset_of!(ExportNamedDeclaration, span) == 0);
     assert!(offset_of!(ExportNamedDeclaration, declaration) == 8);
     assert!(offset_of!(ExportNamedDeclaration, specifiers) == 24);
-    assert!(offset_of!(ExportNamedDeclaration, source) == 56);
-    assert!(offset_of!(ExportNamedDeclaration, export_kind) == 104);
-    assert!(offset_of!(ExportNamedDeclaration, with_clause) == 112);
+    assert!(offset_of!(ExportNamedDeclaration, source) == 48);
+    assert!(offset_of!(ExportNamedDeclaration, export_kind) == 96);
+    assert!(offset_of!(ExportNamedDeclaration, with_clause) == 104);
 
     // Padding: 0 bytes
     assert!(size_of::<ExportDefaultDeclaration>() == 80);
@@ -843,7 +843,7 @@ const _: () = {
     assert!(align_of::<ModuleExportName>() == 8);
 
     // Padding: 0 bytes
-    assert!(size_of::<V8IntrinsicExpression>() == 64);
+    assert!(size_of::<V8IntrinsicExpression>() == 56);
     assert!(align_of::<V8IntrinsicExpression>() == 8);
     assert!(offset_of!(V8IntrinsicExpression, span) == 0);
     assert!(offset_of!(V8IntrinsicExpression, name) == 8);
@@ -907,15 +907,15 @@ const _: () = {
     assert!(align_of::<RegExpFlags>() == 1);
 
     // Padding: 0 bytes
-    assert!(size_of::<JSXElement>() == 56);
+    assert!(size_of::<JSXElement>() == 48);
     assert!(align_of::<JSXElement>() == 8);
     assert!(offset_of!(JSXElement, span) == 0);
     assert!(offset_of!(JSXElement, opening_element) == 8);
     assert!(offset_of!(JSXElement, children) == 16);
-    assert!(offset_of!(JSXElement, closing_element) == 48);
+    assert!(offset_of!(JSXElement, closing_element) == 40);
 
     // Padding: 0 bytes
-    assert!(size_of::<JSXOpeningElement>() == 64);
+    assert!(size_of::<JSXOpeningElement>() == 56);
     assert!(align_of::<JSXOpeningElement>() == 8);
     assert!(offset_of!(JSXOpeningElement, span) == 0);
     assert!(offset_of!(JSXOpeningElement, name) == 8);
@@ -929,12 +929,12 @@ const _: () = {
     assert!(offset_of!(JSXClosingElement, name) == 8);
 
     // Padding: 0 bytes
-    assert!(size_of::<JSXFragment>() == 56);
+    assert!(size_of::<JSXFragment>() == 48);
     assert!(align_of::<JSXFragment>() == 8);
     assert!(offset_of!(JSXFragment, span) == 0);
     assert!(offset_of!(JSXFragment, opening_fragment) == 8);
     assert!(offset_of!(JSXFragment, children) == 16);
-    assert!(offset_of!(JSXFragment, closing_fragment) == 48);
+    assert!(offset_of!(JSXFragment, closing_fragment) == 40);
 
     // Padding: 0 bytes
     assert!(size_of::<JSXOpeningFragment>() == 8);
@@ -1032,17 +1032,17 @@ const _: () = {
     assert!(offset_of!(TSThisParameter, type_annotation) == 16);
 
     // Padding: 2 bytes
-    assert!(size_of::<TSEnumDeclaration>() == 88);
+    assert!(size_of::<TSEnumDeclaration>() == 80);
     assert!(align_of::<TSEnumDeclaration>() == 8);
     assert!(offset_of!(TSEnumDeclaration, span) == 0);
     assert!(offset_of!(TSEnumDeclaration, id) == 8);
     assert!(offset_of!(TSEnumDeclaration, body) == 40);
-    assert!(offset_of!(TSEnumDeclaration, r#const) == 80);
-    assert!(offset_of!(TSEnumDeclaration, declare) == 81);
-    assert!(offset_of!(TSEnumDeclaration, scope_id) == 84);
+    assert!(offset_of!(TSEnumDeclaration, r#const) == 72);
+    assert!(offset_of!(TSEnumDeclaration, declare) == 73);
+    assert!(offset_of!(TSEnumDeclaration, scope_id) == 76);
 
     // Padding: 0 bytes
-    assert!(size_of::<TSEnumBody>() == 40);
+    assert!(size_of::<TSEnumBody>() == 32);
     assert!(align_of::<TSEnumBody>() == 8);
     assert!(offset_of!(TSEnumBody, span) == 0);
     assert!(offset_of!(TSEnumBody, members) == 8);
@@ -1086,13 +1086,13 @@ const _: () = {
     assert!(offset_of!(TSConditionalType, scope_id) == 72);
 
     // Padding: 0 bytes
-    assert!(size_of::<TSUnionType>() == 40);
+    assert!(size_of::<TSUnionType>() == 32);
     assert!(align_of::<TSUnionType>() == 8);
     assert!(offset_of!(TSUnionType, span) == 0);
     assert!(offset_of!(TSUnionType, types) == 8);
 
     // Padding: 0 bytes
-    assert!(size_of::<TSIntersectionType>() == 40);
+    assert!(size_of::<TSIntersectionType>() == 32);
     assert!(align_of::<TSIntersectionType>() == 8);
     assert!(offset_of!(TSIntersectionType, span) == 0);
     assert!(offset_of!(TSIntersectionType, types) == 8);
@@ -1127,7 +1127,7 @@ const _: () = {
     assert!(offset_of!(TSIndexedAccessType, index_type) == 24);
 
     // Padding: 0 bytes
-    assert!(size_of::<TSTupleType>() == 40);
+    assert!(size_of::<TSTupleType>() == 32);
     assert!(align_of::<TSTupleType>() == 8);
     assert!(offset_of!(TSTupleType, span) == 0);
     assert!(offset_of!(TSTupleType, element_types) == 8);
@@ -1243,7 +1243,7 @@ const _: () = {
     assert!(offset_of!(TSQualifiedName, right) == 24);
 
     // Padding: 0 bytes
-    assert!(size_of::<TSTypeParameterInstantiation>() == 40);
+    assert!(size_of::<TSTypeParameterInstantiation>() == 32);
     assert!(align_of::<TSTypeParameterInstantiation>() == 8);
     assert!(offset_of!(TSTypeParameterInstantiation, span) == 0);
     assert!(offset_of!(TSTypeParameterInstantiation, params) == 8);
@@ -1260,7 +1260,7 @@ const _: () = {
     assert!(offset_of!(TSTypeParameter, r#const) == 74);
 
     // Padding: 0 bytes
-    assert!(size_of::<TSTypeParameterDeclaration>() == 40);
+    assert!(size_of::<TSTypeParameterDeclaration>() == 32);
     assert!(align_of::<TSTypeParameterDeclaration>() == 8);
     assert!(offset_of!(TSTypeParameterDeclaration, span) == 0);
     assert!(offset_of!(TSTypeParameterDeclaration, params) == 8);
@@ -1286,18 +1286,18 @@ const _: () = {
     assert!(offset_of!(TSClassImplements, type_arguments) == 24);
 
     // Padding: 3 bytes
-    assert!(size_of::<TSInterfaceDeclaration>() == 96);
+    assert!(size_of::<TSInterfaceDeclaration>() == 88);
     assert!(align_of::<TSInterfaceDeclaration>() == 8);
     assert!(offset_of!(TSInterfaceDeclaration, span) == 0);
     assert!(offset_of!(TSInterfaceDeclaration, id) == 8);
     assert!(offset_of!(TSInterfaceDeclaration, type_parameters) == 40);
     assert!(offset_of!(TSInterfaceDeclaration, extends) == 48);
-    assert!(offset_of!(TSInterfaceDeclaration, body) == 80);
-    assert!(offset_of!(TSInterfaceDeclaration, declare) == 88);
-    assert!(offset_of!(TSInterfaceDeclaration, scope_id) == 92);
+    assert!(offset_of!(TSInterfaceDeclaration, body) == 72);
+    assert!(offset_of!(TSInterfaceDeclaration, declare) == 80);
+    assert!(offset_of!(TSInterfaceDeclaration, scope_id) == 84);
 
     // Padding: 0 bytes
-    assert!(size_of::<TSInterfaceBody>() == 40);
+    assert!(size_of::<TSInterfaceBody>() == 32);
     assert!(align_of::<TSInterfaceBody>() == 8);
     assert!(offset_of!(TSInterfaceBody, span) == 0);
     assert!(offset_of!(TSInterfaceBody, body) == 8);
@@ -1316,13 +1316,13 @@ const _: () = {
     assert!(align_of::<TSSignature>() == 8);
 
     // Padding: 6 bytes
-    assert!(size_of::<TSIndexSignature>() == 56);
+    assert!(size_of::<TSIndexSignature>() == 48);
     assert!(align_of::<TSIndexSignature>() == 8);
     assert!(offset_of!(TSIndexSignature, span) == 0);
     assert!(offset_of!(TSIndexSignature, parameters) == 8);
-    assert!(offset_of!(TSIndexSignature, type_annotation) == 40);
-    assert!(offset_of!(TSIndexSignature, readonly) == 48);
-    assert!(offset_of!(TSIndexSignature, r#static) == 49);
+    assert!(offset_of!(TSIndexSignature, type_annotation) == 32);
+    assert!(offset_of!(TSIndexSignature, readonly) == 40);
+    assert!(offset_of!(TSIndexSignature, r#static) == 41);
 
     // Padding: 0 bytes
     assert!(size_of::<TSCallSignatureDeclaration>() == 40);
@@ -1404,14 +1404,14 @@ const _: () = {
     assert!(align_of::<TSModuleDeclarationBody>() == 8);
 
     // Padding: 0 bytes
-    assert!(size_of::<TSModuleBlock>() == 72);
+    assert!(size_of::<TSModuleBlock>() == 56);
     assert!(align_of::<TSModuleBlock>() == 8);
     assert!(offset_of!(TSModuleBlock, span) == 0);
     assert!(offset_of!(TSModuleBlock, directives) == 8);
-    assert!(offset_of!(TSModuleBlock, body) == 40);
+    assert!(offset_of!(TSModuleBlock, body) == 32);
 
     // Padding: 0 bytes
-    assert!(size_of::<TSTypeLiteral>() == 40);
+    assert!(size_of::<TSTypeLiteral>() == 32);
     assert!(align_of::<TSTypeLiteral>() == 8);
     assert!(offset_of!(TSTypeLiteral, span) == 0);
     assert!(offset_of!(TSTypeLiteral, members) == 8);
@@ -1475,11 +1475,11 @@ const _: () = {
     assert!(align_of::<TSMappedTypeModifierOperator>() == 1);
 
     // Padding: 0 bytes
-    assert!(size_of::<TSTemplateLiteralType>() == 72);
+    assert!(size_of::<TSTemplateLiteralType>() == 56);
     assert!(align_of::<TSTemplateLiteralType>() == 8);
     assert!(offset_of!(TSTemplateLiteralType, span) == 0);
     assert!(offset_of!(TSTemplateLiteralType, quasis) == 8);
-    assert!(offset_of!(TSTemplateLiteralType, types) == 40);
+    assert!(offset_of!(TSTemplateLiteralType, types) == 32);
 
     // Padding: 0 bytes
     assert!(size_of::<TSAsExpression>() == 40);

--- a/crates/oxc_ast/src/generated/derive_dummy.rs
+++ b/crates/oxc_ast/src/generated/derive_dummy.rs
@@ -451,7 +451,7 @@ impl<'a> Dummy<'a> for SimpleAssignmentTarget<'a> {
 impl<'a> Dummy<'a> for AssignmentTargetPattern<'a> {
     /// Create a dummy [`AssignmentTargetPattern`].
     ///
-    /// Has cost of making 1 allocation (64 bytes).
+    /// Has cost of making 1 allocation (56 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self::ArrayAssignmentTarget(Dummy::dummy(allocator))
     }
@@ -651,7 +651,7 @@ impl<'a> Dummy<'a> for BlockStatement<'a> {
 impl<'a> Dummy<'a> for Declaration<'a> {
     /// Create a dummy [`Declaration`].
     ///
-    /// Has cost of making 1 allocation (56 bytes).
+    /// Has cost of making 1 allocation (48 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self::VariableDeclaration(Dummy::dummy(allocator))
     }
@@ -911,7 +911,7 @@ impl<'a> Dummy<'a> for ThrowStatement<'a> {
 impl<'a> Dummy<'a> for TryStatement<'a> {
     /// Create a dummy [`TryStatement`].
     ///
-    /// Has cost of making 1 allocation (48 bytes).
+    /// Has cost of making 1 allocation (40 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
             span: Dummy::dummy(allocator),
@@ -925,7 +925,7 @@ impl<'a> Dummy<'a> for TryStatement<'a> {
 impl<'a> Dummy<'a> for CatchClause<'a> {
     /// Create a dummy [`CatchClause`].
     ///
-    /// Has cost of making 1 allocation (48 bytes).
+    /// Has cost of making 1 allocation (40 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
             span: Dummy::dummy(allocator),
@@ -1042,7 +1042,7 @@ impl<'a> Dummy<'a> for BindingRestElement<'a> {
 impl<'a> Dummy<'a> for Function<'a> {
     /// Create a dummy [`Function`].
     ///
-    /// Has cost of making 1 allocation (56 bytes).
+    /// Has cost of making 1 allocation (48 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
             span: Dummy::dummy(allocator),
@@ -1128,7 +1128,7 @@ impl<'a> Dummy<'a> for FunctionBody<'a> {
 impl<'a> Dummy<'a> for ArrowFunctionExpression<'a> {
     /// Create a dummy [`ArrowFunctionExpression`].
     ///
-    /// Has cost of making 2 allocations (128 bytes).
+    /// Has cost of making 2 allocations (104 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
             span: Dummy::dummy(allocator),
@@ -1160,7 +1160,7 @@ impl<'a> Dummy<'a> for YieldExpression<'a> {
 impl<'a> Dummy<'a> for Class<'a> {
     /// Create a dummy [`Class`].
     ///
-    /// Has cost of making 1 allocation (40 bytes).
+    /// Has cost of making 1 allocation (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
             span: Dummy::dummy(allocator),
@@ -1201,7 +1201,7 @@ impl<'a> Dummy<'a> for ClassBody<'a> {
 impl<'a> Dummy<'a> for ClassElement<'a> {
     /// Create a dummy [`ClassElement`].
     ///
-    /// Has cost of making 1 allocation (48 bytes).
+    /// Has cost of making 1 allocation (40 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self::StaticBlock(Dummy::dummy(allocator))
     }
@@ -1210,7 +1210,7 @@ impl<'a> Dummy<'a> for ClassElement<'a> {
 impl<'a> Dummy<'a> for MethodDefinition<'a> {
     /// Create a dummy [`MethodDefinition`].
     ///
-    /// Has cost of making 3 allocations (168 bytes).
+    /// Has cost of making 3 allocations (160 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
             span: Dummy::dummy(allocator),
@@ -1642,7 +1642,7 @@ impl<'a> Dummy<'a> for RegExpPattern<'a> {
 impl<'a> Dummy<'a> for JSXElement<'a> {
     /// Create a dummy [`JSXElement`].
     ///
-    /// Has cost of making 2 allocations (72 bytes).
+    /// Has cost of making 2 allocations (64 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
             span: Dummy::dummy(allocator),
@@ -2340,7 +2340,7 @@ impl<'a> Dummy<'a> for TSClassImplements<'a> {
 impl<'a> Dummy<'a> for TSInterfaceDeclaration<'a> {
     /// Create a dummy [`TSInterfaceDeclaration`].
     ///
-    /// Has cost of making 1 allocation (40 bytes).
+    /// Has cost of making 1 allocation (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
             span: Dummy::dummy(allocator),
@@ -2406,7 +2406,7 @@ impl<'a> Dummy<'a> for TSIndexSignature<'a> {
 impl<'a> Dummy<'a> for TSCallSignatureDeclaration<'a> {
     /// Create a dummy [`TSCallSignatureDeclaration`].
     ///
-    /// Has cost of making 1 allocation (56 bytes).
+    /// Has cost of making 1 allocation (48 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
             span: Dummy::dummy(allocator),
@@ -2431,7 +2431,7 @@ impl<'a> Dummy<'a> for TSMethodSignatureKind {
 impl<'a> Dummy<'a> for TSMethodSignature<'a> {
     /// Create a dummy [`TSMethodSignature`].
     ///
-    /// Has cost of making 2 allocations (64 bytes).
+    /// Has cost of making 2 allocations (56 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
             span: Dummy::dummy(allocator),
@@ -2451,7 +2451,7 @@ impl<'a> Dummy<'a> for TSMethodSignature<'a> {
 impl<'a> Dummy<'a> for TSConstructSignatureDeclaration<'a> {
     /// Create a dummy [`TSConstructSignatureDeclaration`].
     ///
-    /// Has cost of making 1 allocation (56 bytes).
+    /// Has cost of making 1 allocation (48 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
             span: Dummy::dummy(allocator),
@@ -2550,7 +2550,7 @@ impl<'a> Dummy<'a> for TSModuleDeclarationName<'a> {
 impl<'a> Dummy<'a> for TSModuleDeclarationBody<'a> {
     /// Create a dummy [`TSModuleDeclarationBody`].
     ///
-    /// Has cost of making 1 allocation (72 bytes).
+    /// Has cost of making 1 allocation (56 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self::TSModuleBlock(Dummy::dummy(allocator))
     }
@@ -2627,7 +2627,7 @@ impl<'a> Dummy<'a> for TSImportType<'a> {
 impl<'a> Dummy<'a> for TSFunctionType<'a> {
     /// Create a dummy [`TSFunctionType`].
     ///
-    /// Has cost of making 3 allocations (88 bytes).
+    /// Has cost of making 3 allocations (80 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
             span: Dummy::dummy(allocator),
@@ -2643,7 +2643,7 @@ impl<'a> Dummy<'a> for TSFunctionType<'a> {
 impl<'a> Dummy<'a> for TSConstructorType<'a> {
     /// Create a dummy [`TSConstructorType`].
     ///
-    /// Has cost of making 3 allocations (88 bytes).
+    /// Has cost of making 3 allocations (80 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
             span: Dummy::dummy(allocator),
@@ -2805,7 +2805,7 @@ impl<'a> Dummy<'a> for TSNamespaceExportDeclaration<'a> {
 impl<'a> Dummy<'a> for TSInstantiationExpression<'a> {
     /// Create a dummy [`TSInstantiationExpression`].
     ///
-    /// Has cost of making 2 allocations (48 bytes).
+    /// Has cost of making 2 allocations (40 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
             span: Dummy::dummy(allocator),

--- a/crates/oxc_regular_expression/src/generated/assert_layouts.rs
+++ b/crates/oxc_regular_expression/src/generated/assert_layouts.rs
@@ -10,19 +10,19 @@ use crate::ast::*;
 #[cfg(target_pointer_width = "64")]
 const _: () = {
     // Padding: 0 bytes
-    assert!(size_of::<Pattern>() == 48);
+    assert!(size_of::<Pattern>() == 40);
     assert!(align_of::<Pattern>() == 8);
     assert!(offset_of!(Pattern, span) == 0);
     assert!(offset_of!(Pattern, body) == 8);
 
     // Padding: 0 bytes
-    assert!(size_of::<Disjunction>() == 40);
+    assert!(size_of::<Disjunction>() == 32);
     assert!(align_of::<Disjunction>() == 8);
     assert!(offset_of!(Disjunction, span) == 0);
     assert!(offset_of!(Disjunction, body) == 8);
 
     // Padding: 0 bytes
-    assert!(size_of::<Alternative>() == 40);
+    assert!(size_of::<Alternative>() == 32);
     assert!(align_of::<Alternative>() == 8);
     assert!(offset_of!(Alternative, span) == 0);
     assert!(offset_of!(Alternative, body) == 8);
@@ -40,7 +40,7 @@ const _: () = {
     assert!(align_of::<BoundaryAssertionKind>() == 1);
 
     // Padding: 7 bytes
-    assert!(size_of::<LookAroundAssertion>() == 56);
+    assert!(size_of::<LookAroundAssertion>() == 48);
     assert!(align_of::<LookAroundAssertion>() == 8);
     assert!(offset_of!(LookAroundAssertion, span) == 0);
     assert!(offset_of!(LookAroundAssertion, kind) == 8);
@@ -92,7 +92,7 @@ const _: () = {
     assert!(offset_of!(Dot, span) == 0);
 
     // Padding: 5 bytes
-    assert!(size_of::<CharacterClass>() == 48);
+    assert!(size_of::<CharacterClass>() == 40);
     assert!(align_of::<CharacterClass>() == 8);
     assert!(offset_of!(CharacterClass, span) == 0);
     assert!(offset_of!(CharacterClass, negative) == 8);
@@ -114,28 +114,28 @@ const _: () = {
     assert!(offset_of!(CharacterClassRange, max) == 24);
 
     // Padding: 7 bytes
-    assert!(size_of::<ClassStringDisjunction>() == 48);
+    assert!(size_of::<ClassStringDisjunction>() == 40);
     assert!(align_of::<ClassStringDisjunction>() == 8);
     assert!(offset_of!(ClassStringDisjunction, span) == 0);
     assert!(offset_of!(ClassStringDisjunction, strings) == 8);
     assert!(offset_of!(ClassStringDisjunction, body) == 16);
 
     // Padding: 7 bytes
-    assert!(size_of::<ClassString>() == 48);
+    assert!(size_of::<ClassString>() == 40);
     assert!(align_of::<ClassString>() == 8);
     assert!(offset_of!(ClassString, span) == 0);
     assert!(offset_of!(ClassString, strings) == 8);
     assert!(offset_of!(ClassString, body) == 16);
 
     // Padding: 0 bytes
-    assert!(size_of::<CapturingGroup>() == 64);
+    assert!(size_of::<CapturingGroup>() == 56);
     assert!(align_of::<CapturingGroup>() == 8);
     assert!(offset_of!(CapturingGroup, span) == 0);
     assert!(offset_of!(CapturingGroup, name) == 8);
     assert!(offset_of!(CapturingGroup, body) == 24);
 
     // Padding: 0 bytes
-    assert!(size_of::<IgnoreGroup>() == 64);
+    assert!(size_of::<IgnoreGroup>() == 56);
     assert!(align_of::<IgnoreGroup>() == 8);
     assert!(offset_of!(IgnoreGroup, span) == 0);
     assert!(offset_of!(IgnoreGroup, modifiers) == 8);

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -35,8 +35,8 @@ function deserialize(buffer, sourceTextInput, sourceLenInput) {
 }
 
 function deserializeProgram(pos) {
-  const body = deserializeVecDirective(pos + 88);
-  body.push(...deserializeVecStatement(pos + 120));
+  const body = deserializeVecDirective(pos + 80);
+  body.push(...deserializeVecStatement(pos + 104));
 
   const start = deserializeU32(pos);
   const end = deserializeU32(pos + 4);
@@ -47,7 +47,7 @@ function deserializeProgram(pos) {
     end,
     body,
     sourceType: deserializeModuleKind(pos + 9),
-    hashbang: deserializeOptionHashbang(pos + 64),
+    hashbang: deserializeOptionHashbang(pos + 56),
   };
   return program;
 }
@@ -137,7 +137,7 @@ function deserializeTemplateLiteral(pos) {
     type: 'TemplateLiteral',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expressions: deserializeVecExpression(pos + 40),
+    expressions: deserializeVecExpression(pos + 32),
     quasis: deserializeVecTemplateElement(pos + 8),
   };
 }
@@ -214,7 +214,7 @@ function deserializeCallExpression(pos) {
     end: deserializeU32(pos + 4),
     callee: deserializeExpression(pos + 8),
     arguments: deserializeVecArgument(pos + 32),
-    optional: deserializeBool(pos + 64),
+    optional: deserializeBool(pos + 56),
   };
 }
 
@@ -326,7 +326,7 @@ function deserializeAssignmentExpression(pos) {
 
 function deserializeArrayAssignmentTarget(pos) {
   const elements = deserializeVecOptionAssignmentTargetMaybeDefault(pos + 8);
-  const rest = deserializeOptionAssignmentTargetRest(pos + 40);
+  const rest = deserializeOptionAssignmentTargetRest(pos + 32);
   if (rest !== null) elements.push(rest);
   return {
     type: 'ArrayPattern',
@@ -338,7 +338,7 @@ function deserializeArrayAssignmentTarget(pos) {
 
 function deserializeObjectAssignmentTarget(pos) {
   const properties = deserializeVecAssignmentTargetProperty(pos + 8);
-  const rest = deserializeOptionAssignmentTargetRest(pos + 40);
+  const rest = deserializeOptionAssignmentTargetRest(pos + 32);
   if (rest !== null) properties.push(rest);
   return {
     type: 'ObjectPattern',
@@ -713,7 +713,7 @@ function deserializeAssignmentPattern(pos) {
 
 function deserializeObjectPattern(pos) {
   const properties = deserializeVecBindingProperty(pos + 8);
-  const rest = deserializeOptionBoxBindingRestElement(pos + 40);
+  const rest = deserializeOptionBoxBindingRestElement(pos + 32);
   if (rest !== null) properties.push(rest);
   return {
     type: 'ObjectPattern',
@@ -739,7 +739,7 @@ function deserializeBindingProperty(pos) {
 
 function deserializeArrayPattern(pos) {
   const elements = deserializeVecOptionBindingPattern(pos + 8);
-  const rest = deserializeOptionBoxBindingRestElement(pos + 40);
+  const rest = deserializeOptionBoxBindingRestElement(pos + 32);
   if (rest !== null) elements.push(rest);
   return {
     type: 'ArrayPattern',
@@ -775,8 +775,8 @@ function deserializeFunction(pos) {
 
 function deserializeFormalParameters(pos) {
   const params = deserializeVecFormalParameter(pos + 16);
-  if (uint32[(pos + 48) >> 2] !== 0 && uint32[(pos + 52) >> 2] !== 0) {
-    pos = uint32[(pos + 48) >> 2];
+  if (uint32[(pos + 40) >> 2] !== 0 && uint32[(pos + 44) >> 2] !== 0) {
+    pos = uint32[(pos + 40) >> 2];
     params.push({
       type: 'RestElement',
       start: deserializeU32(pos),
@@ -788,12 +788,12 @@ function deserializeFormalParameters(pos) {
 }
 
 function deserializeFormalParameter(pos) {
-  return deserializeBindingPatternKind(pos + 40);
+  return deserializeBindingPatternKind(pos + 32);
 }
 
 function deserializeFunctionBody(pos) {
   const body = deserializeVecDirective(pos + 8);
-  body.push(...deserializeVecStatement(pos + 40));
+  body.push(...deserializeVecStatement(pos + 32));
   return {
     type: 'BlockStatement',
     start: deserializeU32(pos),
@@ -833,9 +833,9 @@ function deserializeClass(pos) {
     type: deserializeClassType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    id: deserializeOptionBindingIdentifier(pos + 48),
-    superClass: deserializeOptionExpression(pos + 88),
-    body: deserializeBoxClassBody(pos + 144),
+    id: deserializeOptionBindingIdentifier(pos + 40),
+    superClass: deserializeOptionExpression(pos + 80),
+    body: deserializeBoxClassBody(pos + 128),
   };
 }
 
@@ -853,11 +853,11 @@ function deserializeMethodDefinition(pos) {
     type: deserializeMethodDefinitionType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    static: deserializeBool(pos + 74),
-    computed: deserializeBool(pos + 73),
-    key: deserializePropertyKey(pos + 48),
-    kind: deserializeMethodDefinitionKind(pos + 72),
-    value: deserializeBoxFunction(pos + 64),
+    static: deserializeBool(pos + 66),
+    computed: deserializeBool(pos + 65),
+    key: deserializePropertyKey(pos + 40),
+    kind: deserializeMethodDefinitionKind(pos + 64),
+    value: deserializeBoxFunction(pos + 56),
   };
 }
 
@@ -866,10 +866,10 @@ function deserializePropertyDefinition(pos) {
     type: deserializePropertyDefinitionType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    static: deserializeBool(pos + 89),
-    computed: deserializeBool(pos + 88),
-    key: deserializePropertyKey(pos + 48),
-    value: deserializeOptionExpression(pos + 72),
+    static: deserializeBool(pos + 81),
+    computed: deserializeBool(pos + 80),
+    key: deserializePropertyKey(pos + 40),
+    value: deserializeOptionExpression(pos + 64),
   };
 }
 
@@ -896,10 +896,10 @@ function deserializeAccessorProperty(pos) {
     type: deserializeAccessorPropertyType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    key: deserializePropertyKey(pos + 48),
-    value: deserializeOptionExpression(pos + 72),
-    computed: deserializeBool(pos + 88),
-    static: deserializeBool(pos + 89),
+    key: deserializePropertyKey(pos + 40),
+    value: deserializeOptionExpression(pos + 64),
+    computed: deserializeBool(pos + 80),
+    static: deserializeBool(pos + 81),
   };
 }
 
@@ -916,13 +916,13 @@ function deserializeImportExpression(pos) {
 function deserializeImportDeclaration(pos) {
   let specifiers = deserializeOptionVecImportDeclarationSpecifier(pos + 8);
   if (specifiers === null) specifiers = [];
-  const withClause = deserializeOptionBoxWithClause(pos + 96);
+  const withClause = deserializeOptionBoxWithClause(pos + 88);
   return {
     type: 'ImportDeclaration',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     specifiers,
-    source: deserializeStringLiteral(pos + 40),
+    source: deserializeStringLiteral(pos + 32),
     attributes: withClause === null ? [] : withClause.attributes,
   };
 }
@@ -972,14 +972,14 @@ function deserializeImportAttribute(pos) {
 }
 
 function deserializeExportNamedDeclaration(pos) {
-  const withClause = deserializeOptionBoxWithClause(pos + 112);
+  const withClause = deserializeOptionBoxWithClause(pos + 104);
   return {
     type: 'ExportNamedDeclaration',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     declaration: deserializeOptionDeclaration(pos + 8),
     specifiers: deserializeVecExportSpecifier(pos + 24),
-    source: deserializeOptionStringLiteral(pos + 56),
+    source: deserializeOptionStringLiteral(pos + 48),
     attributes: withClause === null ? [] : withClause.attributes,
   };
 }
@@ -1132,7 +1132,7 @@ function deserializeRegExpFlags(pos) {
 }
 
 function deserializeJSXElement(pos) {
-  const closingElement = deserializeOptionBoxJSXClosingElement(pos + 48);
+  const closingElement = deserializeOptionBoxJSXClosingElement(pos + 40);
   const openingElement = deserializeBoxJSXOpeningElement(pos + 8);
   if (closingElement === null) openingElement.selfClosing = true;
   return {
@@ -1171,7 +1171,7 @@ function deserializeJSXFragment(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     openingFragment: deserializeJSXOpeningFragment(pos + 8),
-    closingFragment: deserializeJSXClosingFragment(pos + 48),
+    closingFragment: deserializeJSXClosingFragment(pos + 40),
     children: deserializeVecJSXChild(pos + 16),
   };
 }
@@ -1298,8 +1298,8 @@ function deserializeTSEnumDeclaration(pos) {
     end: deserializeU32(pos + 4),
     id: deserializeBindingIdentifier(pos + 8),
     body: deserializeTSEnumBody(pos + 40),
-    const: deserializeBool(pos + 80),
-    declare: deserializeBool(pos + 81),
+    const: deserializeBool(pos + 72),
+    declare: deserializeBool(pos + 73),
   };
 }
 
@@ -1666,8 +1666,8 @@ function deserializeTSInterfaceDeclaration(pos) {
     id: deserializeBindingIdentifier(pos + 8),
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 40),
     extends: deserializeVecTSInterfaceHeritage(pos + 48),
-    body: deserializeBoxTSInterfaceBody(pos + 80),
-    declare: deserializeBool(pos + 88),
+    body: deserializeBoxTSInterfaceBody(pos + 72),
+    declare: deserializeBool(pos + 80),
   };
 }
 
@@ -1701,9 +1701,9 @@ function deserializeTSIndexSignature(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     parameters: deserializeVecTSIndexSignatureName(pos + 8),
-    typeAnnotation: deserializeBoxTSTypeAnnotation(pos + 40),
-    readonly: deserializeBool(pos + 48),
-    static: deserializeBool(pos + 49),
+    typeAnnotation: deserializeBoxTSTypeAnnotation(pos + 32),
+    readonly: deserializeBool(pos + 40),
+    static: deserializeBool(pos + 41),
     accessibility: null,
   };
 }
@@ -1836,7 +1836,7 @@ function deserializeTSModuleDeclaration(pos) {
 
 function deserializeTSModuleBlock(pos) {
   const body = deserializeVecDirective(pos + 8);
-  body.push(...deserializeVecStatement(pos + 40));
+  body.push(...deserializeVecStatement(pos + 32));
   return {
     type: 'TSModuleBlock',
     start: deserializeU32(pos),
@@ -1934,7 +1934,7 @@ function deserializeTSTemplateLiteralType(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     quasis: deserializeVecTemplateElement(pos + 8),
-    types: deserializeVecTSType(pos + 40),
+    types: deserializeVecTSType(pos + 32),
   };
 }
 
@@ -2127,9 +2127,9 @@ function deserializeSourceType(pos) {
 function deserializeRawTransferData(pos) {
   return {
     program: deserializeProgram(pos),
-    comments: deserializeVecComment(pos + 160),
-    module: deserializeEcmaScriptModule(pos + 192),
-    errors: deserializeVecError(pos + 328),
+    comments: deserializeVecComment(pos + 136),
+    module: deserializeEcmaScriptModule(pos + 160),
+    errors: deserializeVecError(pos + 264),
   };
 }
 
@@ -2138,7 +2138,7 @@ function deserializeError(pos) {
     severity: deserializeErrorSeverity(pos),
     message: deserializeStr(pos + 8),
     labels: deserializeVecErrorLabel(pos + 24),
-    helpMessage: deserializeOptionStr(pos + 56),
+    helpMessage: deserializeOptionStr(pos + 48),
   };
 }
 
@@ -2154,9 +2154,9 @@ function deserializeEcmaScriptModule(pos) {
   return {
     hasModuleSyntax: deserializeBool(pos),
     staticImports: deserializeVecStaticImport(pos + 8),
-    staticExports: deserializeVecStaticExport(pos + 40),
-    dynamicImports: deserializeVecDynamicImport(pos + 72),
-    importMetas: deserializeVecSpan(pos + 104),
+    staticExports: deserializeVecStaticExport(pos + 32),
+    dynamicImports: deserializeVecDynamicImport(pos + 56),
+    importMetas: deserializeVecSpan(pos + 80),
   };
 }
 
@@ -4051,7 +4051,7 @@ function deserializeStr(pos) {
 function deserializeVecComment(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeComment(pos));
@@ -4068,7 +4068,7 @@ function deserializeOptionHashbang(pos) {
 function deserializeVecDirective(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeDirective(pos));
@@ -4080,7 +4080,7 @@ function deserializeVecDirective(pos) {
 function deserializeVecStatement(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeStatement(pos));
@@ -4267,7 +4267,7 @@ function deserializeOptionSymbolId(pos) {
 function deserializeVecArrayExpressionElement(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeArrayExpressionElement(pos));
@@ -4283,7 +4283,7 @@ function deserializeBoxSpreadElement(pos) {
 function deserializeVecObjectPropertyKind(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeObjectPropertyKind(pos));
@@ -4311,7 +4311,7 @@ function deserializeBoxPrivateIdentifier(pos) {
 function deserializeVecTemplateElement(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeTemplateElement(pos));
@@ -4323,7 +4323,7 @@ function deserializeVecTemplateElement(pos) {
 function deserializeVecExpression(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeExpression(pos));
@@ -4361,7 +4361,7 @@ function deserializeBoxPrivateFieldExpression(pos) {
 function deserializeVecArgument(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeArgument(pos));
@@ -4386,7 +4386,7 @@ function deserializeOptionAssignmentTargetMaybeDefault(pos) {
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeOptionAssignmentTargetMaybeDefault(pos));
@@ -4403,7 +4403,7 @@ function deserializeOptionAssignmentTargetRest(pos) {
 function deserializeVecAssignmentTargetProperty(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeAssignmentTargetProperty(pos));
@@ -4528,7 +4528,7 @@ function deserializeBoxTSImportEqualsDeclaration(pos) {
 function deserializeVecVariableDeclarator(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeVariableDeclarator(pos));
@@ -4555,11 +4555,11 @@ function deserializeOptionLabelIdentifier(pos) {
 function deserializeVecSwitchCase(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeSwitchCase(pos));
-    pos += 56;
+    pos += 48;
   }
   return arr;
 }
@@ -4611,7 +4611,7 @@ function deserializeBoxAssignmentPattern(pos) {
 function deserializeVecBindingProperty(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeBindingProperty(pos));
@@ -4637,7 +4637,7 @@ function deserializeOptionBindingPattern(pos) {
 function deserializeVecOptionBindingPattern(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeOptionBindingPattern(pos));
@@ -4685,11 +4685,11 @@ function deserializeOptionBoxFunctionBody(pos) {
 function deserializeVecFormalParameter(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeFormalParameter(pos));
-    pos += 80;
+    pos += 72;
   }
   return arr;
 }
@@ -4697,7 +4697,7 @@ function deserializeVecFormalParameter(pos) {
 function deserializeVecDecorator(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeDecorator(pos));
@@ -4714,7 +4714,7 @@ function deserializeOptionTSAccessibility(pos) {
 function deserializeVecTSClassImplements(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeTSClassImplements(pos));
@@ -4730,7 +4730,7 @@ function deserializeBoxClassBody(pos) {
 function deserializeVecClassElement(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeClassElement(pos));
@@ -4791,7 +4791,7 @@ function deserializeOptionImportPhase(pos) {
 function deserializeVecImportDeclarationSpecifier(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeImportDeclarationSpecifier(pos));
@@ -4829,7 +4829,7 @@ function deserializeBoxImportNamespaceSpecifier(pos) {
 function deserializeVecImportAttribute(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeImportAttribute(pos));
@@ -4846,7 +4846,7 @@ function deserializeOptionDeclaration(pos) {
 function deserializeVecExportSpecifier(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeExportSpecifier(pos));
@@ -4889,7 +4889,7 @@ function deserializeBoxJSXOpeningElement(pos) {
 function deserializeVecJSXChild(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeJSXChild(pos));
@@ -4910,7 +4910,7 @@ function deserializeOptionBoxJSXClosingElement(pos) {
 function deserializeVecJSXAttributeItem(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeJSXAttributeItem(pos));
@@ -4959,7 +4959,7 @@ function deserializeBoxJSXSpreadChild(pos) {
 function deserializeVecTSEnumMember(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeTSEnumMember(pos));
@@ -5119,7 +5119,7 @@ function deserializeBoxJSDocUnknownType(pos) {
 function deserializeVecTSType(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeTSType(pos));
@@ -5131,7 +5131,7 @@ function deserializeVecTSType(pos) {
 function deserializeVecTSTupleElement(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeTSTupleElement(pos));
@@ -5160,7 +5160,7 @@ function deserializeOptionTSType(pos) {
 function deserializeVecTSTypeParameter(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeTSTypeParameter(pos));
@@ -5172,7 +5172,7 @@ function deserializeVecTSTypeParameter(pos) {
 function deserializeVecTSInterfaceHeritage(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeTSInterfaceHeritage(pos));
@@ -5188,7 +5188,7 @@ function deserializeBoxTSInterfaceBody(pos) {
 function deserializeVecTSSignature(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeTSSignature(pos));
@@ -5216,7 +5216,7 @@ function deserializeBoxTSMethodSignature(pos) {
 function deserializeVecTSIndexSignatureName(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeTSIndexSignatureName(pos));
@@ -5269,11 +5269,11 @@ function deserializeOptionNameSpan(pos) {
 function deserializeVecAlternative(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeAlternative(pos));
-    pos += 40;
+    pos += 32;
   }
   return arr;
 }
@@ -5281,7 +5281,7 @@ function deserializeVecAlternative(pos) {
 function deserializeVecTerm(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeTerm(pos));
@@ -5347,7 +5347,7 @@ function deserializeOptionU64(pos) {
 function deserializeVecCharacterClassContents(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeCharacterClassContents(pos));
@@ -5367,11 +5367,11 @@ function deserializeBoxClassStringDisjunction(pos) {
 function deserializeVecClassString(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeClassString(pos));
-    pos += 48;
+    pos += 40;
   }
   return arr;
 }
@@ -5379,7 +5379,7 @@ function deserializeVecClassString(pos) {
 function deserializeVecCharacter(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeCharacter(pos));
@@ -5401,11 +5401,11 @@ function deserializeOptionModifier(pos) {
 function deserializeVecError(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeError(pos));
-    pos += 72;
+    pos += 64;
   }
   return arr;
 }
@@ -5413,7 +5413,7 @@ function deserializeVecError(pos) {
 function deserializeVecErrorLabel(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeErrorLabel(pos));
@@ -5425,11 +5425,11 @@ function deserializeVecErrorLabel(pos) {
 function deserializeVecStaticImport(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeStaticImport(pos));
-    pos += 64;
+    pos += 56;
   }
   return arr;
 }
@@ -5437,11 +5437,11 @@ function deserializeVecStaticImport(pos) {
 function deserializeVecStaticExport(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeStaticExport(pos));
-    pos += 40;
+    pos += 32;
   }
   return arr;
 }
@@ -5449,7 +5449,7 @@ function deserializeVecStaticExport(pos) {
 function deserializeVecDynamicImport(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeDynamicImport(pos));
@@ -5461,7 +5461,7 @@ function deserializeVecDynamicImport(pos) {
 function deserializeVecSpan(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeSpan(pos));
@@ -5473,7 +5473,7 @@ function deserializeVecSpan(pos) {
 function deserializeVecImportEntry(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeImportEntry(pos));
@@ -5485,7 +5485,7 @@ function deserializeVecImportEntry(pos) {
 function deserializeVecExportEntry(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeExportEntry(pos));

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -35,8 +35,8 @@ function deserialize(buffer, sourceTextInput, sourceLenInput) {
 }
 
 function deserializeProgram(pos) {
-  const body = deserializeVecDirective(pos + 88);
-  body.push(...deserializeVecStatement(pos + 120));
+  const body = deserializeVecDirective(pos + 80);
+  body.push(...deserializeVecStatement(pos + 104));
 
   const end = deserializeU32(pos + 4);
 
@@ -63,7 +63,7 @@ function deserializeProgram(pos) {
     end,
     body,
     sourceType: deserializeModuleKind(pos + 9),
-    hashbang: deserializeOptionHashbang(pos + 64),
+    hashbang: deserializeOptionHashbang(pos + 56),
   };
   return program;
 }
@@ -166,7 +166,7 @@ function deserializeTemplateLiteral(pos) {
     type: 'TemplateLiteral',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expressions: deserializeVecExpression(pos + 40),
+    expressions: deserializeVecExpression(pos + 32),
     quasis: deserializeVecTemplateElement(pos + 8),
   };
 }
@@ -244,7 +244,7 @@ function deserializeCallExpression(pos) {
     end: deserializeU32(pos + 4),
     callee: deserializeExpression(pos + 8),
     arguments: deserializeVecArgument(pos + 32),
-    optional: deserializeBool(pos + 64),
+    optional: deserializeBool(pos + 56),
     typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
   };
 }
@@ -358,7 +358,7 @@ function deserializeAssignmentExpression(pos) {
 
 function deserializeArrayAssignmentTarget(pos) {
   const elements = deserializeVecOptionAssignmentTargetMaybeDefault(pos + 8);
-  const rest = deserializeOptionAssignmentTargetRest(pos + 40);
+  const rest = deserializeOptionAssignmentTargetRest(pos + 32);
   if (rest !== null) elements.push(rest);
   return {
     type: 'ArrayPattern',
@@ -373,7 +373,7 @@ function deserializeArrayAssignmentTarget(pos) {
 
 function deserializeObjectAssignmentTarget(pos) {
   const properties = deserializeVecAssignmentTargetProperty(pos + 8);
-  const rest = deserializeOptionAssignmentTargetRest(pos + 40);
+  const rest = deserializeOptionAssignmentTargetRest(pos + 32);
   if (rest !== null) properties.push(rest);
   return {
     type: 'ObjectPattern',
@@ -538,7 +538,7 @@ function deserializeVariableDeclaration(pos) {
     end: deserializeU32(pos + 4),
     declarations: deserializeVecVariableDeclarator(pos + 16),
     kind: deserializeVariableDeclarationKind(pos + 8),
-    declare: deserializeBool(pos + 48),
+    declare: deserializeBool(pos + 40),
   };
 }
 
@@ -773,7 +773,7 @@ function deserializeAssignmentPattern(pos) {
 
 function deserializeObjectPattern(pos) {
   const properties = deserializeVecBindingProperty(pos + 8);
-  const rest = deserializeOptionBoxBindingRestElement(pos + 40);
+  const rest = deserializeOptionBoxBindingRestElement(pos + 32);
   if (rest !== null) properties.push(rest);
   return {
     type: 'ObjectPattern',
@@ -803,7 +803,7 @@ function deserializeBindingProperty(pos) {
 
 function deserializeArrayPattern(pos) {
   const elements = deserializeVecOptionBindingPattern(pos + 8);
-  const rest = deserializeOptionBoxBindingRestElement(pos + 40);
+  const rest = deserializeOptionBoxBindingRestElement(pos + 32);
   if (rest !== null) elements.push(rest);
   return {
     type: 'ArrayPattern',
@@ -851,8 +851,8 @@ function deserializeFunction(pos) {
 
 function deserializeFormalParameters(pos) {
   const params = deserializeVecFormalParameter(pos + 16);
-  if (uint32[(pos + 48) >> 2] !== 0 && uint32[(pos + 52) >> 2] !== 0) {
-    pos = uint32[(pos + 48) >> 2];
+  if (uint32[(pos + 40) >> 2] !== 0 && uint32[(pos + 44) >> 2] !== 0) {
+    pos = uint32[(pos + 40) >> 2];
     params.push({
       type: 'RestElement',
       start: deserializeU32(pos),
@@ -870,16 +870,16 @@ function deserializeFormalParameters(pos) {
 }
 
 function deserializeFormalParameter(pos) {
-  const accessibility = deserializeOptionTSAccessibility(pos + 72),
-    readonly = deserializeBool(pos + 73),
-    override = deserializeBool(pos + 74);
+  const accessibility = deserializeOptionTSAccessibility(pos + 64),
+    readonly = deserializeBool(pos + 65),
+    override = deserializeBool(pos + 66);
   let param;
   if (accessibility === null && !readonly && !override) {
     param = {
-      ...deserializeBindingPatternKind(pos + 40),
+      ...deserializeBindingPatternKind(pos + 32),
       decorators: deserializeVecDecorator(pos + 8),
-      optional: deserializeBool(pos + 64),
-      typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 56),
+      optional: deserializeBool(pos + 56),
+      typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 48),
     };
   } else {
     param = {
@@ -889,7 +889,7 @@ function deserializeFormalParameter(pos) {
       accessibility,
       decorators: deserializeVecDecorator(pos + 8),
       override,
-      parameter: deserializeBindingPattern(pos + 40),
+      parameter: deserializeBindingPattern(pos + 32),
       readonly,
       static: false,
     };
@@ -899,7 +899,7 @@ function deserializeFormalParameter(pos) {
 
 function deserializeFunctionBody(pos) {
   const body = deserializeVecDirective(pos + 8);
-  body.push(...deserializeVecStatement(pos + 40));
+  body.push(...deserializeVecStatement(pos + 32));
   return {
     type: 'BlockStatement',
     start: deserializeU32(pos),
@@ -941,15 +941,15 @@ function deserializeClass(pos) {
     type: deserializeClassType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    id: deserializeOptionBindingIdentifier(pos + 48),
-    superClass: deserializeOptionExpression(pos + 88),
-    body: deserializeBoxClassBody(pos + 144),
+    id: deserializeOptionBindingIdentifier(pos + 40),
+    superClass: deserializeOptionExpression(pos + 80),
+    body: deserializeBoxClassBody(pos + 128),
     decorators: deserializeVecDecorator(pos + 16),
-    typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 80),
-    superTypeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 104),
-    implements: deserializeVecTSClassImplements(pos + 112),
-    abstract: deserializeBool(pos + 152),
-    declare: deserializeBool(pos + 153),
+    typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 72),
+    superTypeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 96),
+    implements: deserializeVecTSClassImplements(pos + 104),
+    abstract: deserializeBool(pos + 136),
+    declare: deserializeBool(pos + 137),
   };
 }
 
@@ -963,8 +963,8 @@ function deserializeClassBody(pos) {
 }
 
 function deserializeMethodDefinition(pos) {
-  const kind = deserializeMethodDefinitionKind(pos + 72);
-  let key = deserializePropertyKey(pos + 48);
+  const kind = deserializeMethodDefinitionKind(pos + 64);
+  let key = deserializePropertyKey(pos + 40);
   if (kind === 'constructor') {
     key = {
       type: 'Identifier',
@@ -980,15 +980,15 @@ function deserializeMethodDefinition(pos) {
     type: deserializeMethodDefinitionType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    static: deserializeBool(pos + 74),
-    computed: deserializeBool(pos + 73),
+    static: deserializeBool(pos + 66),
+    computed: deserializeBool(pos + 65),
     key,
     kind,
-    value: deserializeBoxFunction(pos + 64),
+    value: deserializeBoxFunction(pos + 56),
     decorators: deserializeVecDecorator(pos + 16),
-    override: deserializeBool(pos + 75),
-    optional: deserializeBool(pos + 76),
-    accessibility: deserializeOptionTSAccessibility(pos + 77),
+    override: deserializeBool(pos + 67),
+    optional: deserializeBool(pos + 68),
+    accessibility: deserializeOptionTSAccessibility(pos + 69),
   };
 }
 
@@ -997,18 +997,18 @@ function deserializePropertyDefinition(pos) {
     type: deserializePropertyDefinitionType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    static: deserializeBool(pos + 89),
-    computed: deserializeBool(pos + 88),
-    key: deserializePropertyKey(pos + 48),
-    value: deserializeOptionExpression(pos + 72),
+    static: deserializeBool(pos + 81),
+    computed: deserializeBool(pos + 80),
+    key: deserializePropertyKey(pos + 40),
+    value: deserializeOptionExpression(pos + 64),
     decorators: deserializeVecDecorator(pos + 16),
-    declare: deserializeBool(pos + 90),
-    override: deserializeBool(pos + 91),
-    optional: deserializeBool(pos + 92),
-    definite: deserializeBool(pos + 93),
-    readonly: deserializeBool(pos + 94),
-    typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 64),
-    accessibility: deserializeOptionTSAccessibility(pos + 95),
+    declare: deserializeBool(pos + 82),
+    override: deserializeBool(pos + 83),
+    optional: deserializeBool(pos + 84),
+    definite: deserializeBool(pos + 85),
+    readonly: deserializeBool(pos + 86),
+    typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 56),
+    accessibility: deserializeOptionTSAccessibility(pos + 87),
   };
 }
 
@@ -1035,16 +1035,16 @@ function deserializeAccessorProperty(pos) {
     type: deserializeAccessorPropertyType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    key: deserializePropertyKey(pos + 48),
-    typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 64),
-    value: deserializeOptionExpression(pos + 72),
-    computed: deserializeBool(pos + 88),
-    static: deserializeBool(pos + 89),
+    key: deserializePropertyKey(pos + 40),
+    typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 56),
+    value: deserializeOptionExpression(pos + 64),
+    computed: deserializeBool(pos + 80),
+    static: deserializeBool(pos + 81),
     decorators: deserializeVecDecorator(pos + 16),
-    definite: deserializeBool(pos + 91),
-    accessibility: deserializeOptionTSAccessibility(pos + 92),
+    definite: deserializeBool(pos + 83),
+    accessibility: deserializeOptionTSAccessibility(pos + 84),
     optional: false,
-    override: deserializeBool(pos + 90),
+    override: deserializeBool(pos + 82),
     readonly: false,
     declare: false,
   };
@@ -1063,15 +1063,15 @@ function deserializeImportExpression(pos) {
 function deserializeImportDeclaration(pos) {
   let specifiers = deserializeOptionVecImportDeclarationSpecifier(pos + 8);
   if (specifiers === null) specifiers = [];
-  const withClause = deserializeOptionBoxWithClause(pos + 96);
+  const withClause = deserializeOptionBoxWithClause(pos + 88);
   return {
     type: 'ImportDeclaration',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     specifiers,
-    source: deserializeStringLiteral(pos + 40),
+    source: deserializeStringLiteral(pos + 32),
     attributes: withClause === null ? [] : withClause.attributes,
-    importKind: deserializeImportOrExportKind(pos + 104),
+    importKind: deserializeImportOrExportKind(pos + 96),
   };
 }
 
@@ -1121,16 +1121,16 @@ function deserializeImportAttribute(pos) {
 }
 
 function deserializeExportNamedDeclaration(pos) {
-  const withClause = deserializeOptionBoxWithClause(pos + 112);
+  const withClause = deserializeOptionBoxWithClause(pos + 104);
   return {
     type: 'ExportNamedDeclaration',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     declaration: deserializeOptionDeclaration(pos + 8),
     specifiers: deserializeVecExportSpecifier(pos + 24),
-    source: deserializeOptionStringLiteral(pos + 56),
+    source: deserializeOptionStringLiteral(pos + 48),
     attributes: withClause === null ? [] : withClause.attributes,
-    exportKind: deserializeImportOrExportKind(pos + 104),
+    exportKind: deserializeImportOrExportKind(pos + 96),
   };
 }
 
@@ -1285,7 +1285,7 @@ function deserializeRegExpFlags(pos) {
 }
 
 function deserializeJSXElement(pos) {
-  const closingElement = deserializeOptionBoxJSXClosingElement(pos + 48);
+  const closingElement = deserializeOptionBoxJSXClosingElement(pos + 40);
   const openingElement = deserializeBoxJSXOpeningElement(pos + 8);
   if (closingElement === null) openingElement.selfClosing = true;
   return {
@@ -1325,7 +1325,7 @@ function deserializeJSXFragment(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     openingFragment: deserializeJSXOpeningFragment(pos + 8),
-    closingFragment: deserializeJSXClosingFragment(pos + 48),
+    closingFragment: deserializeJSXClosingFragment(pos + 40),
     children: deserializeVecJSXChild(pos + 16),
   };
 }
@@ -1450,8 +1450,8 @@ function deserializeTSEnumDeclaration(pos) {
     end: deserializeU32(pos + 4),
     id: deserializeBindingIdentifier(pos + 8),
     body: deserializeTSEnumBody(pos + 40),
-    const: deserializeBool(pos + 80),
-    declare: deserializeBool(pos + 81),
+    const: deserializeBool(pos + 72),
+    declare: deserializeBool(pos + 73),
   };
 }
 
@@ -1818,8 +1818,8 @@ function deserializeTSInterfaceDeclaration(pos) {
     id: deserializeBindingIdentifier(pos + 8),
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 40),
     extends: deserializeVecTSInterfaceHeritage(pos + 48),
-    body: deserializeBoxTSInterfaceBody(pos + 80),
-    declare: deserializeBool(pos + 88),
+    body: deserializeBoxTSInterfaceBody(pos + 72),
+    declare: deserializeBool(pos + 80),
   };
 }
 
@@ -1853,9 +1853,9 @@ function deserializeTSIndexSignature(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     parameters: deserializeVecTSIndexSignatureName(pos + 8),
-    typeAnnotation: deserializeBoxTSTypeAnnotation(pos + 40),
-    readonly: deserializeBool(pos + 48),
-    static: deserializeBool(pos + 49),
+    typeAnnotation: deserializeBoxTSTypeAnnotation(pos + 32),
+    readonly: deserializeBool(pos + 40),
+    static: deserializeBool(pos + 41),
     accessibility: null,
   };
 }
@@ -1988,7 +1988,7 @@ function deserializeTSModuleDeclaration(pos) {
 
 function deserializeTSModuleBlock(pos) {
   const body = deserializeVecDirective(pos + 8);
-  body.push(...deserializeVecStatement(pos + 40));
+  body.push(...deserializeVecStatement(pos + 32));
   return {
     type: 'TSModuleBlock',
     start: deserializeU32(pos),
@@ -2086,7 +2086,7 @@ function deserializeTSTemplateLiteralType(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     quasis: deserializeVecTemplateElement(pos + 8),
-    types: deserializeVecTSType(pos + 40),
+    types: deserializeVecTSType(pos + 32),
   };
 }
 
@@ -2279,9 +2279,9 @@ function deserializeSourceType(pos) {
 function deserializeRawTransferData(pos) {
   return {
     program: deserializeProgram(pos),
-    comments: deserializeVecComment(pos + 160),
-    module: deserializeEcmaScriptModule(pos + 192),
-    errors: deserializeVecError(pos + 328),
+    comments: deserializeVecComment(pos + 136),
+    module: deserializeEcmaScriptModule(pos + 160),
+    errors: deserializeVecError(pos + 264),
   };
 }
 
@@ -2290,7 +2290,7 @@ function deserializeError(pos) {
     severity: deserializeErrorSeverity(pos),
     message: deserializeStr(pos + 8),
     labels: deserializeVecErrorLabel(pos + 24),
-    helpMessage: deserializeOptionStr(pos + 56),
+    helpMessage: deserializeOptionStr(pos + 48),
   };
 }
 
@@ -2306,9 +2306,9 @@ function deserializeEcmaScriptModule(pos) {
   return {
     hasModuleSyntax: deserializeBool(pos),
     staticImports: deserializeVecStaticImport(pos + 8),
-    staticExports: deserializeVecStaticExport(pos + 40),
-    dynamicImports: deserializeVecDynamicImport(pos + 72),
-    importMetas: deserializeVecSpan(pos + 104),
+    staticExports: deserializeVecStaticExport(pos + 32),
+    dynamicImports: deserializeVecDynamicImport(pos + 56),
+    importMetas: deserializeVecSpan(pos + 80),
   };
 }
 
@@ -4203,7 +4203,7 @@ function deserializeStr(pos) {
 function deserializeVecComment(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeComment(pos));
@@ -4220,7 +4220,7 @@ function deserializeOptionHashbang(pos) {
 function deserializeVecDirective(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeDirective(pos));
@@ -4232,7 +4232,7 @@ function deserializeVecDirective(pos) {
 function deserializeVecStatement(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeStatement(pos));
@@ -4419,7 +4419,7 @@ function deserializeOptionSymbolId(pos) {
 function deserializeVecArrayExpressionElement(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeArrayExpressionElement(pos));
@@ -4435,7 +4435,7 @@ function deserializeBoxSpreadElement(pos) {
 function deserializeVecObjectPropertyKind(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeObjectPropertyKind(pos));
@@ -4463,7 +4463,7 @@ function deserializeBoxPrivateIdentifier(pos) {
 function deserializeVecTemplateElement(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeTemplateElement(pos));
@@ -4475,7 +4475,7 @@ function deserializeVecTemplateElement(pos) {
 function deserializeVecExpression(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeExpression(pos));
@@ -4513,7 +4513,7 @@ function deserializeBoxPrivateFieldExpression(pos) {
 function deserializeVecArgument(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeArgument(pos));
@@ -4538,7 +4538,7 @@ function deserializeOptionAssignmentTargetMaybeDefault(pos) {
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeOptionAssignmentTargetMaybeDefault(pos));
@@ -4555,7 +4555,7 @@ function deserializeOptionAssignmentTargetRest(pos) {
 function deserializeVecAssignmentTargetProperty(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeAssignmentTargetProperty(pos));
@@ -4680,7 +4680,7 @@ function deserializeBoxTSImportEqualsDeclaration(pos) {
 function deserializeVecVariableDeclarator(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeVariableDeclarator(pos));
@@ -4707,11 +4707,11 @@ function deserializeOptionLabelIdentifier(pos) {
 function deserializeVecSwitchCase(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeSwitchCase(pos));
-    pos += 56;
+    pos += 48;
   }
   return arr;
 }
@@ -4763,7 +4763,7 @@ function deserializeBoxAssignmentPattern(pos) {
 function deserializeVecBindingProperty(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeBindingProperty(pos));
@@ -4789,7 +4789,7 @@ function deserializeOptionBindingPattern(pos) {
 function deserializeVecOptionBindingPattern(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeOptionBindingPattern(pos));
@@ -4837,11 +4837,11 @@ function deserializeOptionBoxFunctionBody(pos) {
 function deserializeVecFormalParameter(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeFormalParameter(pos));
-    pos += 80;
+    pos += 72;
   }
   return arr;
 }
@@ -4849,7 +4849,7 @@ function deserializeVecFormalParameter(pos) {
 function deserializeVecDecorator(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeDecorator(pos));
@@ -4866,7 +4866,7 @@ function deserializeOptionTSAccessibility(pos) {
 function deserializeVecTSClassImplements(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeTSClassImplements(pos));
@@ -4882,7 +4882,7 @@ function deserializeBoxClassBody(pos) {
 function deserializeVecClassElement(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeClassElement(pos));
@@ -4943,7 +4943,7 @@ function deserializeOptionImportPhase(pos) {
 function deserializeVecImportDeclarationSpecifier(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeImportDeclarationSpecifier(pos));
@@ -4981,7 +4981,7 @@ function deserializeBoxImportNamespaceSpecifier(pos) {
 function deserializeVecImportAttribute(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeImportAttribute(pos));
@@ -4998,7 +4998,7 @@ function deserializeOptionDeclaration(pos) {
 function deserializeVecExportSpecifier(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeExportSpecifier(pos));
@@ -5041,7 +5041,7 @@ function deserializeBoxJSXOpeningElement(pos) {
 function deserializeVecJSXChild(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeJSXChild(pos));
@@ -5062,7 +5062,7 @@ function deserializeOptionBoxJSXClosingElement(pos) {
 function deserializeVecJSXAttributeItem(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeJSXAttributeItem(pos));
@@ -5111,7 +5111,7 @@ function deserializeBoxJSXSpreadChild(pos) {
 function deserializeVecTSEnumMember(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeTSEnumMember(pos));
@@ -5271,7 +5271,7 @@ function deserializeBoxJSDocUnknownType(pos) {
 function deserializeVecTSType(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeTSType(pos));
@@ -5283,7 +5283,7 @@ function deserializeVecTSType(pos) {
 function deserializeVecTSTupleElement(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeTSTupleElement(pos));
@@ -5312,7 +5312,7 @@ function deserializeOptionTSType(pos) {
 function deserializeVecTSTypeParameter(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeTSTypeParameter(pos));
@@ -5324,7 +5324,7 @@ function deserializeVecTSTypeParameter(pos) {
 function deserializeVecTSInterfaceHeritage(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeTSInterfaceHeritage(pos));
@@ -5340,7 +5340,7 @@ function deserializeBoxTSInterfaceBody(pos) {
 function deserializeVecTSSignature(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeTSSignature(pos));
@@ -5368,7 +5368,7 @@ function deserializeBoxTSMethodSignature(pos) {
 function deserializeVecTSIndexSignatureName(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeTSIndexSignatureName(pos));
@@ -5421,11 +5421,11 @@ function deserializeOptionNameSpan(pos) {
 function deserializeVecAlternative(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeAlternative(pos));
-    pos += 40;
+    pos += 32;
   }
   return arr;
 }
@@ -5433,7 +5433,7 @@ function deserializeVecAlternative(pos) {
 function deserializeVecTerm(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeTerm(pos));
@@ -5499,7 +5499,7 @@ function deserializeOptionU64(pos) {
 function deserializeVecCharacterClassContents(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeCharacterClassContents(pos));
@@ -5519,11 +5519,11 @@ function deserializeBoxClassStringDisjunction(pos) {
 function deserializeVecClassString(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeClassString(pos));
-    pos += 48;
+    pos += 40;
   }
   return arr;
 }
@@ -5531,7 +5531,7 @@ function deserializeVecClassString(pos) {
 function deserializeVecCharacter(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeCharacter(pos));
@@ -5553,11 +5553,11 @@ function deserializeOptionModifier(pos) {
 function deserializeVecError(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeError(pos));
-    pos += 72;
+    pos += 64;
   }
   return arr;
 }
@@ -5565,7 +5565,7 @@ function deserializeVecError(pos) {
 function deserializeVecErrorLabel(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeErrorLabel(pos));
@@ -5577,11 +5577,11 @@ function deserializeVecErrorLabel(pos) {
 function deserializeVecStaticImport(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeStaticImport(pos));
-    pos += 64;
+    pos += 56;
   }
   return arr;
 }
@@ -5589,11 +5589,11 @@ function deserializeVecStaticImport(pos) {
 function deserializeVecStaticExport(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeStaticExport(pos));
-    pos += 40;
+    pos += 32;
   }
   return arr;
 }
@@ -5601,7 +5601,7 @@ function deserializeVecStaticExport(pos) {
 function deserializeVecDynamicImport(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeDynamicImport(pos));
@@ -5613,7 +5613,7 @@ function deserializeVecDynamicImport(pos) {
 function deserializeVecSpan(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeSpan(pos));
@@ -5625,7 +5625,7 @@ function deserializeVecSpan(pos) {
 function deserializeVecImportEntry(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeImportEntry(pos));
@@ -5637,7 +5637,7 @@ function deserializeVecImportEntry(pos) {
 function deserializeVecExportEntry(pos) {
   const arr = [],
     pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
+    len = uint32[pos32 + 5];
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeExportEntry(pos));

--- a/napi/parser/src/generated/assert_layouts.rs
+++ b/napi/parser/src/generated/assert_layouts.rs
@@ -10,20 +10,20 @@ use crate::raw_transfer_types::*;
 #[cfg(target_pointer_width = "64")]
 const _: () = {
     // Padding: 0 bytes
-    assert!(size_of::<RawTransferData>() == 360);
+    assert!(size_of::<RawTransferData>() == 288);
     assert!(align_of::<RawTransferData>() == 8);
     assert!(offset_of!(RawTransferData, program) == 0);
-    assert!(offset_of!(RawTransferData, comments) == 160);
-    assert!(offset_of!(RawTransferData, module) == 192);
-    assert!(offset_of!(RawTransferData, errors) == 328);
+    assert!(offset_of!(RawTransferData, comments) == 136);
+    assert!(offset_of!(RawTransferData, module) == 160);
+    assert!(offset_of!(RawTransferData, errors) == 264);
 
     // Padding: 7 bytes
-    assert!(size_of::<Error>() == 72);
+    assert!(size_of::<Error>() == 64);
     assert!(align_of::<Error>() == 8);
     assert!(offset_of!(Error, severity) == 0);
     assert!(offset_of!(Error, message) == 8);
     assert!(offset_of!(Error, labels) == 24);
-    assert!(offset_of!(Error, help_message) == 56);
+    assert!(offset_of!(Error, help_message) == 48);
 
     assert!(size_of::<ErrorSeverity>() == 1);
     assert!(align_of::<ErrorSeverity>() == 1);
@@ -35,23 +35,23 @@ const _: () = {
     assert!(offset_of!(ErrorLabel, span) == 16);
 
     // Padding: 7 bytes
-    assert!(size_of::<EcmaScriptModule>() == 136);
+    assert!(size_of::<EcmaScriptModule>() == 104);
     assert!(align_of::<EcmaScriptModule>() == 8);
     assert!(offset_of!(EcmaScriptModule, has_module_syntax) == 0);
     assert!(offset_of!(EcmaScriptModule, static_imports) == 8);
-    assert!(offset_of!(EcmaScriptModule, static_exports) == 40);
-    assert!(offset_of!(EcmaScriptModule, dynamic_imports) == 72);
-    assert!(offset_of!(EcmaScriptModule, import_metas) == 104);
+    assert!(offset_of!(EcmaScriptModule, static_exports) == 32);
+    assert!(offset_of!(EcmaScriptModule, dynamic_imports) == 56);
+    assert!(offset_of!(EcmaScriptModule, import_metas) == 80);
 
     // Padding: 0 bytes
-    assert!(size_of::<StaticImport>() == 64);
+    assert!(size_of::<StaticImport>() == 56);
     assert!(align_of::<StaticImport>() == 8);
     assert!(offset_of!(StaticImport, span) == 0);
     assert!(offset_of!(StaticImport, module_request) == 8);
     assert!(offset_of!(StaticImport, entries) == 32);
 
     // Padding: 0 bytes
-    assert!(size_of::<StaticExport>() == 40);
+    assert!(size_of::<StaticExport>() == 32);
     assert!(align_of::<StaticExport>() == 8);
     assert!(offset_of!(StaticExport, span) == 0);
     assert!(offset_of!(StaticExport, entries) == 8);

--- a/tasks/ast_tools/src/generators/assert_layouts.rs
+++ b/tasks/ast_tools/src/generators/assert_layouts.rs
@@ -301,7 +301,7 @@ fn calculate_layout_for_box() -> Layout {
 /// They have a single niche on the first field - the pointer which is `NonNull`.
 fn calculate_layout_for_vec() -> Layout {
     Layout {
-        layout_64: PlatformLayout::from_size_align_niche(32, 8, Niche::new(0, 8, 1, 0)),
+        layout_64: PlatformLayout::from_size_align_niche(24, 8, Niche::new(0, 8, 1, 0)),
         layout_32: PlatformLayout::from_size_align_niche(16, 4, Niche::new(0, 4, 1, 0)),
     }
 }

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -27,7 +27,7 @@ use super::define_generator;
 // Offsets of `Vec`'s fields.
 // `Vec` is `#[repr(transparent)]` and `RawVec` is `#[repr(C)]`, so these offsets are fixed.
 const VEC_PTR_FIELD_OFFSET: usize = 0;
-const VEC_LEN_FIELD_OFFSET: usize = 24;
+const VEC_LEN_FIELD_OFFSET: usize = 20;
 
 /// Generator for raw transfer deserializer.
 pub struct RawTransferGenerator;


### PR DESCRIPTION
Related: 
* #6488 
* #9706

Finished first step(32 -> 24) of #9706.

Change `len` and `cap` fields from `usize` to `u32`, so that the `Vec` size can reduced size to `24`. Also, to avoid some unnecessary unit conversion. I changed many `RawVec` methods to take `u32` rather than `usize`.

The performance looks great now! And we reduced 1%-3% memory usage in the parser.