### PR TITLE
feat(ast_tools): introduce `#[js_only]` attr for struct fields and converters

### DIFF
--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -130,7 +130,7 @@ pub struct JSXFragment<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(via = JSXOpeningFragmentConverter, add_fields(attributes = TsEmptyArray, selfClosing = TsFalse))]
+#[estree(add_fields(attributes = JsEmptyArray, selfClosing = JsFalse))]
 pub struct JSXOpeningFragment {
     /// Node location in source code
     pub span: Span,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -2049,7 +2049,13 @@ impl ESTree for JSXFragment<'_> {
 
 impl ESTree for JSXOpeningFragment {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        crate::serialize::jsx::JSXOpeningFragmentConverter(self).serialize(serializer)
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", &JsonSafeString("JSXOpeningFragment"));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_js_field("attributes", &crate::serialize::basic::JsEmptyArray(self));
+        state.serialize_js_field("selfClosing", &crate::serialize::basic::JsFalse(self));
+        state.end();
     }
 }
 

--- a/crates/oxc_ast/src/serialize/basic.rs
+++ b/crates/oxc_ast/src/serialize/basic.rs
@@ -46,6 +46,18 @@ impl<T> ESTree for False<T> {
     }
 }
 
+/// Serialized as `false`. Field only present in JS ESTree AST (not TS-ESTree).
+#[ast_meta]
+#[estree(ts_type = "false", raw_deser = "false")]
+#[js_only]
+pub struct JsFalse<T>(pub T);
+
+impl<T> ESTree for JsFalse<T> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        false.serialize(serializer);
+    }
+}
+
 /// Serialized as `false`. Field only present in TS-ESTree AST.
 #[ast_meta]
 #[estree(ts_type = "false", raw_deser = "false")]
@@ -111,6 +123,18 @@ pub struct EmptyArray<T>(pub T);
 impl<T> ESTree for EmptyArray<T> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         [(); 0].serialize(serializer);
+    }
+}
+
+/// Serialized as `[]`. Field only present in JS ESTree AST (not TS-ESTree).
+#[ast_meta]
+#[estree(ts_type = "[]", raw_deser = "[]")]
+#[js_only]
+pub struct JsEmptyArray<T>(pub T);
+
+impl<T> ESTree for JsEmptyArray<T> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        EmptyArray(()).serialize(serializer);
     }
 }
 

--- a/crates/oxc_ast_macros/src/lib.rs
+++ b/crates/oxc_ast_macros/src/lib.rs
@@ -74,6 +74,7 @@ pub fn ast_meta(_args: TokenStream, input: TokenStream) -> TokenStream {
         content_eq,
         estree,
         generate_derive,
+        js_only,
         plural,
         scope,
         span,

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -1178,14 +1178,13 @@ function deserializeJSXFragment(pos) {
 }
 
 function deserializeJSXOpeningFragment(pos) {
-  const node = {
+  return {
     type: 'JSXOpeningFragment',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     attributes: [],
     selfClosing: false,
   };
-  return node;
 }
 
 function deserializeJSXClosingFragment(pos) {

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -1332,12 +1332,11 @@ function deserializeJSXFragment(pos) {
 }
 
 function deserializeJSXOpeningFragment(pos) {
-  const node = {
+  return {
     type: 'JSXOpeningFragment',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
-  return node;
 }
 
 function deserializeJSXClosingFragment(pos) {

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -272,7 +272,7 @@ impl<'s> StructDeserializerGenerator<'s> {
         struct_def: &StructDef,
         struct_offset: u32,
     ) {
-        if !self.is_ts && field.estree.is_ts {
+        if (self.is_ts && field.estree.is_js) || (!self.is_ts && field.estree.is_ts) {
             return;
         }
 
@@ -372,7 +372,7 @@ impl<'s> StructDeserializerGenerator<'s> {
         struct_offset: u32,
     ) {
         let converter = self.schema.meta_by_name(converter_name);
-        if !self.is_ts && converter.estree.is_ts {
+        if (self.is_ts && converter.estree.is_js) || (!self.is_ts && converter.estree.is_ts) {
             return;
         }
 

--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -271,7 +271,7 @@ fn generate_ts_type_def_for_struct_field_impl<'s>(
     }
 
     let field_camel_name = get_struct_field_name(field);
-    let question_mark = if field.estree.is_ts { "?" } else { "" };
+    let question_mark = if field.estree.is_js || field.estree.is_ts { "?" } else { "" };
     write_it!(fields_str, "\n\t{field_camel_name}{question_mark}: {field_type_name};");
 }
 
@@ -287,7 +287,7 @@ fn generate_ts_type_def_for_added_struct_field(
     let Some(ts_type) = converter.estree.ts_type.as_deref() else {
         panic!("No `ts_type` provided for ESTree converter `{converter_name}`");
     };
-    let question_mark = if converter.estree.is_ts { "?" } else { "" };
+    let question_mark = if converter.estree.is_js || converter.estree.is_ts { "?" } else { "" };
     write_it!(fields_str, "\n\t{field_name}{question_mark}: {ts_type};");
 }
 

--- a/tasks/ast_tools/src/schema/extensions/estree.rs
+++ b/tasks/ast_tools/src/schema/extensions/estree.rs
@@ -79,6 +79,8 @@ pub struct ESTreeStructField {
     pub no_flatten: bool,
     /// `true` for fields containing a `&str` or `Atom` which does not need escaping in JSON
     pub json_safe: bool,
+    /// `true` if field is only included in JS ESTree AST (not TS-ESTree AST).
+    pub is_js: bool,
     /// `true` if field is only included in TS-ESTree AST (not JS ESTree AST).
     pub is_ts: bool,
 }
@@ -103,6 +105,8 @@ pub struct ESTreeMeta {
     pub ts_type: Option<String>,
     /// JS code for raw transfer deserializer.
     pub raw_deser: Option<String>,
+    /// `true` if meta type is for a struct field which is present only in JS AST.
+    pub is_js: bool,
     /// `true` if meta type is for a struct field which is present only in TS AST.
     pub is_ts: bool,
 }


### PR DESCRIPTION
Codegen for `ESTree` impls supports a `#[ts]` attribute on struct fields which only appear in TS-ESTree AST. Add a `#[js_only]` attribute which does the same thing in reverse - indicates a field only appears in the JS ESTree AST, and not in TS-ESTree.

This allows removing a custom serializer and hacky workaround for `JSXOpeningFragment`.
