### PR TITLE
fix(linter): fix rule config not being correctly applied

### DIFF
--- a/apps/oxlint/fixtures/issue_11054/.oxlintrc.json
+++ b/apps/oxlint/fixtures/issue_11054/.oxlintrc.json
@@ -1,0 +1,12 @@
+{
+  "rules": {
+    "no-unused-vars": [
+      2,
+      {
+        "args": "none",
+        "caughtErrors": "none",
+        "varsIgnorePattern": "^h|React|createElement|Fragment$"
+      }
+    ]
+  }
+}

--- a/apps/oxlint/fixtures/issue_11054/index.js
+++ b/apps/oxlint/fixtures/issue_11054/index.js
@@ -1,0 +1,1 @@
+import { createElement } from "preact";

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1159,4 +1159,10 @@ mod test {
         let args = &["--import-plugin", "-D", "import/no-cycle"];
         Tester::new().with_cwd("fixtures/import-cycle".into()).test_and_snapshot(args);
     }
+
+    #[test]
+    fn test_rule_config_being_enabled_correctly() {
+        let args = &["-c", ".oxlintrc.json"];
+        Tester::new().with_cwd("fixtures/issue_11054".into()).test_and_snapshot(args);
+    }
 }

--- a/apps/oxlint/src/snapshots/fixtures__issue_11054_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__issue_11054_-c .oxlintrc.json@oxlint.snap
@@ -1,0 +1,12 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: -c .oxlintrc.json
+working directory: fixtures/issue_11054
+----------
+Found 0 warnings and 0 errors.
+Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -147,6 +147,7 @@ impl OxlintRules {
             rules_for_override.remove(&rule);
         }
         for (rule, severity) in rules_to_replace {
+            let _ = rules_for_override.remove(&rule);
             rules_for_override.insert(rule, severity);
         }
     }


### PR DESCRIPTION
since `rules_for_override` was converted from a `FxHashSet` to ` FxHashMap`, the behaviour changed. rather than calling `.replace`, we call `insert` which updates the value, but does not update the key.

As per the docs:

> The key is not updated, though; this matters for types that can be == without being identical.

I've written a test for this to hopefully prevent a regression and validated the test fails on main.


fixes #11054
