### PR TITLE
fix(editor): send only `workspace/didChangeConfiguration` when some workspace configuration is effected

### DIFF
--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -323,7 +323,7 @@ export async function activate(context: ExtensionContext) {
       if (client.isRunning()) {
         await client.restart();
       }
-    } else if (client.isRunning()) {
+    } else if (configService.effectsWorkspaceConfigChange(event) && client.isRunning()) {
       await client.sendNotification(
         'workspace/didChangeConfiguration',
         {


### PR DESCRIPTION
this was missed when coping the changes from #10515 to #10875