### PR TITLE
style(ast/estree): reformat `raw_deser` code

### DIFF
--- a/crates/oxc_ast/src/serialize/js.rs
+++ b/crates/oxc_ast/src/serialize/js.rs
@@ -357,7 +357,7 @@ impl ESTree for ArrowFunctionExpressionBody<'_> {
     ts_type = "IdentifierReference | AssignmentTargetWithDefault",
     raw_deser = "
         const init = DESER[Option<Expression>](POS_OFFSET.init),
-            keyCopy = {...THIS.key},
+            keyCopy = { ...THIS.key },
             value = init === null
                 ? keyCopy
                 : {

--- a/crates/oxc_ast/src/serialize/jsx.rs
+++ b/crates/oxc_ast/src/serialize/jsx.rs
@@ -59,7 +59,7 @@ impl ESTree for JSXOpeningElementSelfClosing<'_, '_> {
     ts_type = "JSXIdentifier",
     raw_deser = "
         const ident = DESER[Box<IdentifierReference>](POS);
-        {type: 'JSXIdentifier', start: ident.start, end: ident.end, name: ident.name}
+        { type: 'JSXIdentifier', start: ident.start, end: ident.end, name: ident.name }
     "
 )]
 pub struct JSXElementIdentifierReference<'a, 'b>(pub &'b IdentifierReference<'a>);
@@ -78,7 +78,7 @@ impl ESTree for JSXElementIdentifierReference<'_, '_> {
     ts_type = "JSXIdentifier",
     raw_deser = "
         const thisExpr = DESER[Box<ThisExpression>](POS);
-        {type: 'JSXIdentifier', start: thisExpr.start, end: thisExpr.end, name: 'this'}
+        { type: 'JSXIdentifier', start: thisExpr.start, end: thisExpr.end, name: 'this' }
     "
 )]
 pub struct JSXElementThisExpression<'b>(pub &'b ThisExpression);

--- a/crates/oxc_ast/src/serialize/mod.rs
+++ b/crates/oxc_ast/src/serialize/mod.rs
@@ -136,7 +136,7 @@ impl Program<'_> {
         const first = body[0];
         start = first.start;
         if (first.type === 'ExportNamedDeclaration' || first.type === 'ExportDefaultDeclaration') {
-            const {declaration} = first;
+            const { declaration } = first;
             if (
                 declaration !== null && declaration.type === 'ClassDeclaration'
                 && declaration.decorators.length > 0


### PR DESCRIPTION
Pure style change. Just reformat code to match `dprint`.