### PR TITLE
refactor(lexer): tidy tests for `Token`

### DIFF
--- a/crates/oxc_parser/src/lexer/token.rs
+++ b/crates/oxc_parser/src/lexer/token.rs
@@ -136,11 +136,12 @@ impl Token {
 }
 
 #[cfg(test)]
-mod size_asserts {
+mod test {
     use super::Kind;
     use super::Token;
-    // Test new size
-    const _: () = assert!(std::mem::size_of::<Token>() == 16);
+
+    // Test size of `Token`
+    const _: () = assert!(size_of::<Token>() == 16);
 
     // Test default token values
     #[test]


### PR DESCRIPTION
Follow-on after #10933. That PR made some cosmetic changes to the tests for `Token` which weren't necessary. Revert them.