### PR TITLE
refactor(ast/estree): rename serializers

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -962,7 +962,7 @@ pub struct AssignmentTargetPropertyIdentifier<'a> {
     pub span: Span,
     #[estree(rename = "key")]
     pub binding: IdentifierReference<'a>,
-    #[estree(rename = "value", via = AssignmentTargetPropertyIdentifierValue)]
+    #[estree(rename = "value", via = AssignmentTargetPropertyIdentifierInit)]
     pub init: Option<Expression<'a>>,
 }
 

--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -38,7 +38,7 @@ pub struct JSXElement<'a> {
     /// Node location in source code
     pub span: Span,
     /// Opening tag of the element.
-    #[estree(via = JSXElementOpening)]
+    #[estree(via = JSXElementOpeningElement)]
     pub opening_element: Box<'a, JSXOpeningElement<'a>>,
     /// Children of the element.
     /// This can be text, other elements, or expressions.

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -725,7 +725,7 @@ impl ESTree for AssignmentTargetPropertyIdentifier<'_> {
         state.serialize_field("key", &self.binding);
         state.serialize_field(
             "value",
-            &crate::serialize::js::AssignmentTargetPropertyIdentifierValue(self),
+            &crate::serialize::js::AssignmentTargetPropertyIdentifierInit(self),
         );
         state.serialize_field("kind", &crate::serialize::basic::Init(self));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
@@ -1999,7 +1999,10 @@ impl ESTree for JSXElement<'_> {
         state.serialize_field("type", &JsonSafeString("JSXElement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("openingElement", &crate::serialize::jsx::JSXElementOpening(self));
+        state.serialize_field(
+            "openingElement",
+            &crate::serialize::jsx::JSXElementOpeningElement(self),
+        );
         state.serialize_field("closingElement", &self.closing_element);
         state.serialize_field("children", &self.children);
         state.end();

--- a/crates/oxc_ast/src/serialize/js.rs
+++ b/crates/oxc_ast/src/serialize/js.rs
@@ -375,11 +375,11 @@ impl ESTree for ArrowFunctionExpressionBody<'_> {
         value
     "
 )]
-pub struct AssignmentTargetPropertyIdentifierValue<'a>(
+pub struct AssignmentTargetPropertyIdentifierInit<'a>(
     pub &'a AssignmentTargetPropertyIdentifier<'a>,
 );
 
-impl ESTree for AssignmentTargetPropertyIdentifierValue<'_> {
+impl ESTree for AssignmentTargetPropertyIdentifierInit<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         if let Some(init) = &self.0.init {
             let mut state = serializer.serialize_struct();

--- a/crates/oxc_ast/src/serialize/jsx.rs
+++ b/crates/oxc_ast/src/serialize/jsx.rs
@@ -17,9 +17,9 @@ use super::EmptyArray;
         openingElement
     "
 )]
-pub struct JSXElementOpening<'a, 'b>(pub &'b JSXElement<'a>);
+pub struct JSXElementOpeningElement<'a, 'b>(pub &'b JSXElement<'a>);
 
-impl ESTree for JSXElementOpening<'_, '_> {
+impl ESTree for JSXElementOpeningElement<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let element = self.0;
         let opening_element = element.opening_element.as_ref();


### PR DESCRIPTION
Pure refactor. Rename `AssignmentTargetPropertyIdentifierInit` and `JSXElementOpeningElement` serializers, to follow the naming convention of `<type name><field name>`.