### PR TITLE
refactor(editor): use always the provided language server

### DIFF
--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -148,29 +148,7 @@ export async function activate(context: ExtensionContext) {
         outputChannel.error(`Invalid bin path: ${bin}`, e);
       }
     }
-
-    const workspaceFolders = workspace.workspaceFolders;
-    const isWindows = process.platform === 'win32';
-
-    if (workspaceFolders?.length && !isWindows) {
-      try {
-        return await Promise.any(
-          workspaceFolders.map(async (folder) => {
-            const binPath = join(
-              folder.uri.fsPath,
-              'node_modules',
-              '.bin',
-              'oxc_language_server',
-            );
-
-            await fsPromises.access(binPath);
-            return binPath;
-          }),
-        );
-      } catch {}
-    }
-
-    const ext = isWindows ? '.exe' : '';
+    const ext = process.platform === 'win32' ? '.exe' : '';
     // NOTE: The `./target/release` path is aligned with the path defined in .github/workflows/release_vscode.yml
     return (
       process.env.SERVER_PATH_DEV ??


### PR DESCRIPTION
Now, the editor will not look into `node_modules` folder to use a custom `oxc_language_server`.
The editor will always use the provided language server.

## Reasons

Because the language server in `node_modules` could be a different version than the extension and changes like #10890 can break the communication between them.

Avoiding the JS Wrapper and resolving #9925 and avoiding a new setting #11018

closes #9925 
closes #11018