### PR TITLE
fix(transformer/legacy-decorator): static class fields cannot be accessed in static field initializer when `class-properties` plugin is not enabled

### DIFF
--- a/crates/oxc_transformer/src/context.rs
+++ b/crates/oxc_transformer/src/context.rs
@@ -44,6 +44,10 @@ pub struct TransformCtx<'a> {
     pub statement_injector: StatementInjectorStore<'a>,
     /// Manage inserting statements at top of program globally
     pub top_level_statements: TopLevelStatementsStore<'a>,
+
+    // State for multiple plugins interacting
+    /// `true` if class properties plugin is enabled
+    pub is_class_properties_plugin_enabled: bool,
 }
 
 impl TransformCtx<'_> {
@@ -65,6 +69,7 @@ impl TransformCtx<'_> {
             var_declarations: VarDeclarationsStore::new(),
             statement_injector: StatementInjectorStore::new(),
             top_level_statements: TopLevelStatementsStore::new(),
+            is_class_properties_plugin_enabled: options.env.es2022.class_properties.is_some(),
         }
     }
 

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -136,13 +136,10 @@ impl<'a> Transformer<'a> {
                 .proposals
                 .explicit_resource_management
                 .then(|| ExplicitResourceManagement::new(&self.ctx)),
-            x0_typescript: program.source_type.is_typescript().then(|| {
-                TypeScript::new(
-                    &self.typescript,
-                    self.env.es2022.class_properties.is_some(),
-                    &self.ctx,
-                )
-            }),
+            x0_typescript: program
+                .source_type
+                .is_typescript()
+                .then(|| TypeScript::new(&self.typescript, &self.ctx)),
             x1_jsx: Jsx::new(self.jsx, self.env.es2018.object_rest_spread, ast_builder, &self.ctx),
             x2_es2022: ES2022::new(
                 self.env.es2022,

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 578ac4df
 
-Passed: 153/255
+Passed: 153/257
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -497,7 +497,7 @@ after transform: SymbolId(4): ScopeId(1)
 rebuilt        : SymbolId(5): ScopeId(4)
 
 
-# legacy-decorators (4/74)
+# legacy-decorators (4/76)
 * oxc/metadata/abstract-class/input.ts
 Symbol reference IDs mismatch for "Dependency":
 after transform: SymbolId(1): [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
@@ -581,6 +581,46 @@ rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol span mismatch for "C":
 after transform: SymbolId(3): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(3): Span { start: 106, end: 107 }
+
+* oxc/static-field/input.ts
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
+Scope children mismatch:
+after transform: ScopeId(3): []
+rebuilt        : ScopeId(3): [ScopeId(4)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(ClassStaticBlock)
+rebuilt        : ScopeId(4): ScopeFlags(StrictMode | ClassStaticBlock)
+Scope parent mismatch:
+after transform: ScopeId(4): Some(ScopeId(0))
+rebuilt        : ScopeId(4): Some(ScopeId(3))
+Symbol span mismatch for "Foo":
+after transform: SymbolId(2): Span { start: 103, end: 106 }
+rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "Foo":
+after transform: SymbolId(2): [ReferenceId(4), ReferenceId(6), ReferenceId(8)]
+rebuilt        : SymbolId(3): [ReferenceId(5), ReferenceId(9)]
+Symbol span mismatch for "Foo":
+after transform: SymbolId(3): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(4): Span { start: 103, end: 106 }
+Unresolved references mismatch:
+after transform: ["ClassDecorator", "babelHelpers", "console"]
+rebuilt        : ["babelHelpers", "console"]
+
+* oxc/static-field-with-class-properties/input.ts
+Symbol span mismatch for "Foo":
+after transform: SymbolId(2): Span { start: 103, end: 106 }
+rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "Foo":
+after transform: SymbolId(2): [ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10)]
+rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(6), ReferenceId(10)]
+Symbol span mismatch for "Foo":
+after transform: SymbolId(3): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(4): Span { start: 103, end: 106 }
+Unresolved references mismatch:
+after transform: ["ClassDecorator", "babelHelpers", "console"]
+rebuilt        : ["babelHelpers", "console"]
 
 * oxc/with-class-private-properties/input.ts
 Symbol span mismatch for "C":

--- a/tasks/transform_conformance/snapshots/oxc_exec.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc_exec.snap.md
@@ -2,7 +2,7 @@ commit: 578ac4df
 
 node: v22.14.0
 
-Passed: 6 of 8 (75.00%)
+Passed: 8 of 10 (80.00%)
 
 Failures:
 

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/static-field-with-class-properties/exec.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/static-field-with-class-properties/exec.ts
@@ -1,0 +1,10 @@
+function Bar(): ClassDecorator {
+  return (_target) => {
+    console.log(Bar.name)
+  }
+}
+
+@Bar()
+class Foo {
+  static foo = `${Foo.name}`;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/static-field-with-class-properties/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/static-field-with-class-properties/input.ts
@@ -1,0 +1,10 @@
+function Bar(): ClassDecorator {
+  return (_target) => {
+    console.log(Bar.name)
+  }
+}
+
+@Bar()
+class Foo {
+  static foo = `${Foo.name}`;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/static-field-with-class-properties/options.json
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/static-field-with-class-properties/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "transform-legacy-decorator",
+    "transform-class-properties"
+  ]
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/static-field-with-class-properties/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/static-field-with-class-properties/output.js
@@ -1,0 +1,9 @@
+var _Foo;
+function Bar() {
+  return (_target) => {
+    console.log(Bar.name);
+  };
+}
+let Foo = _Foo = class Foo {};
+babelHelpers.defineProperty(Foo, "foo", `${_Foo.name}`);
+Foo = _Foo = babelHelpers.decorate([Bar()], Foo);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/static-field/exec.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/static-field/exec.ts
@@ -1,0 +1,10 @@
+function Bar(): ClassDecorator {
+  return (_target) => {
+    console.log(Bar.name)
+  }
+}
+
+@Bar()
+class Foo {
+  static foo = `${Foo.name}`;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/static-field/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/static-field/input.ts
@@ -1,0 +1,10 @@
+function Bar(): ClassDecorator {
+  return (_target) => {
+    console.log(Bar.name)
+  }
+}
+
+@Bar()
+class Foo {
+  static foo = `${Foo.name}`;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/static-field/options.json
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/static-field/options.json
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "transform-legacy-decorator"
+  ]
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/static-field/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/static-field/output.js
@@ -1,0 +1,13 @@
+var _Foo;
+function Bar() {
+  return (_target) => {
+    console.log(Bar.name);
+  };
+}
+let Foo = _Foo = class Foo {
+  static {
+    _Foo = this;
+  }
+  static foo = `${_Foo.name}`;
+};
+Foo = _Foo = babelHelpers.decorate([Bar()], Foo);


### PR DESCRIPTION
close: https://github.com/oxc-project/oxc/issues/11111

This is the missing part we were ported from [TypeScript](https://github.com/microsoft/TypeScript/blob/b86ab7dbe0eb2f1c9a624486d72590d638495c97/src/compiler/transformers/legacyDecorators.ts#L345-L366).

