### PR TITLE
perf(ast/estree): streamline raw deserializer for `WithClause`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -2491,10 +2491,13 @@ pub struct ImportNamespaceSpecifier<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(no_ts_def)]
+#[estree(no_type, no_ts_def)]
 pub struct WithClause<'a> {
+    #[estree(skip)]
     pub span: Span,
+    #[estree(skip)]
     pub attributes_keyword: IdentifierName<'a>, // `with` or `assert`
+    #[estree(rename = "attributes")]
     pub with_entries: Vec<'a, ImportAttribute<'a>>,
 }
 

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1731,11 +1731,7 @@ impl ESTree for ImportNamespaceSpecifier<'_> {
 impl ESTree for WithClause<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", &JsonSafeString("WithClause"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
-        state.serialize_field("attributesKeyword", &self.attributes_keyword);
-        state.serialize_field("withEntries", &self.with_entries);
+        state.serialize_field("attributes", &self.with_entries);
         state.end();
     }
 }

--- a/crates/oxc_ast/src/serialize/js.rs
+++ b/crates/oxc_ast/src/serialize/js.rs
@@ -221,7 +221,7 @@ impl ESTree for ImportDeclarationSpecifiers<'_, '_> {
     ts_type = "Array<ImportAttribute>",
     raw_deser = "
         const withClause = DESER[Option<Box<WithClause>>](POS_OFFSET.with_clause);
-        withClause === null ? [] : withClause.withEntries
+        withClause === null ? [] : withClause.attributes
     "
 )]
 pub struct ImportDeclarationWithClause<'a, 'b>(pub &'b ImportDeclaration<'a>);
@@ -241,7 +241,7 @@ impl ESTree for ImportDeclarationWithClause<'_, '_> {
     ts_type = "Array<ImportAttribute>",
     raw_deser = "
         const withClause = DESER[Option<Box<WithClause>>](POS_OFFSET.with_clause);
-        withClause === null ? [] : withClause.withEntries
+        withClause === null ? [] : withClause.attributes
     "
 )]
 pub struct ExportNamedDeclarationWithClause<'a, 'b>(pub &'b ExportNamedDeclaration<'a>);
@@ -261,7 +261,7 @@ impl ESTree for ExportNamedDeclarationWithClause<'_, '_> {
     ts_type = "Array<ImportAttribute>",
     raw_deser = "
         const withClause = DESER[Option<Box<WithClause>>](POS_OFFSET.with_clause);
-        withClause === null ? [] : withClause.withEntries
+        withClause === null ? [] : withClause.attributes
     "
 )]
 pub struct ExportAllDeclarationWithClause<'a, 'b>(pub &'b ExportAllDeclaration<'a>);

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -923,7 +923,7 @@ function deserializeImportDeclaration(pos) {
     end: deserializeU32(pos + 4),
     specifiers,
     source: deserializeStringLiteral(pos + 40),
-    attributes: withClause === null ? [] : withClause.withEntries,
+    attributes: withClause === null ? [] : withClause.attributes,
   };
 }
 
@@ -957,11 +957,7 @@ function deserializeImportNamespaceSpecifier(pos) {
 
 function deserializeWithClause(pos) {
   return {
-    type: 'WithClause',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
-    attributesKeyword: deserializeIdentifierName(pos + 8),
-    withEntries: deserializeVecImportAttribute(pos + 32),
+    attributes: deserializeVecImportAttribute(pos + 32),
   };
 }
 
@@ -984,7 +980,7 @@ function deserializeExportNamedDeclaration(pos) {
     declaration: deserializeOptionDeclaration(pos + 8),
     specifiers: deserializeVecExportSpecifier(pos + 24),
     source: deserializeOptionStringLiteral(pos + 56),
-    attributes: withClause === null ? [] : withClause.withEntries,
+    attributes: withClause === null ? [] : withClause.attributes,
   };
 }
 
@@ -1005,7 +1001,7 @@ function deserializeExportAllDeclaration(pos) {
     end: deserializeU32(pos + 4),
     exported: deserializeOptionModuleExportName(pos + 8),
     source: deserializeStringLiteral(pos + 64),
-    attributes: withClause === null ? [] : withClause.withEntries,
+    attributes: withClause === null ? [] : withClause.attributes,
   };
 }
 

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -1070,7 +1070,7 @@ function deserializeImportDeclaration(pos) {
     end: deserializeU32(pos + 4),
     specifiers,
     source: deserializeStringLiteral(pos + 40),
-    attributes: withClause === null ? [] : withClause.withEntries,
+    attributes: withClause === null ? [] : withClause.attributes,
     importKind: deserializeImportOrExportKind(pos + 104),
   };
 }
@@ -1106,11 +1106,7 @@ function deserializeImportNamespaceSpecifier(pos) {
 
 function deserializeWithClause(pos) {
   return {
-    type: 'WithClause',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
-    attributesKeyword: deserializeIdentifierName(pos + 8),
-    withEntries: deserializeVecImportAttribute(pos + 32),
+    attributes: deserializeVecImportAttribute(pos + 32),
   };
 }
 
@@ -1133,7 +1129,7 @@ function deserializeExportNamedDeclaration(pos) {
     declaration: deserializeOptionDeclaration(pos + 8),
     specifiers: deserializeVecExportSpecifier(pos + 24),
     source: deserializeOptionStringLiteral(pos + 56),
-    attributes: withClause === null ? [] : withClause.withEntries,
+    attributes: withClause === null ? [] : withClause.attributes,
     exportKind: deserializeImportOrExportKind(pos + 104),
   };
 }
@@ -1156,7 +1152,7 @@ function deserializeExportAllDeclaration(pos) {
     end: deserializeU32(pos + 4),
     exported: deserializeOptionModuleExportName(pos + 8),
     source: deserializeStringLiteral(pos + 64),
-    attributes: withClause === null ? [] : withClause.withEntries,
+    attributes: withClause === null ? [] : withClause.attributes,
     exportKind: deserializeImportOrExportKind(pos + 120),
   };
 }


### PR DESCRIPTION
All the fields of `WithClause` except `with_entries` are ignored, so there's no point deserializing them.
