### PR TITLE
feat(ast/estree): add `phase` field to `ImportExpression` in TS-ESTree AST

### DIFF
--- a/.github/actions/clone-submodules/action.yml
+++ b/.github/actions/clone-submodules/action.yml
@@ -38,4 +38,4 @@ runs:
         show-progress: false
         repository: oxc-project/acorn-test262
         path: tasks/coverage/acorn-test262
-        ref: baea9081ae0d889218ce761c96b655ad1afec0e6 # Latest main at 20/5/25
+        ref: bf1f5de027151b5e2e671cba0a6085907be3ab37 # Latest main at 20/5/25

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -2389,7 +2389,6 @@ pub struct ImportExpression<'a> {
     pub span: Span,
     pub source: Expression<'a>,
     pub options: Option<Expression<'a>>,
-    #[js_only]
     pub phase: Option<ImportPhase>,
 }
 

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1650,7 +1650,7 @@ impl ESTree for ImportExpression<'_> {
         state.serialize_field("end", &self.span.end);
         state.serialize_field("source", &self.source);
         state.serialize_field("options", &self.options);
-        state.serialize_js_field("phase", &self.phase);
+        state.serialize_field("phase", &self.phase);
         state.end();
     }
 }

--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ submodules:
   just clone-submodule tasks/coverage/babel https://github.com/babel/babel.git 1d4546bcb80009303aab386b59f4df1fd335c1d5
   just clone-submodule tasks/coverage/typescript https://github.com/microsoft/TypeScript.git 81c951894e93bdc37c6916f18adcd80de76679bc
   just clone-submodule tasks/prettier_conformance/prettier https://github.com/prettier/prettier.git 7584432401a47a26943dd7a9ca9a8e032ead7285
-  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 baea9081ae0d889218ce761c96b655ad1afec0e6
+  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 bf1f5de027151b5e2e671cba0a6085907be3ab37
   just update-transformer-fixtures
 
 # Install git pre-commit to format files

--- a/napi/parser/README.md
+++ b/napi/parser/README.md
@@ -20,6 +20,9 @@ The only differences between Oxc's AST and ESTree / TS-ESTree are:
 
 - Support for Stage 3 ECMA features [`import defer`](https://github.com/tc39/proposal-defer-import-eval)
   and [`import source`](https://github.com/tc39/proposal-source-phase-imports).
+- In TS-ESTree AST, `import.defer(...)` and `import.source(...)` are represented as an `ImportExpression`
+  with `'defer'` or `'source'` in `phase` field (as in ESTree spec), where TS-ESLint represents these
+  as a `CallExpression` with `MetaProperty` as its `callee`.
 - Addition of a non-standard `hashbang` field to `Program`.
 
 That aside, the AST should completely align with Acorn's ESTree AST or TS-ESLint's TS-ESTree.

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -1057,6 +1057,7 @@ function deserializeImportExpression(pos) {
     end: deserializeU32(pos + 4),
     source: deserializeExpression(pos + 8),
     options: deserializeOptionExpression(pos + 24),
+    phase: deserializeOptionImportPhase(pos + 40),
   };
 }
 

--- a/napi/parser/test/parse.test.ts
+++ b/napi/parser/test/parse.test.ts
@@ -474,13 +474,20 @@ describe('parse', () => {
             });
           });
 
-          it.skip('TS-ESTree', () => {
+          // This does *not* align with TS-ESLint.
+          // See https://github.com/oxc-project/oxc/pull/11193.
+          it('TS-ESTree', () => {
             const ret = parseSync('test.ts', 'import.defer("x");');
             expect(ret.errors.length).toBe(0);
             expect(ret.program.body.length).toBe(1);
             // @ts-ignore
             expect(ret.program.body[0].expression).toEqual({
-              // TODO
+              type: 'ImportExpression',
+              start: 0,
+              end: 17,
+              source: { type: 'Literal', start: 13, end: 16, value: 'x', raw: '"x"' },
+              options: null,
+              phase: 'defer',
             });
           });
         });
@@ -501,13 +508,20 @@ describe('parse', () => {
             });
           });
 
-          it.skip('TS-ESTree', () => {
+          // This does *not* align with TS-ESLint.
+          // See https://github.com/oxc-project/oxc/pull/11193.
+          it('TS-ESTree', () => {
             const ret = parseSync('test.ts', 'import.source("x");');
             expect(ret.errors.length).toBe(0);
             expect(ret.program.body.length).toBe(1);
             // @ts-ignore
             expect(ret.program.body[0].expression).toEqual({
-              // TODO
+              type: 'ImportExpression',
+              start: 0,
+              end: 18,
+              source: { type: 'Literal', start: 14, end: 17, value: 'x', raw: '"x"' },
+              options: null,
+              phase: 'source',
             });
           });
         });

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -742,7 +742,7 @@ export interface ImportExpression extends Span {
   type: 'ImportExpression';
   source: Expression;
   options: Expression | null;
-  phase?: ImportPhase | null;
+  phase: ImportPhase | null;
 }
 
 export interface ImportDeclaration extends Span {

--- a/tasks/coverage/snapshots/estree_acorn_jsx.snap
+++ b/tasks/coverage/snapshots/estree_acorn_jsx.snap
@@ -1,4 +1,4 @@
-commit: baea9081
+commit: bf1f5de0
 
 estree_acorn_jsx Summary:
 AST Parsed     : 39/39 (100.00%)


### PR DESCRIPTION
Related to #10978. Add `phase` property to `ImportExpression` in TS-ESTree AST.

This aligns with ESTree spec, but does *not* align with TS-ESLint - TS-ESLint outputs a `CallExpression` with a `MetaProperty` as its `callee` instead.

We don't have the necessary information in our AST to match TS-ESLint, because we don't have the spans of `import`, `defer`, or `import.defer`, to use for the `MetaProperty`, or the `IdentifierName`s it contains.

This is not completely ideal, but I figure it's preferable to represent this syntax *somehow* in the AST, rather than completely ignoring it, in which case there's no way to distinguish between `import("x")`, `import.defer("x")`, and `import.source("x")`.

Presumably TS-ESLint will change their AST shape to conform to ESTree spec once these reach stage 4, so I don't think we should expend effort changing our AST to align with them in the meantime. TypeScript doesn't even have test cases for these (we'd know if they did, as we'd be failing them) - so I doubt these are popular constructs in TS.

`acorn-test262` submodule is bumped to include https://github.com/oxc-project/acorn-test262/pull/36 which adds the `phase` field to `ImportExpression`s in test snapshots.
