### PR TITLE
refactor(language_server/editor): refresh file watchers without restarting the server (didChangeWorkspaceFolders)

### DIFF
--- a/editors/vscode/client/ConfigService.ts
+++ b/editors/vscode/client/ConfigService.ts
@@ -38,10 +38,8 @@ export class ConfigService implements IDisposable {
     }));
   }
 
-  public addWorkspaceConfig(workspace: WorkspaceFolder): WorkspaceConfig {
-    let workspaceConfig = new WorkspaceConfig(workspace);
-    this.workspaceConfigs.set(workspace.uri.path, workspaceConfig);
-    return workspaceConfig;
+  public addWorkspaceConfig(workspace: WorkspaceFolder): void {
+    this.workspaceConfigs.set(workspace.uri.path, new WorkspaceConfig(workspace));
   }
 
   public removeWorkspaceConfig(workspace: WorkspaceFolder): void {

--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -238,29 +238,11 @@ export async function activate(context: ExtensionContext) {
   context.subscriptions.push(onDeleteFilesDispose);
 
   const onDidChangeWorkspaceFoldersDispose = workspace.onDidChangeWorkspaceFolders(async (event) => {
-    let needRestart = false;
     for (const folder of event.added) {
-      const workspaceConfig = configService.addWorkspaceConfig(folder);
-
-      if (workspaceConfig.isCustomConfigPath) {
-        needRestart = true;
-      }
+      configService.addWorkspaceConfig(folder);
     }
     for (const folder of event.removed) {
-      const workspaceConfig = configService.getWorkspaceConfig(folder.uri);
-      if (workspaceConfig?.isCustomConfigPath) {
-        needRestart = true;
-      }
       configService.removeWorkspaceConfig(folder);
-    }
-
-    if (client === undefined) {
-      return;
-    }
-
-    // Server does not support currently adding/removing watchers on the fly
-    if (needRestart && client.isRunning()) {
-      await client.restart();
     }
   });
 


### PR DESCRIPTION
Now VSCode does not need to restart the language server, 
because the language server will tell now to (un)watch for oxlint files and the npm package `vscode-languageclient` will handle the rest.