### PR TITLE
perf(parser): remove redundant checks

### DIFF
--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -239,11 +239,7 @@ impl<'a> ParserImpl<'a> {
         }
 
         let kind = self.cur_kind();
-        if kind.is_identifier_or_keyword()
-            || kind.is_number()
-            || kind == Kind::Star
-            || kind == Kind::LBrack
-        {
+        if kind.is_identifier_or_keyword() || kind == Kind::Star || kind == Kind::LBrack {
             let is_ambient = modifiers.contains(ModifierKind::Declare);
             return if is_ambient {
                 self.context(Context::Ambient, Context::empty(), |p| {

--- a/crates/oxc_parser/src/lexer/kind.rs
+++ b/crates/oxc_parser/src/lexer/kind.rs
@@ -248,7 +248,10 @@ impl Kind {
     /// `IdentifierName` but not `ReservedWord`
     #[inline]
     pub fn is_identifier(self) -> bool {
-        self.is_identifier_name() && !self.is_reserved_keyword()
+        matches!(self, Ident)
+            || self.is_contextual_keyword()
+            || self.is_strict_mode_contextual_keyword()
+            || self.is_future_reserved_keyword()
     }
 
     /// TypeScript Identifier
@@ -305,9 +308,7 @@ impl Kind {
 
     #[inline]
     pub fn is_identifier_or_keyword(self) -> bool {
-        self.is_literal_property_name()
-            || matches!(self, Self::PrivateIdentifier)
-            || self.is_all_keyword()
+        self.is_literal_property_name() || matches!(self, Self::PrivateIdentifier)
     }
 
     #[inline]

--- a/crates/oxc_parser/src/lexer/kind.rs
+++ b/crates/oxc_parser/src/lexer/kind.rs
@@ -248,10 +248,7 @@ impl Kind {
     /// `IdentifierName` but not `ReservedWord`
     #[inline]
     pub fn is_identifier(self) -> bool {
-        matches!(self, Ident)
-            || self.is_contextual_keyword()
-            || self.is_strict_mode_contextual_keyword()
-            || self.is_future_reserved_keyword()
+        self.is_identifier_name() && !self.is_reserved_keyword()
     }
 
     /// TypeScript Identifier


### PR DESCRIPTION
1. `is_number` in `class.rs` can be removed, because `is_identifier_or_keyword` implies `is_literal_property_name` implying `is_number`
2. ~~Avoids checking for `is_reserved_keyword` one way and then the other way.~~
3. `is_all_keyword` in `is_identifier_or_keyword` can be removed, because `is_literal_property_name` implies `is_identifier_name` implying `is_all_keyword`

Let's see if those changes yield any improvements in the benchmark or if the compiler was smart enough to optimize that.

Edit: removed the second change because it's not worth the sacrificed readability