### PR TITLE
fix(transformer/typescript): panics when `setPublicClassFields = true` and the class includes private field

### DIFF
--- a/crates/oxc_transformer/src/typescript/class.rs
+++ b/crates/oxc_transformer/src/typescript/class.rs
@@ -89,7 +89,8 @@ impl<'a> TypeScript<'a, '_> {
         let mut computed_key_assignments = Vec::new();
         for element in &mut class.body.body {
             match element {
-                ClassElement::PropertyDefinition(prop) => {
+                // `set_public_class_fields: true` only needs to transform non-private class fields.
+                ClassElement::PropertyDefinition(prop) if !prop.key.is_private_identifier() => {
                     if let Some(value) = prop.value.take() {
                         let assignment = self.convert_property_definition(
                             &mut prop.key,
@@ -277,8 +278,7 @@ impl<'a> TypeScript<'a, '_> {
                 create_this_property_access(SPAN, ident.name, ctx)
             }
             PropertyKey::PrivateIdentifier(_) => {
-                // Handled in `convert_instance_property` and `convert_static_property`
-                unreachable!();
+                unreachable!("PrivateIdentifier is skipped in transform_class_fields");
             }
             key @ match_expression!(PropertyKey) => {
                 let key = key.to_expression_mut();

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -462,9 +462,9 @@ rebuilt        : ScopeId(19): Some(ScopeId(15))
 Scope parent mismatch:
 after transform: ScopeId(20): Some(ScopeId(0))
 rebuilt        : ScopeId(20): Some(ScopeId(15))
-Unresolved references mismatch:
-after transform: ["a", "b", "c", "console", "dce", "e", "x", "y", "z"]
-rebuilt        : ["a", "b", "c", "console", "e", "x", "y", "z"]
+Unresolved reference IDs mismatch for "dce":
+after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(4), ReferenceId(9), ReferenceId(12), ReferenceId(14), ReferenceId(17)]
+rebuilt        : [ReferenceId(5)]
 
 
 # babel-plugin-transform-react-jsx (42/45)

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/use-define-for-class-fields-without-class-properties/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/use-define-for-class-fields-without-class-properties/input.ts
@@ -4,6 +4,11 @@ class Cls {
 	@dce
 	z;
 
+	#x: number;
+	#y = 1;
+	@dce
+	#z;
+
 	[x]: number;
 	[y] = 1;
 	@dce

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/use-define-for-class-fields-without-class-properties/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/use-define-for-class-fields-without-class-properties/output.js
@@ -9,6 +9,9 @@ class Cls {
   static {
     x, _y = y, z;
   }
+  #x;
+  #y = 1;
+  @dce #z;
 }
 
 class ClsWithConstructor extends Cls {


### PR DESCRIPTION
close: #11084

We don't need to transform the private field, which is part of class-properties work, so `unreachable` is expected. The bug is that we haven't skipped it. 