### PR TITLE
fix(napi/playground): Always display syntax errors

### DIFF
--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -129,6 +129,7 @@ impl Oxc {
             Parser::new(&allocator, &source_text, source_type)
                 .with_options(oxc_parser_options)
                 .parse();
+        self.diagnostics.extend(errors);
 
         let mut semantic_builder = SemanticBuilder::new();
         if run_options.transform.unwrap_or_default() {
@@ -146,7 +147,7 @@ impl Oxc {
             ))
         });
         if run_options.syntax.unwrap_or_default() {
-            self.diagnostics.extend(errors.into_iter().chain(semantic_ret.errors));
+            self.diagnostics.extend(semantic_ret.errors);
         }
 
         let linter_module_record = Arc::new(ModuleRecord::new(&path, &module_record, &semantic));


### PR DESCRIPTION
Related #11029

Currently, if the `Check Syntax Errors` option is OFF, it appears that no errors are found during parsing.

![image](https://github.com/user-attachments/assets/95c7c82e-0b53-4c3e-8327-54e73c5981ea)

But actually the parser returns `errors`, this is the gap between playground and parser.

![image](https://github.com/user-attachments/assets/268d6895-6bd0-4744-89d6-bb848da13653)

---

Does this change make sense?
If so, I will update the playground label from `Check Syntax Errors` to `Check Semantic Errors` later.