### PR TITLE
test(ast/estree): re-order ESTree conformance tests and rename JSX tester

### DIFF
--- a/tasks/coverage/src/lib.rs
+++ b/tasks/coverage/src/lib.rs
@@ -16,7 +16,7 @@ use std::{path::PathBuf, process::Command};
 
 use oxc_tasks_common::project_root;
 use runtime::Test262RuntimeCase;
-use tools::estree::{AcornJsxCase, AcornJsxSuite, EstreeTypescriptCase};
+use tools::estree::{AcornJsxSuite, EstreeJsxCase, EstreeTypescriptCase};
 
 use crate::{
     babel::{BabelCase, BabelSuite},
@@ -115,9 +115,9 @@ impl AppArgs {
     }
 
     pub fn run_estree(&self) {
-        TypeScriptSuite::<EstreeTypescriptCase>::new().run("estree_typescript", self);
-        AcornJsxSuite::<AcornJsxCase>::new().run("estree_acorn_jsx", self);
         Test262Suite::<EstreeTest262Case>::new().run("estree_test262", self);
+        AcornJsxSuite::<EstreeJsxCase>::new().run("estree_acorn_jsx", self);
+        TypeScriptSuite::<EstreeTypescriptCase>::new().run("estree_typescript", self);
     }
 
     /// # Panics

--- a/tasks/coverage/src/tools/estree.rs
+++ b/tasks/coverage/src/tools/estree.rs
@@ -166,13 +166,13 @@ impl<T: Case> Suite<T> for AcornJsxSuite<T> {
     }
 }
 
-pub struct AcornJsxCase {
+pub struct EstreeJsxCase {
     path: PathBuf,
     code: String,
     result: TestResult,
 }
 
-impl Case for AcornJsxCase {
+impl Case for EstreeJsxCase {
     fn new(path: PathBuf, code: String) -> Self {
         Self { path, code, result: TestResult::ToBeRun }
     }


### PR DESCRIPTION
Pure refactor. Run ESTree conformance test suites in same order as other conformance testers. And rename the `Case` type for JSX tests, for consistency.
