### PR TITLE
fix(allocator): `Allocator::from_raw_parts` do not use const assertion for endianness test

### DIFF
--- a/crates/oxc_allocator/src/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/from_raw_parts.rs
@@ -54,15 +54,15 @@ impl Allocator {
     ///
     /// # Panics
     ///
-    /// Panics if cannot determine layout of Bumpalo's `Bump` type.
+    /// Panics if cannot determine layout of Bumpalo's `Bump` type, or on a big endian system.
     ///
     /// [`RAW_MIN_ALIGN`]: Self::RAW_MIN_ALIGN
     /// [`RAW_MIN_SIZE`]: Self::RAW_MIN_SIZE
     pub unsafe fn from_raw_parts(ptr: NonNull<u8>, size: usize) -> Self {
         // Only support little-endian systems.
         // Calculating offset of `current_chunk_footer` on big-endian systems would be difficult.
-        #[cfg(target_endian = "big")]
-        const {
+        #[expect(clippy::manual_assert)]
+        if cfg!(target_endian = "big") {
             panic!("`Allocator::from_raw_parts` is not supported on big-endian systems.");
         }
 


### PR DESCRIPTION
Currently we panic at compile time if attempt to compile `oxc_allocator` with `from_raw_parts` feature enabled on a big-endian system. Instead, panic at runtime.

This will allow `napi/parser` to be built on big endian systems.

The panic will still be optimized out on little-endian systems, and `napi/parser` will not use raw transfer on big endian, so `Allocator::from_raw_parts` won't be called, so this panic should never occur. But the check ensures the soundness of `Allocator::from_raw_parts`.
