### PR TITLE
refactor(ast_macros): move logic out of generated code

### DIFF
--- a/crates/oxc_ast_macros/src/ast.rs
+++ b/crates/oxc_ast_macros/src/ast.rs
@@ -44,17 +44,20 @@ fn enum_repr(enum_: &ItemEnum) -> TokenStream {
 /// If `GetSpan` is not in scope, or it is not the correct `oxc_span::GetSpan`,
 /// this will raise a compilation error.
 fn assert_generated_derives(attrs: &[Attribute]) -> TokenStream {
-    // NOTE: At this level we don't care if a trait is derived multiple times, It is the
-    // responsibility of the `ast_tools` to raise errors for those.
+    // We don't care here if a trait is derived multiple times.
+    // It is the responsibility of `oxc_ast_tools` to raise errors for those.
     let assertions = attrs
         .iter()
         .filter(|attr| attr.path().is_ident("generate_derive"))
         .flat_map(parse_attr)
         .map(|trait_ident| {
             let trait_name = trait_ident.to_string();
-            let (trait_path, generics) = get_trait_crate_and_generics(&trait_name);
+            let Some((trait_path, generics)) = get_trait_crate_and_generics(&trait_name) else {
+                panic!("Invalid derive trait(generate_derive): {trait_name}");
+            };
+
+            // These are wrapped in a scope to avoid the need for unique identifiers
             quote! {{
-                // NOTE: these are wrapped in a scope to avoid the need for unique identifiers.
                 trait AssertionTrait: #trait_path #generics {}
                 impl<T: #trait_ident #generics> AssertionTrait for T {}
             }}

--- a/crates/oxc_ast_macros/src/generated/derived_traits.rs
+++ b/crates/oxc_ast_macros/src/generated/derived_traits.rs
@@ -4,8 +4,8 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-pub fn get_trait_crate_and_generics(trait_name: &str) -> (TokenStream, TokenStream) {
-    match trait_name {
+pub fn get_trait_crate_and_generics(trait_name: &str) -> Option<(TokenStream, TokenStream)> {
+    let res = match trait_name {
         "CloneIn" => (quote!(::oxc_allocator::CloneIn), quote!(< 'static >)),
         "Dummy" => (quote!(::oxc_allocator::Dummy), quote!(< 'static >)),
         "TakeIn" => (quote!(::oxc_allocator::TakeIn), quote!(< 'static >)),
@@ -14,6 +14,7 @@ pub fn get_trait_crate_and_generics(trait_name: &str) -> (TokenStream, TokenStre
         "GetSpanMut" => (quote!(::oxc_span::GetSpanMut), TokenStream::new()),
         "ContentEq" => (quote!(::oxc_span::ContentEq), TokenStream::new()),
         "ESTree" => (quote!(::oxc_estree::ESTree), TokenStream::new()),
-        _ => panic!("Invalid derive trait(generate_derive): {trait_name}"),
-    }
+        _ => return None,
+    };
+    Some(res)
 }

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -389,11 +389,12 @@ fn generate_proc_macro() -> RawOutput {
         use quote::quote;
 
         ///@@line_break
-        pub fn get_trait_crate_and_generics(trait_name: &str) -> (TokenStream, TokenStream) {
-            match trait_name {
+        pub fn get_trait_crate_and_generics(trait_name: &str) -> Option<(TokenStream, TokenStream)> {
+            let res = match trait_name {
                 #(#match_arms,)*
-                _ => panic!("Invalid derive trait(generate_derive): {trait_name}"),
-            }
+                _ => return None,
+            };
+            Some(res)
         }
     };
 


### PR DESCRIPTION
Reduce logic in generated code for `oxc_ast_macros` crate, and handle it in static code instead.

Also, improve code comments.