### PR TITLE
refactor(ast_tools): shorten code in generator for `Utf8ToUtf16Converter`

### DIFF
--- a/tasks/ast_tools/src/generators/utf8_to_utf16.rs
+++ b/tasks/ast_tools/src/generators/utf8_to_utf16.rs
@@ -72,12 +72,8 @@ fn generate(schema: &Schema, codegen: &Codegen) -> TokenStream {
             return None;
         }
 
-        // Skip types in `oxc_regular_expression`, `oxc_syntax`, and `napi/parser` crates.
-        // They don't appear in ESTree AST.
-        if matches!(
-            struct_def.file(schema).krate(),
-            "oxc_regular_expression" | "oxc_syntax" | "napi/parser"
-        ) {
+        // Skip types in `oxc_syntax` and `napi/parser` crates. They don't appear in ESTree AST.
+        if matches!(struct_def.file(schema).krate(), "oxc_syntax" | "napi/parser") {
             return None;
         }
 


### PR DESCRIPTION
No need to skip types in `oxc_regular_expression` crate, as they no longer derive `ESTree`.