### PR TITLE
fix(linter): false negative in no-restriced-imports with `patterns` and side effects

### DIFF
--- a/crates/oxc_linter/src/snapshots/eslint_no_restricted_imports.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_restricted_imports.snap
@@ -815,6 +815,13 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: foo is forbidden, use bar instead
 
+  ⚠ eslint(no-restricted-imports): 'foo' import is restricted from being used by a pattern.
+   ╭─[no_restricted_imports.tsx:1:1]
+ 1 │ import 'foo'
+   · ────────────
+   ╰────
+  help: foo is forbidden, use bar instead
+
   ⚠ eslint(no-restricted-imports): 'import1' import is restricted from being used.
    ╭─[no_restricted_imports.tsx:1:1]
  1 │ import foo from 'import1';


### PR DESCRIPTION
previously, when using `patterns` with side effects imports, the diagnostic would not be reported, this PR fixes it by checking the module name against patterns.

fixes #10984