### PR TITLE
perf(linter): avoid iterating lines twice if blank lines are skipped

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/max_lines.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_lines.rs
@@ -82,33 +82,29 @@ impl Rule for MaxLines {
 
     #[expect(clippy::cast_possible_truncation)]
     fn run_once(&self, ctx: &LintContext) {
+        let source_text = ctx.source_text();
+
         let comment_lines = if self.skip_comments {
             ctx.semantic()
                 .comments()
                 .iter()
-                .map(|comment| count_comment_lines(comment, ctx.source_text()))
+                .map(|comment| count_comment_lines(comment, source_text))
                 .sum()
         } else {
             0
         };
 
-        let lines_in_file =
-            if ctx.source_text().is_empty() { 1 } else { ctx.source_text().lines().count() };
-
-        let blank_lines = if self.skip_blank_lines {
-            ctx.source_text().lines().filter(|&line| line.trim().is_empty()).count()
+        let lines_in_file = if self.skip_blank_lines {
+            source_text.lines().filter(|&line| !line.trim().is_empty()).count()
         } else {
-            0
+            source_text.lines().count()
         };
 
-        if lines_in_file.saturating_sub(blank_lines).saturating_sub(comment_lines) > self.max {
+        let final_lines = lines_in_file.max(1).saturating_sub(comment_lines);
+        if final_lines > self.max {
             // Point to end of the file for `eslint-disable max-lines` to work.
-            let end = ctx.source_text().len().saturating_sub(1) as u32;
-            ctx.diagnostic(max_lines_diagnostic(
-                lines_in_file.saturating_sub(blank_lines).saturating_sub(comment_lines),
-                self.max,
-                Span::new(end, end),
-            ));
+            let end = source_text.len().saturating_sub(1) as u32;
+            ctx.diagnostic(max_lines_diagnostic(final_lines, self.max, Span::new(end, end)));
         }
     }
 }

--- a/crates/oxc_linter/src/rules/eslint/max_lines.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_lines.rs
@@ -82,28 +82,26 @@ impl Rule for MaxLines {
 
     #[expect(clippy::cast_possible_truncation)]
     fn run_once(&self, ctx: &LintContext) {
-        let source_text = ctx.source_text();
-
         let comment_lines = if self.skip_comments {
             ctx.semantic()
                 .comments()
                 .iter()
-                .map(|comment| count_comment_lines(comment, source_text))
+                .map(|comment| count_comment_lines(comment, ctx.source_text()))
                 .sum()
         } else {
             0
         };
 
         let lines_in_file = if self.skip_blank_lines {
-            source_text.lines().filter(|&line| !line.trim().is_empty()).count()
+            ctx.source_text().lines().filter(|&line| !line.trim().is_empty()).count()
         } else {
-            source_text.lines().count()
+            ctx.source_text().lines().count()
         };
 
         let final_lines = lines_in_file.max(1).saturating_sub(comment_lines);
         if final_lines > self.max {
             // Point to end of the file for `eslint-disable max-lines` to work.
-            let end = source_text.len().saturating_sub(1) as u32;
+            let end = ctx.source_text().len().saturating_sub(1) as u32;
             ctx.diagnostic(max_lines_diagnostic(final_lines, self.max, Span::new(end, end)));
         }
     }

--- a/crates/oxc_linter/src/rules/eslint/max_lines_per_function.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_lines_per_function.rs
@@ -193,18 +193,17 @@ impl Rule for MaxLinesPerFunction {
         };
 
         let code = &source_text[span.start as usize..span.end as usize];
-        let lines_in_function = code.lines().count();
-        let blank_lines = if self.skip_blank_lines {
-            code.lines().filter(|&line| line.trim().is_empty()).count()
+        let lines_in_function = if self.skip_blank_lines {
+            code.lines().filter(|&line| !line.trim().is_empty()).count()
         } else {
-            0
+            code.lines().count()
         };
-        let result_lines =
-            lines_in_function.saturating_sub(blank_lines).saturating_sub(comment_lines);
-        if result_lines > self.max {
+
+        let final_lines = lines_in_function.saturating_sub(comment_lines);
+        if final_lines > self.max {
             let name =
                 get_function_name_with_kind(node, ctx.nodes().parent_node(node.id()).unwrap());
-            ctx.diagnostic(max_lines_per_function_diagnostic(&name, result_lines, self.max, span));
+            ctx.diagnostic(max_lines_per_function_diagnostic(&name, final_lines, self.max, span));
         }
     }
 }


### PR DESCRIPTION
Both rules `eslint/max-lines` and `eslint/max-lines-per-function` previously did count all lines and then count all blank lines again to subtract them if config parameter skipBlankLines was enabled. Just count all non-blank lines if skipBlankLines is enabled to avoid one redundant iteration over all lines.