### PR TITLE
fix(estree): Ensure the same key order for `AssignmentPattern`

### DIFF
--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -610,11 +610,11 @@ impl ESTree for ElisionConverter<'_> {
                 end: DESER[u32]( POS_OFFSET<BindingRestElement>.span.end ),
                 argument: DESER[BindingPatternKind]( POS_OFFSET<BindingRestElement>.argument.kind ),
                 /* IF_TS */
+                decorators: [],
+                optional: DESER[bool]( POS_OFFSET<BindingRestElement>.argument.optional ),
                 typeAnnotation: DESER[Option<Box<TSTypeAnnotation>>](
                     POS_OFFSET<BindingRestElement>.argument.type_annotation
                 ),
-                optional: DESER[bool]( POS_OFFSET<BindingRestElement>.argument.optional ),
-                decorators: [],
                 value: null,
                 /* END_IF_TS */
             });
@@ -649,9 +649,9 @@ impl ESTree for FormalParametersRest<'_, '_> {
         state.serialize_field("start", &rest.span.start);
         state.serialize_field("end", &rest.span.end);
         state.serialize_field("argument", &rest.argument.kind);
-        state.serialize_ts_field("typeAnnotation", &rest.argument.type_annotation);
-        state.serialize_ts_field("optional", &rest.argument.optional);
         state.serialize_ts_field("decorators", &EmptyArray(()));
+        state.serialize_ts_field("optional", &rest.argument.optional);
+        state.serialize_ts_field("typeAnnotation", &rest.argument.type_annotation);
         state.serialize_ts_field("value", &Null(()));
         state.end();
     }
@@ -881,9 +881,9 @@ impl ESTree for ArrowFunctionExpressionBody<'_> {
                     left: keyCopy,
                     right: init,
                     /* IF_TS */
-                    typeAnnotation: null,
-                    optional: false,
                     decorators: [],
+                    optional: false,
+                    typeAnnotation: null,
                     /* END_IF_TS */
                 };
         value
@@ -902,9 +902,9 @@ impl ESTree for AssignmentTargetPropertyIdentifierValue<'_> {
             state.serialize_field("end", &self.0.span.end);
             state.serialize_field("left", &self.0.binding);
             state.serialize_field("right", init);
-            state.serialize_ts_field("typeAnnotation", &Null(()));
-            state.serialize_ts_field("optional", &False(()));
             state.serialize_ts_field("decorators", &EmptyArray(()));
+            state.serialize_ts_field("optional", &False(()));
+            state.serialize_ts_field("typeAnnotation", &Null(()));
             state.end();
         } else {
             self.0.binding.serialize(serializer);

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -426,9 +426,9 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
         end: end,
         left: keyCopy,
         right: init,
-        typeAnnotation: null,
-        optional: false,
         decorators: [],
+        optional: false,
+        typeAnnotation: null,
       };
   return {
     type: 'Property',
@@ -858,11 +858,11 @@ function deserializeFormalParameters(pos) {
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       argument: deserializeBindingPatternKind(pos + 8),
+      decorators: [],
+      optional: deserializeBool(pos + 32),
       typeAnnotation: deserializeOptionBoxTSTypeAnnotation(
         pos + 24,
       ),
-      optional: deserializeBool(pos + 32),
-      decorators: [],
       value: null,
     });
   }


### PR DESCRIPTION
Part of #9705 

With this PR, all AST nodes now have a consistent key order for each node type.
(Checked by https://github.com/leaysgur/oxc_estree_ts-ast-diff-viewer/blob/main/scripts/verify-key-order-oxc.js)

Except for:

- `Literal`: `regex` and `bigint` keys
- `TSModuleDeclaration`: `body` key is missing when `declare module "jq";`