### PR TITLE
fix(linter): false positive with negative matches in no-restricted-imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1798,7 +1798,6 @@ dependencies = [
  "cow-utils",
  "fast-glob",
  "globset",
- "ignore",
  "indexmap",
  "insta",
  "itertools",

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -49,7 +49,6 @@ convert_case = { workspace = true }
 cow-utils = { workspace = true }
 fast-glob = { workspace = true }
 globset = { workspace = true }
-ignore = { workspace = true }
 indexmap = { workspace = true, features = ["rayon"] }
 itertools = { workspace = true }
 javascript-globals = { workspace = true }

--- a/crates/oxc_linter/src/snapshots/eslint_no_restricted_imports.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_restricted_imports.snap
@@ -787,6 +787,27 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: foo is forbidden, use bar instead
 
+  ⚠ eslint(no-restricted-imports): 'foo' import is restricted from being used by a pattern.
+   ╭─[no_restricted_imports.tsx:1:1]
+ 1 │ import {x} from "foo"; import {x2} from "./index.mjs"; import {x3} from "index";
+   · ──────────────────────
+   ╰────
+  help: foo is forbidden, use bar instead
+
+  ⚠ eslint(no-restricted-imports): './index.mjs' import is restricted from being used by a pattern.
+   ╭─[no_restricted_imports.tsx:1:24]
+ 1 │ import {x} from "foo"; import {x2} from "./index.mjs"; import {x3} from "index";
+   ·                        ───────────────────────────────
+   ╰────
+  help: foo is forbidden, use bar instead
+
+  ⚠ eslint(no-restricted-imports): 'index' import is restricted from being used by a pattern.
+   ╭─[no_restricted_imports.tsx:1:56]
+ 1 │ import {x} from "foo"; import {x2} from "./index.mjs"; import {x3} from "index";
+   ·                                                        ─────────────────────────
+   ╰────
+  help: foo is forbidden, use bar instead
+
   ⚠ eslint(no-restricted-imports): 'import1' import is restricted from being used.
    ╭─[no_restricted_imports.tsx:1:1]
  1 │ import foo from 'import1';


### PR DESCRIPTION
this was an absolute nightmare to fix.
TLDR is that `GitignoreBuilder` nor `OverrideBuilder` do not contain the flexibility or have the behaviour we want to achieve this here. They don't go through the full list of patterns (for perf reasons), but that has the caveat of meaning it does not work correctly with eslint

closes #10911