### PR TITLE
fix(ast_visit): fix visitation order for `FormalParameters` in `Utf8ToUtf16Converter`

### DIFF
--- a/crates/oxc_ast_visit/src/generated/utf8_to_utf16_converter.rs
+++ b/crates/oxc_ast_visit/src/generated/utf8_to_utf16_converter.rs
@@ -404,12 +404,6 @@ impl<'a> VisitMut<'a> for Utf8ToUtf16Converter<'_> {
         self.convert_offset(&mut it.span.end);
     }
 
-    fn visit_formal_parameters(&mut self, it: &mut FormalParameters<'a>) {
-        self.convert_offset(&mut it.span.start);
-        walk_mut::walk_formal_parameters(self, it);
-        self.convert_offset(&mut it.span.end);
-    }
-
     fn visit_formal_parameter(&mut self, it: &mut FormalParameter<'a>) {
         self.convert_offset(&mut it.span.start);
         walk_mut::walk_formal_parameter(self, it);
@@ -1065,6 +1059,10 @@ impl<'a> VisitMut<'a> for Utf8ToUtf16Converter<'_> {
         self.convert_offset(&mut it.span.start);
         walk_mut::walk_js_doc_unknown_type(self, it);
         self.convert_offset(&mut it.span.end);
+    }
+
+    fn visit_formal_parameters(&mut self, params: &mut FormalParameters<'a>) {
+        walk_mut::walk_formal_parameters(self, params);
     }
 
     fn visit_object_property(&mut self, prop: &mut ObjectProperty<'a>) {


### PR DESCRIPTION
Fix visitation order in `Utf8ToUtf16Converter` to process span offsets in ascending order in `FormalParameters`.

`FormalParameters`'s span starts before `TSThisParameter` that precedes it in types like `Function`, so visiting `TSThisParameter` followed by `FormalParameters` results in out-of-order span offset conversion.

`FormalParameters`'s span doesn't appear in ESTree AST, so solution is just to skip converting its span entirely.