### PR TITLE
docs(ast): fix docs for `ExportSpecifier`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -2590,12 +2590,16 @@ pub struct ExportAllDeclaration<'a> {
 ///
 /// Each [`ExportSpecifier`] is one of the named exports in an [`ExportNamedDeclaration`].
 ///
+/// Note: `export_kind` relates to whether this specific `ExportSpecifier` is preceded by `type` keyword.
+/// If the whole `ExportNamedDeclaration` has a `type` prefix, its `ExportSpecifier`s will still have
+/// `export_kind: ImportOrExportKind::Value`. e.g. in this case: `export type { Foo, Bar }`.
+///
 /// ## Example
 ///
 /// ```ts
 /// //       ____ export_kind
-/// import { type Foo as Bar } from './foo';
-/// //   exported ^^^    ^^^ local
+/// export { type Foo as Bar };
+/// //      local ^^^    ^^^ exported
 /// ```
 #[ast(visit)]
 #[derive(Debug)]
@@ -2605,7 +2609,7 @@ pub struct ExportSpecifier<'a> {
     pub local: ModuleExportName<'a>,
     pub exported: ModuleExportName<'a>,
     #[ts]
-    pub export_kind: ImportOrExportKind, // `export type *`
+    pub export_kind: ImportOrExportKind, // `export { type Foo as Bar };`
 }
 
 inherit_variants! {


### PR DESCRIPTION
The code examples were incorrect previously.