### PR TITLE
refactor(linter): store severity separately, remove `RuleWithSeverity`

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,4 +1,4 @@
-ignore-interior-mutability = ["oxc_linter::rule::RuleWithSeverity"]
+ignore-interior-mutability = ["oxc_linter::rules::RuleEnum"]
 
 disallowed-methods = [
   { path = "str::to_ascii_lowercase", reason = "To avoid memory allocation, use `cow_utils::CowUtils::cow_to_ascii_lowercase` instead." },

--- a/crates/oxc_linter/src/config/mod.rs
+++ b/crates/oxc_linter/src/config/mod.rs
@@ -50,7 +50,7 @@ mod test {
     use std::env;
 
     use oxc_span::CompactStr;
-    use rustc_hash::FxHashSet;
+    use rustc_hash::FxHashMap;
     use serde::Deserialize;
 
     use super::Oxlintrc;
@@ -111,10 +111,10 @@ mod test {
         let fixture_path: std::path::PathBuf =
             env::current_dir().unwrap().join("fixtures/eslint_config_vitest_replace.json");
         let config = Oxlintrc::from_file(&fixture_path).unwrap();
-        let mut set = FxHashSet::default();
+        let mut set = FxHashMap::default();
         config.rules.override_rules(&mut set, &RULES);
 
-        let rule = set.into_iter().next().unwrap();
+        let (rule, _) = set.into_iter().next().unwrap();
         assert_eq!(rule.name(), "no-disabled-tests");
         assert_eq!(rule.plugin_name(), "jest");
     }

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, fmt};
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use schemars::{JsonSchema, r#gen::SchemaGenerator, schema::Schema};
 use serde::{
     Deserialize, Serialize, Serializer,
@@ -11,12 +11,12 @@ use serde::{
 use oxc_diagnostics::{Error, OxcDiagnostic};
 
 use crate::{
-    AllowWarnDeny, RuleWithSeverity,
+    AllowWarnDeny,
     rules::{RULES, RuleEnum},
     utils::{is_eslint_rule_adapted_to_typescript, is_jest_rule_adapted_to_vitest},
 };
 
-type RuleSet = FxHashSet<RuleWithSeverity>;
+type RuleSet = FxHashMap<RuleEnum, AllowWarnDeny>;
 
 // TS type is `Record<string, RuleConf>`
 //   - type SeverityConf = 0 | 1 | 2 | "off" | "warn" | "error";
@@ -60,8 +60,8 @@ pub struct ESLintRule {
 impl OxlintRules {
     pub(crate) fn override_rules(&self, rules_for_override: &mut RuleSet, all_rules: &[RuleEnum]) {
         use itertools::Itertools;
-        let mut rules_to_replace: Vec<RuleWithSeverity> = vec![];
-        let mut rules_to_remove: Vec<RuleWithSeverity> = vec![];
+        let mut rules_to_replace: Vec<(RuleEnum, AllowWarnDeny)> = vec![];
+        let mut rules_to_remove: Vec<RuleEnum> = vec![];
 
         // Rules can have the same name but different plugin names
         let lookup = self.rules.iter().into_group_map_by(|r| r.rule_name.as_str());
@@ -84,16 +84,14 @@ impl OxlintRules {
                             {
                                 let config = rule_config.config.clone().unwrap_or_default();
                                 let rule = rule.read_json(config);
-                                rules_to_replace.push(RuleWithSeverity::new(rule, severity));
+                                rules_to_replace.push((rule, severity));
                             }
                         }
                         AllowWarnDeny::Allow => {
-                            if let Some(rule) = rules_for_override
-                                .iter()
-                                .find(|r| r.name() == rule_name && r.plugin_name() == plugin_name)
-                            {
-                                let rule = rule.clone();
-                                rules_to_remove.push(rule);
+                            if let Some((rule, _)) = rules_for_override.iter().find(|(r, _)| {
+                                r.name() == rule_name && r.plugin_name() == plugin_name
+                            }) {
+                                rules_to_remove.push(rule.clone());
                             }
                             // If the given rule is not found in the rule list (for example, if all rules are disabled),
                             // then look it up in the entire rules list and add it.
@@ -103,7 +101,7 @@ impl OxlintRules {
                             {
                                 let config = rule_config.config.clone().unwrap_or_default();
                                 let rule = rule.read_json(config);
-                                rules_to_remove.push(RuleWithSeverity::new(rule, severity));
+                                rules_to_remove.push(rule);
                             }
                         }
                     }
@@ -111,7 +109,7 @@ impl OxlintRules {
                 _ => {
                     let rules = rules_for_override
                         .iter()
-                        .filter_map(|r| {
+                        .filter_map(|(r, _)| {
                             if r.name() == *name { Some((r.plugin_name(), r)) } else { None }
                         })
                         .collect::<FxHashMap<_, _>>();
@@ -125,10 +123,8 @@ impl OxlintRules {
                         if rule_config.severity.is_warn_deny() {
                             let config = rule_config.config.clone().unwrap_or_default();
                             if let Some(rule) = rules.get(&plugin_name) {
-                                rules_to_replace.push(RuleWithSeverity::new(
-                                    rule.read_json(config),
-                                    rule_config.severity,
-                                ));
+                                rules_to_replace
+                                    .push((rule.read_json(config), rule_config.severity));
                             }
                             // If the given rule is not found in the rule list (for example, if all rules are disabled),
                             // then look it up in the entire rules list and add it.
@@ -136,10 +132,8 @@ impl OxlintRules {
                                 .iter()
                                 .find(|r| r.name() == rule_name && r.plugin_name() == plugin_name)
                             {
-                                rules_to_replace.push(RuleWithSeverity::new(
-                                    rule.read_json(config),
-                                    rule_config.severity,
-                                ));
+                                rules_to_replace
+                                    .push((rule.read_json(config), rule_config.severity));
                             }
                         } else if let Some(&rule) = rules.get(&plugin_name) {
                             rules_to_remove.push(rule.clone());
@@ -152,8 +146,8 @@ impl OxlintRules {
         for rule in rules_to_remove {
             rules_for_override.remove(&rule);
         }
-        for rule in rules_to_replace {
-            rules_for_override.replace(rule);
+        for (rule, severity) in rules_to_replace {
+            rules_for_override.insert(rule, severity);
         }
     }
 }
@@ -354,7 +348,7 @@ mod test {
     use serde_json::{Value, json};
 
     use crate::{
-        AllowWarnDeny, RuleWithSeverity,
+        AllowWarnDeny,
         rules::{RULES, RuleEnum},
     };
 
@@ -417,9 +411,9 @@ mod test {
             r#override(&mut rules, &config);
 
             assert_eq!(rules.len(), 1, "{config:?}");
-            let rule = rules.iter().next().unwrap();
+            let (rule, severity) = rules.iter().next().unwrap();
             assert_eq!(rule.name(), "no-console", "{config:?}");
-            assert_eq!(rule.severity, AllowWarnDeny::Deny, "{config:?}");
+            assert_eq!(severity, &AllowWarnDeny::Deny, "{config:?}");
         }
     }
 
@@ -440,15 +434,15 @@ mod test {
             1,
             "eslint rules should be configurable by their typescript-eslint reimplementations: {config:?}"
         );
-        let rule = rules.iter().next().unwrap();
+        let (rule, severity) = rules.iter().next().unwrap();
         assert_eq!(
             rule.name(),
             "no-console",
             "eslint rules should be configurable by their typescript-eslint reimplementations: {config:?}"
         );
         assert_eq!(
-            rule.severity,
-            AllowWarnDeny::Deny,
+            severity,
+            &AllowWarnDeny::Deny,
             "eslint rules should be configurable by their typescript-eslint reimplementations: {config:?}"
         );
     }
@@ -456,10 +450,7 @@ mod test {
     #[test]
     fn test_override_allow() {
         let mut rules = RuleSet::default();
-        rules.insert(RuleWithSeverity {
-            rule: RuleEnum::EslintNoConsole(Default::default()),
-            severity: AllowWarnDeny::Deny,
-        });
+        rules.insert(RuleEnum::EslintNoConsole(Default::default()), AllowWarnDeny::Deny);
         r#override(&mut rules, &json!({ "eslint/no-console": "off" }));
 
         assert!(rules.is_empty());
@@ -478,23 +469,20 @@ mod test {
             r#override(&mut rules, config);
 
             assert_eq!(rules.len(), 1, "{config:?}");
-            let rule = rules.iter().next().unwrap();
+            let (rule, severity) = rules.iter().next().unwrap();
             assert_eq!(rule.name(), "no-unused-vars", "{config:?}");
-            assert_eq!(rule.severity, AllowWarnDeny::Deny, "{config:?}");
+            assert_eq!(severity, &AllowWarnDeny::Deny, "{config:?}");
         }
 
         for config in &configs {
             let mut rules = RuleSet::default();
-            rules.insert(RuleWithSeverity {
-                rule: RuleEnum::EslintNoUnusedVars(Default::default()),
-                severity: AllowWarnDeny::Warn,
-            });
+            rules.insert(RuleEnum::EslintNoUnusedVars(Default::default()), AllowWarnDeny::Warn);
             r#override(&mut rules, config);
 
             assert_eq!(rules.len(), 1, "{config:?}");
-            let rule = rules.iter().next().unwrap();
+            let (rule, severity) = rules.iter().next().unwrap();
             assert_eq!(rule.name(), "no-unused-vars", "{config:?}");
-            assert_eq!(rule.severity, AllowWarnDeny::Deny, "{config:?}");
+            assert_eq!(severity, &AllowWarnDeny::Deny, "{config:?}");
         }
     }
 }

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -5,13 +5,14 @@ use oxc_semantic::Semantic;
 use oxc_span::{SourceType, Span};
 
 use crate::{
-    FrameworkFlags, RuleWithSeverity,
+    AllowWarnDeny, FrameworkFlags,
     config::{LintConfig, LintPlugins},
     disable_directives::{DisableDirectives, DisableDirectivesBuilder},
     fixer::{FixKind, Message},
     frameworks,
     module_record::ModuleRecord,
     options::LintOptions,
+    rules::RuleEnum,
 };
 
 use super::{LintContext, plugin_name_to_prefix};
@@ -226,7 +227,7 @@ impl<'a> ContextHost<'a> {
     }
 
     /// Creates a new [`LintContext`] for a specific rule.
-    pub fn spawn(self: Rc<Self>, rule: &RuleWithSeverity) -> LintContext<'a> {
+    pub fn spawn(self: Rc<Self>, rule: &RuleEnum, severity: AllowWarnDeny) -> LintContext<'a> {
         let rule_name = rule.name();
         let plugin_name = rule.plugin_name();
 
@@ -236,8 +237,8 @@ impl<'a> ContextHost<'a> {
             current_plugin_name: plugin_name,
             current_plugin_prefix: plugin_name_to_prefix(plugin_name),
             #[cfg(debug_assertions)]
-            current_rule_fix_capabilities: rule.rule.fix(),
-            severity: rule.severity.into(),
+            current_rule_fix_capabilities: rule.fix(),
+            severity: severity.into(),
         }
     }
 

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -38,7 +38,7 @@ pub use crate::{
     module_record::ModuleRecord,
     options::LintOptions,
     options::{AllowWarnDeny, InvalidFilterKind, LintFilter, LintFilterKind},
-    rule::{RuleCategory, RuleFixMeta, RuleMeta, RuleWithSeverity},
+    rule::{RuleCategory, RuleFixMeta, RuleMeta},
     service::{LintService, LintServiceOptions, RuntimeFileSystem},
     utils::read_to_string,
 };
@@ -64,7 +64,6 @@ fn size_asserts() {
 
 #[derive(Debug, Clone)]
 pub struct Linter {
-    // rules: Vec<RuleWithSeverity>,
     options: LintOptions,
     // config: Arc<LintConfig>,
     config: ConfigStore,
@@ -112,8 +111,8 @@ impl Linter {
 
         let rules = rules
             .iter()
-            .filter(|rule| rule.should_run(&ctx_host))
-            .map(|rule| (rule, Rc::clone(&ctx_host).spawn(rule)));
+            .filter(|(rule, _)| rule.should_run(&ctx_host))
+            .map(|(rule, severity)| (rule, Rc::clone(&ctx_host).spawn(rule, *severity)));
 
         let semantic = ctx_host.semantic();
 

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -1,16 +1,11 @@
-use std::{
-    borrow::{Borrow, Cow},
-    fmt,
-    hash::{Hash, Hasher},
-    ops::Deref,
-};
+use std::{borrow::Cow, fmt, hash::Hash};
 
 use oxc_semantic::SymbolId;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AllowWarnDeny, AstNode, FixKind, RuleEnum,
+    AstNode, FixKind,
     context::{ContextHost, LintContext},
     utils::PossibleJestNode,
 };
@@ -262,46 +257,6 @@ impl RuleFixMeta {
 impl From<RuleFixMeta> for FixKind {
     fn from(value: RuleFixMeta) -> Self {
         value.fix_kind()
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct RuleWithSeverity {
-    pub rule: RuleEnum,
-    pub severity: AllowWarnDeny,
-}
-
-impl Hash for RuleWithSeverity {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.rule.hash(state);
-    }
-}
-
-impl PartialEq for RuleWithSeverity {
-    fn eq(&self, other: &Self) -> bool {
-        self.rule == other.rule
-    }
-}
-
-impl Eq for RuleWithSeverity {}
-
-impl Deref for RuleWithSeverity {
-    type Target = RuleEnum;
-
-    fn deref(&self) -> &Self::Target {
-        &self.rule
-    }
-}
-
-impl Borrow<RuleEnum> for RuleWithSeverity {
-    fn borrow(&self) -> &RuleEnum {
-        &self.rule
-    }
-}
-
-impl RuleWithSeverity {
-    pub fn new(rule: RuleEnum, severity: AllowWarnDeny) -> Self {
-        Self { rule, severity }
     }
 }
 

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 
 use crate::{
     AllowWarnDeny, ConfigStore, ConfigStoreBuilder, LintPlugins, LintService, LintServiceOptions,
-    Linter, Oxlintrc, RuleEnum, RuleWithSeverity,
+    Linter, Oxlintrc, RuleEnum,
     fixer::{FixKind, Fixer},
     options::LintOptions,
     read_to_string,
@@ -492,7 +492,7 @@ impl Tester {
                             .unwrap()
                     })
                     .with_plugins(self.plugins)
-                    .with_rule(RuleWithSeverity::new(rule, AllowWarnDeny::Warn))
+                    .with_rule(rule, AllowWarnDeny::Warn)
                     .build()
                     .unwrap(),
                 FxHashMap::default(),


### PR DESCRIPTION
Originally I thought this might improve performance by storing the `AllowWarnDeny` separately, since it only occupies 1 byte, while the struct needs to be aligned to 8 bytes (I think?). But it didn't really make any difference. However, I think it's still worth merging as removing the `RuleWithSeverity` struct makes it conceptually simpler, since we don't have yet another rule-like struct in the codebase. 