### PR TITLE
refactor(codegen): make `Statement::Gen` code more compact

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -111,108 +111,29 @@ impl Gen for Statement<'_> {
                 p.print_statement_comments(stmt.span.start);
                 stmt.print(p, ctx);
             }
-            Self::BreakStatement(stmt) => {
-                p.print_statement_comments(stmt.span.start);
-                stmt.print(p, ctx);
-            }
-            Self::ContinueStatement(stmt) => {
-                p.print_statement_comments(stmt.span.start);
-                stmt.print(p, ctx);
-            }
-            Self::DebuggerStatement(stmt) => {
-                p.print_statement_comments(stmt.span.start);
-                stmt.print(p, ctx);
-            }
-            Self::DoWhileStatement(stmt) => {
-                p.print_statement_comments(stmt.span.start);
-                stmt.print(p, ctx);
-            }
-            Self::EmptyStatement(stmt) => {
-                p.print_statement_comments(stmt.span.start);
-                stmt.print(p, ctx);
-            }
-            Self::ExpressionStatement(stmt) => {
-                p.print_statement_comments(stmt.span.start);
-                stmt.print(p, ctx);
-            }
-            Self::ForInStatement(stmt) => {
-                p.print_statement_comments(stmt.span.start);
-                stmt.print(p, ctx);
-            }
-            Self::ForOfStatement(stmt) => {
-                p.print_statement_comments(stmt.span.start);
-                stmt.print(p, ctx);
-            }
-            Self::ForStatement(stmt) => {
-                p.print_statement_comments(stmt.span.start);
-                stmt.print(p, ctx);
-            }
-            Self::IfStatement(stmt) => {
-                p.print_statement_comments(stmt.span.start);
-                stmt.print(p, ctx);
-            }
-            Self::LabeledStatement(stmt) => {
-                p.print_statement_comments(stmt.span.start);
-                stmt.print(p, ctx);
-            }
-            Self::ReturnStatement(stmt) => {
-                p.print_statement_comments(stmt.span.start);
-                stmt.print(p, ctx);
-            }
-            Self::SwitchStatement(stmt) => {
-                p.print_statement_comments(stmt.span.start);
-                stmt.print(p, ctx);
-            }
-            Self::ThrowStatement(stmt) => {
-                p.print_statement_comments(stmt.span.start);
-                stmt.print(p, ctx);
-            }
-            Self::TryStatement(stmt) => {
-                p.print_statement_comments(stmt.span.start);
-                stmt.print(p, ctx);
-            }
-            Self::WhileStatement(stmt) => {
-                p.print_statement_comments(stmt.span.start);
-                stmt.print(p, ctx);
-            }
-            Self::WithStatement(stmt) => {
-                p.print_statement_comments(stmt.span.start);
-                stmt.print(p, ctx);
-            }
-            Self::ImportDeclaration(decl) => {
-                p.print_statement_comments(decl.span.start);
-                decl.print(p, ctx);
-            }
-            Self::ExportAllDeclaration(decl) => {
-                p.print_statement_comments(decl.span.start);
-                decl.print(p, ctx);
-            }
-            Self::ExportDefaultDeclaration(decl) => {
-                p.print_statement_comments(decl.span.start);
-                if let ExportDefaultDeclarationKind::FunctionDeclaration(func) = &decl.declaration {
-                    if func.pure && p.print_annotation_comment {
-                        p.print_str(NO_SIDE_EFFECTS_NEW_LINE_COMMENT);
-                    }
-                }
-                decl.print(p, ctx);
-            }
-            Self::ExportNamedDeclaration(decl) => {
-                p.print_statement_comments(decl.span.start);
-                if let Some(Declaration::FunctionDeclaration(func)) = &decl.declaration {
-                    if func.pure && p.print_annotation_comment {
-                        p.print_str(NO_SIDE_EFFECTS_NEW_LINE_COMMENT);
-                    }
-                }
-                decl.print(p, ctx);
-            }
-            Self::TSExportAssignment(decl) => {
-                p.print_statement_comments(decl.span.start);
-                decl.print(p, ctx);
-            }
-            Self::TSNamespaceExportDeclaration(decl) => {
-                p.print_statement_comments(decl.span.start);
-                decl.print(p, ctx);
-            }
+            Self::BreakStatement(stmt) => stmt.print(p, ctx),
+            Self::ContinueStatement(stmt) => stmt.print(p, ctx),
+            Self::DebuggerStatement(stmt) => stmt.print(p, ctx),
+            Self::DoWhileStatement(stmt) => stmt.print(p, ctx),
+            Self::EmptyStatement(stmt) => stmt.print(p, ctx),
+            Self::ExpressionStatement(stmt) => stmt.print(p, ctx),
+            Self::ForInStatement(stmt) => stmt.print(p, ctx),
+            Self::ForOfStatement(stmt) => stmt.print(p, ctx),
+            Self::ForStatement(stmt) => stmt.print(p, ctx),
+            Self::IfStatement(stmt) => stmt.print(p, ctx),
+            Self::LabeledStatement(stmt) => stmt.print(p, ctx),
+            Self::ReturnStatement(stmt) => stmt.print(p, ctx),
+            Self::SwitchStatement(stmt) => stmt.print(p, ctx),
+            Self::ThrowStatement(stmt) => stmt.print(p, ctx),
+            Self::TryStatement(stmt) => stmt.print(p, ctx),
+            Self::WhileStatement(stmt) => stmt.print(p, ctx),
+            Self::WithStatement(stmt) => stmt.print(p, ctx),
+            Self::ImportDeclaration(decl) => decl.print(p, ctx),
+            Self::ExportAllDeclaration(decl) => decl.print(p, ctx),
+            Self::ExportDefaultDeclaration(decl) => decl.print(p, ctx),
+            Self::ExportNamedDeclaration(decl) => decl.print(p, ctx),
+            Self::TSExportAssignment(decl) => decl.print(p, ctx),
+            Self::TSNamespaceExportDeclaration(decl) => decl.print(p, ctx),
             Self::VariableDeclaration(decl) => {
                 p.print_statement_comments(decl.span.start);
                 p.print_indent();
@@ -242,26 +163,26 @@ impl Gen for Statement<'_> {
                 p.print_soft_newline();
             }
             Self::TSTypeAliasDeclaration(decl) => {
-                p.print_statement_comments(decl.span.start);
                 p.print_indent();
+                p.print_statement_comments(decl.span.start);
                 decl.print(p, ctx);
                 p.print_semicolon_after_statement();
             }
             Self::TSInterfaceDeclaration(decl) => {
-                p.print_statement_comments(decl.span.start);
                 p.print_indent();
+                p.print_statement_comments(decl.span.start);
                 decl.print(p, ctx);
                 p.print_soft_newline();
             }
             Self::TSEnumDeclaration(decl) => {
-                p.print_statement_comments(decl.span.start);
                 p.print_indent();
+                p.print_statement_comments(decl.span.start);
                 decl.print(p, ctx);
                 p.print_soft_newline();
             }
             Self::TSImportEqualsDeclaration(decl) => {
-                p.print_statement_comments(decl.span.start);
                 p.print_indent();
+                p.print_statement_comments(decl.span.start);
                 decl.print(p, ctx);
                 p.print_semicolon_after_statement();
             }
@@ -271,6 +192,7 @@ impl Gen for Statement<'_> {
 
 impl Gen for ExpressionStatement<'_> {
     fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+        p.print_statement_comments(self.span.start);
         p.add_source_mapping(self.span);
         p.print_indent();
         p.start_of_stmt = p.code_len();
@@ -285,6 +207,7 @@ impl Gen for ExpressionStatement<'_> {
 
 impl Gen for IfStatement<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+        p.print_statement_comments(self.span.start);
         p.add_source_mapping(self.span);
         p.print_indent();
         print_if(self, p, ctx);
@@ -380,6 +303,7 @@ impl Gen for BlockStatement<'_> {
 
 impl Gen for ForStatement<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+        p.print_statement_comments(self.span.start);
         p.add_source_mapping(self.span);
         p.print_indent();
         p.print_space_before_identifier();
@@ -412,6 +336,7 @@ impl Gen for ForStatement<'_> {
 
 impl Gen for ForInStatement<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+        p.print_statement_comments(self.span.start);
         p.add_source_mapping(self.span);
         p.print_indent();
         p.print_space_before_identifier();
@@ -431,6 +356,7 @@ impl Gen for ForInStatement<'_> {
 
 impl Gen for ForOfStatement<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+        p.print_statement_comments(self.span.start);
         p.add_source_mapping(self.span);
         p.print_indent();
         p.print_space_before_identifier();
@@ -477,6 +403,7 @@ impl Gen for ForStatementLeft<'_> {
 
 impl Gen for WhileStatement<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+        p.print_statement_comments(self.span.start);
         p.add_source_mapping(self.span);
         p.print_indent();
         p.print_space_before_identifier();
@@ -491,6 +418,7 @@ impl Gen for WhileStatement<'_> {
 
 impl Gen for DoWhileStatement<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+        p.print_statement_comments(self.span.start);
         p.add_source_mapping(self.span);
         p.print_indent();
         p.print_space_before_identifier();
@@ -522,6 +450,7 @@ impl Gen for DoWhileStatement<'_> {
 
 impl Gen for EmptyStatement {
     fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+        p.print_statement_comments(self.span.start);
         p.add_source_mapping(self.span);
         p.print_indent();
         p.print_semicolon();
@@ -531,6 +460,7 @@ impl Gen for EmptyStatement {
 
 impl Gen for ContinueStatement<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+        p.print_statement_comments(self.span.start);
         p.add_source_mapping(self.span);
         p.print_indent();
         p.print_space_before_identifier();
@@ -545,6 +475,7 @@ impl Gen for ContinueStatement<'_> {
 
 impl Gen for BreakStatement<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+        p.print_statement_comments(self.span.start);
         p.add_source_mapping(self.span);
         p.print_indent();
         p.print_space_before_identifier();
@@ -559,6 +490,7 @@ impl Gen for BreakStatement<'_> {
 
 impl Gen for SwitchStatement<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+        p.print_statement_comments(self.span.start);
         p.add_source_mapping(self.span);
         p.print_indent();
         p.print_space_before_identifier();
@@ -610,6 +542,7 @@ impl Gen for SwitchCase<'_> {
 
 impl Gen for ReturnStatement<'_> {
     fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+        p.print_statement_comments(self.span.start);
         p.add_source_mapping(self.span);
         p.print_indent();
         p.print_space_before_identifier();
@@ -624,6 +557,7 @@ impl Gen for ReturnStatement<'_> {
 
 impl Gen for LabeledStatement<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+        p.print_statement_comments(self.span.start);
         if !p.options.minify && (p.indent > 0 || p.print_next_indent_as_space) {
             p.add_source_mapping(self.span);
             p.print_indent();
@@ -637,6 +571,7 @@ impl Gen for LabeledStatement<'_> {
 
 impl Gen for TryStatement<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+        p.print_statement_comments(self.span.start);
         p.add_source_mapping(self.span);
         p.print_indent();
         p.print_space_before_identifier();
@@ -674,6 +609,7 @@ impl Gen for CatchClause<'_> {
 
 impl Gen for ThrowStatement<'_> {
     fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+        p.print_statement_comments(self.span.start);
         p.add_source_mapping(self.span);
         p.print_indent();
         p.print_space_before_identifier();
@@ -686,6 +622,7 @@ impl Gen for ThrowStatement<'_> {
 
 impl Gen for WithStatement<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+        p.print_statement_comments(self.span.start);
         p.add_source_mapping(self.span);
         p.print_indent();
         p.print_space_before_identifier();
@@ -699,6 +636,7 @@ impl Gen for WithStatement<'_> {
 
 impl Gen for DebuggerStatement {
     fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+        p.print_statement_comments(self.span.start);
         p.add_source_mapping(self.span);
         p.print_indent();
         p.print_space_before_identifier();
@@ -866,6 +804,7 @@ impl Gen for FormalParameters<'_> {
 
 impl Gen for ImportDeclaration<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+        p.print_statement_comments(self.span.start);
         p.add_source_mapping(self.span);
         p.print_indent();
         p.print_space_before_identifier();
@@ -1012,6 +951,12 @@ impl Gen for ImportAttribute<'_> {
 
 impl Gen for ExportNamedDeclaration<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+        p.print_statement_comments(self.span.start);
+        if let Some(Declaration::FunctionDeclaration(func)) = &self.declaration {
+            if func.pure && p.print_annotation_comment {
+                p.print_str(NO_SIDE_EFFECTS_NEW_LINE_COMMENT);
+            }
+        }
         p.add_source_mapping(self.span);
         p.print_indent();
         p.print_str("export");
@@ -1065,6 +1010,7 @@ impl Gen for ExportNamedDeclaration<'_> {
 impl Gen for TSExportAssignment<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_indent();
+        p.print_statement_comments(self.span.start);
         p.print_str("export = ");
         self.expression.print_expr(p, Precedence::Lowest, ctx);
         p.print_semicolon_after_statement();
@@ -1074,6 +1020,7 @@ impl Gen for TSExportAssignment<'_> {
 impl Gen for TSNamespaceExportDeclaration<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_indent();
+        p.print_statement_comments(self.span.start);
         p.print_str("export as namespace ");
         self.id.print(p, ctx);
         p.print_semicolon_after_statement();
@@ -1118,6 +1065,7 @@ impl Gen for ModuleExportName<'_> {
 
 impl Gen for ExportAllDeclaration<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+        p.print_statement_comments(self.span.start);
         p.add_source_mapping(self.span);
         p.print_indent();
         p.print_str("export");
@@ -1150,6 +1098,12 @@ impl Gen for ExportAllDeclaration<'_> {
 
 impl Gen for ExportDefaultDeclaration<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+        p.print_statement_comments(self.span.start);
+        if let ExportDefaultDeclarationKind::FunctionDeclaration(func) = &self.declaration {
+            if func.pure && p.print_annotation_comment {
+                p.print_str(NO_SIDE_EFFECTS_NEW_LINE_COMMENT);
+            }
+        }
         p.add_source_mapping(self.span);
         p.print_indent();
         p.print_str("export default ");


### PR DESCRIPTION
To improve instructions cache.

relates #10931