### PR TITLE
refactor(ast_tools): print number of padding bytes in layout assertions files

### DIFF
--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -9,6 +9,7 @@ use crate::ast::*;
 
 #[cfg(target_pointer_width = "64")]
 const _: () = {
+    // Padding: 9 bytes
     assert!(size_of::<Program>() == 160);
     assert!(align_of::<Program>() == 8);
     assert!(offset_of!(Program, span) == 0);
@@ -23,32 +24,38 @@ const _: () = {
     assert!(size_of::<Expression>() == 16);
     assert!(align_of::<Expression>() == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<IdentifierName>() == 24);
     assert!(align_of::<IdentifierName>() == 8);
     assert!(offset_of!(IdentifierName, span) == 0);
     assert!(offset_of!(IdentifierName, name) == 8);
 
+    // Padding: 4 bytes
     assert!(size_of::<IdentifierReference>() == 32);
     assert!(align_of::<IdentifierReference>() == 8);
     assert!(offset_of!(IdentifierReference, span) == 0);
     assert!(offset_of!(IdentifierReference, name) == 8);
     assert!(offset_of!(IdentifierReference, reference_id) == 24);
 
+    // Padding: 4 bytes
     assert!(size_of::<BindingIdentifier>() == 32);
     assert!(align_of::<BindingIdentifier>() == 8);
     assert!(offset_of!(BindingIdentifier, span) == 0);
     assert!(offset_of!(BindingIdentifier, name) == 8);
     assert!(offset_of!(BindingIdentifier, symbol_id) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<LabelIdentifier>() == 24);
     assert!(align_of::<LabelIdentifier>() == 8);
     assert!(offset_of!(LabelIdentifier, span) == 0);
     assert!(offset_of!(LabelIdentifier, name) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<ThisExpression>() == 8);
     assert!(align_of::<ThisExpression>() == 8);
     assert!(offset_of!(ThisExpression, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<ArrayExpression>() == 40);
     assert!(align_of::<ArrayExpression>() == 8);
     assert!(offset_of!(ArrayExpression, span) == 0);
@@ -57,10 +64,12 @@ const _: () = {
     assert!(size_of::<ArrayExpressionElement>() == 16);
     assert!(align_of::<ArrayExpressionElement>() == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<Elision>() == 8);
     assert!(align_of::<Elision>() == 8);
     assert!(offset_of!(Elision, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<ObjectExpression>() == 40);
     assert!(align_of::<ObjectExpression>() == 8);
     assert!(offset_of!(ObjectExpression, span) == 0);
@@ -69,6 +78,7 @@ const _: () = {
     assert!(size_of::<ObjectPropertyKind>() == 16);
     assert!(align_of::<ObjectPropertyKind>() == 8);
 
+    // Padding: 12 bytes
     assert!(size_of::<ObjectProperty>() == 56);
     assert!(align_of::<ObjectProperty>() == 8);
     assert!(offset_of!(ObjectProperty, span) == 0);
@@ -85,12 +95,14 @@ const _: () = {
     assert!(size_of::<PropertyKind>() == 1);
     assert!(align_of::<PropertyKind>() == 1);
 
+    // Padding: 0 bytes
     assert!(size_of::<TemplateLiteral>() == 72);
     assert!(align_of::<TemplateLiteral>() == 8);
     assert!(offset_of!(TemplateLiteral, span) == 0);
     assert!(offset_of!(TemplateLiteral, quasis) == 8);
     assert!(offset_of!(TemplateLiteral, expressions) == 40);
 
+    // Padding: 0 bytes
     assert!(size_of::<TaggedTemplateExpression>() == 104);
     assert!(align_of::<TaggedTemplateExpression>() == 8);
     assert!(offset_of!(TaggedTemplateExpression, span) == 0);
@@ -98,6 +110,7 @@ const _: () = {
     assert!(offset_of!(TaggedTemplateExpression, type_arguments) == 24);
     assert!(offset_of!(TaggedTemplateExpression, quasi) == 32);
 
+    // Padding: 6 bytes
     assert!(size_of::<TemplateElement>() == 48);
     assert!(align_of::<TemplateElement>() == 8);
     assert!(offset_of!(TemplateElement, span) == 0);
@@ -105,6 +118,7 @@ const _: () = {
     assert!(offset_of!(TemplateElement, tail) == 40);
     assert!(offset_of!(TemplateElement, lone_surrogates) == 41);
 
+    // Padding: 0 bytes
     assert!(size_of::<TemplateElementValue>() == 32);
     assert!(align_of::<TemplateElementValue>() == 8);
     assert!(offset_of!(TemplateElementValue, raw) == 0);
@@ -113,6 +127,7 @@ const _: () = {
     assert!(size_of::<MemberExpression>() == 16);
     assert!(align_of::<MemberExpression>() == 8);
 
+    // Padding: 7 bytes
     assert!(size_of::<ComputedMemberExpression>() == 48);
     assert!(align_of::<ComputedMemberExpression>() == 8);
     assert!(offset_of!(ComputedMemberExpression, span) == 0);
@@ -120,6 +135,7 @@ const _: () = {
     assert!(offset_of!(ComputedMemberExpression, expression) == 24);
     assert!(offset_of!(ComputedMemberExpression, optional) == 40);
 
+    // Padding: 7 bytes
     assert!(size_of::<StaticMemberExpression>() == 56);
     assert!(align_of::<StaticMemberExpression>() == 8);
     assert!(offset_of!(StaticMemberExpression, span) == 0);
@@ -127,6 +143,7 @@ const _: () = {
     assert!(offset_of!(StaticMemberExpression, property) == 24);
     assert!(offset_of!(StaticMemberExpression, optional) == 48);
 
+    // Padding: 7 bytes
     assert!(size_of::<PrivateFieldExpression>() == 56);
     assert!(align_of::<PrivateFieldExpression>() == 8);
     assert!(offset_of!(PrivateFieldExpression, span) == 0);
@@ -134,6 +151,7 @@ const _: () = {
     assert!(offset_of!(PrivateFieldExpression, field) == 24);
     assert!(offset_of!(PrivateFieldExpression, optional) == 48);
 
+    // Padding: 6 bytes
     assert!(size_of::<CallExpression>() == 72);
     assert!(align_of::<CallExpression>() == 8);
     assert!(offset_of!(CallExpression, span) == 0);
@@ -143,6 +161,7 @@ const _: () = {
     assert!(offset_of!(CallExpression, optional) == 64);
     assert!(offset_of!(CallExpression, pure) == 65);
 
+    // Padding: 7 bytes
     assert!(size_of::<NewExpression>() == 72);
     assert!(align_of::<NewExpression>() == 8);
     assert!(offset_of!(NewExpression, span) == 0);
@@ -151,12 +170,14 @@ const _: () = {
     assert!(offset_of!(NewExpression, arguments) == 32);
     assert!(offset_of!(NewExpression, pure) == 64);
 
+    // Padding: 0 bytes
     assert!(size_of::<MetaProperty>() == 56);
     assert!(align_of::<MetaProperty>() == 8);
     assert!(offset_of!(MetaProperty, span) == 0);
     assert!(offset_of!(MetaProperty, meta) == 8);
     assert!(offset_of!(MetaProperty, property) == 32);
 
+    // Padding: 0 bytes
     assert!(size_of::<SpreadElement>() == 24);
     assert!(align_of::<SpreadElement>() == 8);
     assert!(offset_of!(SpreadElement, span) == 0);
@@ -165,6 +186,7 @@ const _: () = {
     assert!(size_of::<Argument>() == 16);
     assert!(align_of::<Argument>() == 8);
 
+    // Padding: 6 bytes
     assert!(size_of::<UpdateExpression>() == 32);
     assert!(align_of::<UpdateExpression>() == 8);
     assert!(offset_of!(UpdateExpression, span) == 0);
@@ -172,12 +194,14 @@ const _: () = {
     assert!(offset_of!(UpdateExpression, prefix) == 9);
     assert!(offset_of!(UpdateExpression, argument) == 16);
 
+    // Padding: 7 bytes
     assert!(size_of::<UnaryExpression>() == 32);
     assert!(align_of::<UnaryExpression>() == 8);
     assert!(offset_of!(UnaryExpression, span) == 0);
     assert!(offset_of!(UnaryExpression, operator) == 8);
     assert!(offset_of!(UnaryExpression, argument) == 16);
 
+    // Padding: 7 bytes
     assert!(size_of::<BinaryExpression>() == 48);
     assert!(align_of::<BinaryExpression>() == 8);
     assert!(offset_of!(BinaryExpression, span) == 0);
@@ -185,12 +209,14 @@ const _: () = {
     assert!(offset_of!(BinaryExpression, operator) == 24);
     assert!(offset_of!(BinaryExpression, right) == 32);
 
+    // Padding: 0 bytes
     assert!(size_of::<PrivateInExpression>() == 48);
     assert!(align_of::<PrivateInExpression>() == 8);
     assert!(offset_of!(PrivateInExpression, span) == 0);
     assert!(offset_of!(PrivateInExpression, left) == 8);
     assert!(offset_of!(PrivateInExpression, right) == 32);
 
+    // Padding: 7 bytes
     assert!(size_of::<LogicalExpression>() == 48);
     assert!(align_of::<LogicalExpression>() == 8);
     assert!(offset_of!(LogicalExpression, span) == 0);
@@ -198,6 +224,7 @@ const _: () = {
     assert!(offset_of!(LogicalExpression, operator) == 24);
     assert!(offset_of!(LogicalExpression, right) == 32);
 
+    // Padding: 0 bytes
     assert!(size_of::<ConditionalExpression>() == 56);
     assert!(align_of::<ConditionalExpression>() == 8);
     assert!(offset_of!(ConditionalExpression, span) == 0);
@@ -205,6 +232,7 @@ const _: () = {
     assert!(offset_of!(ConditionalExpression, consequent) == 24);
     assert!(offset_of!(ConditionalExpression, alternate) == 40);
 
+    // Padding: 7 bytes
     assert!(size_of::<AssignmentExpression>() == 48);
     assert!(align_of::<AssignmentExpression>() == 8);
     assert!(offset_of!(AssignmentExpression, span) == 0);
@@ -221,18 +249,21 @@ const _: () = {
     assert!(size_of::<AssignmentTargetPattern>() == 16);
     assert!(align_of::<AssignmentTargetPattern>() == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<ArrayAssignmentTarget>() == 64);
     assert!(align_of::<ArrayAssignmentTarget>() == 8);
     assert!(offset_of!(ArrayAssignmentTarget, span) == 0);
     assert!(offset_of!(ArrayAssignmentTarget, elements) == 8);
     assert!(offset_of!(ArrayAssignmentTarget, rest) == 40);
 
+    // Padding: 0 bytes
     assert!(size_of::<ObjectAssignmentTarget>() == 64);
     assert!(align_of::<ObjectAssignmentTarget>() == 8);
     assert!(offset_of!(ObjectAssignmentTarget, span) == 0);
     assert!(offset_of!(ObjectAssignmentTarget, properties) == 8);
     assert!(offset_of!(ObjectAssignmentTarget, rest) == 40);
 
+    // Padding: 0 bytes
     assert!(size_of::<AssignmentTargetRest>() == 24);
     assert!(align_of::<AssignmentTargetRest>() == 8);
     assert!(offset_of!(AssignmentTargetRest, span) == 0);
@@ -241,6 +272,7 @@ const _: () = {
     assert!(size_of::<AssignmentTargetMaybeDefault>() == 16);
     assert!(align_of::<AssignmentTargetMaybeDefault>() == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<AssignmentTargetWithDefault>() == 40);
     assert!(align_of::<AssignmentTargetWithDefault>() == 8);
     assert!(offset_of!(AssignmentTargetWithDefault, span) == 0);
@@ -250,12 +282,14 @@ const _: () = {
     assert!(size_of::<AssignmentTargetProperty>() == 16);
     assert!(align_of::<AssignmentTargetProperty>() == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<AssignmentTargetPropertyIdentifier>() == 56);
     assert!(align_of::<AssignmentTargetPropertyIdentifier>() == 8);
     assert!(offset_of!(AssignmentTargetPropertyIdentifier, span) == 0);
     assert!(offset_of!(AssignmentTargetPropertyIdentifier, binding) == 8);
     assert!(offset_of!(AssignmentTargetPropertyIdentifier, init) == 40);
 
+    // Padding: 7 bytes
     assert!(size_of::<AssignmentTargetPropertyProperty>() == 48);
     assert!(align_of::<AssignmentTargetPropertyProperty>() == 8);
     assert!(offset_of!(AssignmentTargetPropertyProperty, span) == 0);
@@ -263,20 +297,24 @@ const _: () = {
     assert!(offset_of!(AssignmentTargetPropertyProperty, binding) == 24);
     assert!(offset_of!(AssignmentTargetPropertyProperty, computed) == 40);
 
+    // Padding: 0 bytes
     assert!(size_of::<SequenceExpression>() == 40);
     assert!(align_of::<SequenceExpression>() == 8);
     assert!(offset_of!(SequenceExpression, span) == 0);
     assert!(offset_of!(SequenceExpression, expressions) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<Super>() == 8);
     assert!(align_of::<Super>() == 8);
     assert!(offset_of!(Super, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<AwaitExpression>() == 24);
     assert!(align_of::<AwaitExpression>() == 8);
     assert!(offset_of!(AwaitExpression, span) == 0);
     assert!(offset_of!(AwaitExpression, argument) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<ChainExpression>() == 24);
     assert!(align_of::<ChainExpression>() == 8);
     assert!(offset_of!(ChainExpression, span) == 0);
@@ -285,6 +323,7 @@ const _: () = {
     assert!(size_of::<ChainElement>() == 16);
     assert!(align_of::<ChainElement>() == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<ParenthesizedExpression>() == 24);
     assert!(align_of::<ParenthesizedExpression>() == 8);
     assert!(offset_of!(ParenthesizedExpression, span) == 0);
@@ -293,17 +332,20 @@ const _: () = {
     assert!(size_of::<Statement>() == 16);
     assert!(align_of::<Statement>() == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<Directive>() == 72);
     assert!(align_of::<Directive>() == 8);
     assert!(offset_of!(Directive, span) == 0);
     assert!(offset_of!(Directive, expression) == 8);
     assert!(offset_of!(Directive, directive) == 56);
 
+    // Padding: 0 bytes
     assert!(size_of::<Hashbang>() == 24);
     assert!(align_of::<Hashbang>() == 8);
     assert!(offset_of!(Hashbang, span) == 0);
     assert!(offset_of!(Hashbang, value) == 8);
 
+    // Padding: 4 bytes
     assert!(size_of::<BlockStatement>() == 48);
     assert!(align_of::<BlockStatement>() == 8);
     assert!(offset_of!(BlockStatement, span) == 0);
@@ -313,6 +355,7 @@ const _: () = {
     assert!(size_of::<Declaration>() == 16);
     assert!(align_of::<Declaration>() == 8);
 
+    // Padding: 14 bytes
     assert!(size_of::<VariableDeclaration>() == 56);
     assert!(align_of::<VariableDeclaration>() == 8);
     assert!(offset_of!(VariableDeclaration, span) == 0);
@@ -323,6 +366,7 @@ const _: () = {
     assert!(size_of::<VariableDeclarationKind>() == 1);
     assert!(align_of::<VariableDeclarationKind>() == 1);
 
+    // Padding: 14 bytes
     assert!(size_of::<VariableDeclarator>() == 72);
     assert!(align_of::<VariableDeclarator>() == 8);
     assert!(offset_of!(VariableDeclarator, span) == 0);
@@ -331,15 +375,18 @@ const _: () = {
     assert!(offset_of!(VariableDeclarator, init) == 48);
     assert!(offset_of!(VariableDeclarator, definite) == 64);
 
+    // Padding: 0 bytes
     assert!(size_of::<EmptyStatement>() == 8);
     assert!(align_of::<EmptyStatement>() == 8);
     assert!(offset_of!(EmptyStatement, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<ExpressionStatement>() == 24);
     assert!(align_of::<ExpressionStatement>() == 8);
     assert!(offset_of!(ExpressionStatement, span) == 0);
     assert!(offset_of!(ExpressionStatement, expression) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<IfStatement>() == 56);
     assert!(align_of::<IfStatement>() == 8);
     assert!(offset_of!(IfStatement, span) == 0);
@@ -347,18 +394,21 @@ const _: () = {
     assert!(offset_of!(IfStatement, consequent) == 24);
     assert!(offset_of!(IfStatement, alternate) == 40);
 
+    // Padding: 0 bytes
     assert!(size_of::<DoWhileStatement>() == 40);
     assert!(align_of::<DoWhileStatement>() == 8);
     assert!(offset_of!(DoWhileStatement, span) == 0);
     assert!(offset_of!(DoWhileStatement, body) == 8);
     assert!(offset_of!(DoWhileStatement, test) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<WhileStatement>() == 40);
     assert!(align_of::<WhileStatement>() == 8);
     assert!(offset_of!(WhileStatement, span) == 0);
     assert!(offset_of!(WhileStatement, test) == 8);
     assert!(offset_of!(WhileStatement, body) == 24);
 
+    // Padding: 4 bytes
     assert!(size_of::<ForStatement>() == 80);
     assert!(align_of::<ForStatement>() == 8);
     assert!(offset_of!(ForStatement, span) == 0);
@@ -371,6 +421,7 @@ const _: () = {
     assert!(size_of::<ForStatementInit>() == 16);
     assert!(align_of::<ForStatementInit>() == 8);
 
+    // Padding: 4 bytes
     assert!(size_of::<ForInStatement>() == 64);
     assert!(align_of::<ForInStatement>() == 8);
     assert!(offset_of!(ForInStatement, span) == 0);
@@ -382,6 +433,7 @@ const _: () = {
     assert!(size_of::<ForStatementLeft>() == 16);
     assert!(align_of::<ForStatementLeft>() == 8);
 
+    // Padding: 11 bytes
     assert!(size_of::<ForOfStatement>() == 72);
     assert!(align_of::<ForOfStatement>() == 8);
     assert!(offset_of!(ForOfStatement, span) == 0);
@@ -391,27 +443,32 @@ const _: () = {
     assert!(offset_of!(ForOfStatement, body) == 48);
     assert!(offset_of!(ForOfStatement, scope_id) == 64);
 
+    // Padding: 0 bytes
     assert!(size_of::<ContinueStatement>() == 32);
     assert!(align_of::<ContinueStatement>() == 8);
     assert!(offset_of!(ContinueStatement, span) == 0);
     assert!(offset_of!(ContinueStatement, label) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<BreakStatement>() == 32);
     assert!(align_of::<BreakStatement>() == 8);
     assert!(offset_of!(BreakStatement, span) == 0);
     assert!(offset_of!(BreakStatement, label) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<ReturnStatement>() == 24);
     assert!(align_of::<ReturnStatement>() == 8);
     assert!(offset_of!(ReturnStatement, span) == 0);
     assert!(offset_of!(ReturnStatement, argument) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<WithStatement>() == 40);
     assert!(align_of::<WithStatement>() == 8);
     assert!(offset_of!(WithStatement, span) == 0);
     assert!(offset_of!(WithStatement, object) == 8);
     assert!(offset_of!(WithStatement, body) == 24);
 
+    // Padding: 4 bytes
     assert!(size_of::<SwitchStatement>() == 64);
     assert!(align_of::<SwitchStatement>() == 8);
     assert!(offset_of!(SwitchStatement, span) == 0);
@@ -419,23 +476,27 @@ const _: () = {
     assert!(offset_of!(SwitchStatement, cases) == 24);
     assert!(offset_of!(SwitchStatement, scope_id) == 56);
 
+    // Padding: 0 bytes
     assert!(size_of::<SwitchCase>() == 56);
     assert!(align_of::<SwitchCase>() == 8);
     assert!(offset_of!(SwitchCase, span) == 0);
     assert!(offset_of!(SwitchCase, test) == 8);
     assert!(offset_of!(SwitchCase, consequent) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<LabeledStatement>() == 48);
     assert!(align_of::<LabeledStatement>() == 8);
     assert!(offset_of!(LabeledStatement, span) == 0);
     assert!(offset_of!(LabeledStatement, label) == 8);
     assert!(offset_of!(LabeledStatement, body) == 32);
 
+    // Padding: 0 bytes
     assert!(size_of::<ThrowStatement>() == 24);
     assert!(align_of::<ThrowStatement>() == 8);
     assert!(offset_of!(ThrowStatement, span) == 0);
     assert!(offset_of!(ThrowStatement, argument) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TryStatement>() == 32);
     assert!(align_of::<TryStatement>() == 8);
     assert!(offset_of!(TryStatement, span) == 0);
@@ -443,6 +504,7 @@ const _: () = {
     assert!(offset_of!(TryStatement, handler) == 16);
     assert!(offset_of!(TryStatement, finalizer) == 24);
 
+    // Padding: 4 bytes
     assert!(size_of::<CatchClause>() == 64);
     assert!(align_of::<CatchClause>() == 8);
     assert!(offset_of!(CatchClause, span) == 0);
@@ -450,15 +512,18 @@ const _: () = {
     assert!(offset_of!(CatchClause, body) == 48);
     assert!(offset_of!(CatchClause, scope_id) == 56);
 
+    // Padding: 0 bytes
     assert!(size_of::<CatchParameter>() == 40);
     assert!(align_of::<CatchParameter>() == 8);
     assert!(offset_of!(CatchParameter, span) == 0);
     assert!(offset_of!(CatchParameter, pattern) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<DebuggerStatement>() == 8);
     assert!(align_of::<DebuggerStatement>() == 8);
     assert!(offset_of!(DebuggerStatement, span) == 0);
 
+    // Padding: 7 bytes
     assert!(size_of::<BindingPattern>() == 32);
     assert!(align_of::<BindingPattern>() == 8);
     assert!(offset_of!(BindingPattern, kind) == 0);
@@ -468,18 +533,21 @@ const _: () = {
     assert!(size_of::<BindingPatternKind>() == 16);
     assert!(align_of::<BindingPatternKind>() == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<AssignmentPattern>() == 56);
     assert!(align_of::<AssignmentPattern>() == 8);
     assert!(offset_of!(AssignmentPattern, span) == 0);
     assert!(offset_of!(AssignmentPattern, left) == 8);
     assert!(offset_of!(AssignmentPattern, right) == 40);
 
+    // Padding: 0 bytes
     assert!(size_of::<ObjectPattern>() == 48);
     assert!(align_of::<ObjectPattern>() == 8);
     assert!(offset_of!(ObjectPattern, span) == 0);
     assert!(offset_of!(ObjectPattern, properties) == 8);
     assert!(offset_of!(ObjectPattern, rest) == 40);
 
+    // Padding: 6 bytes
     assert!(size_of::<BindingProperty>() == 64);
     assert!(align_of::<BindingProperty>() == 8);
     assert!(offset_of!(BindingProperty, span) == 0);
@@ -488,17 +556,20 @@ const _: () = {
     assert!(offset_of!(BindingProperty, shorthand) == 56);
     assert!(offset_of!(BindingProperty, computed) == 57);
 
+    // Padding: 0 bytes
     assert!(size_of::<ArrayPattern>() == 48);
     assert!(align_of::<ArrayPattern>() == 8);
     assert!(offset_of!(ArrayPattern, span) == 0);
     assert!(offset_of!(ArrayPattern, elements) == 8);
     assert!(offset_of!(ArrayPattern, rest) == 40);
 
+    // Padding: 0 bytes
     assert!(size_of::<BindingRestElement>() == 40);
     assert!(align_of::<BindingRestElement>() == 8);
     assert!(offset_of!(BindingRestElement, span) == 0);
     assert!(offset_of!(BindingRestElement, argument) == 8);
 
+    // Padding: 15 bytes
     assert!(size_of::<Function>() == 104);
     assert!(align_of::<Function>() == 8);
     assert!(offset_of!(Function, span) == 0);
@@ -518,6 +589,7 @@ const _: () = {
     assert!(size_of::<FunctionType>() == 1);
     assert!(align_of::<FunctionType>() == 1);
 
+    // Padding: 7 bytes
     assert!(size_of::<FormalParameters>() == 56);
     assert!(align_of::<FormalParameters>() == 8);
     assert!(offset_of!(FormalParameters, span) == 0);
@@ -525,6 +597,7 @@ const _: () = {
     assert!(offset_of!(FormalParameters, items) == 16);
     assert!(offset_of!(FormalParameters, rest) == 48);
 
+    // Padding: 5 bytes
     assert!(size_of::<FormalParameter>() == 80);
     assert!(align_of::<FormalParameter>() == 8);
     assert!(offset_of!(FormalParameter, span) == 0);
@@ -537,12 +610,14 @@ const _: () = {
     assert!(size_of::<FormalParameterKind>() == 1);
     assert!(align_of::<FormalParameterKind>() == 1);
 
+    // Padding: 0 bytes
     assert!(size_of::<FunctionBody>() == 72);
     assert!(align_of::<FunctionBody>() == 8);
     assert!(offset_of!(FunctionBody, span) == 0);
     assert!(offset_of!(FunctionBody, directives) == 8);
     assert!(offset_of!(FunctionBody, statements) == 40);
 
+    // Padding: 9 bytes
     assert!(size_of::<ArrowFunctionExpression>() == 56);
     assert!(align_of::<ArrowFunctionExpression>() == 8);
     assert!(offset_of!(ArrowFunctionExpression, span) == 0);
@@ -555,12 +630,14 @@ const _: () = {
     assert!(offset_of!(ArrowFunctionExpression, scope_id) == 48);
     assert!(offset_of!(ArrowFunctionExpression, pure) == 52);
 
+    // Padding: 7 bytes
     assert!(size_of::<YieldExpression>() == 32);
     assert!(align_of::<YieldExpression>() == 8);
     assert!(offset_of!(YieldExpression, span) == 0);
     assert!(offset_of!(YieldExpression, delegate) == 8);
     assert!(offset_of!(YieldExpression, argument) == 16);
 
+    // Padding: 9 bytes
     assert!(size_of::<Class>() == 160);
     assert!(align_of::<Class>() == 8);
     assert!(offset_of!(Class, span) == 0);
@@ -579,6 +656,7 @@ const _: () = {
     assert!(size_of::<ClassType>() == 1);
     assert!(align_of::<ClassType>() == 1);
 
+    // Padding: 0 bytes
     assert!(size_of::<ClassBody>() == 40);
     assert!(align_of::<ClassBody>() == 8);
     assert!(offset_of!(ClassBody, span) == 0);
@@ -587,6 +665,7 @@ const _: () = {
     assert!(size_of::<ClassElement>() == 16);
     assert!(align_of::<ClassElement>() == 8);
 
+    // Padding: 9 bytes
     assert!(size_of::<MethodDefinition>() == 80);
     assert!(align_of::<MethodDefinition>() == 8);
     assert!(offset_of!(MethodDefinition, span) == 0);
@@ -604,6 +683,7 @@ const _: () = {
     assert!(size_of::<MethodDefinitionType>() == 1);
     assert!(align_of::<MethodDefinitionType>() == 1);
 
+    // Padding: 7 bytes
     assert!(size_of::<PropertyDefinition>() == 96);
     assert!(align_of::<PropertyDefinition>() == 8);
     assert!(offset_of!(PropertyDefinition, span) == 0);
@@ -627,11 +707,13 @@ const _: () = {
     assert!(size_of::<MethodDefinitionKind>() == 1);
     assert!(align_of::<MethodDefinitionKind>() == 1);
 
+    // Padding: 0 bytes
     assert!(size_of::<PrivateIdentifier>() == 24);
     assert!(align_of::<PrivateIdentifier>() == 8);
     assert!(offset_of!(PrivateIdentifier, span) == 0);
     assert!(offset_of!(PrivateIdentifier, name) == 8);
 
+    // Padding: 4 bytes
     assert!(size_of::<StaticBlock>() == 48);
     assert!(align_of::<StaticBlock>() == 8);
     assert!(offset_of!(StaticBlock, span) == 0);
@@ -644,6 +726,7 @@ const _: () = {
     assert!(size_of::<AccessorPropertyType>() == 1);
     assert!(align_of::<AccessorPropertyType>() == 1);
 
+    // Padding: 10 bytes
     assert!(size_of::<AccessorProperty>() == 96);
     assert!(align_of::<AccessorProperty>() == 8);
     assert!(offset_of!(AccessorProperty, span) == 0);
@@ -658,6 +741,7 @@ const _: () = {
     assert!(offset_of!(AccessorProperty, definite) == 91);
     assert!(offset_of!(AccessorProperty, accessibility) == 92);
 
+    // Padding: 7 bytes
     assert!(size_of::<ImportExpression>() == 48);
     assert!(align_of::<ImportExpression>() == 8);
     assert!(offset_of!(ImportExpression, span) == 0);
@@ -665,6 +749,7 @@ const _: () = {
     assert!(offset_of!(ImportExpression, options) == 24);
     assert!(offset_of!(ImportExpression, phase) == 40);
 
+    // Padding: 14 bytes
     assert!(size_of::<ImportDeclaration>() == 112);
     assert!(align_of::<ImportDeclaration>() == 8);
     assert!(offset_of!(ImportDeclaration, span) == 0);
@@ -680,6 +765,7 @@ const _: () = {
     assert!(size_of::<ImportDeclarationSpecifier>() == 16);
     assert!(align_of::<ImportDeclarationSpecifier>() == 8);
 
+    // Padding: 7 bytes
     assert!(size_of::<ImportSpecifier>() == 104);
     assert!(align_of::<ImportSpecifier>() == 8);
     assert!(offset_of!(ImportSpecifier, span) == 0);
@@ -687,22 +773,26 @@ const _: () = {
     assert!(offset_of!(ImportSpecifier, local) == 64);
     assert!(offset_of!(ImportSpecifier, import_kind) == 96);
 
+    // Padding: 0 bytes
     assert!(size_of::<ImportDefaultSpecifier>() == 40);
     assert!(align_of::<ImportDefaultSpecifier>() == 8);
     assert!(offset_of!(ImportDefaultSpecifier, span) == 0);
     assert!(offset_of!(ImportDefaultSpecifier, local) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<ImportNamespaceSpecifier>() == 40);
     assert!(align_of::<ImportNamespaceSpecifier>() == 8);
     assert!(offset_of!(ImportNamespaceSpecifier, span) == 0);
     assert!(offset_of!(ImportNamespaceSpecifier, local) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<WithClause>() == 64);
     assert!(align_of::<WithClause>() == 8);
     assert!(offset_of!(WithClause, span) == 0);
     assert!(offset_of!(WithClause, attributes_keyword) == 8);
     assert!(offset_of!(WithClause, with_entries) == 32);
 
+    // Padding: 0 bytes
     assert!(size_of::<ImportAttribute>() == 112);
     assert!(align_of::<ImportAttribute>() == 8);
     assert!(offset_of!(ImportAttribute, span) == 0);
@@ -712,6 +802,7 @@ const _: () = {
     assert!(size_of::<ImportAttributeKey>() == 56);
     assert!(align_of::<ImportAttributeKey>() == 8);
 
+    // Padding: 7 bytes
     assert!(size_of::<ExportNamedDeclaration>() == 120);
     assert!(align_of::<ExportNamedDeclaration>() == 8);
     assert!(offset_of!(ExportNamedDeclaration, span) == 0);
@@ -721,12 +812,14 @@ const _: () = {
     assert!(offset_of!(ExportNamedDeclaration, export_kind) == 104);
     assert!(offset_of!(ExportNamedDeclaration, with_clause) == 112);
 
+    // Padding: 0 bytes
     assert!(size_of::<ExportDefaultDeclaration>() == 80);
     assert!(align_of::<ExportDefaultDeclaration>() == 8);
     assert!(offset_of!(ExportDefaultDeclaration, span) == 0);
     assert!(offset_of!(ExportDefaultDeclaration, exported) == 8);
     assert!(offset_of!(ExportDefaultDeclaration, declaration) == 64);
 
+    // Padding: 7 bytes
     assert!(size_of::<ExportAllDeclaration>() == 128);
     assert!(align_of::<ExportAllDeclaration>() == 8);
     assert!(offset_of!(ExportAllDeclaration, span) == 0);
@@ -735,6 +828,7 @@ const _: () = {
     assert!(offset_of!(ExportAllDeclaration, with_clause) == 112);
     assert!(offset_of!(ExportAllDeclaration, export_kind) == 120);
 
+    // Padding: 7 bytes
     assert!(size_of::<ExportSpecifier>() == 128);
     assert!(align_of::<ExportSpecifier>() == 8);
     assert!(offset_of!(ExportSpecifier, span) == 0);
@@ -748,21 +842,25 @@ const _: () = {
     assert!(size_of::<ModuleExportName>() == 56);
     assert!(align_of::<ModuleExportName>() == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<V8IntrinsicExpression>() == 64);
     assert!(align_of::<V8IntrinsicExpression>() == 8);
     assert!(offset_of!(V8IntrinsicExpression, span) == 0);
     assert!(offset_of!(V8IntrinsicExpression, name) == 8);
     assert!(offset_of!(V8IntrinsicExpression, arguments) == 32);
 
+    // Padding: 7 bytes
     assert!(size_of::<BooleanLiteral>() == 16);
     assert!(align_of::<BooleanLiteral>() == 8);
     assert!(offset_of!(BooleanLiteral, span) == 0);
     assert!(offset_of!(BooleanLiteral, value) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<NullLiteral>() == 8);
     assert!(align_of::<NullLiteral>() == 8);
     assert!(offset_of!(NullLiteral, span) == 0);
 
+    // Padding: 7 bytes
     assert!(size_of::<NumericLiteral>() == 40);
     assert!(align_of::<NumericLiteral>() == 8);
     assert!(offset_of!(NumericLiteral, span) == 0);
@@ -770,6 +868,7 @@ const _: () = {
     assert!(offset_of!(NumericLiteral, raw) == 16);
     assert!(offset_of!(NumericLiteral, base) == 32);
 
+    // Padding: 7 bytes
     assert!(size_of::<StringLiteral>() == 48);
     assert!(align_of::<StringLiteral>() == 8);
     assert!(offset_of!(StringLiteral, span) == 0);
@@ -777,31 +876,37 @@ const _: () = {
     assert!(offset_of!(StringLiteral, raw) == 24);
     assert!(offset_of!(StringLiteral, lone_surrogates) == 40);
 
+    // Padding: 7 bytes
     assert!(size_of::<BigIntLiteral>() == 32);
     assert!(align_of::<BigIntLiteral>() == 8);
     assert!(offset_of!(BigIntLiteral, span) == 0);
     assert!(offset_of!(BigIntLiteral, raw) == 8);
     assert!(offset_of!(BigIntLiteral, base) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<RegExpLiteral>() == 56);
     assert!(align_of::<RegExpLiteral>() == 8);
     assert!(offset_of!(RegExpLiteral, span) == 0);
     assert!(offset_of!(RegExpLiteral, regex) == 8);
     assert!(offset_of!(RegExpLiteral, raw) == 40);
 
+    // Padding: 7 bytes
     assert!(size_of::<RegExp>() == 32);
     assert!(align_of::<RegExp>() == 8);
     assert!(offset_of!(RegExp, pattern) == 0);
     assert!(offset_of!(RegExp, flags) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<RegExpPattern>() == 24);
     assert!(align_of::<RegExpPattern>() == 8);
     assert!(offset_of!(RegExpPattern, text) == 0);
     assert!(offset_of!(RegExpPattern, pattern) == 16);
 
+    // Padding: 0 bytes
     assert!(size_of::<RegExpFlags>() == 1);
     assert!(align_of::<RegExpFlags>() == 1);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXElement>() == 56);
     assert!(align_of::<JSXElement>() == 8);
     assert!(offset_of!(JSXElement, span) == 0);
@@ -809,6 +914,7 @@ const _: () = {
     assert!(offset_of!(JSXElement, children) == 16);
     assert!(offset_of!(JSXElement, closing_element) == 48);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXOpeningElement>() == 64);
     assert!(align_of::<JSXOpeningElement>() == 8);
     assert!(offset_of!(JSXOpeningElement, span) == 0);
@@ -816,11 +922,13 @@ const _: () = {
     assert!(offset_of!(JSXOpeningElement, type_arguments) == 24);
     assert!(offset_of!(JSXOpeningElement, attributes) == 32);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXClosingElement>() == 24);
     assert!(align_of::<JSXClosingElement>() == 8);
     assert!(offset_of!(JSXClosingElement, span) == 0);
     assert!(offset_of!(JSXClosingElement, name) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXFragment>() == 56);
     assert!(align_of::<JSXFragment>() == 8);
     assert!(offset_of!(JSXFragment, span) == 0);
@@ -828,10 +936,12 @@ const _: () = {
     assert!(offset_of!(JSXFragment, children) == 16);
     assert!(offset_of!(JSXFragment, closing_fragment) == 48);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXOpeningFragment>() == 8);
     assert!(align_of::<JSXOpeningFragment>() == 8);
     assert!(offset_of!(JSXOpeningFragment, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXClosingFragment>() == 8);
     assert!(align_of::<JSXClosingFragment>() == 8);
     assert!(offset_of!(JSXClosingFragment, span) == 0);
@@ -839,12 +949,14 @@ const _: () = {
     assert!(size_of::<JSXElementName>() == 16);
     assert!(align_of::<JSXElementName>() == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXNamespacedName>() == 56);
     assert!(align_of::<JSXNamespacedName>() == 8);
     assert!(offset_of!(JSXNamespacedName, span) == 0);
     assert!(offset_of!(JSXNamespacedName, namespace) == 8);
     assert!(offset_of!(JSXNamespacedName, name) == 32);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXMemberExpression>() == 48);
     assert!(align_of::<JSXMemberExpression>() == 8);
     assert!(offset_of!(JSXMemberExpression, span) == 0);
@@ -854,6 +966,7 @@ const _: () = {
     assert!(size_of::<JSXMemberExpressionObject>() == 16);
     assert!(align_of::<JSXMemberExpressionObject>() == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXExpressionContainer>() == 24);
     assert!(align_of::<JSXExpressionContainer>() == 8);
     assert!(offset_of!(JSXExpressionContainer, span) == 0);
@@ -862,6 +975,7 @@ const _: () = {
     assert!(size_of::<JSXExpression>() == 16);
     assert!(align_of::<JSXExpression>() == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXEmptyExpression>() == 8);
     assert!(align_of::<JSXEmptyExpression>() == 8);
     assert!(offset_of!(JSXEmptyExpression, span) == 0);
@@ -869,12 +983,14 @@ const _: () = {
     assert!(size_of::<JSXAttributeItem>() == 16);
     assert!(align_of::<JSXAttributeItem>() == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXAttribute>() == 40);
     assert!(align_of::<JSXAttribute>() == 8);
     assert!(offset_of!(JSXAttribute, span) == 0);
     assert!(offset_of!(JSXAttribute, name) == 8);
     assert!(offset_of!(JSXAttribute, value) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXSpreadAttribute>() == 24);
     assert!(align_of::<JSXSpreadAttribute>() == 8);
     assert!(offset_of!(JSXSpreadAttribute, span) == 0);
@@ -886,6 +1002,7 @@ const _: () = {
     assert!(size_of::<JSXAttributeValue>() == 16);
     assert!(align_of::<JSXAttributeValue>() == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXIdentifier>() == 24);
     assert!(align_of::<JSXIdentifier>() == 8);
     assert!(offset_of!(JSXIdentifier, span) == 0);
@@ -894,23 +1011,27 @@ const _: () = {
     assert!(size_of::<JSXChild>() == 16);
     assert!(align_of::<JSXChild>() == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXSpreadChild>() == 24);
     assert!(align_of::<JSXSpreadChild>() == 8);
     assert!(offset_of!(JSXSpreadChild, span) == 0);
     assert!(offset_of!(JSXSpreadChild, expression) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXText>() == 40);
     assert!(align_of::<JSXText>() == 8);
     assert!(offset_of!(JSXText, span) == 0);
     assert!(offset_of!(JSXText, value) == 8);
     assert!(offset_of!(JSXText, raw) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSThisParameter>() == 24);
     assert!(align_of::<TSThisParameter>() == 8);
     assert!(offset_of!(TSThisParameter, span) == 0);
     assert!(offset_of!(TSThisParameter, this_span) == 8);
     assert!(offset_of!(TSThisParameter, type_annotation) == 16);
 
+    // Padding: 2 bytes
     assert!(size_of::<TSEnumDeclaration>() == 88);
     assert!(align_of::<TSEnumDeclaration>() == 8);
     assert!(offset_of!(TSEnumDeclaration, span) == 0);
@@ -920,11 +1041,13 @@ const _: () = {
     assert!(offset_of!(TSEnumDeclaration, declare) == 81);
     assert!(offset_of!(TSEnumDeclaration, scope_id) == 84);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSEnumBody>() == 40);
     assert!(align_of::<TSEnumBody>() == 8);
     assert!(offset_of!(TSEnumBody, span) == 0);
     assert!(offset_of!(TSEnumBody, members) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSEnumMember>() == 40);
     assert!(align_of::<TSEnumMember>() == 8);
     assert!(offset_of!(TSEnumMember, span) == 0);
@@ -934,11 +1057,13 @@ const _: () = {
     assert!(size_of::<TSEnumMemberName>() == 16);
     assert!(align_of::<TSEnumMemberName>() == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSTypeAnnotation>() == 24);
     assert!(align_of::<TSTypeAnnotation>() == 8);
     assert!(offset_of!(TSTypeAnnotation, span) == 0);
     assert!(offset_of!(TSTypeAnnotation, type_annotation) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSLiteralType>() == 24);
     assert!(align_of::<TSLiteralType>() == 8);
     assert!(offset_of!(TSLiteralType, span) == 0);
@@ -950,6 +1075,7 @@ const _: () = {
     assert!(size_of::<TSType>() == 16);
     assert!(align_of::<TSType>() == 8);
 
+    // Padding: 4 bytes
     assert!(size_of::<TSConditionalType>() == 80);
     assert!(align_of::<TSConditionalType>() == 8);
     assert!(offset_of!(TSConditionalType, span) == 0);
@@ -959,21 +1085,25 @@ const _: () = {
     assert!(offset_of!(TSConditionalType, false_type) == 56);
     assert!(offset_of!(TSConditionalType, scope_id) == 72);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSUnionType>() == 40);
     assert!(align_of::<TSUnionType>() == 8);
     assert!(offset_of!(TSUnionType, span) == 0);
     assert!(offset_of!(TSUnionType, types) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSIntersectionType>() == 40);
     assert!(align_of::<TSIntersectionType>() == 8);
     assert!(offset_of!(TSIntersectionType, span) == 0);
     assert!(offset_of!(TSIntersectionType, types) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSParenthesizedType>() == 24);
     assert!(align_of::<TSParenthesizedType>() == 8);
     assert!(offset_of!(TSParenthesizedType, span) == 0);
     assert!(offset_of!(TSParenthesizedType, type_annotation) == 8);
 
+    // Padding: 7 bytes
     assert!(size_of::<TSTypeOperator>() == 32);
     assert!(align_of::<TSTypeOperator>() == 8);
     assert!(offset_of!(TSTypeOperator, span) == 0);
@@ -983,22 +1113,26 @@ const _: () = {
     assert!(size_of::<TSTypeOperatorOperator>() == 1);
     assert!(align_of::<TSTypeOperatorOperator>() == 1);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSArrayType>() == 24);
     assert!(align_of::<TSArrayType>() == 8);
     assert!(offset_of!(TSArrayType, span) == 0);
     assert!(offset_of!(TSArrayType, element_type) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSIndexedAccessType>() == 40);
     assert!(align_of::<TSIndexedAccessType>() == 8);
     assert!(offset_of!(TSIndexedAccessType, span) == 0);
     assert!(offset_of!(TSIndexedAccessType, object_type) == 8);
     assert!(offset_of!(TSIndexedAccessType, index_type) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSTupleType>() == 40);
     assert!(align_of::<TSTupleType>() == 8);
     assert!(offset_of!(TSTupleType, span) == 0);
     assert!(offset_of!(TSTupleType, element_types) == 8);
 
+    // Padding: 7 bytes
     assert!(size_of::<TSNamedTupleMember>() == 56);
     assert!(align_of::<TSNamedTupleMember>() == 8);
     assert!(offset_of!(TSNamedTupleMember, span) == 0);
@@ -1006,11 +1140,13 @@ const _: () = {
     assert!(offset_of!(TSNamedTupleMember, element_type) == 32);
     assert!(offset_of!(TSNamedTupleMember, optional) == 48);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSOptionalType>() == 24);
     assert!(align_of::<TSOptionalType>() == 8);
     assert!(offset_of!(TSOptionalType, span) == 0);
     assert!(offset_of!(TSOptionalType, type_annotation) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSRestType>() == 24);
     assert!(align_of::<TSRestType>() == 8);
     assert!(offset_of!(TSRestType, span) == 0);
@@ -1019,62 +1155,77 @@ const _: () = {
     assert!(size_of::<TSTupleElement>() == 16);
     assert!(align_of::<TSTupleElement>() == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSAnyKeyword>() == 8);
     assert!(align_of::<TSAnyKeyword>() == 8);
     assert!(offset_of!(TSAnyKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSStringKeyword>() == 8);
     assert!(align_of::<TSStringKeyword>() == 8);
     assert!(offset_of!(TSStringKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSBooleanKeyword>() == 8);
     assert!(align_of::<TSBooleanKeyword>() == 8);
     assert!(offset_of!(TSBooleanKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSNumberKeyword>() == 8);
     assert!(align_of::<TSNumberKeyword>() == 8);
     assert!(offset_of!(TSNumberKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSNeverKeyword>() == 8);
     assert!(align_of::<TSNeverKeyword>() == 8);
     assert!(offset_of!(TSNeverKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSIntrinsicKeyword>() == 8);
     assert!(align_of::<TSIntrinsicKeyword>() == 8);
     assert!(offset_of!(TSIntrinsicKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSUnknownKeyword>() == 8);
     assert!(align_of::<TSUnknownKeyword>() == 8);
     assert!(offset_of!(TSUnknownKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSNullKeyword>() == 8);
     assert!(align_of::<TSNullKeyword>() == 8);
     assert!(offset_of!(TSNullKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSUndefinedKeyword>() == 8);
     assert!(align_of::<TSUndefinedKeyword>() == 8);
     assert!(offset_of!(TSUndefinedKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSVoidKeyword>() == 8);
     assert!(align_of::<TSVoidKeyword>() == 8);
     assert!(offset_of!(TSVoidKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSSymbolKeyword>() == 8);
     assert!(align_of::<TSSymbolKeyword>() == 8);
     assert!(offset_of!(TSSymbolKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSThisType>() == 8);
     assert!(align_of::<TSThisType>() == 8);
     assert!(offset_of!(TSThisType, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSObjectKeyword>() == 8);
     assert!(align_of::<TSObjectKeyword>() == 8);
     assert!(offset_of!(TSObjectKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSBigIntKeyword>() == 8);
     assert!(align_of::<TSBigIntKeyword>() == 8);
     assert!(offset_of!(TSBigIntKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSTypeReference>() == 32);
     assert!(align_of::<TSTypeReference>() == 8);
     assert!(offset_of!(TSTypeReference, span) == 0);
@@ -1084,17 +1235,20 @@ const _: () = {
     assert!(size_of::<TSTypeName>() == 16);
     assert!(align_of::<TSTypeName>() == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSQualifiedName>() == 48);
     assert!(align_of::<TSQualifiedName>() == 8);
     assert!(offset_of!(TSQualifiedName, span) == 0);
     assert!(offset_of!(TSQualifiedName, left) == 8);
     assert!(offset_of!(TSQualifiedName, right) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSTypeParameterInstantiation>() == 40);
     assert!(align_of::<TSTypeParameterInstantiation>() == 8);
     assert!(offset_of!(TSTypeParameterInstantiation, span) == 0);
     assert!(offset_of!(TSTypeParameterInstantiation, params) == 8);
 
+    // Padding: 5 bytes
     assert!(size_of::<TSTypeParameter>() == 80);
     assert!(align_of::<TSTypeParameter>() == 8);
     assert!(offset_of!(TSTypeParameter, span) == 0);
@@ -1105,11 +1259,13 @@ const _: () = {
     assert!(offset_of!(TSTypeParameter, out) == 73);
     assert!(offset_of!(TSTypeParameter, r#const) == 74);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSTypeParameterDeclaration>() == 40);
     assert!(align_of::<TSTypeParameterDeclaration>() == 8);
     assert!(offset_of!(TSTypeParameterDeclaration, span) == 0);
     assert!(offset_of!(TSTypeParameterDeclaration, params) == 8);
 
+    // Padding: 3 bytes
     assert!(size_of::<TSTypeAliasDeclaration>() == 72);
     assert!(align_of::<TSTypeAliasDeclaration>() == 8);
     assert!(offset_of!(TSTypeAliasDeclaration, span) == 0);
@@ -1122,12 +1278,14 @@ const _: () = {
     assert!(size_of::<TSAccessibility>() == 1);
     assert!(align_of::<TSAccessibility>() == 1);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSClassImplements>() == 32);
     assert!(align_of::<TSClassImplements>() == 8);
     assert!(offset_of!(TSClassImplements, span) == 0);
     assert!(offset_of!(TSClassImplements, expression) == 8);
     assert!(offset_of!(TSClassImplements, type_arguments) == 24);
 
+    // Padding: 3 bytes
     assert!(size_of::<TSInterfaceDeclaration>() == 96);
     assert!(align_of::<TSInterfaceDeclaration>() == 8);
     assert!(offset_of!(TSInterfaceDeclaration, span) == 0);
@@ -1138,11 +1296,13 @@ const _: () = {
     assert!(offset_of!(TSInterfaceDeclaration, declare) == 88);
     assert!(offset_of!(TSInterfaceDeclaration, scope_id) == 92);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSInterfaceBody>() == 40);
     assert!(align_of::<TSInterfaceBody>() == 8);
     assert!(offset_of!(TSInterfaceBody, span) == 0);
     assert!(offset_of!(TSInterfaceBody, body) == 8);
 
+    // Padding: 5 bytes
     assert!(size_of::<TSPropertySignature>() == 40);
     assert!(align_of::<TSPropertySignature>() == 8);
     assert!(offset_of!(TSPropertySignature, span) == 0);
@@ -1155,6 +1315,7 @@ const _: () = {
     assert!(size_of::<TSSignature>() == 16);
     assert!(align_of::<TSSignature>() == 8);
 
+    // Padding: 6 bytes
     assert!(size_of::<TSIndexSignature>() == 56);
     assert!(align_of::<TSIndexSignature>() == 8);
     assert!(offset_of!(TSIndexSignature, span) == 0);
@@ -1163,6 +1324,7 @@ const _: () = {
     assert!(offset_of!(TSIndexSignature, readonly) == 48);
     assert!(offset_of!(TSIndexSignature, r#static) == 49);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSCallSignatureDeclaration>() == 40);
     assert!(align_of::<TSCallSignatureDeclaration>() == 8);
     assert!(offset_of!(TSCallSignatureDeclaration, span) == 0);
@@ -1174,6 +1336,7 @@ const _: () = {
     assert!(size_of::<TSMethodSignatureKind>() == 1);
     assert!(align_of::<TSMethodSignatureKind>() == 1);
 
+    // Padding: 9 bytes
     assert!(size_of::<TSMethodSignature>() == 72);
     assert!(align_of::<TSMethodSignature>() == 8);
     assert!(offset_of!(TSMethodSignature, span) == 0);
@@ -1187,6 +1350,7 @@ const _: () = {
     assert!(offset_of!(TSMethodSignature, return_type) == 56);
     assert!(offset_of!(TSMethodSignature, scope_id) == 64);
 
+    // Padding: 4 bytes
     assert!(size_of::<TSConstructSignatureDeclaration>() == 40);
     assert!(align_of::<TSConstructSignatureDeclaration>() == 8);
     assert!(offset_of!(TSConstructSignatureDeclaration, span) == 0);
@@ -1195,18 +1359,21 @@ const _: () = {
     assert!(offset_of!(TSConstructSignatureDeclaration, return_type) == 24);
     assert!(offset_of!(TSConstructSignatureDeclaration, scope_id) == 32);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSIndexSignatureName>() == 32);
     assert!(align_of::<TSIndexSignatureName>() == 8);
     assert!(offset_of!(TSIndexSignatureName, span) == 0);
     assert!(offset_of!(TSIndexSignatureName, name) == 8);
     assert!(offset_of!(TSIndexSignatureName, type_annotation) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSInterfaceHeritage>() == 32);
     assert!(align_of::<TSInterfaceHeritage>() == 8);
     assert!(offset_of!(TSInterfaceHeritage, span) == 0);
     assert!(offset_of!(TSInterfaceHeritage, expression) == 8);
     assert!(offset_of!(TSInterfaceHeritage, type_arguments) == 24);
 
+    // Padding: 7 bytes
     assert!(size_of::<TSTypePredicate>() == 40);
     assert!(align_of::<TSTypePredicate>() == 8);
     assert!(offset_of!(TSTypePredicate, span) == 0);
@@ -1217,6 +1384,7 @@ const _: () = {
     assert!(size_of::<TSTypePredicateName>() == 16);
     assert!(align_of::<TSTypePredicateName>() == 8);
 
+    // Padding: 2 bytes
     assert!(size_of::<TSModuleDeclaration>() == 88);
     assert!(align_of::<TSModuleDeclaration>() == 8);
     assert!(offset_of!(TSModuleDeclaration, span) == 0);
@@ -1235,22 +1403,26 @@ const _: () = {
     assert!(size_of::<TSModuleDeclarationBody>() == 16);
     assert!(align_of::<TSModuleDeclarationBody>() == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSModuleBlock>() == 72);
     assert!(align_of::<TSModuleBlock>() == 8);
     assert!(offset_of!(TSModuleBlock, span) == 0);
     assert!(offset_of!(TSModuleBlock, directives) == 8);
     assert!(offset_of!(TSModuleBlock, body) == 40);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSTypeLiteral>() == 40);
     assert!(align_of::<TSTypeLiteral>() == 8);
     assert!(offset_of!(TSTypeLiteral, span) == 0);
     assert!(offset_of!(TSTypeLiteral, members) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSInferType>() == 16);
     assert!(align_of::<TSInferType>() == 8);
     assert!(offset_of!(TSInferType, span) == 0);
     assert!(offset_of!(TSInferType, type_parameter) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSTypeQuery>() == 32);
     assert!(align_of::<TSTypeQuery>() == 8);
     assert!(offset_of!(TSTypeQuery, span) == 0);
@@ -1260,6 +1432,7 @@ const _: () = {
     assert!(size_of::<TSTypeQueryExprName>() == 16);
     assert!(align_of::<TSTypeQueryExprName>() == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSImportType>() == 56);
     assert!(align_of::<TSImportType>() == 8);
     assert!(offset_of!(TSImportType, span) == 0);
@@ -1268,6 +1441,7 @@ const _: () = {
     assert!(offset_of!(TSImportType, qualifier) == 32);
     assert!(offset_of!(TSImportType, type_arguments) == 48);
 
+    // Padding: 4 bytes
     assert!(size_of::<TSFunctionType>() == 48);
     assert!(align_of::<TSFunctionType>() == 8);
     assert!(offset_of!(TSFunctionType, span) == 0);
@@ -1277,6 +1451,7 @@ const _: () = {
     assert!(offset_of!(TSFunctionType, return_type) == 32);
     assert!(offset_of!(TSFunctionType, scope_id) == 40);
 
+    // Padding: 7 bytes
     assert!(size_of::<TSConstructorType>() == 40);
     assert!(align_of::<TSConstructorType>() == 8);
     assert!(offset_of!(TSConstructorType, span) == 0);
@@ -1285,6 +1460,7 @@ const _: () = {
     assert!(offset_of!(TSConstructorType, params) == 24);
     assert!(offset_of!(TSConstructorType, return_type) == 32);
 
+    // Padding: 2 bytes
     assert!(size_of::<TSMappedType>() == 56);
     assert!(align_of::<TSMappedType>() == 8);
     assert!(offset_of!(TSMappedType, span) == 0);
@@ -1298,30 +1474,35 @@ const _: () = {
     assert!(size_of::<TSMappedTypeModifierOperator>() == 1);
     assert!(align_of::<TSMappedTypeModifierOperator>() == 1);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSTemplateLiteralType>() == 72);
     assert!(align_of::<TSTemplateLiteralType>() == 8);
     assert!(offset_of!(TSTemplateLiteralType, span) == 0);
     assert!(offset_of!(TSTemplateLiteralType, quasis) == 8);
     assert!(offset_of!(TSTemplateLiteralType, types) == 40);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSAsExpression>() == 40);
     assert!(align_of::<TSAsExpression>() == 8);
     assert!(offset_of!(TSAsExpression, span) == 0);
     assert!(offset_of!(TSAsExpression, expression) == 8);
     assert!(offset_of!(TSAsExpression, type_annotation) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSSatisfiesExpression>() == 40);
     assert!(align_of::<TSSatisfiesExpression>() == 8);
     assert!(offset_of!(TSSatisfiesExpression, span) == 0);
     assert!(offset_of!(TSSatisfiesExpression, expression) == 8);
     assert!(offset_of!(TSSatisfiesExpression, type_annotation) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSTypeAssertion>() == 40);
     assert!(align_of::<TSTypeAssertion>() == 8);
     assert!(offset_of!(TSTypeAssertion, span) == 0);
     assert!(offset_of!(TSTypeAssertion, type_annotation) == 8);
     assert!(offset_of!(TSTypeAssertion, expression) == 24);
 
+    // Padding: 7 bytes
     assert!(size_of::<TSImportEqualsDeclaration>() == 64);
     assert!(align_of::<TSImportEqualsDeclaration>() == 8);
     assert!(offset_of!(TSImportEqualsDeclaration, span) == 0);
@@ -1332,31 +1513,37 @@ const _: () = {
     assert!(size_of::<TSModuleReference>() == 16);
     assert!(align_of::<TSModuleReference>() == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSExternalModuleReference>() == 56);
     assert!(align_of::<TSExternalModuleReference>() == 8);
     assert!(offset_of!(TSExternalModuleReference, span) == 0);
     assert!(offset_of!(TSExternalModuleReference, expression) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSNonNullExpression>() == 24);
     assert!(align_of::<TSNonNullExpression>() == 8);
     assert!(offset_of!(TSNonNullExpression, span) == 0);
     assert!(offset_of!(TSNonNullExpression, expression) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<Decorator>() == 24);
     assert!(align_of::<Decorator>() == 8);
     assert!(offset_of!(Decorator, span) == 0);
     assert!(offset_of!(Decorator, expression) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSExportAssignment>() == 24);
     assert!(align_of::<TSExportAssignment>() == 8);
     assert!(offset_of!(TSExportAssignment, span) == 0);
     assert!(offset_of!(TSExportAssignment, expression) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSNamespaceExportDeclaration>() == 32);
     assert!(align_of::<TSNamespaceExportDeclaration>() == 8);
     assert!(offset_of!(TSNamespaceExportDeclaration, span) == 0);
     assert!(offset_of!(TSNamespaceExportDeclaration, id) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSInstantiationExpression>() == 32);
     assert!(align_of::<TSInstantiationExpression>() == 8);
     assert!(offset_of!(TSInstantiationExpression, span) == 0);
@@ -1366,18 +1553,21 @@ const _: () = {
     assert!(size_of::<ImportOrExportKind>() == 1);
     assert!(align_of::<ImportOrExportKind>() == 1);
 
+    // Padding: 7 bytes
     assert!(size_of::<JSDocNullableType>() == 32);
     assert!(align_of::<JSDocNullableType>() == 8);
     assert!(offset_of!(JSDocNullableType, span) == 0);
     assert!(offset_of!(JSDocNullableType, type_annotation) == 8);
     assert!(offset_of!(JSDocNullableType, postfix) == 24);
 
+    // Padding: 7 bytes
     assert!(size_of::<JSDocNonNullableType>() == 32);
     assert!(align_of::<JSDocNonNullableType>() == 8);
     assert!(offset_of!(JSDocNonNullableType, span) == 0);
     assert!(offset_of!(JSDocNonNullableType, type_annotation) == 8);
     assert!(offset_of!(JSDocNonNullableType, postfix) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSDocUnknownType>() == 8);
     assert!(align_of::<JSDocUnknownType>() == 8);
     assert!(offset_of!(JSDocUnknownType, span) == 0);
@@ -1391,6 +1581,7 @@ const _: () = {
     assert!(size_of::<CommentAnnotation>() == 1);
     assert!(align_of::<CommentAnnotation>() == 1);
 
+    // Padding: 7 bytes
     assert!(size_of::<Comment>() == 24);
     assert!(align_of::<Comment>() == 8);
     assert!(offset_of!(Comment, span) == 0);
@@ -1404,6 +1595,7 @@ const _: () = {
 
 #[cfg(target_pointer_width = "32")]
 const _: () = {
+    // Padding: 1 bytes
     assert!(size_of::<Program>() == 88);
     assert!(align_of::<Program>() == 4);
     assert!(offset_of!(Program, span) == 0);
@@ -1418,32 +1610,38 @@ const _: () = {
     assert!(size_of::<Expression>() == 8);
     assert!(align_of::<Expression>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<IdentifierName>() == 16);
     assert!(align_of::<IdentifierName>() == 4);
     assert!(offset_of!(IdentifierName, span) == 0);
     assert!(offset_of!(IdentifierName, name) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<IdentifierReference>() == 20);
     assert!(align_of::<IdentifierReference>() == 4);
     assert!(offset_of!(IdentifierReference, span) == 0);
     assert!(offset_of!(IdentifierReference, name) == 8);
     assert!(offset_of!(IdentifierReference, reference_id) == 16);
 
+    // Padding: 0 bytes
     assert!(size_of::<BindingIdentifier>() == 20);
     assert!(align_of::<BindingIdentifier>() == 4);
     assert!(offset_of!(BindingIdentifier, span) == 0);
     assert!(offset_of!(BindingIdentifier, name) == 8);
     assert!(offset_of!(BindingIdentifier, symbol_id) == 16);
 
+    // Padding: 0 bytes
     assert!(size_of::<LabelIdentifier>() == 16);
     assert!(align_of::<LabelIdentifier>() == 4);
     assert!(offset_of!(LabelIdentifier, span) == 0);
     assert!(offset_of!(LabelIdentifier, name) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<ThisExpression>() == 8);
     assert!(align_of::<ThisExpression>() == 4);
     assert!(offset_of!(ThisExpression, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<ArrayExpression>() == 24);
     assert!(align_of::<ArrayExpression>() == 4);
     assert!(offset_of!(ArrayExpression, span) == 0);
@@ -1452,10 +1650,12 @@ const _: () = {
     assert!(size_of::<ArrayExpressionElement>() == 12);
     assert!(align_of::<ArrayExpressionElement>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<Elision>() == 8);
     assert!(align_of::<Elision>() == 4);
     assert!(offset_of!(Elision, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<ObjectExpression>() == 24);
     assert!(align_of::<ObjectExpression>() == 4);
     assert!(offset_of!(ObjectExpression, span) == 0);
@@ -1464,6 +1664,7 @@ const _: () = {
     assert!(size_of::<ObjectPropertyKind>() == 8);
     assert!(align_of::<ObjectPropertyKind>() == 4);
 
+    // Padding: 4 bytes
     assert!(size_of::<ObjectProperty>() == 32);
     assert!(align_of::<ObjectProperty>() == 4);
     assert!(offset_of!(ObjectProperty, span) == 0);
@@ -1480,12 +1681,14 @@ const _: () = {
     assert!(size_of::<PropertyKind>() == 1);
     assert!(align_of::<PropertyKind>() == 1);
 
+    // Padding: 0 bytes
     assert!(size_of::<TemplateLiteral>() == 40);
     assert!(align_of::<TemplateLiteral>() == 4);
     assert!(offset_of!(TemplateLiteral, span) == 0);
     assert!(offset_of!(TemplateLiteral, quasis) == 8);
     assert!(offset_of!(TemplateLiteral, expressions) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<TaggedTemplateExpression>() == 60);
     assert!(align_of::<TaggedTemplateExpression>() == 4);
     assert!(offset_of!(TaggedTemplateExpression, span) == 0);
@@ -1493,6 +1696,7 @@ const _: () = {
     assert!(offset_of!(TaggedTemplateExpression, type_arguments) == 16);
     assert!(offset_of!(TaggedTemplateExpression, quasi) == 20);
 
+    // Padding: 2 bytes
     assert!(size_of::<TemplateElement>() == 28);
     assert!(align_of::<TemplateElement>() == 4);
     assert!(offset_of!(TemplateElement, span) == 0);
@@ -1500,6 +1704,7 @@ const _: () = {
     assert!(offset_of!(TemplateElement, tail) == 24);
     assert!(offset_of!(TemplateElement, lone_surrogates) == 25);
 
+    // Padding: 0 bytes
     assert!(size_of::<TemplateElementValue>() == 16);
     assert!(align_of::<TemplateElementValue>() == 4);
     assert!(offset_of!(TemplateElementValue, raw) == 0);
@@ -1508,6 +1713,7 @@ const _: () = {
     assert!(size_of::<MemberExpression>() == 8);
     assert!(align_of::<MemberExpression>() == 4);
 
+    // Padding: 3 bytes
     assert!(size_of::<ComputedMemberExpression>() == 28);
     assert!(align_of::<ComputedMemberExpression>() == 4);
     assert!(offset_of!(ComputedMemberExpression, span) == 0);
@@ -1515,6 +1721,7 @@ const _: () = {
     assert!(offset_of!(ComputedMemberExpression, expression) == 16);
     assert!(offset_of!(ComputedMemberExpression, optional) == 24);
 
+    // Padding: 3 bytes
     assert!(size_of::<StaticMemberExpression>() == 36);
     assert!(align_of::<StaticMemberExpression>() == 4);
     assert!(offset_of!(StaticMemberExpression, span) == 0);
@@ -1522,6 +1729,7 @@ const _: () = {
     assert!(offset_of!(StaticMemberExpression, property) == 16);
     assert!(offset_of!(StaticMemberExpression, optional) == 32);
 
+    // Padding: 3 bytes
     assert!(size_of::<PrivateFieldExpression>() == 36);
     assert!(align_of::<PrivateFieldExpression>() == 4);
     assert!(offset_of!(PrivateFieldExpression, span) == 0);
@@ -1529,6 +1737,7 @@ const _: () = {
     assert!(offset_of!(PrivateFieldExpression, field) == 16);
     assert!(offset_of!(PrivateFieldExpression, optional) == 32);
 
+    // Padding: 2 bytes
     assert!(size_of::<CallExpression>() == 40);
     assert!(align_of::<CallExpression>() == 4);
     assert!(offset_of!(CallExpression, span) == 0);
@@ -1538,6 +1747,7 @@ const _: () = {
     assert!(offset_of!(CallExpression, optional) == 36);
     assert!(offset_of!(CallExpression, pure) == 37);
 
+    // Padding: 3 bytes
     assert!(size_of::<NewExpression>() == 40);
     assert!(align_of::<NewExpression>() == 4);
     assert!(offset_of!(NewExpression, span) == 0);
@@ -1546,12 +1756,14 @@ const _: () = {
     assert!(offset_of!(NewExpression, arguments) == 20);
     assert!(offset_of!(NewExpression, pure) == 36);
 
+    // Padding: 0 bytes
     assert!(size_of::<MetaProperty>() == 40);
     assert!(align_of::<MetaProperty>() == 4);
     assert!(offset_of!(MetaProperty, span) == 0);
     assert!(offset_of!(MetaProperty, meta) == 8);
     assert!(offset_of!(MetaProperty, property) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<SpreadElement>() == 16);
     assert!(align_of::<SpreadElement>() == 4);
     assert!(offset_of!(SpreadElement, span) == 0);
@@ -1560,6 +1772,7 @@ const _: () = {
     assert!(size_of::<Argument>() == 8);
     assert!(align_of::<Argument>() == 4);
 
+    // Padding: 2 bytes
     assert!(size_of::<UpdateExpression>() == 20);
     assert!(align_of::<UpdateExpression>() == 4);
     assert!(offset_of!(UpdateExpression, span) == 0);
@@ -1567,12 +1780,14 @@ const _: () = {
     assert!(offset_of!(UpdateExpression, prefix) == 9);
     assert!(offset_of!(UpdateExpression, argument) == 12);
 
+    // Padding: 3 bytes
     assert!(size_of::<UnaryExpression>() == 20);
     assert!(align_of::<UnaryExpression>() == 4);
     assert!(offset_of!(UnaryExpression, span) == 0);
     assert!(offset_of!(UnaryExpression, operator) == 8);
     assert!(offset_of!(UnaryExpression, argument) == 12);
 
+    // Padding: 3 bytes
     assert!(size_of::<BinaryExpression>() == 28);
     assert!(align_of::<BinaryExpression>() == 4);
     assert!(offset_of!(BinaryExpression, span) == 0);
@@ -1580,12 +1795,14 @@ const _: () = {
     assert!(offset_of!(BinaryExpression, operator) == 16);
     assert!(offset_of!(BinaryExpression, right) == 20);
 
+    // Padding: 0 bytes
     assert!(size_of::<PrivateInExpression>() == 32);
     assert!(align_of::<PrivateInExpression>() == 4);
     assert!(offset_of!(PrivateInExpression, span) == 0);
     assert!(offset_of!(PrivateInExpression, left) == 8);
     assert!(offset_of!(PrivateInExpression, right) == 24);
 
+    // Padding: 3 bytes
     assert!(size_of::<LogicalExpression>() == 28);
     assert!(align_of::<LogicalExpression>() == 4);
     assert!(offset_of!(LogicalExpression, span) == 0);
@@ -1593,6 +1810,7 @@ const _: () = {
     assert!(offset_of!(LogicalExpression, operator) == 16);
     assert!(offset_of!(LogicalExpression, right) == 20);
 
+    // Padding: 0 bytes
     assert!(size_of::<ConditionalExpression>() == 32);
     assert!(align_of::<ConditionalExpression>() == 4);
     assert!(offset_of!(ConditionalExpression, span) == 0);
@@ -1600,6 +1818,7 @@ const _: () = {
     assert!(offset_of!(ConditionalExpression, consequent) == 16);
     assert!(offset_of!(ConditionalExpression, alternate) == 24);
 
+    // Padding: 3 bytes
     assert!(size_of::<AssignmentExpression>() == 28);
     assert!(align_of::<AssignmentExpression>() == 4);
     assert!(offset_of!(AssignmentExpression, span) == 0);
@@ -1616,18 +1835,21 @@ const _: () = {
     assert!(size_of::<AssignmentTargetPattern>() == 8);
     assert!(align_of::<AssignmentTargetPattern>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<ArrayAssignmentTarget>() == 40);
     assert!(align_of::<ArrayAssignmentTarget>() == 4);
     assert!(offset_of!(ArrayAssignmentTarget, span) == 0);
     assert!(offset_of!(ArrayAssignmentTarget, elements) == 8);
     assert!(offset_of!(ArrayAssignmentTarget, rest) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<ObjectAssignmentTarget>() == 40);
     assert!(align_of::<ObjectAssignmentTarget>() == 4);
     assert!(offset_of!(ObjectAssignmentTarget, span) == 0);
     assert!(offset_of!(ObjectAssignmentTarget, properties) == 8);
     assert!(offset_of!(ObjectAssignmentTarget, rest) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<AssignmentTargetRest>() == 16);
     assert!(align_of::<AssignmentTargetRest>() == 4);
     assert!(offset_of!(AssignmentTargetRest, span) == 0);
@@ -1636,6 +1858,7 @@ const _: () = {
     assert!(size_of::<AssignmentTargetMaybeDefault>() == 8);
     assert!(align_of::<AssignmentTargetMaybeDefault>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<AssignmentTargetWithDefault>() == 24);
     assert!(align_of::<AssignmentTargetWithDefault>() == 4);
     assert!(offset_of!(AssignmentTargetWithDefault, span) == 0);
@@ -1645,12 +1868,14 @@ const _: () = {
     assert!(size_of::<AssignmentTargetProperty>() == 8);
     assert!(align_of::<AssignmentTargetProperty>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<AssignmentTargetPropertyIdentifier>() == 36);
     assert!(align_of::<AssignmentTargetPropertyIdentifier>() == 4);
     assert!(offset_of!(AssignmentTargetPropertyIdentifier, span) == 0);
     assert!(offset_of!(AssignmentTargetPropertyIdentifier, binding) == 8);
     assert!(offset_of!(AssignmentTargetPropertyIdentifier, init) == 28);
 
+    // Padding: 3 bytes
     assert!(size_of::<AssignmentTargetPropertyProperty>() == 28);
     assert!(align_of::<AssignmentTargetPropertyProperty>() == 4);
     assert!(offset_of!(AssignmentTargetPropertyProperty, span) == 0);
@@ -1658,20 +1883,24 @@ const _: () = {
     assert!(offset_of!(AssignmentTargetPropertyProperty, binding) == 16);
     assert!(offset_of!(AssignmentTargetPropertyProperty, computed) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<SequenceExpression>() == 24);
     assert!(align_of::<SequenceExpression>() == 4);
     assert!(offset_of!(SequenceExpression, span) == 0);
     assert!(offset_of!(SequenceExpression, expressions) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<Super>() == 8);
     assert!(align_of::<Super>() == 4);
     assert!(offset_of!(Super, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<AwaitExpression>() == 16);
     assert!(align_of::<AwaitExpression>() == 4);
     assert!(offset_of!(AwaitExpression, span) == 0);
     assert!(offset_of!(AwaitExpression, argument) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<ChainExpression>() == 16);
     assert!(align_of::<ChainExpression>() == 4);
     assert!(offset_of!(ChainExpression, span) == 0);
@@ -1680,6 +1909,7 @@ const _: () = {
     assert!(size_of::<ChainElement>() == 8);
     assert!(align_of::<ChainElement>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<ParenthesizedExpression>() == 16);
     assert!(align_of::<ParenthesizedExpression>() == 4);
     assert!(offset_of!(ParenthesizedExpression, span) == 0);
@@ -1688,17 +1918,20 @@ const _: () = {
     assert!(size_of::<Statement>() == 8);
     assert!(align_of::<Statement>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<Directive>() == 44);
     assert!(align_of::<Directive>() == 4);
     assert!(offset_of!(Directive, span) == 0);
     assert!(offset_of!(Directive, expression) == 8);
     assert!(offset_of!(Directive, directive) == 36);
 
+    // Padding: 0 bytes
     assert!(size_of::<Hashbang>() == 16);
     assert!(align_of::<Hashbang>() == 4);
     assert!(offset_of!(Hashbang, span) == 0);
     assert!(offset_of!(Hashbang, value) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<BlockStatement>() == 28);
     assert!(align_of::<BlockStatement>() == 4);
     assert!(offset_of!(BlockStatement, span) == 0);
@@ -1708,6 +1941,7 @@ const _: () = {
     assert!(size_of::<Declaration>() == 8);
     assert!(align_of::<Declaration>() == 4);
 
+    // Padding: 6 bytes
     assert!(size_of::<VariableDeclaration>() == 32);
     assert!(align_of::<VariableDeclaration>() == 4);
     assert!(offset_of!(VariableDeclaration, span) == 0);
@@ -1718,6 +1952,7 @@ const _: () = {
     assert!(size_of::<VariableDeclarationKind>() == 1);
     assert!(align_of::<VariableDeclarationKind>() == 1);
 
+    // Padding: 6 bytes
     assert!(size_of::<VariableDeclarator>() == 40);
     assert!(align_of::<VariableDeclarator>() == 4);
     assert!(offset_of!(VariableDeclarator, span) == 0);
@@ -1726,15 +1961,18 @@ const _: () = {
     assert!(offset_of!(VariableDeclarator, init) == 28);
     assert!(offset_of!(VariableDeclarator, definite) == 36);
 
+    // Padding: 0 bytes
     assert!(size_of::<EmptyStatement>() == 8);
     assert!(align_of::<EmptyStatement>() == 4);
     assert!(offset_of!(EmptyStatement, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<ExpressionStatement>() == 16);
     assert!(align_of::<ExpressionStatement>() == 4);
     assert!(offset_of!(ExpressionStatement, span) == 0);
     assert!(offset_of!(ExpressionStatement, expression) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<IfStatement>() == 32);
     assert!(align_of::<IfStatement>() == 4);
     assert!(offset_of!(IfStatement, span) == 0);
@@ -1742,18 +1980,21 @@ const _: () = {
     assert!(offset_of!(IfStatement, consequent) == 16);
     assert!(offset_of!(IfStatement, alternate) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<DoWhileStatement>() == 24);
     assert!(align_of::<DoWhileStatement>() == 4);
     assert!(offset_of!(DoWhileStatement, span) == 0);
     assert!(offset_of!(DoWhileStatement, body) == 8);
     assert!(offset_of!(DoWhileStatement, test) == 16);
 
+    // Padding: 0 bytes
     assert!(size_of::<WhileStatement>() == 24);
     assert!(align_of::<WhileStatement>() == 4);
     assert!(offset_of!(WhileStatement, span) == 0);
     assert!(offset_of!(WhileStatement, test) == 8);
     assert!(offset_of!(WhileStatement, body) == 16);
 
+    // Padding: 0 bytes
     assert!(size_of::<ForStatement>() == 44);
     assert!(align_of::<ForStatement>() == 4);
     assert!(offset_of!(ForStatement, span) == 0);
@@ -1766,6 +2007,7 @@ const _: () = {
     assert!(size_of::<ForStatementInit>() == 8);
     assert!(align_of::<ForStatementInit>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<ForInStatement>() == 36);
     assert!(align_of::<ForInStatement>() == 4);
     assert!(offset_of!(ForInStatement, span) == 0);
@@ -1777,6 +2019,7 @@ const _: () = {
     assert!(size_of::<ForStatementLeft>() == 8);
     assert!(align_of::<ForStatementLeft>() == 4);
 
+    // Padding: 3 bytes
     assert!(size_of::<ForOfStatement>() == 40);
     assert!(align_of::<ForOfStatement>() == 4);
     assert!(offset_of!(ForOfStatement, span) == 0);
@@ -1786,27 +2029,32 @@ const _: () = {
     assert!(offset_of!(ForOfStatement, body) == 28);
     assert!(offset_of!(ForOfStatement, scope_id) == 36);
 
+    // Padding: 0 bytes
     assert!(size_of::<ContinueStatement>() == 24);
     assert!(align_of::<ContinueStatement>() == 4);
     assert!(offset_of!(ContinueStatement, span) == 0);
     assert!(offset_of!(ContinueStatement, label) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<BreakStatement>() == 24);
     assert!(align_of::<BreakStatement>() == 4);
     assert!(offset_of!(BreakStatement, span) == 0);
     assert!(offset_of!(BreakStatement, label) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<ReturnStatement>() == 16);
     assert!(align_of::<ReturnStatement>() == 4);
     assert!(offset_of!(ReturnStatement, span) == 0);
     assert!(offset_of!(ReturnStatement, argument) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<WithStatement>() == 24);
     assert!(align_of::<WithStatement>() == 4);
     assert!(offset_of!(WithStatement, span) == 0);
     assert!(offset_of!(WithStatement, object) == 8);
     assert!(offset_of!(WithStatement, body) == 16);
 
+    // Padding: 0 bytes
     assert!(size_of::<SwitchStatement>() == 36);
     assert!(align_of::<SwitchStatement>() == 4);
     assert!(offset_of!(SwitchStatement, span) == 0);
@@ -1814,23 +2062,27 @@ const _: () = {
     assert!(offset_of!(SwitchStatement, cases) == 16);
     assert!(offset_of!(SwitchStatement, scope_id) == 32);
 
+    // Padding: 0 bytes
     assert!(size_of::<SwitchCase>() == 32);
     assert!(align_of::<SwitchCase>() == 4);
     assert!(offset_of!(SwitchCase, span) == 0);
     assert!(offset_of!(SwitchCase, test) == 8);
     assert!(offset_of!(SwitchCase, consequent) == 16);
 
+    // Padding: 0 bytes
     assert!(size_of::<LabeledStatement>() == 32);
     assert!(align_of::<LabeledStatement>() == 4);
     assert!(offset_of!(LabeledStatement, span) == 0);
     assert!(offset_of!(LabeledStatement, label) == 8);
     assert!(offset_of!(LabeledStatement, body) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<ThrowStatement>() == 16);
     assert!(align_of::<ThrowStatement>() == 4);
     assert!(offset_of!(ThrowStatement, span) == 0);
     assert!(offset_of!(ThrowStatement, argument) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TryStatement>() == 20);
     assert!(align_of::<TryStatement>() == 4);
     assert!(offset_of!(TryStatement, span) == 0);
@@ -1838,6 +2090,7 @@ const _: () = {
     assert!(offset_of!(TryStatement, handler) == 12);
     assert!(offset_of!(TryStatement, finalizer) == 16);
 
+    // Padding: 0 bytes
     assert!(size_of::<CatchClause>() == 40);
     assert!(align_of::<CatchClause>() == 4);
     assert!(offset_of!(CatchClause, span) == 0);
@@ -1845,15 +2098,18 @@ const _: () = {
     assert!(offset_of!(CatchClause, body) == 32);
     assert!(offset_of!(CatchClause, scope_id) == 36);
 
+    // Padding: 0 bytes
     assert!(size_of::<CatchParameter>() == 24);
     assert!(align_of::<CatchParameter>() == 4);
     assert!(offset_of!(CatchParameter, span) == 0);
     assert!(offset_of!(CatchParameter, pattern) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<DebuggerStatement>() == 8);
     assert!(align_of::<DebuggerStatement>() == 4);
     assert!(offset_of!(DebuggerStatement, span) == 0);
 
+    // Padding: 3 bytes
     assert!(size_of::<BindingPattern>() == 16);
     assert!(align_of::<BindingPattern>() == 4);
     assert!(offset_of!(BindingPattern, kind) == 0);
@@ -1863,18 +2119,21 @@ const _: () = {
     assert!(size_of::<BindingPatternKind>() == 8);
     assert!(align_of::<BindingPatternKind>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<AssignmentPattern>() == 32);
     assert!(align_of::<AssignmentPattern>() == 4);
     assert!(offset_of!(AssignmentPattern, span) == 0);
     assert!(offset_of!(AssignmentPattern, left) == 8);
     assert!(offset_of!(AssignmentPattern, right) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<ObjectPattern>() == 28);
     assert!(align_of::<ObjectPattern>() == 4);
     assert!(offset_of!(ObjectPattern, span) == 0);
     assert!(offset_of!(ObjectPattern, properties) == 8);
     assert!(offset_of!(ObjectPattern, rest) == 24);
 
+    // Padding: 2 bytes
     assert!(size_of::<BindingProperty>() == 36);
     assert!(align_of::<BindingProperty>() == 4);
     assert!(offset_of!(BindingProperty, span) == 0);
@@ -1883,17 +2142,20 @@ const _: () = {
     assert!(offset_of!(BindingProperty, shorthand) == 32);
     assert!(offset_of!(BindingProperty, computed) == 33);
 
+    // Padding: 0 bytes
     assert!(size_of::<ArrayPattern>() == 28);
     assert!(align_of::<ArrayPattern>() == 4);
     assert!(offset_of!(ArrayPattern, span) == 0);
     assert!(offset_of!(ArrayPattern, elements) == 8);
     assert!(offset_of!(ArrayPattern, rest) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<BindingRestElement>() == 24);
     assert!(align_of::<BindingRestElement>() == 4);
     assert!(offset_of!(BindingRestElement, span) == 0);
     assert!(offset_of!(BindingRestElement, argument) == 8);
 
+    // Padding: 7 bytes
     assert!(size_of::<Function>() == 64);
     assert!(align_of::<Function>() == 4);
     assert!(offset_of!(Function, span) == 0);
@@ -1913,6 +2175,7 @@ const _: () = {
     assert!(size_of::<FunctionType>() == 1);
     assert!(align_of::<FunctionType>() == 1);
 
+    // Padding: 3 bytes
     assert!(size_of::<FormalParameters>() == 32);
     assert!(align_of::<FormalParameters>() == 4);
     assert!(offset_of!(FormalParameters, span) == 0);
@@ -1920,6 +2183,7 @@ const _: () = {
     assert!(offset_of!(FormalParameters, items) == 12);
     assert!(offset_of!(FormalParameters, rest) == 28);
 
+    // Padding: 1 bytes
     assert!(size_of::<FormalParameter>() == 44);
     assert!(align_of::<FormalParameter>() == 4);
     assert!(offset_of!(FormalParameter, span) == 0);
@@ -1932,12 +2196,14 @@ const _: () = {
     assert!(size_of::<FormalParameterKind>() == 1);
     assert!(align_of::<FormalParameterKind>() == 1);
 
+    // Padding: 0 bytes
     assert!(size_of::<FunctionBody>() == 40);
     assert!(align_of::<FunctionBody>() == 4);
     assert!(offset_of!(FunctionBody, span) == 0);
     assert!(offset_of!(FunctionBody, directives) == 8);
     assert!(offset_of!(FunctionBody, statements) == 24);
 
+    // Padding: 5 bytes
     assert!(size_of::<ArrowFunctionExpression>() == 36);
     assert!(align_of::<ArrowFunctionExpression>() == 4);
     assert!(offset_of!(ArrowFunctionExpression, span) == 0);
@@ -1950,12 +2216,14 @@ const _: () = {
     assert!(offset_of!(ArrowFunctionExpression, scope_id) == 28);
     assert!(offset_of!(ArrowFunctionExpression, pure) == 32);
 
+    // Padding: 3 bytes
     assert!(size_of::<YieldExpression>() == 20);
     assert!(align_of::<YieldExpression>() == 4);
     assert!(offset_of!(YieldExpression, span) == 0);
     assert!(offset_of!(YieldExpression, delegate) == 8);
     assert!(offset_of!(YieldExpression, argument) == 12);
 
+    // Padding: 5 bytes
     assert!(size_of::<Class>() == 92);
     assert!(align_of::<Class>() == 4);
     assert!(offset_of!(Class, span) == 0);
@@ -1974,6 +2242,7 @@ const _: () = {
     assert!(size_of::<ClassType>() == 1);
     assert!(align_of::<ClassType>() == 1);
 
+    // Padding: 0 bytes
     assert!(size_of::<ClassBody>() == 24);
     assert!(align_of::<ClassBody>() == 4);
     assert!(offset_of!(ClassBody, span) == 0);
@@ -1982,6 +2251,7 @@ const _: () = {
     assert!(size_of::<ClassElement>() == 8);
     assert!(align_of::<ClassElement>() == 4);
 
+    // Padding: 5 bytes
     assert!(size_of::<MethodDefinition>() == 48);
     assert!(align_of::<MethodDefinition>() == 4);
     assert!(offset_of!(MethodDefinition, span) == 0);
@@ -1999,6 +2269,7 @@ const _: () = {
     assert!(size_of::<MethodDefinitionType>() == 1);
     assert!(align_of::<MethodDefinitionType>() == 1);
 
+    // Padding: 3 bytes
     assert!(size_of::<PropertyDefinition>() == 56);
     assert!(align_of::<PropertyDefinition>() == 4);
     assert!(offset_of!(PropertyDefinition, span) == 0);
@@ -2022,11 +2293,13 @@ const _: () = {
     assert!(size_of::<MethodDefinitionKind>() == 1);
     assert!(align_of::<MethodDefinitionKind>() == 1);
 
+    // Padding: 0 bytes
     assert!(size_of::<PrivateIdentifier>() == 16);
     assert!(align_of::<PrivateIdentifier>() == 4);
     assert!(offset_of!(PrivateIdentifier, span) == 0);
     assert!(offset_of!(PrivateIdentifier, name) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<StaticBlock>() == 28);
     assert!(align_of::<StaticBlock>() == 4);
     assert!(offset_of!(StaticBlock, span) == 0);
@@ -2039,6 +2312,7 @@ const _: () = {
     assert!(size_of::<AccessorPropertyType>() == 1);
     assert!(align_of::<AccessorPropertyType>() == 1);
 
+    // Padding: 6 bytes
     assert!(size_of::<AccessorProperty>() == 56);
     assert!(align_of::<AccessorProperty>() == 4);
     assert!(offset_of!(AccessorProperty, span) == 0);
@@ -2053,6 +2327,7 @@ const _: () = {
     assert!(offset_of!(AccessorProperty, definite) == 51);
     assert!(offset_of!(AccessorProperty, accessibility) == 52);
 
+    // Padding: 3 bytes
     assert!(size_of::<ImportExpression>() == 28);
     assert!(align_of::<ImportExpression>() == 4);
     assert!(offset_of!(ImportExpression, span) == 0);
@@ -2060,6 +2335,7 @@ const _: () = {
     assert!(offset_of!(ImportExpression, options) == 16);
     assert!(offset_of!(ImportExpression, phase) == 24);
 
+    // Padding: 6 bytes
     assert!(size_of::<ImportDeclaration>() == 64);
     assert!(align_of::<ImportDeclaration>() == 4);
     assert!(offset_of!(ImportDeclaration, span) == 0);
@@ -2075,6 +2351,7 @@ const _: () = {
     assert!(size_of::<ImportDeclarationSpecifier>() == 8);
     assert!(align_of::<ImportDeclarationSpecifier>() == 4);
 
+    // Padding: 3 bytes
     assert!(size_of::<ImportSpecifier>() == 64);
     assert!(align_of::<ImportSpecifier>() == 4);
     assert!(offset_of!(ImportSpecifier, span) == 0);
@@ -2082,22 +2359,26 @@ const _: () = {
     assert!(offset_of!(ImportSpecifier, local) == 40);
     assert!(offset_of!(ImportSpecifier, import_kind) == 60);
 
+    // Padding: 0 bytes
     assert!(size_of::<ImportDefaultSpecifier>() == 28);
     assert!(align_of::<ImportDefaultSpecifier>() == 4);
     assert!(offset_of!(ImportDefaultSpecifier, span) == 0);
     assert!(offset_of!(ImportDefaultSpecifier, local) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<ImportNamespaceSpecifier>() == 28);
     assert!(align_of::<ImportNamespaceSpecifier>() == 4);
     assert!(offset_of!(ImportNamespaceSpecifier, span) == 0);
     assert!(offset_of!(ImportNamespaceSpecifier, local) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<WithClause>() == 40);
     assert!(align_of::<WithClause>() == 4);
     assert!(offset_of!(WithClause, span) == 0);
     assert!(offset_of!(WithClause, attributes_keyword) == 8);
     assert!(offset_of!(WithClause, with_entries) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<ImportAttribute>() == 68);
     assert!(align_of::<ImportAttribute>() == 4);
     assert!(offset_of!(ImportAttribute, span) == 0);
@@ -2107,6 +2388,7 @@ const _: () = {
     assert!(size_of::<ImportAttributeKey>() == 32);
     assert!(align_of::<ImportAttributeKey>() == 4);
 
+    // Padding: 3 bytes
     assert!(size_of::<ExportNamedDeclaration>() == 68);
     assert!(align_of::<ExportNamedDeclaration>() == 4);
     assert!(offset_of!(ExportNamedDeclaration, span) == 0);
@@ -2116,12 +2398,14 @@ const _: () = {
     assert!(offset_of!(ExportNamedDeclaration, export_kind) == 60);
     assert!(offset_of!(ExportNamedDeclaration, with_clause) == 64);
 
+    // Padding: 0 bytes
     assert!(size_of::<ExportDefaultDeclaration>() == 48);
     assert!(align_of::<ExportDefaultDeclaration>() == 4);
     assert!(offset_of!(ExportDefaultDeclaration, span) == 0);
     assert!(offset_of!(ExportDefaultDeclaration, exported) == 8);
     assert!(offset_of!(ExportDefaultDeclaration, declaration) == 40);
 
+    // Padding: 3 bytes
     assert!(size_of::<ExportAllDeclaration>() == 76);
     assert!(align_of::<ExportAllDeclaration>() == 4);
     assert!(offset_of!(ExportAllDeclaration, span) == 0);
@@ -2130,6 +2414,7 @@ const _: () = {
     assert!(offset_of!(ExportAllDeclaration, with_clause) == 68);
     assert!(offset_of!(ExportAllDeclaration, export_kind) == 72);
 
+    // Padding: 3 bytes
     assert!(size_of::<ExportSpecifier>() == 76);
     assert!(align_of::<ExportSpecifier>() == 4);
     assert!(offset_of!(ExportSpecifier, span) == 0);
@@ -2143,21 +2428,25 @@ const _: () = {
     assert!(size_of::<ModuleExportName>() == 32);
     assert!(align_of::<ModuleExportName>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<V8IntrinsicExpression>() == 40);
     assert!(align_of::<V8IntrinsicExpression>() == 4);
     assert!(offset_of!(V8IntrinsicExpression, span) == 0);
     assert!(offset_of!(V8IntrinsicExpression, name) == 8);
     assert!(offset_of!(V8IntrinsicExpression, arguments) == 24);
 
+    // Padding: 3 bytes
     assert!(size_of::<BooleanLiteral>() == 12);
     assert!(align_of::<BooleanLiteral>() == 4);
     assert!(offset_of!(BooleanLiteral, span) == 0);
     assert!(offset_of!(BooleanLiteral, value) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<NullLiteral>() == 8);
     assert!(align_of::<NullLiteral>() == 4);
     assert!(offset_of!(NullLiteral, span) == 0);
 
+    // Padding: 7 bytes
     assert!(size_of::<NumericLiteral>() == 32);
     assert!(align_of::<NumericLiteral>() == 8);
     assert!(offset_of!(NumericLiteral, span) == 0);
@@ -2165,6 +2454,7 @@ const _: () = {
     assert!(offset_of!(NumericLiteral, raw) == 16);
     assert!(offset_of!(NumericLiteral, base) == 24);
 
+    // Padding: 3 bytes
     assert!(size_of::<StringLiteral>() == 28);
     assert!(align_of::<StringLiteral>() == 4);
     assert!(offset_of!(StringLiteral, span) == 0);
@@ -2172,31 +2462,37 @@ const _: () = {
     assert!(offset_of!(StringLiteral, raw) == 16);
     assert!(offset_of!(StringLiteral, lone_surrogates) == 24);
 
+    // Padding: 3 bytes
     assert!(size_of::<BigIntLiteral>() == 20);
     assert!(align_of::<BigIntLiteral>() == 4);
     assert!(offset_of!(BigIntLiteral, span) == 0);
     assert!(offset_of!(BigIntLiteral, raw) == 8);
     assert!(offset_of!(BigIntLiteral, base) == 16);
 
+    // Padding: 0 bytes
     assert!(size_of::<RegExpLiteral>() == 32);
     assert!(align_of::<RegExpLiteral>() == 4);
     assert!(offset_of!(RegExpLiteral, span) == 0);
     assert!(offset_of!(RegExpLiteral, regex) == 8);
     assert!(offset_of!(RegExpLiteral, raw) == 24);
 
+    // Padding: 3 bytes
     assert!(size_of::<RegExp>() == 16);
     assert!(align_of::<RegExp>() == 4);
     assert!(offset_of!(RegExp, pattern) == 0);
     assert!(offset_of!(RegExp, flags) == 12);
 
+    // Padding: 0 bytes
     assert!(size_of::<RegExpPattern>() == 12);
     assert!(align_of::<RegExpPattern>() == 4);
     assert!(offset_of!(RegExpPattern, text) == 0);
     assert!(offset_of!(RegExpPattern, pattern) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<RegExpFlags>() == 1);
     assert!(align_of::<RegExpFlags>() == 1);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXElement>() == 32);
     assert!(align_of::<JSXElement>() == 4);
     assert!(offset_of!(JSXElement, span) == 0);
@@ -2204,6 +2500,7 @@ const _: () = {
     assert!(offset_of!(JSXElement, children) == 12);
     assert!(offset_of!(JSXElement, closing_element) == 28);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXOpeningElement>() == 36);
     assert!(align_of::<JSXOpeningElement>() == 4);
     assert!(offset_of!(JSXOpeningElement, span) == 0);
@@ -2211,11 +2508,13 @@ const _: () = {
     assert!(offset_of!(JSXOpeningElement, type_arguments) == 16);
     assert!(offset_of!(JSXOpeningElement, attributes) == 20);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXClosingElement>() == 16);
     assert!(align_of::<JSXClosingElement>() == 4);
     assert!(offset_of!(JSXClosingElement, span) == 0);
     assert!(offset_of!(JSXClosingElement, name) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXFragment>() == 40);
     assert!(align_of::<JSXFragment>() == 4);
     assert!(offset_of!(JSXFragment, span) == 0);
@@ -2223,10 +2522,12 @@ const _: () = {
     assert!(offset_of!(JSXFragment, children) == 16);
     assert!(offset_of!(JSXFragment, closing_fragment) == 32);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXOpeningFragment>() == 8);
     assert!(align_of::<JSXOpeningFragment>() == 4);
     assert!(offset_of!(JSXOpeningFragment, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXClosingFragment>() == 8);
     assert!(align_of::<JSXClosingFragment>() == 4);
     assert!(offset_of!(JSXClosingFragment, span) == 0);
@@ -2234,12 +2535,14 @@ const _: () = {
     assert!(size_of::<JSXElementName>() == 8);
     assert!(align_of::<JSXElementName>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXNamespacedName>() == 40);
     assert!(align_of::<JSXNamespacedName>() == 4);
     assert!(offset_of!(JSXNamespacedName, span) == 0);
     assert!(offset_of!(JSXNamespacedName, namespace) == 8);
     assert!(offset_of!(JSXNamespacedName, name) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXMemberExpression>() == 32);
     assert!(align_of::<JSXMemberExpression>() == 4);
     assert!(offset_of!(JSXMemberExpression, span) == 0);
@@ -2249,6 +2552,7 @@ const _: () = {
     assert!(size_of::<JSXMemberExpressionObject>() == 8);
     assert!(align_of::<JSXMemberExpressionObject>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXExpressionContainer>() == 20);
     assert!(align_of::<JSXExpressionContainer>() == 4);
     assert!(offset_of!(JSXExpressionContainer, span) == 0);
@@ -2257,6 +2561,7 @@ const _: () = {
     assert!(size_of::<JSXExpression>() == 12);
     assert!(align_of::<JSXExpression>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXEmptyExpression>() == 8);
     assert!(align_of::<JSXEmptyExpression>() == 4);
     assert!(offset_of!(JSXEmptyExpression, span) == 0);
@@ -2264,12 +2569,14 @@ const _: () = {
     assert!(size_of::<JSXAttributeItem>() == 8);
     assert!(align_of::<JSXAttributeItem>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXAttribute>() == 24);
     assert!(align_of::<JSXAttribute>() == 4);
     assert!(offset_of!(JSXAttribute, span) == 0);
     assert!(offset_of!(JSXAttribute, name) == 8);
     assert!(offset_of!(JSXAttribute, value) == 16);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXSpreadAttribute>() == 16);
     assert!(align_of::<JSXSpreadAttribute>() == 4);
     assert!(offset_of!(JSXSpreadAttribute, span) == 0);
@@ -2281,6 +2588,7 @@ const _: () = {
     assert!(size_of::<JSXAttributeValue>() == 8);
     assert!(align_of::<JSXAttributeValue>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXIdentifier>() == 16);
     assert!(align_of::<JSXIdentifier>() == 4);
     assert!(offset_of!(JSXIdentifier, span) == 0);
@@ -2289,23 +2597,27 @@ const _: () = {
     assert!(size_of::<JSXChild>() == 8);
     assert!(align_of::<JSXChild>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXSpreadChild>() == 16);
     assert!(align_of::<JSXSpreadChild>() == 4);
     assert!(offset_of!(JSXSpreadChild, span) == 0);
     assert!(offset_of!(JSXSpreadChild, expression) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSXText>() == 24);
     assert!(align_of::<JSXText>() == 4);
     assert!(offset_of!(JSXText, span) == 0);
     assert!(offset_of!(JSXText, value) == 8);
     assert!(offset_of!(JSXText, raw) == 16);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSThisParameter>() == 20);
     assert!(align_of::<TSThisParameter>() == 4);
     assert!(offset_of!(TSThisParameter, span) == 0);
     assert!(offset_of!(TSThisParameter, this_span) == 8);
     assert!(offset_of!(TSThisParameter, type_annotation) == 16);
 
+    // Padding: 2 bytes
     assert!(size_of::<TSEnumDeclaration>() == 60);
     assert!(align_of::<TSEnumDeclaration>() == 4);
     assert!(offset_of!(TSEnumDeclaration, span) == 0);
@@ -2315,11 +2627,13 @@ const _: () = {
     assert!(offset_of!(TSEnumDeclaration, declare) == 53);
     assert!(offset_of!(TSEnumDeclaration, scope_id) == 56);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSEnumBody>() == 24);
     assert!(align_of::<TSEnumBody>() == 4);
     assert!(offset_of!(TSEnumBody, span) == 0);
     assert!(offset_of!(TSEnumBody, members) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSEnumMember>() == 24);
     assert!(align_of::<TSEnumMember>() == 4);
     assert!(offset_of!(TSEnumMember, span) == 0);
@@ -2329,11 +2643,13 @@ const _: () = {
     assert!(size_of::<TSEnumMemberName>() == 8);
     assert!(align_of::<TSEnumMemberName>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSTypeAnnotation>() == 16);
     assert!(align_of::<TSTypeAnnotation>() == 4);
     assert!(offset_of!(TSTypeAnnotation, span) == 0);
     assert!(offset_of!(TSTypeAnnotation, type_annotation) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSLiteralType>() == 16);
     assert!(align_of::<TSLiteralType>() == 4);
     assert!(offset_of!(TSLiteralType, span) == 0);
@@ -2345,6 +2661,7 @@ const _: () = {
     assert!(size_of::<TSType>() == 8);
     assert!(align_of::<TSType>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSConditionalType>() == 44);
     assert!(align_of::<TSConditionalType>() == 4);
     assert!(offset_of!(TSConditionalType, span) == 0);
@@ -2354,21 +2671,25 @@ const _: () = {
     assert!(offset_of!(TSConditionalType, false_type) == 32);
     assert!(offset_of!(TSConditionalType, scope_id) == 40);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSUnionType>() == 24);
     assert!(align_of::<TSUnionType>() == 4);
     assert!(offset_of!(TSUnionType, span) == 0);
     assert!(offset_of!(TSUnionType, types) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSIntersectionType>() == 24);
     assert!(align_of::<TSIntersectionType>() == 4);
     assert!(offset_of!(TSIntersectionType, span) == 0);
     assert!(offset_of!(TSIntersectionType, types) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSParenthesizedType>() == 16);
     assert!(align_of::<TSParenthesizedType>() == 4);
     assert!(offset_of!(TSParenthesizedType, span) == 0);
     assert!(offset_of!(TSParenthesizedType, type_annotation) == 8);
 
+    // Padding: 3 bytes
     assert!(size_of::<TSTypeOperator>() == 20);
     assert!(align_of::<TSTypeOperator>() == 4);
     assert!(offset_of!(TSTypeOperator, span) == 0);
@@ -2378,22 +2699,26 @@ const _: () = {
     assert!(size_of::<TSTypeOperatorOperator>() == 1);
     assert!(align_of::<TSTypeOperatorOperator>() == 1);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSArrayType>() == 16);
     assert!(align_of::<TSArrayType>() == 4);
     assert!(offset_of!(TSArrayType, span) == 0);
     assert!(offset_of!(TSArrayType, element_type) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSIndexedAccessType>() == 24);
     assert!(align_of::<TSIndexedAccessType>() == 4);
     assert!(offset_of!(TSIndexedAccessType, span) == 0);
     assert!(offset_of!(TSIndexedAccessType, object_type) == 8);
     assert!(offset_of!(TSIndexedAccessType, index_type) == 16);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSTupleType>() == 24);
     assert!(align_of::<TSTupleType>() == 4);
     assert!(offset_of!(TSTupleType, span) == 0);
     assert!(offset_of!(TSTupleType, element_types) == 8);
 
+    // Padding: 3 bytes
     assert!(size_of::<TSNamedTupleMember>() == 36);
     assert!(align_of::<TSNamedTupleMember>() == 4);
     assert!(offset_of!(TSNamedTupleMember, span) == 0);
@@ -2401,11 +2726,13 @@ const _: () = {
     assert!(offset_of!(TSNamedTupleMember, element_type) == 24);
     assert!(offset_of!(TSNamedTupleMember, optional) == 32);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSOptionalType>() == 16);
     assert!(align_of::<TSOptionalType>() == 4);
     assert!(offset_of!(TSOptionalType, span) == 0);
     assert!(offset_of!(TSOptionalType, type_annotation) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSRestType>() == 16);
     assert!(align_of::<TSRestType>() == 4);
     assert!(offset_of!(TSRestType, span) == 0);
@@ -2414,62 +2741,77 @@ const _: () = {
     assert!(size_of::<TSTupleElement>() == 8);
     assert!(align_of::<TSTupleElement>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSAnyKeyword>() == 8);
     assert!(align_of::<TSAnyKeyword>() == 4);
     assert!(offset_of!(TSAnyKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSStringKeyword>() == 8);
     assert!(align_of::<TSStringKeyword>() == 4);
     assert!(offset_of!(TSStringKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSBooleanKeyword>() == 8);
     assert!(align_of::<TSBooleanKeyword>() == 4);
     assert!(offset_of!(TSBooleanKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSNumberKeyword>() == 8);
     assert!(align_of::<TSNumberKeyword>() == 4);
     assert!(offset_of!(TSNumberKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSNeverKeyword>() == 8);
     assert!(align_of::<TSNeverKeyword>() == 4);
     assert!(offset_of!(TSNeverKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSIntrinsicKeyword>() == 8);
     assert!(align_of::<TSIntrinsicKeyword>() == 4);
     assert!(offset_of!(TSIntrinsicKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSUnknownKeyword>() == 8);
     assert!(align_of::<TSUnknownKeyword>() == 4);
     assert!(offset_of!(TSUnknownKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSNullKeyword>() == 8);
     assert!(align_of::<TSNullKeyword>() == 4);
     assert!(offset_of!(TSNullKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSUndefinedKeyword>() == 8);
     assert!(align_of::<TSUndefinedKeyword>() == 4);
     assert!(offset_of!(TSUndefinedKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSVoidKeyword>() == 8);
     assert!(align_of::<TSVoidKeyword>() == 4);
     assert!(offset_of!(TSVoidKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSSymbolKeyword>() == 8);
     assert!(align_of::<TSSymbolKeyword>() == 4);
     assert!(offset_of!(TSSymbolKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSThisType>() == 8);
     assert!(align_of::<TSThisType>() == 4);
     assert!(offset_of!(TSThisType, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSObjectKeyword>() == 8);
     assert!(align_of::<TSObjectKeyword>() == 4);
     assert!(offset_of!(TSObjectKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSBigIntKeyword>() == 8);
     assert!(align_of::<TSBigIntKeyword>() == 4);
     assert!(offset_of!(TSBigIntKeyword, span) == 0);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSTypeReference>() == 20);
     assert!(align_of::<TSTypeReference>() == 4);
     assert!(offset_of!(TSTypeReference, span) == 0);
@@ -2479,17 +2821,20 @@ const _: () = {
     assert!(size_of::<TSTypeName>() == 8);
     assert!(align_of::<TSTypeName>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSQualifiedName>() == 32);
     assert!(align_of::<TSQualifiedName>() == 4);
     assert!(offset_of!(TSQualifiedName, span) == 0);
     assert!(offset_of!(TSQualifiedName, left) == 8);
     assert!(offset_of!(TSQualifiedName, right) == 16);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSTypeParameterInstantiation>() == 24);
     assert!(align_of::<TSTypeParameterInstantiation>() == 4);
     assert!(offset_of!(TSTypeParameterInstantiation, span) == 0);
     assert!(offset_of!(TSTypeParameterInstantiation, params) == 8);
 
+    // Padding: 1 bytes
     assert!(size_of::<TSTypeParameter>() == 48);
     assert!(align_of::<TSTypeParameter>() == 4);
     assert!(offset_of!(TSTypeParameter, span) == 0);
@@ -2500,11 +2845,13 @@ const _: () = {
     assert!(offset_of!(TSTypeParameter, out) == 45);
     assert!(offset_of!(TSTypeParameter, r#const) == 46);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSTypeParameterDeclaration>() == 24);
     assert!(align_of::<TSTypeParameterDeclaration>() == 4);
     assert!(offset_of!(TSTypeParameterDeclaration, span) == 0);
     assert!(offset_of!(TSTypeParameterDeclaration, params) == 8);
 
+    // Padding: 3 bytes
     assert!(size_of::<TSTypeAliasDeclaration>() == 48);
     assert!(align_of::<TSTypeAliasDeclaration>() == 4);
     assert!(offset_of!(TSTypeAliasDeclaration, span) == 0);
@@ -2517,12 +2864,14 @@ const _: () = {
     assert!(size_of::<TSAccessibility>() == 1);
     assert!(align_of::<TSAccessibility>() == 1);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSClassImplements>() == 20);
     assert!(align_of::<TSClassImplements>() == 4);
     assert!(offset_of!(TSClassImplements, span) == 0);
     assert!(offset_of!(TSClassImplements, expression) == 8);
     assert!(offset_of!(TSClassImplements, type_arguments) == 16);
 
+    // Padding: 3 bytes
     assert!(size_of::<TSInterfaceDeclaration>() == 60);
     assert!(align_of::<TSInterfaceDeclaration>() == 4);
     assert!(offset_of!(TSInterfaceDeclaration, span) == 0);
@@ -2533,11 +2882,13 @@ const _: () = {
     assert!(offset_of!(TSInterfaceDeclaration, declare) == 52);
     assert!(offset_of!(TSInterfaceDeclaration, scope_id) == 56);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSInterfaceBody>() == 24);
     assert!(align_of::<TSInterfaceBody>() == 4);
     assert!(offset_of!(TSInterfaceBody, span) == 0);
     assert!(offset_of!(TSInterfaceBody, body) == 8);
 
+    // Padding: 1 bytes
     assert!(size_of::<TSPropertySignature>() == 24);
     assert!(align_of::<TSPropertySignature>() == 4);
     assert!(offset_of!(TSPropertySignature, span) == 0);
@@ -2550,6 +2901,7 @@ const _: () = {
     assert!(size_of::<TSSignature>() == 8);
     assert!(align_of::<TSSignature>() == 4);
 
+    // Padding: 2 bytes
     assert!(size_of::<TSIndexSignature>() == 32);
     assert!(align_of::<TSIndexSignature>() == 4);
     assert!(offset_of!(TSIndexSignature, span) == 0);
@@ -2558,6 +2910,7 @@ const _: () = {
     assert!(offset_of!(TSIndexSignature, readonly) == 28);
     assert!(offset_of!(TSIndexSignature, r#static) == 29);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSCallSignatureDeclaration>() == 24);
     assert!(align_of::<TSCallSignatureDeclaration>() == 4);
     assert!(offset_of!(TSCallSignatureDeclaration, span) == 0);
@@ -2569,6 +2922,7 @@ const _: () = {
     assert!(size_of::<TSMethodSignatureKind>() == 1);
     assert!(align_of::<TSMethodSignatureKind>() == 1);
 
+    // Padding: 1 bytes
     assert!(size_of::<TSMethodSignature>() == 40);
     assert!(align_of::<TSMethodSignature>() == 4);
     assert!(offset_of!(TSMethodSignature, span) == 0);
@@ -2582,6 +2936,7 @@ const _: () = {
     assert!(offset_of!(TSMethodSignature, return_type) == 32);
     assert!(offset_of!(TSMethodSignature, scope_id) == 36);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSConstructSignatureDeclaration>() == 24);
     assert!(align_of::<TSConstructSignatureDeclaration>() == 4);
     assert!(offset_of!(TSConstructSignatureDeclaration, span) == 0);
@@ -2590,18 +2945,21 @@ const _: () = {
     assert!(offset_of!(TSConstructSignatureDeclaration, return_type) == 16);
     assert!(offset_of!(TSConstructSignatureDeclaration, scope_id) == 20);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSIndexSignatureName>() == 20);
     assert!(align_of::<TSIndexSignatureName>() == 4);
     assert!(offset_of!(TSIndexSignatureName, span) == 0);
     assert!(offset_of!(TSIndexSignatureName, name) == 8);
     assert!(offset_of!(TSIndexSignatureName, type_annotation) == 16);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSInterfaceHeritage>() == 20);
     assert!(align_of::<TSInterfaceHeritage>() == 4);
     assert!(offset_of!(TSInterfaceHeritage, span) == 0);
     assert!(offset_of!(TSInterfaceHeritage, expression) == 8);
     assert!(offset_of!(TSInterfaceHeritage, type_arguments) == 16);
 
+    // Padding: 3 bytes
     assert!(size_of::<TSTypePredicate>() == 28);
     assert!(align_of::<TSTypePredicate>() == 4);
     assert!(offset_of!(TSTypePredicate, span) == 0);
@@ -2612,6 +2970,7 @@ const _: () = {
     assert!(size_of::<TSTypePredicateName>() == 12);
     assert!(align_of::<TSTypePredicateName>() == 4);
 
+    // Padding: 2 bytes
     assert!(size_of::<TSModuleDeclaration>() == 56);
     assert!(align_of::<TSModuleDeclaration>() == 4);
     assert!(offset_of!(TSModuleDeclaration, span) == 0);
@@ -2630,22 +2989,26 @@ const _: () = {
     assert!(size_of::<TSModuleDeclarationBody>() == 8);
     assert!(align_of::<TSModuleDeclarationBody>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSModuleBlock>() == 40);
     assert!(align_of::<TSModuleBlock>() == 4);
     assert!(offset_of!(TSModuleBlock, span) == 0);
     assert!(offset_of!(TSModuleBlock, directives) == 8);
     assert!(offset_of!(TSModuleBlock, body) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSTypeLiteral>() == 24);
     assert!(align_of::<TSTypeLiteral>() == 4);
     assert!(offset_of!(TSTypeLiteral, span) == 0);
     assert!(offset_of!(TSTypeLiteral, members) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSInferType>() == 12);
     assert!(align_of::<TSInferType>() == 4);
     assert!(offset_of!(TSInferType, span) == 0);
     assert!(offset_of!(TSInferType, type_parameter) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSTypeQuery>() == 20);
     assert!(align_of::<TSTypeQuery>() == 4);
     assert!(offset_of!(TSTypeQuery, span) == 0);
@@ -2655,6 +3018,7 @@ const _: () = {
     assert!(size_of::<TSTypeQueryExprName>() == 8);
     assert!(align_of::<TSTypeQueryExprName>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSImportType>() == 32);
     assert!(align_of::<TSImportType>() == 4);
     assert!(offset_of!(TSImportType, span) == 0);
@@ -2663,6 +3027,7 @@ const _: () = {
     assert!(offset_of!(TSImportType, qualifier) == 20);
     assert!(offset_of!(TSImportType, type_arguments) == 28);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSFunctionType>() == 28);
     assert!(align_of::<TSFunctionType>() == 4);
     assert!(offset_of!(TSFunctionType, span) == 0);
@@ -2672,6 +3037,7 @@ const _: () = {
     assert!(offset_of!(TSFunctionType, return_type) == 20);
     assert!(offset_of!(TSFunctionType, scope_id) == 24);
 
+    // Padding: 3 bytes
     assert!(size_of::<TSConstructorType>() == 24);
     assert!(align_of::<TSConstructorType>() == 4);
     assert!(offset_of!(TSConstructorType, span) == 0);
@@ -2680,6 +3046,7 @@ const _: () = {
     assert!(offset_of!(TSConstructorType, params) == 16);
     assert!(offset_of!(TSConstructorType, return_type) == 20);
 
+    // Padding: 2 bytes
     assert!(size_of::<TSMappedType>() == 36);
     assert!(align_of::<TSMappedType>() == 4);
     assert!(offset_of!(TSMappedType, span) == 0);
@@ -2693,30 +3060,35 @@ const _: () = {
     assert!(size_of::<TSMappedTypeModifierOperator>() == 1);
     assert!(align_of::<TSMappedTypeModifierOperator>() == 1);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSTemplateLiteralType>() == 40);
     assert!(align_of::<TSTemplateLiteralType>() == 4);
     assert!(offset_of!(TSTemplateLiteralType, span) == 0);
     assert!(offset_of!(TSTemplateLiteralType, quasis) == 8);
     assert!(offset_of!(TSTemplateLiteralType, types) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSAsExpression>() == 24);
     assert!(align_of::<TSAsExpression>() == 4);
     assert!(offset_of!(TSAsExpression, span) == 0);
     assert!(offset_of!(TSAsExpression, expression) == 8);
     assert!(offset_of!(TSAsExpression, type_annotation) == 16);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSSatisfiesExpression>() == 24);
     assert!(align_of::<TSSatisfiesExpression>() == 4);
     assert!(offset_of!(TSSatisfiesExpression, span) == 0);
     assert!(offset_of!(TSSatisfiesExpression, expression) == 8);
     assert!(offset_of!(TSSatisfiesExpression, type_annotation) == 16);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSTypeAssertion>() == 24);
     assert!(align_of::<TSTypeAssertion>() == 4);
     assert!(offset_of!(TSTypeAssertion, span) == 0);
     assert!(offset_of!(TSTypeAssertion, type_annotation) == 8);
     assert!(offset_of!(TSTypeAssertion, expression) == 16);
 
+    // Padding: 3 bytes
     assert!(size_of::<TSImportEqualsDeclaration>() == 40);
     assert!(align_of::<TSImportEqualsDeclaration>() == 4);
     assert!(offset_of!(TSImportEqualsDeclaration, span) == 0);
@@ -2727,31 +3099,37 @@ const _: () = {
     assert!(size_of::<TSModuleReference>() == 8);
     assert!(align_of::<TSModuleReference>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSExternalModuleReference>() == 36);
     assert!(align_of::<TSExternalModuleReference>() == 4);
     assert!(offset_of!(TSExternalModuleReference, span) == 0);
     assert!(offset_of!(TSExternalModuleReference, expression) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSNonNullExpression>() == 16);
     assert!(align_of::<TSNonNullExpression>() == 4);
     assert!(offset_of!(TSNonNullExpression, span) == 0);
     assert!(offset_of!(TSNonNullExpression, expression) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<Decorator>() == 16);
     assert!(align_of::<Decorator>() == 4);
     assert!(offset_of!(Decorator, span) == 0);
     assert!(offset_of!(Decorator, expression) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSExportAssignment>() == 16);
     assert!(align_of::<TSExportAssignment>() == 4);
     assert!(offset_of!(TSExportAssignment, span) == 0);
     assert!(offset_of!(TSExportAssignment, expression) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSNamespaceExportDeclaration>() == 24);
     assert!(align_of::<TSNamespaceExportDeclaration>() == 4);
     assert!(offset_of!(TSNamespaceExportDeclaration, span) == 0);
     assert!(offset_of!(TSNamespaceExportDeclaration, id) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<TSInstantiationExpression>() == 20);
     assert!(align_of::<TSInstantiationExpression>() == 4);
     assert!(offset_of!(TSInstantiationExpression, span) == 0);
@@ -2761,18 +3139,21 @@ const _: () = {
     assert!(size_of::<ImportOrExportKind>() == 1);
     assert!(align_of::<ImportOrExportKind>() == 1);
 
+    // Padding: 3 bytes
     assert!(size_of::<JSDocNullableType>() == 20);
     assert!(align_of::<JSDocNullableType>() == 4);
     assert!(offset_of!(JSDocNullableType, span) == 0);
     assert!(offset_of!(JSDocNullableType, type_annotation) == 8);
     assert!(offset_of!(JSDocNullableType, postfix) == 16);
 
+    // Padding: 3 bytes
     assert!(size_of::<JSDocNonNullableType>() == 20);
     assert!(align_of::<JSDocNonNullableType>() == 4);
     assert!(offset_of!(JSDocNonNullableType, span) == 0);
     assert!(offset_of!(JSDocNonNullableType, type_annotation) == 8);
     assert!(offset_of!(JSDocNonNullableType, postfix) == 16);
 
+    // Padding: 0 bytes
     assert!(size_of::<JSDocUnknownType>() == 8);
     assert!(align_of::<JSDocUnknownType>() == 4);
     assert!(offset_of!(JSDocUnknownType, span) == 0);
@@ -2786,6 +3167,7 @@ const _: () = {
     assert!(size_of::<CommentAnnotation>() == 1);
     assert!(align_of::<CommentAnnotation>() == 1);
 
+    // Padding: 3 bytes
     assert!(size_of::<Comment>() == 20);
     assert!(align_of::<Comment>() == 4);
     assert!(offset_of!(Comment, span) == 0);

--- a/crates/oxc_regular_expression/src/generated/assert_layouts.rs
+++ b/crates/oxc_regular_expression/src/generated/assert_layouts.rs
@@ -9,16 +9,19 @@ use crate::ast::*;
 
 #[cfg(target_pointer_width = "64")]
 const _: () = {
+    // Padding: 0 bytes
     assert!(size_of::<Pattern>() == 48);
     assert!(align_of::<Pattern>() == 8);
     assert!(offset_of!(Pattern, span) == 0);
     assert!(offset_of!(Pattern, body) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<Disjunction>() == 40);
     assert!(align_of::<Disjunction>() == 8);
     assert!(offset_of!(Disjunction, span) == 0);
     assert!(offset_of!(Disjunction, body) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<Alternative>() == 40);
     assert!(align_of::<Alternative>() == 8);
     assert!(offset_of!(Alternative, span) == 0);
@@ -27,6 +30,7 @@ const _: () = {
     assert!(size_of::<Term>() == 16);
     assert!(align_of::<Term>() == 8);
 
+    // Padding: 7 bytes
     assert!(size_of::<BoundaryAssertion>() == 16);
     assert!(align_of::<BoundaryAssertion>() == 8);
     assert!(offset_of!(BoundaryAssertion, span) == 0);
@@ -35,6 +39,7 @@ const _: () = {
     assert!(size_of::<BoundaryAssertionKind>() == 1);
     assert!(align_of::<BoundaryAssertionKind>() == 1);
 
+    // Padding: 7 bytes
     assert!(size_of::<LookAroundAssertion>() == 56);
     assert!(align_of::<LookAroundAssertion>() == 8);
     assert!(offset_of!(LookAroundAssertion, span) == 0);
@@ -44,6 +49,7 @@ const _: () = {
     assert!(size_of::<LookAroundAssertionKind>() == 1);
     assert!(align_of::<LookAroundAssertionKind>() == 1);
 
+    // Padding: 7 bytes
     assert!(size_of::<Quantifier>() == 56);
     assert!(align_of::<Quantifier>() == 8);
     assert!(offset_of!(Quantifier, span) == 0);
@@ -52,6 +58,7 @@ const _: () = {
     assert!(offset_of!(Quantifier, greedy) == 32);
     assert!(offset_of!(Quantifier, body) == 40);
 
+    // Padding: 3 bytes
     assert!(size_of::<Character>() == 16);
     assert!(align_of::<Character>() == 8);
     assert!(offset_of!(Character, span) == 0);
@@ -61,6 +68,7 @@ const _: () = {
     assert!(size_of::<CharacterKind>() == 1);
     assert!(align_of::<CharacterKind>() == 1);
 
+    // Padding: 7 bytes
     assert!(size_of::<CharacterClassEscape>() == 16);
     assert!(align_of::<CharacterClassEscape>() == 8);
     assert!(offset_of!(CharacterClassEscape, span) == 0);
@@ -69,6 +77,7 @@ const _: () = {
     assert!(size_of::<CharacterClassEscapeKind>() == 1);
     assert!(align_of::<CharacterClassEscapeKind>() == 1);
 
+    // Padding: 6 bytes
     assert!(size_of::<UnicodePropertyEscape>() == 48);
     assert!(align_of::<UnicodePropertyEscape>() == 8);
     assert!(offset_of!(UnicodePropertyEscape, span) == 0);
@@ -77,10 +86,12 @@ const _: () = {
     assert!(offset_of!(UnicodePropertyEscape, name) == 16);
     assert!(offset_of!(UnicodePropertyEscape, value) == 32);
 
+    // Padding: 0 bytes
     assert!(size_of::<Dot>() == 8);
     assert!(align_of::<Dot>() == 8);
     assert!(offset_of!(Dot, span) == 0);
 
+    // Padding: 5 bytes
     assert!(size_of::<CharacterClass>() == 48);
     assert!(align_of::<CharacterClass>() == 8);
     assert!(offset_of!(CharacterClass, span) == 0);
@@ -95,53 +106,62 @@ const _: () = {
     assert!(size_of::<CharacterClassContents>() == 16);
     assert!(align_of::<CharacterClassContents>() == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<CharacterClassRange>() == 40);
     assert!(align_of::<CharacterClassRange>() == 8);
     assert!(offset_of!(CharacterClassRange, span) == 0);
     assert!(offset_of!(CharacterClassRange, min) == 8);
     assert!(offset_of!(CharacterClassRange, max) == 24);
 
+    // Padding: 7 bytes
     assert!(size_of::<ClassStringDisjunction>() == 48);
     assert!(align_of::<ClassStringDisjunction>() == 8);
     assert!(offset_of!(ClassStringDisjunction, span) == 0);
     assert!(offset_of!(ClassStringDisjunction, strings) == 8);
     assert!(offset_of!(ClassStringDisjunction, body) == 16);
 
+    // Padding: 7 bytes
     assert!(size_of::<ClassString>() == 48);
     assert!(align_of::<ClassString>() == 8);
     assert!(offset_of!(ClassString, span) == 0);
     assert!(offset_of!(ClassString, strings) == 8);
     assert!(offset_of!(ClassString, body) == 16);
 
+    // Padding: 0 bytes
     assert!(size_of::<CapturingGroup>() == 64);
     assert!(align_of::<CapturingGroup>() == 8);
     assert!(offset_of!(CapturingGroup, span) == 0);
     assert!(offset_of!(CapturingGroup, name) == 8);
     assert!(offset_of!(CapturingGroup, body) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<IgnoreGroup>() == 64);
     assert!(align_of::<IgnoreGroup>() == 8);
     assert!(offset_of!(IgnoreGroup, span) == 0);
     assert!(offset_of!(IgnoreGroup, modifiers) == 8);
     assert!(offset_of!(IgnoreGroup, body) == 24);
 
+    // Padding: 2 bytes
     assert!(size_of::<Modifiers>() == 16);
     assert!(align_of::<Modifiers>() == 8);
     assert!(offset_of!(Modifiers, span) == 0);
     assert!(offset_of!(Modifiers, enabling) == 8);
     assert!(offset_of!(Modifiers, disabling) == 11);
 
+    // Padding: 0 bytes
     assert!(size_of::<Modifier>() == 3);
     assert!(align_of::<Modifier>() == 1);
     assert!(offset_of!(Modifier, ignore_case) == 0);
     assert!(offset_of!(Modifier, multiline) == 1);
     assert!(offset_of!(Modifier, sticky) == 2);
 
+    // Padding: 4 bytes
     assert!(size_of::<IndexedReference>() == 16);
     assert!(align_of::<IndexedReference>() == 8);
     assert!(offset_of!(IndexedReference, span) == 0);
     assert!(offset_of!(IndexedReference, index) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<NamedReference>() == 24);
     assert!(align_of::<NamedReference>() == 8);
     assert!(offset_of!(NamedReference, span) == 0);
@@ -150,16 +170,19 @@ const _: () = {
 
 #[cfg(target_pointer_width = "32")]
 const _: () = {
+    // Padding: 0 bytes
     assert!(size_of::<Pattern>() == 32);
     assert!(align_of::<Pattern>() == 4);
     assert!(offset_of!(Pattern, span) == 0);
     assert!(offset_of!(Pattern, body) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<Disjunction>() == 24);
     assert!(align_of::<Disjunction>() == 4);
     assert!(offset_of!(Disjunction, span) == 0);
     assert!(offset_of!(Disjunction, body) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<Alternative>() == 24);
     assert!(align_of::<Alternative>() == 4);
     assert!(offset_of!(Alternative, span) == 0);
@@ -168,6 +191,7 @@ const _: () = {
     assert!(size_of::<Term>() == 12);
     assert!(align_of::<Term>() == 4);
 
+    // Padding: 3 bytes
     assert!(size_of::<BoundaryAssertion>() == 12);
     assert!(align_of::<BoundaryAssertion>() == 4);
     assert!(offset_of!(BoundaryAssertion, span) == 0);
@@ -176,6 +200,7 @@ const _: () = {
     assert!(size_of::<BoundaryAssertionKind>() == 1);
     assert!(align_of::<BoundaryAssertionKind>() == 1);
 
+    // Padding: 3 bytes
     assert!(size_of::<LookAroundAssertion>() == 36);
     assert!(align_of::<LookAroundAssertion>() == 4);
     assert!(offset_of!(LookAroundAssertion, span) == 0);
@@ -185,6 +210,7 @@ const _: () = {
     assert!(size_of::<LookAroundAssertionKind>() == 1);
     assert!(align_of::<LookAroundAssertionKind>() == 1);
 
+    // Padding: 3 bytes
     assert!(size_of::<Quantifier>() == 48);
     assert!(align_of::<Quantifier>() == 8);
     assert!(offset_of!(Quantifier, span) == 0);
@@ -193,6 +219,7 @@ const _: () = {
     assert!(offset_of!(Quantifier, greedy) == 32);
     assert!(offset_of!(Quantifier, body) == 36);
 
+    // Padding: 3 bytes
     assert!(size_of::<Character>() == 16);
     assert!(align_of::<Character>() == 4);
     assert!(offset_of!(Character, span) == 0);
@@ -202,6 +229,7 @@ const _: () = {
     assert!(size_of::<CharacterKind>() == 1);
     assert!(align_of::<CharacterKind>() == 1);
 
+    // Padding: 3 bytes
     assert!(size_of::<CharacterClassEscape>() == 12);
     assert!(align_of::<CharacterClassEscape>() == 4);
     assert!(offset_of!(CharacterClassEscape, span) == 0);
@@ -210,6 +238,7 @@ const _: () = {
     assert!(size_of::<CharacterClassEscapeKind>() == 1);
     assert!(align_of::<CharacterClassEscapeKind>() == 1);
 
+    // Padding: 2 bytes
     assert!(size_of::<UnicodePropertyEscape>() == 28);
     assert!(align_of::<UnicodePropertyEscape>() == 4);
     assert!(offset_of!(UnicodePropertyEscape, span) == 0);
@@ -218,10 +247,12 @@ const _: () = {
     assert!(offset_of!(UnicodePropertyEscape, name) == 12);
     assert!(offset_of!(UnicodePropertyEscape, value) == 20);
 
+    // Padding: 0 bytes
     assert!(size_of::<Dot>() == 8);
     assert!(align_of::<Dot>() == 4);
     assert!(offset_of!(Dot, span) == 0);
 
+    // Padding: 1 bytes
     assert!(size_of::<CharacterClass>() == 28);
     assert!(align_of::<CharacterClass>() == 4);
     assert!(offset_of!(CharacterClass, span) == 0);
@@ -236,53 +267,62 @@ const _: () = {
     assert!(size_of::<CharacterClassContents>() == 8);
     assert!(align_of::<CharacterClassContents>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<CharacterClassRange>() == 40);
     assert!(align_of::<CharacterClassRange>() == 4);
     assert!(offset_of!(CharacterClassRange, span) == 0);
     assert!(offset_of!(CharacterClassRange, min) == 8);
     assert!(offset_of!(CharacterClassRange, max) == 24);
 
+    // Padding: 3 bytes
     assert!(size_of::<ClassStringDisjunction>() == 28);
     assert!(align_of::<ClassStringDisjunction>() == 4);
     assert!(offset_of!(ClassStringDisjunction, span) == 0);
     assert!(offset_of!(ClassStringDisjunction, strings) == 8);
     assert!(offset_of!(ClassStringDisjunction, body) == 12);
 
+    // Padding: 3 bytes
     assert!(size_of::<ClassString>() == 28);
     assert!(align_of::<ClassString>() == 4);
     assert!(offset_of!(ClassString, span) == 0);
     assert!(offset_of!(ClassString, strings) == 8);
     assert!(offset_of!(ClassString, body) == 12);
 
+    // Padding: 0 bytes
     assert!(size_of::<CapturingGroup>() == 40);
     assert!(align_of::<CapturingGroup>() == 4);
     assert!(offset_of!(CapturingGroup, span) == 0);
     assert!(offset_of!(CapturingGroup, name) == 8);
     assert!(offset_of!(CapturingGroup, body) == 16);
 
+    // Padding: 0 bytes
     assert!(size_of::<IgnoreGroup>() == 48);
     assert!(align_of::<IgnoreGroup>() == 4);
     assert!(offset_of!(IgnoreGroup, span) == 0);
     assert!(offset_of!(IgnoreGroup, modifiers) == 8);
     assert!(offset_of!(IgnoreGroup, body) == 24);
 
+    // Padding: 2 bytes
     assert!(size_of::<Modifiers>() == 16);
     assert!(align_of::<Modifiers>() == 4);
     assert!(offset_of!(Modifiers, span) == 0);
     assert!(offset_of!(Modifiers, enabling) == 8);
     assert!(offset_of!(Modifiers, disabling) == 11);
 
+    // Padding: 0 bytes
     assert!(size_of::<Modifier>() == 3);
     assert!(align_of::<Modifier>() == 1);
     assert!(offset_of!(Modifier, ignore_case) == 0);
     assert!(offset_of!(Modifier, multiline) == 1);
     assert!(offset_of!(Modifier, sticky) == 2);
 
+    // Padding: 0 bytes
     assert!(size_of::<IndexedReference>() == 12);
     assert!(align_of::<IndexedReference>() == 4);
     assert!(offset_of!(IndexedReference, span) == 0);
     assert!(offset_of!(IndexedReference, index) == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<NamedReference>() == 16);
     assert!(align_of::<NamedReference>() == 4);
     assert!(offset_of!(NamedReference, span) == 0);

--- a/crates/oxc_span/src/generated/assert_layouts.rs
+++ b/crates/oxc_span/src/generated/assert_layouts.rs
@@ -9,11 +9,13 @@ use crate::*;
 
 #[cfg(target_pointer_width = "64")]
 const _: () = {
+    // Padding: 0 bytes
     assert!(size_of::<Span>() == 8);
     assert!(align_of::<Span>() == 8);
     assert!(offset_of!(Span, start) == 0);
     assert!(offset_of!(Span, end) == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<SourceType>() == 3);
     assert!(align_of::<SourceType>() == 1);
     assert!(offset_of!(SourceType, language) == 0);
@@ -32,11 +34,13 @@ const _: () = {
 
 #[cfg(target_pointer_width = "32")]
 const _: () = {
+    // Padding: 0 bytes
     assert!(size_of::<Span>() == 8);
     assert!(align_of::<Span>() == 4);
     assert!(offset_of!(Span, start) == 0);
     assert!(offset_of!(Span, end) == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<SourceType>() == 3);
     assert!(align_of::<SourceType>() == 1);
     assert!(offset_of!(SourceType, language) == 0);

--- a/crates/oxc_syntax/src/generated/assert_layouts.rs
+++ b/crates/oxc_syntax/src/generated/assert_layouts.rs
@@ -11,14 +11,17 @@ use crate::{module_record::*, number::*, operator::*, reference::*, scope::*, sy
 
 #[cfg(target_pointer_width = "64")]
 const _: () = {
+    // Padding: 0 bytes
     assert!(size_of::<NonMaxU32>() == 4);
     assert!(align_of::<NonMaxU32>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<NameSpan>() == 24);
     assert!(align_of::<NameSpan>() == 8);
     assert!(offset_of!(NameSpan, name) == 0);
     assert!(offset_of!(NameSpan, span) == 16);
 
+    // Padding: 7 bytes
     assert!(size_of::<ImportEntry>() == 96);
     assert!(align_of::<ImportEntry>() == 8);
     assert!(offset_of!(ImportEntry, statement_span) == 0);
@@ -30,6 +33,7 @@ const _: () = {
     assert!(size_of::<ImportImportName>() == 32);
     assert!(align_of::<ImportImportName>() == 8);
 
+    // Padding: 7 bytes
     assert!(size_of::<ExportEntry>() == 144);
     assert!(align_of::<ExportEntry>() == 8);
     assert!(offset_of!(ExportEntry, statement_span) == 0);
@@ -49,6 +53,7 @@ const _: () = {
     assert!(size_of::<ExportLocalName>() == 32);
     assert!(align_of::<ExportLocalName>() == 8);
 
+    // Padding: 0 bytes
     assert!(size_of::<DynamicImport>() == 16);
     assert!(align_of::<DynamicImport>() == 8);
     assert!(offset_of!(DynamicImport, span) == 0);
@@ -75,26 +80,32 @@ const _: () = {
     assert!(size_of::<UpdateOperator>() == 1);
     assert!(align_of::<UpdateOperator>() == 1);
 
+    // Padding: 0 bytes
     assert!(size_of::<ScopeId>() == 4);
     assert!(align_of::<ScopeId>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<SymbolId>() == 4);
     assert!(align_of::<SymbolId>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<ReferenceId>() == 4);
     assert!(align_of::<ReferenceId>() == 4);
 };
 
 #[cfg(target_pointer_width = "32")]
 const _: () = {
+    // Padding: 0 bytes
     assert!(size_of::<NonMaxU32>() == 4);
     assert!(align_of::<NonMaxU32>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<NameSpan>() == 16);
     assert!(align_of::<NameSpan>() == 4);
     assert!(offset_of!(NameSpan, name) == 0);
     assert!(offset_of!(NameSpan, span) == 8);
 
+    // Padding: 3 bytes
     assert!(size_of::<ImportEntry>() == 64);
     assert!(align_of::<ImportEntry>() == 4);
     assert!(offset_of!(ImportEntry, statement_span) == 0);
@@ -106,6 +117,7 @@ const _: () = {
     assert!(size_of::<ImportImportName>() == 20);
     assert!(align_of::<ImportImportName>() == 4);
 
+    // Padding: 3 bytes
     assert!(size_of::<ExportEntry>() == 96);
     assert!(align_of::<ExportEntry>() == 4);
     assert!(offset_of!(ExportEntry, statement_span) == 0);
@@ -125,6 +137,7 @@ const _: () = {
     assert!(size_of::<ExportLocalName>() == 20);
     assert!(align_of::<ExportLocalName>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<DynamicImport>() == 16);
     assert!(align_of::<DynamicImport>() == 4);
     assert!(offset_of!(DynamicImport, span) == 0);
@@ -151,12 +164,15 @@ const _: () = {
     assert!(size_of::<UpdateOperator>() == 1);
     assert!(align_of::<UpdateOperator>() == 1);
 
+    // Padding: 0 bytes
     assert!(size_of::<ScopeId>() == 4);
     assert!(align_of::<ScopeId>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<SymbolId>() == 4);
     assert!(align_of::<SymbolId>() == 4);
 
+    // Padding: 0 bytes
     assert!(size_of::<ReferenceId>() == 4);
     assert!(align_of::<ReferenceId>() == 4);
 };

--- a/napi/parser/src/generated/assert_layouts.rs
+++ b/napi/parser/src/generated/assert_layouts.rs
@@ -9,6 +9,7 @@ use crate::raw_transfer_types::*;
 
 #[cfg(target_pointer_width = "64")]
 const _: () = {
+    // Padding: 0 bytes
     assert!(size_of::<RawTransferData>() == 360);
     assert!(align_of::<RawTransferData>() == 8);
     assert!(offset_of!(RawTransferData, program) == 0);
@@ -16,6 +17,7 @@ const _: () = {
     assert!(offset_of!(RawTransferData, module) == 192);
     assert!(offset_of!(RawTransferData, errors) == 328);
 
+    // Padding: 7 bytes
     assert!(size_of::<Error>() == 72);
     assert!(align_of::<Error>() == 8);
     assert!(offset_of!(Error, severity) == 0);
@@ -26,11 +28,13 @@ const _: () = {
     assert!(size_of::<ErrorSeverity>() == 1);
     assert!(align_of::<ErrorSeverity>() == 1);
 
+    // Padding: 0 bytes
     assert!(size_of::<ErrorLabel>() == 24);
     assert!(align_of::<ErrorLabel>() == 8);
     assert!(offset_of!(ErrorLabel, message) == 0);
     assert!(offset_of!(ErrorLabel, span) == 16);
 
+    // Padding: 7 bytes
     assert!(size_of::<EcmaScriptModule>() == 136);
     assert!(align_of::<EcmaScriptModule>() == 8);
     assert!(offset_of!(EcmaScriptModule, has_module_syntax) == 0);
@@ -39,12 +43,14 @@ const _: () = {
     assert!(offset_of!(EcmaScriptModule, dynamic_imports) == 72);
     assert!(offset_of!(EcmaScriptModule, import_metas) == 104);
 
+    // Padding: 0 bytes
     assert!(size_of::<StaticImport>() == 64);
     assert!(align_of::<StaticImport>() == 8);
     assert!(offset_of!(StaticImport, span) == 0);
     assert!(offset_of!(StaticImport, module_request) == 8);
     assert!(offset_of!(StaticImport, entries) == 32);
 
+    // Padding: 0 bytes
     assert!(size_of::<StaticExport>() == 40);
     assert!(align_of::<StaticExport>() == 8);
     assert!(offset_of!(StaticExport, span) == 0);
@@ -53,6 +59,7 @@ const _: () = {
 
 #[cfg(target_pointer_width = "32")]
 const _: () = {
+    // Padding: 0 bytes
     assert!(size_of::<RawTransferData>() == 188);
     assert!(align_of::<RawTransferData>() == 4);
     assert!(offset_of!(RawTransferData, program) == 0);
@@ -60,6 +67,7 @@ const _: () = {
     assert!(offset_of!(RawTransferData, module) == 104);
     assert!(offset_of!(RawTransferData, errors) == 172);
 
+    // Padding: 3 bytes
     assert!(size_of::<Error>() == 36);
     assert!(align_of::<Error>() == 4);
     assert!(offset_of!(Error, severity) == 0);
@@ -70,11 +78,13 @@ const _: () = {
     assert!(size_of::<ErrorSeverity>() == 1);
     assert!(align_of::<ErrorSeverity>() == 1);
 
+    // Padding: 0 bytes
     assert!(size_of::<ErrorLabel>() == 16);
     assert!(align_of::<ErrorLabel>() == 4);
     assert!(offset_of!(ErrorLabel, message) == 0);
     assert!(offset_of!(ErrorLabel, span) == 8);
 
+    // Padding: 3 bytes
     assert!(size_of::<EcmaScriptModule>() == 68);
     assert!(align_of::<EcmaScriptModule>() == 4);
     assert!(offset_of!(EcmaScriptModule, has_module_syntax) == 0);
@@ -83,12 +93,14 @@ const _: () = {
     assert!(offset_of!(EcmaScriptModule, dynamic_imports) == 36);
     assert!(offset_of!(EcmaScriptModule, import_metas) == 52);
 
+    // Padding: 0 bytes
     assert!(size_of::<StaticImport>() == 40);
     assert!(align_of::<StaticImport>() == 4);
     assert!(offset_of!(StaticImport, span) == 0);
     assert!(offset_of!(StaticImport, module_request) == 8);
     assert!(offset_of!(StaticImport, entries) == 24);
 
+    // Padding: 0 bytes
     assert!(size_of::<StaticExport>() == 24);
     assert!(align_of::<StaticExport>() == 4);
     assert!(offset_of!(StaticExport, span) == 0);


### PR DESCRIPTION
Add comments to `assert_layouts.rs` files stating the number of padding bytes each type contains. This is useful when trying to reduce size of AST types.
