### PR TITLE
perf(parser): store `Token` as `[u64; 2]`

### DIFF
--- a/crates/oxc_parser/src/lexer/token.rs
+++ b/crates/oxc_parser/src/lexer/token.rs
@@ -6,40 +6,56 @@ use oxc_span::Span;
 
 use super::kind::Kind;
 
-// Bit layout for `u128`:
+// `Token` is stored as a `[u64; 2]`.
+//
+// Packing the data into a pair of `u64`s provides a significant speed-up to the parser
+// vs a struct with separate fields.
+// https://github.com/oxc-project/oxc/pull/10933
+//
+// Stored as 2 x `u64`s rather than 1 x `u128`, so `Token` is aligned on 8, not 16.
+// This reduces the size of `Lookahead` to 24 bytes (it's 32 bytes when `Token` is aligned on 16).
+//
+// Bit layout:
+//
+// 1st `u64`:
 // - Bits 0-31 (32 bits): `start`
 // - Bits 32-63 (32 bits): `end`
-// - Bits 64-71 (8 bits): `kind` (as u8)
-// - Bit 72 (1 bit): `is_on_new_line`
-// - Bit 73 (1 bit): `escaped`
-// - Bit 74 (1 bit): `lone_surrogates`
-// - Bit 75 (1 bit): `has_separator`
+//
+// 2nd `u64`:
+// - Bits 0-7 (8 bits): `kind` (as u8)
+// - Bit 8 (1 bit): `is_on_new_line`
+// - Bit 9 (1 bit): `escaped`
+// - Bit 10 (1 bit): `lone_surrogates`
+// - Bit 11 (1 bit): `has_separator`
 
+// 1st `u64`
 const START_SHIFT: u32 = 0;
 const END_SHIFT: u32 = 32;
-const KIND_SHIFT: u32 = 64;
-const IS_ON_NEW_LINE_SHIFT: u32 = 72;
-const ESCAPED_SHIFT: u32 = 73;
-const LONE_SURROGATES_SHIFT: u32 = 74;
-const HAS_SEPARATOR_SHIFT: u32 = 75;
+const START_MASK: u64 = 0xFFFF_FFFF; // 32 bits
+const END_MASK: u64 = 0xFFFF_FFFF; // 32 bits
 
-const START_MASK: u128 = 0xFFFF_FFFF; // 32 bits
-const END_MASK: u128 = 0xFFFF_FFFF; // 32 bits
-const KIND_MASK: u128 = 0xFF; // 8 bits
+// 2nd `u64`
+const KIND_SHIFT: u32 = 0;
+const IS_ON_NEW_LINE_SHIFT: u32 = 8;
+const ESCAPED_SHIFT: u32 = 9;
+const LONE_SURROGATES_SHIFT: u32 = 10;
+const HAS_SEPARATOR_SHIFT: u32 = 11;
 
-const IS_ON_NEW_LINE_FLAG: u128 = 1 << IS_ON_NEW_LINE_SHIFT;
-const ESCAPED_FLAG: u128 = 1 << ESCAPED_SHIFT;
-const LONE_SURROGATES_FLAG: u128 = 1 << LONE_SURROGATES_SHIFT;
-const HAS_SEPARATOR_FLAG: u128 = 1 << HAS_SEPARATOR_SHIFT;
+const KIND_MASK: u64 = 0xFF; // 8 bits
+
+const IS_ON_NEW_LINE_FLAG: u64 = 1 << IS_ON_NEW_LINE_SHIFT;
+const ESCAPED_FLAG: u64 = 1 << ESCAPED_SHIFT;
+const LONE_SURROGATES_FLAG: u64 = 1 << LONE_SURROGATES_SHIFT;
+const HAS_SEPARATOR_FLAG: u64 = 1 << HAS_SEPARATOR_SHIFT;
 
 #[derive(Debug, Clone, Copy)]
 #[repr(transparent)]
-pub struct Token(u128);
+pub struct Token([u64; 2]);
 
 impl Default for Token {
     #[inline]
     fn default() -> Self {
-        // `Kind::default()` is `Kind::Eof`. So `0` is equivalent to:
+        // `Kind::default()` is `Kind::Eof`. So `[0; 2]` is equivalent to:
         // start: 0,
         // end: 0,
         // kind: Kind::default(),
@@ -48,7 +64,7 @@ impl Default for Token {
         // lone_surrogates: false,
         // has_separator: false,
         const _: () = assert!(Kind::Eof as u8 == 0);
-        Self(0)
+        Self([0; 2])
     }
 }
 
@@ -57,7 +73,7 @@ impl Token {
     pub(super) fn new_on_new_line() -> Self {
         // Start with a default token, then set the flag
         let mut token = Self::default();
-        token.0 |= IS_ON_NEW_LINE_FLAG;
+        token.0[1] |= IS_ON_NEW_LINE_FLAG;
         token
     }
 }
@@ -71,26 +87,26 @@ impl Token {
 
     #[inline]
     pub fn start(&self) -> u32 {
-        ((self.0 >> START_SHIFT) & START_MASK) as u32
+        ((self.0[0] >> START_SHIFT) & START_MASK) as u32
     }
 
     #[inline]
     pub(crate) fn set_start(&mut self, start: u32) {
-        self.0 &= !(START_MASK << START_SHIFT); // Clear current `start` bits
-        self.0 |= u128::from(start) << START_SHIFT;
+        self.0[0] &= !(START_MASK << START_SHIFT); // Clear current `start` bits
+        self.0[0] |= u64::from(start) << START_SHIFT;
     }
 
     #[inline]
     pub fn end(&self) -> u32 {
-        ((self.0 >> END_SHIFT) & END_MASK) as u32
+        ((self.0[0] >> END_SHIFT) & END_MASK) as u32
     }
 
     #[inline]
     pub(crate) fn set_end(&mut self, end: u32) {
         let start = self.start();
         debug_assert!(end >= start, "Token end ({end}) cannot be less than start ({start})");
-        self.0 &= !(END_MASK << END_SHIFT); // Clear current `end` bits
-        self.0 |= u128::from(end) << END_SHIFT;
+        self.0[0] &= !(END_MASK << END_SHIFT); // Clear current `end` bits
+        self.0[0] |= u64::from(end) << END_SHIFT;
     }
 
     #[inline]
@@ -98,53 +114,53 @@ impl Token {
         // SAFETY: `Kind` is `#[repr(u8)]`. Only `Token::default` and `Token::set_kind` set these bits,
         // and they set them to the `u8` value of an existing `Kind`.
         // So transmuting these bits back to `Kind` must produce a valid `Kind`.
-        unsafe { mem::transmute::<u8, Kind>(((self.0 >> KIND_SHIFT) & KIND_MASK) as u8) }
+        unsafe { mem::transmute::<u8, Kind>(((self.0[1] >> KIND_SHIFT) & KIND_MASK) as u8) }
     }
 
     #[inline]
     pub(crate) fn set_kind(&mut self, kind: Kind) {
-        self.0 &= !(KIND_MASK << KIND_SHIFT); // Clear current `kind` bits
-        self.0 |= u128::from(kind as u8) << KIND_SHIFT;
+        self.0[1] &= !(KIND_MASK << KIND_SHIFT); // Clear current `kind` bits
+        self.0[1] |= u64::from(kind as u8) << KIND_SHIFT;
     }
 
     #[inline]
     pub fn is_on_new_line(&self) -> bool {
-        (self.0 & IS_ON_NEW_LINE_FLAG) != 0
+        (self.0[1] & IS_ON_NEW_LINE_FLAG) != 0
     }
 
     #[inline]
     pub(crate) fn set_is_on_new_line(&mut self, value: bool) {
-        self.0 = (self.0 & !IS_ON_NEW_LINE_FLAG) | (u128::from(value) * IS_ON_NEW_LINE_FLAG);
+        self.0[1] = (self.0[1] & !IS_ON_NEW_LINE_FLAG) | (u64::from(value) * IS_ON_NEW_LINE_FLAG);
     }
 
     #[inline]
     pub fn escaped(&self) -> bool {
-        (self.0 & ESCAPED_FLAG) != 0
+        (self.0[1] & ESCAPED_FLAG) != 0
     }
 
     #[inline]
     pub(crate) fn set_escaped(&mut self, escaped: bool) {
-        self.0 = (self.0 & !ESCAPED_FLAG) | (u128::from(escaped) * ESCAPED_FLAG);
+        self.0[1] = (self.0[1] & !ESCAPED_FLAG) | (u64::from(escaped) * ESCAPED_FLAG);
     }
 
     #[inline]
     pub fn lone_surrogates(&self) -> bool {
-        (self.0 & LONE_SURROGATES_FLAG) != 0
+        (self.0[1] & LONE_SURROGATES_FLAG) != 0
     }
 
     #[inline]
     pub(crate) fn set_lone_surrogates(&mut self, value: bool) {
-        self.0 = (self.0 & !LONE_SURROGATES_FLAG) | (u128::from(value) * LONE_SURROGATES_FLAG);
+        self.0[1] = (self.0[1] & !LONE_SURROGATES_FLAG) | (u64::from(value) * LONE_SURROGATES_FLAG);
     }
 
     #[inline]
     pub fn has_separator(&self) -> bool {
-        (self.0 & HAS_SEPARATOR_FLAG) != 0
+        (self.0[1] & HAS_SEPARATOR_FLAG) != 0
     }
 
     #[inline]
     pub(crate) fn set_has_separator(&mut self, value: bool) {
-        self.0 = (self.0 & !HAS_SEPARATOR_FLAG) | (u128::from(value) * HAS_SEPARATOR_FLAG);
+        self.0[1] = (self.0[1] & !HAS_SEPARATOR_FLAG) | (u64::from(value) * HAS_SEPARATOR_FLAG);
     }
 }
 


### PR DESCRIPTION
Store token as `[u64; 2]` instead of `u128`, so it's aligned on 8, not 16. This makes `Lookahead` 24 bytes instead of 32.