### PR TITLE
perf(mangler)!: `Mangler::build_with_semantic` take mut ref to `Semantic`

### DIFF
--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -58,12 +58,13 @@ impl Minifier {
             Stats::default()
         };
         let scoping = self.options.mangle.map(|options| {
-            let semantic = SemanticBuilder::new()
+            let mut semantic = SemanticBuilder::new()
                 .with_stats(stats)
                 .with_scope_tree_child_ids(true)
                 .build(program)
                 .semantic;
-            Mangler::default().with_options(options).build_with_semantic(semantic, program)
+            Mangler::default().with_options(options).build_with_semantic(&mut semantic, program);
+            semantic.into_scoping()
         });
         MinifierReturn { scoping }
     }

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -116,6 +116,10 @@ impl<'a> Semantic<'a> {
         &mut self.scoping
     }
 
+    pub fn scoping_mut_and_nodes(&mut self) -> (&mut Scoping, &AstNodes<'a>) {
+        (&mut self.scoping, &self.nodes)
+    }
+
     pub fn classes(&self) -> &ClassTable {
         &self.classes
     }

--- a/tasks/benchmark/benches/minifier.rs
+++ b/tasks/benchmark/benches/minifier.rs
@@ -61,10 +61,10 @@ fn bench_mangler(criterion: &mut Criterion) {
             b.iter_with_setup_wrapper(|runner| {
                 allocator.reset();
                 let program = Parser::new(&allocator, source_text, source_type).parse().program;
-                let semantic =
+                let mut semantic =
                     SemanticBuilder::new().with_scope_tree_child_ids(true).build(&program).semantic;
                 runner.run(|| {
-                    let _ = Mangler::new().build_with_semantic(semantic, &program);
+                    Mangler::new().build_with_semantic(&mut semantic, &program);
                 });
             });
         });


### PR DESCRIPTION
`Semantic` is a very large type (600 bytes). The mangler only uses a part of it (`Scoping` and `AstNodes`), so it's a waste to copy the whole type onto the stack and then return it again.

Change `Mangler::build_with_semantic` to take `&mut Semantic` instead.

I hope this may also help a bit with wild variance in mangler benchmarks, as `Semantic` will no longer get dropped in the measured section (I don't think should be part of the measurement anyway, as the drop time of `Semantic` is not relevant in this benchmark).
