### PR TITLE
refactor(ast): move `AstBuilder` type definition

### DIFF
--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -8,7 +8,7 @@ use oxc_syntax::{
     comment_node::CommentNodeId, number::NumberBase, operator::UnaryOperator, scope::ScopeId,
 };
 
-use crate::{AstBuilder, ast::*};
+use crate::ast::*;
 
 /// Type that can be used in any AST builder method call which requires an `IntoIn<'a, Anything<'a>>`.
 /// Pass `NONE` instead of `None::<Anything<'a>>`.
@@ -26,6 +26,13 @@ impl<'a> AllocatorAccessor<'a> for AstBuilder<'a> {
     fn allocator(self) -> &'a Allocator {
         self.allocator
     }
+}
+
+/// AST builder for creating AST nodes.
+#[derive(Clone, Copy)]
+pub struct AstBuilder<'a> {
+    /// The memory allocator used to allocate AST nodes in the arena.
+    pub allocator: &'a Allocator,
 }
 
 impl<'a> AstBuilder<'a> {

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -17,14 +17,7 @@ use oxc_syntax::{
     comment_node::CommentNodeId, reference::ReferenceId, scope::ScopeId, symbol::SymbolId,
 };
 
-use crate::ast::*;
-
-/// AST builder for creating AST nodes
-#[derive(Clone, Copy)]
-pub struct AstBuilder<'a> {
-    /// The memory allocator used to allocate AST nodes in the arena.
-    pub allocator: &'a Allocator,
-}
+use crate::{AstBuilder, ast::*};
 
 impl<'a> AstBuilder<'a> {
     /// Build a [`Program`].

--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -74,8 +74,7 @@ pub use generated::{ast_builder, ast_kind};
 
 pub use crate::{
     ast::comment::{Comment, CommentContent, CommentKind, CommentPosition},
-    ast_builder::AstBuilder,
-    ast_builder_impl::NONE,
+    ast_builder_impl::{AstBuilder, NONE},
     ast_kind::{AstKind, AstType},
     trivia::{CommentsRange, comments_range, has_comments_between},
 };

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -91,15 +91,7 @@ impl Generator for AstBuilderGenerator {
             };
 
             ///@@line_break
-            use crate::ast::*;
-
-            ///@@line_break
-            /// AST builder for creating AST nodes
-            #[derive(Clone, Copy)]
-            pub struct AstBuilder<'a> {
-                /// The memory allocator used to allocate AST nodes in the arena.
-                pub allocator: &'a Allocator,
-            }
+            use crate::{AstBuilder, ast::*};
 
             ///@@line_break
             impl<'a> AstBuilder<'a> {


### PR DESCRIPTION
Pure refactor. Move the type definition out of generated file and define it statically instead. We can now change `AstBuilder` without having to alter the codegen.