### PR TITLE
fix(isolated-declarations): type of class setter/getter cannot be inferred when the key is a global `Symbol.xxx` expression

### DIFF
--- a/crates/oxc_isolated_declarations/tests/fixtures/set-get-accessor.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/set-get-accessor.ts
@@ -28,3 +28,42 @@ class ClsBad {
   set a(v) {
   }
 }
+
+
+/// Infer type from the function body of the getter
+class GlobalSymbol1 {
+  set [Symbol.toStringTag](v) {
+  }
+  get [Symbol.toStringTag]() {
+    return "string";
+  }
+}
+
+// Infer type from the parameter type of the setter
+class GlobalSymbol2 {
+  set [Symbol.toStringTag](v: number) {
+  }
+  get [Symbol.toStringTag]() {
+    return GlobalSymbol2
+  }
+}
+
+// Infer type from the parameter type of the setter
+class GlobalSymbol3 {
+  set [Symbol.toStringTag](v: number) {
+  }
+  get [Symbol.toStringTag](): string {
+    return "string";
+  }
+}
+
+// Cannot infer type from the function body of the getter
+class GlobalSymbol4 {
+  set [Symbol.toStringTag](v) {
+  }
+  get [Symbol.toStringTag]() {
+    return GlobalSymbol4;
+  }
+}
+
+

--- a/crates/oxc_isolated_declarations/tests/snapshots/set-get-accessor.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/set-get-accessor.snap
@@ -22,6 +22,26 @@ declare class ClsBad {
 	get a();
 	set a(v);
 }
+/// Infer type from the function body of the getter
+declare class GlobalSymbol1 {
+	set [Symbol.toStringTag](v: string);
+	get [Symbol.toStringTag](): string;
+}
+// Infer type from the parameter type of the setter
+declare class GlobalSymbol2 {
+	set [Symbol.toStringTag](v: number);
+	get [Symbol.toStringTag](): number;
+}
+// Infer type from the parameter type of the setter
+declare class GlobalSymbol3 {
+	set [Symbol.toStringTag](v: number);
+	get [Symbol.toStringTag](): number;
+}
+// Cannot infer type from the function body of the getter
+declare class GlobalSymbol4 {
+	set [Symbol.toStringTag](v);
+	get [Symbol.toStringTag]();
+}
 
 
 ==================== Errors ====================
@@ -33,6 +53,15 @@ declare class ClsBad {
  25 |   get a() {
     :       ^
  26 |     return;
+    `----
+
+  x TS9009: At least one accessor must have an explicit return type annotation
+  | with --isolatedDeclarations.
+    ,-[64:8]
+ 63 |   }
+ 64 |   get [Symbol.toStringTag]() {
+    :        ^^^^^^^^^^^^^^^^^^
+ 65 |     return GlobalSymbol4;
     `----
 
 


### PR DESCRIPTION
Similar to #11229, using `PropertyKey` to store accessor annotation because `[Symbol.xxx]` is not a static name.