### PR TITLE
perf(transformer/jsx): use `memchr` for parsing JSX pragma comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2178,6 +2178,7 @@ dependencies = [
  "indexmap",
  "insta",
  "itoa",
+ "memchr",
  "oxc-browserslist",
  "oxc_allocator",
  "oxc_ast",

--- a/crates/oxc_transformer/Cargo.toml
+++ b/crates/oxc_transformer/Cargo.toml
@@ -40,6 +40,7 @@ compact_str = { workspace = true }
 cow-utils = { workspace = true }
 indexmap = { workspace = true }
 itoa = { workspace = true }
+memchr = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }


### PR DESCRIPTION
Use `memchr` for finding `@` when parsing JSX pragmas from comments.

This wins back most (but not all) of the perf loss of #10983 on `antd.js` benchmark, and preserves the perf gain of #10983 on `cal.com.tsx` benchmark.

Interestingly, using `memchr` to search just for `@` and then checking next 3 bytes are `jsx` separately is measurably faster than using `memchr::memmem::Finder` to search for `@jsx`.
