### PR TITLE
refactor(ast): inline `Comment` newline flags setters

### DIFF
--- a/crates/oxc_ast/src/ast/comment.rs
+++ b/crates/oxc_ast/src/ast/comment.rs
@@ -252,6 +252,7 @@ impl Comment {
     }
 
     /// Sets the state of `newlines` to include/exclude a newline after the comment.
+    #[inline]
     pub fn set_followed_by_newline(&mut self, followed_by_newline: bool) {
         if followed_by_newline {
             self.newlines.insert(CommentNewlines::TRAILING);
@@ -261,6 +262,7 @@ impl Comment {
     }
 
     /// Sets the state of `newlines` to include/exclude a newline before the comment.
+    #[inline]
     pub fn set_preceded_by_newline(&mut self, preceded_by_newline: bool) {
         if preceded_by_newline {
             self.newlines.insert(CommentNewlines::LEADING);


### PR DESCRIPTION
Follow-on after #11096. Add `#[inline]` to these trivial functions. Usually they're called with a static value, so if they're inlined compiler will be able to remove the branch.

Probably compiler would inline these anyway as they're so small, but just to make sure.