### PR TITLE
fix(ast/estree): fix field order and type def for `RestElement` in `FormalParameters`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1774,8 +1774,10 @@ pub enum FunctionType {
         interface FormalParameterRest extends Span {
             type: 'RestElement';
             argument: BindingPatternKind;
-            typeAnnotation: TSTypeAnnotation | null;
-            optional: boolean;
+            decorators?: [],
+            optional?: boolean;
+            typeAnnotation?: TSTypeAnnotation | null;
+            value?: null;
         }
     "
 )]

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -610,11 +610,11 @@ impl ESTree for ElisionConverter<'_> {
                 end: DESER[u32]( POS_OFFSET<BindingRestElement>.span.end ),
                 argument: DESER[BindingPatternKind]( POS_OFFSET<BindingRestElement>.argument.kind ),
                 /* IF_TS */
+                decorators: [],
+                optional: DESER[bool]( POS_OFFSET<BindingRestElement>.argument.optional ),
                 typeAnnotation: DESER[Option<Box<TSTypeAnnotation>>](
                     POS_OFFSET<BindingRestElement>.argument.type_annotation
                 ),
-                optional: DESER[bool]( POS_OFFSET<BindingRestElement>.argument.optional ),
-                decorators: [],
                 value: null,
                 /* END_IF_TS */
             });
@@ -649,9 +649,9 @@ impl ESTree for FormalParametersRest<'_, '_> {
         state.serialize_field("start", &rest.span.start);
         state.serialize_field("end", &rest.span.end);
         state.serialize_field("argument", &rest.argument.kind);
-        state.serialize_ts_field("typeAnnotation", &rest.argument.type_annotation);
-        state.serialize_ts_field("optional", &rest.argument.optional);
         state.serialize_ts_field("decorators", &EmptyArray(()));
+        state.serialize_ts_field("optional", &rest.argument.optional);
+        state.serialize_ts_field("typeAnnotation", &rest.argument.type_annotation);
         state.serialize_ts_field("value", &Null(()));
         state.end();
     }

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -858,11 +858,11 @@ function deserializeFormalParameters(pos) {
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       argument: deserializeBindingPatternKind(pos + 8),
+      decorators: [],
+      optional: deserializeBool(pos + 32),
       typeAnnotation: deserializeOptionBoxTSTypeAnnotation(
         pos + 24,
       ),
-      optional: deserializeBool(pos + 32),
-      decorators: [],
       value: null,
     });
   }

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -600,8 +600,10 @@ export type FunctionType =
 export interface FormalParameterRest extends Span {
   type: 'RestElement';
   argument: BindingPatternKind;
-  typeAnnotation: TSTypeAnnotation | null;
-  optional: boolean;
+  decorators?: [];
+  optional?: boolean;
+  typeAnnotation?: TSTypeAnnotation | null;
+  value?: null;
 }
 
 export type FormalParameter =


### PR DESCRIPTION
Change field order for a `RestElement` in `FormalParameters` to contain `decorators`, `optional`, `typeAnnotation` in that order - to match `RestElement` in other positions.

Fix TS type def for `FormalParameterRest` to include all fields.
