### PR TITLE
fix(ast)!: fix field order for `TSNamedTupleMember`

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -490,7 +490,8 @@ pub struct TSTupleType<'a> {
 /// ## Example
 /// ```ts
 /// type Foo = [first: string, second: number];
-/// //          ^^^^^^^^^^^^^
+/// //          ^^^^^^^^^^^^^ TSNamedTupleMember
+/// //    label ^^^^^  ^^^^^^ element_type
 /// ```
 ///
 /// ## Reference
@@ -500,8 +501,8 @@ pub struct TSTupleType<'a> {
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSNamedTupleMember<'a> {
     pub span: Span,
-    pub element_type: TSTupleElement<'a>,
     pub label: IdentifierName<'a>,
+    pub element_type: TSTupleElement<'a>,
     pub optional: bool,
 }
 

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -1002,8 +1002,8 @@ const _: () = {
     assert!(size_of::<TSNamedTupleMember>() == 56);
     assert!(align_of::<TSNamedTupleMember>() == 8);
     assert!(offset_of!(TSNamedTupleMember, span) == 0);
-    assert!(offset_of!(TSNamedTupleMember, element_type) == 8);
-    assert!(offset_of!(TSNamedTupleMember, label) == 24);
+    assert!(offset_of!(TSNamedTupleMember, label) == 8);
+    assert!(offset_of!(TSNamedTupleMember, element_type) == 32);
     assert!(offset_of!(TSNamedTupleMember, optional) == 48);
 
     assert!(size_of::<TSOptionalType>() == 24);
@@ -2397,8 +2397,8 @@ const _: () = {
     assert!(size_of::<TSNamedTupleMember>() == 36);
     assert!(align_of::<TSNamedTupleMember>() == 4);
     assert!(offset_of!(TSNamedTupleMember, span) == 0);
-    assert!(offset_of!(TSNamedTupleMember, element_type) == 8);
-    assert!(offset_of!(TSNamedTupleMember, label) == 16);
+    assert!(offset_of!(TSNamedTupleMember, label) == 8);
+    assert!(offset_of!(TSNamedTupleMember, element_type) == 24);
     assert!(offset_of!(TSNamedTupleMember, optional) == 32);
 
     assert!(size_of::<TSOptionalType>() == 16);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -10563,21 +10563,21 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `element_type`
     /// * `label`
+    /// * `element_type`
     /// * `optional`
     #[inline]
     pub fn ts_type_named_tuple_member(
         self,
         span: Span,
-        element_type: TSTupleElement<'a>,
         label: IdentifierName<'a>,
+        element_type: TSTupleElement<'a>,
         optional: bool,
     ) -> TSType<'a> {
         TSType::TSNamedTupleMember(self.alloc_ts_named_tuple_member(
             span,
-            element_type,
             label,
+            element_type,
             optional,
         ))
     }
@@ -11170,18 +11170,18 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `element_type`
     /// * `label`
+    /// * `element_type`
     /// * `optional`
     #[inline]
     pub fn ts_named_tuple_member(
         self,
         span: Span,
-        element_type: TSTupleElement<'a>,
         label: IdentifierName<'a>,
+        element_type: TSTupleElement<'a>,
         optional: bool,
     ) -> TSNamedTupleMember<'a> {
-        TSNamedTupleMember { span, element_type, label, optional }
+        TSNamedTupleMember { span, label, element_type, optional }
     }
 
     /// Build a [`TSNamedTupleMember`], and store it in the memory arena.
@@ -11191,18 +11191,18 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `element_type`
     /// * `label`
+    /// * `element_type`
     /// * `optional`
     #[inline]
     pub fn alloc_ts_named_tuple_member(
         self,
         span: Span,
-        element_type: TSTupleElement<'a>,
         label: IdentifierName<'a>,
+        element_type: TSTupleElement<'a>,
         optional: bool,
     ) -> Box<'a, TSNamedTupleMember<'a>> {
-        Box::new_in(self.ts_named_tuple_member(span, element_type, label, optional), self.allocator)
+        Box::new_in(self.ts_named_tuple_member(span, label, element_type, optional), self.allocator)
     }
 
     /// Build a [`TSOptionalType`].

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -6229,8 +6229,8 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSNamedTupleMember<'_> {
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSNamedTupleMember {
             span: CloneIn::clone_in(&self.span, allocator),
-            element_type: CloneIn::clone_in(&self.element_type, allocator),
             label: CloneIn::clone_in(&self.label, allocator),
+            element_type: CloneIn::clone_in(&self.element_type, allocator),
             optional: CloneIn::clone_in(&self.optional, allocator),
         }
     }
@@ -6238,8 +6238,8 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSNamedTupleMember<'_> {
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSNamedTupleMember {
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            element_type: CloneIn::clone_in_with_semantic_ids(&self.element_type, allocator),
             label: CloneIn::clone_in_with_semantic_ids(&self.label, allocator),
+            element_type: CloneIn::clone_in_with_semantic_ids(&self.element_type, allocator),
             optional: CloneIn::clone_in_with_semantic_ids(&self.optional, allocator),
         }
     }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -1900,8 +1900,8 @@ impl ContentEq for TSTupleType<'_> {
 
 impl ContentEq for TSNamedTupleMember<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.element_type, &other.element_type)
-            && ContentEq::content_eq(&self.label, &other.label)
+        ContentEq::content_eq(&self.label, &other.label)
+            && ContentEq::content_eq(&self.element_type, &other.element_type)
             && ContentEq::content_eq(&self.optional, &other.optional)
     }
 }

--- a/crates/oxc_ast/src/generated/derive_dummy.rs
+++ b/crates/oxc_ast/src/generated/derive_dummy.rs
@@ -2068,8 +2068,8 @@ impl<'a> Dummy<'a> for TSNamedTupleMember<'a> {
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
             span: Dummy::dummy(allocator),
-            element_type: Dummy::dummy(allocator),
             label: Dummy::dummy(allocator),
+            element_type: Dummy::dummy(allocator),
             optional: Dummy::dummy(allocator),
         }
     }

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -2525,8 +2525,8 @@ impl ESTree for TSNamedTupleMember<'_> {
         state.serialize_field("type", &JsonSafeString("TSNamedTupleMember"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("elementType", &self.element_type);
         state.serialize_field("label", &self.label);
+        state.serialize_field("elementType", &self.element_type);
         state.serialize_field("optional", &self.optional);
         state.end();
     }

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -3369,8 +3369,8 @@ pub mod walk {
         let kind = AstKind::TSNamedTupleMember(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        visitor.visit_ts_tuple_element(&it.element_type);
         visitor.visit_identifier_name(&it.label);
+        visitor.visit_ts_tuple_element(&it.element_type);
         visitor.leave_node(kind);
     }
 

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -3536,8 +3536,8 @@ pub mod walk_mut {
         let kind = AstType::TSNamedTupleMember;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        visitor.visit_ts_tuple_element(&mut it.element_type);
         visitor.visit_identifier_name(&mut it.label);
+        visitor.visit_ts_tuple_element(&mut it.element_type);
         visitor.leave_node(kind);
     }
 

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -873,8 +873,8 @@ impl<'a> ParserImpl<'a> {
             return if dotdotdot {
                 let type_annotation = self.ast.ts_type_named_tuple_member(
                     self.end_span(member_span),
-                    element_type,
                     label,
+                    element_type,
                     // TODO: A tuple member cannot be both optional and rest. (TS5085)
                     // See typescript suite <conformance/types/tuple/restTupleElements1.ts>
                     optional,
@@ -883,8 +883,8 @@ impl<'a> ParserImpl<'a> {
             } else {
                 TSTupleElement::from(self.ast.ts_type_named_tuple_member(
                     span,
-                    element_type,
                     label,
+                    element_type,
                     optional,
                 ))
             };

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-labelled-rest.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-labelled-rest.snap
@@ -34,7 +34,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 10
+            "node_id": 11
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-labelled.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-labelled.snap
@@ -41,7 +41,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T1",
-            "node_id": 14
+            "node_id": 15
           }
         ]
       },
@@ -55,7 +55,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T2",
-            "node_id": 19
+            "node_id": 20
           }
         ]
       },

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -230,8 +230,8 @@ pub(crate) enum AncestorType {
     TSIndexedAccessTypeObjectType = 207,
     TSIndexedAccessTypeIndexType = 208,
     TSTupleTypeElementTypes = 209,
-    TSNamedTupleMemberElementType = 210,
-    TSNamedTupleMemberLabel = 211,
+    TSNamedTupleMemberLabel = 210,
+    TSNamedTupleMemberElementType = 211,
     TSOptionalTypeTypeAnnotation = 212,
     TSRestTypeTypeAnnotation = 213,
     TSTypeReferenceTypeName = 214,
@@ -713,10 +713,10 @@ pub enum Ancestor<'a, 't> {
         AncestorType::TSIndexedAccessTypeIndexType as u16,
     TSTupleTypeElementTypes(TSTupleTypeWithoutElementTypes<'a, 't>) =
         AncestorType::TSTupleTypeElementTypes as u16,
-    TSNamedTupleMemberElementType(TSNamedTupleMemberWithoutElementType<'a, 't>) =
-        AncestorType::TSNamedTupleMemberElementType as u16,
     TSNamedTupleMemberLabel(TSNamedTupleMemberWithoutLabel<'a, 't>) =
         AncestorType::TSNamedTupleMemberLabel as u16,
+    TSNamedTupleMemberElementType(TSNamedTupleMemberWithoutElementType<'a, 't>) =
+        AncestorType::TSNamedTupleMemberElementType as u16,
     TSOptionalTypeTypeAnnotation(TSOptionalTypeWithoutTypeAnnotation<'a, 't>) =
         AncestorType::TSOptionalTypeTypeAnnotation as u16,
     TSRestTypeTypeAnnotation(TSRestTypeWithoutTypeAnnotation<'a, 't>) =
@@ -1571,7 +1571,7 @@ impl<'a, 't> Ancestor<'a, 't> {
 
     #[inline]
     pub fn is_ts_named_tuple_member(self) -> bool {
-        matches!(self, Self::TSNamedTupleMemberElementType(_) | Self::TSNamedTupleMemberLabel(_))
+        matches!(self, Self::TSNamedTupleMemberLabel(_) | Self::TSNamedTupleMemberElementType(_))
     }
 
     #[inline]
@@ -2407,8 +2407,8 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::TSIndexedAccessTypeObjectType(a) => a.address(),
             Self::TSIndexedAccessTypeIndexType(a) => a.address(),
             Self::TSTupleTypeElementTypes(a) => a.address(),
-            Self::TSNamedTupleMemberElementType(a) => a.address(),
             Self::TSNamedTupleMemberLabel(a) => a.address(),
+            Self::TSNamedTupleMemberElementType(a) => a.address(),
             Self::TSOptionalTypeTypeAnnotation(a) => a.address(),
             Self::TSRestTypeTypeAnnotation(a) => a.address(),
             Self::TSTypeReferenceTypeName(a) => a.address(),
@@ -11782,47 +11782,11 @@ impl<'a, 't> GetAddress for TSTupleTypeWithoutElementTypes<'a, 't> {
 }
 
 pub(crate) const OFFSET_TS_NAMED_TUPLE_MEMBER_SPAN: usize = offset_of!(TSNamedTupleMember, span);
+pub(crate) const OFFSET_TS_NAMED_TUPLE_MEMBER_LABEL: usize = offset_of!(TSNamedTupleMember, label);
 pub(crate) const OFFSET_TS_NAMED_TUPLE_MEMBER_ELEMENT_TYPE: usize =
     offset_of!(TSNamedTupleMember, element_type);
-pub(crate) const OFFSET_TS_NAMED_TUPLE_MEMBER_LABEL: usize = offset_of!(TSNamedTupleMember, label);
 pub(crate) const OFFSET_TS_NAMED_TUPLE_MEMBER_OPTIONAL: usize =
     offset_of!(TSNamedTupleMember, optional);
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct TSNamedTupleMemberWithoutElementType<'a, 't>(
-    pub(crate) *const TSNamedTupleMember<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> TSNamedTupleMemberWithoutElementType<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_NAMED_TUPLE_MEMBER_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn label(self) -> &'t IdentifierName<'a> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_NAMED_TUPLE_MEMBER_LABEL)
-                as *const IdentifierName<'a>)
-        }
-    }
-
-    #[inline]
-    pub fn optional(self) -> &'t bool {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_NAMED_TUPLE_MEMBER_OPTIONAL) as *const bool)
-        }
-    }
-}
-
-impl<'a, 't> GetAddress for TSNamedTupleMemberWithoutElementType<'a, 't> {
-    #[inline]
-    fn address(&self) -> Address {
-        Address::from_ptr(self.0)
-    }
-}
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -11854,6 +11818,42 @@ impl<'a, 't> TSNamedTupleMemberWithoutLabel<'a, 't> {
 }
 
 impl<'a, 't> GetAddress for TSNamedTupleMemberWithoutLabel<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
+pub struct TSNamedTupleMemberWithoutElementType<'a, 't>(
+    pub(crate) *const TSNamedTupleMember<'a>,
+    pub(crate) PhantomData<&'t ()>,
+);
+
+impl<'a, 't> TSNamedTupleMemberWithoutElementType<'a, 't> {
+    #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_NAMED_TUPLE_MEMBER_SPAN) as *const Span) }
+    }
+
+    #[inline]
+    pub fn label(self) -> &'t IdentifierName<'a> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_NAMED_TUPLE_MEMBER_LABEL)
+                as *const IdentifierName<'a>)
+        }
+    }
+
+    #[inline]
+    pub fn optional(self) -> &'t bool {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_NAMED_TUPLE_MEMBER_OPTIONAL) as *const bool)
+        }
+    }
+}
+
+impl<'a, 't> GetAddress for TSNamedTupleMemberWithoutElementType<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -4166,19 +4166,19 @@ unsafe fn walk_ts_named_tuple_member<'a, Tr: Traverse<'a>>(
     ctx: &mut TraverseCtx<'a>,
 ) {
     traverser.enter_ts_named_tuple_member(&mut *node, ctx);
-    let pop_token = ctx.push_stack(Ancestor::TSNamedTupleMemberElementType(
-        ancestor::TSNamedTupleMemberWithoutElementType(node, PhantomData),
+    let pop_token = ctx.push_stack(Ancestor::TSNamedTupleMemberLabel(
+        ancestor::TSNamedTupleMemberWithoutLabel(node, PhantomData),
     ));
+    walk_identifier_name(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_NAMED_TUPLE_MEMBER_LABEL) as *mut IdentifierName,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::TSNamedTupleMemberElementType);
     walk_ts_tuple_element(
         traverser,
         (node as *mut u8).add(ancestor::OFFSET_TS_NAMED_TUPLE_MEMBER_ELEMENT_TYPE)
             as *mut TSTupleElement,
-        ctx,
-    );
-    ctx.retag_stack(AncestorType::TSNamedTupleMemberLabel);
-    walk_identifier_name(
-        traverser,
-        (node as *mut u8).add(ancestor::OFFSET_TS_NAMED_TUPLE_MEMBER_LABEL) as *mut IdentifierName,
         ctx,
     );
     ctx.pop_stack(pop_token);

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -1427,8 +1427,8 @@ function deserializeTSNamedTupleMember(pos) {
     type: 'TSNamedTupleMember',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    elementType: deserializeTSTupleElement(pos + 8),
-    label: deserializeIdentifierName(pos + 24),
+    label: deserializeIdentifierName(pos + 8),
+    elementType: deserializeTSTupleElement(pos + 32),
     optional: deserializeBool(pos + 48),
   };
 }

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -1579,8 +1579,8 @@ function deserializeTSNamedTupleMember(pos) {
     type: 'TSNamedTupleMember',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    elementType: deserializeTSTupleElement(pos + 8),
-    label: deserializeIdentifierName(pos + 24),
+    label: deserializeIdentifierName(pos + 8),
+    elementType: deserializeTSTupleElement(pos + 32),
     optional: deserializeBool(pos + 48),
   };
 }

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1092,8 +1092,8 @@ export interface TSTupleType extends Span {
 
 export interface TSNamedTupleMember extends Span {
   type: 'TSNamedTupleMember';
-  elementType: TSTupleElement;
   label: IdentifierName;
+  elementType: TSTupleElement;
   optional: boolean;
 }
 


### PR DESCRIPTION
Fix field order for `TSNamedTupleMember`. Move `label` to before `element_type`, because it comes first in source:

```ts
type Foo = [first: string, second: number];
//    label ^^^^^  ^^^^^^ element_type
```
