### PR TITLE
fix(isolated-declarations): lost leading comments of `export default` function/class/interface

### DIFF
--- a/crates/oxc_isolated_declarations/src/module.rs
+++ b/crates/oxc_isolated_declarations/src/module.rs
@@ -59,8 +59,30 @@ impl<'a> IsolatedDeclarations<'a> {
         declaration.map(|(var_decl, declaration)| {
             let exported =
                 ModuleExportName::IdentifierName(self.ast.identifier_name(SPAN, "default"));
+            // When `var_decl` is Some, the comments are moved to the variable declaration, otherwise
+            // keep the comments on the export default declaration to avoid losing them.
+            // ```ts
+            // // comment
+            // export default function(): void {}
+            //
+            // // comment
+            // export default 1;
+            // ```
+            //
+            // to
+            //
+            // ```ts
+            // // comment
+            // export default function(): void;
+            //
+            // // comment
+            // const _default = 1;
+            // export default _default;
+            // ```
+
+            let span = if var_decl.is_some() { SPAN } else { decl.span };
             let declaration =
-                self.ast.module_declaration_export_default_declaration(SPAN, exported, declaration);
+                self.ast.module_declaration_export_default_declaration(span, exported, declaration);
             (var_decl, Statement::from(declaration))
         })
     }

--- a/crates/oxc_isolated_declarations/tests/fixtures/export-default.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/export-default.ts
@@ -1,6 +1,6 @@
-const defaultDelimitersClose = new Uint8Array([125, 125])
+const defaultDelimitersClose = new Uint8Array([125, 125]);
 
+/** comment should be a leading comment of the class */
 export default class Tokenizer {
-  public delimiterClose: Uint8Array = defaultDelimitersClose
+	public delimiterClose: Uint8Array = defaultDelimitersClose;
 }
-

--- a/crates/oxc_isolated_declarations/tests/snapshots/export-default.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/export-default.snap
@@ -5,6 +5,7 @@ input_file: crates/oxc_isolated_declarations/tests/fixtures/export-default.ts
 ```
 ==================== .D.TS ====================
 
+/** comment should be a leading comment of the class */
 export default class Tokenizer {
 	delimiterClose: Uint8Array;
 }


### PR DESCRIPTION
close: #10989