### PR TITLE
fix(span)!: `SourceType::from_path(".js")` return js instead of jsx

### DIFF
--- a/apps/oxlint/fixtures/linter/js_as_jsx.js
+++ b/apps/oxlint/fixtures/linter/js_as_jsx.js
@@ -1,0 +1,2 @@
+debugger;
+<div /> // Should `.js` file pass as `.jsx`.

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -779,6 +779,12 @@ mod test {
     }
 
     #[test]
+    fn js_and_jsx() {
+        let args = &["fixtures/linter/js_as_jsx.js"];
+        Tester::new().test_and_snapshot(args);
+    }
+
+    #[test]
     fn lint_vue_file() {
         let args = &["fixtures/vue/debugger.vue"];
         Tester::new().test_and_snapshot(args);

--- a/apps/oxlint/src/snapshots/_fixtures__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter@oxlint.snap
@@ -20,6 +20,14 @@ working directory:
    `----
   help: Remove the debugger statement
 
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[fixtures/linter/js_as_jsx.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+ 2 | <div /> // Should `.js` file pass as `.jsx`.
+   `----
+  help: Remove the debugger statement
+
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/use-isnan.html\eslint(use-isnan)]8;;\: Requires calls to isNaN() when checking for NaN
    ,-[fixtures/linter/nan.js:1:8]
  1 | 123 == NaN;
@@ -27,8 +35,8 @@ working directory:
    `----
   help: Use the isNaN function to compare with NaN.
 
-Found 3 warnings and 0 errors.
-Finished in <variable>ms on 3 files with 101 rules using 1 threads.
+Found 4 warnings and 0 errors.
+Finished in <variable>ms on 4 files with 101 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter__js_and_jsx.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__js_and_jsx.js@oxlint.snap
@@ -2,11 +2,11 @@
 source: apps/oxlint/src/tester.rs
 ---
 ########## 
-arguments: -A all fixtures/linter
+arguments: fixtures/linter/js_and_jsx.js
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 4 files with 0 rules using 1 threads.
+Finished in <variable>ms on 0 files with 101 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter__js_as_jsx.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__js_as_jsx.js@oxlint.snap
@@ -1,0 +1,21 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: fixtures/linter/js_as_jsx.js
+working directory: 
+----------
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[fixtures/linter/js_as_jsx.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+ 2 | <div /> // Should `.js` file pass as `.jsx`.
+   `----
+  help: Remove the debugger statement
+
+Found 1 warning and 0 errors.
+Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -221,7 +221,12 @@ impl<'l> Runtime<'l> {
         if not_supported_yet {
             return None;
         }
-        let source_type = source_type.unwrap_or_default();
+
+        let mut source_type = source_type.unwrap_or_default();
+        // Treat JS and JSX files to maximize chance of parsing files.
+        if source_type.is_javascript() {
+            source_type = source_type.with_jsx(true);
+        }
 
         let file_result = self.file_system.read_to_string(path).map_err(|e| {
             Error::new(OxcDiagnostic::error(format!(

--- a/crates/oxc_span/src/source_type.rs
+++ b/crates/oxc_span/src/source_type.rs
@@ -149,8 +149,8 @@ impl From<FileExtension> for SourceType {
         };
 
         let variant = match file_ext {
-            Js | Mjs | Cjs | Jsx | Tsx => LanguageVariant::Jsx,
-            Ts | Mts | Cts => LanguageVariant::Standard,
+            Jsx | Tsx => LanguageVariant::Jsx,
+            Js | Mjs | Cjs | Ts | Mts | Cts => LanguageVariant::Standard,
         };
 
         SourceType { language, module_kind, variant }
@@ -673,7 +673,7 @@ mod tests {
             assert!(!ty.is_typescript(), "{ty:?}");
         }
 
-        assert_eq!(SourceType::jsx(), js);
+        assert_eq!(SourceType::mjs(), js);
         assert_eq!(SourceType::jsx().with_module(true), jsx);
 
         assert!(js.is_module());
@@ -686,9 +686,9 @@ mod tests {
         assert!(!cjs.is_strict());
         assert!(jsx.is_strict());
 
-        assert!(js.is_jsx());
-        assert!(mjs.is_jsx());
-        assert!(cjs.is_jsx());
+        assert!(js.is_javascript());
+        assert!(mjs.is_javascript());
+        assert!(cjs.is_javascript());
         assert!(jsx.is_jsx());
     }
 }

--- a/crates/oxc_transformer/src/options/babel/mod.rs
+++ b/crates/oxc_transformer/src/options/babel/mod.rs
@@ -169,6 +169,9 @@ impl BabelOptions {
 
     pub fn is_jsx(&self) -> bool {
         self.plugins.syntax_jsx
+            || self.presets.jsx.is_some()
+            || self.plugins.react_jsx.is_some()
+            || self.plugins.react_jsx_dev.is_some()
     }
 
     pub fn is_typescript(&self) -> bool {

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -1,9 +1,9 @@
 commit: 578ac4df
 
 parser_babel Summary:
-AST Parsed     : 2309/2322 (99.44%)
-Positive Passed: 2288/2322 (98.54%)
-Negative Passed: 1561/1673 (93.31%)
+AST Parsed     : 2311/2322 (99.53%)
+Positive Passed: 2290/2322 (98.62%)
+Negative Passed: 1565/1673 (93.54%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/invalid-startindex-and-startline-specified-without-startcolumn/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/startline-and-startcolumn-specified/input.js
@@ -47,14 +47,6 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/flow/expect-plugin/export-interface/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/flow/expect-plugin/export-type/input.js
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-fragment/input.js
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-jsx-expression/input.js
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/jsx/errors/_no_plugin/input.js
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/jsx/errors/_no_plugin-non-BMP-identifier/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/arrow-like-in-conditional-2/input.ts
 
@@ -351,22 +343,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022
  1 │ await 0
    · ─────
  2 │ 
-   ╰────
-
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-ts-type-param-no-flow/input.js
-
-  × Unexpected token. Did you mean `{'>'}` or `&gt;`?
-   ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-ts-type-param-no-flow/input.js:1:10]
- 1 │ <div>() => {}
-   ·          ▲
-   ╰────
-
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-ts-type-param-no-flow-babel-7/input.js
-
-  × Unexpected token. Did you mean `{'>'}` or `&gt;`?
-   ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-ts-type-param-no-flow-babel-7/input.js:1:10]
- 1 │ <div>() => {}
-   ·          ▲
    ╰────
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/generic-tsx-babel-7/input.ts
@@ -3878,9 +3854,9 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
 
   × Unexpected token
-   ╭─[babel/packages/babel-parser/test/fixtures/es2015/modules/invalid-xml-comment-in-module/input.js:1:2]
+   ╭─[babel/packages/babel-parser/test/fixtures/es2015/modules/invalid-xml-comment-in-module/input.js:1:1]
  1 │ <!--bar-->
-   ·  ─
+   · ─
    ╰────
 
   × Expected `,` but found `Identifier`
@@ -11518,10 +11494,37 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·             ─
    ╰────
 
-  × Unexpected token. Did you mean `{'>'}` or `&gt;`?
-   ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-type-param/input.js:1:10]
+  × Unexpected token
+   ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-fragment/input.js:3:5]
+ 2 │   return (
+ 3 │     <>Hello</>
+   ·     ─
+ 4 │   );
+   ╰────
+
+  × Unexpected token
+   ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-jsx-expression/input.js:1:1]
+ 1 │ <div>{name}</div>
+   · ─
+   ╰────
+
+  × Unexpected token
+   ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-type-param/input.js:1:1]
  1 │ <div>() => {}
-   ·          ▲
+   · ─
+   ╰────
+
+  × Unexpected token
+   ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no_plugin/input.js:1:1]
+ 1 │ <div></div>
+   · ─
+   ╰────
+
+  × Unexpected token
+   ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no_plugin-non-BMP-identifier/input.js:1:1]
+ 1 │ <
+   · ─
+ 2 │   𠮷
    ╰────
 
   × Unexpected token. Did you mean `{'>'}` or `&gt;`?

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -15414,41 +15414,42 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
   help: Did you mean to write 'undefined | null | undefined'?
 
   × Unexpected token
-   ╭─[typescript/tests/cases/compiler/parseJsxElementInUnaryExpressionNoCrash1.ts:1:4]
+   ╭─[typescript/tests/cases/compiler/parseJsxElementInUnaryExpressionNoCrash1.ts:1:2]
  1 │ ~< <
-   ·    ─
+   ·  ─
    ╰────
 
   × Unexpected token
-   ╭─[typescript/tests/cases/compiler/parseJsxElementInUnaryExpressionNoCrash2.ts:1:9]
+   ╭─[typescript/tests/cases/compiler/parseJsxElementInUnaryExpressionNoCrash2.ts:1:2]
  1 │ ~<></> <
+   ·  ─
    ╰────
 
   × Unexpected token
-   ╭─[typescript/tests/cases/compiler/parseJsxElementInUnaryExpressionNoCrash3.ts:1:4]
+   ╭─[typescript/tests/cases/compiler/parseJsxElementInUnaryExpressionNoCrash3.ts:1:2]
  1 │ !< {:>
-   ·    ─
+   ·  ─
    ╰────
 
   × Unexpected token
-   ╭─[typescript/tests/cases/compiler/parseUnaryExpressionNoTypeAssertionInJsx1.ts:2:21]
+   ╭─[typescript/tests/cases/compiler/parseUnaryExpressionNoTypeAssertionInJsx1.ts:2:13]
  1 │ const x = "oops";
  2 │ const y = + <number> x;
-   ·                     ───
+   ·             ─
    ╰────
 
   × Unexpected token
-   ╭─[typescript/tests/cases/compiler/parseUnaryExpressionNoTypeAssertionInJsx2.ts:2:15]
+   ╭─[typescript/tests/cases/compiler/parseUnaryExpressionNoTypeAssertionInJsx2.ts:2:13]
  1 │ const x = "oops";
  2 │ const y = + <> x;
-   ·               ───
+   ·             ─
    ╰────
 
   × Unexpected token
-   ╭─[typescript/tests/cases/compiler/parseUnaryExpressionNoTypeAssertionInJsx3.ts:2:14]
+   ╭─[typescript/tests/cases/compiler/parseUnaryExpressionNoTypeAssertionInJsx3.ts:2:13]
  1 │ const x = "oops";
  2 │ const y = + <1234> x;
-   ·              ────
+   ·             ─
    ╰────
 
   × Unexpected token

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -2,7 +2,7 @@ commit: 578ac4df
 
 semantic_babel Summary:
 AST Parsed     : 2322/2322 (100.00%)
-Positive Passed: 1905/2322 (82.04%)
+Positive Passed: 1907/2322 (82.13%)
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/annex-b/enabled/3.3-function-in-if-body/input.js
 Symbol scope ID mismatch for "f":
 after transform: SymbolId(0): ScopeId(4294967294)
@@ -235,12 +235,6 @@ semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/
 Unresolved references mismatch:
 after transform: ["T", "foo"]
 rebuilt        : ["foo"]
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-ts-type-param-no-flow/input.js
-Unexpected token. Did you mean `{'>'}` or `&gt;`?
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-ts-type-param-no-flow-babel-7/input.js
-Unexpected token. Did you mean `{'>'}` or `&gt;`?
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/arrow-function-with-newline/input.ts
 Unresolved references mismatch:

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -411,6 +411,7 @@ impl TestRunner {
         formatter_options: FormatOptions,
     ) -> String {
         let allocator = Allocator::default();
+        let source_type = source_type.with_jsx(source_type.is_javascript());
         let ret = Parser::new(&allocator, source_text, source_type)
             .with_options(ParseOptions {
                 preserve_parens: false,

--- a/tasks/prettier_conformance/src/spec.rs
+++ b/tasks/prettier_conformance/src/spec.rs
@@ -36,7 +36,10 @@ impl SpecParser {
         self.source_text.clone_from(&spec_content);
 
         let allocator = Allocator::default();
-        let source_type = SourceType::from_path(spec).unwrap_or_default();
+        let mut source_type = SourceType::from_path(spec).unwrap_or_default();
+        if source_type.is_javascript() {
+            source_type = source_type.with_jsx(true);
+        }
 
         let mut ret = Parser::new(&allocator, &spec_content, source_type).parse();
         self.visit_program(&mut ret.program);

--- a/tasks/transform_conformance/src/test_case.rs
+++ b/tasks/transform_conformance/src/test_case.rs
@@ -90,10 +90,8 @@ impl TestCase {
     fn source_type(path: &Path, options: &BabelOptions) -> SourceType {
         // Some babel test cases have a js extension, but contain typescript code.
         // Therefore, if the typescript plugin exists, enable typescript.
-        let mut source_type = SourceType::from_path(path)
-            .unwrap()
-            .with_script(true)
-            .with_jsx(options.plugins.syntax_jsx);
+        let mut source_type =
+            SourceType::from_path(path).unwrap().with_script(true).with_jsx(options.is_jsx());
         source_type = match options.source_type.as_deref() {
             Some("unambiguous") => source_type.with_unambiguous(true),
             Some("script") => source_type.with_script(true),


### PR DESCRIPTION
closes #11020

Previously `SourceType::from_path(".js")` treats a `.js` file as `.jsx`
to maximize parse rate for the linter.

Force the `.jsx` change in the linter instead of a generic solution for `SourceType::from_path`.