### PR TITLE
refactor(allocator): introduce `Alloc` trait

### DIFF
--- a/crates/oxc_allocator/src/alloc.rs
+++ b/crates/oxc_allocator/src/alloc.rs
@@ -1,0 +1,183 @@
+// All methods just delegate to `Bump`'s methods
+#![expect(clippy::inline_always)]
+
+use std::{
+    alloc::{Layout, handle_alloc_error},
+    ptr::NonNull,
+};
+
+use allocator_api2::alloc::Allocator;
+use bumpalo::Bump;
+
+/// Trait describing an allocator.
+///
+/// It's a simpler version of `allocator_api2`'s [`Allocator`] trait.
+///
+/// The difference between these methods and [`Allocator`]'s versions of them are:
+///
+/// * `shrink` and `grow` return a pointer and panic/abort if allocation fails,
+///   instead of returning `Result::Err`.
+/// * All methods return a `NonNull<u8>`, instead of `NonNull<[u8]>`.
+pub trait Alloc {
+    /// Allocate space for an object with the given [`Layout`].
+    ///
+    /// The returned pointer points at uninitialized memory, and should be initialized
+    /// with [`std::ptr::write`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if reserving space for `layout` fails.
+    #[expect(dead_code)]
+    fn alloc(&self, layout: Layout) -> NonNull<u8>;
+
+    /// Deallocate the memory referenced by `ptr`.
+    ///
+    /// # SAFETY
+    ///
+    /// * `ptr` must denote a block of memory currently allocated via this allocator.
+    /// * `layout` must be the same [`Layout`] that block was originally allocated with.
+    #[expect(dead_code)]
+    unsafe fn dealloc(&self, ptr: NonNull<u8>, layout: Layout);
+
+    /// Grow an existing allocation to new [`Layout`].
+    ///
+    /// If the allocation cannot be grown in place, the data from the whole of the old allocation
+    /// is copied to the start of the new allocation.
+    ///
+    /// If the allocation is grown in place, no memory copying will occur.
+    ///
+    /// Either way, the pointer returned points to the new allocation.
+    ///
+    /// Any access to the old `ptr` is Undefined Behavior, even if the allocation was grown in-place.
+    /// The newly returned pointer is the only valid pointer for accessing this memory now.
+    ///
+    /// # SAFETY
+    ///
+    /// * `ptr` must denote a block of memory currently allocated via this allocator.
+    /// * `old_layout` must be the same [`Layout`] that block was originally allocated with.
+    /// * `new_layout.size()` must be greater than or equal to `old_layout.size()`.
+    #[expect(dead_code)]
+    unsafe fn grow(&self, ptr: NonNull<u8>, old_layout: Layout, new_layout: Layout) -> NonNull<u8>;
+
+    /// Shrink an existing allocation to new [`Layout`].
+    ///
+    /// If the allocation cannot be shrunk in place, `new_layout.size()` bytes of data
+    /// from the old allocation are copied to the new allocation.
+    ///
+    /// If the allocation is shrunk in place, no memory copying will occur.
+    ///
+    /// Either way, the pointer returned points to the new allocation.
+    ///
+    /// Any access to the old `ptr` is Undefined Behavior, even if the allocation was shrunk in-place.
+    /// The newly returned pointer is the only valid pointer for accessing this memory now.
+    ///
+    /// # SAFETY
+    ///
+    /// * `ptr` must denote a block of memory currently allocated via this allocator.
+    /// * `old_layout` must be the same [`Layout`] that block was originally allocated with.
+    /// * `new_layout.size()` must be smaller than or equal to `old_layout.size()`.
+    #[expect(dead_code)]
+    unsafe fn shrink(
+        &self,
+        ptr: NonNull<u8>,
+        old_layout: Layout,
+        new_layout: Layout,
+    ) -> NonNull<u8>;
+}
+
+/// Implement [`Alloc`] for [`bumpalo::Bump`].
+///
+/// All methods except `alloc` delegate to [`Bump`]'s impl of `allocator_api2`'s [`Allocator`] trait.
+impl Alloc for Bump {
+    /// Allocate space for an object with the given [`Layout`].
+    ///
+    /// The returned pointer points at uninitialized memory, and should be initialized
+    /// with [`std::ptr::write`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if reserving space for `layout` fails.
+    #[inline(always)]
+    fn alloc(&self, layout: Layout) -> NonNull<u8> {
+        self.alloc_layout(layout)
+    }
+
+    /// Deallocate the memory referenced by `ptr`.
+    ///
+    /// # SAFETY
+    ///
+    /// * `ptr` must denote a block of memory currently allocated via this allocator.
+    /// * `layout` must be the same [`Layout`] that block was originally allocated with.
+    #[inline(always)]
+    unsafe fn dealloc(&self, ptr: NonNull<u8>, layout: Layout) {
+        // SAFETY: Safety requirements of `Allocator::deallocate` are the same as for this method
+        unsafe { self.deallocate(ptr, layout) }
+    }
+
+    /// Grow an existing allocation to new [`Layout`].
+    ///
+    /// If the allocation cannot be grown in place, the data from the whole of the old allocation
+    /// is copied to the start of the new allocation.
+    ///
+    /// If the allocation is grown in place, no memory copying will occur.
+    ///
+    /// Either way, the pointer returned points to the new allocation.
+    ///
+    /// Any access to the old `ptr` is Undefined Behavior, even if the allocation was grown in-place.
+    /// The newly returned pointer is the only valid pointer for accessing this memory now.
+    ///
+    /// # SAFETY
+    ///
+    /// * `ptr` must denote a block of memory currently allocated via this allocator.
+    /// * `old_layout` must be the same [`Layout`] that block was originally allocated with.
+    /// * `new_layout.size()` must be greater than or equal to `old_layout.size()`.
+    ///
+    /// # Panics
+    ///
+    /// Panics / aborts if reserving space for `new_layout` fails.
+    #[inline(always)]
+    unsafe fn grow(&self, ptr: NonNull<u8>, old_layout: Layout, new_layout: Layout) -> NonNull<u8> {
+        // SAFETY: Safety requirements of `Allocator::grow` are the same as for this method
+        let res = unsafe { Allocator::grow(&self, ptr, old_layout, new_layout) };
+        match res {
+            Ok(new_ptr) => new_ptr.cast::<u8>(),
+            Err(_) => handle_alloc_error(new_layout), // panic/abort
+        }
+    }
+
+    /// Shrink an existing allocation to new [`Layout`].
+    ///
+    /// If the allocation cannot be shrunk in place, the `layout.new()` bytes of data
+    /// from the old allocation are copied to the new allocation.
+    ///
+    /// If the allocation is shrunk in place, no memory copying will occur.
+    ///
+    /// Either way, the pointer returned points to the new allocation.
+    ///
+    /// Any access to the old `ptr` is Undefined Behavior, even if the allocation was shrunk in-place.
+    /// The newly returned pointer is the only valid pointer for accessing this memory now.
+    ///
+    /// # SAFETY
+    ///
+    /// * `ptr` must denote a block of memory currently allocated via this allocator.
+    /// * `old_layout` must be the same [`Layout`] that block was originally allocated with.
+    /// * `new_layout.size()` must be smaller than or equal to `old_layout.size()`.
+    ///
+    /// # Panics
+    ///
+    /// Panics / aborts if reserving space for `new_layout` fails.
+    #[inline(always)]
+    unsafe fn shrink(
+        &self,
+        ptr: NonNull<u8>,
+        old_layout: Layout,
+        new_layout: Layout,
+    ) -> NonNull<u8> {
+        // SAFETY: Safety requirements of `Allocator::shrink` are the same as for this method
+        let res = unsafe { Allocator::shrink(&self, ptr, old_layout, new_layout) };
+        match res {
+            Ok(new_ptr) => new_ptr.cast::<u8>(),
+            Err(_) => handle_alloc_error(new_layout), // panic/abort
+        }
+    }
+}

--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -22,6 +22,7 @@
 #![warn(missing_docs)]
 
 mod address;
+mod alloc;
 mod allocator;
 mod allocator_api2;
 mod boxed;


### PR DESCRIPTION
First step towards replacing `bumpalo` with our own allocator (#11145).

Introduce `Alloc` trait and implement it for `bumpalo::Bump`. A later PR will parameterize `Vec` with `Alloc`, instead of a static dependency on `Bump`.

We can later on replace `Bump` with our own `Arena` type. `Arena` will also implement `Alloc`, so the two will be able to be swapped with a minimum of fuss.

### Why do we need a trait at all?

Why couldn't `Vec` just statically depend on `Arena`, same as it now does on `Bump`?

Rationale for a trait here is: My intent is to have 2 different variants of `Arena` to support filling allocator chunks from both ends (string data fills from the start, all other types fill from the end). This will have 3 advantages: 

1. More tightly packed data. `&str` / `Atom` is the only type in the AST which is not aligned on 8. Strings currently often tend to end up with unnecessary padding bytes around them.
2. Packing all string data into a single immutable stretch of memory has potential to speed up all string operations (https://github.com/oxc-project/backlog/issues/46#issuecomment-2603153807).
3. It should unblock the biggest current perf bottleneck in raw transfer, by allowing all strings in the AST to be converted to UTF-16 in a single shot (as if they were just 1 long string), rather than converting each string individually.

`String` is a wrapper around `Vec`, and it's preferable not to have to implement `Vec` twice for front-filling (strings) and back-filling (all other types). `Vec<T, A: Alloc>` is a simpler solution.
