### PR TITLE
fix(linter): add `gitlab` to linter `--help` docs

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -194,7 +194,7 @@ pub struct WarningOptions {
 #[derive(Debug, Clone, Bpaf)]
 pub struct OutputOptions {
     /// Use a specific output format. Possible values:
-    /// `checkstyle`, `default`, `github`, `json`, `junit`, `stylish`, `unix`
+    /// `checkstyle`, `default`, `github`, `gitlab`, `json`, `junit`, `stylish`, `unix`
     #[bpaf(long, short, fallback(OutputFormat::Default), hide_usage)]
     pub format: OutputFormat,
 }

--- a/tasks/website/src/linter/snapshots/cli.snap
+++ b/tasks/website/src/linter/snapshots/cli.snap
@@ -110,7 +110,7 @@ Arguments:
 
 ## Output
 - **`-f`**, **`--format`**=_`ARG`_ &mdash; 
-  Use a specific output format. Possible values: `checkstyle`, `default`, `github`, `json`, `junit`, `stylish`, `unix`
+  Use a specific output format. Possible values: `checkstyle`, `default`, `github`, `gitlab`, `json`, `junit`, `stylish`, `unix`
 
 
 

--- a/tasks/website/src/linter/snapshots/cli_terminal.snap
+++ b/tasks/website/src/linter/snapshots/cli_terminal.snap
@@ -68,7 +68,7 @@ Handle Warnings
 
 Output
     -f, --format=ARG          Use a specific output format. Possible values: `checkstyle`,
-                              `default`, `github`, `json`, `junit`, `stylish`, `unix`
+                              `default`, `github`, `gitlab`, `json`, `junit`, `stylish`, `unix`
 
 Miscellaneous
         --silent              Do not display any diagnostics


### PR DESCRIPTION
before:
```
Output
    -f, --format=ARG          Use a specific output format. Possible values: `checkstyle`,
                              `default`, `github`, `json`, `junit`, `stylish`, `unix`
```

after:
```
Output
    -f, --format=ARG          Use a specific output format. Possible values: `checkstyle`,
                              `default`, `github`, `gitlab`, `json`, `junit`, `stylish`, `unix`
```