### PR TITLE
fix(linter): false positive with `withResolvers` in prefer-await-to-then

### DIFF
--- a/crates/oxc_linter/src/rules/promise/prefer_await_to_then.rs
+++ b/crates/oxc_linter/src/rules/promise/prefer_await_to_then.rs
@@ -78,7 +78,7 @@ impl Rule for PreferAwaitToThen {
             return;
         };
 
-        if is_promise(call_expr).is_none() {
+        if is_promise(call_expr).is_none_or(|v| v == "withResolvers") {
             return;
         }
 
@@ -137,6 +137,7 @@ fn test() {
             "async function hi() { await thing().then() }",
             Some(serde_json::json!({ "strict": false })),
         ),
+        ("const { promise, resolve } = Promise.withResolvers()", None),
     ];
 
     let fail = vec![


### PR DESCRIPTION
fixes #10895