### PR TITLE
docs(linter): improve docs for `eslint/no-debugger`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_debugger.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_debugger.rs
@@ -16,32 +16,32 @@ pub struct NoDebugger;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Checks for usage of the `debugger` statement
     ///
     /// ### Why is this bad?
+    ///
     /// `debugger` statements do not affect functionality when a debugger isn't attached.
     /// They're most commonly an accidental debugging leftover.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
-    ///
     /// ```javascript
     /// async function main() {
-    ///     const data = await getData();
-    ///     const result = complexCalculation(data);
-    ///     debugger;
+    ///   const data = await getData();
+    ///   const result = complexCalculation(data);
+    ///   debugger;
     /// }
     /// ```
     ///
     /// Examples of **correct** code for this rule:
     /// ```javascript
     /// async function main() {
-    ///     const data = await getData();
-    ///     const result = complexCalculation(data);
+    ///   const data = await getData();
+    ///   const result = complexCalculation(data);
     /// }
     /// ```
-    ///
     NoDebugger,
     eslint,
     correctness,


### PR DESCRIPTION
According to #6050