### PR TITLE
test(transformer/jsx): fix tests for JSX pragma parsing

### DIFF
--- a/crates/oxc_transformer/src/jsx/comments.rs
+++ b/crates/oxc_transformer/src/jsx/comments.rs
@@ -248,14 +248,6 @@ mod tests {
                     assert_eq!(&pragmas, expected);
                 }
             }
-
-            let mut comment_str = *comment_str;
-            let mut pragmas = vec![];
-            while let Some((pragma_type, value, remaining)) = find_jsx_pragma(comment_str) {
-                pragmas.push((pragma_type, value));
-                comment_str = remaining;
-            }
-            assert_eq!(&pragmas, expected);
         }
     }
 }


### PR DESCRIPTION
Remove duplicated logic in tests. I forgot to remove this block when I added the prefix/postfix testing. It's pointless as the block above covers all these cases already.
