### PR TITLE
perf(ast): reduce size of `Comment` to 16 bytes

### DIFF
--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -1581,16 +1581,18 @@ const _: () = {
     assert!(size_of::<CommentAnnotation>() == 1);
     assert!(align_of::<CommentAnnotation>() == 1);
 
-    // Padding: 7 bytes
-    assert!(size_of::<Comment>() == 24);
+    assert!(size_of::<CommentNewlines>() == 1);
+    assert!(align_of::<CommentNewlines>() == 1);
+
+    // Padding: 0 bytes
+    assert!(size_of::<Comment>() == 16);
     assert!(align_of::<Comment>() == 8);
     assert!(offset_of!(Comment, span) == 0);
     assert!(offset_of!(Comment, attached_to) == 8);
     assert!(offset_of!(Comment, kind) == 12);
     assert!(offset_of!(Comment, position) == 13);
-    assert!(offset_of!(Comment, preceded_by_newline) == 14);
-    assert!(offset_of!(Comment, followed_by_newline) == 15);
-    assert!(offset_of!(Comment, annotation) == 16);
+    assert!(offset_of!(Comment, newlines) == 14);
+    assert!(offset_of!(Comment, annotation) == 15);
 };
 
 #[cfg(target_pointer_width = "32")]
@@ -3167,16 +3169,18 @@ const _: () = {
     assert!(size_of::<CommentAnnotation>() == 1);
     assert!(align_of::<CommentAnnotation>() == 1);
 
-    // Padding: 3 bytes
-    assert!(size_of::<Comment>() == 20);
+    assert!(size_of::<CommentNewlines>() == 1);
+    assert!(align_of::<CommentNewlines>() == 1);
+
+    // Padding: 0 bytes
+    assert!(size_of::<Comment>() == 16);
     assert!(align_of::<Comment>() == 4);
     assert!(offset_of!(Comment, span) == 0);
     assert!(offset_of!(Comment, attached_to) == 8);
     assert!(offset_of!(Comment, kind) == 12);
     assert!(offset_of!(Comment, position) == 13);
-    assert!(offset_of!(Comment, preceded_by_newline) == 14);
-    assert!(offset_of!(Comment, followed_by_newline) == 15);
-    assert!(offset_of!(Comment, annotation) == 16);
+    assert!(offset_of!(Comment, newlines) == 14);
+    assert!(offset_of!(Comment, annotation) == 15);
 };
 
 #[cfg(not(any(target_pointer_width = "64", target_pointer_width = "32")))]

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -7866,6 +7866,20 @@ impl<'new_alloc> CloneIn<'new_alloc> for CommentAnnotation {
     }
 }
 
+impl<'new_alloc> CloneIn<'new_alloc> for CommentNewlines {
+    type Cloned = CommentNewlines;
+
+    #[inline(always)]
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        *self
+    }
+
+    #[inline(always)]
+    fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        *self
+    }
+}
+
 impl<'new_alloc> CloneIn<'new_alloc> for Comment {
     type Cloned = Comment;
 
@@ -7875,8 +7889,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Comment {
             attached_to: CloneIn::clone_in(&self.attached_to, allocator),
             kind: CloneIn::clone_in(&self.kind, allocator),
             position: CloneIn::clone_in(&self.position, allocator),
-            preceded_by_newline: CloneIn::clone_in(&self.preceded_by_newline, allocator),
-            followed_by_newline: CloneIn::clone_in(&self.followed_by_newline, allocator),
+            newlines: CloneIn::clone_in(&self.newlines, allocator),
             annotation: CloneIn::clone_in(&self.annotation, allocator),
         }
     }
@@ -7887,14 +7900,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Comment {
             attached_to: CloneIn::clone_in_with_semantic_ids(&self.attached_to, allocator),
             kind: CloneIn::clone_in_with_semantic_ids(&self.kind, allocator),
             position: CloneIn::clone_in_with_semantic_ids(&self.position, allocator),
-            preceded_by_newline: CloneIn::clone_in_with_semantic_ids(
-                &self.preceded_by_newline,
-                allocator,
-            ),
-            followed_by_newline: CloneIn::clone_in_with_semantic_ids(
-                &self.followed_by_newline,
-                allocator,
-            ),
+            newlines: CloneIn::clone_in_with_semantic_ids(&self.newlines, allocator),
             annotation: CloneIn::clone_in_with_semantic_ids(&self.annotation, allocator),
         }
     }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -2482,13 +2482,18 @@ impl ContentEq for CommentAnnotation {
     }
 }
 
+impl ContentEq for CommentNewlines {
+    fn content_eq(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+
 impl ContentEq for Comment {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.attached_to, &other.attached_to)
             && ContentEq::content_eq(&self.kind, &other.kind)
             && ContentEq::content_eq(&self.position, &other.position)
-            && ContentEq::content_eq(&self.preceded_by_newline, &other.preceded_by_newline)
-            && ContentEq::content_eq(&self.followed_by_newline, &other.followed_by_newline)
+            && ContentEq::content_eq(&self.newlines, &other.newlines)
             && ContentEq::content_eq(&self.annotation, &other.annotation)
     }
 }

--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -96,7 +96,7 @@ impl Codegen<'_> {
     pub(crate) fn print_comments(&mut self, comments: &[Comment]) {
         for (i, comment) in comments.iter().enumerate() {
             if i == 0 {
-                if comment.preceded_by_newline {
+                if comment.preceded_by_newline() {
                     // Skip printing newline if this comment is already on a newline.
                     if let Some(b) = self.last_byte() {
                         match b {
@@ -113,7 +113,7 @@ impl Codegen<'_> {
                 }
             }
             if i >= 1 {
-                if comment.preceded_by_newline {
+                if comment.preceded_by_newline() {
                     self.print_hard_newline();
                     self.print_indent();
                 } else if comment.is_legal() {
@@ -122,7 +122,7 @@ impl Codegen<'_> {
             }
             self.print_comment(comment);
             if i == comments.len() - 1 {
-                if comment.is_line() || comment.followed_by_newline {
+                if comment.is_line() || comment.followed_by_newline() {
                     self.print_hard_newline();
                 } else {
                     self.print_next_indent_as_space = true;

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -69,7 +69,7 @@ impl TriviaBuilder {
         // The last unprocessed comment is on a newline.
         let len = self.comments.len();
         if self.processed < len {
-            self.comments[len - 1].followed_by_newline = true;
+            self.comments[len - 1].set_followed_by_newline(true);
             if !self.saw_newline {
                 self.processed = self.comments.len();
             }
@@ -131,10 +131,10 @@ impl TriviaBuilder {
         }
 
         // This newly added comment may be preceded by a newline.
-        comment.preceded_by_newline = self.saw_newline;
+        comment.set_preceded_by_newline(self.saw_newline);
         if comment.is_line() {
             // A line comment is always followed by a newline. This is never set in `handle_newline`.
-            comment.followed_by_newline = true;
+            comment.set_followed_by_newline(true);
             if self.should_be_treated_as_trailing_comment() {
                 self.processed = self.comments.len() + 1; // +1 to include this comment.
             }
@@ -241,7 +241,7 @@ fn contains_license_or_preserve_comment(s: &str) -> bool {
 #[cfg(test)]
 mod test {
     use oxc_allocator::Allocator;
-    use oxc_ast::{Comment, CommentAnnotation, CommentKind, CommentPosition};
+    use oxc_ast::{Comment, CommentAnnotation, CommentKind, CommentPosition, ast::CommentNewlines};
     use oxc_span::{SourceType, Span};
 
     use crate::Parser;
@@ -268,8 +268,7 @@ mod test {
                 kind: CommentKind::Block,
                 position: CommentPosition::Leading,
                 attached_to: 70,
-                preceded_by_newline: true,
-                followed_by_newline: true,
+                newlines: CommentNewlines::LeadingAndTrailing,
                 annotation: CommentAnnotation::None,
             },
             Comment {
@@ -277,8 +276,7 @@ mod test {
                 kind: CommentKind::Line,
                 position: CommentPosition::Leading,
                 attached_to: 70,
-                preceded_by_newline: true,
-                followed_by_newline: true,
+                newlines: CommentNewlines::LeadingAndTrailing,
                 annotation: CommentAnnotation::None,
             },
             Comment {
@@ -286,8 +284,7 @@ mod test {
                 kind: CommentKind::Block,
                 position: CommentPosition::Leading,
                 attached_to: 70,
-                preceded_by_newline: true,
-                followed_by_newline: false,
+                newlines: CommentNewlines::Leading,
                 annotation: CommentAnnotation::None,
             },
             Comment {
@@ -295,8 +292,7 @@ mod test {
                 kind: CommentKind::Block,
                 position: CommentPosition::Trailing,
                 attached_to: 0,
-                preceded_by_newline: false,
-                followed_by_newline: false,
+                newlines: CommentNewlines::None,
                 annotation: CommentAnnotation::None,
             },
             Comment {
@@ -304,8 +300,7 @@ mod test {
                 kind: CommentKind::Line,
                 position: CommentPosition::Trailing,
                 attached_to: 0,
-                preceded_by_newline: false,
-                followed_by_newline: true,
+                newlines: CommentNewlines::Trailing,
                 annotation: CommentAnnotation::None,
             },
             Comment {
@@ -313,8 +308,7 @@ mod test {
                 kind: CommentKind::Line,
                 position: CommentPosition::Leading,
                 attached_to: 147,
-                preceded_by_newline: true,
-                followed_by_newline: true,
+                newlines: CommentNewlines::LeadingAndTrailing,
                 annotation: CommentAnnotation::None,
             },
         ];
@@ -338,8 +332,7 @@ token /* Trailing 1 */
                 kind: CommentKind::Block,
                 position: CommentPosition::Leading,
                 attached_to: 36,
-                preceded_by_newline: true,
-                followed_by_newline: true,
+                newlines: CommentNewlines::LeadingAndTrailing,
                 annotation: CommentAnnotation::None,
             },
             Comment {
@@ -347,8 +340,7 @@ token /* Trailing 1 */
                 kind: CommentKind::Block,
                 position: CommentPosition::Trailing,
                 attached_to: 0,
-                preceded_by_newline: false,
-                followed_by_newline: true,
+                newlines: CommentNewlines::Trailing,
                 annotation: CommentAnnotation::None,
             },
         ];
@@ -373,8 +365,7 @@ token /* Trailing 1 */
                 kind: CommentKind::Block,
                 position: CommentPosition::Leading,
                 attached_to: 28,
-                preceded_by_newline: true,
-                followed_by_newline: true,
+                newlines: CommentNewlines::LeadingAndTrailing,
                 annotation: CommentAnnotation::None,
             },
             Comment {
@@ -382,8 +373,7 @@ token /* Trailing 1 */
                 kind: CommentKind::Block,
                 position: CommentPosition::Leading,
                 attached_to: 28,
-                preceded_by_newline: true,
-                followed_by_newline: true,
+                newlines: CommentNewlines::LeadingAndTrailing,
                 annotation: CommentAnnotation::None,
             },
         ];
@@ -406,8 +396,7 @@ token /* Trailing 1 */
                 kind: CommentKind::Line,
                 position: CommentPosition::Leading,
                 attached_to: 57,
-                preceded_by_newline: false,
-                followed_by_newline: true,
+                newlines: CommentNewlines::Trailing,
                 annotation: CommentAnnotation::None,
             },
             Comment {
@@ -415,8 +404,7 @@ token /* Trailing 1 */
                 kind: CommentKind::Line,
                 position: CommentPosition::Leading,
                 attached_to: 129,
-                preceded_by_newline: false,
-                followed_by_newline: true,
+                newlines: CommentNewlines::Trailing,
                 annotation: CommentAnnotation::None,
             },
         ];
@@ -438,8 +426,7 @@ token /* Trailing 1 */
                 kind: CommentKind::Line,
                 position: CommentPosition::Leading,
                 attached_to: 55,
-                preceded_by_newline: false,
-                followed_by_newline: true,
+                newlines: CommentNewlines::Trailing,
                 annotation: CommentAnnotation::None,
             },
             Comment {
@@ -447,8 +434,7 @@ token /* Trailing 1 */
                 kind: CommentKind::Line,
                 position: CommentPosition::Leading,
                 attached_to: 116,
-                preceded_by_newline: false,
-                followed_by_newline: true,
+                newlines: CommentNewlines::Trailing,
                 annotation: CommentAnnotation::None,
             },
         ];

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -4055,7 +4055,7 @@ function deserializeVecComment(pos) {
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeComment(pos));
-    pos += 24;
+    pos += 16;
   }
   return arr;
 }

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -4207,7 +4207,7 @@ function deserializeVecComment(pos) {
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeComment(pos));
-    pos += 24;
+    pos += 16;
   }
   return arr;
 }


### PR DESCRIPTION
I noticed that most of `Comment` consisted of enums which were only 1 byte in size, but only used a few bits in each byte. There are few enough fields that we can actually store all of them in a single `u16` bit flag, which reduces the size of `Comment` from 24 bytes to 16 bytes.