### PR TITLE
chore(linter): move `typescript/consistent-type-imports` our of nursery

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -103,7 +103,7 @@ declare_oxc_lint!(
     /// ```
     ConsistentTypeImports,
     typescript,
-    nursery,
+    style,
     conditional_fix
 );
 


### PR DESCRIPTION
this rule has been out for 10 months, and has 0? issues reported on it, lets stabilize it, and move it to ready for vue core to use