### PR TITLE
fix(codegen)!: a legal comment can also be a jsdoc comment

### DIFF
--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -1578,8 +1578,8 @@ const _: () = {
     assert!(size_of::<CommentPosition>() == 1);
     assert!(align_of::<CommentPosition>() == 1);
 
-    assert!(size_of::<CommentAnnotation>() == 1);
-    assert!(align_of::<CommentAnnotation>() == 1);
+    assert!(size_of::<CommentContent>() == 1);
+    assert!(align_of::<CommentContent>() == 1);
 
     // Padding: 0 bytes
     assert!(size_of::<CommentNewlines>() == 1);
@@ -1593,7 +1593,7 @@ const _: () = {
     assert!(offset_of!(Comment, kind) == 12);
     assert!(offset_of!(Comment, position) == 13);
     assert!(offset_of!(Comment, newlines) == 14);
-    assert!(offset_of!(Comment, annotation) == 15);
+    assert!(offset_of!(Comment, content) == 15);
 };
 
 #[cfg(target_pointer_width = "32")]
@@ -3167,8 +3167,8 @@ const _: () = {
     assert!(size_of::<CommentPosition>() == 1);
     assert!(align_of::<CommentPosition>() == 1);
 
-    assert!(size_of::<CommentAnnotation>() == 1);
-    assert!(align_of::<CommentAnnotation>() == 1);
+    assert!(size_of::<CommentContent>() == 1);
+    assert!(align_of::<CommentContent>() == 1);
 
     // Padding: 0 bytes
     assert!(size_of::<CommentNewlines>() == 1);
@@ -3182,7 +3182,7 @@ const _: () = {
     assert!(offset_of!(Comment, kind) == 12);
     assert!(offset_of!(Comment, position) == 13);
     assert!(offset_of!(Comment, newlines) == 14);
-    assert!(offset_of!(Comment, annotation) == 15);
+    assert!(offset_of!(Comment, content) == 15);
 };
 
 #[cfg(not(any(target_pointer_width = "64", target_pointer_width = "32")))]

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -7852,8 +7852,8 @@ impl<'new_alloc> CloneIn<'new_alloc> for CommentPosition {
     }
 }
 
-impl<'new_alloc> CloneIn<'new_alloc> for CommentAnnotation {
-    type Cloned = CommentAnnotation;
+impl<'new_alloc> CloneIn<'new_alloc> for CommentContent {
+    type Cloned = CommentContent;
 
     #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
@@ -7876,7 +7876,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Comment {
             kind: CloneIn::clone_in(&self.kind, allocator),
             position: CloneIn::clone_in(&self.position, allocator),
             newlines: CloneIn::clone_in(&self.newlines, allocator),
-            annotation: CloneIn::clone_in(&self.annotation, allocator),
+            content: CloneIn::clone_in(&self.content, allocator),
         }
     }
 
@@ -7887,7 +7887,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Comment {
             kind: CloneIn::clone_in_with_semantic_ids(&self.kind, allocator),
             position: CloneIn::clone_in_with_semantic_ids(&self.position, allocator),
             newlines: CloneIn::clone_in_with_semantic_ids(&self.newlines, allocator),
-            annotation: CloneIn::clone_in_with_semantic_ids(&self.annotation, allocator),
+            content: CloneIn::clone_in_with_semantic_ids(&self.content, allocator),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -2476,7 +2476,7 @@ impl ContentEq for CommentPosition {
     }
 }
 
-impl ContentEq for CommentAnnotation {
+impl ContentEq for CommentContent {
     fn content_eq(&self, other: &Self) -> bool {
         self == other
     }
@@ -2488,6 +2488,6 @@ impl ContentEq for Comment {
             && ContentEq::content_eq(&self.kind, &other.kind)
             && ContentEq::content_eq(&self.position, &other.position)
             && ContentEq::content_eq(&self.newlines, &other.newlines)
-            && ContentEq::content_eq(&self.annotation, &other.annotation)
+            && ContentEq::content_eq(&self.content, &other.content)
     }
 }

--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -73,7 +73,7 @@ mod generated {
 pub use generated::{ast_builder, ast_kind};
 
 pub use crate::{
-    ast::comment::{Comment, CommentAnnotation, CommentKind, CommentPosition},
+    ast::comment::{Comment, CommentContent, CommentKind, CommentPosition},
     ast_builder::AstBuilder,
     ast_builder_impl::NONE,
     ast_kind::{AstKind, AstType},

--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -22,16 +22,14 @@ impl Codegen<'_> {
                 continue;
             }
             let mut add = false;
-            if comment.is_legal() {
-                if self.options.print_legal_comment() {
+            if comment.is_leading() {
+                if comment.is_legal() && self.options.print_legal_comment() {
                     add = true;
                 }
-            } else if comment.is_leading() {
-                if comment.is_annotation() {
-                    if self.options.print_annotation_comment() {
-                        add = true;
-                    }
-                } else if self.options.print_normal_comment() {
+                if comment.is_annotation() && self.options.print_annotation_comment() {
+                    add = true;
+                }
+                if comment.is_normal() && self.options.print_normal_comment() {
                     add = true;
                 }
             }

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -739,7 +739,9 @@ impl Gen for FunctionBody<'_> {
         let span_end = self.span.end;
         let comments_at_end = if span_end > 0 { p.get_comments(span_end - 1) } else { None };
         let single_line = if self.is_empty() {
-            comments_at_end.as_ref().is_none_or(|comments| comments.iter().all(|c| c.is_block()))
+            comments_at_end.as_ref().is_none_or(|comments| {
+                comments.iter().all(|c| !c.preceded_by_newline() && !c.followed_by_newline())
+            })
         } else {
             false
         };

--- a/crates/oxc_codegen/tests/integration/comments.rs
+++ b/crates/oxc_codegen/tests/integration/comments.rs
@@ -211,7 +211,8 @@ pub mod legal {
 
     #[test]
     fn legal_eof_comment() {
-        let options = CodegenOptions { legal_comments: LegalComment::Eof, ..Default::default() };
+        let options =
+            CodegenOptions { legal_comments: LegalComment::Eof, ..CodegenOptions::default() };
         snapshot_options("legal_eof_comments", &cases(), &options);
     }
 
@@ -220,7 +221,7 @@ pub mod legal {
         let options = CodegenOptions {
             minify: true,
             legal_comments: LegalComment::Eof,
-            ..Default::default()
+            ..CodegenOptions::default()
         };
         snapshot_options("legal_eof_minify_comments", &cases(), &options);
     }
@@ -229,7 +230,7 @@ pub mod legal {
     fn legal_linked_comment() {
         let options = CodegenOptions {
             legal_comments: LegalComment::Linked(String::from("test.js")),
-            ..Default::default()
+            ..CodegenOptions::default()
         };
         snapshot_options("legal_linked_comments", &cases(), &options);
     }
@@ -237,7 +238,7 @@ pub mod legal {
     #[test]
     fn legal_external_comment() {
         let options =
-            CodegenOptions { legal_comments: LegalComment::External, ..Default::default() };
+            CodegenOptions { legal_comments: LegalComment::External, ..CodegenOptions::default() };
         let code = "/* @license */\n/* @preserve */\nfoo;\n";
         let ret = codegen_options(code, &options);
         assert_eq!(ret.code, "foo;\n");

--- a/crates/oxc_codegen/tests/integration/snapshots/legal_eof_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/legal_eof_comments.snap
@@ -99,10 +99,10 @@ function foo() {
 ----------
 function foo() {
 	(() => {
-	/**
-	* @preserve
-	*/
-})();
+		/**
+		* @preserve
+		*/
+	})();
 	/**
 	* @preserve
 	*/
@@ -110,12 +110,20 @@ function foo() {
 /**
 * @preserve
 */
+/**
+ * @preserve
+*/
+
 ########## 8
 /**
 * @preserve
 */
 
 ----------
+/**
+* @preserve
+*/
+
 /**
 * @preserve
 */

--- a/crates/oxc_codegen/tests/integration/snapshots/legal_eof_minify_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/legal_eof_minify_comments.snap
@@ -92,12 +92,20 @@ function foo(){(()=>{
 /**
 * @preserve
 */
+/**
+* @preserve
+*/
+
 ########## 8
 /**
 * @preserve
 */
 
 ----------
+/**
+* @preserve
+*/
+
 /**
 * @preserve
 */

--- a/crates/oxc_codegen/tests/integration/snapshots/legal_inline_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/legal_inline_comments.snap
@@ -92,10 +92,10 @@ function foo() {
 ----------
 function foo() {
 	(() => {
-	/**
-	* @preserve
-	*/
-})();
+		/**
+		* @preserve
+		*/
+	})();
 	/**
 	* @preserve
 	*/

--- a/crates/oxc_codegen/tests/integration/snapshots/legal_linked_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/legal_linked_comments.snap
@@ -85,10 +85,10 @@ function foo() {
 ----------
 function foo() {
 	(() => {
-	/**
-	* @preserve
-	*/
-})();
+		/**
+		* @preserve
+		*/
+	})();
 	/**
 	* @preserve
 	*/
@@ -96,6 +96,7 @@ function foo() {
 /**
 * @preserve
 */
+/*! For license information please see test.js */
 ########## 8
 /**
 * @preserve
@@ -105,3 +106,5 @@ function foo() {
 /**
 * @preserve
 */
+
+/*! For license information please see test.js */


### PR DESCRIPTION
Breaking change: Changed the `CommentAnnotation` to `CommentContent` to
remove ambiguity on what an annotation is.

e.g. `/** @license */`

fixes #11093