### PR TITLE
docs(linter): fix incorrect backticks of fenced code blocks

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
@@ -94,7 +94,7 @@ declare_oxc_lint!(
     ///
     /// ```javascript
     /// const b = a|0;
-    /// ``````
+    /// ```
     NoBitwise,
     eslint,
     restriction

--- a/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
@@ -181,7 +181,7 @@ fn check_parents<'a>(
             // function foo() {
             //   foo()
             // }
-            // ````
+            // ```
             // To avoid infinite loop, we need to check if the function is already visited when
             // call `check_parents`.
             let boolean = symbol_table.get_resolved_references(symbol_id).any(|reference| {

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
@@ -74,14 +74,14 @@ declare_oxc_lint!(
     ///     <a href="#" onClick={foo}>Perform action</a>
     ///     <a onClick={foo}>Perform action</a>
     /// </>
-    /// ````
+    /// ```
     ///
     /// All these anchor implementations indicate that the element is only used to execute JavaScript code. All the above should be replaced with:
     ///
     /// ```jsx
     /// <button onClick={foo}>Perform action</button>
     /// ```
-    /// `
+    ///
     /// ### Why is this bad?
     /// There are **many reasons** why an anchor should not have a logic and have a correct `href` attribute:
     /// - it can disrupt the correct flow of the user navigation e.g. a user that wants to open the link

--- a/crates/oxc_linter/src/rules/jsx_a11y/lang.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/lang.rs
@@ -42,7 +42,7 @@ declare_oxc_lint!(
     /// ```jsx
     /// <html>
     /// <html lang="foo">
-    /// ````
+    /// ```
     ///
     /// Examples of **correct** code for this rule:
     /// ```jsx

--- a/crates/oxc_regular_expression/src/parser/pattern_parser/character.rs
+++ b/crates/oxc_regular_expression/src/parser/pattern_parser/character.rs
@@ -23,7 +23,7 @@ pub fn is_class_set_syntax_character(cp: u32) -> bool {
 // ```
 // ClassSetReservedDoublePunctuator :: one of
 //   && !! ## $$ %% ** ++ ,, .. :: ;; << == >> ?? @@ ^^ `` ~~
-// ````
+// ```
 pub fn is_class_set_reserved_double_punctuator(cp1: u32, cp2: u32) -> bool {
     char::from_u32(cp1).is_some_and(|ch1| {
         char::from_u32(cp2).is_some_and(|ch2| {

--- a/tasks/prettier_conformance/src/spec.rs
+++ b/tasks/prettier_conformance/src/spec.rs
@@ -51,7 +51,7 @@ impl VisitMut<'_> for SpecParser {
     //
     // runFormatTest(import.meta, parser, {});
     // runFormatTest(import.meta, parser, { semi: false });
-    // ````
+    // ```
     fn visit_variable_declarator(&mut self, decl: &mut VariableDeclarator<'_>) {
         let Some(name) = decl.id.get_identifier_name() else { return };
         if !matches!(name.as_str(), "parser" | "parsers") {


### PR DESCRIPTION
Continuation of #10914