### PR TITLE
fix(linter/prefer-todo): false fix for `test['skip']`

### DIFF
--- a/crates/oxc_linter/src/snapshots/jest_prefer_todo.snap
+++ b/crates/oxc_linter/src/snapshots/jest_prefer_todo.snap
@@ -6,21 +6,21 @@ source: crates/oxc_linter/src/tester.rs
  1 │ test('i need to write this test');
    · ────
    ╰────
-  help: Replace `` with `.todo`.
+  help: Insert `.todo`
 
   ⚠ eslint-plugin-jest(prefer-todo): Suggest using `test.todo`.
    ╭─[prefer_todo.tsx:1:1]
  1 │ test('i need to write this test',);
    · ────
    ╰────
-  help: Replace `` with `.todo`.
+  help: Insert `.todo`
 
   ⚠ eslint-plugin-jest(prefer-todo): Suggest using `test.todo`.
    ╭─[prefer_todo.tsx:1:1]
  1 │ test(`i need to write this test`);
    · ────
    ╰────
-  help: Replace `` with `.todo`.
+  help: Insert `.todo`
 
   ⚠ eslint-plugin-jest(prefer-todo): Suggest using `test.todo`.
    ╭─[prefer_todo.tsx:1:1]


### PR DESCRIPTION
```js
test['skip']('i need to write this test');
```
should be fixed to
```js
test['todo']('i need to write this test');
```
instead of 
```js
test[todo]('i need to write this test');
```