### PR TITLE
fix(transformer/legacy-decorator): abstract class doesn't work in metadata

### DIFF
--- a/crates/oxc_transformer/src/decorator/legacy/metadata.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/metadata.rs
@@ -107,7 +107,7 @@ impl<'a, 'ctx> LegacyDecoratorMetadata<'a, 'ctx> {
 
 impl<'a> Traverse<'a> for LegacyDecoratorMetadata<'a, '_> {
     fn enter_class(&mut self, class: &mut Class<'a>, ctx: &mut TraverseCtx<'a>) {
-        if class.is_expression() || class.is_typescript_syntax() {
+        if class.is_expression() || class.declare {
             return;
         }
 

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -808,7 +808,7 @@ impl<'a> LegacyDecorator<'a, '_> {
     /// Check if a class or its elements have decorators.
     fn check_class_has_decorated(class: &Class<'a>) -> ClassDecoratorInfo {
         // Legacy decorator does not allow in class expression.
-        if class.is_expression() || class.is_typescript_syntax() {
+        if class.is_expression() || class.declare {
             return ClassDecoratorInfo::default();
         }
 

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 578ac4df
 
-Passed: 152/253
+Passed: 152/254
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -497,7 +497,18 @@ after transform: SymbolId(4): ScopeId(1)
 rebuilt        : SymbolId(5): ScopeId(4)
 
 
-# legacy-decorators (4/73)
+# legacy-decorators (4/74)
+* oxc/metadata/abstract-class/input.ts
+Symbol reference IDs mismatch for "Dependency":
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
+rebuilt        : SymbolId(1): [ReferenceId(6), ReferenceId(7)]
+Symbol span mismatch for "AbstractClass":
+after transform: SymbolId(2): Span { start: 69, end: 82 }
+rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
+Symbol span mismatch for "AbstractClass":
+after transform: SymbolId(5): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(4): Span { start: 69, end: 82 }
+
 * oxc/metadata/bound-type-reference/input.ts
 Symbol reference IDs mismatch for "BoundTypeReference":
 after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6)]

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/abstract-class/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/abstract-class/input.ts
@@ -1,0 +1,6 @@
+import { dce, Dependency } from "mod";
+
+@dce()
+export abstract class AbstractClass {
+	constructor(public dependency: Dependency) {}
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/abstract-class/output.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/abstract-class/output.ts
@@ -1,0 +1,11 @@
+import { dce, Dependency } from "mod";
+
+var _ref;
+let AbstractClass = class AbstractClass {
+  constructor(dependency) {
+    this.dependency = dependency;
+  }
+};
+AbstractClass = babelHelpers.decorate([dce(), babelHelpers.decorateMetadata("design:paramtypes", [typeof (_ref = typeof Dependency !== "undefined" && Dependency) === "function" ? _ref : Object])], AbstractClass);
+
+export { AbstractClass };


### PR DESCRIPTION
close: #10926 