### PR TITLE
fix(ast)!: fix field order for `NewExpression`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -621,10 +621,10 @@ pub struct CallExpression<'a> {
 pub struct NewExpression<'a> {
     pub span: Span,
     pub callee: Expression<'a>,
-    pub arguments: Vec<'a, Argument<'a>>,
     #[ts]
     pub type_arguments: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
     /// `true` if the new expression is marked with a `/* @__PURE__ */` comment
+    pub arguments: Vec<'a, Argument<'a>>,
     #[builder(default)]
     #[estree(skip)]
     pub pure: bool,

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -147,8 +147,8 @@ const _: () = {
     assert!(align_of::<NewExpression>() == 8);
     assert!(offset_of!(NewExpression, span) == 0);
     assert!(offset_of!(NewExpression, callee) == 8);
-    assert!(offset_of!(NewExpression, arguments) == 24);
-    assert!(offset_of!(NewExpression, type_arguments) == 56);
+    assert!(offset_of!(NewExpression, type_arguments) == 24);
+    assert!(offset_of!(NewExpression, arguments) == 32);
     assert!(offset_of!(NewExpression, pure) == 64);
 
     assert!(size_of::<MetaProperty>() == 56);
@@ -1542,8 +1542,8 @@ const _: () = {
     assert!(align_of::<NewExpression>() == 4);
     assert!(offset_of!(NewExpression, span) == 0);
     assert!(offset_of!(NewExpression, callee) == 8);
-    assert!(offset_of!(NewExpression, arguments) == 16);
-    assert!(offset_of!(NewExpression, type_arguments) == 32);
+    assert!(offset_of!(NewExpression, type_arguments) == 16);
+    assert!(offset_of!(NewExpression, arguments) == 20);
     assert!(offset_of!(NewExpression, pure) == 36);
 
     assert!(size_of::<MetaProperty>() == 40);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -827,15 +827,15 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
-    /// * `arguments`
     /// * `type_arguments`
+    /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[inline]
     pub fn expression_new<T1>(
         self,
         span: Span,
         callee: Expression<'a>,
-        arguments: Vec<'a, Argument<'a>>,
         type_arguments: T1,
+        arguments: Vec<'a, Argument<'a>>,
     ) -> Expression<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
@@ -843,8 +843,8 @@ impl<'a> AstBuilder<'a> {
         Expression::NewExpression(self.alloc_new_expression(
             span,
             callee,
-            arguments,
             type_arguments,
+            arguments,
         ))
     }
 
@@ -855,16 +855,16 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
-    /// * `arguments`
     /// * `type_arguments`
-    /// * `pure`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
+    /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
+    /// * `pure`
     #[inline]
     pub fn expression_new_with_pure<T1>(
         self,
         span: Span,
         callee: Expression<'a>,
-        arguments: Vec<'a, Argument<'a>>,
         type_arguments: T1,
+        arguments: Vec<'a, Argument<'a>>,
         pure: bool,
     ) -> Expression<'a>
     where
@@ -873,8 +873,8 @@ impl<'a> AstBuilder<'a> {
         Expression::NewExpression(self.alloc_new_expression_with_pure(
             span,
             callee,
-            arguments,
             type_arguments,
+            arguments,
             pure,
         ))
     }
@@ -2133,15 +2133,15 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
-    /// * `arguments`
     /// * `type_arguments`
+    /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[inline]
     pub fn new_expression<T1>(
         self,
         span: Span,
         callee: Expression<'a>,
-        arguments: Vec<'a, Argument<'a>>,
         type_arguments: T1,
+        arguments: Vec<'a, Argument<'a>>,
     ) -> NewExpression<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
@@ -2149,8 +2149,8 @@ impl<'a> AstBuilder<'a> {
         NewExpression {
             span,
             callee,
-            arguments,
             type_arguments: type_arguments.into_in(self.allocator),
+            arguments,
             pure: Default::default(),
         }
     }
@@ -2163,20 +2163,20 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
-    /// * `arguments`
     /// * `type_arguments`
+    /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[inline]
     pub fn alloc_new_expression<T1>(
         self,
         span: Span,
         callee: Expression<'a>,
-        arguments: Vec<'a, Argument<'a>>,
         type_arguments: T1,
+        arguments: Vec<'a, Argument<'a>>,
     ) -> Box<'a, NewExpression<'a>>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        Box::new_in(self.new_expression(span, callee, arguments, type_arguments), self.allocator)
+        Box::new_in(self.new_expression(span, callee, type_arguments, arguments), self.allocator)
     }
 
     /// Build a [`NewExpression`] with `pure`.
@@ -2187,16 +2187,16 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
-    /// * `arguments`
     /// * `type_arguments`
-    /// * `pure`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
+    /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
+    /// * `pure`
     #[inline]
     pub fn new_expression_with_pure<T1>(
         self,
         span: Span,
         callee: Expression<'a>,
-        arguments: Vec<'a, Argument<'a>>,
         type_arguments: T1,
+        arguments: Vec<'a, Argument<'a>>,
         pure: bool,
     ) -> NewExpression<'a>
     where
@@ -2205,8 +2205,8 @@ impl<'a> AstBuilder<'a> {
         NewExpression {
             span,
             callee,
-            arguments,
             type_arguments: type_arguments.into_in(self.allocator),
+            arguments,
             pure,
         }
     }
@@ -2219,23 +2219,23 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
-    /// * `arguments`
     /// * `type_arguments`
-    /// * `pure`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
+    /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
+    /// * `pure`
     #[inline]
     pub fn alloc_new_expression_with_pure<T1>(
         self,
         span: Span,
         callee: Expression<'a>,
-        arguments: Vec<'a, Argument<'a>>,
         type_arguments: T1,
+        arguments: Vec<'a, Argument<'a>>,
         pure: bool,
     ) -> Box<'a, NewExpression<'a>>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         Box::new_in(
-            self.new_expression_with_pure(span, callee, arguments, type_arguments, pure),
+            self.new_expression_with_pure(span, callee, type_arguments, arguments, pure),
             self.allocator,
         )
     }

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -1256,8 +1256,8 @@ impl<'new_alloc> CloneIn<'new_alloc> for NewExpression<'_> {
         NewExpression {
             span: CloneIn::clone_in(&self.span, allocator),
             callee: CloneIn::clone_in(&self.callee, allocator),
-            arguments: CloneIn::clone_in(&self.arguments, allocator),
             type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
+            arguments: CloneIn::clone_in(&self.arguments, allocator),
             pure: CloneIn::clone_in(&self.pure, allocator),
         }
     }
@@ -1266,8 +1266,8 @@ impl<'new_alloc> CloneIn<'new_alloc> for NewExpression<'_> {
         NewExpression {
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             callee: CloneIn::clone_in_with_semantic_ids(&self.callee, allocator),
-            arguments: CloneIn::clone_in_with_semantic_ids(&self.arguments, allocator),
             type_arguments: CloneIn::clone_in_with_semantic_ids(&self.type_arguments, allocator),
+            arguments: CloneIn::clone_in_with_semantic_ids(&self.arguments, allocator),
             pure: CloneIn::clone_in_with_semantic_ids(&self.pure, allocator),
         }
     }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -352,8 +352,8 @@ impl ContentEq for CallExpression<'_> {
 impl ContentEq for NewExpression<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.callee, &other.callee)
-            && ContentEq::content_eq(&self.arguments, &other.arguments)
             && ContentEq::content_eq(&self.type_arguments, &other.type_arguments)
+            && ContentEq::content_eq(&self.arguments, &other.arguments)
             && ContentEq::content_eq(&self.pure, &other.pure)
     }
 }

--- a/crates/oxc_ast/src/generated/derive_dummy.rs
+++ b/crates/oxc_ast/src/generated/derive_dummy.rs
@@ -296,8 +296,8 @@ impl<'a> Dummy<'a> for NewExpression<'a> {
         Self {
             span: Dummy::dummy(allocator),
             callee: Dummy::dummy(allocator),
-            arguments: Dummy::dummy(allocator),
             type_arguments: Dummy::dummy(allocator),
+            arguments: Dummy::dummy(allocator),
             pure: Dummy::dummy(allocator),
         }
     }

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -1637,10 +1637,10 @@ pub mod walk {
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.callee);
-        visitor.visit_arguments(&it.arguments);
         if let Some(type_arguments) = &it.type_arguments {
             visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
+        visitor.visit_arguments(&it.arguments);
         visitor.leave_node(kind);
     }
 

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -1653,10 +1653,10 @@ pub mod walk_mut {
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.callee);
-        visitor.visit_arguments(&mut it.arguments);
         if let Some(type_arguments) = &mut it.type_arguments {
             visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
+        visitor.visit_arguments(&mut it.arguments);
         visitor.leave_node(kind);
     }
 

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -902,7 +902,7 @@ impl<'a> ParserImpl<'a> {
             self.error(diagnostics::new_optional_chain(span));
         }
 
-        self.ast.expression_new(span, callee, arguments, type_arguments)
+        self.ast.expression_new(span, callee, type_arguments, arguments)
     }
 
     /// Section 13.3 Call Expression

--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -869,12 +869,12 @@ fn create_new_weakmap<'a>(
     let symbol_id = *symbol_id
         .get_or_insert_with(|| ctx.scoping().find_binding(ctx.current_scope_id(), "WeakMap"));
     let ident = ctx.create_ident_expr(SPAN, Atom::from("WeakMap"), symbol_id, ReferenceFlags::Read);
-    ctx.ast.expression_new_with_pure(SPAN, ident, ctx.ast.vec(), NONE, true)
+    ctx.ast.expression_new_with_pure(SPAN, ident, NONE, ctx.ast.vec(), true)
 }
 
 /// Create `new WeakSet()` expression.
 fn create_new_weakset<'a>(ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
     let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), "WeakSet");
     let ident = ctx.create_ident_expr(SPAN, Atom::from("WeakSet"), symbol_id, ReferenceFlags::Read);
-    ctx.ast.expression_new_with_pure(SPAN, ident, ctx.ast.vec(), NONE, true)
+    ctx.ast.expression_new_with_pure(SPAN, ident, NONE, ctx.ast.vec(), true)
 }

--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -187,7 +187,7 @@ impl<'a> RegExp<'a, '_> {
             )),
         ]);
 
-        *expr = ctx.ast.expression_new(regexp.span, callee, arguments, NONE);
+        *expr = ctx.ast.expression_new(regexp.span, callee, NONE, arguments);
     }
 
     /// Check if the regular expression contains any unsupported syntax.

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -43,8 +43,8 @@ pub(crate) enum AncestorType {
     CallExpressionTypeArguments = 20,
     CallExpressionArguments = 21,
     NewExpressionCallee = 22,
-    NewExpressionArguments = 23,
-    NewExpressionTypeArguments = 24,
+    NewExpressionTypeArguments = 23,
+    NewExpressionArguments = 24,
     MetaPropertyMeta = 25,
     MetaPropertyProperty = 26,
     SpreadElementArgument = 27,
@@ -379,10 +379,10 @@ pub enum Ancestor<'a, 't> {
         AncestorType::CallExpressionArguments as u16,
     NewExpressionCallee(NewExpressionWithoutCallee<'a, 't>) =
         AncestorType::NewExpressionCallee as u16,
-    NewExpressionArguments(NewExpressionWithoutArguments<'a, 't>) =
-        AncestorType::NewExpressionArguments as u16,
     NewExpressionTypeArguments(NewExpressionWithoutTypeArguments<'a, 't>) =
         AncestorType::NewExpressionTypeArguments as u16,
+    NewExpressionArguments(NewExpressionWithoutArguments<'a, 't>) =
+        AncestorType::NewExpressionArguments as u16,
     MetaPropertyMeta(MetaPropertyWithoutMeta<'a, 't>) = AncestorType::MetaPropertyMeta as u16,
     MetaPropertyProperty(MetaPropertyWithoutProperty<'a, 't>) =
         AncestorType::MetaPropertyProperty as u16,
@@ -960,8 +960,8 @@ impl<'a, 't> Ancestor<'a, 't> {
         matches!(
             self,
             Self::NewExpressionCallee(_)
-                | Self::NewExpressionArguments(_)
                 | Self::NewExpressionTypeArguments(_)
+                | Self::NewExpressionArguments(_)
         )
     }
 
@@ -2220,8 +2220,8 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::CallExpressionTypeArguments(a) => a.address(),
             Self::CallExpressionArguments(a) => a.address(),
             Self::NewExpressionCallee(a) => a.address(),
-            Self::NewExpressionArguments(a) => a.address(),
             Self::NewExpressionTypeArguments(a) => a.address(),
+            Self::NewExpressionArguments(a) => a.address(),
             Self::MetaPropertyMeta(a) => a.address(),
             Self::MetaPropertyProperty(a) => a.address(),
             Self::SpreadElementArgument(a) => a.address(),
@@ -3424,9 +3424,9 @@ impl<'a, 't> GetAddress for CallExpressionWithoutArguments<'a, 't> {
 
 pub(crate) const OFFSET_NEW_EXPRESSION_SPAN: usize = offset_of!(NewExpression, span);
 pub(crate) const OFFSET_NEW_EXPRESSION_CALLEE: usize = offset_of!(NewExpression, callee);
-pub(crate) const OFFSET_NEW_EXPRESSION_ARGUMENTS: usize = offset_of!(NewExpression, arguments);
 pub(crate) const OFFSET_NEW_EXPRESSION_TYPE_ARGUMENTS: usize =
     offset_of!(NewExpression, type_arguments);
+pub(crate) const OFFSET_NEW_EXPRESSION_ARGUMENTS: usize = offset_of!(NewExpression, arguments);
 pub(crate) const OFFSET_NEW_EXPRESSION_PURE: usize = offset_of!(NewExpression, pure);
 
 #[repr(transparent)]
@@ -3443,18 +3443,18 @@ impl<'a, 't> NewExpressionWithoutCallee<'a, 't> {
     }
 
     #[inline]
-    pub fn arguments(self) -> &'t Vec<'a, Argument<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_ARGUMENTS)
-                as *const Vec<'a, Argument<'a>>)
-        }
-    }
-
-    #[inline]
     pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_TYPE_ARGUMENTS)
                 as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn arguments(self) -> &'t Vec<'a, Argument<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_ARGUMENTS)
+                as *const Vec<'a, Argument<'a>>)
         }
     }
 
@@ -3465,47 +3465,6 @@ impl<'a, 't> NewExpressionWithoutCallee<'a, 't> {
 }
 
 impl<'a, 't> GetAddress for NewExpressionWithoutCallee<'a, 't> {
-    #[inline]
-    fn address(&self) -> Address {
-        Address::from_ptr(self.0)
-    }
-}
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct NewExpressionWithoutArguments<'a, 't>(
-    pub(crate) *const NewExpression<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> NewExpressionWithoutArguments<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn callee(self) -> &'t Expression<'a> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_CALLEE) as *const Expression<'a>)
-        }
-    }
-
-    #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
-        }
-    }
-
-    #[inline]
-    pub fn pure(self) -> &'t bool {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_PURE) as *const bool) }
-    }
-}
-
-impl<'a, 't> GetAddress for NewExpressionWithoutArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)
@@ -3547,6 +3506,47 @@ impl<'a, 't> NewExpressionWithoutTypeArguments<'a, 't> {
 }
 
 impl<'a, 't> GetAddress for NewExpressionWithoutTypeArguments<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
+pub struct NewExpressionWithoutArguments<'a, 't>(
+    pub(crate) *const NewExpression<'a>,
+    pub(crate) PhantomData<&'t ()>,
+);
+
+impl<'a, 't> NewExpressionWithoutArguments<'a, 't> {
+    #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_SPAN) as *const Span) }
+    }
+
+    #[inline]
+    pub fn callee(self) -> &'t Expression<'a> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_CALLEE) as *const Expression<'a>)
+        }
+    }
+
+    #[inline]
+    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_TYPE_ARGUMENTS)
+                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn pure(self) -> &'t bool {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_PURE) as *const bool) }
+    }
+}
+
+impl<'a, 't> GetAddress for NewExpressionWithoutArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)

--- a/crates/oxc_traverse/src/generated/scopes_collector.rs
+++ b/crates/oxc_traverse/src/generated/scopes_collector.rs
@@ -324,10 +324,10 @@ impl<'a> Visit<'a> for ChildScopeCollector {
     #[inline]
     fn visit_new_expression(&mut self, it: &NewExpression<'a>) {
         self.visit_expression(&it.callee);
-        self.visit_arguments(&it.arguments);
         if let Some(type_arguments) = &it.type_arguments {
             self.visit_ts_type_parameter_instantiation(type_arguments);
         }
+        self.visit_arguments(&it.arguments);
     }
 
     #[inline(always)]

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -663,18 +663,18 @@ unsafe fn walk_new_expression<'a, Tr: Traverse<'a>>(
         (node as *mut u8).add(ancestor::OFFSET_NEW_EXPRESSION_CALLEE) as *mut Expression,
         ctx,
     );
-    ctx.retag_stack(AncestorType::NewExpressionArguments);
-    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_NEW_EXPRESSION_ARGUMENTS)
-        as *mut Vec<Argument>)
-    {
-        walk_argument(traverser, item as *mut _, ctx);
-    }
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_NEW_EXPRESSION_TYPE_ARGUMENTS)
         as *mut Option<Box<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::NewExpressionTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::NewExpressionArguments);
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_NEW_EXPRESSION_ARGUMENTS)
+        as *mut Vec<Argument>)
+    {
+        walk_argument(traverser, item as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_new_expression(&mut *node, ctx);

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -224,7 +224,7 @@ function deserializeNewExpression(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     callee: deserializeExpression(pos + 8),
-    arguments: deserializeVecArgument(pos + 24),
+    arguments: deserializeVecArgument(pos + 32),
   };
 }
 

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -255,8 +255,8 @@ function deserializeNewExpression(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     callee: deserializeExpression(pos + 8),
-    arguments: deserializeVecArgument(pos + 24),
-    typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 56),
+    arguments: deserializeVecArgument(pos + 32),
+    typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
   };
 }
 

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -16788,7 +16788,7 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(10)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7)]
 Symbol reference IDs mismatch for "ConcreteClass":
-after transform: SymbolId(8): [ReferenceId(8), ReferenceId(11), ReferenceId(13)]
+after transform: SymbolId(8): [ReferenceId(8), ReferenceId(11), ReferenceId(12)]
 rebuilt        : SymbolId(4): [ReferenceId(4), ReferenceId(7)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/inferenceErasedSignatures.ts


### PR DESCRIPTION
Fix field order for `NewExpression`. Move `type_arguments` to before `arguments`, because they come first in source:

```tsx
const foo = new Foo<T>(1, 2, 3);
```
