### PR TITLE
docs(linter): improve docs for `eslint/no-constructor-return`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_constructor_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constructor_return.rs
@@ -26,19 +26,19 @@ declare_oxc_lint!(
     /// In JavaScript, returning a value in the constructor of a class may be a mistake.
     /// Forbidding this pattern prevents mistakes resulting from unfamiliarity with the language or a copy-paste error.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
-    /// ```rust
+    /// ```js
     /// class C {
-    ///     constructor() { return 42; }
+    ///   constructor() { return 42; }
     /// }
     /// ```
     ///
     /// Examples of **correct** code for this rule:
-    /// ```rust
+    /// ```js
     /// class C {
-    ///     constructor() { this.value = 42; }
+    ///   constructor() { this.value = 42; }
     /// }
     /// ```
     NoConstructorReturn,


### PR DESCRIPTION
According to #6050