### PR TITLE
feat(codegen): rework printing normal / legal / annotation comments

### DIFF
--- a/crates/oxc_ast/src/ast/comment.rs
+++ b/crates/oxc_ast/src/ast/comment.rs
@@ -49,15 +49,14 @@ pub enum CommentAnnotation {
     #[default]
     None = 0,
 
-    /// `/** jsdoc */`
-    /// <https://jsdoc.app>
-    Jsdoc = 1,
-
     /// Legal Comment
     /// e.g. `/* @license */`, `/* @preserve */`, or starts with `//!` or `/*!`.
-    ///
     /// <https://esbuild.github.io/api/#legal-comments>
-    Legal = 2,
+    Legal = 1,
+
+    /// `/** jsdoc */`
+    /// <https://jsdoc.app>
+    Jsdoc = 2,
 
     /// `/* #__PURE__ */`
     /// <https://github.com/javascript-compiler-hints/compiler-notations-spec>

--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -1,7 +1,6 @@
-use oxc_span::{GetSpan, Span};
 use rustc_hash::FxHashMap;
 
-use oxc_ast::{Comment, CommentKind, ast::Argument};
+use oxc_ast::{Comment, CommentKind};
 use oxc_syntax::identifier::is_line_terminator;
 
 use crate::{Codegen, LegalComment};
@@ -10,7 +9,12 @@ pub type CommentsMap = FxHashMap</* attached_to */ u32, Vec<Comment>>;
 
 impl Codegen<'_> {
     pub(crate) fn build_comments(&mut self, comments: &[Comment]) {
-        self.comments.reserve(comments.len());
+        if !self.options.comments
+            && self.options.legal_comments.is_none()
+            && !self.options.annotation_comments
+        {
+            return;
+        }
         let move_legal_comments = {
             let legal_comments = &self.options.legal_comments;
             matches!(
@@ -23,10 +27,25 @@ impl Codegen<'_> {
             if comment.is_pure() || comment.is_no_side_effects() {
                 continue;
             }
-            if comment.is_legal() && move_legal_comments {
-                self.legal_comments.push(*comment);
+            let mut add = false;
+            if comment.is_legal() {
+                if move_legal_comments {
+                    self.legal_comments.push(*comment);
+                } else if self.options.print_legal_comment() {
+                    add = true;
+                }
+            } else if comment.is_leading() {
+                if comment.is_annotation() {
+                    if self.options.print_annotation_comment() {
+                        add = true;
+                    }
+                } else if self.options.print_normal_comment() {
+                    add = true;
+                }
             }
-            self.comments.entry(comment.attached_to).or_default().push(*comment);
+            if add {
+                self.comments.entry(comment.attached_to).or_default().push(*comment);
+            }
         }
     }
 
@@ -34,80 +53,31 @@ impl Codegen<'_> {
         self.comments.contains_key(&start)
     }
 
-    pub(crate) fn contains_comment_in_call_like_expression(
-        &self,
-        span: Span,
-        arguments: &[Argument<'_>],
-    ) -> (bool, bool) {
-        let has_comment_before_right_paren =
-            self.print_annotation_comment && span.end > 0 && self.has_comment(span.end - 1);
-
-        let has_comment = has_comment_before_right_paren
-            || self.print_annotation_comment
-                && arguments.iter().any(|item| self.has_comment(item.span().start));
-
-        (has_comment, has_comment_before_right_paren)
-    }
-
-    /// Whether to keep leading comments.
-    fn should_keep_leading_comment(comment: &Comment) -> bool {
-        comment.preceded_by_newline && comment.is_annotation()
-    }
-
     pub(crate) fn print_leading_comments(&mut self, start: u32) {
-        if !self.print_any_comment {
-            return;
+        if let Some(comments) = self.comments.remove(&start) {
+            self.print_comments(&comments);
         }
-        let Some(comments) = self.comments.remove(&start) else {
-            return;
-        };
-        let comments =
-            comments.into_iter().filter(Self::should_keep_leading_comment).collect::<Vec<_>>();
-        self.print_comments(&comments);
     }
 
     pub(crate) fn get_statement_comments(&mut self, start: u32) -> Option<Vec<Comment>> {
-        let comments = self.comments.remove(&start)?;
-
-        let mut leading_comments = vec![];
-
-        for comment in comments {
-            if comment.is_legal() {
-                match &self.options.legal_comments {
-                    LegalComment::None if self.options.comments => {
-                        leading_comments.push(comment);
-                        continue;
-                    }
-                    LegalComment::Inline => {
-                        leading_comments.push(comment);
-                        continue;
-                    }
-                    LegalComment::Eof | LegalComment::Linked(_) | LegalComment::External => {
-                        /* noop, handled by `build_comments`. */
-                        continue;
-                    }
-                    LegalComment::None => {}
-                }
-            }
-            if Self::should_keep_leading_comment(&comment) {
-                leading_comments.push(comment);
-            }
+        if self.comments.is_empty() {
+            return None;
         }
-
-        Some(leading_comments)
+        self.comments.remove(&start)
     }
 
     /// A statement comment also includes legal comments
     #[inline]
     pub(crate) fn print_statement_comments(&mut self, start: u32) {
-        if self.print_any_comment {
-            if let Some(comments) = self.get_statement_comments(start) {
-                self.print_comments(&comments);
-            }
+        if let Some(comments) = self.get_statement_comments(start) {
+            self.print_comments(&comments);
         }
     }
 
     pub(crate) fn print_expr_comments(&mut self, start: u32) -> bool {
+        if self.comments.is_empty() {
+            return false;
+        }
         let Some(comments) = self.comments.remove(&start) else { return false };
 
         for comment in &comments {

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -15,10 +15,7 @@ mod str;
 
 use std::borrow::Cow;
 
-use oxc_ast::ast::{
-    Argument, BindingIdentifier, BlockStatement, Comment, Expression, IdentifierReference, Program,
-    Statement,
-};
+use oxc_ast::ast::*;
 use oxc_data_structures::{code_buffer::CodeBuffer, stack::Stack};
 use oxc_semantic::Scoping;
 use oxc_span::{GetSpan, SPAN, Span};
@@ -107,11 +104,6 @@ pub struct Codegen<'a> {
     /// Fast path for [CodegenOptions::single_quote]
     quote: Quote,
 
-    /// Fast path for if print comments
-    print_any_comment: bool,
-    print_legal_comment: bool,
-    print_annotation_comment: bool,
-
     // Builders
     comments: CommentsMap,
 
@@ -146,9 +138,6 @@ impl<'a> Codegen<'a> {
     #[must_use]
     pub fn new() -> Self {
         let options = CodegenOptions::default();
-        let print_any_comment = options.print_any_comment();
-        let print_legal_comment = options.print_legal_comment();
-        let print_annotation_comment = options.print_annotation_comment();
         Self {
             options,
             source_text: None,
@@ -167,9 +156,6 @@ impl<'a> Codegen<'a> {
             is_jsx: false,
             indent: 0,
             quote: Quote::Double,
-            print_any_comment,
-            print_legal_comment,
-            print_annotation_comment,
             comments: CommentsMap::default(),
             legal_comments: vec![],
             sourcemap_builder: None,
@@ -180,9 +166,6 @@ impl<'a> Codegen<'a> {
     #[must_use]
     pub fn with_options(mut self, options: CodegenOptions) -> Self {
         self.quote = if options.single_quote { Quote::Single } else { Quote::Double };
-        self.print_any_comment = options.print_any_comment();
-        self.print_legal_comment = options.print_legal_comment();
-        self.print_annotation_comment = options.print_annotation_comment();
         self.options = options;
         self
     }
@@ -211,14 +194,7 @@ impl<'a> Codegen<'a> {
         self.quote = if self.options.single_quote { Quote::Single } else { Quote::Double };
         self.source_text = Some(program.source_text);
         self.code.reserve(program.source_text.len());
-
-        if self.print_any_comment {
-            if program.comments.is_empty() {
-                self.print_any_comment = false;
-            } else {
-                self.build_comments(&program.comments);
-            }
-        }
+        self.build_comments(&program.comments);
         if let Some(path) = &self.options.source_map_path {
             self.sourcemap_builder = Some(SourcemapBuilder::new(path, program.source_text));
         }
@@ -469,6 +445,44 @@ impl<'a> Codegen<'a> {
         self.needs_semicolon = false;
     }
 
+    fn print_directives_and_statements(
+        &mut self,
+        directives: &[Directive<'_>],
+        stmts: &[Statement<'_>],
+        ctx: Context,
+    ) {
+        for directive in directives {
+            directive.print(self, ctx);
+        }
+        let Some((first, rest)) = stmts.split_first() else {
+            return;
+        };
+
+        // Ensure first string literal is not a directive.
+        let mut first_needs_parens = false;
+        if directives.is_empty() && !self.options.minify {
+            if let Statement::ExpressionStatement(s) = first {
+                let s = s.expression.without_parentheses();
+                if matches!(s, Expression::StringLiteral(_)) {
+                    first_needs_parens = true;
+                    self.print_ascii_byte(b'(');
+                    s.print_expr(self, Precedence::Lowest, ctx);
+                    self.print_ascii_byte(b')');
+                    self.print_semicolon_after_statement();
+                }
+            }
+        }
+
+        if !first_needs_parens {
+            first.print(self, ctx);
+        }
+
+        for stmt in rest {
+            self.print_semicolon_if_needed();
+            stmt.print(self, ctx);
+        }
+    }
+
     #[inline]
     fn print_list<T: Gen>(&mut self, items: &[T], ctx: Context) {
         let Some((first, rest)) = items.split_first() else {
@@ -480,6 +494,44 @@ impl<'a> Codegen<'a> {
             self.print_soft_space();
             item.print(self, ctx);
         }
+    }
+
+    #[inline]
+    fn print_expressions<T: GenExpr>(&mut self, items: &[T], precedence: Precedence, ctx: Context) {
+        let Some((first, rest)) = items.split_first() else {
+            return;
+        };
+        first.print_expr(self, precedence, ctx);
+        for item in rest {
+            self.print_comma();
+            self.print_soft_space();
+            item.print_expr(self, precedence, ctx);
+        }
+    }
+
+    fn print_arguments(&mut self, span: Span, arguments: &[Argument<'_>], ctx: Context) {
+        self.print_ascii_byte(b'(');
+
+        let has_comment_before_right_paren = span.end > 0 && self.has_comment(span.end - 1);
+
+        let has_comment = has_comment_before_right_paren
+            || arguments.iter().any(|item| self.has_comment(item.span().start));
+
+        if has_comment {
+            self.indent();
+            self.print_list_with_comments(arguments, ctx);
+            // Handle `/* comment */);`
+            if !has_comment_before_right_paren
+                || (span.end > 0 && !self.print_expr_comments(span.end - 1))
+            {
+                self.print_soft_newline();
+            }
+            self.dedent();
+            self.print_indent();
+        } else {
+            self.print_list(arguments, ctx);
+        }
+        self.print_ascii_byte(b')');
     }
 
     fn print_list_with_comments(&mut self, items: &[Argument<'_>], ctx: Context) {
@@ -502,19 +554,6 @@ impl<'a> Codegen<'a> {
                 self.print_indent();
             }
             item.print(self, ctx);
-        }
-    }
-
-    #[inline]
-    fn print_expressions<T: GenExpr>(&mut self, items: &[T], precedence: Precedence, ctx: Context) {
-        let Some((first, rest)) = items.split_first() else {
-            return;
-        };
-        first.print_expr(self, precedence, ctx);
-        for item in rest {
-            self.print_comma();
-            self.print_soft_space();
-            item.print_expr(self, precedence, ctx);
         }
     }
 

--- a/crates/oxc_codegen/src/options.rs
+++ b/crates/oxc_codegen/src/options.rs
@@ -13,19 +13,30 @@ pub struct CodegenOptions {
     /// Default is `false`.
     pub minify: bool,
 
-    /// Print all comments?
+    /// Print normal comments?
+    ///
+    /// At present, only some leading comments are preserved.
+    ///
+    /// Does not control legal and annotation comments.
     ///
     /// Default is `true`.
     pub comments: bool,
 
-    /// Print annotation comments, e.g. `/* #__PURE__ */` and `/* #__NO_SIDE_EFFECTS__ */`.
+    /// Print annotation comments.
+    ///
+    /// * jsdoc: `/** jsdoc */`
+    /// * pure: `/* #__PURE__ */` and `/* #__NO_SIDE_EFFECTS__ */`
+    /// * webpack: `/* webpackChunkName */`
+    /// * vite: `/* @vite-ignore */`
+    /// * coverage: `v8 ignore`, `c8 ignore`, `node:coverage`, `istanbul ignore`
     ///
     /// Default is `true`.
     pub annotation_comments: bool,
 
     /// Print legal comments.
     ///
-    /// <https://esbuild.github.io/api/#legal-comments>
+    /// * starts with `//!` or `/*!`.
+    /// * contains `/* @license */` or `/* @preserve */`
     ///
     /// Default is [LegalComment::Inline].
     pub legal_comments: LegalComment,
@@ -64,16 +75,19 @@ impl CodegenOptions {
         }
     }
 
-    pub(crate) fn print_any_comment(&self) -> bool {
+    #[inline]
+    pub(crate) fn print_normal_comment(&self) -> bool {
         self.comments
     }
 
+    #[inline]
     pub(crate) fn print_legal_comment(&self) -> bool {
-        self.comments || !self.legal_comments.is_none()
+        self.legal_comments.is_inline()
     }
 
+    #[inline]
     pub(crate) fn print_annotation_comment(&self) -> bool {
-        self.comments || self.annotation_comments
+        self.annotation_comments
     }
 }
 

--- a/crates/oxc_codegen/tests/integration/comments.rs
+++ b/crates/oxc_codegen/tests/integration/comments.rs
@@ -457,3 +457,64 @@ delete /* @__PURE__ */ (() => {})();",
         snapshot("pure_comments", &cases);
     }
 }
+
+pub mod options {
+    use oxc_codegen::{CodegenOptions, LegalComment};
+
+    use crate::codegen_options;
+
+    #[test]
+    fn test() {
+        let code = "
+//! Top Legal Comment
+function foo() {
+    /** JSDoc Comment */
+    function bar() {
+        /* #__PURE__ */ x();
+    }
+    function baz() {
+        //! Function Legal Comment
+    }
+    x(/* Normal Comment */);
+    x(/** Call Expression Annotation Comment */ token);
+}";
+
+        for comments in [true, false] {
+            for annotation in [true, false] {
+                for legal in [LegalComment::Inline, LegalComment::Eof, LegalComment::None] {
+                    let options = CodegenOptions {
+                        comments,
+                        annotation_comments: annotation,
+                        legal_comments: legal.clone(),
+                        ..CodegenOptions::default()
+                    };
+                    let printed = codegen_options(code, &options).code;
+
+                    if comments {
+                        assert!(printed.contains("Normal Comment"));
+                    } else {
+                        assert!(!printed.contains("Normal Comment"));
+                    }
+
+                    if annotation {
+                        assert!(printed.contains("JSDoc Comment"));
+                        assert!(printed.contains("__PURE__"));
+                        assert!(printed.contains("Call Expression Annotation Comment"));
+                    } else {
+                        assert!(!printed.contains("JSDoc Comment"));
+                        assert!(!printed.contains("__PURE__"));
+                        assert!(!printed.contains("Call Expression Annotation Comment"));
+                    }
+
+                    if legal.is_none() {
+                        assert!(!printed.contains("Top Legal Comment"));
+                        assert!(!printed.contains("Function Legal Comment"));
+                    } else {
+                        assert!(printed.contains("Top Legal Comment"));
+                        assert!(printed.contains("Function Legal Comment"));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/oxc_codegen/tests/integration/main.rs
+++ b/crates/oxc_codegen/tests/integration/main.rs
@@ -10,10 +10,12 @@ use oxc_codegen::{Codegen, CodegenOptions, CodegenReturn};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 
+#[track_caller]
 pub fn codegen(source_text: &str) -> String {
     codegen_options(source_text, &CodegenOptions::default()).code
 }
 
+#[track_caller]
 pub fn codegen_options(source_text: &str, options: &CodegenOptions) -> CodegenReturn {
     let allocator = Allocator::default();
     let source_type = SourceType::ts();
@@ -23,10 +25,12 @@ pub fn codegen_options(source_text: &str, options: &CodegenOptions) -> CodegenRe
     Codegen::new().with_options(options).build(&ret.program)
 }
 
+#[track_caller]
 pub fn snapshot(name: &str, cases: &[&str]) {
     snapshot_options(name, cases, &CodegenOptions::default());
 }
 
+#[track_caller]
 pub fn snapshot_options(name: &str, cases: &[&str], options: &CodegenOptions) {
     use std::fmt::Write;
 

--- a/crates/oxc_codegen/tests/integration/snapshots/jsodc.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/jsodc.snap
@@ -172,6 +172,7 @@ this.Book = function(title) {
 	/** The title of the book. */
 	this.title = title;
 };
+// https://github.com/oxc-project/oxc/issues/6006
 export enum DefinitionKind {
 	/**
 	* Definition is a referenced variable.

--- a/crates/oxc_codegen/tests/integration/snapshots/legal_eof_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/legal_eof_comments.snap
@@ -100,10 +100,10 @@ function foo() {
 ----------
 function foo() {
 	(() => {
-		/**
-		* @preserve
-		*/
-	})();
+	/**
+	* @preserve
+	*/
+})();
 	/**
 	* @preserve
 	*/

--- a/crates/oxc_codegen/tests/integration/snapshots/legal_inline_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/legal_inline_comments.snap
@@ -92,10 +92,10 @@ function foo() {
 ----------
 function foo() {
 	(() => {
-		/**
-		* @preserve
-		*/
-	})();
+	/**
+	* @preserve
+	*/
+})();
 	/**
 	* @preserve
 	*/

--- a/crates/oxc_codegen/tests/integration/snapshots/legal_linked_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/legal_linked_comments.snap
@@ -85,10 +85,10 @@ function foo() {
 ----------
 function foo() {
 	(() => {
-		/**
-		* @preserve
-		*/
-	})();
+	/**
+	* @preserve
+	*/
+})();
 	/**
 	* @preserve
 	*/

--- a/crates/oxc_codegen/tests/integration/snapshots/ts.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/ts.snap
@@ -307,9 +307,9 @@ import 'module-name';
 import {} from "mod";
 export let name1, name2;
 export const name3 = 1, name4 = 2;
-export function functionName() {}
+export function functionName() {/* … */}
 export class ClassName {}
-export function* generatorFunctionName() {}
+export function* generatorFunctionName() {/* … */}
 export const { name5, name2: bar } = o;
 export const [name6, name7] = array;
 export { name8, name81 };

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -121,9 +121,5 @@ export import b = require("b");
     ];
 
     snapshot("ts", &cases);
-    snapshot_options(
-        "minify",
-        &cases,
-        &CodegenOptions { minify: true, ..CodegenOptions::default() },
-    );
+    snapshot_options("minify", &cases, &CodegenOptions::minify());
 }

--- a/crates/oxc_isolated_declarations/tests/snapshots/async-function.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/async-function.snap
@@ -5,11 +5,14 @@ input_file: crates/oxc_isolated_declarations/tests/fixtures/async-function.ts
 ```
 ==================== .D.TS ====================
 
+// Correct
 declare function asyncFunctionGood(): Promise<number>;
 declare const asyncFunctionGoo2: () => Promise<number>;
 declare class AsyncClassGood {
 	method(): number;
 }
+// Need to explicit return type for async functions
+// Incorrect
 declare function asyncFunction();
 declare const asyncFunction2: unknown;
 declare class AsyncClassBad {

--- a/crates/oxc_isolated_declarations/tests/snapshots/function-parameters.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/function-parameters.snap
@@ -5,11 +5,13 @@ input_file: crates/oxc_isolated_declarations/tests/fixtures/function-parameters.
 ```
 ==================== .D.TS ====================
 
+// Correct
 export declare function fnDeclGood(p?: T, rParam?: string): void;
 export declare function fnDeclGood2(p?: T, rParam?: number): void;
 export declare function fooGood([a, b]?: any[]): number;
 export declare const fooGood2: ({ a, b }?: object) => number;
 export declare function fooGood3({ a, b: [{ c }] }: object): void;
+// Incorrect
 export declare function fnDeclBad<T>(p: T, rParam: T, r2: T): void;
 export declare function fnDeclBad2<T>(p: T, r2: T): void;
 export declare function fnDeclBad3<T>(p: T, rParam?: T, r2: T): void;

--- a/crates/oxc_isolated_declarations/tests/snapshots/function-signatures.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/function-signatures.snap
@@ -5,7 +5,10 @@ input_file: crates/oxc_isolated_declarations/tests/fixtures/function-signatures.
 ```
 ==================== .D.TS ====================
 
+// All of these are valid function signatures under isolatedDeclarations
 export declare function A(): void;
 export declare function B(): (() => void) | undefined;
+// There should be no declaration for the implementation signature, just the
+// two overloads.
 export declare function C(x: string): void;
 export declare function C(x: number): void;

--- a/crates/oxc_isolated_declarations/tests/snapshots/generator.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/generator.snap
@@ -5,10 +5,13 @@ input_file: crates/oxc_isolated_declarations/tests/fixtures/generator.ts
 ```
 ==================== .D.TS ====================
 
+// Correct
 declare function generatorGood(): Generator<number>;
 declare class GeneratorClassGood {
 	method(): Generator<number>;
 }
+// Need to explicit return type for async functions
+// Incorrect
 declare function generatorBad();
 declare class GeneratorClassBad {
 	method();

--- a/crates/oxc_isolated_declarations/tests/snapshots/infer-expression.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/infer-expression.snap
@@ -5,12 +5,17 @@ input_file: crates/oxc_isolated_declarations/tests/fixtures/infer-expression.ts
 ```
 ==================== .D.TS ====================
 
+// Correct
+// ParenthesizedExpression
 declare const n: number;
 declare const s: string;
 declare const t: string;
 declare const b: boolean;
+// UnaryExpression
 declare let unaryA: number;
 declare const unaryB = -12n;
+// Incorrect
+// UnaryExpression
 declare const unaryC: unknown;
 declare const unaryD: unknown;
 declare const unaryE: {};

--- a/crates/oxc_isolated_declarations/tests/snapshots/infer-return-type.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/infer-return-type.snap
@@ -6,10 +6,14 @@ input_file: crates/oxc_isolated_declarations/tests/fixtures/infer-return-type.ts
 ==================== .D.TS ====================
 
 declare function foo(): number;
+// inferred type is number
 declare function bar(): number | undefined;
+// inferred type is number | undefined
 declare function baz();
+// We can't infer return type if there are multiple return statements with different types
 declare function qux(): string;
 declare function quux(): string;
+// Inferred type is string
 declare function returnFunctionOrNothing(): (() => number) | undefined;
 
 

--- a/crates/oxc_isolated_declarations/tests/snapshots/set-get-accessor.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/set-get-accessor.snap
@@ -5,6 +5,7 @@ input_file: crates/oxc_isolated_declarations/tests/fixtures/set-get-accessor.ts
 ```
 ==================== .D.TS ====================
 
+// Correct
 declare class Cls {
 	get a(): number;
 	set a(value);
@@ -16,6 +17,7 @@ declare class Cls {
 	private accessor e;
 	private static accessor f;
 }
+// Incorrect
 declare class ClsBad {
 	get a();
 	set a(v);

--- a/crates/oxc_isolated_declarations/tests/snapshots/signatures.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/signatures.snap
@@ -24,6 +24,7 @@ export interface I {
 	set value(_: string);
 	get value(): string;
 }
+// Do nothing
 export interface Ref<
 	T = any,
 	S = T

--- a/crates/oxc_transformer_plugins/tests/integrations/replace_global_defines.rs
+++ b/crates/oxc_transformer_plugins/tests/integrations/replace_global_defines.rs
@@ -190,7 +190,9 @@ fn this_expr() {
         // This code should be the same as above
         (() => { ok( this, this.foo, this.foo.bar, this.foo.baz, this.bar,) })();
     ",
-        "ok(1, 2, 3, 2 .baz, 1 .bar);",
+        "
+        // This code should be the same as above
+        ok(1, 2, 3, 2 .baz, 1 .bar);",
         config.clone(),
     );
 

--- a/tasks/coverage/snapshots/codegen_babel.snap
+++ b/tasks/coverage/snapshots/codegen_babel.snap
@@ -2,4 +2,8 @@ commit: 578ac4df
 
 codegen_babel Summary:
 AST Parsed     : 2322/2322 (100.00%)
-Positive Passed: 2322/2322 (100.00%)
+Positive Passed: 2320/2322 (99.91%)
+Normal: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/uncategorised/47/input.js
+
+Normal: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/uncategorised/48/input.js
+

--- a/tasks/coverage/snapshots/minifier_babel.snap
+++ b/tasks/coverage/snapshots/minifier_babel.snap
@@ -2,4 +2,8 @@ commit: 578ac4df
 
 minifier_babel Summary:
 AST Parsed     : 1732/1732 (100.00%)
-Positive Passed: 1732/1732 (100.00%)
+Positive Passed: 1730/1732 (99.88%)
+Compress: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/uncategorised/47/input.js
+
+Compress: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/uncategorised/48/input.js
+

--- a/tasks/coverage/snapshots/transformer_babel.snap
+++ b/tasks/coverage/snapshots/transformer_babel.snap
@@ -2,4 +2,8 @@ commit: 578ac4df
 
 transformer_babel Summary:
 AST Parsed     : 2322/2322 (100.00%)
-Positive Passed: 2322/2322 (100.00%)
+Positive Passed: 2320/2322 (99.91%)
+Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/uncategorised/47/input.js
+
+Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/uncategorised/48/input.js
+

--- a/tasks/coverage/snapshots/transpile.snap
+++ b/tasks/coverage/snapshots/transpile.snap
@@ -386,6 +386,7 @@ export class InClassMethodBad {
 	o(array: T = [], rParam: string): void {}
 }
 ;
+// https://github.com/microsoft/TypeScript/issues/60976
 class Bar {}
 export class ClsWithRequiredInitializedParameter {
 	constructor(private arr: Bar = new Bar(), private bool: boolean) {}

--- a/tasks/coverage/src/driver.rs
+++ b/tasks/coverage/src/driver.rs
@@ -62,8 +62,13 @@ impl CompilerInterface for Driver {
     }
 
     fn codegen_options(&self) -> Option<CodegenOptions> {
-        self.codegen
-            .then(|| CodegenOptions { minify: self.remove_whitespace, ..CodegenOptions::default() })
+        self.codegen.then(|| {
+            if self.remove_whitespace {
+                CodegenOptions::minify()
+            } else {
+                CodegenOptions::default()
+            }
+        })
     }
 
     fn handle_errors(&mut self, errors: Vec<OxcDiagnostic>) {

--- a/tasks/coverage/src/typescript/transpile_runner.rs
+++ b/tasks/coverage/src/typescript/transpile_runner.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use oxc::{
     allocator::Allocator,
-    codegen::Codegen,
+    codegen::{Codegen, CodegenOptions},
     diagnostics::OxcDiagnostic,
     isolated_declarations::{IsolatedDeclarations, IsolatedDeclarationsOptions},
     parser::Parser,
@@ -181,6 +181,9 @@ fn transpile(path: &Path, source_text: &str) -> (String, Vec<OxcDiagnostic>) {
     let ret =
         IsolatedDeclarations::new(&allocator, IsolatedDeclarationsOptions { strip_internal: true })
             .build(&ret.program);
-    let printed = Codegen::new().build(&ret.program).code;
+    let printed = Codegen::new()
+        .with_options(CodegenOptions { comments: false, ..CodegenOptions::default() })
+        .build(&ret.program)
+        .code;
     (printed, ret.errors)
 }

--- a/tasks/transform_conformance/src/driver.rs
+++ b/tasks/transform_conformance/src/driver.rs
@@ -68,6 +68,8 @@ impl CompilerInterface for Driver {
                 self.errors.extend(errors);
             }
         }
+        // Clear comments to avoid pure annotation comments that cause mismatch.
+        program.comments.clear();
         ControlFlow::Continue(())
     }
 }


### PR DESCRIPTION
fixes #10948

This PR changes how comment options are interpreted.

`CodegenOptions::comments`, `CodegenOptions::annotation_comments` and `CodegenOptions::legal_comments` are now independent of each other.

### `CodegenOptions::comments`

Controls printing of normal comments. At present, only some leading comments are preserved. It does not control legal and annotation comments.


### `CodegenOptions::annotation_comments`

Controls printing of annotation comments

* jsdoc: `/** jsdoc */`                                                 
* pure: `/* #__PURE__ */` and `/* #__NO_SIDE_EFFECTS__ */`              
* webpack: `/* webpackChunkName */`                                     
* vite: `/* @vite-ignore */`                                            
* coverage: `v8 ignore`, `c8 ignore`, `node:coverage`, `istanbul ignore`

### `CodegenOptions::legal_comments`

Controls printing of legal comments

* starts with `//!` or `/*!`.                   
* contains `/* @license */` or `/* @preserve */`

---

Comment generation is also changed:

codegen first builds a comments map by keeping only the needed comments.
Printing functions will then print out comments in their respective positions.

---

This PR reveals some incorrect comment interpretation:  

* https://github.com/oxc-project/oxc/issues/10998

