### PR TITLE
fix(semantic): update `symbol_declarations` when a function is found after a var

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -1292,6 +1292,19 @@ fn test_report_vars_only_used_as_types() {
         .test();
 }
 
+#[test]
+fn test_js() {
+    let pass = vec![
+        // https://github.com/oxc-project/oxc/issues/11215
+        "export function promisify() { var fn; function fn() {}; return fn; }",
+    ];
+
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, vec![])
+        .change_rule_path_extension("js")
+        .intentionally_allow_no_fix_tests()
+        .test();
+}
+
 // #[test]
 // fn test_template() {
 //     let pass = vec![];

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1012,9 +1012,6 @@ rebuilt        : ScopeId(7): []
 Symbol flags mismatch for "a":
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable)
 rebuilt        : SymbolId(8): SymbolFlags(Function)
-Symbol span mismatch for "a":
-after transform: SymbolId(0): Span { start: 27, end: 28 }
-rebuilt        : SymbolId(8): Span { start: 86, end: 87 }
 Symbol scope ID mismatch for "a":
 after transform: SymbolId(0): ScopeId(2)
 rebuilt        : SymbolId(8): ScopeId(0)


### PR DESCRIPTION
Fixes #11215

I'm really not happy with this fix, but I can't see a better solution.

Since we only do 1x pass in semantic we can't hoist the function declaraions + declare them before the var declarations, hence here, we have to update the original declaration to point to the function declaration.