### PR TITLE
ci(miri): fix Miri

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -49,7 +49,9 @@ jobs:
           rustup override set nightly
           cargo miri setup
 
+      # `--lib --bins --tests` omits doctests, which Miri can't run
+      # https://github.com/oxc-project/oxc/pull/11092
       - name: Test with Miri
         run: |
-          cargo miri test --doc --all-features -p oxc_ast -p oxc_data_structures
-          cargo miri test -p oxc_parser -p oxc_transformer
+          cargo miri test --lib --bins --tests --all-features -p oxc_ast -p oxc_data_structures
+          cargo miri test --lib --bins --tests -p oxc_parser -p oxc_transformer

--- a/crates/oxc_allocator/src/vec2/mod.rs
+++ b/crates/oxc_allocator/src/vec2/mod.rs
@@ -1643,7 +1643,10 @@ impl<'bump, T: 'bump> Vec<'bump, T> {
     /// except by the pointer `other`, and that they are not read after this call.
     #[inline]
     unsafe fn append_elements(&mut self, other: *const [T]) {
-        let count = (*other).len();
+        // See https://github.com/oxc-project/oxc/pull/11092 for why this `#[allow]` attribute.
+        // TODO: Remove this once we bump MSRV and it's no longer required.
+        #[allow(clippy::needless_borrow, clippy::allow_attributes)]
+        let count = (&*other).len();
         self.reserve(count);
         let len = self.len();
         ptr::copy_nonoverlapping(other as *const T, self.as_mut_ptr().add(len), count);


### PR DESCRIPTION
Miri is failing on main. It seems to have started with #11088, though that could be a coincidence - maybe it's just latest nightly made some change which broke Miri.

2 things are causing the fails:

1. "fatal error: cross-interpreting doctests is not currently supported by Miri".
2. A lint error that only occurs on nightly in `Vec::append_elements`.

Fix (1) by disabling doc tests.

Fix (2) by changing the code. The `#[allow]` attribute is needed because the amended code triggers a *different* clippy warning on stable!
