### PR TITLE
refactor(linter/prefer-todo): remove unnecessary `codegen`

### DIFF
--- a/crates/oxc_linter/src/rules/jest/prefer_todo.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_todo.rs
@@ -8,16 +8,11 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{
     context::LintContext,
-    fixer::{RuleFix, RuleFixer},
     rule::Rule,
     utils::{JestFnKind, JestGeneralFnKind, PossibleJestNode, is_type_of_jest_fn_call},
 };
 
-fn empty_test(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Suggest using `test.todo`.").with_label(span)
-}
-
-fn un_implemented_test_diagnostic(span: Span) -> OxcDiagnostic {
+fn prefer_todo_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Suggest using `test.todo`.").with_label(span)
 }
 
@@ -56,53 +51,59 @@ declare_oxc_lint!(
 impl Rule for PreferTodo {
     fn run_on_jest_node<'a, 'c>(
         &self,
-        jest_node: &PossibleJestNode<'a, 'c>,
+        possible_jest_node: &PossibleJestNode<'a, 'c>,
         ctx: &'c LintContext<'a>,
     ) {
-        run(jest_node, ctx);
-    }
-}
+        let node = possible_jest_node.node;
+        if let AstKind::CallExpression(call_expr) = node.kind() {
+            let counts = call_expr.arguments.len();
 
-fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
-    let node = possible_jest_node.node;
-    if let AstKind::CallExpression(call_expr) = node.kind() {
-        let counts = call_expr.arguments.len();
+            if counts < 1
+                || should_filter_case(call_expr)
+                || !is_string_type(&call_expr.arguments[0])
+                || !is_type_of_jest_fn_call(
+                    call_expr,
+                    possible_jest_node,
+                    ctx,
+                    &[JestFnKind::General(JestGeneralFnKind::Test)],
+                )
+            {
+                return;
+            }
 
-        if counts < 1
-            || should_filter_case(call_expr)
-            || !is_string_type(&call_expr.arguments[0])
-            || !is_type_of_jest_fn_call(
-                call_expr,
-                possible_jest_node,
-                ctx,
-                &[JestFnKind::General(JestGeneralFnKind::Test)],
-            )
-        {
-            return;
-        }
+            if (counts == 1 && !filter_todo_case(call_expr))
+                || (counts > 1 && is_empty_function(call_expr))
+            {
+                let span = call_expr.callee.span();
+                ctx.diagnostic_with_fix(prefer_todo_diagnostic(span), |fixer| {
+                    let fix = if let Expression::Identifier(ident) = &call_expr.callee {
+                        fixer.insert_text_after_range(ident.span, ".todo")
+                    } else {
+                        match &call_expr.callee {
+                            Expression::StaticMemberExpression(mem_expr) => {
+                                fixer.replace(mem_expr.property.span, "todo")
+                            }
+                            Expression::ComputedMemberExpression(mem_expr) => {
+                                fixer.replace(mem_expr.expression.span(), "'todo'")
+                            }
+                            _ => return fixer.delete_range(call_expr.span),
+                        }
+                    };
 
-        if counts == 1 && !filter_todo_case(call_expr) {
-            let span = call_expr.callee.span();
-            ctx.diagnostic_with_fix(un_implemented_test_diagnostic(span), |fixer| {
-                if let Expression::Identifier(ident) = &call_expr.callee {
-                    return fixer.insert_text_after_range(ident.span, ".todo");
-                }
-                match &call_expr.callee {
-                    Expression::StaticMemberExpression(mem_expr) => {
-                        fixer.replace(mem_expr.property.span, "todo")
+                    if counts == 1 {
+                        return fix;
                     }
-                    Expression::ComputedMemberExpression(mem_expr) => {
-                        fixer.replace(mem_expr.expression.span(), "'todo'")
-                    }
-                    _ => fixer.delete_range(call_expr.span),
-                }
-            });
-        }
 
-        if counts > 1 && is_empty_function(call_expr) {
-            ctx.diagnostic_with_fix(empty_test(call_expr.span), |fixer| {
-                build_code(fixer, call_expr)
-            });
+                    let multi_fixer = fixer.for_multifix();
+                    let mut multi_fix = multi_fixer.new_fix_with_capacity(2);
+                    multi_fix.push(fix);
+                    multi_fix.push(multi_fixer.delete_range(Span::new(
+                        call_expr.arguments[0].span().end,
+                        call_expr.span.end - 1,
+                    )));
+                    multi_fix.with_message("Replace with `test.todo` or `it.todo`.")
+                });
+            }
         }
     }
 }
@@ -139,49 +140,6 @@ fn is_empty_function(expr: &CallExpression) -> bool {
         }
         _ => false,
     }
-}
-
-fn build_code<'a>(fixer: RuleFixer<'_, 'a>, expr: &CallExpression<'a>) -> RuleFix<'a> {
-    let mut formatter = fixer.codegen();
-
-    match &expr.callee {
-        Expression::Identifier(ident) => {
-            formatter.print_str(ident.name.as_str());
-            formatter.print_str(".todo(");
-        }
-        Expression::ComputedMemberExpression(expr) => {
-            if let Expression::Identifier(ident) = &expr.object {
-                formatter.print_str(ident.name.as_str());
-                formatter.print_str("[");
-                formatter.print_str("'todo'");
-                formatter.print_str("](");
-            }
-        }
-        Expression::StaticMemberExpression(expr) => {
-            if let Expression::Identifier(ident) = &expr.object {
-                formatter.print_str(ident.name.as_str());
-                formatter.print_str(".todo(");
-            }
-        }
-        _ => {}
-    }
-
-    if let Argument::StringLiteral(ident) = &expr.arguments[0] {
-        // Todo: this punctuation should read from the config
-        formatter.print_ascii_byte(b'\'');
-        formatter.print_str(ident.value.as_str());
-        formatter.print_ascii_byte(b'\'');
-        formatter.print_ascii_byte(b')');
-    } else if let Argument::TemplateLiteral(temp) = &expr.arguments[0] {
-        formatter.print_ascii_byte(b'`');
-        for q in &temp.quasis {
-            formatter.print_str(q.value.raw.as_str());
-        }
-        formatter.print_ascii_byte(b'`');
-        formatter.print_ascii_byte(b')');
-    }
-
-    fixer.replace(expr.span, formatter)
 }
 
 #[test]

--- a/crates/oxc_linter/src/snapshots/jest_prefer_todo.snap
+++ b/crates/oxc_linter/src/snapshots/jest_prefer_todo.snap
@@ -25,41 +25,41 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint-plugin-jest(prefer-todo): Suggest using `test.todo`.
    ╭─[prefer_todo.tsx:1:1]
  1 │ it('foo', function () {})
-   · ─────────────────────────
+   · ──
    ╰────
-  help: Replace `it('foo', function () {})` with `it.todo('foo')`.
+  help: Replace with `test.todo` or `it.todo`.
 
   ⚠ eslint-plugin-jest(prefer-todo): Suggest using `test.todo`.
    ╭─[prefer_todo.tsx:1:1]
  1 │ it('foo', () => {})
-   · ───────────────────
+   · ──
    ╰────
-  help: Replace `it('foo', () => {})` with `it.todo('foo')`.
+  help: Replace with `test.todo` or `it.todo`.
 
   ⚠ eslint-plugin-jest(prefer-todo): Suggest using `test.todo`.
    ╭─[prefer_todo.tsx:1:1]
  1 │ test.skip('i need to write this test', () => {});
-   · ────────────────────────────────────────────────
+   · ─────────
    ╰────
-  help: Replace `test.skip('i need to write this test', () => {})` with `test.todo('i need to write this test')`.
+  help: Replace with `test.todo` or `it.todo`.
 
   ⚠ eslint-plugin-jest(prefer-todo): Suggest using `test.todo`.
    ╭─[prefer_todo.tsx:1:1]
  1 │ test.skip('i need to write this test', function() {});
-   · ─────────────────────────────────────────────────────
+   · ─────────
    ╰────
-  help: Replace `test.skip('i need to write this test', function() {})` with `test.todo('i need to write this test')`.
+  help: Replace with `test.todo` or `it.todo`.
 
   ⚠ eslint-plugin-jest(prefer-todo): Suggest using `test.todo`.
    ╭─[prefer_todo.tsx:1:1]
  1 │ test[`skip`]('i need to write this test', function() {});
-   · ────────────────────────────────────────────────────────
+   · ────────────
    ╰────
-  help: Replace `test[`skip`]('i need to write this test', function() {})` with `test['todo']('i need to write this test')`.
+  help: Replace with `test.todo` or `it.todo`.
 
   ⚠ eslint-plugin-jest(prefer-todo): Suggest using `test.todo`.
    ╭─[prefer_todo.tsx:1:1]
  1 │ test[`skip`]('i need to write this test', function() {});
-   · ────────────────────────────────────────────────────────
+   · ────────────
    ╰────
-  help: Replace `test[`skip`]('i need to write this test', function() {})` with `test['todo']('i need to write this test')`.
+  help: Replace with `test.todo` or `it.todo`.


### PR DESCRIPTION
closes #11098

- Inlined unncessary `run`
- Removed unnecessary `codegen`