### PR TITLE
refactor(allocator): `InnerVec` use `Alloc` trait

### DIFF
--- a/crates/oxc_allocator/src/alloc.rs
+++ b/crates/oxc_allocator/src/alloc.rs
@@ -27,7 +27,6 @@ pub trait Alloc {
     /// # Panics
     ///
     /// Panics if reserving space for `layout` fails.
-    #[expect(dead_code)]
     fn alloc(&self, layout: Layout) -> NonNull<u8>;
 
     /// Deallocate the memory referenced by `ptr`.
@@ -36,7 +35,6 @@ pub trait Alloc {
     ///
     /// * `ptr` must denote a block of memory currently allocated via this allocator.
     /// * `layout` must be the same [`Layout`] that block was originally allocated with.
-    #[expect(dead_code)]
     unsafe fn dealloc(&self, ptr: NonNull<u8>, layout: Layout);
 
     /// Grow an existing allocation to new [`Layout`].
@@ -56,7 +54,6 @@ pub trait Alloc {
     /// * `ptr` must denote a block of memory currently allocated via this allocator.
     /// * `old_layout` must be the same [`Layout`] that block was originally allocated with.
     /// * `new_layout.size()` must be greater than or equal to `old_layout.size()`.
-    #[expect(dead_code)]
     unsafe fn grow(&self, ptr: NonNull<u8>, old_layout: Layout, new_layout: Layout) -> NonNull<u8>;
 
     /// Shrink an existing allocation to new [`Layout`].
@@ -76,7 +73,6 @@ pub trait Alloc {
     /// * `ptr` must denote a block of memory currently allocated via this allocator.
     /// * `old_layout` must be the same [`Layout`] that block was originally allocated with.
     /// * `new_layout.size()` must be smaller than or equal to `old_layout.size()`.
-    #[expect(dead_code)]
     unsafe fn shrink(
         &self,
         ptr: NonNull<u8>,


### PR DESCRIPTION
Parameterize `InnerVec` (otherwise known as `Vec2`) and `RawVec` with `Alloc` trait introduced in #11198.

`InnerVec` and `RawVec` no longer have a dependency on `bumpalo::Bump`. The rationale for that is discussed in #11198.

The only substantive change this PR makes is that all `Alloc` methods panic/abort if allocation fails, rather than returning a `Result::Err`. This alters the behavior of `try_*` methods, which previously wouldn't panic. However, I don't believe we use any of those methods, and we have no plans to, so in my view we should remove them. In practice it should be very difficult to exhaust all memory, and if we did there's no way to gracefully recover from that (what would we do? only parse half the file?). So this has little/no practical impact.

That apart, this PR is pure refactor. The diff is large, but it's almost entirely adding the `A: Alloc` bound to all methods / iterators, and removing `Bump`.
