### PR TITLE
wip(minifier): update semantics

### DIFF
--- a/crates/oxc_minifier/src/collect_references.rs
+++ b/crates/oxc_minifier/src/collect_references.rs
@@ -1,0 +1,38 @@
+use std::marker::PhantomData;
+
+use oxc_ast::ast::*;
+use oxc_ast_visit::Visit;
+use oxc_semantic::ReferenceId;
+use rustc_hash::FxHashSet;
+
+pub struct CollectReferences<'a> {
+    refs: FxHashSet<ReferenceId>,
+    _marker: PhantomData<&'a ()>,
+}
+
+impl<'a> Visit<'a> for CollectReferences<'a> {
+    fn visit_identifier_reference(&mut self, ident: &IdentifierReference<'a>) {
+        self.refs.insert(ident.reference_id());
+    }
+}
+
+impl<'a> CollectReferences<'a> {
+    pub fn new() -> Self {
+        Self { refs: FxHashSet::default(), _marker: PhantomData }
+    }
+
+    pub fn collect_in_expr(&mut self, expr: &Expression<'a>) -> FxHashSet<ReferenceId> {
+        self.refs.clear();
+        self.visit_expression(expr);
+        self.refs.clone()
+    }
+
+    pub fn collect_in_assignment_target(
+        &mut self,
+        target: &AssignmentTarget<'a>,
+    ) -> FxHashSet<ReferenceId> {
+        self.refs.clear();
+        self.visit_assignment_target(target);
+        self.refs.clone()
+    }
+}

--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -7,6 +7,7 @@ mod ctx;
 mod keep_var;
 mod options;
 mod peephole;
+mod collect_references;
 
 #[cfg(test)]
 mod tester;

--- a/crates/oxc_minifier/src/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditions.rs
@@ -12,7 +12,7 @@ use super::{PeepholeOptimizations, State};
 /// <https://github.com/google/closure-compiler/blob/v20240609/src/com/google/javascript/jscomp/PeepholeMinimizeConditions.java>
 impl<'a> PeepholeOptimizations {
     pub fn minimize_conditions_exit_expression(
-        &self,
+        &mut self,
         expr: &mut Expression<'a>,
         state: &mut State,
         ctx: Ctx<'a, '_>,
@@ -62,7 +62,7 @@ impl<'a> PeepholeOptimizations {
     // associative. For example, the "+" operator is not associative for
     // floating-point numbers.
     pub fn join_with_left_associative_op(
-        &self,
+        &mut self,
         span: Span,
         op: LogicalOperator,
         a: Expression<'a>,

--- a/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
@@ -7,7 +7,7 @@ use crate::ctx::Ctx;
 use super::PeepholeOptimizations;
 
 impl<'a> PeepholeOptimizations {
-    pub fn try_fold_stmt_in_boolean_context(&self, stmt: &mut Statement<'a>, ctx: Ctx<'a, '_>) {
+    pub fn try_fold_stmt_in_boolean_context(&mut self, stmt: &mut Statement<'a>, ctx: Ctx<'a, '_>) {
         let expr = match stmt {
             Statement::IfStatement(s) => Some(&mut s.test),
             Statement::WhileStatement(s) => Some(&mut s.test),
@@ -25,7 +25,7 @@ impl<'a> PeepholeOptimizations {
     ///
     /// `SimplifyBooleanExpr`: <https://github.com/evanw/esbuild/blob/v0.24.2/internal/js_ast/js_ast_helpers.go#L2059>
     pub fn try_fold_expr_in_boolean_context(
-        &self,
+        &mut self,
         expr: &mut Expression<'a>,
         ctx: Ctx<'a, '_>,
     ) -> bool {

--- a/crates/oxc_minifier/src/peephole/minimize_for_statement.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_for_statement.rs
@@ -8,7 +8,7 @@ use super::{PeepholeOptimizations, State};
 impl<'a> PeepholeOptimizations {
     /// `mangleFor`: <https://github.com/evanw/esbuild/blob/v0.24.2/internal/js_ast/js_parser.go#L9801>
     pub fn minimize_for_statement(
-        &self,
+        &mut self,
         for_stmt: &mut ForStatement<'a>,
         state: &mut State,
         ctx: Ctx<'a, '_>,

--- a/crates/oxc_minifier/src/peephole/minimize_if_statement.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_if_statement.rs
@@ -10,7 +10,7 @@ use super::{PeepholeOptimizations, State};
 impl<'a> PeepholeOptimizations {
     /// `MangleIf`: <https://github.com/evanw/esbuild/blob/v0.24.2/internal/js_parser/js_parser.go#L9860>
     pub fn try_minimize_if(
-        &self,
+        &mut self,
         if_stmt: &mut IfStatement<'a>,
         state: &mut State,
         ctx: Ctx<'a, '_>,

--- a/crates/oxc_minifier/src/peephole/minimize_not_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_not_expression.rs
@@ -8,7 +8,7 @@ use super::PeepholeOptimizations;
 
 impl<'a> PeepholeOptimizations {
     pub fn minimize_not(
-        &self,
+        &mut self,
         span: Span,
         expr: Expression<'a>,
         ctx: Ctx<'a, '_>,
@@ -20,7 +20,7 @@ impl<'a> PeepholeOptimizations {
 
     /// `MaybeSimplifyNot`: <https://github.com/evanw/esbuild/blob/v0.24.2/internal/js_ast/js_ast_helpers.go#L73>
     pub fn try_minimize_not(
-        &self,
+        &mut self,
         expr: &mut UnaryExpression<'a>,
         ctx: Ctx<'a, '_>,
     ) -> Option<Expression<'a>> {

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -31,7 +31,7 @@ impl<'a> PeepholeOptimizations {
     /// ## MinimizeExitPoints:
     /// <https://github.com/google/closure-compiler/blob/v20240609/src/com/google/javascript/jscomp/MinimizeExitPoints.java>
     pub fn minimize_statements(
-        &self,
+        &mut self,
         stmts: &mut Vec<'a, Statement<'a>>,
         state: &mut State,
         ctx: Ctx<'a, '_>,
@@ -285,7 +285,7 @@ impl<'a> PeepholeOptimizations {
     }
 
     fn minimize_statement(
-        &self,
+        &mut self,
         stmt: Statement<'a>,
         i: usize,
         stmts: &mut Vec<'a, Statement<'a>>,
@@ -421,7 +421,7 @@ impl<'a> PeepholeOptimizations {
 
     #[expect(clippy::cast_possible_truncation)]
     fn handle_if_statement(
-        &self,
+        &mut self,
         i: usize,
         stmts: &mut Vec<'a, Statement<'a>>,
         mut if_stmt: Box<'a, IfStatement<'a>>,

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -17,7 +17,7 @@ use super::{LatePeepholeOptimizations, PeepholeOptimizations, State};
 /// <https://github.com/google/closure-compiler/blob/v20240609/src/com/google/javascript/jscomp/PeepholeRemoveDeadCode.java>
 impl<'a, 'b> PeepholeOptimizations {
     pub fn remove_dead_code_exit_statement(
-        &self,
+        &mut self,
         stmt: &mut Statement<'a>,
         state: &mut State,
         ctx: Ctx<'a, '_>,
@@ -38,7 +38,7 @@ impl<'a, 'b> PeepholeOptimizations {
     }
 
     pub fn remove_dead_code_exit_expression(
-        &self,
+        &mut self,
         expr: &mut Expression<'a>,
         state: &mut State,
         ctx: Ctx<'a, '_>,
@@ -244,7 +244,7 @@ impl<'a, 'b> PeepholeOptimizations {
     }
 
     fn try_fold_for(
-        &self,
+        &mut self,
         for_stmt: &mut ForStatement<'a>,
         state: &mut State,
         ctx: Ctx<'a, 'b>,
@@ -335,7 +335,7 @@ impl<'a, 'b> PeepholeOptimizations {
     }
 
     fn try_fold_expression_stmt(
-        &self,
+        &mut self,
         stmt: &mut Statement<'a>,
         state: &mut State,
         ctx: Ctx<'a, 'b>,
@@ -390,7 +390,7 @@ impl<'a, 'b> PeepholeOptimizations {
 
     /// Try folding conditional expression (?:) if the condition results of the condition is known.
     fn try_fold_conditional_expression(
-        &self,
+        &mut self,
         expr: &mut ConditionalExpression<'a>,
         state: &mut State,
         ctx: Ctx<'a, 'b>,
@@ -442,7 +442,7 @@ impl<'a, 'b> PeepholeOptimizations {
     }
 
     fn try_fold_sequence_expression(
-        &self,
+        &mut self,
         sequence_expr: &mut SequenceExpression<'a>,
         state: &mut State,
         ctx: Ctx<'a, 'b>,

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -17,7 +17,7 @@ use super::{PeepholeOptimizations, State};
 impl<'a> PeepholeOptimizations {
     /// `SimplifyUnusedExpr`: <https://github.com/evanw/esbuild/blob/v0.24.2/internal/js_ast/js_ast_helpers.go#L534>
     pub fn remove_unused_expression(
-        &self,
+        &mut self,
         e: &mut Expression<'a>,
         state: &mut State,
         ctx: Ctx<'a, '_>,
@@ -38,7 +38,7 @@ impl<'a> PeepholeOptimizations {
     }
 
     fn fold_unary_expression(
-        &self,
+        &mut self,
         e: &mut Expression<'a>,
         state: &mut State,
         ctx: Ctx<'a, '_>,
@@ -64,7 +64,7 @@ impl<'a> PeepholeOptimizations {
     }
 
     fn fold_sequence_expression(
-        &self,
+        &mut self,
         e: &mut Expression<'a>,
         state: &mut State,
         ctx: Ctx<'a, '_>,
@@ -81,7 +81,7 @@ impl<'a> PeepholeOptimizations {
     }
 
     fn fold_logical_expression(
-        &self,
+        &mut self,
         e: &mut Expression<'a>,
         state: &mut State,
         ctx: Ctx<'a, '_>,
@@ -123,7 +123,7 @@ impl<'a> PeepholeOptimizations {
                             None
                         };
                         if let Some((name, id)) = name_and_id {
-                            if Self::inject_optional_chaining_if_matched(
+                            if self.inject_optional_chaining_if_matched(
                                 &name,
                                 id,
                                 logical_right,
@@ -186,7 +186,7 @@ impl<'a> PeepholeOptimizations {
 
     // `([1,2,3, foo()])` -> `foo()`
     fn fold_array_expression(
-        &self,
+        &mut self,
         e: &mut Expression<'a>,
         state: &mut State,
         ctx: Ctx<'a, '_>,
@@ -241,7 +241,7 @@ impl<'a> PeepholeOptimizations {
     }
 
     fn fold_new_constructor(
-        &self,
+        &mut self,
         e: &mut Expression<'a>,
         state: &mut State,
         ctx: Ctx<'a, '_>,
@@ -310,7 +310,7 @@ impl<'a> PeepholeOptimizations {
 
     // "`${1}2${foo()}3`" -> "`${foo()}`"
     fn fold_template_literal(
-        &self,
+        &mut self,
         e: &mut Expression<'a>,
         state: &mut State,
         ctx: Ctx<'a, '_>,
@@ -395,7 +395,7 @@ impl<'a> PeepholeOptimizations {
 
     // `({ 1: 1, [foo()]: bar() })` -> `foo(), bar()`
     fn fold_object_expression(
-        &self,
+        &mut self,
         e: &mut Expression<'a>,
         state: &mut State,
         ctx: Ctx<'a, '_>,
@@ -471,7 +471,7 @@ impl<'a> PeepholeOptimizations {
     }
 
     fn fold_conditional_expression(
-        &self,
+        &mut self,
         e: &mut Expression<'a>,
         state: &mut State,
         ctx: Ctx<'a, '_>,
@@ -525,7 +525,7 @@ impl<'a> PeepholeOptimizations {
     }
 
     fn fold_binary_expression(
-        &self,
+        &mut self,
         e: &mut Expression<'a>,
         state: &mut State,
         ctx: Ctx<'a, '_>,
@@ -627,7 +627,7 @@ impl<'a> PeepholeOptimizations {
     }
 
     fn fold_call_expression(
-        &self,
+        &mut self,
         e: &mut Expression<'a>,
         state: &mut State,
         ctx: Ctx<'a, '_>,
@@ -694,7 +694,7 @@ impl<'a> PeepholeOptimizations {
     }
 
     fn fold_arguments_into_needed_expressions(
-        &self,
+        &mut self,
         args: &mut Vec<'a, Argument<'a>>,
         state: &mut State,
         ctx: Ctx<'a, '_>,

--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -7,7 +7,7 @@ use oxc_index::{Idx, IndexVec};
 use oxc_span::{Atom, Span};
 use oxc_syntax::{
     node::NodeId,
-    reference::{Reference, ReferenceId},
+    reference::{Reference, ReferenceFlags, ReferenceId},
     scope::{ScopeFlags, ScopeId},
     symbol::{SymbolFlags, SymbolId},
 };
@@ -302,6 +302,10 @@ impl Scoping {
 
     pub fn create_reference(&mut self, reference: Reference) -> ReferenceId {
         self.references.push(reference)
+    }
+
+    pub fn delete_reference(&mut self, reference_id: ReferenceId) {
+        self.references[reference_id] = Reference::new(NodeId::DUMMY, ReferenceFlags::empty());
     }
 
     /// Get a resolved or unresolved reference.

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -1,7 +1,7 @@
            | Oxc        | ESBuild    | Oxc        | ESBuild    |
 Original   | minified   | minified   | gzip       | gzip       | Fixture
 -------------------------------------------------------------------------------------
-72.14 kB   | 23.49 kB   | 23.70 kB   | 8.47 kB    | 8.54 kB    | react.development.js
+72.14 kB   | 23.48 kB   | 23.70 kB   | 8.48 kB    | 8.54 kB    | react.development.js
 
 173.90 kB  | 59.52 kB   | 59.82 kB   | 19.18 kB   | 19.33 kB   | moment.js 
 
@@ -21,7 +21,7 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 3.20 MB    | 1.01 MB    | 1.01 MB    | 324.14 kB  | 331.56 kB  | echarts.js
 
-6.69 MB    | 2.28 MB    | 2.31 MB    | 466.11 kB  | 488.28 kB  | antd.js   
+6.69 MB    | 2.28 MB    | 2.31 MB    | 465.80 kB  | 488.28 kB  | antd.js   
 
-10.95 MB   | 3.35 MB    | 3.49 MB    | 860.94 kB  | 915.50 kB  | typescript.js
+10.95 MB   | 3.35 MB    | 3.49 MB    | 859.39 kB  | 915.50 kB  | typescript.js
 


### PR DESCRIPTION
I had this commit locally for a while but forgot to push it.

This PR makes the minifier to update the semantics information when removing a reference. This is needed for #10033.

@Boshen What do you think of this approach? If it looks good, I'll rebase this on main branch and add a test similar to `tasks/transform_checker`.
