### PR TITLE
docs(napi): update docs for `oxc-parser`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -8,6 +8,8 @@
 // They are purely markers for codegen used in `tasks/ast_tools` and `crates/oxc_traverse/scripts`. See docs in those crates.
 // Read [`macro@oxc_ast_macros::ast`] for more information.
 
+// Dummy comment to force CI to run.
+
 use std::cell::Cell;
 
 use oxc_allocator::{Box, CloneIn, Dummy, GetAddress, TakeIn, Vec};

--- a/napi/parser/README.md
+++ b/napi/parser/README.md
@@ -8,14 +8,20 @@ See https://stackblitz.com/edit/oxc-parser for usage example.
 
 ### ESTree
 
-When parsing `.js` or `.jsx` files, the AST returned is fully conformant with the
-[ESTree standard](https://github.com/estree/estree).
+When parsing JS or JSX files, the AST returned is fully conformant with the
+[ESTree standard](https://github.com/estree/estree), the same as produced by
+[Acorn](https://www.npmjs.com/package/acorn).
 
-It is fully aligned with Acorn's AST, and any deviation would be considered a bug.
-
-The returned TypeScript AST will conform to [@typescript-eslint/typescript-estree](https://www.npmjs.com/package/@typescript-eslint/typescript-estree) in the near future.
+When parsing TypeScript, the AST conforms to [@typescript-eslint/typescript-estree](https://www.npmjs.com/package/@typescript-eslint/typescript-estree)'s TS-ESTree format.
 
 If you need all ASTs in the same with-TS-properties format, use the `astType: 'ts'` option.
+
+The only differences between Oxc's AST and ESTree / TS-ESTree are:
+
+- Addition of a non-standard `hashbang` field to `Program`.
+
+That aside, the AST should completely align with Acorn's ESTree AST or TS-ESLint's TS-ESTree.
+Any deviation would be considered a bug.
 
 ### AST Types
 


### PR DESCRIPTION
Update docs for `oxc-parser` NPM package to clarify:

1. TS AST now aligns with TS-ESLint.
2. We align with Acorn for plain JS ESTree.
3. We add a non-standard `hashbang` property to `Program`.
