### PR TITLE
perf(linter): remove unnecessary `codegen` in `eslint/prefer-numeric-literals`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
@@ -10,10 +10,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use phf::{Map, phf_map, phf_ordered_set};
 
-use crate::{
-    AstNode, ast_util::get_symbol_id_of_variable, context::LintContext, fixer::RuleFixer,
-    rule::Rule,
-};
+use crate::{AstNode, ast_util::get_symbol_id_of_variable, context::LintContext, rule::Rule};
 
 fn prefer_numeric_literals_diagnostic(span: Span, prefix_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Use {prefix_name} literals instead of parseInt()."))
@@ -147,10 +144,30 @@ fn check_arguments<'a>(call_expr: &CallExpression<'a>, ctx: &LintContext<'a>) {
                 ctx.diagnostic_with_fix(
                     prefer_numeric_literals_diagnostic(call_expr.span, name),
                     |fixer| {
-                        fixer.replace(
-                            call_expr.span,
-                            generate_fix(fixer, ctx, call_expr, &argument, prefix),
-                        )
+                        let code = {
+                            let span = call_expr.span;
+                            let mut code = String::with_capacity(prefix.len() + argument.len() + 2);
+
+                            if span.start > 1 {
+                                let start = ctx.source_text().as_bytes()[span.start as usize - 1];
+                                if start.is_ascii_alphabetic() || !start.is_ascii() {
+                                    code.push(' ');
+                                }
+                            }
+
+                            code.push_str(prefix);
+                            code.push_str(&argument);
+
+                            if (span.end as usize) < ctx.source_text().len() {
+                                let end = ctx.source_text().as_bytes()[span.end as usize];
+                                if end.is_ascii_alphabetic() || !end.is_ascii() {
+                                    code.push(' ');
+                                }
+                            }
+
+                            code
+                        };
+                        fixer.replace(call_expr.span, code)
                     },
                 );
             }
@@ -188,36 +205,6 @@ fn get_string_argument(call_expr: &CallExpression) -> Option<String> {
     }
 
     None
-}
-
-fn generate_fix<'a>(
-    fixer: RuleFixer<'_, 'a>,
-    ctx: &LintContext<'a>,
-    call_expr: &CallExpression<'a>,
-    argument: &str,
-    prefix: &str,
-) -> String {
-    let mut formatter = fixer.codegen();
-    let span = call_expr.span;
-
-    if span.start > 1 {
-        let start = ctx.source_text().as_bytes()[span.start as usize - 1];
-        if start.is_ascii_alphabetic() || !start.is_ascii() {
-            formatter.print_str(" ");
-        }
-    }
-
-    formatter.print_str(prefix);
-    formatter.print_str(argument);
-
-    if (span.end as usize) < ctx.source_text().len() {
-        let end = ctx.source_text().as_bytes()[span.end as usize];
-        if end.is_ascii_alphabetic() || !end.is_ascii() {
-            formatter.print_str(" ");
-        }
-    }
-
-    formatter.into_source_text()
 }
 
 #[test]


### PR DESCRIPTION
Related to #11098