### PR TITLE
fix(napi): computed final source type from `lang` then `sourceType`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1933,6 +1933,7 @@ dependencies = [
  "oxc_ast",
  "oxc_ast_visit",
  "oxc_diagnostics",
+ "oxc_span",
  "oxc_syntax",
 ]
 

--- a/crates/oxc_napi/Cargo.toml
+++ b/crates/oxc_napi/Cargo.toml
@@ -24,6 +24,7 @@ crate-type = ["lib", "cdylib"]
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true, features = ["serialize"] }
 oxc_diagnostics = { workspace = true }
+oxc_span = { workspace = true }
 oxc_syntax = { workspace = true }
 
 napi = { workspace = true }

--- a/crates/oxc_napi/src/lib.rs
+++ b/crates/oxc_napi/src/lib.rs
@@ -6,6 +6,7 @@ pub use error::*;
 
 use oxc_ast::{CommentKind, ast::Program};
 use oxc_ast_visit::utf8_to_utf16::Utf8ToUtf16;
+use oxc_span::SourceType;
 use oxc_syntax::module_record::ModuleRecord;
 
 /// Convert spans to UTF-16
@@ -55,4 +56,24 @@ pub fn convert_utf8_to_utf16(
     }
 
     comments
+}
+
+pub fn get_source_type(
+    filename: &str,
+    lang: Option<&str>,
+    source_type: Option<&str>,
+) -> SourceType {
+    let ty = match lang {
+        Some("js") => SourceType::mjs(),
+        Some("jsx") => SourceType::jsx(),
+        Some("ts") => SourceType::ts(),
+        Some("tsx") => SourceType::tsx(),
+        _ => SourceType::from_path(filename).unwrap_or_default(),
+    };
+    match source_type {
+        Some("script") => ty.with_script(true),
+        Some("module") => ty.with_module(true),
+        Some("unambiguous") => ty.with_unambiguous(true),
+        _ => ty,
+    }
 }

--- a/crates/oxc_parser/examples/parser.rs
+++ b/crates/oxc_parser/examples/parser.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), String> {
 
     let path = Path::new(&name);
     let source_text = fs::read_to_string(path).map_err(|_| format!("Missing '{name}'"))?;
-    let source_type = SourceType::from_path(path).unwrap();
+    let source_type = SourceType::from_path(path).unwrap().with_script(true).with_jsx(true);
 
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, &source_text, source_type)

--- a/napi/parser/index.d.ts
+++ b/napi/parser/index.d.ts
@@ -140,9 +140,10 @@ export interface OxcError {
 export declare function parseAsync(filename: string, sourceText: string, options?: ParserOptions | undefined | null): Promise<ParseResult>
 
 export interface ParserOptions {
-  sourceType?: 'script' | 'module' | 'unambiguous' | undefined
   /** Treat the source text as `js`, `jsx`, `ts`, or `tsx`. */
   lang?: 'js' | 'jsx' | 'ts' | 'tsx'
+  /** Treat the source text as `script` or `module` code. */
+  sourceType?: 'script' | 'module' | 'unambiguous' | undefined
   /**
    * Return an AST which includes TypeScript-related properties, or excludes them.
    *

--- a/napi/parser/src/raw_transfer.rs
+++ b/napi/parser/src/raw_transfer.rs
@@ -12,9 +12,10 @@ use oxc::{
     ast_visit::utf8_to_utf16::Utf8ToUtf16,
     semantic::SemanticBuilder,
 };
+use oxc_napi::get_source_type;
 
 use crate::{
-    AstType, ParserOptions, get_source_and_ast_type, parse,
+    AstType, ParserOptions, get_ast_type, parse,
     raw_transfer_types::{EcmaScriptModule, Error, RawTransferData},
 };
 
@@ -124,7 +125,9 @@ pub unsafe fn parse_sync_raw(
     // Enclose parsing logic in a scope to make 100% sure no references to within `Allocator`
     // exist after this.
     let options = options.unwrap_or_default();
-    let (source_type, ast_type) = get_source_and_ast_type(&filename, &options);
+    let source_type =
+        get_source_type(&filename, options.lang.as_deref(), options.source_type.as_deref());
+    let ast_type = get_ast_type(source_type, &options);
 
     let data_ptr = {
         // SAFETY: We checked above that `source_len` does not exceed length of buffer

--- a/napi/parser/src/types.rs
+++ b/napi/parser/src/types.rs
@@ -7,12 +7,13 @@ use oxc_napi::{Comment, OxcError};
 #[napi(object)]
 #[derive(Default)]
 pub struct ParserOptions {
-    #[napi(ts_type = "'script' | 'module' | 'unambiguous' | undefined")]
-    pub source_type: Option<String>,
-
     /// Treat the source text as `js`, `jsx`, `ts`, or `tsx`.
     #[napi(ts_type = "'js' | 'jsx' | 'ts' | 'tsx'")]
     pub lang: Option<String>,
+
+    /// Treat the source text as `script` or `module` code.
+    #[napi(ts_type = "'script' | 'module' | 'unambiguous' | undefined")]
+    pub source_type: Option<String>,
 
     /// Return an AST which includes TypeScript-related properties, or excludes them.
     ///

--- a/napi/transform/index.d.ts
+++ b/napi/transform/index.d.ts
@@ -361,9 +361,10 @@ export declare function transform(filename: string, sourceText: string, options?
  * @see {@link transform}
  */
 export interface TransformOptions {
-  sourceType?: 'script' | 'module' | 'unambiguous' | undefined
   /** Treat the source text as `js`, `jsx`, `ts`, or `tsx`. */
   lang?: 'js' | 'jsx' | 'ts' | 'tsx'
+  /** Treat the source text as `script` or `module` code. */
+  sourceType?: 'script' | 'module' | 'unambiguous' | undefined
   /**
    * The current working directory. Used to resolve relative paths in other
    * options.


### PR DESCRIPTION
closes #10980

Previously final source type was only computed when `lang` is not set.

It is changed to:

* compute source type from `lang`, use filename extension if `lang` is not set
* reset the computed source type with 'script` or `module` if provided