### PR TITLE
fix(isolated-declarations): object property key was generated incorrectly

### DIFF
--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -16,9 +16,7 @@ use crate::{
 impl<'a> IsolatedDeclarations<'a> {
     pub(crate) fn is_literal_key(key: &PropertyKey<'a>) -> bool {
         match key {
-            PropertyKey::StringLiteral(_)
-            | PropertyKey::NumericLiteral(_)
-            | PropertyKey::BigIntLiteral(_) => true,
+            PropertyKey::StringLiteral(_) | PropertyKey::NumericLiteral(_) => true,
             PropertyKey::TemplateLiteral(l) => l.expressions.is_empty(),
             PropertyKey::UnaryExpression(expr) => {
                 expr.operator.is_arithmetic()

--- a/crates/oxc_isolated_declarations/tests/fixtures/object.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/object.ts
@@ -44,3 +44,12 @@ const ObjectMethods = {
 	b(): number {},
 	c() {},
 };
+
+const ObjectKeys = {
+	a: 0,
+	["b"]: 1,
+	[`c`]: 2,
+	[3]: 3,
+	[-3]: 4,
+	[4n]: 5,
+};

--- a/crates/oxc_isolated_declarations/tests/snapshots/object.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/object.snap
@@ -23,6 +23,13 @@ declare const ObjectMethods: {
 	b(): number
 	c()
 };
+declare const ObjectKeys: {
+	a: number
+	b: number
+	c: number
+	3: number
+	[-3]: number
+};
 
 
 ==================== Errors ====================
@@ -50,6 +57,15 @@ declare const ObjectMethods: {
  45 |     c() {},
     :     ^
  46 | };
+    `----
+
+  x TS9038: Computed property names on class or object literals cannot be
+  | inferred with --isolatedDeclarations.
+    ,-[54:3]
+ 53 |     [-3]: 4,
+ 54 |     [4n]: 5,
+    :      ^^
+ 55 | };
     `----
 
 

--- a/tasks/coverage/snapshots/transpile.snap
+++ b/tasks/coverage/snapshots/transpile.snap
@@ -103,10 +103,10 @@ export declare class C {
 	["2"]: number;
 }
 export declare const D: {
-	Symbol.iterator: number
-	globalThis.Symbol.toStringTag: number
+	[Symbol.iterator]: number
+	[globalThis.Symbol.toStringTag]: number
 	1: number
-	"2": number
+	2: number
 };
 export {};
 


### PR DESCRIPTION
Just for aligning with `TypeScript`, the object key should be converted to a static property key when possible

```ts
const ObjectKeys = {
	a: 0,
	["b"]: 1,
	[`c`]: 2,
	[3]: 3,
	[-3]: 4,
	[4n]: 5,
};
```

```ts
declare const ObjectKeys: {
	a: number
	b: number
	c: number
	3: number
	[-3]: number
};
```

`BigInt` is invalid as a property key in TypeScript, so `4n` doesn't emit.