### PR TITLE
refactor(linter): remove overrides index vec

### DIFF
--- a/crates/oxc_linter/src/config/overrides.rs
+++ b/crates/oxc_linter/src/config/overrides.rs
@@ -4,36 +4,17 @@ use std::{
     path::Path,
 };
 
-use nonmax::NonMaxU32;
 use schemars::{JsonSchema, r#gen, schema::Schema};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
-use oxc_index::{Idx, IndexVec};
-
 use crate::{LintPlugins, OxlintEnv, OxlintGlobals, config::OxlintRules};
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct OverrideId(NonMaxU32);
-
-impl Idx for OverrideId {
-    #[expect(clippy::cast_possible_truncation)]
-    fn from_usize(idx: usize) -> Self {
-        assert!(idx < u32::MAX as usize);
-        // SAFETY: We just checked `idx` is a legal value for `NonMaxU32`
-        Self(unsafe { NonMaxU32::new_unchecked(idx as u32) })
-    }
-
-    fn index(self) -> usize {
-        self.0.get() as usize
-    }
-}
 
 // nominal wrapper required to add JsonSchema impl
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
-pub struct OxlintOverrides(IndexVec<OverrideId, OxlintOverride>);
+pub struct OxlintOverrides(Vec<OxlintOverride>);
 
 impl Deref for OxlintOverrides {
-    type Target = IndexVec<OverrideId, OxlintOverride>;
+    type Target = Vec<OxlintOverride>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -48,7 +29,7 @@ impl DerefMut for OxlintOverrides {
 
 impl IntoIterator for OxlintOverrides {
     type Item = OxlintOverride;
-    type IntoIter = <IndexVec<OverrideId, OxlintOverride> as IntoIterator>::IntoIter;
+    type IntoIter = <Vec<OxlintOverride> as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
@@ -58,7 +39,7 @@ impl IntoIterator for OxlintOverrides {
 impl OxlintOverrides {
     #[inline]
     pub fn empty() -> Self {
-        Self(IndexVec::new())
+        Self(Vec::new())
     }
 
     // must be explicitly defined to make serde happy


### PR DESCRIPTION
we never index directly into the vec, so using an index vec here is unnecessary 