### PR TITLE
refactor(ast/estree): rename custom serializers for fields containing `FormalParameters`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1727,7 +1727,7 @@ pub struct Function<'a> {
     /// Function parameters.
     ///
     /// Does not include `this` parameters used by some TypeScript functions.
-    #[estree(via = FunctionFormalParameters)]
+    #[estree(via = FunctionParams)]
     pub params: Box<'a, FormalParameters<'a>>,
     /// The TypeScript return type annotation.
     #[ts]

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1020,7 +1020,7 @@ pub struct TSCallSignatureDeclaration<'a> {
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     #[estree(skip)]
     pub this_param: Option<Box<'a, TSThisParameter<'a>>>,
-    #[estree(via = TSCallSignatureDeclarationFormalParameters)]
+    #[estree(via = TSCallSignatureDeclarationParams)]
     pub params: Box<'a, FormalParameters<'a>>,
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
 }
@@ -1059,7 +1059,7 @@ pub struct TSMethodSignature<'a> {
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     #[estree(skip)]
     pub this_param: Option<Box<'a, TSThisParameter<'a>>>,
-    #[estree(via = TSMethodSignatureFormalParameters)]
+    #[estree(via = TSMethodSignatureParams)]
     pub params: Box<'a, FormalParameters<'a>>,
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
     pub scope_id: Cell<Option<ScopeId>>,
@@ -1388,7 +1388,7 @@ pub struct TSFunctionType<'a> {
     #[estree(skip)]
     pub this_param: Option<Box<'a, TSThisParameter<'a>>>,
     /// Function parameters. Akin to [`Function::params`].
-    #[estree(via = TSFunctionTypeFormalParameters)]
+    #[estree(via = TSFunctionTypeParams)]
     pub params: Box<'a, FormalParameters<'a>>,
     /// Return type of the function.
     /// ```ts

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1355,7 +1355,7 @@ impl ESTree for Function<'_> {
         state.serialize_field("expression", &crate::serialize::False(self));
         state.serialize_field("generator", &self.generator);
         state.serialize_field("async", &self.r#async);
-        state.serialize_field("params", &crate::serialize::FunctionFormalParameters(self));
+        state.serialize_field("params", &crate::serialize::FunctionParams(self));
         state.serialize_field("body", &self.body);
         state.serialize_ts_field("declare", &self.declare);
         state.serialize_ts_field("typeParameters", &self.type_parameters);
@@ -2926,10 +2926,7 @@ impl ESTree for TSCallSignatureDeclaration<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeParameters", &self.type_parameters);
-        state.serialize_field(
-            "params",
-            &crate::serialize::TSCallSignatureDeclarationFormalParameters(self),
-        );
+        state.serialize_field("params", &crate::serialize::TSCallSignatureDeclarationParams(self));
         state.serialize_field("returnType", &self.return_type);
         state.end();
     }
@@ -2956,7 +2953,7 @@ impl ESTree for TSMethodSignature<'_> {
         state.serialize_field("optional", &self.optional);
         state.serialize_field("kind", &self.kind);
         state.serialize_field("typeParameters", &self.type_parameters);
-        state.serialize_field("params", &crate::serialize::TSMethodSignatureFormalParameters(self));
+        state.serialize_field("params", &crate::serialize::TSMethodSignatureParams(self));
         state.serialize_field("returnType", &self.return_type);
         state.serialize_field("accessibility", &crate::serialize::Null(self));
         state.serialize_field("readonly", &crate::serialize::False(self));
@@ -3138,7 +3135,7 @@ impl ESTree for TSFunctionType<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeParameters", &self.type_parameters);
-        state.serialize_field("params", &crate::serialize::TSFunctionTypeFormalParameters(self));
+        state.serialize_field("params", &crate::serialize::TSFunctionTypeParams(self));
         state.serialize_field("returnType", &self.return_type);
         state.end();
     }

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -746,9 +746,9 @@ impl ESTree for FormalParameterConverter<'_, '_> {
         params
     "
 )]
-pub struct FunctionFormalParameters<'a, 'b>(pub &'b Function<'a>);
+pub struct FunctionParams<'a, 'b>(pub &'b Function<'a>);
 
-impl ESTree for FunctionFormalParameters<'_, '_> {
+impl ESTree for FunctionParams<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut seq = serializer.serialize_sequence();
 
@@ -1469,11 +1469,9 @@ impl ESTree for TSTypeNameAsMemberExpression<'_, '_> {
         params
     "
 )]
-pub struct TSCallSignatureDeclarationFormalParameters<'a, 'b>(
-    pub &'b TSCallSignatureDeclaration<'a>,
-);
+pub struct TSCallSignatureDeclarationParams<'a, 'b>(pub &'b TSCallSignatureDeclaration<'a>);
 
-impl ESTree for TSCallSignatureDeclarationFormalParameters<'_, '_> {
+impl ESTree for TSCallSignatureDeclarationParams<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let v = self.0;
         serialize_formal_params_with_this_param(v.this_param.as_deref(), &v.params, serializer);
@@ -1493,9 +1491,9 @@ impl ESTree for TSCallSignatureDeclarationFormalParameters<'_, '_> {
         params
     "
 )]
-pub struct TSMethodSignatureFormalParameters<'a, 'b>(pub &'b TSMethodSignature<'a>);
+pub struct TSMethodSignatureParams<'a, 'b>(pub &'b TSMethodSignature<'a>);
 
-impl ESTree for TSMethodSignatureFormalParameters<'_, '_> {
+impl ESTree for TSMethodSignatureParams<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let v = self.0;
         serialize_formal_params_with_this_param(v.this_param.as_deref(), &v.params, serializer);
@@ -1515,9 +1513,9 @@ impl ESTree for TSMethodSignatureFormalParameters<'_, '_> {
         params
     "
 )]
-pub struct TSFunctionTypeFormalParameters<'a, 'b>(pub &'b TSFunctionType<'a>);
+pub struct TSFunctionTypeParams<'a, 'b>(pub &'b TSFunctionType<'a>);
 
-impl ESTree for TSFunctionTypeFormalParameters<'_, '_> {
+impl ESTree for TSFunctionTypeParams<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let v = self.0;
         serialize_formal_params_with_this_param(v.this_param.as_deref(), &v.params, serializer);
@@ -1525,9 +1523,9 @@ impl ESTree for TSFunctionTypeFormalParameters<'_, '_> {
 }
 
 /// Shared serialization logic used by:
-/// - `TSCallSignatureDeclarationFormalParameters`
-/// - `TSMethodSignatureFormalParameters`
-/// - `TSFunctionTypeFormalParameters`
+/// - `TSCallSignatureDeclarationParams`
+/// - `TSMethodSignatureParams`
+/// - `TSFunctionTypeParams`
 fn serialize_formal_params_with_this_param<'a, S: Serializer>(
     this_param: Option<&TSThisParameter<'a>>,
     params: &FormalParameters<'a>,


### PR DESCRIPTION
Pure refactor. Rename serializers to follow consistent naming convention of `<type name><field name>`.
