### PR TITLE
fix(ci): use jsdelivr for all benchmark files

### DIFF
--- a/napi/parser/bench.bench.mjs
+++ b/napi/parser/bench.bench.mjs
@@ -5,9 +5,9 @@ import { parseSync } from './index.js';
 
 // Same fixtures as used in Rust parser benchmarks
 let fixtureUrls = [
-  'https://raw.githubusercontent.com/microsoft/TypeScript/v5.3.3/src/compiler/checker.ts',
-  'https://raw.githubusercontent.com/oxc-project/benchmark-files/main/cal.com.tsx',
-  'https://raw.githubusercontent.com/oxc-project/benchmark-files/main/RadixUIAdoptionSection.jsx',
+  'https://cdn.jsdelivr.net/gh/microsoft/TypeScript@v5.3.3/src/compiler/checker.ts',
+  'https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@main/cal.com.tsx',
+  'https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@main/RadixUIAdoptionSection.jsx',
   'https://cdn.jsdelivr.net/npm/pdfjs-dist@4.0.269/build/pdf.mjs',
   'https://cdn.jsdelivr.net/npm/antd@5.12.5/dist/antd.js',
 ];

--- a/napi/parser/test/parse-raw.test.ts
+++ b/napi/parser/test/parse-raw.test.ts
@@ -25,11 +25,11 @@ const INFINITY_REGEXP = new RegExp(`"${INFINITY_PLACEHOLDER}"`, 'g');
 // TODO: Enable them again once that work is complete.
 const benchFixtureUrls = [
   // TypeScript syntax (2.81MB)
-  // 'https://raw.githubusercontent.com/microsoft/TypeScript/v5.3.3/src/compiler/checker.ts',
+  // 'https://cdn.jsdelivr.net/gh/microsoft/TypeScript@v5.3.3/src/compiler/checker.ts',
   // Real world app tsx (1.0M)
-  // 'https://raw.githubusercontent.com/oxc-project/benchmark-files/main/cal.com.tsx',
+  // 'https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@main/cal.com.tsx',
   // Real world content-heavy app jsx (3K)
-  'https://raw.githubusercontent.com/oxc-project/benchmark-files/main/RadixUIAdoptionSection.jsx',
+  'https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@main/RadixUIAdoptionSection.jsx',
   // Heavy with classes (554K)
   'https://cdn.jsdelivr.net/npm/pdfjs-dist@4.0.269/build/pdf.mjs',
   // ES5 (3.9M)

--- a/tasks/benchmark/benches/isolated_declarations.rs
+++ b/tasks/benchmark/benches/isolated_declarations.rs
@@ -8,9 +8,8 @@ use oxc_tasks_common::TestFile;
 fn bench_isolated_declarations(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("isolated-declarations");
 
-    let file = TestFile::new(
-        "https://raw.githubusercontent.com/oxc-project/benchmark-files/main/vue-id.ts",
-    );
+    let file =
+        TestFile::new("https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@main/vue-id.ts");
 
     let id = BenchmarkId::from_parameter(&file.file_name);
     let source_text = file.source_text.as_str();

--- a/tasks/common/src/test_file.rs
+++ b/tasks/common/src/test_file.rs
@@ -64,11 +64,11 @@ impl TestFiles {
     fn complicated_urls() -> [&'static str; 5] {
         [
             // TypeScript syntax (2.81MB)
-            "https://raw.githubusercontent.com/microsoft/TypeScript/v5.3.3/src/compiler/checker.ts",
+            "https://cdn.jsdelivr.net/gh/microsoft/TypeScript@v5.3.3/src/compiler/checker.ts",
             // Real world app tsx (1.0M)
-            "https://raw.githubusercontent.com/oxc-project/benchmark-files/main/cal.com.tsx",
+            "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@main/cal.com.tsx",
             // Real world content-heavy app jsx (3K)
-            "https://raw.githubusercontent.com/oxc-project/benchmark-files/main/RadixUIAdoptionSection.jsx",
+            "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@main/RadixUIAdoptionSection.jsx",
             // Heavy with classes (554K)
             "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.0.269/build/pdf.mjs",
             // ES5 (3.9M)


### PR DESCRIPTION
https://github.blog/changelog/2025-05-08-updated-rate-limits-for-unauthenticated-requests/
