### PR TITLE
feat(isolated-declarations): report an error for object methods whose return type cannot be inferred

### DIFF
--- a/crates/oxc_isolated_declarations/tests/fixtures/object.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/object.ts
@@ -36,3 +36,11 @@ const E = {
 		// do something
 	},
 };
+
+const ObjectMethods = {
+	a() {
+		return 0;
+	},
+	b(): number {},
+	c() {},
+};

--- a/crates/oxc_isolated_declarations/tests/snapshots/object.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/object.snap
@@ -18,6 +18,11 @@ declare const D: {
 	state: number
 };
 declare const E: {};
+declare const ObjectMethods: {
+	a(): number
+	b(): number
+	c()
+};
 
 
 ==================== Errors ====================
@@ -36,6 +41,15 @@ declare const E: {};
  35 |     set state(v) {
     :              ^^^
  36 |         // do something
+    `----
+
+  x TS9008: Method must have an explicit return type annotation with
+  | --isolatedDeclarations.
+    ,-[45:2]
+ 44 |     b(): number {},
+ 45 |     c() {},
+    :     ^
+ 46 | };
     `----
 
 


### PR DESCRIPTION
The same as `class`, if the method's return type cannot be inferred, it should report an error.

```ts
const A = {
  method() {   
//^^^^^^^ Method must have an explicit return type annotation with --isolatedDeclarations.
  }
}
```