### PR TITLE
fix(transformer/optional-chaining): optional chaining expression isn't being transformed correctly when inside a double call expression

### DIFF
--- a/crates/oxc_transformer/src/es2020/optional_chaining.rs
+++ b/crates/oxc_transformer/src/es2020/optional_chaining.rs
@@ -340,7 +340,9 @@ impl<'a> OptionalChaining<'a, '_> {
         // If this chain expression is a callee of a CallExpression, we need to transform it to accept a proper context
         // `(Foo?.["m"])();` -> `(...  _Foo["m"].bind(_Foo))();`
         //                                       ^^^^^^^^^^^ Here we will handle the `right` part to bind a proper context
-        if matches!(ctx.ancestor(1), Ancestor::CallExpressionCallee(_)) {
+        if ctx.parent().is_parenthesized_expression()
+            && matches!(ctx.ancestor(1), Ancestor::CallExpressionCallee(_))
+        {
             chain_expr = self.transform_expression_to_bind_context(chain_expr, ctx);
         }
         // Clear states

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 1d4546bc
 
-Passed: 153/257
+Passed: 154/258
 
 # All Passed:
 * babel-plugin-transform-class-static-block

--- a/tasks/transform_conformance/tests/babel-plugin-transform-optional-chaining/test/fixtures/inside-double-call-expression/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-optional-chaining/test/fixtures/inside-double-call-expression/input.js
@@ -1,0 +1,6 @@
+const a = {}
+
+call(a?.b)(a?.c)
+call((a?.b))((a?.c))
+call(a?.b())(a?.c())
+call((a?.b()))((a?.c()))

--- a/tasks/transform_conformance/tests/babel-plugin-transform-optional-chaining/test/fixtures/inside-double-call-expression/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-optional-chaining/test/fixtures/inside-double-call-expression/output.js
@@ -1,0 +1,5 @@
+const a = {};
+call(a === null || a === void 0 ? void 0 : a.b)(a === null || a === void 0 ? void 0 : a.c);
+call(a === null || a === void 0 ? void 0 : a.b)(a === null || a === void 0 ? void 0 : a.c);
+call(a === null || a === void 0 ? void 0 : a.b())(a === null || a === void 0 ? void 0 : a.c());
+call(a === null || a === void 0 ? void 0 : a.b())(a === null || a === void 0 ? void 0 : a.c());

--- a/tasks/transform_conformance/tests/babel-plugin-transform-optional-chaining/test/fixtures/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-optional-chaining/test/fixtures/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-optional-chaining"]
+}


### PR DESCRIPTION
close: https://github.com/oxc-project/oxc/issues/11141