### PR TITLE
fix(linter/no-img-element): improve diagnostic and docs

### DIFF
--- a/crates/oxc_linter/src/snapshots/nextjs_no_img_element.snap
+++ b/crates/oxc_linter/src/snapshots/nextjs_no_img_element.snap
@@ -1,20 +1,41 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-next(no-img-element): Prevent usage of `<img>` element due to slower LCP and higher bandwidth.
+  ⚠ eslint-plugin-next(no-img-element): Using `<img>` could result in slower LCP and higher bandwidth.
    ╭─[no_img_element.tsx:6:19]
  5 │                         <div>
  6 │                           <img
-   ·                            ───
+   ·                            ─┬─
+   ·                             ╰── Use `<Image />` from `next/image` instead.
  7 │                             src="/test.png"
+   ·                                 ─────┬─────
+   ·                                      ╰── Use a static image import instead.
+ 8 │                             alt="Test picture"
    ╰────
-  help: See https://nextjs.org/docs/messages/no-img-element
+  help: Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images.
+        See https://nextjs.org/docs/messages/no-img-element
 
-  ⚠ eslint-plugin-next(no-img-element): Prevent usage of `<img>` element due to slower LCP and higher bandwidth.
+  ⚠ eslint-plugin-next(no-img-element): Using `<img>` could result in slower LCP and higher bandwidth.
    ╭─[no_img_element.tsx:5:17]
  4 │                       return (
  5 │                         <img
-   ·                          ───
+   ·                          ─┬─
+   ·                           ╰── Use `<Image />` from `next/image` instead.
  6 │                           src="/test.png"
+   ·                               ─────┬─────
+   ·                                    ╰── Use a static image import instead.
+ 7 │                           alt="Test picture"
    ╰────
-  help: See https://nextjs.org/docs/messages/no-img-element
+  help: Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images.
+        See https://nextjs.org/docs/messages/no-img-element
+
+  ⚠ eslint-plugin-next(no-img-element): Using `<img>` could result in slower LCP and higher bandwidth.
+   ╭─[no_img_element.tsx:4:7]
+ 3 │         export const MyComponent = () => (
+ 4 │            <img src={somePicture.src} alt='foo' />
+   ·             ─┬─
+   ·              ╰── Use `<Image />` from `next/image` instead.
+ 5 │         );
+   ╰────
+  help: Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images.
+        See https://nextjs.org/docs/messages/no-img-element


### PR DESCRIPTION
## What This PR Does

Updates `eslint-next-plugin/no-img-element` to make diagnostic messages/labels/etc more informative and add documentation