### PR TITLE
refactor(language_server): add intern capability for `didChangeWatchedFiles.dynamicRegistration`

### DIFF
--- a/crates/oxc_language_server/src/capabilities.rs
+++ b/crates/oxc_language_server/src/capabilities.rs
@@ -13,6 +13,7 @@ pub struct Capabilities {
     pub workspace_apply_edit: bool,
     pub workspace_execute_command: bool,
     pub workspace_configuration: bool,
+    pub dynamic_watchers: bool,
 }
 
 impl From<ClientCapabilities> for Capabilities {
@@ -33,12 +34,18 @@ impl From<ClientCapabilities> for Capabilities {
             .workspace
             .as_ref()
             .is_some_and(|workspace| workspace.configuration.is_some_and(|config| config));
+        let dynamic_watchers = value.workspace.is_some_and(|workspace| {
+            workspace.did_change_watched_files.is_some_and(|watched_files| {
+                watched_files.dynamic_registration.is_some_and(|dynamic| dynamic)
+            })
+        });
 
         Self {
             code_action_provider,
             workspace_apply_edit,
             workspace_execute_command,
             workspace_configuration,
+            dynamic_watchers,
         }
     }
 }
@@ -85,8 +92,9 @@ impl From<Capabilities> for ServerCapabilities {
 mod test {
     use tower_lsp_server::lsp_types::{
         ClientCapabilities, CodeActionClientCapabilities, CodeActionKindLiteralSupport,
-        CodeActionLiteralSupport, DynamicRegistrationClientCapabilities,
-        TextDocumentClientCapabilities, WorkspaceClientCapabilities,
+        CodeActionLiteralSupport, DidChangeWatchedFilesClientCapabilities,
+        DynamicRegistrationClientCapabilities, TextDocumentClientCapabilities,
+        WorkspaceClientCapabilities,
     };
 
     use super::Capabilities;
@@ -221,5 +229,39 @@ mod test {
         let capabilities = Capabilities::from(client_capabilities);
 
         assert!(capabilities.workspace_apply_edit);
+    }
+
+    #[test]
+    fn test_dynamic_watchers_vscode() {
+        let client_capabilities = ClientCapabilities {
+            workspace: Some(WorkspaceClientCapabilities {
+                did_change_watched_files: Some(DidChangeWatchedFilesClientCapabilities {
+                    dynamic_registration: Some(true),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let capabilities = Capabilities::from(client_capabilities);
+        assert!(capabilities.dynamic_watchers);
+    }
+
+    #[test]
+    fn test_dynamic_watchers_intellij() {
+        let client_capabilities = ClientCapabilities {
+            workspace: Some(WorkspaceClientCapabilities {
+                did_change_watched_files: Some(DidChangeWatchedFilesClientCapabilities {
+                    dynamic_registration: Some(true),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let capabilities = Capabilities::from(client_capabilities);
+        assert!(capabilities.dynamic_watchers);
     }
 }


### PR DESCRIPTION
Current State: The client initializes the file watchers and tells the client for changes. 
Goal: The Server should tell clients to watch for specific files. 
This will help for other editors which does not have a custom implementation like VSCode does.

See https://github.com/oxc-project/oxc/pull/11078 how to use this capability.