### PR TITLE
fix(ast/estree): fix field order for `FormalParameter`

### DIFF
--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -677,9 +677,9 @@ impl ESTree for FormalParametersRest<'_, '_> {
         if (accessibility === null && !readonly && !override) {
             param = {
                 ...DESER[BindingPatternKind](POS_OFFSET.pattern.kind),
-                typeAnnotation: DESER[Option<Box<TSTypeAnnotation>>](POS_OFFSET.pattern.type_annotation),
-                optional: DESER[bool](POS_OFFSET.pattern.optional),
                 decorators: DESER[Vec<Decorator>](POS_OFFSET.decorators),
+                optional: DESER[bool](POS_OFFSET.pattern.optional),
+                typeAnnotation: DESER[Option<Box<TSTypeAnnotation>>](POS_OFFSET.pattern.type_annotation),
             };
         } else {
             param = {
@@ -720,9 +720,9 @@ impl ESTree for FormalParameterConverter<'_, '_> {
             } else {
                 let mut state = serializer.serialize_struct();
                 param.pattern.kind.serialize(FlatStructSerializer(&mut state));
-                state.serialize_field("typeAnnotation", &param.pattern.type_annotation);
-                state.serialize_field("optional", &param.pattern.optional);
                 state.serialize_field("decorators", &param.decorators);
+                state.serialize_field("optional", &param.pattern.optional);
+                state.serialize_field("typeAnnotation", &param.pattern.type_annotation);
                 state.end();
             }
         } else {

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -877,9 +877,9 @@ function deserializeFormalParameter(pos) {
   if (accessibility === null && !readonly && !override) {
     param = {
       ...deserializeBindingPatternKind(pos + 40),
-      typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 56),
-      optional: deserializeBool(pos + 64),
       decorators: deserializeVecDecorator(pos + 8),
+      optional: deserializeBool(pos + 64),
+      typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 56),
     };
   } else {
     param = {


### PR DESCRIPTION
Order last 3 fields: `decorators`, `optional`, `typeAnnotation` - to match these types in other positions.