### PR TITLE
fix(ast)!: fix field order for `TSTypeAssertion`

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1541,13 +1541,21 @@ pub struct TSSatisfiesExpression<'a> {
     pub type_annotation: TSType<'a>,
 }
 
+/// TypeScript Type Assertion
+///
+/// ## Example
+/// ```ts
+/// //                ___ expression
+/// let foo = <number>bar;
+/// //        ^^^^^^^^ type_annotation
+/// ```
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSTypeAssertion<'a> {
     pub span: Span,
-    pub expression: Expression<'a>,
     pub type_annotation: TSType<'a>,
+    pub expression: Expression<'a>,
 }
 
 #[ast(visit)]

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -1319,8 +1319,8 @@ const _: () = {
     assert!(size_of::<TSTypeAssertion>() == 40);
     assert!(align_of::<TSTypeAssertion>() == 8);
     assert!(offset_of!(TSTypeAssertion, span) == 0);
-    assert!(offset_of!(TSTypeAssertion, expression) == 8);
-    assert!(offset_of!(TSTypeAssertion, type_annotation) == 24);
+    assert!(offset_of!(TSTypeAssertion, type_annotation) == 8);
+    assert!(offset_of!(TSTypeAssertion, expression) == 24);
 
     assert!(size_of::<TSImportEqualsDeclaration>() == 64);
     assert!(align_of::<TSImportEqualsDeclaration>() == 8);
@@ -2714,8 +2714,8 @@ const _: () = {
     assert!(size_of::<TSTypeAssertion>() == 24);
     assert!(align_of::<TSTypeAssertion>() == 4);
     assert!(offset_of!(TSTypeAssertion, span) == 0);
-    assert!(offset_of!(TSTypeAssertion, expression) == 8);
-    assert!(offset_of!(TSTypeAssertion, type_annotation) == 16);
+    assert!(offset_of!(TSTypeAssertion, type_annotation) == 8);
+    assert!(offset_of!(TSTypeAssertion, expression) == 16);
 
     assert!(size_of::<TSImportEqualsDeclaration>() == 40);
     assert!(align_of::<TSImportEqualsDeclaration>() == 4);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -1140,16 +1140,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `expression`
     /// * `type_annotation`
+    /// * `expression`
     #[inline]
     pub fn expression_ts_type_assertion(
         self,
         span: Span,
-        expression: Expression<'a>,
         type_annotation: TSType<'a>,
+        expression: Expression<'a>,
     ) -> Expression<'a> {
-        Expression::TSTypeAssertion(self.alloc_ts_type_assertion(span, expression, type_annotation))
+        Expression::TSTypeAssertion(self.alloc_ts_type_assertion(span, type_annotation, expression))
     }
 
     /// Build an [`Expression::TSNonNullExpression`].
@@ -2718,19 +2718,19 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `expression`
     /// * `type_annotation`
+    /// * `expression`
     #[inline]
     pub fn simple_assignment_target_ts_type_assertion(
         self,
         span: Span,
-        expression: Expression<'a>,
         type_annotation: TSType<'a>,
+        expression: Expression<'a>,
     ) -> SimpleAssignmentTarget<'a> {
         SimpleAssignmentTarget::TSTypeAssertion(self.alloc_ts_type_assertion(
             span,
-            expression,
             type_annotation,
+            expression,
         ))
     }
 
@@ -14142,16 +14142,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `expression`
     /// * `type_annotation`
+    /// * `expression`
     #[inline]
     pub fn ts_type_assertion(
         self,
         span: Span,
-        expression: Expression<'a>,
         type_annotation: TSType<'a>,
+        expression: Expression<'a>,
     ) -> TSTypeAssertion<'a> {
-        TSTypeAssertion { span, expression, type_annotation }
+        TSTypeAssertion { span, type_annotation, expression }
     }
 
     /// Build a [`TSTypeAssertion`], and store it in the memory arena.
@@ -14161,16 +14161,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `expression`
     /// * `type_annotation`
+    /// * `expression`
     #[inline]
     pub fn alloc_ts_type_assertion(
         self,
         span: Span,
-        expression: Expression<'a>,
         type_annotation: TSType<'a>,
+        expression: Expression<'a>,
     ) -> Box<'a, TSTypeAssertion<'a>> {
-        Box::new_in(self.ts_type_assertion(span, expression, type_annotation), self.allocator)
+        Box::new_in(self.ts_type_assertion(span, type_annotation, expression), self.allocator)
     }
 
     /// Build a [`TSImportEqualsDeclaration`].

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -7577,16 +7577,16 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeAssertion<'_> {
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeAssertion {
             span: CloneIn::clone_in(&self.span, allocator),
-            expression: CloneIn::clone_in(&self.expression, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
+            expression: CloneIn::clone_in(&self.expression, allocator),
         }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeAssertion {
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
             type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
+            expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -2377,8 +2377,8 @@ impl ContentEq for TSSatisfiesExpression<'_> {
 
 impl ContentEq for TSTypeAssertion<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.expression, &other.expression)
-            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
+        ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
+            && ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_dummy.rs
+++ b/crates/oxc_ast/src/generated/derive_dummy.rs
@@ -2728,8 +2728,8 @@ impl<'a> Dummy<'a> for TSTypeAssertion<'a> {
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
             span: Dummy::dummy(allocator),
-            expression: Dummy::dummy(allocator),
             type_annotation: Dummy::dummy(allocator),
+            expression: Dummy::dummy(allocator),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -3226,8 +3226,8 @@ impl ESTree for TSTypeAssertion<'_> {
         state.serialize_field("type", &JsonSafeString("TSTypeAssertion"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("expression", &self.expression);
         state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.serialize_field("expression", &self.expression);
         state.end();
     }
 }

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -3992,8 +3992,8 @@ pub mod walk {
         let kind = AstKind::TSTypeAssertion(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        visitor.visit_expression(&it.expression);
         visitor.visit_ts_type(&it.type_annotation);
+        visitor.visit_expression(&it.expression);
         visitor.leave_node(kind);
     }
 

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -4213,8 +4213,8 @@ pub mod walk_mut {
         let kind = AstType::TSTypeAssertion;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        visitor.visit_expression(&mut it.expression);
         visitor.visit_ts_type(&mut it.type_annotation);
+        visitor.visit_expression(&mut it.expression);
         visitor.leave_node(kind);
     }
 

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -437,7 +437,7 @@ impl<'a> ParserImpl<'a> {
         self.expect(Kind::RAngle);
         let lhs_span = self.start_span();
         let expression = self.parse_simple_unary_expression(lhs_span);
-        self.ast.expression_ts_type_assertion(self.end_span(span), expression, type_annotation)
+        self.ast.expression_ts_type_assertion(self.end_span(span), type_annotation, expression)
     }
 
     pub(crate) fn parse_ts_import_equals_declaration(&mut self, span: u32) -> Declaration<'a> {

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/assignments/left-hand.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/assignments/left-hand.snap
@@ -25,7 +25,7 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/assignments/left-hand.ts
             "flags": "ReferenceFlags(Write)",
             "id": 1,
             "name": "Foo",
-            "node_id": 19
+            "node_id": 20
           },
           {
             "flags": "ReferenceFlags(Write)",
@@ -49,7 +49,7 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/assignments/left-hand.ts
             "flags": "ReferenceFlags(Read)",
             "id": 5,
             "name": "Foo",
-            "node_id": 53
+            "node_id": 54
           },
           {
             "flags": "ReferenceFlags(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/angle-bracket.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/angle-bracket.snap
@@ -25,9 +25,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
         "references": [
           {
             "flags": "ReferenceFlags(Read)",
-            "id": 0,
+            "id": 1,
             "name": "x",
-            "node_id": 11
+            "node_id": 14
           }
         ]
       },
@@ -39,9 +39,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
         "references": [
           {
             "flags": "ReferenceFlags(Type)",
-            "id": 1,
+            "id": 0,
             "name": "T",
-            "node_id": 14
+            "node_id": 13
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/angle-bracket-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/angle-bracket-assignment.snap
@@ -19,7 +19,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
             "flags": "ReferenceFlags(Read | Write)",
             "id": 0,
             "name": "x",
-            "node_id": 14
+            "node_id": 15
           }
         ]
       }

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -302,8 +302,8 @@ pub(crate) enum AncestorType {
     TSAsExpressionTypeAnnotation = 279,
     TSSatisfiesExpressionExpression = 280,
     TSSatisfiesExpressionTypeAnnotation = 281,
-    TSTypeAssertionExpression = 282,
-    TSTypeAssertionTypeAnnotation = 283,
+    TSTypeAssertionTypeAnnotation = 282,
+    TSTypeAssertionExpression = 283,
     TSImportEqualsDeclarationId = 284,
     TSImportEqualsDeclarationModuleReference = 285,
     TSExternalModuleReferenceExpression = 286,
@@ -859,10 +859,10 @@ pub enum Ancestor<'a, 't> {
         AncestorType::TSSatisfiesExpressionExpression as u16,
     TSSatisfiesExpressionTypeAnnotation(TSSatisfiesExpressionWithoutTypeAnnotation<'a, 't>) =
         AncestorType::TSSatisfiesExpressionTypeAnnotation as u16,
-    TSTypeAssertionExpression(TSTypeAssertionWithoutExpression<'a, 't>) =
-        AncestorType::TSTypeAssertionExpression as u16,
     TSTypeAssertionTypeAnnotation(TSTypeAssertionWithoutTypeAnnotation<'a, 't>) =
         AncestorType::TSTypeAssertionTypeAnnotation as u16,
+    TSTypeAssertionExpression(TSTypeAssertionWithoutExpression<'a, 't>) =
+        AncestorType::TSTypeAssertionExpression as u16,
     TSImportEqualsDeclarationId(TSImportEqualsDeclarationWithoutId<'a, 't>) =
         AncestorType::TSImportEqualsDeclarationId as u16,
     TSImportEqualsDeclarationModuleReference(
@@ -1802,7 +1802,7 @@ impl<'a, 't> Ancestor<'a, 't> {
 
     #[inline]
     pub fn is_ts_type_assertion(self) -> bool {
-        matches!(self, Self::TSTypeAssertionExpression(_) | Self::TSTypeAssertionTypeAnnotation(_))
+        matches!(self, Self::TSTypeAssertionTypeAnnotation(_) | Self::TSTypeAssertionExpression(_))
     }
 
     #[inline]
@@ -2479,8 +2479,8 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::TSAsExpressionTypeAnnotation(a) => a.address(),
             Self::TSSatisfiesExpressionExpression(a) => a.address(),
             Self::TSSatisfiesExpressionTypeAnnotation(a) => a.address(),
-            Self::TSTypeAssertionExpression(a) => a.address(),
             Self::TSTypeAssertionTypeAnnotation(a) => a.address(),
+            Self::TSTypeAssertionExpression(a) => a.address(),
             Self::TSImportEqualsDeclarationId(a) => a.address(),
             Self::TSImportEqualsDeclarationModuleReference(a) => a.address(),
             Self::TSExternalModuleReferenceExpression(a) => a.address(),
@@ -15132,39 +15132,10 @@ impl<'a, 't> GetAddress for TSSatisfiesExpressionWithoutTypeAnnotation<'a, 't> {
 }
 
 pub(crate) const OFFSET_TS_TYPE_ASSERTION_SPAN: usize = offset_of!(TSTypeAssertion, span);
-pub(crate) const OFFSET_TS_TYPE_ASSERTION_EXPRESSION: usize =
-    offset_of!(TSTypeAssertion, expression);
 pub(crate) const OFFSET_TS_TYPE_ASSERTION_TYPE_ANNOTATION: usize =
     offset_of!(TSTypeAssertion, type_annotation);
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct TSTypeAssertionWithoutExpression<'a, 't>(
-    pub(crate) *const TSTypeAssertion<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> TSTypeAssertionWithoutExpression<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_TYPE_ASSERTION_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn type_annotation(self) -> &'t TSType<'a> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_TYPE_ASSERTION_TYPE_ANNOTATION)
-                as *const TSType<'a>)
-        }
-    }
-}
-
-impl<'a, 't> GetAddress for TSTypeAssertionWithoutExpression<'a, 't> {
-    #[inline]
-    fn address(&self) -> Address {
-        Address::from_ptr(self.0)
-    }
-}
+pub(crate) const OFFSET_TS_TYPE_ASSERTION_EXPRESSION: usize =
+    offset_of!(TSTypeAssertion, expression);
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -15189,6 +15160,35 @@ impl<'a, 't> TSTypeAssertionWithoutTypeAnnotation<'a, 't> {
 }
 
 impl<'a, 't> GetAddress for TSTypeAssertionWithoutTypeAnnotation<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
+pub struct TSTypeAssertionWithoutExpression<'a, 't>(
+    pub(crate) *const TSTypeAssertion<'a>,
+    pub(crate) PhantomData<&'t ()>,
+);
+
+impl<'a, 't> TSTypeAssertionWithoutExpression<'a, 't> {
+    #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_TYPE_ASSERTION_SPAN) as *const Span) }
+    }
+
+    #[inline]
+    pub fn type_annotation(self) -> &'t TSType<'a> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_TYPE_ASSERTION_TYPE_ANNOTATION)
+                as *const TSType<'a>)
+        }
+    }
+}
+
+impl<'a, 't> GetAddress for TSTypeAssertionWithoutExpression<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)

--- a/crates/oxc_traverse/src/generated/scopes_collector.rs
+++ b/crates/oxc_traverse/src/generated/scopes_collector.rs
@@ -1943,8 +1943,8 @@ impl<'a> Visit<'a> for ChildScopeCollector {
 
     #[inline]
     fn visit_ts_type_assertion(&mut self, it: &TSTypeAssertion<'a>) {
-        self.visit_expression(&it.expression);
         self.visit_ts_type(&it.type_annotation);
+        self.visit_expression(&it.expression);
     }
 
     #[inline(always)]

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -5370,18 +5370,18 @@ unsafe fn walk_ts_type_assertion<'a, Tr: Traverse<'a>>(
     ctx: &mut TraverseCtx<'a>,
 ) {
     traverser.enter_ts_type_assertion(&mut *node, ctx);
-    let pop_token = ctx.push_stack(Ancestor::TSTypeAssertionExpression(
-        ancestor::TSTypeAssertionWithoutExpression(node, PhantomData),
+    let pop_token = ctx.push_stack(Ancestor::TSTypeAssertionTypeAnnotation(
+        ancestor::TSTypeAssertionWithoutTypeAnnotation(node, PhantomData),
     ));
-    walk_expression(
-        traverser,
-        (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_ASSERTION_EXPRESSION) as *mut Expression,
-        ctx,
-    );
-    ctx.retag_stack(AncestorType::TSTypeAssertionTypeAnnotation);
     walk_ts_type(
         traverser,
         (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_ASSERTION_TYPE_ANNOTATION) as *mut TSType,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::TSTypeAssertionExpression);
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_ASSERTION_EXPRESSION) as *mut Expression,
         ctx,
     );
     ctx.pop_stack(pop_token);

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -1948,8 +1948,8 @@ function deserializeTSTypeAssertion(pos) {
     type: 'TSTypeAssertion',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expression: deserializeExpression(pos + 8),
-    typeAnnotation: deserializeTSType(pos + 24),
+    typeAnnotation: deserializeTSType(pos + 8),
+    expression: deserializeExpression(pos + 24),
   };
 }
 

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -2100,8 +2100,8 @@ function deserializeTSTypeAssertion(pos) {
     type: 'TSTypeAssertion',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expression: deserializeExpression(pos + 8),
-    typeAnnotation: deserializeTSType(pos + 24),
+    typeAnnotation: deserializeTSType(pos + 8),
+    expression: deserializeExpression(pos + 24),
   };
 }
 

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1398,8 +1398,8 @@ export interface TSSatisfiesExpression extends Span {
 
 export interface TSTypeAssertion extends Span {
   type: 'TSTypeAssertion';
-  expression: Expression;
   typeAnnotation: TSType;
+  expression: Expression;
 }
 
 export interface TSImportEqualsDeclaration extends Span {

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -333,6 +333,9 @@ after transform: ["T", "a", "b", "c", "x", "y"]
 rebuilt        : ["a", "b", "c", "x", "y"]
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/for-of-lhs/input.ts
+Reference flags mismatch for "a":
+after transform: ReferenceId(3): ReferenceFlags(Read)
+rebuilt        : ReferenceId(1): ReferenceFlags(Write)
 Unresolved references mismatch:
 after transform: ["T", "a"]
 rebuilt        : ["a"]

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -107,7 +107,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["console", "delint", "fileNames", "process", "readFileSync", "ts"]
 rebuilt        : ScopeId(0): ["delint", "fileNames", "ts"]
 Symbol reference IDs mismatch for "ts":
-after transform: SymbolId(3): [ReferenceId(0), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(10), ReferenceId(11), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(23), ReferenceId(25), ReferenceId(28), ReferenceId(30), ReferenceId(32), ReferenceId(34), ReferenceId(37), ReferenceId(40), ReferenceId(50), ReferenceId(54)]
+after transform: SymbolId(3): [ReferenceId(0), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(14), ReferenceId(15), ReferenceId(18), ReferenceId(23), ReferenceId(25), ReferenceId(28), ReferenceId(29), ReferenceId(32), ReferenceId(34), ReferenceId(37), ReferenceId(40), ReferenceId(50), ReferenceId(54)]
 rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(11), ReferenceId(14), ReferenceId(19), ReferenceId(21), ReferenceId(24), ReferenceId(27), ReferenceId(29), ReferenceId(32), ReferenceId(44), ReferenceId(48)]
 Reference symbol mismatch for "console":
 after transform: SymbolId(1) "console"
@@ -19422,7 +19422,7 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Symbol reference IDs mismatch for "C1":
-after transform: SymbolId(5): [ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(11), ReferenceId(12)]
+after transform: SymbolId(5): [ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(12)]
 rebuilt        : SymbolId(3): [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mapConstructor.ts


### PR DESCRIPTION
Fix field order for `TSTypeAssertion`. Move `type_annotation` to before `expression`, because it comes first in source:

```ts
//                ___ expression
let foo = <number>bar;
//        ^^^^^^^^ type_annotation
```
