### PR TITLE
refactor(allocator): `TakeIn::take_in_box` accept any `AllocatorAccessor`

### DIFF
--- a/crates/oxc_allocator/src/take_in.rs
+++ b/crates/oxc_allocator/src/take_in.rs
@@ -14,7 +14,8 @@ pub trait TakeIn<'a>: Dummy<'a> {
 
     /// Replace node with a boxed dummy.
     #[must_use]
-    fn take_in_box(&mut self, allocator: &'a Allocator) -> Box<'a, Self> {
+    fn take_in_box<A: AllocatorAccessor<'a>>(&mut self, allocator_accessor: A) -> Box<'a, Self> {
+        let allocator = allocator_accessor.allocator();
         let dummy = Dummy::dummy(allocator);
         Box::new_in(mem::replace(self, dummy), allocator)
     }

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -281,7 +281,7 @@ impl<'a, 'b> PeepholeOptimizations {
                                 .declarations
                                 .splice(0..0, var_init.declarations.take_in(ctx.ast));
                         } else {
-                            var_decl = Some(var_init.take_in_box(ctx.ast.allocator));
+                            var_decl = Some(var_init.take_in_box(ctx.ast));
                         }
                     }
                     Some(var_decl.map_or_else(

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -537,7 +537,7 @@ impl<'a> LegacyDecorator<'a, '_> {
         let span = class.span;
         class.r#type = ClassType::ClassExpression;
         let initializer = Self::get_class_initializer(
-            Expression::ClassExpression(class.take_in_box(ctx.ast.allocator)),
+            Expression::ClassExpression(class.take_in_box(ctx.ast)),
             alias_binding,
             ctx,
         );

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -298,7 +298,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let body = wrapper_function.body.take().unwrap();
-        let params = wrapper_function.params.take_in_box(ctx.ast.allocator);
+        let params = wrapper_function.params.take_in_box(ctx.ast);
         let id = wrapper_function.id.take();
         let has_function_id = id.is_some();
 
@@ -385,8 +385,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
         }
 
         // Construct the IIFE
-        let callee =
-            Expression::FunctionExpression(wrapper_function.take_in_box(ctx.ast.allocator));
+        let callee = Expression::FunctionExpression(wrapper_function.take_in_box(ctx.ast));
         ctx.ast.expression_call_with_pure(SPAN, callee, NONE, ctx.ast.vec(), false, true)
     }
 
@@ -461,7 +460,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
         arrow: &mut ArrowFunctionExpression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
-        let mut body = arrow.body.take_in_box(ctx.ast.allocator);
+        let mut body = arrow.body.take_in_box(ctx.ast);
 
         // If the arrow's expression is true, we need to wrap the only one expression with return statement.
         if arrow.expression {
@@ -473,7 +472,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
             *statement = ctx.ast.statement_return(expression.span(), Some(expression));
         }
 
-        let params = arrow.params.take_in_box(ctx.ast.allocator);
+        let params = arrow.params.take_in_box(ctx.ast);
         let generator_function_id = arrow.scope_id();
         ctx.scoping_mut().scope_flags_mut(generator_function_id).remove(ScopeFlags::Arrow);
         let function_name = Self::infer_function_name_from_parent_node(ctx);

--- a/crates/oxc_transformer/src/es2022/class_properties/private_method.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_method.rs
@@ -47,7 +47,7 @@ impl<'a> ClassProperties<'a, '_> {
             return None;
         };
 
-        let mut function = value.take_in_box(ctx.ast.allocator);
+        let mut function = value.take_in_box(ctx.ast);
 
         let resolved_private_prop = if *kind == MethodDefinitionKind::Set {
             self.classes_stack.find_writeable_private_prop(ident)


### PR DESCRIPTION
Pure refactor. `TakeIn::take_in_box` accept any `AllocatorAccessor`, same as `take_in` does. This change allows shortening calling code, and improves consistency between the 2 methods.
