### PR TITLE
perf(parser): Remove `Lexer::lookahead: VecDeque`

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -64,7 +64,7 @@ impl<'a> ParserImpl<'a> {
     /// Peek next token, returns EOF for final peek
     #[inline]
     pub(crate) fn peek_token(&mut self) -> Token {
-        self.lexer.lookahead(1)
+        self.nth(1)
     }
 
     /// Peek next kind, returns EOF for final peek
@@ -76,7 +76,7 @@ impl<'a> ParserImpl<'a> {
     /// Peek at kind
     #[inline]
     pub(crate) fn peek_at(&mut self, kind: Kind) -> bool {
-        self.peek_token().kind() == kind
+        self.peek_kind() == kind
     }
 
     /// Peek nth token
@@ -85,7 +85,13 @@ impl<'a> ParserImpl<'a> {
         if n == 0 {
             return self.cur_token();
         }
-        self.lexer.lookahead(n)
+        self.lookahead(|p| {
+            // Advance n times then get the token
+            for _ in 0..n {
+                p.bump_any();
+            }
+            p.cur_token()
+        })
     }
 
     /// Peek at nth kind

--- a/crates/oxc_parser/src/lexer/jsx.rs
+++ b/crates/oxc_parser/src/lexer/jsx.rs
@@ -116,9 +116,6 @@ impl Lexer<'_> {
         }
         self.consume_char();
 
-        // Clear the current lookahead `Minus` Token
-        self.lookahead.clear();
-
         // Consume bytes which are part of identifier tail
         let next_byte = byte_search! {
             lexer: self,

--- a/crates/oxc_parser/src/lexer/punctuation.rs
+++ b/crates/oxc_parser/src/lexer/punctuation.rs
@@ -61,9 +61,6 @@ impl Lexer<'_> {
     pub(crate) fn re_lex_right_angle(&mut self) -> Token {
         self.token.set_start(self.offset());
         let kind = self.read_right_angle();
-        if kind != Kind::RAngle {
-            self.lookahead.clear();
-        }
         self.finish_next(kind)
     }
 

--- a/crates/oxc_parser/src/lexer/regex.rs
+++ b/crates/oxc_parser/src/lexer/regex.rs
@@ -21,7 +21,6 @@ impl Lexer<'_> {
                 },
         );
         let (pattern_end, flags, flags_error) = self.read_regex();
-        self.lookahead.clear();
         let token = self.finish_next(Kind::RegExp);
         (token, pattern_end, flags, flags_error)
     }

--- a/crates/oxc_parser/src/lexer/template.rs
+++ b/crates/oxc_parser/src/lexer/template.rs
@@ -389,7 +389,6 @@ impl<'a> Lexer<'a> {
     pub(crate) fn next_template_substitution_tail(&mut self) -> Token {
         self.token.set_start(self.offset() - 1);
         let kind = self.read_template_literal(Kind::TemplateMiddle, Kind::TemplateTail);
-        self.lookahead.clear();
         self.finish_next(kind)
     }
 

--- a/crates/oxc_parser/src/lexer/typescript.rs
+++ b/crates/oxc_parser/src/lexer/typescript.rs
@@ -11,7 +11,6 @@ impl Lexer<'_> {
         self.token.set_start(self.offset() - offset);
         self.source.back(offset as usize - 1);
         let kind = Kind::LAngle;
-        self.lookahead.clear();
         self.finish_next(kind)
     }
 
@@ -25,7 +24,6 @@ impl Lexer<'_> {
         self.token.set_start(self.offset() - offset);
         self.source.back(offset as usize - 1);
         let kind = Kind::RAngle;
-        self.lookahead.clear();
         self.finish_next(kind)
     }
 }


### PR DESCRIPTION
Part of #11194

I found that `ParserImpl::lookahead` was already implemented and it did not seem to depend on `Lexer::lookahead`.
So, I replaced all the `ParserImpl::peek_xxx()` methods and removed `Lexer::lookahead` as a first step.