### PR TITLE
refactor(lexer): harden safety of transmute

### DIFF
--- a/crates/oxc_parser/src/lexer/token.rs
+++ b/crates/oxc_parser/src/lexer/token.rs
@@ -1,5 +1,7 @@
 //! Token
 
+use std::mem;
+
 use oxc_span::Span;
 
 use super::kind::Kind;
@@ -55,9 +57,10 @@ impl Token {
 
     #[inline]
     pub fn kind(&self) -> Kind {
-        // SAFETY: This conversion is safe because `Kind` is `#[repr(u8)]`,
-        // and we ensure the value stored is a valid `Kind` variant
-        unsafe { std::mem::transmute(((self.0 >> KIND_SHIFT) & KIND_MASK) as u8) }
+        // SAFETY: `Kind` is `#[repr(u8)]`. Only `Token::set_kind` alters these bits,
+        // and it sets them to the `u8` value of an existing `Kind`.
+        // So transmuting these bits back to `Kind` must produce a valid `Kind`.
+        unsafe { mem::transmute::<u8, Kind>(((self.0 >> KIND_SHIFT) & KIND_MASK) as u8) }
     }
 
     #[inline]


### PR DESCRIPTION
Follow-on after #10933. It's preferable to include explicit type params in calls to `mem::transmute` rather than relying on type inference. This ensures any later changes won't inadvertently cause UB.

Also expand the safety comment.
