### PR TITLE
fix(parser): fix parsing repeated static in class field

### DIFF
--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -2,7 +2,7 @@ use oxc_codegen::CodegenOptions;
 
 use crate::{
     snapshot, snapshot_options,
-    tester::{test_same, test_tsx},
+    tester::{test, test_same, test_tsx},
 };
 
 #[test]
@@ -13,6 +13,10 @@ fn cases() {
     test_same("class C {\n\tp = await(0);\n}\n");
     test_same(
         "class Foo {\n\t#name: string;\n\tf() {\n\t\t#name in other && this.#name === other.#name;\n\t}\n}\n",
+    );
+    test(
+        "class C {\n\tstatic\nstatic\n\tstatic\na() {}\n}\n",
+        "class C {\n\tstatic static;\n\tstatic a() {}\n}\n",
     );
 }
 

--- a/crates/oxc_codegen/tests/integration/unit.rs
+++ b/crates/oxc_codegen/tests/integration/unit.rs
@@ -75,6 +75,11 @@ fn class() {
         "export default class Foo {\n\t@x @y accessor #aDef = 1;\n}\n",
     );
     test_minify("class { static [computed] }", "class{static[computed]}");
+
+    test(
+        "class C {\n\tstatic\nstatic\n\tstatic\na() {}\n}\n",
+        "class C {\n\tstatic static;\n\tstatic a() {}\n}\n",
+    );
 }
 
 #[test]

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1800,7 +1800,9 @@ mod test {
             "class C { static accessor ['__proto__'] = 0 }",
             "class C { static accessor __proto__ = 0 }",
         );
-        test("class C { static static ['__proto__']() {} }", "class C { static __proto__() {} }");
+
+        // wrong test case
+        // test("class C { static static ['__proto__']() {} }", "class C { static __proto__() {} }");
 
         // <https://tc39.es/ecma262/2024/multipage/ecmascript-language-functions-and-classes.html#sec-static-semantics-classelementkind>
         // <https://tc39.es/ecma262/2024/multipage/ecmascript-language-functions-and-classes.html#sec-class-definitions-static-semantics-early-errors>

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1801,9 +1801,6 @@ mod test {
             "class C { static accessor __proto__ = 0 }",
         );
 
-        // wrong test case
-        // test("class C { static static ['__proto__']() {} }", "class C { static __proto__() {} }");
-
         // <https://tc39.es/ecma262/2024/multipage/ecmascript-language-functions-and-classes.html#sec-static-semantics-classelementkind>
         // <https://tc39.es/ecma262/2024/multipage/ecmascript-language-functions-and-classes.html#sec-class-definitions-static-semantics-early-errors>
         // <https://arai-a.github.io/ecma262-compare/?pr=2417&id=sec-class-definitions-static-semantics-early-errors>

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -209,7 +209,7 @@ impl<'a> ParserImpl<'a> {
         let mut r#static = modifiers.contains(ModifierKind::Static);
         let mut r#async = modifiers.contains(ModifierKind::Async);
 
-        if self.at(Kind::Static) {
+        if !r#static && self.at(Kind::Static) {
             // static { block }
             if self.peek_at(Kind::LCurly) {
                 self.bump(Kind::Static);

--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -462,7 +462,7 @@ impl<'a> ParserImpl<'a> {
                 }
             }
             Kind::Default => self.next_token_can_follow_default_keyword(),
-            Kind::Get | Kind::Set => {
+            Kind::Static | Kind::Get | Kind::Set => {
                 self.bump_any();
                 self.can_follow_modifier()
             }

--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -462,7 +462,7 @@ impl<'a> ParserImpl<'a> {
                 }
             }
             Kind::Default => self.next_token_can_follow_default_keyword(),
-            Kind::Static | Kind::Get | Kind::Set => {
+            Kind::Get | Kind::Set => {
                 self.bump_any();
                 self.can_follow_modifier()
             }

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -3,7 +3,7 @@ commit: 578ac4df
 parser_babel Summary:
 AST Parsed     : 2309/2322 (99.44%)
 Positive Passed: 2288/2322 (98.54%)
-Negative Passed: 1560/1673 (93.25%)
+Negative Passed: 1562/1673 (93.37%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/invalid-startindex-and-startline-specified-without-startcolumn/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/startline-and-startcolumn-specified/input.js
@@ -39,8 +39,6 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/private-in/invalid-private-followed-by-in-2/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/es2015-generator/generator-parameter-binding-property-reserved/input.js
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0276/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-private-property/typescript-invalid-abstract/input.ts
 
@@ -171,8 +169,6 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/ty
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/static-blocks/invalid-static-block-with-modifier-override-01/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/static-blocks/invalid-static-block-with-modifier-override-01/invalid-static-block-with-modifier-abstract/input.ts
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/static-blocks/invalid-static-block-with-modifier-static/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/static-blocks/invalid-static-blocks-with-modifer-declare-01/input.ts
 
@@ -11394,6 +11390,13 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Try insert a semicolon here
 
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0276/input.js:1:23]
+ 1 │ class A {static static static(){}}
+   ·                       ▲
+   ╰────
+  help: Try insert a semicolon here
+
   × Identifier expected. 'enum' is a reserved word that cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0277/input.js:1:12]
  1 │ class A {a(enum){}}
@@ -12943,6 +12946,15 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·                   ─
  3 │ }
    ╰────
+
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/static-blocks/invalid-static-block-with-modifier-static/input.ts:2:16]
+ 1 │ class Foo {
+ 2 │   static static {}
+   ·                ▲
+ 3 │ }
+   ╰────
+  help: Try insert a semicolon here
 
   × Unexpected token
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/static-blocks/invalid-static-blocks-with-modifer-declare-02/input.ts:2:18]

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: 15392346
 parser_typescript Summary:
 AST Parsed     : 6521/6528 (99.89%)
 Positive Passed: 6509/6528 (99.71%)
-Negative Passed: 1315/5757 (22.84%)
+Negative Passed: 1321/5757 (22.95%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration24.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
@@ -3742,8 +3742,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/spreadOfPara
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/spyComparisonChecking.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticAsIdentifier.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticClassMemberError.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution4.ts
@@ -3759,8 +3757,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticMethod
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticMethodsReferencingClassTypeParameters.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticMismatchBecauseOfPrototype.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticModifierAlreadySeen.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticMustPrecedePublic.ts
 
@@ -7486,8 +7482,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserObjectCreation1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration10.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexSignatures/parserIndexSignature4.ts
@@ -7512,17 +7506,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration3.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration8.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration9.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberFunctionDeclarations/parserMemberFunctionDeclaration2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberFunctionDeclarations/parserMemberFunctionDeclaration3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberFunctionDeclarations/parserMemberFunctionDeclaration5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberVariableDeclarations/parserMemberVariableDeclaration2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberVariableDeclarations/parserMemberVariableDeclaration3.ts
 
@@ -14445,6 +14433,15 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╰────
   help: Remove the duplicate modifier.
 
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[typescript/tests/cases/compiler/multipleClassPropertyModifiersErrors.ts:4:15]
+ 3 │     private private p2;
+ 4 │     static static p3;
+   ·                  ▲
+ 5 │     public private p4;
+   ╰────
+  help: Try insert a semicolon here
+
   × Identifier `x` has already been declared
    ╭─[typescript/tests/cases/compiler/nameCollisions.ts:2:9]
  1 │ module T {
@@ -16426,11 +16423,29 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
   help: A `break` statement can only be used within an enclosing iteration or switch statement.
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
+    ╭─[typescript/tests/cases/compiler/staticAsIdentifier.ts:12:18]
+ 11 │ class C3 {
+ 12 │     static static p: string;
+    ·                  ▲
+ 13 │ }
+    ╰────
+  help: Try insert a semicolon here
+
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[typescript/tests/cases/compiler/staticClassProps.ts:4:15]
  3 │     public foo() {
  4 │         static z = 1;
    ·               ▲
  5 │     }
+   ╰────
+  help: Try insert a semicolon here
+
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[typescript/tests/cases/compiler/staticModifierAlreadySeen.ts:2:18]
+ 1 │ class C {
+ 2 │     static static foo = 1;
+   ·                  ▲
+ 3 │     public static static bar() { }
    ╰────
   help: Try insert a semicolon here
 
@@ -26507,6 +26522,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    · ─
    ╰────
 
+  × Unexpected token
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration10.ts:2:18]
+ 1 │ class C {
+ 2 │    static static [x: string]: string;
+   ·                  ─
+ 3 │ }
+   ╰────
+
   × TS(1071): 'public' modifier cannot appear on an index signature.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration7.ts:2:4]
  1 │ class C {
@@ -26688,6 +26711,15 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╰────
   help: Remove the duplicate modifier.
 
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration8.ts:2:18]
+ 1 │ class C {
+ 2 │     static static get Foo() { }
+   ·                  ▲
+ 3 │ }
+   ╰────
+  help: Try insert a semicolon here
+
   × TS(1030): public' modifier already seen.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/MemberFunctionDeclarations/parserMemberFunctionDeclaration1.ts:2:12]
  1 │ class C {
@@ -26696,6 +26728,15 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │ }
    ╰────
   help: Remove the duplicate modifier.
+
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/MemberFunctionDeclarations/parserMemberFunctionDeclaration2.ts:2:18]
+ 1 │ class C {
+ 2 │     static static Foo() { }
+   ·                  ▲
+ 3 │ }
+   ╰────
+  help: Try insert a semicolon here
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/MemberFunctionDeclarations/parserMemberFunctionDeclaration4.ts:2:11]
@@ -26770,6 +26811,15 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │ }
    ╰────
   help: Remove the duplicate modifier.
+
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/MemberVariableDeclarations/parserMemberVariableDeclaration2.ts:2:16]
+ 1 │ class C {
+ 2 │   static static Foo;
+   ·                ▲
+ 3 │ }
+   ╰────
+  help: Try insert a semicolon here
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/MemberVariableDeclarations/parserMemberVariableDeclaration4.ts:2:9]


### PR DESCRIPTION
- Fix: #10942

This is a syntax error and should not parse.

```
class A {static static static(){}}
```