### PR TITLE
test(ast/estree): check span offsets are converted in ascending order in ESTree conformance tests

### DIFF
--- a/crates/oxc/Cargo.toml
+++ b/crates/oxc/Cargo.toml
@@ -77,5 +77,8 @@ serialize = [
   "oxc_syntax/serialize",
 ]
 
+# Only for conformance tests
+conformance = ["oxc_ast_visit/conformance"]
+
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/oxc_ast_visit/Cargo.toml
+++ b/crates/oxc_ast_visit/Cargo.toml
@@ -32,3 +32,5 @@ serialize = [
   "oxc_span/serialize",
   "oxc_syntax/serialize",
 ]
+# Only for conformance tests
+conformance = []

--- a/crates/oxc_ast_visit/src/utf8_to_utf16.rs
+++ b/crates/oxc_ast_visit/src/utf8_to_utf16.rs
@@ -8,7 +8,7 @@ use oxc_syntax::module_record::{ModuleRecord, VisitMutModuleRecord};
 
 use crate::VisitMut;
 
-/// Convert UTF-8 span offsets to UTF-16.
+/// Conversion table of UTF-8 span offsets to UTF-16.
 pub struct Utf8ToUtf16 {
     translations: Vec<Translation>,
 }
@@ -40,7 +40,13 @@ impl Utf8ToUtf16 {
         // Remove the dummy entry.
         // Therefore, `translations` always has at least 2 entries, if it has any.
         if translations.len() == 1 {
-            translations.clear();
+            // In conformance tests, force offset conversion to happen on all inputs,
+            // even if they are pure ASCII
+            if cfg!(feature = "conformance") {
+                translations.push(Translation { utf8_offset: u32::MAX, utf16_difference: 0 });
+            } else {
+                translations.clear();
+            }
         }
 
         Self { translations }
@@ -58,7 +64,7 @@ impl Utf8ToUtf16 {
         } else {
             // SAFETY: `translations` contains at least 2 entries if it's not empty.
             // We just checked it's not empty.
-            Some(unsafe { Utf8ToUtf16Converter::new(&self.translations) })
+            Some(unsafe { Utf8ToUtf16Converter::new(&self.translations, false) })
         }
     }
 
@@ -67,6 +73,30 @@ impl Utf8ToUtf16 {
         if let Some(mut converter) = self.converter() {
             converter.visit_program(program);
         }
+    }
+
+    /// Convert all spans in AST to UTF-16.
+    ///
+    /// Additionally, checks that conversion of offsets during traversal via [`Utf8ToUtf16Converter`]
+    /// happens in ascending order of offset. Panics if it doesn't.
+    ///
+    /// This results in the fastest conversion, and [`Utf8ToUtf16Converter`] is designed to ensure that
+    /// [`Utf8ToUtf16Converter::convert_offset`] is called with offsets strictly in ascending order.
+    /// This should always be the case when the AST has come direct from parser.
+    /// It might well not be the case in an AST which has been modified, e.g. by transformer or minifier.
+    ///
+    /// This method is for use only in conformance tests, and requires `conformance` Cargo feature.
+    ///
+    /// # Panics
+    ///
+    /// Panics if offsets are converted out of order.
+    #[cfg(feature = "conformance")]
+    pub fn convert_program_with_ascending_order_checks(&self, program: &mut Program<'_>) {
+        assert!(self.translations.len() >= 2);
+
+        // SAFETY: We just checked `translations` contains at least 2 entries
+        let mut converter = unsafe { Utf8ToUtf16Converter::new(&self.translations, true) };
+        converter.visit_program(program);
     }
 
     /// Convert all spans in comments to UTF-16.
@@ -126,6 +156,14 @@ pub struct Utf8ToUtf16Converter<'t> {
     range_start_utf16: u32,
     /// Index of current `Translation`
     index: u32,
+    /// Previous UTF-8 offset which [`Utf8ToUtf16Converter::convert_offset`] was called with.
+    /// Only used in conformance tests.
+    #[cfg(feature = "conformance")]
+    previous_offset_utf8: u32,
+    /// `true` if offsets will be converted in ascending order.
+    /// Only used in conformance tests.
+    #[cfg(feature = "conformance")]
+    ascending_order: bool,
 }
 
 impl<'t> Utf8ToUtf16Converter<'t> {
@@ -133,13 +171,24 @@ impl<'t> Utf8ToUtf16Converter<'t> {
     ///
     /// # SAFETY
     /// `translations` must contain at least 2 entries.
-    unsafe fn new(translations: &'t [Translation]) -> Self {
+    #[cfg_attr(not(feature = "conformance"), expect(unused_variables))]
+    unsafe fn new(translations: &'t [Translation], ascending_order: bool) -> Self {
         debug_assert!(translations.len() >= 2);
 
         // SAFETY: Caller guarantees `translations` contains at least 2 entries
         let range_len_utf8 = unsafe { translations.get_unchecked(1) }.utf8_offset;
 
-        Self { translations, range_start_utf8: 0, range_start_utf16: 0, range_len_utf8, index: 0 }
+        Self {
+            translations,
+            range_start_utf8: 0,
+            range_start_utf16: 0,
+            range_len_utf8,
+            index: 0,
+            #[cfg(feature = "conformance")]
+            previous_offset_utf8: 0,
+            #[cfg(feature = "conformance")]
+            ascending_order,
+        }
     }
 
     /// Reset this [`Utf8ToUtf16Converter`] to starting position.
@@ -151,11 +200,21 @@ impl<'t> Utf8ToUtf16Converter<'t> {
         // SAFETY: Caller guaranteed `translations` contains at least 2 entries in `new`
         self.range_len_utf8 = unsafe { self.translations.get_unchecked(1) }.utf8_offset;
         self.index = 0;
+
+        #[cfg(feature = "conformance")]
+        {
+            self.previous_offset_utf8 = 0;
+        }
     }
 
     /// Convert UTF-8 offset to UTF-16.
     ///
     /// Conversion is faster if `convert_offset` is called with offsets in ascending order.
+    ///
+    /// # Panics
+    /// Panics if `offset` is less than previous offset `convert_offset` was called with,
+    /// `conformance` Cargo features is enabled, and `Utf8ToUtf16Converter` was created with
+    /// `ascending_order: true`.
     //
     // This method is optimized for the offset being within the current range.
     // This will be the case if `convert_offset` is called with offsets in ascending order,
@@ -170,6 +229,12 @@ impl<'t> Utf8ToUtf16Converter<'t> {
     #[inline(always)]
     pub fn convert_offset(&mut self, offset: &mut u32) {
         let utf8_offset = *offset;
+
+        #[cfg(feature = "conformance")]
+        if self.ascending_order {
+            assert!(utf8_offset >= self.previous_offset_utf8);
+            self.previous_offset_utf8 = utf8_offset;
+        }
 
         // When AST has been modified, it may contain unspanned AST nodes.
         // Offset 0 always translates to 0.
@@ -202,6 +267,11 @@ impl<'t> Utf8ToUtf16Converter<'t> {
         // Find the range containing this offset
         let utf8_offset = *offset;
         let (next_index, range_end_utf8) = if utf8_offset < self.range_start_utf8 {
+            #[cfg(feature = "conformance")]
+            {
+                assert!(!self.ascending_order);
+            }
+
             self.find_range_before(utf8_offset)
         } else {
             self.find_range_after(utf8_offset)

--- a/tasks/coverage/Cargo.toml
+++ b/tasks/coverage/Cargo.toml
@@ -22,7 +22,7 @@ test = false
 doctest = false
 
 [dependencies]
-oxc = { workspace = true, features = ["full", "isolated_declarations", "serialize"] }
+oxc = { workspace = true, features = ["full", "isolated_declarations", "serialize", "conformance"] }
 oxc_formatter = { workspace = true }
 oxc_tasks_common = { workspace = true }
 oxc_tasks_transform_checker = { workspace = true }

--- a/tasks/coverage/src/tools/estree.rs
+++ b/tasks/coverage/src/tools/estree.rs
@@ -106,7 +106,7 @@ impl Case for EstreeTest262Case {
         }
 
         // Convert spans to UTF16
-        Utf8ToUtf16::new(source_text).convert_program(&mut program);
+        Utf8ToUtf16::new(source_text).convert_program_with_ascending_order_checks(&mut program);
 
         let acorn_json = match fs::read_to_string(&self.acorn_json_path) {
             Ok(acorn_json) => acorn_json,
@@ -218,7 +218,7 @@ impl Case for EstreeJsxCase {
         }
 
         // Convert spans to UTF16
-        Utf8ToUtf16::new(source_text).convert_program(&mut program);
+        Utf8ToUtf16::new(source_text).convert_program_with_ascending_order_checks(&mut program);
 
         let acorn_json_path = workspace_root().join(self.path.with_extension("json"));
         let acorn_json = match fs::read_to_string(&acorn_json_path) {
@@ -373,7 +373,7 @@ impl Case for EstreeTypescriptCase {
             }
 
             let mut program = ret.program;
-            Utf8ToUtf16::new(source_text).convert_program(&mut program);
+            Utf8ToUtf16::new(source_text).convert_program_with_ascending_order_checks(&mut program);
 
             let oxc_json = program.to_pretty_estree_ts_json();
 


### PR DESCRIPTION
Add a Cargo feature `conformance` to `oxc_ast_visit` crate.

When this feature is enabled, it exposes a method `Utf8ToUtf16::convert_program_with_ascending_order_checks` which panics if span offsets are converted out of order.

Use this feature and method in ESTree conformance tests. This ensures:

1. `Utf8ToUtf16Converter` visitor is functioning as intended.
2. All AST types have their fields ordered in order they appear in source code.
