### PR TITLE
fix(lexer): restore debug assert in `Lexer::finish_next`

### DIFF
--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -217,6 +217,7 @@ impl<'a> Lexer<'a> {
     fn finish_next(&mut self, kind: Kind) -> Token {
         self.token.set_kind(kind);
         self.token.set_end(self.offset());
+        debug_assert!(self.token.start() <= self.token.end());
         let token = self.token;
         self.trivia_builder.handle_token(token);
         self.token = Token::default();


### PR DESCRIPTION
#11204 removed a `debug_assert!` from `Lexer::finish_next` which checks that `end` of a `Token` is always >= `start`.

I assume this was unintentional, as this check is useful for making sure lexer is operating correctly in conformance tests. Restore it.
