### PR TITLE
refactor(various): update macros to use `expr` fragment specifier

### DIFF
--- a/crates/oxc_ast_visit/src/utf8_to_utf16.rs
+++ b/crates/oxc_ast_visit/src/utf8_to_utf16.rs
@@ -733,7 +733,7 @@ mod test {
     #[test]
     fn char_lengths() {
         macro_rules! assert_utf8_bytes_eq {
-            ($c:expr_2021, $bytes:expr_2021) => {{
+            ($c:expr, $bytes:expr) => {{
                 let mut buffer = [0; 4];
                 let bytes = $c.encode_utf8(&mut buffer).as_bytes();
                 assert!($bytes == bytes);

--- a/crates/oxc_cfg/src/visit.rs
+++ b/crates/oxc_cfg/src/visit.rs
@@ -66,10 +66,10 @@ where
 /// Return if the expression is a break value, execute the provided statement
 /// if it is a prune value.
 macro_rules! try_control {
-    ($e:expr_2021, $p:stmt) => {
+    ($e:expr, $p:stmt) => {
         try_control!($e, $p, ());
     };
-    ($e:expr_2021, $p:stmt, $q:stmt) => {
+    ($e:expr, $p:stmt, $q:stmt) => {
         match $e {
             x => {
                 #[allow(clippy::redundant_else, clippy::allow_attributes)]

--- a/crates/oxc_data_structures/src/stack/non_empty.rs
+++ b/crates/oxc_data_structures/src/stack/non_empty.rs
@@ -421,7 +421,7 @@ mod tests {
     use super::*;
 
     macro_rules! assert_len_cap_last {
-        ($stack:ident, $len:expr_2021, $capacity:expr_2021, $last:expr_2021) => {
+        ($stack:ident, $len:expr, $capacity:expr, $last:expr) => {
             assert_eq!($stack.len(), $len);
             assert_eq!($stack.capacity(), $capacity);
             assert_eq!($stack.last(), $last);

--- a/crates/oxc_data_structures/src/stack/standard.rs
+++ b/crates/oxc_data_structures/src/stack/standard.rs
@@ -405,7 +405,7 @@ mod tests {
     use super::*;
 
     macro_rules! assert_len_cap_last {
-        ($stack:ident, $len:expr_2021, $capacity:expr_2021, $last:expr_2021) => {
+        ($stack:ident, $len:expr, $capacity:expr, $last:expr) => {
             assert_eq!($stack.len(), $len);
             assert_eq!($stack.capacity(), $capacity);
             assert_eq!($stack.last(), $last);

--- a/crates/oxc_linter/src/module_graph_visitor.rs
+++ b/crates/oxc_linter/src/module_graph_visitor.rs
@@ -189,7 +189,7 @@ impl ModuleGraphVisitor {
         leave: &mut LeaveMod,
     ) -> VisitFoldWhile<T> {
         macro_rules! accumulate {
-            ($acc:expr_2021) => {
+            ($acc:expr) => {
                 accumulator = $acc;
 
                 if accumulator.is_done() {

--- a/crates/oxc_parser/src/lexer/byte_handlers.rs
+++ b/crates/oxc_parser/src/lexer/byte_handlers.rs
@@ -65,7 +65,7 @@ static BYTE_HANDLERS: [ByteHandler; 256] = [
 /// };
 /// ```
 macro_rules! byte_handler {
-    ($id:ident($lex:ident) $body:expr_2021) => {
+    ($id:ident($lex:ident) $body:expr) => {
         const $id: ByteHandler = {
             #[expect(non_snake_case)]
             fn $id($lex: &mut Lexer) -> Kind {
@@ -121,7 +121,7 @@ macro_rules! byte_handler {
 /// };
 /// ```
 macro_rules! ascii_byte_handler {
-    ($id:ident($lex:ident) $body:expr_2021) => {
+    ($id:ident($lex:ident) $body:expr) => {
         byte_handler!($id($lex) {
             // SAFETY: This macro is only used for ASCII characters
             unsafe {
@@ -172,7 +172,7 @@ macro_rules! ascii_byte_handler {
 /// };
 /// ```
 macro_rules! ascii_identifier_handler {
-    ($id:ident($str:ident) $body:expr_2021) => {
+    ($id:ident($str:ident) $body:expr) => {
         byte_handler!($id(lexer) {
             // SAFETY: This macro is only used for ASCII characters
             let $str = unsafe { lexer.identifier_name_handler() };

--- a/crates/oxc_parser/src/lexer/search.rs
+++ b/crates/oxc_parser/src/lexer/search.rs
@@ -94,7 +94,7 @@ impl ByteMatchTable {
 /// ```
 #[expect(unused_macros)]
 macro_rules! byte_match_table {
-    (|$byte:ident| $res:expr_2021) => {{
+    (|$byte:ident| $res:expr) => {{
         use crate::lexer::search::ByteMatchTable;
         // Clippy creates warnings because e.g. `byte_match_table!(|b| b == 0)`
         // is expanded to `ByteMatchTable([(0 == 0), ... ])`
@@ -234,7 +234,7 @@ impl SafeByteMatchTable {
 /// }
 /// ```
 macro_rules! safe_byte_match_table {
-    (|$byte:ident| $res:expr_2021) => {{
+    (|$byte:ident| $res:expr) => {{
         use crate::lexer::search::SafeByteMatchTable;
         // Clippy creates warnings because e.g. `safe_byte_match_table!(|b| b == 0)`
         // is expanded to `SafeByteMatchTable([0 == 0, ... ])`
@@ -368,7 +368,7 @@ macro_rules! byte_search {
     (
         lexer: $lexer:ident,
         table: $table:ident,
-        handle_eof: $eof_handler:expr_2021,
+        handle_eof: $eof_handler:expr,
     ) => {{
         let start = $lexer.source.position();
         byte_search! {
@@ -385,8 +385,8 @@ macro_rules! byte_search {
     (
         lexer: $lexer:ident,
         table: $table:ident,
-        continue_if: ($byte:ident, $pos:ident) $should_continue:expr_2021,
-        handle_eof: $eof_handler:expr_2021,
+        continue_if: ($byte:ident, $pos:ident) $should_continue:expr,
+        handle_eof: $eof_handler:expr,
     ) => {{
         let start = $lexer.source.position();
         byte_search! {
@@ -403,7 +403,7 @@ macro_rules! byte_search {
         lexer: $lexer:ident,
         table: $table:ident,
         start: $start:ident,
-        handle_eof: $eof_handler:expr_2021,
+        handle_eof: $eof_handler:expr,
     ) => {
         byte_search! {
             lexer: $lexer,
@@ -419,8 +419,8 @@ macro_rules! byte_search {
         lexer: $lexer:ident,
         table: $table:ident,
         start: $start:ident,
-        continue_if: ($byte:ident, $pos:ident) $should_continue:expr_2021,
-        handle_eof: $eof_handler:expr_2021,
+        continue_if: ($byte:ident, $pos:ident) $should_continue:expr,
+        handle_eof: $eof_handler:expr,
     ) => {{
         // SAFETY:
         // If `$table` is a `SafeByteMatchTable`, it's guaranteed that `lexer.source`

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -39,7 +39,7 @@ use crate::{
 };
 
 macro_rules! control_flow {
-    ($self:ident, |$cfg:tt| $body:expr_2021) => {
+    ($self:ident, |$cfg:tt| $body:expr) => {
         if let Some($cfg) = &mut $self.cfg { $body } else { Default::default() }
     };
 }

--- a/crates/oxc_semantic/src/stats.rs
+++ b/crates/oxc_semantic/src/stats.rs
@@ -14,7 +14,7 @@ use oxc_syntax::scope::{ScopeFlags, ScopeId};
 
 /// Macro to assert that `left >= right`
 macro_rules! assert_ge {
-    ($left:expr_2021, $right:expr_2021, $($msg_args:tt)+) => {
+    ($left:expr, $right:expr, $($msg_args:tt)+) => {
         match (&$left, &$right) {
             (left, right) => if !(left >= right) {
                 panic!(
@@ -26,7 +26,7 @@ macro_rules! assert_ge {
         }
     };
 
-    ($left:expr_2021, $right:expr_2021) => {
+    ($left:expr, $right:expr) => {
         match (&$left, &$right) {
             (left, right) => if !(left >= right) {
                 panic!(
@@ -37,7 +37,7 @@ macro_rules! assert_ge {
         }
     };
 
-    ($lhs:expr_2021, $rhs:expr_2021,) => {
+    ($lhs:expr, $rhs:expr,) => {
         assert_le!($lhs, $rhs);
     };
 }

--- a/tasks/ast_tools/src/logger.rs
+++ b/tasks/ast_tools/src/logger.rs
@@ -15,7 +15,7 @@ pub fn __internal_log_enable() -> bool {
 ///
 /// Does not include a trailing newline.
 macro_rules! log {
-    ($fmt:literal $(, $args:expr_2021)*) => {
+    ($fmt:literal $(, $args:expr)*) => {
         if $crate::logger::__internal_log_enable() {
             print!($fmt$(, $args)*);
             std::io::Write::flush(&mut std::io::stdout()).unwrap();
@@ -28,7 +28,7 @@ pub(crate) use log;
 ///
 /// Includes a trailing newline.
 macro_rules! logln {
-    ($fmt:literal $(, $args:expr_2021)*) => {
+    ($fmt:literal $(, $args:expr)*) => {
         if $crate::logger::__internal_log_enable() {
             println!($fmt$(, $args)*);
             std::io::Write::flush(&mut std::io::stdout()).unwrap();
@@ -55,7 +55,7 @@ pub(crate) use log_failed;
 
 /// Log a [`Result`].
 macro_rules! log_result {
-    ($result:expr_2021) => {
+    ($result:expr) => {
         match &($result) {
             Ok(_) => {
                 $crate::log_success!();

--- a/tasks/website/src/linter/rules/html.rs
+++ b/tasks/website/src/linter/rules/html.rs
@@ -110,7 +110,7 @@ impl HtmlWriter {
 
 /// Implements a tag factory on [`HtmlWriter`] with optional documentation.
 macro_rules! make_tag {
-    ($name:ident, $($docs:expr_2021),+) => {
+    ($name:ident, $($docs:expr),+) => {
         impl HtmlWriter {
             // create a #[doc = $doc] for each item in $docs
             $(


### PR DESCRIPTION
Pure refactor. `expr_2021` fragment specifier was I assume introduced in these macros by a codemod when we updated to Rust 2024 edition. None of these macros are used with input where there's any difference between `expr_2021` and `expr`, so just use `expr`.
