### PR TITLE
refactor(ast): rename `CommentNewlines` fields

### DIFF
--- a/crates/oxc_ast/src/ast/comment.rs
+++ b/crates/oxc_ast/src/ast/comment.rs
@@ -87,14 +87,12 @@ bitflags! {
     #[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
     /// State of newlines around a comment.
     pub struct CommentNewlines: u8 {
-        /// No newlines before or after
-        const NONE = 0;
         /// Preceded by a newline
-        const LEADING = 1 << 0;
+        const Leading = 1 << 0;
         /// Followed by a newline
-        const TRAILING = 1 << 1;
-        /// Preceded and followed by a newline
-        const LEADING_AND_TRAILING = Self::LEADING.bits() | Self::TRAILING.bits();
+        const Trailing = 1 << 1;
+        /// No newlines before or after
+        const None = 0;
     }
 }
 
@@ -161,7 +159,7 @@ impl Comment {
             attached_to: 0,
             kind,
             position: CommentPosition::Trailing,
-            newlines: CommentNewlines::NONE,
+            newlines: CommentNewlines::None,
             annotation: CommentAnnotation::None,
         }
     }
@@ -255,9 +253,9 @@ impl Comment {
     #[inline]
     pub fn set_followed_by_newline(&mut self, followed_by_newline: bool) {
         if followed_by_newline {
-            self.newlines.insert(CommentNewlines::TRAILING);
+            self.newlines.insert(CommentNewlines::Trailing);
         } else {
-            self.newlines.remove(CommentNewlines::TRAILING);
+            self.newlines.remove(CommentNewlines::Trailing);
         }
     }
 
@@ -265,21 +263,21 @@ impl Comment {
     #[inline]
     pub fn set_preceded_by_newline(&mut self, preceded_by_newline: bool) {
         if preceded_by_newline {
-            self.newlines.insert(CommentNewlines::LEADING);
+            self.newlines.insert(CommentNewlines::Leading);
         } else {
-            self.newlines.remove(CommentNewlines::LEADING);
+            self.newlines.remove(CommentNewlines::Leading);
         }
     }
 
     /// Returns `true` if this comment is preceded by a newline.
     #[inline]
     pub fn preceded_by_newline(self) -> bool {
-        self.newlines.contains(CommentNewlines::LEADING)
+        self.newlines.contains(CommentNewlines::Leading)
     }
 
     /// Returns `true` if this comment is followed by a newline.
     #[inline]
     pub fn followed_by_newline(self) -> bool {
-        self.newlines.contains(CommentNewlines::TRAILING)
+        self.newlines.contains(CommentNewlines::Trailing)
     }
 }

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -268,7 +268,7 @@ mod test {
                 kind: CommentKind::Block,
                 position: CommentPosition::Leading,
                 attached_to: 70,
-                newlines: CommentNewlines::LEADING_AND_TRAILING,
+                newlines: CommentNewlines::Leading | CommentNewlines::Trailing,
                 annotation: CommentAnnotation::None,
             },
             Comment {
@@ -276,7 +276,7 @@ mod test {
                 kind: CommentKind::Line,
                 position: CommentPosition::Leading,
                 attached_to: 70,
-                newlines: CommentNewlines::LEADING_AND_TRAILING,
+                newlines: CommentNewlines::Leading | CommentNewlines::Trailing,
                 annotation: CommentAnnotation::None,
             },
             Comment {
@@ -284,7 +284,7 @@ mod test {
                 kind: CommentKind::Block,
                 position: CommentPosition::Leading,
                 attached_to: 70,
-                newlines: CommentNewlines::LEADING,
+                newlines: CommentNewlines::Leading,
                 annotation: CommentAnnotation::None,
             },
             Comment {
@@ -292,7 +292,7 @@ mod test {
                 kind: CommentKind::Block,
                 position: CommentPosition::Trailing,
                 attached_to: 0,
-                newlines: CommentNewlines::NONE,
+                newlines: CommentNewlines::None,
                 annotation: CommentAnnotation::None,
             },
             Comment {
@@ -300,7 +300,7 @@ mod test {
                 kind: CommentKind::Line,
                 position: CommentPosition::Trailing,
                 attached_to: 0,
-                newlines: CommentNewlines::TRAILING,
+                newlines: CommentNewlines::Trailing,
                 annotation: CommentAnnotation::None,
             },
             Comment {
@@ -308,7 +308,7 @@ mod test {
                 kind: CommentKind::Line,
                 position: CommentPosition::Leading,
                 attached_to: 147,
-                newlines: CommentNewlines::LEADING_AND_TRAILING,
+                newlines: CommentNewlines::Leading | CommentNewlines::Trailing,
                 annotation: CommentAnnotation::None,
             },
         ];
@@ -332,7 +332,7 @@ token /* Trailing 1 */
                 kind: CommentKind::Block,
                 position: CommentPosition::Leading,
                 attached_to: 36,
-                newlines: CommentNewlines::LEADING_AND_TRAILING,
+                newlines: CommentNewlines::Leading | CommentNewlines::Trailing,
                 annotation: CommentAnnotation::None,
             },
             Comment {
@@ -340,7 +340,7 @@ token /* Trailing 1 */
                 kind: CommentKind::Block,
                 position: CommentPosition::Trailing,
                 attached_to: 0,
-                newlines: CommentNewlines::TRAILING,
+                newlines: CommentNewlines::Trailing,
                 annotation: CommentAnnotation::None,
             },
         ];
@@ -365,7 +365,7 @@ token /* Trailing 1 */
                 kind: CommentKind::Block,
                 position: CommentPosition::Leading,
                 attached_to: 28,
-                newlines: CommentNewlines::LEADING_AND_TRAILING,
+                newlines: CommentNewlines::Leading | CommentNewlines::Trailing,
                 annotation: CommentAnnotation::None,
             },
             Comment {
@@ -373,7 +373,7 @@ token /* Trailing 1 */
                 kind: CommentKind::Block,
                 position: CommentPosition::Leading,
                 attached_to: 28,
-                newlines: CommentNewlines::LEADING_AND_TRAILING,
+                newlines: CommentNewlines::Leading | CommentNewlines::Trailing,
                 annotation: CommentAnnotation::None,
             },
         ];
@@ -396,7 +396,7 @@ token /* Trailing 1 */
                 kind: CommentKind::Line,
                 position: CommentPosition::Leading,
                 attached_to: 57,
-                newlines: CommentNewlines::TRAILING,
+                newlines: CommentNewlines::Trailing,
                 annotation: CommentAnnotation::None,
             },
             Comment {
@@ -404,7 +404,7 @@ token /* Trailing 1 */
                 kind: CommentKind::Line,
                 position: CommentPosition::Leading,
                 attached_to: 129,
-                newlines: CommentNewlines::TRAILING,
+                newlines: CommentNewlines::Trailing,
                 annotation: CommentAnnotation::None,
             },
         ];
@@ -426,7 +426,7 @@ token /* Trailing 1 */
                 kind: CommentKind::Line,
                 position: CommentPosition::Leading,
                 attached_to: 55,
-                newlines: CommentNewlines::TRAILING,
+                newlines: CommentNewlines::Trailing,
                 annotation: CommentAnnotation::None,
             },
             Comment {
@@ -434,7 +434,7 @@ token /* Trailing 1 */
                 kind: CommentKind::Line,
                 position: CommentPosition::Leading,
                 attached_to: 116,
-                newlines: CommentNewlines::TRAILING,
+                newlines: CommentNewlines::Trailing,
                 annotation: CommentAnnotation::None,
             },
         ];


### PR DESCRIPTION
Follow-on after #11096. Pure refactor. Our naming convention for `bitflags!` fields is not completely consistent, but mostly we use mixed case. Rename them to match that style.

Also, remove the `LEADING_AND_TRAILING` option, as it's only used in tests.