### PR TITLE
refactor(parser): Remove Lexer peeking for modifiers

### DIFF
--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -318,7 +318,10 @@ impl<'a> ParserImpl<'a> {
         }
 
         match self.cur_kind() {
-            Kind::Const => self.peek_kind() == Kind::Enum,
+            Kind::Const => {
+                self.bump_any();
+                self.at(Kind::Enum)
+            }
             Kind::Export => {
                 self.bump_any();
                 match self.cur_kind() {
@@ -454,7 +457,10 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn next_token_can_follow_modifier(&mut self) {
         let b = match self.cur_kind() {
-            Kind::Const => self.peek_at(Kind::Enum),
+            Kind::Const => {
+                self.bump_any();
+                self.at(Kind::Enum)
+            }
             Kind::Export => {
                 self.bump_any();
                 match self.cur_kind() {


### PR DESCRIPTION
Part of #11194 

NOTE: In TypeScript parser.ts, `next_token_can_follow_modifier` seems to be the only place to handle these checks.

https://github.com/microsoft/TypeScript/blob/b504a1eed45e35b5f54694a1e0a09f35d0a5663c/src/compiler/parser.ts#L2765

But we have two places, may revisit it later.