### PR TITLE
fix(linter): false negative in no-restricted-imports

### DIFF
--- a/crates/oxc_linter/src/snapshots/eslint_no_restricted_imports.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_restricted_imports.snap
@@ -808,6 +808,13 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: foo is forbidden, use bar instead
 
+  ⚠ eslint(no-restricted-imports): 'foo' import is restricted from being used.
+   ╭─[no_restricted_imports.tsx:1:1]
+ 1 │ import 'foo'; import {a} from 'b'
+   · ─────────────
+   ╰────
+  help: foo is forbidden, use bar instead
+
   ⚠ eslint(no-restricted-imports): 'import1' import is restricted from being used.
    ╭─[no_restricted_imports.tsx:1:1]
  1 │ import foo from 'import1';


### PR DESCRIPTION
in scenrio such as

```ts
import 'foo'
import { a } from 'b'
```

if `foo` was banned module, it wouldn't be reported as `module_record.import_entries.is_empty()` would not be true.

we now check if `import 'foo'` is included in `module_record.import_entries` to decide whether to add to side effects map