### PR TITLE
docs(linter): normalize rule docs format

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
@@ -55,10 +55,9 @@ declare_oxc_lint!(
     /// If you don’t want to use a return or don’t need the returned results,
     /// consider using .forEach instead.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
-    ///
     /// ```javascript
     /// let foo = [1, 2, 3, 4];
     /// foo.map((a) => {
@@ -67,7 +66,6 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Examples of **correct** code for this rule:
-    ///
     /// ```javascript
     /// let foo = [1, 2, 3, 4];
     /// foo.map((a) => {

--- a/crates/oxc_linter/src/rules/eslint/block_scoped_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/block_scoped_var.rs
@@ -47,7 +47,6 @@ declare_oxc_lint!(
     ///    }
     ///     console.log(build);
     /// }
-    ///
     /// ```
     BlockScopedVar,
     eslint,

--- a/crates/oxc_linter/src/rules/eslint/default_case_last.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_case_last.rs
@@ -25,10 +25,9 @@ declare_oxc_lint!(
     /// Even if there is no “fall through” logic, it’s still unexpected to see the default clause before or between the case clauses. By convention, it is expected to be the last clause.
     /// If a switch statement should have a default clause, it’s considered a best practice to define it as the last clause.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
-    ///
     /// ```javascript
     /// switch (foo) {
     ///     default:
@@ -53,7 +52,6 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Examples of **correct** code for this rule:
-    ///
     /// ```javascript
     /// switch (foo) {
     ///     case 1:

--- a/crates/oxc_linter/src/rules/eslint/default_param_last.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_param_last.rs
@@ -23,10 +23,9 @@ declare_oxc_lint!(
     ///
     /// Putting default parameter at last allows function calls to omit optional tail arguments.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
-    ///
     /// ```javascript
     /// // Incorrect: optional argument can **not** be omitted
     /// function createUser(isAdmin = false, id) {}
@@ -34,7 +33,6 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Examples of **correct** code for this rule:
-    ///
     /// ```javascript
     /// function createUser(id, isAdmin = false) {}
     /// createUser("tabby")

--- a/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
+++ b/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
@@ -35,7 +35,6 @@ declare_oxc_lint!(
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
-    ///
     /// ```js
     /// const a = [];
     /// const b = true;
@@ -44,7 +43,6 @@ declare_oxc_lint!(
     /// The above will evaluate to `true`, but that is almost surely not what you want.
     ///
     /// Examples of **correct** code for this rule:
-    ///
     /// ```js
     /// const a = [];
     /// const b = true;

--- a/crates/oxc_linter/src/rules/eslint/for_direction.rs
+++ b/crates/oxc_linter/src/rules/eslint/for_direction.rs
@@ -26,9 +26,11 @@ pub struct ForDirection;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow `for` loop update causing the counter to move in the wrong direction.
     ///
     /// ### Why is this bad?
+    ///
     /// A `for` loop with a stop condition that can never be reached, such as one
     /// with a counter that moves in the wrong direction, will run infinitely.
     /// While there are occasions when an infinite loop is intended, the
@@ -41,7 +43,7 @@ declare_oxc_lint!(
     /// that the counter is greater than zero (`i >= 0`) then the loop will never
     /// exit.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```js

--- a/crates/oxc_linter/src/rules/eslint/func_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/func_names.rs
@@ -93,7 +93,7 @@ declare_oxc_lint!(
     /// - `"never"` requires a function expression to not have a name under any
     ///    circumstances.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     ///

--- a/crates/oxc_linter/src/rules/eslint/func_style.rs
+++ b/crates/oxc_linter/src/rules/eslint/func_style.rs
@@ -64,9 +64,11 @@ pub struct FuncStyle {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Enforce the consistent use of either function declarations or expressions assigned to variables
     ///
     /// ### Why is this bad?
+    ///
     /// This rule enforces a particular type of function style, either function declarations or expressions assigned to variables.
     /// You can specify which you prefer in the configuration.
     ///

--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -46,12 +46,13 @@ declare_oxc_lint!(
     /// Requires all getters to have a `return` statement.
     ///
     /// ### Why is this bad?
+    ///
     /// Getters should always return a value. If they don't, it's probably a mistake.
     ///
     /// This rule does not run on TypeScript files, since type checking will
     /// catch getters that do not return a value.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/eslint/grouped_accessor_pairs.rs
+++ b/crates/oxc_linter/src/rules/eslint/grouped_accessor_pairs.rs
@@ -55,9 +55,11 @@ pub struct GroupedAccessorPairs {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Require grouped accessor pairs in object literals and classes
     ///
     /// ### Why is this bad?
+    ///
     /// While it is allowed to define the pair for a getter or a setter anywhere in an object or class definition,
     /// it’s considered a best practice to group accessor functions for the same property.
     ///

--- a/crates/oxc_linter/src/rules/eslint/init_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/init_declarations.rs
@@ -44,9 +44,11 @@ pub struct InitDeclarations {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Require or disallow initialization in variable declarations
     ///
     /// ### Why is this bad?
+    ///
     /// In JavaScript, variables can be assigned during declaration, or at any point afterwards using an assignment statement.
     /// For example, in the following code, foo is initialized during declaration, while bar is initialized later.
     ///

--- a/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
@@ -46,7 +46,9 @@ declare_oxc_lint!(
     /// Files containing multiple classes can often result in a less navigable and poorly
     /// structured codebase. Best practice is to keep each file limited to a single responsibility.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// class Foo {}
     /// class Bar {}

--- a/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
@@ -53,6 +53,16 @@ declare_oxc_lint!(
     /// class Foo {}
     /// class Bar {}
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    ///
+    /// function foo() {
+    ///     var bar = 1;
+    ///     let baz = 2;
+    ///     const qux = 3;
+    /// }
+    /// ```
     MaxClassesPerFile,
     eslint,
     pedantic,

--- a/crates/oxc_linter/src/rules/eslint/max_lines.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_lines.rs
@@ -37,6 +37,7 @@ impl Default for MaxLinesConfig {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Enforce a maximum number of lines per file.
     ///
     /// ### Why is this bad?

--- a/crates/oxc_linter/src/rules/eslint/no_alert.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_alert.rs
@@ -17,6 +17,7 @@ pub struct NoAlert;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow the use of alert, confirm, and prompt
     ///
     /// ### Why is this bad?

--- a/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
@@ -20,6 +20,7 @@ pub struct NoArrayConstructor;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallows creating arrays with the `Array` constructor.
     ///
     /// ### Why is this bad?

--- a/crates/oxc_linter/src/rules/eslint/no_await_in_loop.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_await_in_loop.rs
@@ -25,7 +25,7 @@ declare_oxc_lint!(
     /// It potentially indicates that the async operations are not being effectively parallelized.
     /// Instead, they are being run in series, which can lead to poorer performance.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/eslint/no_caller.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_caller.rs
@@ -36,7 +36,7 @@ declare_oxc_lint!(
     /// code by disallowing the use of `arguments.caller` and `arguments.callee`. As
     /// such, it will warn when `arguments.caller` and `arguments.callee` are used.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```js

--- a/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
@@ -44,6 +44,27 @@ declare_oxc_lint!(
     ///       class C {}
     /// }
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// switch (foo) {
+    ///   case 1: {
+    ///       let x = 1;
+    ///       break;
+    ///   }
+    ///   case 2: {
+    ///       const y = 2;
+    ///       break;
+    ///   }
+    ///   case 3: {
+    ///       function f() {}
+    ///       break;
+    ///   }
+    ///   default: {
+    ///       class C {}
+    ///   }
+    /// }
+    /// ```
     NoCaseDeclarations,
     eslint,
     pedantic

--- a/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
@@ -17,14 +17,18 @@ pub struct NoCaseDeclarations;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow lexical declarations in case clauses.
     ///
     /// ### Why is this bad?
+    ///
     /// The reason is that the lexical declaration is visible
     /// in the entire switch block but it only gets initialized when it is assigned,
     /// which will only happen if the case where it is defined is reached.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// switch (foo) {
     ///   case 1:

--- a/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
@@ -40,8 +40,9 @@ declare_oxc_lint!(
     /// statements. However, it can be difficult to tell whether a specific
     /// assignment was intentional.
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```js
     /// // Check the user's job title
     /// if (user.jobTitle = "manager") {

--- a/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
@@ -49,6 +49,14 @@ declare_oxc_lint!(
     ///     // user.jobTitle is now incorrect
     /// }
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// // Check the user's job title
+    /// if (user.jobTitle === "manager") {
+    ///     // correctly compared `jobTitle`
+    /// }
+    /// ```
     NoCondAssign,
     eslint,
     correctness

--- a/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
@@ -20,13 +20,15 @@ pub struct NoConstAssign;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow reassigning `const` variables.
     ///
     /// ### Why is this bad?
+    ///
     /// We cannot modify variables that are declared using const keyword.
     /// It will raise a runtime error.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```js

--- a/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
@@ -18,9 +18,11 @@ pub struct NoConstantBinaryExpression;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow expressions where the operation doesn't affect the value
     ///
     /// ### Why is this bad?
+    ///
     /// Comparisons which will always evaluate to true or false and logical expressions (`||`, `&&`, `??`) which either always
     /// short-circuit or never short-circuit are both likely indications of programmer error.
     ///
@@ -30,7 +32,9 @@ declare_oxc_lint!(
     /// In JavaScript, where objects are compared by reference, a newly constructed object can never `===` any other value.
     /// This can be surprising for programmers coming from languages where objects are compared by value.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// // One might think this would evaluate as `a + (b ?? c)`:
     /// const x = a + b ?? c;

--- a/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
@@ -47,6 +47,13 @@ declare_oxc_lint!(
     ///
     /// // However, this will always result in `isEmpty` being `false`.
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// const x = a + (b ?? c);
+    ///
+    /// const isEmpty = x.length === 0;
+    /// ```
     NoConstantBinaryExpression,
     eslint,
     correctness

--- a/crates/oxc_linter/src/rules/eslint/no_continue.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_continue.rs
@@ -38,6 +38,16 @@ declare_oxc_lint!(
     ///     sum += i;
     /// }
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// var sum = 0, i;
+    /// for(i = 0; i < 10; i++) {
+    ///   if (i < 5) {
+    ///     sum += i;
+    ///   }
+    /// }
+    /// ```
     NoContinue,
     eslint,
     style

--- a/crates/oxc_linter/src/rules/eslint/no_continue.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_continue.rs
@@ -16,12 +16,16 @@ pub struct NoContinue;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow `continue` statements
     ///
     /// ### Why is this bad?
+    ///
     /// The continue statement terminates execution of the statements in the current iteration of the current or labeled loop, and continues execution of the loop with the next iteration. When used incorrectly it makes code less testable, less readable and less maintainable. Structured control flow statements such as if should be used instead.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// var sum = 0,
     ///     i;

--- a/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
@@ -97,10 +97,9 @@ declare_oxc_lint!(
     /// regular expression containing elements that explicitly match these
     /// characters is most likely a mistake.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
-    ///
     /// ```javascript
     /// var pattern1 = /\x00/;
     /// var pattern2 = /\x0C/;
@@ -112,7 +111,6 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Examples of **correct** code for this rule:
-    ///
     /// ```javascript
     /// var pattern1 = /\x20/;
     /// var pattern2 = /\u0020/;

--- a/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
@@ -31,6 +31,14 @@ declare_oxc_lint!(
     /// var x;
     /// delete x;
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// var x;
+    ///
+    /// var y;
+    /// delete y.prop;
+    /// ```
     NoDeleteVar,
     eslint,
     correctness

--- a/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
@@ -24,7 +24,7 @@ declare_oxc_lint!(
     /// Using the `delete` operator on a variable might lead to unexpected
     /// behavior.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/eslint/no_div_regex.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_div_regex.rs
@@ -31,6 +31,11 @@ declare_oxc_lint!(
     /// ```javascript
     /// function bar() { return /=foo/; }
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// function bar() { return /[=]foo/; }
+    /// ```
     NoDivRegex,
     eslint,
     restriction,

--- a/crates/oxc_linter/src/rules/eslint/no_div_regex.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_div_regex.rs
@@ -25,7 +25,9 @@ declare_oxc_lint!(
     /// Characters /= at the beginning of a regular expression literal can be confused with a
     /// division assignment operator.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// function bar() { return /=foo/; }
     /// ```

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
@@ -23,13 +23,17 @@ pub struct NoDupeClassMembers;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow duplicate class members
     ///
     /// ### Why is this bad?
+    ///
     /// If there are declarations of the same name in class members,
     /// the last declaration overwrites other declarations silently. It can cause unexpected behaviors.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// class A {
     ///   foo() { console.log("foo") }

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
@@ -42,6 +42,15 @@ declare_oxc_lint!(
     /// let a = new A();
     /// a.foo() // Uncaught TypeError: a.foo is not a function
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// class A {
+    ///   foo() { console.log("foo") }
+    /// }
+    /// let a = new A();
+    /// a.foo();
+    /// ```
     NoDupeClassMembers,
     eslint,
     correctness

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_else_if.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_else_if.rs
@@ -29,7 +29,6 @@ declare_oxc_lint!(
     /// Two identical test conditions in the same chain are almost always a mistake in the code. Unless there are side effects in the expressions,
     /// a duplicate will evaluate to the same true or false value as the identical expression earlier in the chain, meaning that its branch can never execute.
     ///
-    ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_keys.rs
@@ -34,7 +34,7 @@ declare_oxc_lint!(
     /// It is safe to disable this rule when using TypeScript because
     /// TypeScript's compiler enforces this check.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```js

--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_case.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_case.rs
@@ -24,7 +24,7 @@ declare_oxc_lint!(
     /// If a switch statement has duplicate test expressions in case clauses,
     /// it is likely that a programmer copied a case clause but forgot to change the test expression.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```js

--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
@@ -39,6 +39,7 @@ declare_oxc_lint!(
     /// Disallow duplicate module imports.
     ///
     /// ### Why is this bad?
+    ///
     /// Using a single import statement per module will make the code clearer because you can see
     /// everything being imported from that module on one line.
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_else_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_else_return.rs
@@ -13,9 +13,11 @@ pub struct NoElseReturn {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow `else` blocks after `return` statements in `if` statements
     ///
     /// ### Why is this bad?
+    ///
     /// If an `if` block contains a `return` statement, the `else` block becomes
     /// unnecessary. Its contents can be placed outside of the block.
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_empty.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty.rs
@@ -34,6 +34,13 @@ declare_oxc_lint!(
     ///
     /// }
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// if (condition) {
+    ///   throw new Error("condition should be false")
+    /// }
+    /// ```
     NoEmpty,
     eslint,
     restriction,

--- a/crates/oxc_linter/src/rules/eslint/no_empty.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty.rs
@@ -18,13 +18,17 @@ pub struct NoEmpty {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallows empty block statements
     ///
     /// ### Why is this bad?
+    ///
     /// Empty block statements, while not technically errors, usually occur due to refactoring that wasn’t completed.
     /// They can cause confusion when reading code.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// if (condition) {
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
@@ -22,12 +22,16 @@ pub struct NoEmptyCharacterClass;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow empty character classes in regular expressions
     ///
     /// ### Why is this bad?
+    ///
     /// Because empty character classes in regular expressions do not match anything, they might be typing mistakes.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// var foo = /^abc[]/;
     /// ```

--- a/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
@@ -35,6 +35,12 @@ declare_oxc_lint!(
     /// ```javascript
     /// var foo = /^abc[]/;
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// var foo = /^abc/;
+    /// var foo2 = /^abc[123]/;
+    /// ```
     NoEmptyCharacterClass,
     eslint,
     correctness

--- a/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
@@ -96,9 +96,11 @@ impl TryFrom<&str> for Allowed {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallows the usages of empty functions
     ///
     /// ### Why is this bad?
+    ///
     /// Empty functions can reduce readability because readers need to guess whether it's
     /// intentional or not. So writing a clear comment for empty functions is a good practice.
     ///
@@ -130,7 +132,7 @@ declare_oxc_lint!(
     /// - `"decoratedFunctions"`
     /// - `"overrideMethods"`
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```typescript

--- a/crates/oxc_linter/src/rules/eslint/no_empty_pattern.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_pattern.rs
@@ -16,9 +16,11 @@ pub struct NoEmptyPattern;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow empty destructuring patterns
     ///
     /// ### Why is this bad?
+    ///
     /// When using destructuring, it’s possible to create a pattern that has no effect.
     /// This happens when empty curly braces are used to the right of
     /// an embedded object destructuring pattern, such as:
@@ -67,7 +69,6 @@ declare_oxc_lint!(
     /// function foo({a = {}}) {}
     /// function foo({a = []}) {}
     /// ```
-    ///
     NoEmptyPattern,
     eslint,
     correctness,

--- a/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
@@ -16,14 +16,16 @@ pub struct NoEmptyStaticBlock;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallows the usages of empty static blocks
     ///
     /// ### Why is this bad?
+    ///
     /// Empty block statements, while not technically errors, usually occur due
     /// to refactoring that wasn’t completed.  They can cause confusion when
     /// reading code.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```js

--- a/crates/oxc_linter/src/rules/eslint/no_eq_null.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eq_null.rs
@@ -19,14 +19,16 @@ pub struct NoEqNull;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow `null` comparisons without type-checking operators.
     ///
     /// ### Why is this bad?
+    ///
     /// Comparing to `null` without a type-checking operator (`==` or `!=`), can
     /// have unintended results as the comparison will evaluate to `true` when
     /// comparing to not just a `null`, but also an `undefined` value.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```js

--- a/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
@@ -35,6 +35,15 @@ declare_oxc_lint!(
     ///     e = 10;
     /// }
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// try {
+    ///     // code
+    /// } catch (e) {
+    ///     let val = 10;
+    /// }
+    /// ```
     NoExAssign,
     eslint,
     correctness

--- a/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
@@ -14,16 +14,20 @@ pub struct NoExAssign;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow reassigning exceptions in catch clauses
     ///
     /// ### Why is this bad?
+    ///
     /// If a catch clause in a try statement accidentally
     /// (or purposely) assigns another value to the exception parameter,
     /// it is impossible to refer to the error from that point on.
     /// Since there is no arguments object to offer alternative access to this data,
     /// assignment of the parameter is absolutely destructive.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// try {
     ///     // code

--- a/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
@@ -37,13 +37,17 @@ pub struct NoExtraBooleanCast {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// This rule disallows unnecessary boolean casts.
     ///
     /// ### Why is this bad?
+    ///
     /// In contexts such as an if statement's test where the result of the expression will already be coerced to a Boolean,
     /// casting to a Boolean via double negation (!!) or a Boolean call is unnecessary.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// var foo = !!!bar;
     /// var foo = Boolean(!!bar);

--- a/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
@@ -58,6 +58,18 @@ declare_oxc_lint!(
     /// // with "enforceForLogicalOperands" option enabled
     /// if (!!foo || bar) {}
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// var foo = !bar;
+    /// var foo = Boolean(bar);
+    ///
+    /// if (foo) {}
+    /// if (foo) {}
+    ///
+    /// // with "enforceForLogicalOperands" option enabled
+    /// if (foo || bar) {}
+    /// ```
     NoExtraBooleanCast,
     eslint,
     correctness,

--- a/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
@@ -160,7 +160,7 @@ declare_oxc_lint!(
     /// is clear that the first case is meant to fall through to the second
     /// case.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```js

--- a/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
@@ -16,6 +16,7 @@ pub struct NoFuncAssign;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow reassigning `function` declarations
     ///
     /// ### Why is this bad?

--- a/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
@@ -27,12 +27,16 @@ impl std::ops::Deref for NoGlobalAssign {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow modifications to read-only global variables.
     ///
     /// ### Why is this bad?
+    ///
     /// In almost all cases, you don’t want to assign a value to these global variables as doing so could result in losing access to important functionality.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// Object = null
     /// ```

--- a/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
@@ -25,8 +25,9 @@ declare_oxc_lint!(
     ///
     /// The updates of imported bindings by ES Modules cause runtime errors.
     ///
+    /// ### Examples
     ///
-    /// ### Example
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// import mod, { named } from "./mod.mjs"
     /// import * as mod_ns from "./mod.mjs"

--- a/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
@@ -44,6 +44,14 @@ declare_oxc_lint!(
     ///     function doSomethingElse () { }
     /// }
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// function doSomethingElse () { }
+    /// if (test) {
+    ///   // your code here
+    /// }
+    /// ```
     NoInnerDeclarations,
     eslint,
     pedantic

--- a/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
@@ -36,8 +36,9 @@ declare_oxc_lint!(
     /// This is often undesirable due to variable hoisting, and moving declarations to the root of the program or function body can increase clarity.
     /// Note that block bindings (let, const) are not hoisted and therefore they are not affected by this rule.
     ///
+    /// ### Examples
     ///
-    /// ### Example
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// if (test) {
     ///     function doSomethingElse () { }

--- a/crates/oxc_linter/src/rules/eslint/no_invalid_regexp.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_invalid_regexp.rs
@@ -28,9 +28,11 @@ pub struct NoInvalidRegexp(Box<NoInvalidRegexpConfig>);
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow invalid regular expression strings in RegExp constructors.
     ///
     /// ### Why is this bad?
+    ///
     /// An invalid pattern in a regular expression literal is a SyntaxError when the code is parsed,
     /// but an invalid string in RegExp constructors throws a SyntaxError only when the code is executed.
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
@@ -15,13 +15,16 @@ pub struct NoIrregularWhitespace;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallows the use of irregular whitespaces in the code.
     ///
     /// ### Why is this bad
     /// The use of irregular whitespaces can hinder code readability and
     /// create inconsistencies, making maintenance and collaboration more challenging.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// function  invalidExample  (  ) {
     ///     return  42;

--- a/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
@@ -30,6 +30,12 @@ declare_oxc_lint!(
     ///     return  42;
     /// }
     /// ```
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// function invalidExample () {
+    ///     return 42;
+    /// }
+    /// ```
     NoIrregularWhitespace,
     eslint,
     correctness

--- a/crates/oxc_linter/src/rules/eslint/no_iterator.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_iterator.rs
@@ -33,7 +33,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/eslint/no_label_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_label_var.rs
@@ -26,7 +26,7 @@ declare_oxc_lint!(
     /// This rule aims to create clearer code by disallowing the bad practice of creating a label
     /// that shares a name with a variable that is in scope.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```js

--- a/crates/oxc_linter/src/rules/eslint/no_multi_str.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_multi_str.rs
@@ -23,7 +23,9 @@ declare_oxc_lint!(
     /// Some consider this to be a bad practice as it was an undocumented feature of JavaScript
     /// that was only formalized later.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// var x = "Line 1 \
     ///  Line 2";

--- a/crates/oxc_linter/src/rules/eslint/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_negated_condition.rs
@@ -27,7 +27,7 @@ declare_oxc_lint!(
     ///
     /// Negated conditions are more difficult to understand. Code can be made more readable by inverting the condition.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
@@ -23,7 +23,7 @@ declare_oxc_lint!(
     /// functions and not classes.  It is easy to make this mistake by assuming
     /// the uppercase letters indicate classes.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```js

--- a/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
@@ -43,7 +43,7 @@ declare_oxc_lint!(
     ///
     /// https://eslint.org/docs/latest/rules/no-new-wrappers
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```js

--- a/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
@@ -23,26 +23,22 @@ pub struct NoNonoctalDecimalEscape;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// This rule disallows \8 and \9 escape sequences in string literals
     ///
     /// ### Why is this bad?
+    ///
     /// ECMAScript specification treats \8 and \9 in string literals as a legacy feature
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
-    ///
-    /// <!-- prettier-ignore-start -->
-    ///
     /// ```javascript
     /// let x = "\8"
     /// let y = "\9"
     /// ```
     ///
-    /// <!-- prettier-ignore-end -->
-    ///
     /// Examples of **correct** code for this rule:
-    ///
     /// ```javascript
     /// let x = "8"
     /// let y = "\\9"

--- a/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
@@ -29,13 +29,15 @@ impl Default for NoObjCalls {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow calling some global objects as functions
     ///
     /// ### Why is this bad?
+    ///
     /// Some global objects are not intended to be called as functions.
     /// Calling them as functions will usually result in a TypeError being thrown.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/eslint/no_proto.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_proto.rs
@@ -16,14 +16,18 @@ pub struct NoProto;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow the use of the `__proto__` property
     ///
     /// ### Why is this bad?
+    ///
     /// The `__proto__` property has been deprecated as of ECMAScript 3.1 and
     /// shouldn’t be used in new code. Use `Object.getPrototypeOf` and
     /// `Object.setPrototypeOf` instead.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// /*eslint no-proto: "error"*/
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_prototype_builtins.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_prototype_builtins.rs
@@ -33,8 +33,9 @@ declare_oxc_lint!(
     ///
     /// To avoid subtle bugs like this, it’s better to always call these methods from Object.prototype. For example, foo.hasOwnProperty("bar") should be replaced with Object.prototype.hasOwnProperty.call(foo, "bar").
     ///
+    /// ### Examples
     ///
-    /// ### Example
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// var hasBarProperty = foo.hasOwnProperty("bar");
     /// var isPrototypeOfBar = foo.isPrototypeOf(bar);

--- a/crates/oxc_linter/src/rules/eslint/no_regex_spaces.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_regex_spaces.rs
@@ -25,6 +25,7 @@ pub struct NoRegexSpaces;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow 2+ consecutive spaces in regular expressions.
     ///
     /// ### Why is this bad?
@@ -37,7 +38,9 @@ declare_oxc_lint!(
     /// var re = /foo {3}bar/;
     /// ```
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// var re = /foo   bar/;
     /// ```

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
@@ -231,10 +231,12 @@ enum GlobResult {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// This rule allows you to specify imports that you don’t want to use in your application.
     /// It applies to static imports only, not dynamic ones.
     ///
     /// ### Why is this bad?
+    ///
     /// Some imports might not make sense in a particular environment.
     /// For example, Node.js’ fs module would not make sense in an environment that didn’t have a file system.
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_return_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_return_assign.rs
@@ -19,9 +19,11 @@ pub struct NoReturnAssign {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallows assignment operators in return statements
     ///
     /// ### Why is this bad?
+    ///
     /// Assignment is allowed by js in return expressions, but usually, an expression with only one equal sign is intended to be a comparison.
     /// However, because of the missing equal sign, this turns to assignment, which is valid js code
     /// Because of this ambiguity, it’s considered a best practice to not use assignment in return statements.

--- a/crates/oxc_linter/src/rules/eslint/no_script_url.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_script_url.rs
@@ -17,9 +17,11 @@ pub struct NoScriptUrl;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow javascript: urls
     ///
     /// ### Why is this bad?
+    ///
     /// Using `javascript:` URLs is considered by some as a form of `eval`. Code
     /// passed in `javascript:` URLs must be parsed and evaluated by the browser
     /// in the same way that `eval` is processed. This can lead to security and

--- a/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
@@ -24,7 +24,7 @@ declare_oxc_lint!(
     /// Comparing a variable against itself is usually an error, either a typo or refactoring error.
     /// It is confusing to the reader and may potentially introduce a runtime error.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
@@ -23,8 +23,9 @@ declare_oxc_lint!(
     /// being ignored. Therefore, returning a value from a setter is either unnecessary or a
     /// possible error, since the returned value cannot be used.
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// class URL {
     ///   set origin() {

--- a/crates/oxc_linter/src/rules/eslint/no_sparse_arrays.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_sparse_arrays.rs
@@ -30,7 +30,6 @@ declare_oxc_lint!(
     /// avoid using them unless you are certain that they are useful in your
     /// code.
     ///
-    ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:

--- a/crates/oxc_linter/src/rules/eslint/no_ternary.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ternary.rs
@@ -16,6 +16,7 @@ pub struct NoTernary;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow ternary operators
     ///
     /// ### Why is this bad?

--- a/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
@@ -25,13 +25,17 @@ pub struct NoThisBeforeSuper;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Requires calling `super()` before using `this` or `super`.
     ///
     /// ### Why is this bad?
+    ///
     /// Getters should always return a value.
     /// If they don't, it's probably a mistake.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// class A1 extends B {
     ///     constructor() {

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -24,7 +24,9 @@ declare_oxc_lint!(
     ///
     /// It is most likely a potential ReferenceError caused by a misspelling of a variable or parameter name.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// var foo = someFunction();
     /// var bar = a + 1;

--- a/crates/oxc_linter/src/rules/eslint/no_undefined.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undefined.rs
@@ -14,6 +14,7 @@ fn no_undefined_diagnostic(span: Span) -> OxcDiagnostic {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow the use of `undefined` as an identifier
     ///
     /// ### Why is this bad?
@@ -51,7 +52,6 @@ declare_oxc_lint!(
     ///
     /// bar(void 0, "lorem");
     /// ```
-    ///
     NoUndefined,
     eslint,
     restriction,

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
@@ -27,7 +27,9 @@ declare_oxc_lint!(
     /// JavaScript suspends the control flow statements of try and catch blocks until the execution of finally block finishes.
     /// So, when return, throw, break, or continue is used in finally, control flow statements inside try and catch are overwritten, which is considered as unexpected behavior.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// // We expect this function to return 1;
     /// (() => {

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
@@ -42,7 +42,9 @@ declare_oxc_lint!(
     /// Therefore, treating an evaluated optional chaining expression as a function, object, number, etc.,
     /// can cause TypeError or unexpected results. For example:
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// var obj = undefined;
     /// 1 in obj?.foo;  // TypeError

--- a/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
@@ -22,7 +22,9 @@ declare_oxc_lint!(
     ///
     /// Labels that are declared and not used anywhere in the code are most likely an error due to incomplete refactoring.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// OUTER_LOOP:
     /// for (const student of students) {

--- a/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
@@ -34,6 +34,16 @@ declare_oxc_lint!(
     ///     doSomething(student);
     /// }
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// for (const student of students) {
+    ///     if (checkScores(student.scores)) {
+    ///         continue;
+    ///     }
+    ///     doSomething(student);
+    /// }
+    /// ```
     NoUnusedLabels,
     eslint,
     correctness,

--- a/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
@@ -82,7 +82,6 @@ declare_oxc_lint!(
     ///					this.#usedAccessor = 42;
     ///			}
     ///	}
-    ///
     /// ```
     NoUnusedPrivateClassMembers,
     eslint,

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -91,7 +91,7 @@ declare_oxc_lint!(
     /// and should not be considered unused. Since ES6 modules are now a TC39
     /// standard, Oxlint does not support this feature.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_useless_backreference.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_backreference.rs
@@ -62,7 +62,6 @@ declare_oxc_lint!(
     /// /(?<name>a)\k<name>/;        // named group used properly
     /// /(?:a|(b))\1/;               // backreference only used when group matches
     /// ```
-    ///
     NoUselessBackreference,
     eslint,
     correctness

--- a/crates/oxc_linter/src/rules/eslint/no_useless_call.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_call.rs
@@ -21,9 +21,11 @@ pub struct NoUselessCall;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow unnecessary calls to `.call()` and `.apply()`
     ///
     /// ### Why is this bad?
+    ///
     /// `Function.prototype.call()` and `Function.prototype.apply()` are slower than the normal function invocation.
     ///
     /// This rule compares code statically to check whether or not thisArg is changed.

--- a/crates/oxc_linter/src/rules/eslint/no_useless_catch.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_catch.rs
@@ -43,6 +43,11 @@ declare_oxc_lint!(
     ///   throw e;
     /// }
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// doSomethingThatMightThrow();
+    /// ```
     NoUselessCatch,
     eslint,
     correctness

--- a/crates/oxc_linter/src/rules/eslint/no_useless_catch.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_catch.rs
@@ -33,7 +33,9 @@ declare_oxc_lint!(
     /// These redundant clauses can be a source of confusion and code bloat,
     /// so it’s better to disallow these unnecessary catch clauses.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// try {
     ///   doSomethingThatMightThrow();

--- a/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
@@ -53,8 +53,7 @@ declare_oxc_lint!(
     /// such, it is unnecessary to provide an empty constructor or one that
     /// simply delegates into its parent class, as in the following examples:
     ///
-    ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
@@ -26,10 +26,9 @@ declare_oxc_lint!(
     /// ### Why is this bad?
     ///
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
-    ///
     /// ```javascript
     /// /*eslint no-useless-escape: "error"*/
     ///
@@ -47,7 +46,6 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Examples of **correct** code for this rule:
-    ///
     /// ```javascript
     /// /*eslint no-useless-escape: "error"*/
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
@@ -43,7 +43,7 @@ declare_oxc_lint!(
     ///
     /// It is unnecessary to rename a variable to the same name.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/eslint/no_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_var.rs
@@ -30,9 +30,12 @@ declare_oxc_lint!(
     /// programmers avoid mistakes.
     ///
     /// ### Why is this bad?
+    ///
     /// Using `var` in an es6 environment triggers this error
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// // error
     /// var x = "y";

--- a/crates/oxc_linter/src/rules/eslint/no_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_var.rs
@@ -37,11 +37,12 @@ declare_oxc_lint!(
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    /// // error
     /// var x = "y";
     /// var CONFIG = {};
+    /// ```
     ///
-    /// // success
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
     /// let x = "y";
     /// const CONFIG = {};
     /// ```

--- a/crates/oxc_linter/src/rules/eslint/no_with.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_with.rs
@@ -16,12 +16,16 @@ pub struct NoWith;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow `with` statements
     ///
     /// ### Why is this bad?
+    ///
     /// The with statement is potentially problematic because it adds members of an object to the current scope, making it impossible to tell what a variable inside the block actually refers to.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// with (point) {
     ///     r = Math.sqrt(x * x + y * y); // is r a member of point?

--- a/crates/oxc_linter/src/rules/eslint/prefer_exponentiation_operator.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_exponentiation_operator.rs
@@ -32,6 +32,11 @@ declare_oxc_lint!(
     /// ```javascript
     /// Math.pow(a, b)
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// a ** b
+    /// ```
     PreferExponentiationOperator,
     eslint,
     style,

--- a/crates/oxc_linter/src/rules/eslint/prefer_exponentiation_operator.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_exponentiation_operator.rs
@@ -26,7 +26,9 @@ declare_oxc_lint!(
     /// standard Math.pow function. Infix notation is considered to be more readable and thus more
     /// preferable than the function notation.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// Math.pow(a, b)
     /// ```

--- a/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
@@ -42,7 +42,9 @@ declare_oxc_lint!(
     /// in ES6, this rule encourages use of those numeric literals instead of parseInt() or
     /// Number.parseInt().
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// parseInt("111110111", 2) === 503;
     /// parseInt(`111110111`, 2) === 503;

--- a/crates/oxc_linter/src/rules/eslint/prefer_object_spread.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_object_spread.rs
@@ -25,9 +25,11 @@ pub struct PreferObjectSpread;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow using `Object.assign` with an object literal as the first argument and prefer the use of object spread instead
     ///
     /// ### Why is this bad?
+    ///
     /// When `Object.assign` is called using an object literal as the first argument, this rule requires using the object spread syntax instead. This rule also warns on cases where an `Object.assign` call is made using a single argument that is an object literal, in this case, the `Object.assign` call is not needed.
     ///
     /// ### Examples

--- a/crates/oxc_linter/src/rules/eslint/radix.rs
+++ b/crates/oxc_linter/src/rules/eslint/radix.rs
@@ -38,12 +38,16 @@ pub struct Radix {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Enforce the consistent use of the radix argument when using `parseInt()`.
     ///
     /// ### Why is this bad?
+    ///
     /// Using the `parseInt()` function without specifying the radix can lead to unexpected results.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// // error
     /// var num = parseInt("071");      // 57

--- a/crates/oxc_linter/src/rules/eslint/radix.rs
+++ b/crates/oxc_linter/src/rules/eslint/radix.rs
@@ -49,10 +49,11 @@ declare_oxc_lint!(
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    /// // error
     /// var num = parseInt("071");      // 57
+    /// ```
     ///
-    /// // success
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
     /// var num = parseInt("071", 10);  // 71
     /// ```
     Radix,

--- a/crates/oxc_linter/src/rules/eslint/require_await.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_await.rs
@@ -55,10 +55,9 @@ declare_oxc_lint!(
     /// yield all the values of another async generator without ever actually
     /// needing to use await.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
-    ///
     /// ```js
     /// async function foo() {
     ///     doSomething();
@@ -66,7 +65,6 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Examples of **correct** code for this rule:
-    ///
     /// ```js
     /// async function foo() {
     ///    await doSomething();

--- a/crates/oxc_linter/src/rules/eslint/require_yield.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_yield.rs
@@ -21,7 +21,9 @@ declare_oxc_lint!(
     ///
     /// Probably a mistake.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// function* foo() {
     ///   return 10;

--- a/crates/oxc_linter/src/rules/eslint/sort_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_imports.rs
@@ -67,7 +67,9 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// import {b, a, c} from 'foo.js'
     ///

--- a/crates/oxc_linter/src/rules/eslint/symbol_description.rs
+++ b/crates/oxc_linter/src/rules/eslint/symbol_description.rs
@@ -36,7 +36,9 @@ declare_oxc_lint!(
     /// // prints - Symbol(some description)
     /// ```
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// var foo = Symbol();
     /// ```

--- a/crates/oxc_linter/src/rules/eslint/symbol_description.rs
+++ b/crates/oxc_linter/src/rules/eslint/symbol_description.rs
@@ -43,7 +43,10 @@ declare_oxc_lint!(
     /// var foo = Symbol();
     /// ```
     ///
-    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// var foo = Symbol("some description");
+    /// ```
     SymbolDescription,
     eslint,
     pedantic,

--- a/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
+++ b/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
@@ -34,7 +34,9 @@ declare_oxc_lint!(
     /// single byte. Since UTF-8 is the dominant encoding of the web, we make "never" the default
     /// option.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ﻿var a = 123;
     /// ```

--- a/crates/oxc_linter/src/rules/eslint/use_isnan.rs
+++ b/crates/oxc_linter/src/rules/eslint/use_isnan.rs
@@ -51,9 +51,11 @@ impl Default for UseIsnan {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallows checking against NaN without using isNaN() call.
     ///
     /// ### Why is this bad?
+    ///
     /// In JavaScript, NaN is a special value of the Number type.
     /// It’s used to represent any of the “not-a-number” values represented
     /// by the double-precision 64-bit format as specified by the IEEE Standard
@@ -66,7 +68,9 @@ declare_oxc_lint!(
     ///
     /// Therefore, use Number.isNaN() or global isNaN() functions to test whether a value is NaN.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// foo == NaN;
     /// foo === NaN;

--- a/crates/oxc_linter/src/rules/eslint/yoda.rs
+++ b/crates/oxc_linter/src/rules/eslint/yoda.rs
@@ -27,12 +27,12 @@ pub struct Yoda {
 }
 
 declare_oxc_lint!(
-    /// ## What it does
+    /// ### What it does
     ///
     /// Require or disallow "Yoda" conditions.
     /// This rule aims to enforce consistent style of conditions which compare a variable to a literal value.
     ///
-    /// ## Why is this bad?
+    /// ### Why is this bad?
     ///
     /// Yoda conditions are so named because the literal value of the condition comes first while the variable comes second. For example, the following is a Yoda condition:
     /// ```js
@@ -50,7 +50,8 @@ declare_oxc_lint!(
     /// Proponents of Yoda conditions highlight that it is impossible to mistakenly use `=` instead of `==` because you cannot assign to a literal value. Doing so will cause a syntax error and you will be informed of the mistake early on. This practice was therefore very common in early programming where tools were not yet available.
     /// Opponents of Yoda conditions point out that tooling has made us better programmers because tools will catch the mistaken use of `=` instead of `==` (ESLint will catch this for you). Therefore, they argue, the utility of the pattern doesn't outweigh the readability hit the code takes while using Yoda conditions.
     ///
-    /// ## Options
+    /// ### Options
+    ///
     /// This rule can take a string option:
     /// * If it is the default `"never"`, then comparisons must never be Yoda conditions.
     /// * If it is `"always"`, then the literal value must always come first.
@@ -59,7 +60,8 @@ declare_oxc_lint!(
     /// * If the `"onlyEquality"` property is `true`, the rule reports yoda conditions *only* for the equality operators `==` and `===`. The default value is `false`.
     /// The `onlyEquality` option allows a superset of the exceptions which `exceptRange` allows, thus both options are not useful together.
     ///
-    /// ### never
+    /// #### never
+    ///
     /// Examples of **incorrect** code for the default `"never"` option:
     /// ```js
     /// if ("red" === color) {
@@ -90,7 +92,6 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Examples of **correct** code for the default `"never"` option:
-    ///
     /// ```js
     /// if (5 & value) {
     ///     // ...
@@ -109,10 +110,9 @@ declare_oxc_lint!(
     /// }
     /// ```
     ///
-    /// ### exceptRange
+    /// #### exceptRange
     ///
     /// Examples of **correct** code for the `"never", { "exceptRange": true }` options:
-    ///
     /// ```js
     /// function isReddish(color) {
     ///     return (color.hue < 60 || 300 < color.hue);
@@ -135,10 +135,9 @@ declare_oxc_lint!(
     /// }
     /// ```
     ///
-    /// ### onlyEquality
+    /// #### onlyEquality
     ///
     /// Examples of **correct** code for the `"never", { "onlyEquality": true }` options:
-    ///
     /// ```js
     /// if (x < -1 || 9 < x) {
     /// }
@@ -150,10 +149,9 @@ declare_oxc_lint!(
     /// }
     /// ```
     ///
-    /// ### always
+    /// #### always
     ///
     /// Examples of **incorrect** code for the `"always"` option:
-    ///
     /// ```js
     /// if (color == "blue") {
     ///     // ...
@@ -165,7 +163,6 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Examples of **correct** code for the `"always"` option:
-    ///
     /// ```js
     /// if ("blue" == value) {
     ///     // ...

--- a/crates/oxc_linter/src/rules/import/first.rs
+++ b/crates/oxc_linter/src/rules/import/first.rs
@@ -86,7 +86,6 @@ declare_oxc_lint!(
     /// import { y } from 'bar';
     /// import { x } from './foo'
     /// ```
-    ///
     First,
     import,
     style,

--- a/crates/oxc_linter/src/rules/import/no_commonjs.rs
+++ b/crates/oxc_linter/src/rules/import/no_commonjs.rs
@@ -44,7 +44,6 @@ declare_oxc_lint!(
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
-    ///
     /// ```js
     /// var mod = require("fs");
     ///
@@ -58,7 +57,6 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Examples of **correct** code for this rule:
-    ///
     /// ```js
     /// var a = b && require("c");
     ///
@@ -103,7 +101,6 @@ declare_oxc_lint!(
     /// module.exports = { x: "y" };
     /// exports.z = function bark() { /* ... */ };
     /// ```
-    ///
     NoCommonjs,
     import,
     restriction

--- a/crates/oxc_linter/src/rules/import/no_named_as_default.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default.rs
@@ -32,7 +32,6 @@ declare_oxc_lint!(
     /// code clarity, making it harder for other developers to understand the intended
     /// imports.
     ///
-    ///
     /// ### Examples
     ///
     /// Given

--- a/crates/oxc_linter/src/rules/import/no_named_default.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_default.rs
@@ -15,9 +15,11 @@ pub struct NoNamedDefault;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Reports use of a default export as a locally named import.
     ///
     /// ### Why is this bad?
+    ///
     /// Rationale: the syntax exists to import default exports expressively, let's use it.
     ///
     /// ### Examples

--- a/crates/oxc_linter/src/rules/import/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/import/no_namespace.rs
@@ -75,7 +75,6 @@ declare_oxc_lint!(
     /// import user from 'user-lib';
     /// import defaultExport, { isUser } from './user';
     /// ```
-    ///
     NoNamespace,
     import,
     style,

--- a/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
+++ b/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
@@ -107,7 +107,6 @@ declare_oxc_lint!(
     ///
     /// ### Examples
     ///
-    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// /*eslint jest/consistent-test-it: ["error", {"fn": "test"}]*/
     /// test('foo'); // valid

--- a/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
+++ b/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
@@ -105,8 +105,9 @@ declare_oxc_lint!(
     ///
     /// It's a good practice to be consistent in your test suite, so that all tests are written in the same way.
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// /*eslint jest/consistent-test-it: ["error", {"fn": "test"}]*/
     /// test('foo'); // valid

--- a/crates/oxc_linter/src/rules/jest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/expect_expect.rs
@@ -66,8 +66,9 @@ declare_oxc_lint!(
     ///
     ///  People may forget to add assertions.
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// it('should be a test', () => {
     ///     console.log('no assertion');

--- a/crates/oxc_linter/src/rules/jest/max_expects.rs
+++ b/crates/oxc_linter/src/rules/jest/max_expects.rs
@@ -30,6 +30,7 @@ impl Default for MaxExpects {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// As more assertions are made, there is a possible tendency for the test to be
     /// more likely to mix multiple objectives. To avoid this, this rule reports when
     /// the maximum number of assertions is exceeded.
@@ -39,8 +40,9 @@ declare_oxc_lint!(
     /// This rule enforces a maximum number of `expect()` calls.
     /// The following patterns are considered warnings (with the default option of `{ "max": 5 } `):
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// test('should not pass', () => {
     ///     expect(true).toBeDefined();

--- a/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
@@ -115,7 +115,6 @@ declare_oxc_lint!(
     ///     });
     /// });
     /// ```
-    ///
     MaxNestedDescribe,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/no_commented_out_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_commented_out_tests.rs
@@ -25,8 +25,9 @@ declare_oxc_lint!(
     /// You may forget to uncomment some tests. This rule raises a warning about commented out tests. It's similar to
     /// no-disabled-tests rule.
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// // describe('foo', () => {});
     /// // it('foo', () => {});

--- a/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
+++ b/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
@@ -36,6 +36,7 @@ impl std::ops::Deref for NoDeprecatedFunctions {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Over the years Jest has accrued some debt in the form of functions that have
     /// either been renamed for clarity, or replaced with more powerful APIs.
     ///
@@ -67,7 +68,9 @@ declare_oxc_lint!(
     /// While typically these deprecated functions are kept in the codebase for a number
     /// of majors, eventually they are removed completely.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// jest.resetModuleRegistry // since Jest 15
     /// jest.addMatchers // since Jest 17

--- a/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
@@ -17,6 +17,7 @@ pub struct NoDisabledTests;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// This rule raises a warning about disabled tests.
     ///
     /// ### Why is this bad?

--- a/crates/oxc_linter/src/rules/jest/no_done_callback.rs
+++ b/crates/oxc_linter/src/rules/jest/no_done_callback.rs
@@ -56,7 +56,9 @@ declare_oxc_lint!(
     ///
     /// This can be very error-prone however, as it requires careful understanding of how assertions work in tests or otherwise tests won't behave as expected.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// beforeEach(done => {
     ///   // ...

--- a/crates/oxc_linter/src/rules/jest/no_duplicate_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_duplicate_hooks.rs
@@ -32,7 +32,7 @@ declare_oxc_lint!(
     ///
     /// Having duplicate hooks in a describe block can lead to confusion and unexpected behavior.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/jest/no_export.rs
+++ b/crates/oxc_linter/src/rules/jest/no_export.rs
@@ -24,7 +24,9 @@ declare_oxc_lint!(
     ///  If you import from a test file, then all the tests in that file will be run in each imported instance.
     /// so bottom line, don't export from a test, but instead move helper functions into a separate file when they need to be shared across tests.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// export function myHelper() {}
     /// describe('a test', () => {

--- a/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
@@ -23,6 +23,7 @@ pub struct NoFocusedTests;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// This rule reminds you to remove `.only` from your tests by raising a warning
     /// whenever you are using the exclusivity feature.
     ///
@@ -34,8 +35,9 @@ declare_oxc_lint!(
     /// have fixed your test and before committing the changes you have to remove
     /// `.only` to ensure all tests are executed on your build system.
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// describe.only('foo', () => {});
     /// it.only('foo', () => {});

--- a/crates/oxc_linter/src/rules/jest/no_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_hooks.rs
@@ -46,8 +46,9 @@ declare_oxc_lint!(
     /// * `afterAll`
     /// * `afterEach`
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// function setupFoo(options) { /* ... */ }
     /// function setupBar(options) { /* ... */ }

--- a/crates/oxc_linter/src/rules/jest/no_identical_title.rs
+++ b/crates/oxc_linter/src/rules/jest/no_identical_title.rs
@@ -44,7 +44,9 @@ declare_oxc_lint!(
     /// Having identical titles for two different tests or test suites may create confusion.
     /// For example, when a test with the same title as another test in the same test suite fails, it is harder to know which one failed and thus harder to fix.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     ///  describe('baz', () => {
     ///    //...

--- a/crates/oxc_linter/src/rules/jest/no_interpolation_in_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_interpolation_in_snapshots.rs
@@ -29,8 +29,9 @@ declare_oxc_lint!(
     /// be overloaded with a matcher by using
     /// [property matchers](https://jestjs.io/docs/en/snapshot-testing#property-matchers).
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// expect(something).toMatchInlineSnapshot(
     ///   `Object {

--- a/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
+++ b/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
@@ -23,7 +23,9 @@ declare_oxc_lint!(
     ///
     /// This rule reports on any usage of Jasmine globals, which is not ported to Jest, and suggests alternatives from Jest's own API.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;
     /// test('my test', () => {

--- a/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
@@ -130,7 +130,6 @@ declare_oxc_lint!(
     /// line 4
     /// `;
     /// ```
-    ///
     NoLargeSnapshots,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
+++ b/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
@@ -26,7 +26,7 @@ declare_oxc_lint!(
     ///
     /// Manually importing mocks from a `__mocks__` directory can lead to unexpected behavior.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```ts

--- a/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
@@ -39,7 +39,9 @@ declare_oxc_lint!(
     ///
     /// Restrict the use of specific `jest` and `vi` methods.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// jest.useFakeTimers();
     /// it('calls the callback after 1 second via advanceTimersByTime', () => {

--- a/crates/oxc_linter/src/rules/jest/no_restricted_matchers.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_matchers.rs
@@ -49,7 +49,9 @@ declare_oxc_lint!(
     ///
     /// Ban specific matchers & modifiers from being used, and can suggest alternatives.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     ///
     /// it('is false', () => {
@@ -69,7 +71,6 @@ declare_oxc_lint!(
     ///   });
     /// });
     /// ```
-    ///
     NoRestrictedMatchers,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect/mod.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect/mod.rs
@@ -49,7 +49,9 @@ declare_oxc_lint!(
     /// Statements like `expect.hasAssertions()` will NOT trigger this rule since these
     /// calls will execute if they are not in a test block.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// describe('a test', () => {
     ///     expect(1).toBe(1);

--- a/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
+++ b/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
@@ -33,7 +33,9 @@ declare_oxc_lint!(
     ///
     /// This rule enforces usages from the only & skip list.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// fit('foo'); // invalid
     /// fdescribe('foo'); // invalid

--- a/crates/oxc_linter/src/rules/jest/no_test_return_statement.rs
+++ b/crates/oxc_linter/src/rules/jest/no_test_return_statement.rs
@@ -32,7 +32,9 @@ declare_oxc_lint!(
     /// If you are returning Promises then you should update the test to use
     /// `async/await`.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// test('one', () => {
     ///    return expect(1).toBe(1);

--- a/crates/oxc_linter/src/rules/jest/no_test_return_statement.rs
+++ b/crates/oxc_linter/src/rules/jest/no_test_return_statement.rs
@@ -40,6 +40,13 @@ declare_oxc_lint!(
     ///    return expect(1).toBe(1);
     /// });
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// test('one', () => {
+    ///    expect(1).toBe(1);
+    /// });
+    /// ```
     NoTestReturnStatement,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
+++ b/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
@@ -33,9 +33,9 @@ declare_oxc_lint!(
     /// strict type. Requiring a type makes it easier to use TypeScript to catch changes
     /// needed in test mocks when the source module changes.
     ///
-    /// ### Example
+    /// ### Examples
     ///
-    /// // invalid
+    /// Examples of **incorrect** code for this rule:
     /// ```typescript
     /// jest.mock('../moduleName', () => {
     ///     return jest.fn(() => 42);
@@ -51,9 +51,8 @@ declare_oxc_lint!(
     /// });
     /// ```
     ///
-    /// // valid
+    /// Examples of **correct** code for this rule:
     /// ```typescript
-    ///
     /// // Uses typeof import()
     /// jest.mock<typeof import('../moduleName')>('../moduleName', () => {
     ///     return jest.fn(() => 42);
@@ -81,7 +80,6 @@ declare_oxc_lint!(
     ///     { virtual: true },
     /// );
     /// ```
-    ///
     NoUntypedMockFactory,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/prefer_called_with.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_called_with.rs
@@ -36,7 +36,7 @@ declare_oxc_lint!(
     /// expect(someFunction).toBeCalled();
     /// expect(someFunction).toHaveBeenCalled();
     /// ```
-    /// 
+    ///
     /// Examples of **correct** code for this rule:
     /// ```javascript
     /// expect(noArgsFunction).toBeCalledWith();

--- a/crates/oxc_linter/src/rules/jest/prefer_called_with.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_called_with.rs
@@ -26,23 +26,24 @@ pub struct PreferCalledWith;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    ///
-    /// // valid
+    /// expect(someFunction).toBeCalled();
+    /// expect(someFunction).toHaveBeenCalled();
+    /// ```
+    /// 
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
     /// expect(noArgsFunction).toBeCalledWith();
     /// expect(roughArgsFunction).toBeCalledWith(expect.anything(), expect.any(Date));
     /// expect(anyArgsFunction).toBeCalledTimes(1);
     /// expect(uncalledFunction).not.toBeCalled();
-    ///
-    /// // invalid
-    /// expect(someFunction).toBeCalled();
-    /// expect(someFunction).toHaveBeenCalled();
     /// ```
-    ///
     PreferCalledWith,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/prefer_comparison_matcher.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_comparison_matcher.rs
@@ -38,22 +38,21 @@ declare_oxc_lint!(
     ///
     /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```js
-    /// // invalid
     /// expect(x > 5).toBe(true);
     /// expect(x < 7).not.toEqual(true);
     /// expect(x <= y).toStrictEqual(true);
     /// ```
     ///
-    /// ```js ///
-    /// // valid
+    /// Examples of **correct** code for this rule:
+    /// ```js
     /// expect(x).toBeGreaterThan(5);
     /// expect(x).not.toBeLessThanOrEqual(7);
     /// expect(x).toBeLessThanOrEqual(y);
     /// // special case - see below
     /// expect(x < 'Carl').toBe(true);
     /// ```
-    ///
     PreferComparisonMatcher,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/prefer_equality_matcher.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_equality_matcher.rs
@@ -24,18 +24,21 @@ pub struct PreferEqualityMatcher;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Jest has built-in matchers for expecting equality, which allow for more readable
     /// tests and error messages if an expectation fails.
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    /// // invalid
     /// expect(x === 5).toBe(true);
     /// expect(name === 'Carl').not.toEqual(true);
     /// expect(myObj !== thatObj).toStrictEqual(true);
-    ///
-    /// // valid
+    /// ```
+    /// 
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
     /// expect(x).toBe(5);
     /// expect(name).not.toEqual('Carl');
     /// expect(myObj).toStrictEqual(thatObj);

--- a/crates/oxc_linter/src/rules/jest/prefer_equality_matcher.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_equality_matcher.rs
@@ -36,7 +36,7 @@ declare_oxc_lint!(
     /// expect(name === 'Carl').not.toEqual(true);
     /// expect(myObj !== thatObj).toStrictEqual(true);
     /// ```
-    /// 
+    ///
     /// Examples of **correct** code for this rule:
     /// ```javascript
     /// expect(x).toBe(5);

--- a/crates/oxc_linter/src/rules/jest/prefer_expect_resolves.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_expect_resolves.rs
@@ -51,7 +51,7 @@ declare_oxc_lint!(
     ///     expect(await myPromise).toBe(true);
     /// });
     /// ```
-    /// 
+    ///
     /// Examples of **correct** code for this rule:
     /// ```javascript
     /// it('passes', async () => {

--- a/crates/oxc_linter/src/rules/jest/prefer_expect_resolves.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_expect_resolves.rs
@@ -39,10 +39,21 @@ declare_oxc_lint!(
     /// Additionally, favoring the first style ensures consistency with its `rejects`
     /// counterpart, as there is no way of "awaiting" a rejection.
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    /// // valid
+    /// it('passes', async () => {
+    ///     expect(await someValue()).toBe(true);
+    /// });
+    /// it('is true', async () => {
+    ///     const myPromise = Promise.resolve(true);
+    ///     expect(await myPromise).toBe(true);
+    /// });
+    /// ```
+    /// 
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
     /// it('passes', async () => {
     ///     await expect(someValue()).resolves.toBe(true);
     /// });
@@ -51,20 +62,10 @@ declare_oxc_lint!(
     ///
     ///     await expect(myPromise).resolves.toBe(true);
     /// });
-    ///
     /// it('errors', async () => {
     ///     await expect(Promise.reject(new Error('oh noes!'))).rejects.toThrowError(
     ///         'oh noes!',
     ///     );
-    /// });
-    ///
-    /// // invalid
-    /// it('passes', async () => {
-    ///     expect(await someValue()).toBe(true);
-    /// });
-    /// it('is true', async () => {
-    ///     const myPromise = Promise.resolve(true);
-    ///     expect(await myPromise).toBe(true);
     /// });
     /// ```
     PreferExpectResolves,

--- a/crates/oxc_linter/src/rules/jest/prefer_hooks_on_top.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_hooks_on_top.rs
@@ -83,7 +83,7 @@ declare_oxc_lint!(
     ///     });
     /// });
     /// ```
-    /// 
+    ///
     /// Examples of **correct** code for this rule:
     /// ```javascript
     /// describe('foo', () => {

--- a/crates/oxc_linter/src/rules/jest/prefer_hooks_on_top.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_hooks_on_top.rs
@@ -30,10 +30,10 @@ declare_oxc_lint!(
     /// specific order, which means it can be confusing if they're intermixed with test
     /// cases.
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    /// // invalid
     /// describe('foo', () => {
     ///     beforeEach(() => {
     ///         seedMyDatabase();
@@ -82,8 +82,10 @@ declare_oxc_lint!(
     ///         removeMyDatabase();
     ///     });
     /// });
-    ///
-    /// // valid
+    /// ```
+    /// 
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
     /// describe('foo', () => {
     ///     beforeAll(() => {
     ///         createMyDatabase();

--- a/crates/oxc_linter/src/rules/jest/prefer_jest_mocked.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_jest_mocked.rs
@@ -40,7 +40,7 @@ declare_oxc_lint!(
     /// (Obj.foo as jest.Mock).mockReturnValue(1);
     /// ([].foo as jest.Mock).mockReturnValue(1);
     /// ```
-    /// 
+    ///
     /// Examples of **correct** code for this rule:
     /// ```typescript
     /// jest.mocked(foo).mockReturnValue(1);

--- a/crates/oxc_linter/src/rules/jest/prefer_jest_mocked.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_jest_mocked.rs
@@ -25,8 +25,6 @@ declare_oxc_lint!(
     /// enforces the use of `jest.mocked()` for better type safety and readability.
     ///
     /// Restricted types:
-    ///
-    ///
     /// - `jest.Mock`
     /// - `jest.MockedFunction`
     /// - `jest.MockedClass`
@@ -34,15 +32,17 @@ declare_oxc_lint!(
     ///
     /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```typescript
-    /// // invalid
     /// (foo as jest.Mock).mockReturnValue(1);
     /// const mock = (foo as jest.Mock).mockReturnValue(1);
     /// (foo as unknown as jest.Mock).mockReturnValue(1);
     /// (Obj.foo as jest.Mock).mockReturnValue(1);
     /// ([].foo as jest.Mock).mockReturnValue(1);
-    ///
-    /// // valid
+    /// ```
+    /// 
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
     /// jest.mocked(foo).mockReturnValue(1);
     /// const mock = jest.mocked(foo).mockReturnValue(1);
     /// jest.mocked(Obj.foo).mockReturnValue(1);

--- a/crates/oxc_linter/src/rules/jest/prefer_lowercase_title/mod.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_lowercase_title/mod.rs
@@ -46,21 +46,23 @@ declare_oxc_lint!(
     /// lowercase letter. This provides more readable test failures. This rule is not
     /// enabled by default.
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    /// // invalid
     /// it('Adds 1 + 2 to equal 3', () => {
     ///     expect(sum(1, 2)).toBe(3);
     /// });
+    /// ```
     ///
-    /// // valid
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
     /// it('adds 1 + 2 to equal 3', () => {
     ///     expect(sum(1, 2)).toBe(3);
     /// });
     /// ```
     ///
-    /// ## Options
+    /// ### Options
     /// ```json
     /// {
     ///     "jest/prefer-lowercase-title": [
@@ -72,7 +74,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     ///
-    /// ### `ignore`
+    /// #### `ignore`
     ///
     /// This array option controls which Jest or Vitest functions are checked by this rule. There
     /// are four possible values:
@@ -91,7 +93,6 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Example of **correct** code for the `{ "ignore": ["test"] }` option:
-    ///
     /// ```js
     /// /* eslint jest/prefer-lowercase-title: ["error", { "ignore": ["test"] }] */
     /// test('Uppercase description');
@@ -103,7 +104,8 @@ declare_oxc_lint!(
     /// it('Uppercase description');
     /// ```
     ///
-    /// ### `allowedPrefixes`
+    /// #### `allowedPrefixes`
+    ///
     /// This array option allows specifying prefixes, which contain capitals that titles
     /// can start with. This can be useful when writing tests for API endpoints, where
     /// you'd like to prefix with the HTTP method.
@@ -115,11 +117,12 @@ declare_oxc_lint!(
     /// describe('GET /live');
     /// ```
     ///
-    /// ### `ignoreTopLevelDescribe`
+    /// #### `ignoreTopLevelDescribe`
+    ///
     /// This option can be set to allow only the top-level `describe` blocks to have a
     /// title starting with an upper-case letter.
-    /// Example of **correct** code for the `{ "ignoreTopLevelDescribe": true }` option:
     ///
+    /// Example of **correct** code for the `{ "ignoreTopLevelDescribe": true }` option:
     /// ```js
     /// /* eslint jest/prefer-lowercase-title: ["error", { "ignoreTopLevelDescribe": true }] */
     /// describe('MyClass', () => {
@@ -131,11 +134,11 @@ declare_oxc_lint!(
     /// });
     /// ```
     ///
-    /// ### `lowercaseFirstCharacterOnly`
+    /// #### `lowercaseFirstCharacterOnly`
+    ///
     /// This option can be set to only validate that the first character of a test name is lowercased.
     ///
     /// Example of **correct** code for the `{ "lowercaseFirstCharacterOnly": true }` option:
-    ///
     /// ```js
     /// /* eslint vitest/prefer-lowercase-title: ["error", { "lowercaseFirstCharacterOnly": true }] */
     /// describe('myClass', () => {
@@ -148,7 +151,6 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Example of **incorrect** code for the `{ "lowercaseFirstCharacterOnly": true }` option:
-    ///
     /// ```js
     /// /* eslint vitest/prefer-lowercase-title: ["error", { "lowercaseFirstCharacterOnly": true }] */
     /// describe('MyClass', () => {

--- a/crates/oxc_linter/src/rules/jest/prefer_mock_promise_shorthand.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_mock_promise_shorthand.rs
@@ -24,10 +24,10 @@ declare_oxc_lint!(
     /// API sugar functions to reduce the amount of boilerplate you have to write.
     /// These methods should be preferred when possible.
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    /// // invalid
     /// jest.fn().mockImplementation(() => Promise.resolve(123));
     /// jest
     ///   .spyOn(fs.promises, 'readFile')
@@ -39,7 +39,7 @@ declare_oxc_lint!(
     ///   .mockReturnValue(Promise.reject(new Error('too many calls!')));
     /// ```
     ///
-    /// // valid
+    /// Examples of **correct** code for this rule:
     /// ```javascript
     /// jest.fn().mockResolvedValue(123);
     /// jest.spyOn(fs.promises, 'readFile').mockRejectedValue(new Error('oh noes!'));
@@ -49,7 +49,6 @@ declare_oxc_lint!(
     ///   .mockResolvedValueOnce(42)
     ///   .mockRejectedValue(new Error('too many calls!'));
     /// ```
-    ///
     PreferMockPromiseShorthand,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/prefer_spy_on.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_spy_on.rs
@@ -40,14 +40,16 @@ declare_oxc_lint!(
     /// `mockFn.mockImplementation()` or by some of the
     /// [other mock functions](https://jestjs.io/docs/en/mock-function-api).
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    /// // invalid
     /// Date.now = jest.fn();
     /// Date.now = jest.fn(() => 10);
+    /// ```
     ///
-    /// // valid
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
     /// jest.spyOn(Date, 'now');
     /// jest.spyOn(Date, 'now').mockImplementation(() => 10);
     /// ```

--- a/crates/oxc_linter/src/rules/jest/prefer_strict_equal.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_strict_equal.rs
@@ -22,16 +22,17 @@ declare_oxc_lint!(
     ///
     /// This rule triggers a warning if `toEqual()` is used to assert equality.
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    /// // invalid
     /// expect({ a: 'a', b: undefined }).toEqual({ a: 'a' });
-    ///
-    /// // valid
-    /// expect({ a: 'a', b: undefined }).toStrictEqual({ a: 'a' });
     /// ```
     ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// expect({ a: 'a', b: undefined }).toStrictEqual({ a: 'a' });
+    /// ```
     PreferStrictEqual,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
@@ -57,7 +57,7 @@ declare_oxc_lint!(
     /// expect(getMessage()).toStrictEqual('hello world');
     /// expect(loadMessage()).resolves.toEqual('hello world');
     /// ```
-    /// 
+    ///
     /// Examples of **correct** code for this rule:
     /// ```javascript
     /// expect(value).not.toBe(5);

--- a/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
@@ -49,20 +49,22 @@ declare_oxc_lint!(
     /// rule recommends using their specific `toBe` matchers, as they give better error
     /// messages as well.
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    /// // valid
+    /// expect(value).not.toEqual(5);
+    /// expect(getMessage()).toStrictEqual('hello world');
+    /// expect(loadMessage()).resolves.toEqual('hello world');
+    /// ```
+    /// 
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
     /// expect(value).not.toBe(5);
     /// expect(getMessage()).toBe('hello world');
     /// expect(loadMessage()).resolves.toBe('hello world');
     /// expect(didError).not.toBe(true);
     /// expect(catchError()).toStrictEqual({ message: 'oh noes!' });
-    ///
-    /// // invalid
-    /// expect(value).not.toEqual(5);
-    /// expect(getMessage()).toStrictEqual('hello world');
-    /// expect(loadMessage()).resolves.toEqual('hello world');
     /// ```
     PreferToBe,
     jest,

--- a/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
@@ -43,7 +43,7 @@ declare_oxc_lint!(
     /// expect(a.includes(b)).toEqual(true);
     /// expect(a.includes(b)).toStrictEqual(true);
     /// ```
-    /// 
+    ///
     /// Examples of **correct** code for this rule:
     /// ```javascript
     /// expect(a).toContain(b);

--- a/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
@@ -33,21 +33,22 @@ declare_oxc_lint!(
     /// TThis rule triggers a warning if `toBe()`, `toEqual()` or `toStrictEqual()` is
     /// used to assert object inclusion in an array
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    /// // valid
-    /// expect(a).toContain(b);
-    /// expect(a).not.toContain(b);
-    ///
-    /// // invalid
     /// expect(a.includes(b)).toBe(true);
     /// expect(a.includes(b)).not.toBe(true);
     /// expect(a.includes(b)).toBe(false);
     /// expect(a.includes(b)).toEqual(true);
     /// expect(a.includes(b)).toStrictEqual(true);
     /// ```
-    ///
+    /// 
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// expect(a).toContain(b);
+    /// expect(a).not.toContain(b);
+    /// ```
     PreferToContain,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
@@ -31,21 +31,19 @@ declare_oxc_lint!(
     /// This rule triggers a warning if `toBe()`, `toEqual()` or `toStrictEqual()` is
     /// used to assert objects length property.
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    /// // valid
-    /// expect.hasAssertions;
-    /// expect.hasAssertions();
-    /// expect(files).toHaveLength(1);
-    /// expect(files.name).toBe('file');
-    ///
-    /// // invalid
     /// expect(files["length"]).toBe(1);
     /// expect(files["length"]).toBe(1,);
     /// expect(files["length"])["not"].toBe(1)
     /// ```
-    ///
+    /// 
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// expect(files).toHaveLength(1);
+    /// ```
     PreferToHaveLength,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
@@ -39,7 +39,7 @@ declare_oxc_lint!(
     /// expect(files["length"]).toBe(1,);
     /// expect(files["length"])["not"].toBe(1)
     /// ```
-    /// 
+    ///
     /// Examples of **correct** code for this rule:
     /// ```javascript
     /// expect(files).toHaveLength(1);

--- a/crates/oxc_linter/src/rules/jest/prefer_todo.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_todo.rs
@@ -26,6 +26,7 @@ pub struct PreferTodo;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// When test cases are empty then it is better to mark them as `test.todo` as it
     /// will be highlighted in the summary output.
     ///
@@ -33,8 +34,9 @@ declare_oxc_lint!(
     ///
     /// This rule triggers a warning if empty test cases are used without 'test.todo'.
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// test('i need to write this test'); // invalid
     /// test('i need to write this test', () => {}); // invalid

--- a/crates/oxc_linter/src/rules/jest/prefer_todo.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_todo.rs
@@ -41,7 +41,10 @@ declare_oxc_lint!(
     /// test('i need to write this test'); // invalid
     /// test('i need to write this test', () => {}); // invalid
     /// test.skip('i need to write this test', () => {}); // invalid
+    /// ```
     ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
     /// test.todo('i need to write this test');
     /// ```
     PreferTodo,

--- a/crates/oxc_linter/src/rules/jest/require_hook.rs
+++ b/crates/oxc_linter/src/rules/jest/require_hook.rs
@@ -96,7 +96,7 @@ declare_oxc_lint!(
     /// });
     /// clearCityDatabase();
     /// ```
-    /// 
+    ///
     /// Examples of **correct** code for this rule:
     /// ```javascript
     /// import { database, isCity } from '../database';

--- a/crates/oxc_linter/src/rules/jest/require_hook.rs
+++ b/crates/oxc_linter/src/rules/jest/require_hook.rs
@@ -41,6 +41,7 @@ impl std::ops::Deref for RequireHook {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// This rule flags any expression that is either at the toplevel of a test file or
     /// directly within the body of a `describe`, _except_ for the following:
     ///
@@ -51,9 +52,10 @@ declare_oxc_lint!(
     /// - Types
     /// - Calls to the standard Jest globals
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    /// // invalid
     /// import { database, isCity } from '../database';
     /// import { Logger } from '../../../src/Logger';
     /// import { loadCities } from '../api';
@@ -93,8 +95,10 @@ declare_oxc_lint!(
     ///     });
     /// });
     /// clearCityDatabase();
-    ///
-    /// // valid
+    /// ```
+    /// 
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
     /// import { database, isCity } from '../database';
     /// import { Logger } from '../../../src/Logger';
     /// import { loadCities } from '../api';
@@ -142,7 +146,6 @@ declare_oxc_lint!(
     ///     clearCityDatabase();
     /// });
     /// ```
-    ///
     RequireHook,
     jest,
     style

--- a/crates/oxc_linter/src/rules/jest/require_to_throw_message.rs
+++ b/crates/oxc_linter/src/rules/jest/require_to_throw_message.rs
@@ -34,7 +34,7 @@ declare_oxc_lint!(
     ///     await expect(a()).rejects.toThrowError();
     /// });
     /// ```
-    /// 
+    ///
     /// Examples of **correct** code for this rule:
     /// ```javascript
     /// test('all the things', async () => {

--- a/crates/oxc_linter/src/rules/jest/require_to_throw_message.rs
+++ b/crates/oxc_linter/src/rules/jest/require_to_throw_message.rs
@@ -20,19 +20,23 @@ pub struct RequireToThrowMessage;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// This rule triggers a warning if `toThrow()` or `toThrowError()` is used without an error message.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    /// // invalid
     /// test('all the things', async () => {
     ///     expect(() => a()).toThrow();
     ///     expect(() => a()).toThrowError();
     ///     await expect(a()).rejects.toThrow();
     ///     await expect(a()).rejects.toThrowError();
     /// });
-    ///
-    /// // valid
+    /// ```
+    /// 
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
     /// test('all the things', async () => {
     ///   expect(() => a()).toThrow('a');
     ///   expect(() => a()).toThrowError('a');
@@ -40,7 +44,6 @@ declare_oxc_lint!(
     ///   await expect(a()).rejects.toThrowError('a');
     /// });
     /// ```
-    ///
     RequireToThrowMessage,
     jest,
     correctness

--- a/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
@@ -52,11 +52,10 @@ declare_oxc_lint!(
     /// (`beforeAll`, `beforeEach`, `afterEach`, `afterAll`) is not located in a
     /// top-level `describe` block.
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    /// // invalid
-    ///
     /// // Above a describe block
     /// test('my test', () => {});
     /// describe('test suite', () => {
@@ -71,9 +70,10 @@ declare_oxc_lint!(
     /// beforeAll('my beforeAll', () => {});
     /// describe('test suite', () => {});
     /// afterEach('my afterEach', () => {});
+    /// ```
     ///
-    /// //valid
-    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
     /// // Above a describe block
     /// // In a describe block
     /// describe('test suite', () => {
@@ -104,7 +104,6 @@ declare_oxc_lint!(
     ///   ]
     /// }
     /// ```
-    ///
     RequireTopLevelDescribe,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/valid_describe_callback.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_describe_callback.rs
@@ -38,8 +38,9 @@ declare_oxc_lint!(
     /// Using an improper `describe()` callback function can lead to unexpected test
     /// errors.
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// // Async callback functions are not allowed
     /// describe('myFunction()', async () => {

--- a/crates/oxc_linter/src/rules/jest/valid_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_expect.rs
@@ -58,11 +58,11 @@ declare_oxc_lint!(
     ///
     /// Checks that `expect()` is called correctly.
     ///
-    /// Why is this bad?
+    /// ### Why is this bad?
     ///
     /// `expect()` is a function that is used to assert values in tests. It should be called with a single argument, which is the value to be tested. If you call `expect()` with no arguments, or with more than one argument, it will not work as expected.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/jest/valid_title.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_title.rs
@@ -53,11 +53,11 @@ declare_oxc_lint!(
     /// - not prefixed with their block name,
     /// - have no leading or trailing spaces.
     ///
-    /// Why is this bad?
+    /// ### Why is this bad?
     ///
     /// Titles that are not valid can be misleading and make it harder to understand the purpose of the test.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/jsx_a11y/alt_text.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/alt_text.rs
@@ -118,7 +118,7 @@ declare_oxc_lint!(
     /// Ensure that the `alt` attribute is present and contains meaningful
     /// text that describes the element's content or purpose.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_has_content.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_has_content.rs
@@ -55,7 +55,6 @@ declare_oxc_lint!(
     /// <a />
     /// <a><TextWrapper aria-hidden /></a>
     /// ```
-    ///
     AnchorHasContent,
     jsx_a11y,
     correctness,

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
@@ -53,6 +53,7 @@ impl Deref for AnchorIsValid {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// The HTML `<a>` element, with a valid href attribute, is formally defined as representing a **hyperlink**.
     /// That is, a link between one HTML document and another, or between one location inside an HTML document and another location inside the same document.
     ///
@@ -83,6 +84,7 @@ declare_oxc_lint!(
     /// ```
     ///
     /// ### Why is this bad?
+    ///
     /// There are **many reasons** why an anchor should not have a logic and have a correct `href` attribute:
     /// - it can disrupt the correct flow of the user navigation e.g. a user that wants to open the link
     /// in another tab, but the default "click" behaviour is prevented

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_activedescendant_has_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_activedescendant_has_tabindex.rs
@@ -32,6 +32,11 @@ declare_oxc_lint!(
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx
+    /// const Bad = <div aria-activedescendant={someID} />
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
     /// const Good = <>
     ///     <CustomComponent />
     ///     <CustomComponent aria-activedescendant={someID} />
@@ -49,8 +54,6 @@ declare_oxc_lint!(
     ///     <input aria-activedescendant={someID} tabIndex={0} />
     ///     <input aria-activedescendant={someID} tabIndex={-1} />
     /// </>
-    ///
-    /// const Bad = <div aria-activedescendant={someID} />
     /// ```
     AriaActivedescendantHasTabindex,
     jsx_a11y,

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_activedescendant_has_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_activedescendant_has_tabindex.rs
@@ -28,7 +28,9 @@ declare_oxc_lint!(
     ///
     /// Enforce elements with aria-activedescendant are tabbable.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```jsx
     /// const Good = <>
     ///     <CustomComponent />

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_props.rs
@@ -26,16 +26,19 @@ pub struct AriaProps;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Enforces that elements do not use invalid ARIA attributes.
     ///
     /// ### Why is this bad?
+    ///
     /// Using invalid ARIA attributes can mislead screen readers and other assistive technologies.
     /// It may cause the accessibility features of the website to fail, making it difficult
     /// for users with disabilities to use the site effectively.
     ///
     /// This rule includes fixes for some common typos.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx
     /// <input aria-labeledby="address_label" />

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
@@ -91,7 +91,7 @@ declare_oxc_lint!(
     /// For the `ignoreNonDOM` option, this determines if developer created
     /// components are checked.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     ///

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_unsupported_elements.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_unsupported_elements.rs
@@ -19,7 +19,7 @@ declare_oxc_lint!(
     /// `meta`, `html`, `script`, `style`. This rule enforces that these DOM
     /// elements do not contain the `role` and/or `aria-*` props.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx
@@ -30,7 +30,6 @@ declare_oxc_lint!(
     /// ```jsx
     ///	<meta charset="UTF-8" />
     /// ```
-    ///
     AriaUnsupportedElements,
     jsx_a11y,
     correctness,

--- a/crates/oxc_linter/src/rules/jsx_a11y/autocomplete_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/autocomplete_valid.rs
@@ -25,12 +25,14 @@ fn autocomplete_valid_diagnostic(span: Span, autocomplete: &str) -> OxcDiagnosti
 pub struct AutocompleteValid(Box<AutocompleteValidConfig>);
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Enforces that an element's autocomplete attribute must be a valid value.
     ///
     /// ### Why is this bad?
+    ///
     /// Incorrectly using the autocomplete attribute may decrease the accessibility of the website for users.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/jsx_a11y/click_events_have_key_events.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/click_events_have_key_events.rs
@@ -33,7 +33,7 @@ declare_oxc_lint!(
     /// Coding for the keyboard is important for users with physical disabilities who cannot use a mouse, AT compatibility, and screenreader users.
     /// This does not apply for interactive or hidden elements.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/jsx_a11y/html_has_lang.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/html_has_lang.rs
@@ -34,13 +34,13 @@ declare_oxc_lint!(
     /// Ensures that every HTML document has a lang attribute
     ///
     /// ### Why is this bad?
+    ///
     /// If the language of a webpage is not specified,
     /// the screen reader assumes the default language set by the user.
     /// Language settings become an issue for users who speak multiple languages
     /// and access website in more than one language.
     ///
-    ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/jsx_a11y/iframe_has_title.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/iframe_has_title.rs
@@ -36,7 +36,7 @@ declare_oxc_lint!(
     ///
     /// This rule checks for title property on iframe element.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
@@ -80,7 +80,7 @@ declare_oxc_lint!(
     /// This rule checks for alternative text on the following elements:
     /// `<img>` and the components which you define in options.components with the exception of components which is hidden from screen reader.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/jsx_a11y/label_has_associated_control.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/label_has_associated_control.rs
@@ -70,9 +70,11 @@ impl Default for LabelHasAssociatedControlConfig {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Enforce that a label tag has a text label and an associated control.
     ///
     /// ### Why is this bad?
+    ///
     /// A form label that either isn't properly associated with a form control (such as an `<input>`), or doesn't contain accessible text, hinders accessibility for users using assistive technologies such as screen readers. The user may not have enough information to understand the purpose of the form control.
     ///
     /// ### Examples

--- a/crates/oxc_linter/src/rules/jsx_a11y/lang.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/lang.rs
@@ -35,7 +35,6 @@ declare_oxc_lint!(
     /// Language settings become an issue for users who speak multiple languages
     /// and access website in more than one language.
     ///
-    ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:

--- a/crates/oxc_linter/src/rules/jsx_a11y/media_has_caption.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/media_has_caption.rs
@@ -39,14 +39,16 @@ impl Default for MediaHasCaptionConfig {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Checks if `<audio>` and `<video>` elements have a `<track>` element for captions.
     /// This ensures media content is accessible to all users, including those with hearing impairments.
     ///
     /// ### Why is this bad?
+    ///
     /// Without captions, audio and video content is not accessible to users who are deaf or hard of hearing.
     /// Captions are also useful for users in noisy environments or where audio is not available.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/jsx_a11y/mouse_events_have_key_events.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/mouse_events_have_key_events.rs
@@ -51,7 +51,7 @@ declare_oxc_lint!(
     /// Coding for the keyboard is important for users with physical disabilities who cannot use a mouse,
     /// AT compatibility, and screenreader users.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_access_key.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_access_key.rs
@@ -19,13 +19,15 @@ pub struct NoAccessKey;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Enforces that the `accessKey` prop is not used on any element to avoid complications with keyboard commands used by a screenreader.
     ///
     /// ### Why is this bad?
+    ///
     /// Access keys are HTML attributes that allow web developers to assign keyboard shortcuts to elements.
     /// Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create accessibility complications so to avoid complications, access keys should not be used.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_aria_hidden_on_focusable.rs
@@ -24,12 +24,14 @@ pub struct NoAriaHiddenOnFocusable;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Enforces that `aria-hidden="true"` is not set on focusable elements.
     ///
     /// ### Why is this bad?
+    ///
     /// `aria-hidden="true"` on focusable elements can lead to confusion or unexpected behavior for screen reader users.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
@@ -46,10 +46,9 @@ declare_oxc_lint!(
     /// For the `ignoreNonDOM` option, this determines if developer created
     /// components are checked.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
-    ///
     /// ```jsx
     /// <div autoFocus />
     /// <div autoFocus="true" />
@@ -58,7 +57,6 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Examples of **correct** code for this rule:
-    ///
     /// ```jsx
     /// <div />
     /// ```

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_distracting_elements.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_distracting_elements.rs
@@ -31,7 +31,7 @@ declare_oxc_lint!(
     ///
     /// This rule checks for marquee and blink element.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
@@ -41,6 +41,7 @@ impl Default for NoNoninteractiveTabindex {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// This rule checks that non-interactive elements don't have a tabIndex which would make them interactive via keyboard navigation.
     ///
     /// ### Why is this bad?

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
@@ -32,9 +32,10 @@ declare_oxc_lint!(
     /// implicit/default role property on element.
     ///
     /// ### Why is this bad?
+    ///
     /// Redundant roles can lead to confusion and verbosity in the codebase.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/jsx_a11y/prefer_tag_over_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/prefer_tag_over_role.rs
@@ -26,12 +26,14 @@ pub struct PreferTagOverRole;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Enforces using semantic HTML tags over `role` attribute.
     ///
     /// ### Why is this bad?
+    ///
     /// Using semantic HTML tags can improve accessibility and readability of the code.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/jsx_a11y/role_has_required_aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/role_has_required_aria_props.rs
@@ -28,7 +28,7 @@ declare_oxc_lint!(
     /// Certain ARIA roles require specific attributes to express necessary
     /// semantics for assistive technology.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
@@ -23,7 +23,7 @@ declare_oxc_lint!(
     ///
     /// Enforce that elements with explicit or implicit roles defined contain only `aria-*` properties supported by that `role`. Many ARIA attributes (states and properties) can only be used on elements with particular roles. Some elements have implicit roles, such as `<a href="#" />`, which will resolve to `role="link"`.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx
@@ -42,7 +42,6 @@ declare_oxc_lint!(
     ///     <li tabIndex="0" role="radio" aria-checked="true">Lake Trout</li>
     /// </ul>
     /// ```
-    ///
     RoleSupportsAriaProps,
     jsx_a11y,
     correctness

--- a/crates/oxc_linter/src/rules/jsx_a11y/scope.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/scope.rs
@@ -26,11 +26,12 @@ declare_oxc_lint!(
     /// The scope prop should be used only on `<th>` elements.
     ///
     /// ### Why is this bad?
+    ///
     /// The scope attribute makes table navigation much easier for screen reader users, provided that it is used correctly.
     /// Incorrectly used, scope can make table navigation much harder and less efficient.
     /// A screen reader operates under the assumption that a table has a header and that this header specifies a scope. Because of the way screen readers function, having an accurate header makes viewing a table far more accessible and more efficient for people who use the device.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/jsx_a11y/tabindex_no_positive.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/tabindex_no_positive.rs
@@ -31,7 +31,7 @@ declare_oxc_lint!(
     /// interaction difficult for keyboard and assistive technology users,
     /// disrupting the logical order of content.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/nextjs/google_font_display.rs
+++ b/crates/oxc_linter/src/rules/nextjs/google_font_display.rs
@@ -38,10 +38,9 @@ declare_oxc_lint!(
     /// layout shift. If swapping to the custom font after it has loaded is
     /// important to you, then use `display=swap`` instead.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
-    ///
     /// ```jsx
     /// import Head from "next/head";
     ///
@@ -58,7 +57,6 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Examples of **correct** code for this rule:
-    ///
     /// ```jsx
     /// import Head from "next/head";
     ///
@@ -73,7 +71,6 @@ declare_oxc_lint!(
     ///     );
     /// };
     /// ```
-    ///
     GoogleFontDisplay,
     nextjs,
     correctness

--- a/crates/oxc_linter/src/rules/nextjs/google_font_preconnect.rs
+++ b/crates/oxc_linter/src/rules/nextjs/google_font_preconnect.rs
@@ -26,7 +26,9 @@ declare_oxc_lint!(
     /// ### Why is this bad?
     ///
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
     GoogleFontPreconnect,

--- a/crates/oxc_linter/src/rules/nextjs/google_font_preconnect.rs
+++ b/crates/oxc_linter/src/rules/nextjs/google_font_preconnect.rs
@@ -31,6 +31,10 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// ```
     GoogleFontPreconnect,
     nextjs,
     correctness

--- a/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
+++ b/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
@@ -32,6 +32,10 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// ```
     InlineScriptId,
     nextjs,
     correctness

--- a/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
+++ b/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
@@ -27,7 +27,9 @@ declare_oxc_lint!(
     /// ### Why is this bad?
     ///
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
     InlineScriptId,

--- a/crates/oxc_linter/src/rules/nextjs/next_script_for_ga.rs
+++ b/crates/oxc_linter/src/rules/nextjs/next_script_for_ga.rs
@@ -34,7 +34,9 @@ declare_oxc_lint!(
     /// ### Why is this bad?
     ///
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
     NextScriptForGa,

--- a/crates/oxc_linter/src/rules/nextjs/next_script_for_ga.rs
+++ b/crates/oxc_linter/src/rules/nextjs/next_script_for_ga.rs
@@ -39,6 +39,10 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// ```
     NextScriptForGa,
     nextjs,
     correctness

--- a/crates/oxc_linter/src/rules/nextjs/no_assign_module_variable.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_assign_module_variable.rs
@@ -26,6 +26,10 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// ```
     NoAssignModuleVariable,
     nextjs,
     correctness

--- a/crates/oxc_linter/src/rules/nextjs/no_assign_module_variable.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_assign_module_variable.rs
@@ -21,7 +21,9 @@ declare_oxc_lint!(
     /// ### Why is this bad?
     ///
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
     NoAssignModuleVariable,

--- a/crates/oxc_linter/src/rules/nextjs/no_async_client_component.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_async_client_component.rs
@@ -24,7 +24,9 @@ declare_oxc_lint!(
     /// ### Why is this bad?
     ///
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
     NoAsyncClientComponent,

--- a/crates/oxc_linter/src/rules/nextjs/no_async_client_component.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_async_client_component.rs
@@ -29,6 +29,10 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// ```
     NoAsyncClientComponent,
     nextjs,
     correctness

--- a/crates/oxc_linter/src/rules/nextjs/no_before_interactive_script_outside_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_before_interactive_script_outside_document.rs
@@ -24,12 +24,15 @@ pub struct NoBeforeInteractiveScriptOutsideDocument;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Prevent usage of `next/script`'s `beforeInteractive` strategy outside of `pages/_document.js`.
     ///
     /// ### Why is this bad?
     ///
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
     NoBeforeInteractiveScriptOutsideDocument,

--- a/crates/oxc_linter/src/rules/nextjs/no_before_interactive_script_outside_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_before_interactive_script_outside_document.rs
@@ -35,6 +35,10 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// ```
     NoBeforeInteractiveScriptOutsideDocument,
     nextjs,
     correctness

--- a/crates/oxc_linter/src/rules/nextjs/no_css_tags.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_css_tags.rs
@@ -24,7 +24,9 @@ declare_oxc_lint!(
     /// ### Why is this bad?
     ///
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
     NoCssTags,

--- a/crates/oxc_linter/src/rules/nextjs/no_css_tags.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_css_tags.rs
@@ -29,6 +29,10 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// ```
     NoCssTags,
     nextjs,
     correctness

--- a/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
@@ -14,12 +14,15 @@ pub struct NoDocumentImportInPage;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Prevent importing `next/document` outside of `pages/_document.js`.
     ///
     /// ### Why is this bad?
     ///
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
     NoDocumentImportInPage,

--- a/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
@@ -25,6 +25,10 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// ```
     NoDocumentImportInPage,
     nextjs,
     correctness

--- a/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
@@ -15,12 +15,16 @@ pub struct NoDuplicateHead;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Prevent duplicate usage of `<Head>` in `pages/_document.js``.
     ///
     /// ### Why is this bad?
+    ///
     /// This can cause unexpected behavior in your application.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```jsx
     /// import Document, { Html, Head, Main, NextScript } from 'next/document'
     /// class MyDocument extends Document {

--- a/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
@@ -34,6 +34,7 @@ declare_oxc_lint!(
     ///     return (
     ///       <Html>
     ///         <Head />
+    ///         <Head />
     ///         <body>
     ///           <Main />
     ///           <NextScript />
@@ -42,7 +43,28 @@ declare_oxc_lint!(
     ///    )
     ///  }
     ///}
-    ///export default MyDocument
+    /// export default MyDocument
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// import Document, { Html, Head, Main, NextScript } from 'next/document'
+    /// class MyDocument extends Document {
+    ///   static async getInitialProps(ctx) {
+    ///   }
+    ///   render() {
+    ///     return (
+    ///       <Html>
+    ///         <Head />
+    ///         <body>
+    ///           <Main />
+    ///           <NextScript />
+    ///         </body>
+    ///       </Html>
+    ///    )
+    ///  }
+    ///}
+    /// export default MyDocument
     /// ```
     NoDuplicateHead,
     nextjs,

--- a/crates/oxc_linter/src/rules/nextjs/no_head_element.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_head_element.rs
@@ -16,12 +16,15 @@ pub struct NoHeadElement;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Prevent usage of `<head>` element.
     ///
     /// ### Why is this bad?
     ///
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
     NoHeadElement,

--- a/crates/oxc_linter/src/rules/nextjs/no_head_element.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_head_element.rs
@@ -27,6 +27,10 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// ```
     NoHeadElement,
     nextjs,
     correctness

--- a/crates/oxc_linter/src/rules/nextjs/no_head_import_in_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_head_import_in_document.rs
@@ -26,6 +26,10 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// ```
     NoHeadImportInDocument,
     nextjs,
     correctness

--- a/crates/oxc_linter/src/rules/nextjs/no_head_import_in_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_head_import_in_document.rs
@@ -21,7 +21,9 @@ declare_oxc_lint!(
     /// ### Why is this bad?
     ///
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
     NoHeadImportInDocument,

--- a/crates/oxc_linter/src/rules/nextjs/no_img_element.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_img_element.rs
@@ -34,7 +34,7 @@ declare_oxc_lint!(
     /// from `next/image` will automatically optimize images and serve them as
     /// static assets.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/nextjs/no_page_custom_font.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_page_custom_font.rs
@@ -38,6 +38,10 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// ```
     NoPageCustomFont,
     nextjs,
     correctness,

--- a/crates/oxc_linter/src/rules/nextjs/no_page_custom_font.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_page_custom_font.rs
@@ -25,13 +25,17 @@ pub struct NoPageCustomFont;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Prevent page-only custom fonts.
     ///
     /// ### Why is this bad?
+    ///
     /// * The custom font you're adding was added to a page - this only adds the font to the specific page and not the entire application.
     /// * The custom font you're adding was added to a separate component within pages/_document.js - this disables automatic font optimization.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
     NoPageCustomFont,

--- a/crates/oxc_linter/src/rules/nextjs/no_script_component_in_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_script_component_in_head.rs
@@ -29,6 +29,10 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// ```
     NoScriptComponentInHead,
     nextjs,
     correctness

--- a/crates/oxc_linter/src/rules/nextjs/no_script_component_in_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_script_component_in_head.rs
@@ -24,7 +24,9 @@ declare_oxc_lint!(
     /// ### Why is this bad?
     ///
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
     NoScriptComponentInHead,

--- a/crates/oxc_linter/src/rules/nextjs/no_styled_jsx_in_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_styled_jsx_in_document.rs
@@ -26,7 +26,9 @@ declare_oxc_lint!(
     ///
     /// Custom CSS like styled-jsx is not allowed in a [Custom Document](https://nextjs.org/docs/pages/building-your-application/routing/custom-document).
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
     NoStyledJsxInDocument,

--- a/crates/oxc_linter/src/rules/nextjs/no_styled_jsx_in_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_styled_jsx_in_document.rs
@@ -31,6 +31,10 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// ```
     NoStyledJsxInDocument,
     nextjs,
     correctness,

--- a/crates/oxc_linter/src/rules/nextjs/no_sync_scripts.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_sync_scripts.rs
@@ -25,7 +25,9 @@ declare_oxc_lint!(
     /// ### Why is this bad?
     ///
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
     NoSyncScripts,

--- a/crates/oxc_linter/src/rules/nextjs/no_sync_scripts.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_sync_scripts.rs
@@ -30,6 +30,10 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// ```
     NoSyncScripts,
     nextjs,
     correctness

--- a/crates/oxc_linter/src/rules/nextjs/no_title_in_document_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_title_in_document_head.rs
@@ -24,7 +24,9 @@ declare_oxc_lint!(
     /// ### Why is this bad?
     ///
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
     NoTitleInDocumentHead,

--- a/crates/oxc_linter/src/rules/nextjs/no_title_in_document_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_title_in_document_head.rs
@@ -29,6 +29,10 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// ```
     NoTitleInDocumentHead,
     nextjs,
     correctness

--- a/crates/oxc_linter/src/rules/nextjs/no_typos.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_typos.rs
@@ -38,6 +38,14 @@ declare_oxc_lint!(
     /// }
     /// export async function getServurSideProps(){};
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// export default function Page() {
+    ///   return <div></div>;
+    /// }
+    /// export async function getServerSideProps(){};
+    /// ```
     NoTypos,
     nextjs,
     correctness,

--- a/crates/oxc_linter/src/rules/nextjs/no_typos.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_typos.rs
@@ -23,12 +23,15 @@ pub struct NoTypos;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Prevent common typos in Next.js's data fetching functions
     ///
     /// ### Why is this bad?
     ///
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// export default function Page() {
     ///   return <div></div>;

--- a/crates/oxc_linter/src/rules/nextjs/no_unwanted_polyfillio.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_unwanted_polyfillio.rs
@@ -27,12 +27,16 @@ pub struct NoUnwantedPolyfillio;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Prevent duplicate polyfills from Polyfill.io.
     ///
     /// ### Why is this bad?
+    ///
     /// You are using polyfills from Polyfill.io and including polyfills already shipped with Next.js. This unnecessarily increases page weight which can affect loading performance.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// <script src='https://polyfill.io/v3/polyfill.min.js?features=Array.prototype.copyWithin'></script>
     ///

--- a/crates/oxc_linter/src/rules/oxc/approx_constant.rs
+++ b/crates/oxc_linter/src/rules/oxc/approx_constant.rs
@@ -28,7 +28,7 @@ declare_oxc_lint!(
     ///
     /// Approximate constants are not as accurate as the constants in the `Math` object.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/oxc/bad_array_method_on_arguments.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_array_method_on_arguments.rs
@@ -21,13 +21,17 @@ pub struct BadArrayMethodOnArguments;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// This rule applies when an array method is called on the arguments object itself.
     ///
     /// ### Why is this bad?
+    ///
     /// The arguments object is not an array, but an array-like object. It should be converted to a real array before calling an array method.
     /// Otherwise, a TypeError exception will be thrown because of the non-existent method.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// function add(x, y) {
     ///   return x + y;

--- a/crates/oxc_linter/src/rules/oxc/bad_array_method_on_arguments.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_array_method_on_arguments.rs
@@ -40,6 +40,16 @@ declare_oxc_lint!(
     ///   return arguments.reduce(add, 0);
     /// }
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// function add(x, y) {
+    ///   return x + y;
+    /// }
+    /// function sum(...args) {
+    ///   return args.reduce(add, 0);
+    /// }
+    /// ```
     BadArrayMethodOnArguments,
     oxc,
     correctness,

--- a/crates/oxc_linter/src/rules/oxc/bad_bitwise_operator.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_bitwise_operator.rs
@@ -57,6 +57,15 @@ declare_oxc_lint!(
     /// options = options | {};
     /// input |= '';
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// if (obj && obj.prop) {
+    ///  console.log(obj.prop);
+    /// }
+    /// options = options || {};
+    /// input ||= '';
+    /// ```
     BadBitwiseOperator,
     oxc,
     restriction // Restricted because there are false positives for enum bitflags in TypeScript,

--- a/crates/oxc_linter/src/rules/oxc/bad_bitwise_operator.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_bitwise_operator.rs
@@ -32,9 +32,11 @@ pub struct BadBitwiseOperator;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// This rule applies when bitwise operators are used where logical operators are expected.
     ///
     /// ### Why is this bad?
+    ///
     /// Bitwise operators have different results from logical operators and a `TypeError` exception may be thrown because short-circuit evaluation is not applied.
     /// (In short-circuit evaluation, right operand evaluation is skipped according to left operand value, e.g. `x` is `false` in `x && y`.)
     ///
@@ -45,7 +47,9 @@ declare_oxc_lint!(
     /// e || ''
     /// ```
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// if (obj & obj.prop) {
     ///  console.log(obj.prop);

--- a/crates/oxc_linter/src/rules/oxc/bad_comparison_sequence.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_comparison_sequence.rs
@@ -33,6 +33,13 @@ declare_oxc_lint!(
     ///  console.log("a, b, and c are the same");
     /// }
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// if (a == b && b == c) {
+    ///  console.log("a, b, and c are the same");
+    /// }
+    /// ```
     BadComparisonSequence,
     oxc,
     correctness

--- a/crates/oxc_linter/src/rules/oxc/bad_comparison_sequence.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_comparison_sequence.rs
@@ -17,13 +17,17 @@ pub struct BadComparisonSequence;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// This rule applies when the comparison operator is applied two or more times in a row.
     ///
     /// ### Why is this bad?
+    ///
     /// Because comparison operator is a binary operator, it is impossible to compare three or more operands at once.
     /// If comparison operator is used to compare three or more operands, only the first two operands are compared and the rest is compared with its result of boolean type.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// if (a == b == c) {
     ///  console.log("a, b, and c are the same");

--- a/crates/oxc_linter/src/rules/oxc/bad_min_max_func.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_min_max_func.rs
@@ -30,7 +30,7 @@ declare_oxc_lint!(
     /// The `Math.min(Math.max(x, y), z)` function is used to clamp a value between two other values.
     /// If the arguments are in the wrong order, the function will always evaluate to a constant result.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
@@ -39,12 +39,10 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Examples of **correct** code for this rule:
-    ///
     /// ```javascript
     /// Math.max(0, Math.min(100, x));
     /// Math.min(1000, Math.max(0, z));
     /// ```
-    ///
     BadMinMaxFunc,
     oxc,
     correctness

--- a/crates/oxc_linter/src/rules/oxc/bad_object_literal_comparison.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_object_literal_comparison.rs
@@ -34,7 +34,7 @@ declare_oxc_lint!(
     ///
     /// If you want to check if an object or array is empty, use `Object.entries()` or `Object.keys()` and their lengths.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/oxc/const_comparisons.rs
+++ b/crates/oxc_linter/src/rules/oxc/const_comparisons.rs
@@ -85,7 +85,7 @@ declare_oxc_lint!(
     /// - Only one of the comparisons has any effect on the result, suggesting that the programmer might have made a mistake, such as flipping one of the comparison operators or using the wrong variable.
     /// - Comparisons like a < a or a >= a are always false or true respectively, making the logic redundant and potentially misleading.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
+++ b/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
@@ -27,7 +27,7 @@ declare_oxc_lint!(
     ///
     /// Redundant comparisons can be confusing and make code harder to understand.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/oxc/erasing_op.rs
+++ b/crates/oxc_linter/src/rules/oxc/erasing_op.rs
@@ -30,7 +30,7 @@ declare_oxc_lint!(
     ///
     /// The whole expression can be replaced by zero. This is most likely not the intended outcome and should probably be corrected.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/oxc/misrefactored_assign_op.rs
+++ b/crates/oxc_linter/src/rules/oxc/misrefactored_assign_op.rs
@@ -37,7 +37,7 @@ declare_oxc_lint!(
     ///
     /// Most likely these are bugs where one meant to write `a op= b`.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/oxc/missing_throw.rs
+++ b/crates/oxc_linter/src/rules/oxc/missing_throw.rs
@@ -23,7 +23,7 @@ declare_oxc_lint!(
     ///
     /// The `throw` keyword is required in front of a `new` expression to throw an error. Omitting it is usually a mistake.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/oxc/no_async_await.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_async_await.rs
@@ -19,7 +19,9 @@ declare_oxc_lint!(
     ///
     /// Disallows the use of async/await.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// async function foo() {
     ///    await bar();

--- a/crates/oxc_linter/src/rules/oxc/no_const_enum.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_const_enum.rs
@@ -26,7 +26,9 @@ declare_oxc_lint!(
     /// Const enums are not supported by bundlers and are incompatible with the isolatedModules mode.
     /// Their use can lead to import nonexistent values (because const enums are erased).
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```ts
     /// const enum Color {
     ///     Red,

--- a/crates/oxc_linter/src/rules/oxc/no_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_optional_chaining.rs
@@ -36,8 +36,9 @@ declare_oxc_lint!(
     ///
     /// Disallow [optional chaining](https://github.com/tc39/proposal-optional-chaining).
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// const foo = obj?.foo;
     /// obj.fn?.();

--- a/crates/oxc_linter/src/rules/oxc/no_rest_spread_properties.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_rest_spread_properties.rs
@@ -35,8 +35,9 @@ declare_oxc_lint!(
     ///
     /// Disallow [Object Rest/Spread Properties](https://github.com/tc39/proposal-object-rest-spread#readme).
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// let { x, ...y } = z;
     /// let z = { x, ...y };

--- a/crates/oxc_linter/src/rules/oxc/number_arg_out_of_range.rs
+++ b/crates/oxc_linter/src/rules/oxc/number_arg_out_of_range.rs
@@ -34,7 +34,8 @@ declare_oxc_lint!(
     /// The precision argument of `Number.prototype.toFixed` and `Number.prototype.toExponential` should be between 0 and 20.
     /// The precision argument of `Number.prototype.toPrecision` should be between 1 and 21.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// var x = 42;
@@ -47,7 +48,6 @@ declare_oxc_lint!(
     /// var x = 42;
     /// var s_radix_16 = x.toString(16);
     /// ```
-    ///
     NumberArgOutOfRange,
     oxc,
     correctness

--- a/crates/oxc_linter/src/rules/oxc/uninvoked_array_callback.rs
+++ b/crates/oxc_linter/src/rules/oxc/uninvoked_array_callback.rs
@@ -38,6 +38,11 @@ declare_oxc_lint!(
     /// ```javascript
     ///   const list = new Array(5).map(_ => createElement());
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    ///   const list = new Array(5).fill().map(_ => createElement());
+    /// ```
     UninvokedArrayCallback,
     oxc,
     correctness

--- a/crates/oxc_linter/src/rules/oxc/uninvoked_array_callback.rs
+++ b/crates/oxc_linter/src/rules/oxc/uninvoked_array_callback.rs
@@ -24,13 +24,17 @@ pub struct UninvokedArrayCallback;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// This rule applies when an Array function has a callback argument used for an array with empty slots.
     ///
     /// ### Why is this bad?
+    ///
     /// When the Array constructor is called with a single number argument, an array with the specified number of empty slots (not actual undefined values) is constructed.
     /// If a callback function is passed to the function of this array, the callback function is never invoked because the array has no actual elements.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     ///   const list = new Array(5).map(_ => createElement());
     /// ```

--- a/crates/oxc_linter/src/rules/promise/catch_or_return.rs
+++ b/crates/oxc_linter/src/rules/promise/catch_or_return.rs
@@ -59,7 +59,6 @@ declare_oxc_lint!(
     /// missing handling of error conditions. In the worst case, unhandled
     /// promise rejections can cause your application to crash.
     ///
-    ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:

--- a/crates/oxc_linter/src/rules/promise/no_promise_in_callback.rs
+++ b/crates/oxc_linter/src/rules/promise/no_promise_in_callback.rs
@@ -16,9 +16,11 @@ pub struct NoPromiseInCallback;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallows the use of Promises within error-first callback functions.
     ///
     /// ### Why is this bad?
+    ///
     /// Mixing Promises and callbacks can lead to unclear and inconsistent code.
     /// Promises and callbacks are different patterns for handling asynchronous code.
     /// Mixing them makes the logic flow harder to follow and complicates error handling,

--- a/crates/oxc_linter/src/rules/promise/no_return_wrap.rs
+++ b/crates/oxc_linter/src/rules/promise/no_return_wrap.rs
@@ -110,7 +110,6 @@ declare_oxc_lint!(
     ///
     /// ### Options
     ///
-    ///
     /// #### allowReject
     ///
     /// `{ type: boolean, default: false }`
@@ -130,7 +129,6 @@ declare_oxc_lint!(
     /// ```js
     /// myPromise().then().catch(() => Promise.reject("err"))
     /// ```
-    ///
     NoReturnWrap,
     promise,
     style,

--- a/crates/oxc_linter/src/rules/react/button_has_type.rs
+++ b/crates/oxc_linter/src/rules/react/button_has_type.rs
@@ -52,7 +52,7 @@ declare_oxc_lint!(
     /// `"submit"` which is often not the desired behavior and may lead to
     /// unexpected page reloads.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
+++ b/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
@@ -33,10 +33,11 @@ pub struct CheckedRequiresOnchangeOrReadonly {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// This rule enforces onChange or readonly attribute for checked property of input elements.
     /// It also warns when checked and defaultChecked properties are used together.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/react/jsx_boolean_value.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_boolean_value.rs
@@ -63,7 +63,8 @@ declare_oxc_lint!(
     ///
     /// In JSX, you can set a boolean attribute to `true` or omit it. This rule will enforce a consistent style for boolean attributes.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx
     /// const Hello = <Hello personal={true} />;
@@ -73,7 +74,6 @@ declare_oxc_lint!(
     /// ```jsx
     /// const Hello = <Hello personal />;
     /// ```
-    ///
     JsxBooleanValue,
     react,
     style,

--- a/crates/oxc_linter/src/rules/react/jsx_filename_extension.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_filename_extension.rs
@@ -56,9 +56,11 @@ impl std::ops::Deref for JsxFilenameExtension {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Enforces consistent use of the JSX file extension.
     ///
     /// ### Why is this bad?
+    ///
     /// Some bundlers or parsers need to know by the file extension that it contains JSX
     ///
     /// ### Examples

--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -46,7 +46,7 @@ declare_oxc_lint!(
     ///
     /// React requires a `key` prop for elements in an array to help identify which items have changed, are added, or are removed.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
@@ -26,7 +26,9 @@ declare_oxc_lint!(
     ///
     /// In JSX, any text node that is not wrapped in curly braces is considered a literal string to be rendered. This can lead to unexpected behavior when the text contains a comment.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```jsx
     /// // Incorrect:
     ///

--- a/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
@@ -30,8 +30,6 @@ declare_oxc_lint!(
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx
-    /// // Incorrect:
-    ///
     /// const Hello = () => {
     ///     return <div>// empty div</div>;
     /// }
@@ -40,12 +38,10 @@ declare_oxc_lint!(
     ///     return <div>/* empty div */</div>;
     /// }
     ///
-    /// // Correct:
+    /// ```
     ///
-    /// const Hello = () => {
-    ///     return <div>// empty div</div>;
-    /// }
-    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
     /// const Hello = () => {
     ///     return <div>{/* empty div */}</div>;
     /// }

--- a/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
@@ -32,7 +32,7 @@ declare_oxc_lint!(
     /// Having duplicate props in a JSX element is most likely a mistake.
     /// Creating JSX elements with duplicate props can cause unexpected behavior in your application.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
@@ -94,6 +94,7 @@ impl JsxNoTargetBlank {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// This rule aims to prevent user generated link hrefs and form actions from creating security vulnerabilities by
     /// requiring `rel='noreferrer'` for external link hrefs and form actions, and optionally any dynamically generated
     /// link hrefs and form actions.
@@ -105,7 +106,9 @@ declare_oxc_lint!(
     /// vulnerability (see [`noreferrer` docs] and [`noopener` docs] for more details).
     /// This rules requires that you accompany `target='_blank'` attributes with `rel='noreferrer'`.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```jsx
     /// /// correct
     /// var Hello = <p target="_blank"></p>

--- a/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
@@ -110,6 +110,12 @@ declare_oxc_lint!(
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx
+    /// var Hello = <a target='_blank' href="https://example.com/"></a>
+    /// var Hello = <a target='_blank' href={dynamicLink}></a>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
     /// /// correct
     /// var Hello = <p target="_blank"></p>
     /// var Hello = <a target="_blank" rel="noreferrer" href="https://example.com"></a>
@@ -117,9 +123,6 @@ declare_oxc_lint!(
     /// var Hello = <a target="_blank" href="relative/path/in/the/host"></a>
     /// var Hello = <a target="_blank" href="/absolute/path/in/the/host"></a>
     /// var Hello = <a></a>
-    /// /// incorrect
-    /// var Hello = <a target='_blank' href="https://example.com/"></a>
-    /// var Hello = <a target='_blank' href={dynamicLink}></a>
     /// ```
     ///
     /// [`noreferrer` docs]: https://html.spec.whatwg.org/multipage/links.html#link-type-noreferrer

--- a/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
@@ -21,12 +21,16 @@ pub struct JsxNoUndef;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow undeclared variables in JSX
     ///
     /// ### Why is this bad?
+    ///
     /// It is most likely a potential ReferenceError caused by a misspelling of a variable or parameter name.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```jsx
     /// const A = () => <App />
     /// const C = <B />

--- a/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
@@ -39,7 +39,7 @@ declare_oxc_lint!(
     ///
     /// Fragments are a useful tool when you need to group multiple children without adding a node to the DOM tree. However, sometimes you might end up with a fragment with a single child. When this child is an element, string, or expression, it's not necessary to use a fragment.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spread_multi.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spread_multi.rs
@@ -38,13 +38,15 @@ pub struct JsxPropsNoSpreadMulti;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Enforces that any unique expression is only spread once.
     ///
     /// ### Why is this bad?
+    ///
     /// Generally spreading the same expression twice is an indicator of a mistake since any attribute between the spreads may be overridden when the intent was not to.
     /// Even when that is not the case this will lead to unnecessary computations being performed.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/react/no_array_index_key.rs
+++ b/crates/oxc_linter/src/rules/react/no_array_index_key.rs
@@ -22,9 +22,11 @@ pub struct NoArrayIndexKey;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Warn if an element uses an Array index in its key.
     ///
     /// ### Why is this bad?
+    ///
     /// It's a bad idea to use the array index since it doesn't uniquely identify your elements.
     /// In cases where the array is sorted or an element is added to the beginning of the array,
     /// the index will be changed even though the element representing that index may be the same.

--- a/crates/oxc_linter/src/rules/react/no_children_prop.rs
+++ b/crates/oxc_linter/src/rules/react/no_children_prop.rs
@@ -27,13 +27,13 @@ declare_oxc_lint!(
     ///
     /// Checks that children are not passed using a prop.
     ///
-    /// Why is this bad?
+    /// ### Why is this bad?
     ///
     /// Children should always be actual children, not passed in as a prop.
     /// When using JSX, the children should be nested between the opening and closing tags.
     /// When not using JSX, the children should be passed as additional arguments to `React.createElement`.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/react/no_danger.rs
+++ b/crates/oxc_linter/src/rules/react/no_danger.rs
@@ -33,10 +33,9 @@ declare_oxc_lint!(
     /// component. This is dangerous because it can easily lead to XSS
     /// vulnerabilities.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
-    ///
     /// ```jsx
     /// import React from "react";
     ///
@@ -44,7 +43,6 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Examples of **correct** code for this rule:
-    ///
     /// ```jsx
     /// import React from "react";
     ///

--- a/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
@@ -36,8 +36,6 @@ declare_oxc_lint!(
     /// calling setState() afterwards may replace the mutation you made
     ///
     /// ### Examples
-    ///
-    /// Examples of **incorrect** code for this rule:
     /// ```jsx
     ///  // error
     ///  var Hello = createReactClass({

--- a/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
@@ -28,12 +28,16 @@ pub struct NoDirectMutationState;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// The restriction coder cannot directly change the value of this.state
     ///
     /// ### Why is this bad?
+    ///
     /// calling setState() afterwards may replace the mutation you made
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```jsx
     ///  // error
     ///  var Hello = createReactClass({

--- a/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
+++ b/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
@@ -20,14 +20,18 @@ pub struct NoFindDomNode;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// This rule disallows the use of `findDOMNode`.
     ///
     /// ### Why is this bad?
+    ///
     /// `findDOMNode` is an escape hatch used to access the underlying DOM node.
     /// In most cases, use of this escape hatch is discouraged because it pierces the component abstraction.
     /// [It has been deprecated in `StrictMode`.](https://legacy.reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage)
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```jsx
     /// class MyComponent extends Component {
     ///   componentDidMount() {

--- a/crates/oxc_linter/src/rules/react/no_is_mounted.rs
+++ b/crates/oxc_linter/src/rules/react/no_is_mounted.rs
@@ -28,7 +28,9 @@ declare_oxc_lint!(
     /// isMounted is an anti-pattern, is not available when using ES6 classes,
     /// and it is on its way to being officially deprecated.///
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```jsx
     /// class Hello extends React.Component {
     ///     someMethod() {

--- a/crates/oxc_linter/src/rules/react/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/react/no_namespace.rs
@@ -21,9 +21,11 @@ pub struct NoNamespace;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Enforce that namespaces are not used in React elements.
     ///
     /// ### Why is this bad?
+    ///
     /// Namespaces in React elements, such as svg:circle, are not supported by React.
     ///
     /// ### Examples

--- a/crates/oxc_linter/src/rules/react/no_render_return_value.rs
+++ b/crates/oxc_linter/src/rules/react/no_render_return_value.rs
@@ -27,7 +27,7 @@ declare_oxc_lint!(
     ///
     /// Using the return value from ReactDOM.render() is a legacy feature and should not be used.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/react/no_set_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_set_state.rs
@@ -29,7 +29,9 @@ declare_oxc_lint!(
     /// especially helpful in read-only applications (that don't use forms), since local component
     /// state should rarely be necessary in such cases.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```jsx
     /// var Hello = createReactClass({
     ///   getInitialState: function() {

--- a/crates/oxc_linter/src/rules/react/no_string_refs.rs
+++ b/crates/oxc_linter/src/rules/react/no_string_refs.rs
@@ -42,7 +42,7 @@ declare_oxc_lint!(
     ///
     /// Using string literals in ref attributes is deprecated in React.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/react/no_unknown_property.rs
+++ b/crates/oxc_linter/src/rules/react/no_unknown_property.rs
@@ -61,12 +61,16 @@ pub struct NoUnknownPropertyConfig {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow usage of unknown DOM property.
     ///
     /// ### Why is this bad?
+    ///
     /// You can use unknown property name that has no effect.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```jsx
     ///  // Unknown properties
     ///  const Hello = <div class="hello">Hello World</div>;

--- a/crates/oxc_linter/src/rules/react/no_unknown_property.rs
+++ b/crates/oxc_linter/src/rules/react/no_unknown_property.rs
@@ -79,6 +79,16 @@ declare_oxc_lint!(
     ///  // Invalid aria-* attribute
     ///  const IconButton = <div aria-foo="bar" />;
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    ///  // Unknown properties
+    ///  const Hello = <div className="hello">Hello World</div>;
+    ///  const Alphabet = <div>Alphabet</div>;
+    ///
+    ///  // Invalid aria-* attribute
+    ///  const IconButton = <div aria-label="bar" />;
+    /// ```
     NoUnknownProperty,
     react,
     restriction,

--- a/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
@@ -33,7 +33,9 @@ declare_oxc_lint!(
     ///
     /// This rule enforces a consistent React class style.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```jsx
     /// var Hello = createReactClass({
     ///   render: function() {

--- a/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
+++ b/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
@@ -28,7 +28,7 @@ declare_oxc_lint!(
     /// When using JSX, `<a />` expands to `React.createElement("a")`. Therefore
     /// the `React` variable must be in scope.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx
@@ -39,7 +39,6 @@ declare_oxc_lint!(
     /// ```jsx
     /// import React from "react";
     /// var a = <a />;
-    ///
     /// ```
     ReactInJsxScope,
     react,

--- a/crates/oxc_linter/src/rules/react/require_render_return.rs
+++ b/crates/oxc_linter/src/rules/react/require_render_return.rs
@@ -48,6 +48,21 @@ declare_oxc_lint!(
     ///   }
     /// }
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// var Hello = createReactClass({
+    ///   render() {
+    ///     return <div>Hello</div>;
+    ///   }
+    /// });
+    ///
+    /// class Hello extends React.Component {
+    ///   render() {
+    ///     return <div>Hello</div>;
+    ///   }
+    /// }
+    /// ```
     RequireRenderReturn,
     react,
     nursery

--- a/crates/oxc_linter/src/rules/react/require_render_return.rs
+++ b/crates/oxc_linter/src/rules/react/require_render_return.rs
@@ -25,12 +25,16 @@ pub struct RequireRenderReturn;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Enforce ES5 or ES6 class for returning value in render function
     ///
     /// ### Why is this bad?
+    ///
     /// When writing the `render` method in a component it is easy to forget to return the JSX content. This rule will warn if the return statement is missing.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```jsx
     /// var Hello = createReactClass({
     ///   render() {

--- a/crates/oxc_linter/src/rules/react/style_prop_object.rs
+++ b/crates/oxc_linter/src/rules/react/style_prop_object.rs
@@ -39,9 +39,11 @@ impl std::ops::Deref for StylePropObject {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Require that the value of the prop `style` be an object or a variable that is an object.
     ///
     /// ### Why is this bad?
+    ///
     /// The `style` prop expects an object mapping from style properties to values when using JSX.
     ///
     /// ### Examples

--- a/crates/oxc_linter/src/rules/react/void_dom_elements_no_children.rs
+++ b/crates/oxc_linter/src/rules/react/void_dom_elements_no_children.rs
@@ -28,13 +28,15 @@ pub struct VoidDomElementsNoChildren;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow void DOM elements (e.g. `<img />`, `<br />`) from receiving children.
     ///
     /// ### Why is this bad?
+    ///
     /// There are some HTML elements that are only self-closing (e.g. img, br, hr). These are collectively known as void DOM elements.
     /// This rule checks that children are not passed to void DOM elements.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_jsx_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_jsx_as_prop.rs
@@ -22,7 +22,7 @@ declare_oxc_lint!(
     /// re-renders of child components. This also leads to harder-to-maintain code
     /// as the component's props are not passed consistently.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_array_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_array_as_prop.rs
@@ -25,7 +25,7 @@ declare_oxc_lint!(
     /// child components. This also leads to harder-to-maintain code as the
     /// component's props are not passed consistently.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
@@ -25,7 +25,7 @@ declare_oxc_lint!(
     /// of child components. This also leads to harder-to-maintain code as the
     /// component's props are not passed consistently.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx

--- a/crates/oxc_linter/src/rules/typescript/adjacent_overload_signatures.rs
+++ b/crates/oxc_linter/src/rules/typescript/adjacent_overload_signatures.rs
@@ -36,12 +36,15 @@ declare_oxc_lint!(
     /// Require that function overload signatures be consecutive.
     ///
     /// ### Why is this bad?
+    ///
     /// Function overload signatures represent multiple ways
     /// a function can be called, potentially with different return types.
     /// It's typical for an interface or type alias describing a function to place all overload signatures next to each other.
     /// If Signatures placed elsewhere in the type are easier to be missed by future developers reading the code.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```typescript
     /// declare namespace Foo {
     ///   export function foo(s: string): void;

--- a/crates/oxc_linter/src/rules/typescript/array_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/array_type.rs
@@ -28,8 +28,24 @@ declare_oxc_lint!(
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```typescript
+    /// /*oxlint array-type: ["error", { "default": "array" }] */
     /// const arr: Array<number> = new Array<number>();
+    /// ```
+    ///
+    /// ```typescript
+    /// /*oxlint array-type: ["error", { "default": "generic" }] */
     /// const arr: number[] = new Array<number>();
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// /*oxlint array-type: ["error", { "default": "array" }] */
+    /// const arr: number[] = new Array<number>();
+    /// ```
+    ///
+    /// ```typescript
+    /// /*oxlint array-type: ["error", { "default": "generic" }] */
+    /// const arr: Array<number> = new Array<number>();
     /// ```
     ArrayType,
     typescript,

--- a/crates/oxc_linter/src/rules/typescript/array_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/array_type.rs
@@ -17,12 +17,16 @@ pub struct ArrayType(Box<ArrayTypeConfig>);
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Require consistently using either `T[]` or `Array<T>` for arrays.
     ///
     /// ### Why is this bad?
+    ///
     /// Using the `Array` type directly is not idiomatic. Instead, use the array type `T[]` or `Array<T>`.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```typescript
     /// const arr: Array<number> = new Array<number>();
     /// const arr: number[] = new Array<number>();

--- a/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
@@ -105,13 +105,17 @@ impl DirectiveConfig {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// This rule lets you set which directive comments you want to allow in your codebase.
     ///
     /// ### Why is this bad?
+    ///
     /// Using TypeScript directives to suppress TypeScript compiler errors
     /// reduces the effectiveness of TypeScript overall.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```ts
     /// if (false) {
     ///   // @ts-ignore: Unreachable code error

--- a/crates/oxc_linter/src/rules/typescript/ban_tslint_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_tslint_comment.rs
@@ -29,6 +29,11 @@ declare_oxc_lint!(
     /// // tslint:disable-next-line
     /// someCode();
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// someCode();
+    /// ```
     BanTslintComment,
     typescript,
     style,

--- a/crates/oxc_linter/src/rules/typescript/ban_tslint_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_tslint_comment.rs
@@ -14,13 +14,17 @@ pub struct BanTslintComment;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// This rule disallows `tslint:<rule-flag>` comments
     ///
     /// ### Why is this bad?
+    ///
     /// Useful when migrating from TSLint to ESLint. Once TSLint has been
     /// removed, this rule helps locate TSLint annotations
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```ts
     /// // tslint:disable-next-line
     /// someCode();

--- a/crates/oxc_linter/src/rules/typescript/ban_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_types.rs
@@ -46,7 +46,9 @@ declare_oxc_lint!(
     ///
     /// Some built-in types have aliases, while some types are considered dangerous or harmful. It's often a good idea to ban certain types to help with consistency and safety.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```typescript
     /// let foo: String = 'foo';
     ///

--- a/crates/oxc_linter/src/rules/typescript/ban_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_types.rs
@@ -54,6 +54,13 @@ declare_oxc_lint!(
     ///
     /// let bar: Boolean = true;
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// let foo: string = 'foo';
+    ///
+    /// let bar: boolean = true;
+    /// ```
     BanTypes,
     typescript,
     pedantic,

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -103,6 +103,11 @@ declare_oxc_lint!(
     ///
     /// type S = import("Foo");
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// import type { Foo } from 'Foo';
+    /// ```
     ConsistentTypeImports,
     typescript,
     style,

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -94,7 +94,9 @@ declare_oxc_lint!(
     ///
     /// inconsistent usage of type imports can make the code harder to read and understand.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```ts
     /// import { Foo } from 'Foo';
     /// type T = Foo;

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -58,10 +58,9 @@ declare_oxc_lint!(
     /// Another benefit of explicit return types is the potential for a speed up of type
     /// checking in large codebases with many large functions.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
-    ///
     /// ```ts
     /// // Should indicate that no value is returned (void)
     /// function test() {
@@ -85,7 +84,6 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Examples of **correct** code for this rule:
-    ///
     /// ```ts
     /// // No return value should be expected (void)
     /// function test(): void {

--- a/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
@@ -18,12 +18,16 @@ pub struct NoConfusingNonNullAssertion;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow non-null assertion in locations that may be confusing.
     ///
     /// ### Why is this bad?
+    ///
     /// Using a non-null assertion (!) next to an assign or equals check (= or == or ===) creates code that is confusing as it looks similar to a not equals check (!= !==).
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```ts
     ///    a! == b; // a non-null assertions(`!`) and an equals test(`==`)
     ///    a !== b; // not equals test(`!==`)

--- a/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
@@ -33,6 +33,13 @@ declare_oxc_lint!(
     ///    a !== b; // not equals test(`!==`)
     ///    a! === b; // a non-null assertions(`!`) and an triple equals test(`===`)
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// a == b;
+    /// a !== b;
+    /// a === b;
+    /// ```
     NoConfusingNonNullAssertion,
     typescript,
     suspicious,

--- a/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
@@ -36,9 +36,11 @@ pub struct NoDuplicateEnumValues;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow duplicate enum member values.
     ///
     /// ### Why is this bad?
+    ///
     /// Although TypeScript supports duplicate enum member values, people
     /// usually expect members to have unique values within the same enum.
     /// Duplicate values can lead to bugs that are hard to track down.

--- a/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
@@ -27,6 +27,12 @@ declare_oxc_lint!(
     /// const container: { [i: string]: 0 } = {};
     /// delete container['aa' + 'b'];
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// const container: { [i: string]: 0 } = {};
+    /// delete container.aab;
+    /// ```
     NoDynamicDelete,
     typescript,
     restriction,

--- a/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
@@ -11,14 +11,18 @@ pub struct NoDynamicDelete;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow using the delete operator on computed key expressions.
     ///
     /// ### Why is this bad?
+    ///
     /// Deleting dynamically computed keys can be dangerous and in some cases not well optimized.
     /// Using the delete operator on keys that aren't runtime constants could be a sign that you're using the wrong data structures.
     /// Consider using a Map or Set if you’re using an object as a key-value collection.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```ts
     /// const container: { [i: string]: 0 } = {};
     /// delete container['aa' + 'b'];

--- a/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
@@ -42,6 +42,16 @@ declare_oxc_lint!(
     /// interface Foo {}
     /// interface Bar extends Foo {}
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// interface Foo {
+    ///     member: string;
+    /// }
+    /// interface Bar extends Foo {
+    ///     member: string;
+    /// }
+    /// ```
     NoEmptyInterface,
     typescript,
     style

--- a/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
@@ -35,7 +35,9 @@ declare_oxc_lint!(
     /// Using an empty interface is often a sign of programmer error, such as misunderstanding the concept of {} or forgetting to fill in fields.
     /// This rule aims to ensure that only meaningful interfaces are declared in the code.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```ts
     /// interface Foo {}
     /// interface Bar extends Foo {}

--- a/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
@@ -44,9 +44,11 @@ impl std::ops::Deref for NoEmptyObjectType {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// To avoid confusion around the `{}` type allowing any non-nullish value, this rule bans usage of the `{}` type. That includes interfaces and object type aliases with no fields.
     ///
     /// ### Why is this bad?
+    ///
     /// The `{}`, or "empty object" type in TypeScript is a common source of confusion for developers unfamiliar with TypeScript's structural typing. `{}` represents any non-nullish value, including literals like 0 and "".
     /// Often, developers writing `{}` actually mean either:
     /// - object: representing any object value

--- a/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
@@ -43,10 +43,9 @@ declare_oxc_lint!(
     /// > TypeScript's `--noImplicitAny` compiler option prevents an implied `any`, but doesn't
     /// > prevent `any` from being explicitly used the way this rule does.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
-    ///
     /// ```typescript
     /// const age: any = 'seventeen';
     /// const ages: any[] = ['seventeen']
@@ -60,7 +59,6 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Examples of **correct** code for this rule:
-    ///
     /// ```typescript
     /// const age: number = 17;
     /// const ages: number[] = [17];
@@ -73,15 +71,14 @@ declare_oxc_lint!(
     /// function greet(param: Array<string>): Array<string> {}
     /// ```
     ///
-    /// ## Options
+    /// ### Options
     ///
-    /// This rule accepts the following options:
+    /// #### `ignoreRestArgs`
     ///
-    /// ### `ignoreRestArgs`
     /// A boolean to specify if arrays from the rest operator are considered ok. `false` by
     /// default.
     ///
-    /// ### `fixToUnknown`
+    /// #### `fixToUnknown`
     ///
     /// Whether to enable auto-fixing in which the `any` type is converted to the `unknown` type.
     /// `false` by default.

--- a/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
@@ -69,6 +69,12 @@ declare_oxc_lint!(
     ///
     ///   abstract class Foo {}
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// const version = 42;
+    /// const isProduction = () => process.env.NODE_ENV === 'production';
+    /// ```
     NoExtraneousClass,
     typescript,
     suspicious,

--- a/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
@@ -49,7 +49,9 @@ declare_oxc_lint!(
     /// fields. Those classes can generally be replaced with a standalone
     /// function.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```ts
     /// class StaticConstants {
     /// 	static readonly version = 42;

--- a/crates/oxc_linter/src/rules/typescript/no_import_type_side_effects.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_import_type_side_effects.rs
@@ -63,6 +63,14 @@ declare_oxc_lint!(
     /// import { type A, type B } from 'mod';
     /// import { type A as AA, type B as BB } from 'mod';
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// import type { A } from 'mod';
+    /// import type { A as AA } from 'mod';
+    /// import type { A, B } from 'mod';
+    /// import type { A as AA, B as BB } from 'mod';
+    /// ```
     NoImportTypeSideEffects,
     typescript,
     restriction,

--- a/crates/oxc_linter/src/rules/typescript/no_import_type_side_effects.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_import_type_side_effects.rs
@@ -54,7 +54,9 @@ declare_oxc_lint!(
     /// desirable - but for most cases you will not want to leave behind an
     /// unnecessary side effect import.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```ts
     /// import { type A } from 'mod';
     /// import { type A as AA } from 'mod';

--- a/crates/oxc_linter/src/rules/typescript/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_namespace.rs
@@ -26,9 +26,11 @@ pub struct NoNamespace {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow TypeScript namespaces.
     ///
     /// ### Why is this bad?
+    ///
     /// TypeScript historically allowed a form of code organization called "custom modules" (module Example {}),
     /// later renamed to "namespaces" (namespace Example). Namespaces are an outdated way to organize TypeScript code.
     /// ES2015 module syntax is now preferred (import/export).

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
@@ -15,6 +15,7 @@ pub struct NoNonNullAssertedNullishCoalescing;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow non-null assertions in the left operand of a nullish coalescing operator.
     ///
     /// ### Why is this bad?

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
@@ -44,14 +44,12 @@ declare_oxc_lint!(
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
-    ///
     /// ```ts
     /// foo?.bar!;
     /// foo?.bar()!;
     /// ```
     ///
     /// Examples of **correct** code for this rule:
-    ///
     /// ```ts
     /// foo?.bar;
     /// foo.bar!;

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
@@ -29,6 +29,13 @@ declare_oxc_lint!(
     /// x!.y;
     /// x.y!;
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// x;
+    /// x?.y;
+    /// x.y;
+    /// ```
     NoNonNullAssertion,
     typescript,
     restriction,

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
@@ -14,12 +14,16 @@ pub struct NoNonNullAssertion;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow non-null assertions using the ! postfix operator.
     ///
     /// ### Why is this bad?
+    ///
     /// TypeScript's ! non-null assertion operator asserts to the type system that an expression is non-nullable, as in not null or undefined. Using assertions to tell the type system new information is often a sign that code is not fully type-safe. It's generally better to structure program logic so that TypeScript understands when values may be nullable.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```ts
     /// x!;
     /// x!.y;

--- a/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
@@ -112,7 +112,6 @@ declare_oxc_lint!(
     /// import foo = require('foo');
     /// import foo from 'foo';
     /// ```
-    ///
     NoRequireImports,
     typescript,
     restriction,

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
@@ -29,7 +29,9 @@ declare_oxc_lint!(
     /// Declaration merging between classes and interfaces is unsafe.
     /// The TypeScript compiler doesn't check whether properties are initialized, which can cause lead to TypeScript not detecting code that will cause runtime errors.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```ts
     /// interface Foo {}
     /// class Foo {}

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
@@ -36,6 +36,12 @@ declare_oxc_lint!(
     /// interface Foo {}
     /// class Foo {}
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// interface Foo {}
+    /// class Bar {}
+    /// ```
     NoUnsafeDeclarationMerging,
     typescript,
     correctness

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_function_type.rs
@@ -21,9 +21,11 @@ pub struct NoUnsafeFunctionType;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow using the unsafe built-in Function type.
     ///
     /// ### Why is this bad?
+    ///
     /// TypeScript's built-in Function type allows being called with any number of arguments and returns type any. Function also allows classes or plain objects that happen to possess all properties of the Function class. It's generally better to specify function parameters and return types with the function type syntax.
     ///
     /// ### Examples

--- a/crates/oxc_linter/src/rules/typescript/no_useless_empty_export.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_useless_empty_export.rs
@@ -19,7 +19,8 @@ declare_oxc_lint!(
     ///
     /// Disallow empty exports that don't change anything in a module file.
     ///
-    /// ## Why is this bad?
+    /// ### Why is this bad?
+    ///
     /// An empty `export {}` statement is sometimes useful in TypeScript code to
     /// turn a file that would otherwise be a script file into a module file.
     /// Per the [TypeScript Handbook Modules page](https://www.typescriptlang.org/docs/handbook/modules/introduction.html):
@@ -36,7 +37,7 @@ declare_oxc_lint!(
     /// This rule reports an `export {}` that doesn't do anything in a file
     /// already using ES modules.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```ts

--- a/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
@@ -43,6 +43,14 @@ declare_oxc_lint!(
     ///  Close,
     /// }
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// enum Status {
+    ///  Open = 1,
+    ///  Close = 2,
+    /// }
+    /// ```
     PreferEnumInitializers,
     typescript,
     pedantic,

--- a/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
@@ -26,12 +26,16 @@ pub struct PreferEnumInitializers;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Require each enum member value to be explicitly initialized.
     ///
     /// ### Why is this bad?
+    ///
     /// In projects where the value of `enum` members are important, allowing implicit values for enums can cause bugs if enums are modified over time.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```typescript
     /// // wrong, the value of `Close` is not constant
     /// enum Status {

--- a/crates/oxc_linter/src/rules/typescript/prefer_for_of.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_for_of.rs
@@ -25,14 +25,16 @@ pub struct PreferForOf;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Enforces the use of for-of loop instead of a for loop with a simple iteration.
     ///
     /// ### Why is this bad?
+    ///
     /// Using a for loop with a simple iteration over an array can be replaced with a more concise
     /// and readable for-of loop. For-of loops are easier to read and less error-prone, as they
     /// eliminate the need for an index variable and manual array access.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```typescript

--- a/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
@@ -39,8 +39,6 @@ declare_oxc_lint!(
     /// This rule suggests using a function type instead of an interface or object type literal with a single call signature.
     ///
     /// ### Examples
-    ///
-    /// Examples of **incorrect** code for this rule:
     /// ```ts
     /// // error
     /// interface Example {

--- a/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
@@ -38,7 +38,9 @@ declare_oxc_lint!(
     ///
     /// This rule suggests using a function type instead of an interface or object type literal with a single call signature.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```ts
     /// // error
     /// interface Example {

--- a/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
@@ -25,13 +25,17 @@ pub struct PreferLiteralEnumMember {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Explicit enum value must only be a literal value (string, number, boolean, etc).
     ///
     /// ### Why is this bad?
+    ///
     /// TypeScript allows the value of an enum member to be many different kinds of valid JavaScript expressions.
     /// However, because enums create their own scope whereby each enum member becomes a variable in that scope, developers are often surprised at the resultant values.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```ts
     /// const imOutside = 2;
     /// const b = 2;

--- a/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
@@ -22,14 +22,18 @@ pub struct PreferNamespaceKeyword;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// This rule reports when the module keyword is used instead of namespace.
     /// This rule does not report on the use of TypeScript module declarations to describe external APIs (declare module 'foo' {}).
     ///
     /// ### Why is this bad?
+    ///
     /// Namespaces are an outdated way to organize TypeScript code. ES2015 module syntax is now preferred (import/export).
     /// For projects still using custom modules / namespaces, it's preferred to refer to them as namespaces.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```typescript
     /// module Example {}
     /// ```

--- a/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
@@ -37,6 +37,11 @@ declare_oxc_lint!(
     /// ```typescript
     /// module Example {}
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// namespace Example {}
+    /// ```
     PreferNamespaceKeyword,
     typescript,
     style,

--- a/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
@@ -44,6 +44,15 @@ declare_oxc_lint!(
     /// * @ts-ignore */
     /// const multiLine: number = 'value';
     /// ```
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```ts
+    /// /**
+    /// * Explaining comment
+    /// *
+    /// * @ts-expect-error */
+    /// const multiLine: number = 'value';
+    /// ```
     PreferTsExpectError,
     typescript,
     pedantic,

--- a/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
@@ -24,13 +24,16 @@ declare_oxc_lint!(
     /// Enforce using @ts-expect-error over @ts-ignore.
     ///
     /// ### Why is this bad?
+    ///
     /// TypeScript allows you to suppress all errors on a line by placing a comment starting with @ts-ignore or @ts-expect-error immediately before the erroring line.
     /// The two directives work the same, except @ts-expect-error causes a type error if placed before a line that's not erroring in the first place.
     ///
     /// This means it's easy for @ts-ignores to be forgotten about, and remain in code even after the error they were suppressing is fixed.
     /// This is dangerous, as if a new error arises on that line it'll be suppressed by the forgotten about @ts-ignore, and so be missed.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```ts
     /// // @ts-ignore
     /// const str: string = 1;

--- a/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
+++ b/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
@@ -57,12 +57,16 @@ impl std::ops::Deref for TripleSlashReference {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow certain triple slash directives in favor of ES6-style import declarations.
     ///
     /// ### Why is this bad?
+    ///
     /// Use of triple-slash reference type directives is generally discouraged in favor of ECMAScript Module imports.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```ts
     /// /// <reference lib="code" />
     /// globalThis.value;

--- a/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
@@ -58,6 +58,7 @@ pub struct ExplicitLengthCheck {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Enforce explicitly comparing the length or size property of a value.
     ///
     /// The non-zero option can be configured with one of the following:

--- a/crates/oxc_linter/src/rules/unicorn/no_array_for_each.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_for_each.rs
@@ -32,7 +32,7 @@ declare_oxc_lint!(
     ///
     /// Additionally, using `for…of` has great benefits if you are using TypeScript, because it does not cause a function boundary to be crossed. This means that type-narrowing earlier on in the current scope will work properly while inside of the loop (without having to re-type-narrow). Furthermore, any mutated variables inside of the loop will picked up on for the purposes of determining if a variable is being used.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/no_array_reduce.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_reduce.rs
@@ -41,7 +41,9 @@ declare_oxc_lint!(
     ///
     /// It's only somewhat useful in the rare case of summing up numbers, which is allowed by default.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// array.reduce(reducer, initialValue);
     /// array.reduceRight(reducer, initialValue);

--- a/crates/oxc_linter/src/rules/unicorn/no_await_expression_member.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_await_expression_member.rs
@@ -24,7 +24,9 @@ declare_oxc_lint!(
     /// When accessing a member from an `await` expression,
     /// the `await` expression has to be parenthesized, which is not readable.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// async function bad() {
     ///     const secondElement = (await getArray())[1];

--- a/crates/oxc_linter/src/rules/unicorn/no_await_expression_member.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_await_expression_member.rs
@@ -31,7 +31,10 @@ declare_oxc_lint!(
     /// async function bad() {
     ///     const secondElement = (await getArray())[1];
     /// }
+    /// ```
     ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
     /// async function good() {
     ///     const [, secondElement] = await getArray();
     /// }

--- a/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
@@ -25,7 +25,7 @@ declare_oxc_lint!(
     /// `Promise.allSettled()`, `Promise.any()`, or `Promise.race()` is likely a
     /// mistake.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/no_console_spaces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_console_spaces.rs
@@ -34,7 +34,7 @@ declare_oxc_lint!(
     ///
     /// The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/no_instanceof_array.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_instanceof_array.rs
@@ -17,12 +17,16 @@ pub struct NoInstanceofArray;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Require `Array.isArray()` instead of `instanceof Array`.
     ///
     /// ### Why is this bad?
+    ///
     /// The instanceof Array check doesn't work across realms/contexts, for example, frames/windows in browsers or the vm module in Node.js.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// array instanceof Array;
     /// [1,2,3] instanceof Array;

--- a/crates/oxc_linter/src/rules/unicorn/no_instanceof_array.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_instanceof_array.rs
@@ -31,6 +31,12 @@ declare_oxc_lint!(
     /// array instanceof Array;
     /// [1,2,3] instanceof Array;
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// Array.isArray(array);
+    /// Array.isArray([1,2,3]);
+    /// ```
     NoInstanceofArray,
     unicorn,
     pedantic,

--- a/crates/oxc_linter/src/rules/unicorn/no_invalid_remove_event_listener.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_invalid_remove_event_listener.rs
@@ -29,7 +29,7 @@ declare_oxc_lint!(
     ///
     /// The [`removeEventListener`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener) function must be called with a reference to the same function that was passed to [`addEventListener`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener). Calling `removeEventListener` with an inline function or the result of an inline `.bind()` call is indicative of an error, and won't actually remove the listener.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/no_length_as_slice_end.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_length_as_slice_end.rs
@@ -31,7 +31,7 @@ declare_oxc_lint!(
     ///
     /// Passing `length` as the end argument of a `slice` call is unnecessary and can be confusing.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/no_lonely_if.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_lonely_if.rs
@@ -28,7 +28,7 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// if (foo) {
-    ///         if (bar) {
+    ///     if (bar) {
     ///     }
     /// }
     /// if (foo) if (bar) baz();

--- a/crates/oxc_linter/src/rules/unicorn/no_lonely_if.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_lonely_if.rs
@@ -23,7 +23,7 @@ declare_oxc_lint!(
     ///
     /// It can be confusing to have an `if` statement without an `else` clause as the only statement in an `if` block.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/no_magic_array_flat_depth.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_magic_array_flat_depth.rs
@@ -26,7 +26,7 @@ declare_oxc_lint!(
     ///
     /// Magic numbers are hard to understand and maintain. When calling `Array.prototype.flat`, it is usually called with `1` or infinity. If you are using a different number, it is better to add a comment explaining the depth.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/no_negation_in_equality_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_negation_in_equality_check.rs
@@ -32,7 +32,7 @@ declare_oxc_lint!(
     ///
     /// A negated expression on the left of an (in)equality check is likely a mistake from trying to negate the whole condition.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/no_new_buffer.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_new_buffer.rs
@@ -23,7 +23,7 @@ declare_oxc_lint!(
     ///
     /// Enforces the use of [Buffer.from](https://nodejs.org/api/buffer.html#static-method-bufferfromarray) and [Buffer.alloc()](https://nodejs.org/api/buffer.html#static-method-bufferallocsize-fill-encoding) instead of [new Buffer()](https://nodejs.org/api/buffer.html#new-bufferarray), which has been deprecated since Node.js 4.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/no_null.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_null.rs
@@ -40,7 +40,7 @@ declare_oxc_lint!(
     /// - Supporting both `null` and `undefined` complicates input validation.
     /// - Using `null` makes TypeScript types more verbose: `type A = {foo?: string | null}` vs `type A = {foo?: string}`.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/no_object_as_default_parameter.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_object_as_default_parameter.rs
@@ -29,7 +29,7 @@ declare_oxc_lint!(
     ///
     /// Default parameters should not be passed to a function through an object literal. The `foo = {a: false}` parameter works fine if only used with one option. As soon as additional options are added, you risk replacing the whole `foo = {a: false, b: true}` object when passing only one option: `{a: true}`. For this reason, object destructuring should be used instead.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/no_process_exit.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_process_exit.rs
@@ -16,12 +16,14 @@ pub struct NoProcessExit;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow `process.exit()`.
     ///
     /// ### Why is this bad?
+    ///
     /// Only use `process.exit()` in CLI apps. Throw an error instead.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs
@@ -30,8 +30,7 @@ declare_oxc_lint!(
     /// Passing a single-element array to `Promise.all()`, `Promise.any()`, or
     /// `Promise.race()` is likely a mistake.
     ///
-    ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
@@ -53,7 +52,6 @@ declare_oxc_lint!(
     ///     const [{ value: foo, reason: error }] = await Promise.allSettled([promise]);
     /// }
     /// ```
-    ///
     NoSinglePromiseInPromiseMethods,
     unicorn,
     correctness,

--- a/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
@@ -22,7 +22,7 @@ declare_oxc_lint!(
     ///
     /// A class with only static members could just be an object instead.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
@@ -35,14 +35,17 @@ pub struct NoThenable;
 
 declare_oxc_lint!(
     /// ### What it does
-    /// disallow `then` property
+    ///
+    /// Disallow `then` property
     ///
     /// ### Why is this bad?
+    ///
     /// If an object is defined as "thenable", once it's accidentally
     /// used in an await expression, it may cause problems:
     ///
+    /// ### Examples
     ///
-    /// ### Example
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     ///     async function example() {
     ///     const foo = {

--- a/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
@@ -58,6 +58,20 @@ declare_oxc_lint!(
     ///     console.log('after'); //<- This will never execute
     /// }
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    ///     async function example() {
+    ///     const foo = {
+    ///         unicorn: 1,
+    ///         bar() {},
+    ///     };
+    ///
+    ///     const { unicorn } = await foo;
+    ///
+    ///     console.log('after');
+    /// }
+    /// ```
     NoThenable,
     unicorn,
     correctness

--- a/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
@@ -25,7 +25,6 @@ declare_oxc_lint!(
     ///
     /// Checking if a value is `undefined` by using `typeof value === 'undefined'` is needlessly verbose. It's generally better to compare against `undefined` directly. The only time `typeof` is needed is when a global variable potentially does not exists, in which case, using `globalThis.value === undefined` may be better.
     ///
-    ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:

--- a/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
@@ -31,6 +31,13 @@ declare_oxc_lint!(
     ///     await await promise;
     /// }
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// async function bad() {
+    ///     await promise;
+    /// }
+    /// ```
     NoUnnecessaryAwait,
     unicorn,
     correctness,

--- a/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
@@ -16,13 +16,16 @@ pub struct NoUnnecessaryAwait;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow awaiting on non-promise values.
     ///
     /// ### Why is this bad?
+    ///
     /// The `await` operator should only be used on `Promise` values.
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// async function bad() {
     ///     await await promise;

--- a/crates/oxc_linter/src/rules/unicorn/no_unreadable_array_destructuring.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unreadable_array_destructuring.rs
@@ -24,7 +24,7 @@ declare_oxc_lint!(
     /// Destructuring is very useful, but it can also make some code harder to read.
     /// This rule prevents ignoring consecutive values when destructuring from an array.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
@@ -51,6 +51,13 @@ declare_oxc_lint!(
     ///    // do something!
     /// }
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// if (array.every(Boolean)) {
+    ///    // do something!
+    /// }
+    /// ```
     NoUselessLengthCheck,
     unicorn,
     correctness,

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
@@ -43,8 +43,9 @@ declare_oxc_lint!(
     ///
     /// An extra unnecessary length check is done.
     ///
-    /// ### Example
+    /// ### Examples
     ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// if (array.length === 0 || array.every(Boolean)) {
     ///    // do something!

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     /// `undefined` is the default value for new variables, parameters, return statements, etc… so specifying it doesn't make any difference.
     ///
     /// ### Examples
+    /// 
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// let foo = undefined;

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
@@ -41,7 +41,7 @@ declare_oxc_lint!(
     /// `undefined` is the default value for new variables, parameters, return statements, etc… so specifying it doesn't make any difference.
     ///
     /// ### Examples
-    /// 
+    ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// let foo = undefined;

--- a/crates/oxc_linter/src/rules/unicorn/no_zero_fractions.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_zero_fractions.rs
@@ -29,7 +29,7 @@ declare_oxc_lint!(
     ///
     /// There is no difference in JavaScript between, for example, `1`, `1.0` and `1.`, so prefer the former for consistency and brevity.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
+++ b/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
@@ -71,6 +71,10 @@ declare_oxc_lint!(
     ///   0o1_0_44_21,
     ///   1_294_28771_2n,
     /// ];
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
     /// const valid = [
     ///   1_234_567,
     ///   1_234.567_89,

--- a/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
+++ b/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
@@ -49,16 +49,19 @@ impl Default for NumericSeparatorsStyleConfig {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Enforces a convention of grouping digits using numeric separators.
     ///
     /// ### Why is this bad?
+    ///
     /// Long numbers can become really hard to read, so cutting it into groups of digits,
     /// separated with a _, is important to keep your code clear. This rule also enforces
     /// a proper usage of the numeric separator, by checking if the groups of digits are
     /// of the correct size.
     ///
+    /// ### Examples
     ///
-    /// ### Example
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// const invalid = [
     ///   1_23_4444,

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
@@ -40,7 +40,7 @@ declare_oxc_lint!(
     ///
     /// This rule aims to standardize the use of `Array#flat()` over legacy techniques to flatten arrays.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_flat_map.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_flat_map.rs
@@ -26,11 +26,16 @@ declare_oxc_lint!(
     ///
     /// It is slightly more efficient to use `.flatMap(…)` instead of `.map(…).flat()`.
     ///
-    /// ### Example
-    /// ```javascript
-    /// const bar = [1,2,3].map(i => [i]).flat(); // ✗ fail
+    /// ### Examples
     ///
-    /// const bar = [1,2,3].flatMap(i => [i]); // ✓ pass
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// const bar = [1,2,3].map(i => [i]).flat();
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// const bar = [1,2,3].flatMap(i => [i]);
     /// ```
     PreferArrayFlatMap,
     unicorn,

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs
@@ -43,7 +43,7 @@ declare_oxc_lint!(
     ///
     /// Using `.some()` is more idiomatic and easier to read.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/prefer_blob_reading_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_blob_reading_methods.rs
@@ -28,7 +28,9 @@ declare_oxc_lint!(
     ///
     /// `FileReader` predates promises, and the newer [`Blob#arrayBuffer()`](https://developer.mozilla.org/en-US/docs/Web/API/Blob/arrayBuffer) and [`Blob#text()`](https://developer.mozilla.org/en-US/docs/Web/API/Blob/text) methods are much cleaner and easier to use.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// async function bad() {
     ///     const arrayBuffer = await new Promise((resolve, reject) => {
@@ -42,7 +44,10 @@ declare_oxc_lint!(
     ///         fileReader.readAsArrayBuffer(blob);
     ///     });
     /// }
+    /// ```
     ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
     /// async function good() {
     ///     const arrayBuffer = await blob.arrayBuffer();
     /// }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_date_now.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_date_now.rs
@@ -40,6 +40,7 @@ declare_oxc_lint!(
     /// Using `Date.now()` is shorter and nicer than `new Date().getTime()`, and avoids unnecessary instantiation of `Date` objects.
     ///
     /// ### Examples
+    ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// const ts = new Date().getTime();

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_append.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_append.rs
@@ -24,6 +24,7 @@ declare_oxc_lint!(
     /// There are [some advantages of using `Node#append()`](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/append), like the ability to append multiple nodes and to append both [`DOMString`](https://developer.mozilla.org/en-US/docs/Web/API/DOMString) and DOM node objects.
     ///
     /// ### Examples
+    ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// foo.appendChild(bar);

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
@@ -49,7 +49,7 @@ declare_oxc_lint!(
     ///
     /// The `dataset` property is a map of strings that contains all the `data-*` attributes from the element. It is a convenient way to access all of them at once.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_text_content.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_text_content.rs
@@ -26,7 +26,7 @@ declare_oxc_lint!(
     /// - `.innerText` is defined only for HTMLElement objects, while `.textContent` is defined for all Node objects.
     /// - `.innerText` is not standard, for example, it is not present in Firefox.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
@@ -27,7 +27,7 @@ declare_oxc_lint!(
     ///
     /// While [`EventEmitter`](https://nodejs.org/api/events.html#class-eventemitter) is only available in Node.js, [`EventTarget`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget) is also available in _Deno_ and browsers.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/prefer_logical_operator_over_ternary.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_logical_operator_over_ternary.rs
@@ -24,7 +24,7 @@ declare_oxc_lint!(
     ///
     /// Using a logical operator is shorter and simpler than a ternary expression.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
@@ -36,7 +36,6 @@ declare_oxc_lint!(
     //  ```javascript
     /// const foo = bar || baz;
     /// console.log(foo ?? bar);
-    ///
     /// ```
     PreferLogicalOperatorOverTernary,
     unicorn,

--- a/crates/oxc_linter/src/rules/unicorn/prefer_math_trunc.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_math_trunc.rs
@@ -30,7 +30,7 @@ declare_oxc_lint!(
     ///
     /// Using bitwise operations to truncate numbers is not clear and do not work in [some cases](https://stackoverflow.com/a/34706108/11687747).
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
@@ -49,7 +49,7 @@ declare_oxc_lint!(
     /// - Appending multiple nodes at once.
     /// - Both `DOMString` and DOM node objects can be manipulated.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_math_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_math_apis.rs
@@ -40,7 +40,7 @@ declare_oxc_lint!(
     ///  - Prefer `Math.log10(x)` over alternatives
     ///  - Prefer `Math.hypot(…)` over alternatives
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/prefer_negative_index.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_negative_index.rs
@@ -29,9 +29,11 @@ enum TypeOptions {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Prefer negative index over `.length` - index when possible
     ///
     /// ### Why is this bad?
+    ///
     /// Conciseness and readability
     ///
     /// ### Examples

--- a/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
@@ -27,7 +27,7 @@ declare_oxc_lint!(
     ///
     /// Node.js builtin modules should be imported using the `node:` protocol to avoid ambiguity with local modules.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/prefer_optional_catch_binding.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_optional_catch_binding.rs
@@ -25,7 +25,7 @@ declare_oxc_lint!(
     ///
     /// It is unnecessary to bind the error to a variable if it is not used.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/prefer_query_selector.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_query_selector.rs
@@ -35,7 +35,7 @@ declare_oxc_lint!(
     /// - Using `.querySelector()` and `.querySelectorAll()` is more flexible and allows for more specific selectors.
     /// - It's better to use the same method to query DOM elements. This helps keep consistency and it lends itself to future improvements (e.g. more specific selectors).
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/prefer_reflect_apply.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_reflect_apply.rs
@@ -27,7 +27,7 @@ declare_oxc_lint!(
     /// In addition, when you accept arbitrary methods,
     /// it's not safe to assume .apply() exists or is not overridden.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
@@ -26,8 +26,7 @@ declare_oxc_lint!(
     ///
     /// When you want to know whether a pattern is found in a string, use [`RegExp#test()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test) instead of [`String#match()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match) and [`RegExp#exec()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec), as it exclusively returns a boolean and therefore is more efficient.
     ///
-    ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
@@ -39,7 +38,6 @@ declare_oxc_lint!(
     /// ```javascript
     /// if (/unicorn/.test(string)) {}
     /// Boolean(string.match(/unicorn/))
-    ///
     /// ```
     PreferRegexpTest,
     unicorn,

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_raw.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_raw.rs
@@ -26,7 +26,7 @@ declare_oxc_lint!(
     ///
     /// Excessive backslashes can make string values less readable which can be avoided by using `String.raw`.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
@@ -31,7 +31,7 @@ declare_oxc_lint!(
     ///
     /// The [`String#replaceAll()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll) method is both faster and safer as you don't have to use a regex and remember to escape it if the string is not a literal. And when used with a regex, it makes the intent clearer.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```js

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_slice.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_slice.rs
@@ -22,7 +22,7 @@ declare_oxc_lint!(
     ///
     /// [`String#substr()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) and [`String#substring()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) are the two lesser known legacy ways to slice a string. It's better to use [`String#slice()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) as it's a more popular option with clearer behavior that has a consistent [`Array` counterpart](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice).
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
@@ -35,7 +35,7 @@ declare_oxc_lint!(
     ///
     /// Using `String#startsWith()` and `String#endsWith()` is more readable and performant as it does not need to parse a regex.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_trim_start_end.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_trim_start_end.rs
@@ -27,7 +27,7 @@ declare_oxc_lint!(
     ///
     /// The `trimLeft` and `trimRight` names are confusing and inconsistent with the rest of the language.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/prefer_type_error.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_type_error.rs
@@ -29,7 +29,7 @@ declare_oxc_lint!(
     ///
     /// Throwing a `TypeError` instead of a generic `Error` after a type checking if-statement is more specific and helps to catch bugs.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/require_array_join_separator.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_array_join_separator.rs
@@ -30,7 +30,7 @@ declare_oxc_lint!(
     /// It's better to make it clear what the separator is when calling Array#join(),
     /// instead of relying on the default comma (',') separator.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -35,12 +35,16 @@ pub struct SwitchCaseBraces {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Require empty switch cases to not have braces. Non-empty braces are required to have braces around them.
     ///
     /// ### Why is this bad?
+    ///
     /// There is less visual clutter for empty cases and proper scope for non-empty cases.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// switch (num) {
     ///     case 1: {

--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -55,6 +55,19 @@ declare_oxc_lint!(
     ///         break;
     /// }
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// switch (num) {
+    ///     case 1: {
+    ///
+    ///     }
+    ///     case 2: {
+    ///         console.log('Case 2');
+    ///         break;
+    ///     }
+    /// }
+    /// ```
     SwitchCaseBraces,
     unicorn,
     style,

--- a/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
@@ -34,7 +34,7 @@ declare_oxc_lint!(
     /// - Inconsistency in text encoding identifiers can make the code harder to read and understand.
     /// - The ECMAScript specification does not define the case sensitivity of text encoding identifiers, but it is common practice to use lowercase.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/vitest/require_local_test_context_for_concurrent_snapshots.rs
+++ b/crates/oxc_linter/src/rules/vitest/require_local_test_context_for_concurrent_snapshots.rs
@@ -71,7 +71,6 @@ declare_oxc_lint!(
     ///         expect(true).toMatchInlineSnapshot();
     ///     })
     /// })
-    ///
     /// ```
     ///
     /// Examples of **correct** code for this rule:


### PR DESCRIPTION
Most of these changes were done automatically using find & replace. This brings many rule docs closer to the desired format of #6050. Also fixed minor issues in some docs discovered while working on this. 