### PR TITLE
refactor(allocator/vec): re-order arguments to `RawVec::from_raw_parts_in`

### DIFF
--- a/crates/oxc_allocator/src/vec2/mod.rs
+++ b/crates/oxc_allocator/src/vec2/mod.rs
@@ -686,7 +686,7 @@ impl<'a, T: 'a> Vec<'a, T> {
         capacity: usize,
         alloc: &'a Bump,
     ) -> Vec<'a, T> {
-        Vec { buf: RawVec::from_raw_parts_in(ptr, alloc, capacity, length) }
+        Vec { buf: RawVec::from_raw_parts_in(ptr, length, capacity, alloc) }
     }
 
     /// Returns the number of elements in the vector, also referred to as its 'length'.

--- a/crates/oxc_allocator/src/vec2/raw_vec.rs
+++ b/crates/oxc_allocator/src/vec2/raw_vec.rs
@@ -134,7 +134,7 @@ impl<'a, T> RawVec<'a, T> {
     ///
     /// If all these values came from a `Vec` created in allocator `a`, then these requirements
     /// are guaranteed to be fulfilled.
-    pub unsafe fn from_raw_parts_in(ptr: *mut T, alloc: &'a Bump, cap: usize, len: usize) -> Self {
+    pub unsafe fn from_raw_parts_in(ptr: *mut T, len: usize, cap: usize, alloc: &'a Bump) -> Self {
         // SAFETY: Caller guarantees `ptr` was allocated, which implies it's not null
         let ptr = unsafe { NonNull::new_unchecked(ptr) };
 


### PR DESCRIPTION
Pure refactor. Change the order of arguments to `RawVec::from_raw_parts` to match the order in `Vec::from_raw_parts`.