### PR TITLE
docs(ast/estree): standardize doc comments for ESTree serializers

### DIFF
--- a/crates/oxc_ast/src/serialize/js.rs
+++ b/crates/oxc_ast/src/serialize/js.rs
@@ -326,7 +326,7 @@ impl ESTree for MethodDefinitionKey<'_, '_> {
     }
 }
 
-/// Serializer for `ArrowFunctionExpression`'s `body` field.
+/// Serializer for `body` field of `ArrowFunctionExpression`.
 ///
 /// Serialize as either an expression (if `expression` property is set),
 /// or a `BlockStatement` (if it's not).
@@ -350,7 +350,7 @@ impl ESTree for ArrowFunctionExpressionBody<'_> {
     }
 }
 
-/// Serializer for `AssignmentTargetPropertyIdentifier`'s `init` field
+/// Serializer for `init` field of `AssignmentTargetPropertyIdentifier`
 /// (which is renamed to `value` in ESTree AST).
 #[ast_meta]
 #[estree(

--- a/crates/oxc_ast/src/serialize/ts.rs
+++ b/crates/oxc_ast/src/serialize/ts.rs
@@ -27,7 +27,7 @@ impl ESTree for TSEnumMemberComputed<'_, '_> {
 
 /// Serializer for `directive` field of `ExpressionStatement`.
 ///
-/// This field is always `null`, and only appears in the TS AST, not JS ESTree.
+/// This field is always `null`, and only appears in the TS-ESTree AST, not JS ESTree.
 #[ast_meta]
 #[estree(ts_type = "string | null", raw_deser = "null")]
 #[ts]


### PR DESCRIPTION
Part of effort to clean up and standardize ESTree serializers. Make all docs comments for serializers follow the same standard form, to make the code easier to follow.