### PR TITLE
refactor(ast): make `AstBuilder` not `Copy`

### DIFF
--- a/crates/oxc_allocator/src/accessor.rs
+++ b/crates/oxc_allocator/src/accessor.rs
@@ -3,12 +3,12 @@ use crate::Allocator;
 /// Accessor for getting the underlying allocator.
 pub trait AllocatorAccessor<'a> {
     /// Get the underlying allocator.
-    fn allocator(self) -> &'a Allocator;
+    fn allocator(&self) -> &'a Allocator;
 }
 
 impl<'a> AllocatorAccessor<'a> for &'a Allocator {
     #[inline]
-    fn allocator(self) -> &'a Allocator {
+    fn allocator(&self) -> &'a Allocator {
         self
     }
 }

--- a/crates/oxc_allocator/src/take_in.rs
+++ b/crates/oxc_allocator/src/take_in.rs
@@ -6,7 +6,7 @@ use crate::{Allocator, AllocatorAccessor, Box, Vec};
 pub trait TakeIn<'a>: Dummy<'a> {
     /// Replace node with a dummy.
     #[must_use]
-    fn take_in<A: AllocatorAccessor<'a>>(&mut self, allocator_accessor: A) -> Self {
+    fn take_in<A: AllocatorAccessor<'a>>(&mut self, allocator_accessor: &A) -> Self {
         let allocator = allocator_accessor.allocator();
         let dummy = Dummy::dummy(allocator);
         mem::replace(self, dummy)
@@ -14,7 +14,7 @@ pub trait TakeIn<'a>: Dummy<'a> {
 
     /// Replace node with a boxed dummy.
     #[must_use]
-    fn take_in_box<A: AllocatorAccessor<'a>>(&mut self, allocator_accessor: A) -> Box<'a, Self> {
+    fn take_in_box<A: AllocatorAccessor<'a>>(&mut self, allocator_accessor: &A) -> Box<'a, Self> {
         let allocator = allocator_accessor.allocator();
         let dummy = Dummy::dummy(allocator);
         Box::new_in(mem::replace(self, dummy), allocator)

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -32,7 +32,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn program(
-        self,
+        &self,
         span: Span,
         source_type: SourceType,
         source_text: &'a str,
@@ -66,7 +66,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn program_with_scope_id(
-        self,
+        &self,
         span: Span,
         source_type: SourceType,
         source_text: &'a str,
@@ -96,7 +96,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code
     /// * `value`: The boolean value itself
     #[inline]
-    pub fn expression_boolean_literal(self, span: Span, value: bool) -> Expression<'a> {
+    pub fn expression_boolean_literal(&self, span: Span, value: bool) -> Expression<'a> {
         Expression::BooleanLiteral(self.alloc_boolean_literal(span, value))
     }
 
@@ -107,7 +107,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     #[inline]
-    pub fn expression_null_literal(self, span: Span) -> Expression<'a> {
+    pub fn expression_null_literal(&self, span: Span) -> Expression<'a> {
         Expression::NullLiteral(self.alloc_null_literal(span))
     }
 
@@ -122,7 +122,7 @@ impl<'a> AstBuilder<'a> {
     /// * `base`: The base representation used by the literal in source code
     #[inline]
     pub fn expression_numeric_literal(
-        self,
+        &self,
         span: Span,
         value: f64,
         raw: Option<Atom<'a>>,
@@ -141,7 +141,7 @@ impl<'a> AstBuilder<'a> {
     /// * `base`: The base representation used by the literal in source code
     #[inline]
     pub fn expression_big_int_literal<A1>(
-        self,
+        &self,
         span: Span,
         raw: A1,
         base: BigintBase,
@@ -162,7 +162,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The regular expression as it appears in source code
     #[inline]
     pub fn expression_reg_exp_literal(
-        self,
+        &self,
         span: Span,
         regex: RegExp<'a>,
         raw: Option<Atom<'a>>,
@@ -180,7 +180,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
     pub fn expression_string_literal<A1>(
-        self,
+        &self,
         span: Span,
         value: A1,
         raw: Option<Atom<'a>>,
@@ -202,7 +202,7 @@ impl<'a> AstBuilder<'a> {
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
     pub fn expression_string_literal_with_lone_surrogates<A1>(
-        self,
+        &self,
         span: Span,
         value: A1,
         raw: Option<Atom<'a>>,
@@ -229,7 +229,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expressions`
     #[inline]
     pub fn expression_template_literal(
-        self,
+        &self,
         span: Span,
         quasis: Vec<'a, TemplateElement<'a>>,
         expressions: Vec<'a, Expression<'a>>,
@@ -245,7 +245,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     #[inline]
-    pub fn expression_identifier<A1>(self, span: Span, name: A1) -> Expression<'a>
+    pub fn expression_identifier<A1>(&self, span: Span, name: A1) -> Expression<'a>
     where
         A1: Into<Atom<'a>>,
     {
@@ -262,7 +262,7 @@ impl<'a> AstBuilder<'a> {
     /// * `reference_id`: Reference ID
     #[inline]
     pub fn expression_identifier_with_reference_id<A1>(
-        self,
+        &self,
         span: Span,
         name: A1,
         reference_id: ReferenceId,
@@ -287,7 +287,7 @@ impl<'a> AstBuilder<'a> {
     /// * `property`
     #[inline]
     pub fn expression_meta_property(
-        self,
+        &self,
         span: Span,
         meta: IdentifierName<'a>,
         property: IdentifierName<'a>,
@@ -302,7 +302,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn expression_super(self, span: Span) -> Expression<'a> {
+    pub fn expression_super(&self, span: Span) -> Expression<'a> {
         Expression::Super(self.alloc_super(span))
     }
 
@@ -315,7 +315,7 @@ impl<'a> AstBuilder<'a> {
     /// * `elements`
     #[inline]
     pub fn expression_array(
-        self,
+        &self,
         span: Span,
         elements: Vec<'a, ArrayExpressionElement<'a>>,
     ) -> Expression<'a> {
@@ -336,7 +336,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`: See `expression` for whether this arrow expression returns an expression.
     #[inline]
     pub fn expression_arrow_function<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         expression: bool,
         r#async: bool,
@@ -378,7 +378,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     #[inline]
     pub fn expression_arrow_function_with_scope_id_and_pure<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         expression: bool,
         r#async: bool,
@@ -421,7 +421,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn expression_assignment(
-        self,
+        &self,
         span: Span,
         operator: AssignmentOperator,
         left: AssignmentTarget<'a>,
@@ -440,7 +440,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `argument`
     #[inline]
-    pub fn expression_await(self, span: Span, argument: Expression<'a>) -> Expression<'a> {
+    pub fn expression_await(&self, span: Span, argument: Expression<'a>) -> Expression<'a> {
         Expression::AwaitExpression(self.alloc_await_expression(span, argument))
     }
 
@@ -455,7 +455,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn expression_binary(
-        self,
+        &self,
         span: Span,
         left: Expression<'a>,
         operator: BinaryOperator,
@@ -476,7 +476,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn expression_call<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -508,7 +508,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
     #[inline]
     pub fn expression_call_with_pure<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -537,7 +537,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
     #[inline]
-    pub fn expression_chain(self, span: Span, expression: ChainElement<'a>) -> Expression<'a> {
+    pub fn expression_chain(&self, span: Span, expression: ChainElement<'a>) -> Expression<'a> {
         Expression::ChainExpression(self.alloc_chain_expression(span, expression))
     }
 
@@ -559,7 +559,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`: Whether the class was `declare`ed
     #[inline]
     pub fn expression_class<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#type: ClassType,
         decorators: Vec<'a, Decorator<'a>>,
@@ -611,7 +611,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
     #[inline]
     pub fn expression_class_with_scope_id<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#type: ClassType,
         decorators: Vec<'a, Decorator<'a>>,
@@ -657,7 +657,7 @@ impl<'a> AstBuilder<'a> {
     /// * `alternate`
     #[inline]
     pub fn expression_conditional(
-        self,
+        &self,
         span: Span,
         test: Expression<'a>,
         consequent: Expression<'a>,
@@ -686,7 +686,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`: The function body.
     #[inline]
     pub fn expression_function<T1, T2, T3, T4, T5>(
-        self,
+        &self,
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
@@ -741,7 +741,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     #[inline]
     pub fn expression_function_with_scope_id_and_pure<T1, T2, T3, T4, T5>(
-        self,
+        &self,
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
@@ -791,7 +791,7 @@ impl<'a> AstBuilder<'a> {
     /// * `phase`
     #[inline]
     pub fn expression_import(
-        self,
+        &self,
         span: Span,
         source: Expression<'a>,
         options: Option<Expression<'a>>,
@@ -811,7 +811,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn expression_logical(
-        self,
+        &self,
         span: Span,
         left: Expression<'a>,
         operator: LogicalOperator,
@@ -831,7 +831,7 @@ impl<'a> AstBuilder<'a> {
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[inline]
     pub fn expression_new<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -860,7 +860,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pure`
     #[inline]
     pub fn expression_new_with_pure<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -888,7 +888,7 @@ impl<'a> AstBuilder<'a> {
     /// * `properties`: Properties declared in the object
     #[inline]
     pub fn expression_object(
-        self,
+        &self,
         span: Span,
         properties: Vec<'a, ObjectPropertyKind<'a>>,
     ) -> Expression<'a> {
@@ -904,7 +904,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn expression_parenthesized(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> Expression<'a> {
@@ -920,7 +920,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expressions`
     #[inline]
     pub fn expression_sequence(
-        self,
+        &self,
         span: Span,
         expressions: Vec<'a, Expression<'a>>,
     ) -> Expression<'a> {
@@ -938,7 +938,7 @@ impl<'a> AstBuilder<'a> {
     /// * `quasi`
     #[inline]
     pub fn expression_tagged_template<T1>(
-        self,
+        &self,
         span: Span,
         tag: Expression<'a>,
         type_arguments: T1,
@@ -962,7 +962,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn expression_this(self, span: Span) -> Expression<'a> {
+    pub fn expression_this(&self, span: Span) -> Expression<'a> {
         Expression::ThisExpression(self.alloc_this_expression(span))
     }
 
@@ -976,7 +976,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn expression_unary(
-        self,
+        &self,
         span: Span,
         operator: UnaryOperator,
         argument: Expression<'a>,
@@ -995,7 +995,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn expression_update(
-        self,
+        &self,
         span: Span,
         operator: UpdateOperator,
         prefix: bool,
@@ -1014,7 +1014,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn expression_yield(
-        self,
+        &self,
         span: Span,
         delegate: bool,
         argument: Option<Expression<'a>>,
@@ -1032,7 +1032,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn expression_private_in(
-        self,
+        &self,
         span: Span,
         left: PrivateIdentifier<'a>,
         right: Expression<'a>,
@@ -1051,7 +1051,7 @@ impl<'a> AstBuilder<'a> {
     /// * `closing_element`: Closing tag of the element.
     #[inline]
     pub fn expression_jsx_element<T1, T2>(
-        self,
+        &self,
         span: Span,
         opening_element: T1,
         children: Vec<'a, JSXChild<'a>>,
@@ -1080,7 +1080,7 @@ impl<'a> AstBuilder<'a> {
     /// * `closing_fragment`: `</>`
     #[inline]
     pub fn expression_jsx_fragment(
-        self,
+        &self,
         span: Span,
         opening_fragment: JSXOpeningFragment,
         children: Vec<'a, JSXChild<'a>>,
@@ -1104,7 +1104,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn expression_ts_as(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
         type_annotation: TSType<'a>,
@@ -1122,7 +1122,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`: The type `expression` must satisfy.
     #[inline]
     pub fn expression_ts_satisfies(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
         type_annotation: TSType<'a>,
@@ -1144,7 +1144,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn expression_ts_type_assertion(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
         expression: Expression<'a>,
@@ -1160,7 +1160,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
     #[inline]
-    pub fn expression_ts_non_null(self, span: Span, expression: Expression<'a>) -> Expression<'a> {
+    pub fn expression_ts_non_null(&self, span: Span, expression: Expression<'a>) -> Expression<'a> {
         Expression::TSNonNullExpression(self.alloc_ts_non_null_expression(span, expression))
     }
 
@@ -1174,7 +1174,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn expression_ts_instantiation<T1>(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
         type_arguments: T1,
@@ -1199,7 +1199,7 @@ impl<'a> AstBuilder<'a> {
     /// * `arguments`
     #[inline]
     pub fn expression_v_8_intrinsic(
-        self,
+        &self,
         span: Span,
         name: IdentifierName<'a>,
         arguments: Vec<'a, Argument<'a>>,
@@ -1218,7 +1218,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn identifier_name<A1>(self, span: Span, name: A1) -> IdentifierName<'a>
+    pub fn identifier_name<A1>(&self, span: Span, name: A1) -> IdentifierName<'a>
     where
         A1: Into<Atom<'a>>,
     {
@@ -1234,7 +1234,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn alloc_identifier_name<A1>(self, span: Span, name: A1) -> Box<'a, IdentifierName<'a>>
+    pub fn alloc_identifier_name<A1>(&self, span: Span, name: A1) -> Box<'a, IdentifierName<'a>>
     where
         A1: Into<Atom<'a>>,
     {
@@ -1250,7 +1250,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     #[inline]
-    pub fn identifier_reference<A1>(self, span: Span, name: A1) -> IdentifierReference<'a>
+    pub fn identifier_reference<A1>(&self, span: Span, name: A1) -> IdentifierReference<'a>
     where
         A1: Into<Atom<'a>>,
     {
@@ -1267,7 +1267,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The name of the identifier being referenced.
     #[inline]
     pub fn alloc_identifier_reference<A1>(
-        self,
+        &self,
         span: Span,
         name: A1,
     ) -> Box<'a, IdentifierReference<'a>>
@@ -1288,7 +1288,7 @@ impl<'a> AstBuilder<'a> {
     /// * `reference_id`: Reference ID
     #[inline]
     pub fn identifier_reference_with_reference_id<A1>(
-        self,
+        &self,
         span: Span,
         name: A1,
         reference_id: ReferenceId,
@@ -1310,7 +1310,7 @@ impl<'a> AstBuilder<'a> {
     /// * `reference_id`: Reference ID
     #[inline]
     pub fn alloc_identifier_reference_with_reference_id<A1>(
-        self,
+        &self,
         span: Span,
         name: A1,
         reference_id: ReferenceId,
@@ -1333,7 +1333,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The identifier name being bound.
     #[inline]
-    pub fn binding_identifier<A1>(self, span: Span, name: A1) -> BindingIdentifier<'a>
+    pub fn binding_identifier<A1>(&self, span: Span, name: A1) -> BindingIdentifier<'a>
     where
         A1: Into<Atom<'a>>,
     {
@@ -1350,7 +1350,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The identifier name being bound.
     #[inline]
     pub fn alloc_binding_identifier<A1>(
-        self,
+        &self,
         span: Span,
         name: A1,
     ) -> Box<'a, BindingIdentifier<'a>>
@@ -1371,7 +1371,7 @@ impl<'a> AstBuilder<'a> {
     /// * `symbol_id`: Unique identifier for this binding.
     #[inline]
     pub fn binding_identifier_with_symbol_id<A1>(
-        self,
+        &self,
         span: Span,
         name: A1,
         symbol_id: SymbolId,
@@ -1393,7 +1393,7 @@ impl<'a> AstBuilder<'a> {
     /// * `symbol_id`: Unique identifier for this binding.
     #[inline]
     pub fn alloc_binding_identifier_with_symbol_id<A1>(
-        self,
+        &self,
         span: Span,
         name: A1,
         symbol_id: SymbolId,
@@ -1410,7 +1410,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn label_identifier<A1>(self, span: Span, name: A1) -> LabelIdentifier<'a>
+    pub fn label_identifier<A1>(&self, span: Span, name: A1) -> LabelIdentifier<'a>
     where
         A1: Into<Atom<'a>>,
     {
@@ -1425,7 +1425,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn this_expression(self, span: Span) -> ThisExpression {
+    pub fn this_expression(&self, span: Span) -> ThisExpression {
         ThisExpression { span }
     }
 
@@ -1437,7 +1437,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_this_expression(self, span: Span) -> Box<'a, ThisExpression> {
+    pub fn alloc_this_expression(&self, span: Span) -> Box<'a, ThisExpression> {
         Box::new_in(self.this_expression(span), self.allocator)
     }
 
@@ -1451,7 +1451,7 @@ impl<'a> AstBuilder<'a> {
     /// * `elements`
     #[inline]
     pub fn array_expression(
-        self,
+        &self,
         span: Span,
         elements: Vec<'a, ArrayExpressionElement<'a>>,
     ) -> ArrayExpression<'a> {
@@ -1468,7 +1468,7 @@ impl<'a> AstBuilder<'a> {
     /// * `elements`
     #[inline]
     pub fn alloc_array_expression(
-        self,
+        &self,
         span: Span,
         elements: Vec<'a, ArrayExpressionElement<'a>>,
     ) -> Box<'a, ArrayExpression<'a>> {
@@ -1484,7 +1484,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`: The expression being spread.
     #[inline]
     pub fn array_expression_element_spread_element(
-        self,
+        &self,
         span: Span,
         argument: Expression<'a>,
     ) -> ArrayExpressionElement<'a> {
@@ -1496,7 +1496,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn array_expression_element_elision(self, span: Span) -> ArrayExpressionElement<'a> {
+    pub fn array_expression_element_elision(&self, span: Span) -> ArrayExpressionElement<'a> {
         ArrayExpressionElement::Elision(self.elision(span))
     }
 
@@ -1505,7 +1505,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn elision(self, span: Span) -> Elision {
+    pub fn elision(&self, span: Span) -> Elision {
         Elision { span }
     }
 
@@ -1519,7 +1519,7 @@ impl<'a> AstBuilder<'a> {
     /// * `properties`: Properties declared in the object
     #[inline]
     pub fn object_expression(
-        self,
+        &self,
         span: Span,
         properties: Vec<'a, ObjectPropertyKind<'a>>,
     ) -> ObjectExpression<'a> {
@@ -1536,7 +1536,7 @@ impl<'a> AstBuilder<'a> {
     /// * `properties`: Properties declared in the object
     #[inline]
     pub fn alloc_object_expression(
-        self,
+        &self,
         span: Span,
         properties: Vec<'a, ObjectPropertyKind<'a>>,
     ) -> Box<'a, ObjectExpression<'a>> {
@@ -1557,7 +1557,7 @@ impl<'a> AstBuilder<'a> {
     /// * `computed`
     #[inline]
     pub fn object_property_kind_object_property(
-        self,
+        &self,
         span: Span,
         kind: PropertyKind,
         key: PropertyKey<'a>,
@@ -1580,7 +1580,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`: The expression being spread.
     #[inline]
     pub fn object_property_kind_spread_property(
-        self,
+        &self,
         span: Span,
         argument: Expression<'a>,
     ) -> ObjectPropertyKind<'a> {
@@ -1602,7 +1602,7 @@ impl<'a> AstBuilder<'a> {
     /// * `computed`
     #[inline]
     pub fn object_property(
-        self,
+        &self,
         span: Span,
         kind: PropertyKind,
         key: PropertyKey<'a>,
@@ -1629,7 +1629,7 @@ impl<'a> AstBuilder<'a> {
     /// * `computed`
     #[inline]
     pub fn alloc_object_property(
-        self,
+        &self,
         span: Span,
         kind: PropertyKind,
         key: PropertyKey<'a>,
@@ -1652,7 +1652,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn property_key_static_identifier<A1>(self, span: Span, name: A1) -> PropertyKey<'a>
+    pub fn property_key_static_identifier<A1>(&self, span: Span, name: A1) -> PropertyKey<'a>
     where
         A1: Into<Atom<'a>>,
     {
@@ -1667,7 +1667,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn property_key_private_identifier<A1>(self, span: Span, name: A1) -> PropertyKey<'a>
+    pub fn property_key_private_identifier<A1>(&self, span: Span, name: A1) -> PropertyKey<'a>
     where
         A1: Into<Atom<'a>>,
     {
@@ -1685,7 +1685,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expressions`
     #[inline]
     pub fn template_literal(
-        self,
+        &self,
         span: Span,
         quasis: Vec<'a, TemplateElement<'a>>,
         expressions: Vec<'a, Expression<'a>>,
@@ -1704,7 +1704,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expressions`
     #[inline]
     pub fn alloc_template_literal(
-        self,
+        &self,
         span: Span,
         quasis: Vec<'a, TemplateElement<'a>>,
         expressions: Vec<'a, Expression<'a>>,
@@ -1724,7 +1724,7 @@ impl<'a> AstBuilder<'a> {
     /// * `quasi`
     #[inline]
     pub fn tagged_template_expression<T1>(
-        self,
+        &self,
         span: Span,
         tag: Expression<'a>,
         type_arguments: T1,
@@ -1753,7 +1753,7 @@ impl<'a> AstBuilder<'a> {
     /// * `quasi`
     #[inline]
     pub fn alloc_tagged_template_expression<T1>(
-        self,
+        &self,
         span: Span,
         tag: Expression<'a>,
         type_arguments: T1,
@@ -1776,7 +1776,7 @@ impl<'a> AstBuilder<'a> {
     /// * `tail`
     #[inline]
     pub fn template_element(
-        self,
+        &self,
         span: Span,
         value: TemplateElementValue<'a>,
         tail: bool,
@@ -1793,7 +1793,7 @@ impl<'a> AstBuilder<'a> {
     /// * `lone_surrogates`: The template element contains lone surrogates.
     #[inline]
     pub fn template_element_with_lone_surrogates(
-        self,
+        &self,
         span: Span,
         value: TemplateElementValue<'a>,
         tail: bool,
@@ -1813,7 +1813,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn member_expression_computed(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         expression: Expression<'a>,
@@ -1835,7 +1835,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn member_expression_static(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         property: IdentifierName<'a>,
@@ -1857,7 +1857,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn member_expression_private_field_expression(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         field: PrivateIdentifier<'a>,
@@ -1880,7 +1880,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn computed_member_expression(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         expression: Expression<'a>,
@@ -1901,7 +1901,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn alloc_computed_member_expression(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         expression: Expression<'a>,
@@ -1925,7 +1925,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn static_member_expression(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         property: IdentifierName<'a>,
@@ -1946,7 +1946,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn alloc_static_member_expression(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         property: IdentifierName<'a>,
@@ -1967,7 +1967,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn private_field_expression(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         field: PrivateIdentifier<'a>,
@@ -1988,7 +1988,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn alloc_private_field_expression(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         field: PrivateIdentifier<'a>,
@@ -2010,7 +2010,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn call_expression<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -2043,7 +2043,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn alloc_call_expression<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -2073,7 +2073,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
     #[inline]
     pub fn call_expression_with_pure<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -2108,7 +2108,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
     #[inline]
     pub fn alloc_call_expression_with_pure<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -2137,7 +2137,7 @@ impl<'a> AstBuilder<'a> {
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[inline]
     pub fn new_expression<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -2167,7 +2167,7 @@ impl<'a> AstBuilder<'a> {
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[inline]
     pub fn alloc_new_expression<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -2192,7 +2192,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pure`
     #[inline]
     pub fn new_expression_with_pure<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -2224,7 +2224,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pure`
     #[inline]
     pub fn alloc_new_expression_with_pure<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -2251,7 +2251,7 @@ impl<'a> AstBuilder<'a> {
     /// * `property`
     #[inline]
     pub fn meta_property(
-        self,
+        &self,
         span: Span,
         meta: IdentifierName<'a>,
         property: IdentifierName<'a>,
@@ -2270,7 +2270,7 @@ impl<'a> AstBuilder<'a> {
     /// * `property`
     #[inline]
     pub fn alloc_meta_property(
-        self,
+        &self,
         span: Span,
         meta: IdentifierName<'a>,
         property: IdentifierName<'a>,
@@ -2287,7 +2287,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `argument`: The expression being spread.
     #[inline]
-    pub fn spread_element(self, span: Span, argument: Expression<'a>) -> SpreadElement<'a> {
+    pub fn spread_element(&self, span: Span, argument: Expression<'a>) -> SpreadElement<'a> {
         SpreadElement { span, argument }
     }
 
@@ -2301,7 +2301,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`: The expression being spread.
     #[inline]
     pub fn alloc_spread_element(
-        self,
+        &self,
         span: Span,
         argument: Expression<'a>,
     ) -> Box<'a, SpreadElement<'a>> {
@@ -2316,7 +2316,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `argument`: The expression being spread.
     #[inline]
-    pub fn argument_spread_element(self, span: Span, argument: Expression<'a>) -> Argument<'a> {
+    pub fn argument_spread_element(&self, span: Span, argument: Expression<'a>) -> Argument<'a> {
         Argument::SpreadElement(self.alloc_spread_element(span, argument))
     }
 
@@ -2332,7 +2332,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn update_expression(
-        self,
+        &self,
         span: Span,
         operator: UpdateOperator,
         prefix: bool,
@@ -2353,7 +2353,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn alloc_update_expression(
-        self,
+        &self,
         span: Span,
         operator: UpdateOperator,
         prefix: bool,
@@ -2373,7 +2373,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn unary_expression(
-        self,
+        &self,
         span: Span,
         operator: UnaryOperator,
         argument: Expression<'a>,
@@ -2392,7 +2392,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn alloc_unary_expression(
-        self,
+        &self,
         span: Span,
         operator: UnaryOperator,
         argument: Expression<'a>,
@@ -2412,7 +2412,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn binary_expression(
-        self,
+        &self,
         span: Span,
         left: Expression<'a>,
         operator: BinaryOperator,
@@ -2433,7 +2433,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn alloc_binary_expression(
-        self,
+        &self,
         span: Span,
         left: Expression<'a>,
         operator: BinaryOperator,
@@ -2453,7 +2453,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn private_in_expression(
-        self,
+        &self,
         span: Span,
         left: PrivateIdentifier<'a>,
         right: Expression<'a>,
@@ -2472,7 +2472,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn alloc_private_in_expression(
-        self,
+        &self,
         span: Span,
         left: PrivateIdentifier<'a>,
         right: Expression<'a>,
@@ -2492,7 +2492,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn logical_expression(
-        self,
+        &self,
         span: Span,
         left: Expression<'a>,
         operator: LogicalOperator,
@@ -2513,7 +2513,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn alloc_logical_expression(
-        self,
+        &self,
         span: Span,
         left: Expression<'a>,
         operator: LogicalOperator,
@@ -2534,7 +2534,7 @@ impl<'a> AstBuilder<'a> {
     /// * `alternate`
     #[inline]
     pub fn conditional_expression(
-        self,
+        &self,
         span: Span,
         test: Expression<'a>,
         consequent: Expression<'a>,
@@ -2555,7 +2555,7 @@ impl<'a> AstBuilder<'a> {
     /// * `alternate`
     #[inline]
     pub fn alloc_conditional_expression(
-        self,
+        &self,
         span: Span,
         test: Expression<'a>,
         consequent: Expression<'a>,
@@ -2576,7 +2576,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn assignment_expression(
-        self,
+        &self,
         span: Span,
         operator: AssignmentOperator,
         left: AssignmentTarget<'a>,
@@ -2597,7 +2597,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn alloc_assignment_expression(
-        self,
+        &self,
         span: Span,
         operator: AssignmentOperator,
         left: AssignmentTarget<'a>,
@@ -2615,7 +2615,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The name of the identifier being referenced.
     #[inline]
     pub fn simple_assignment_target_assignment_target_identifier<A1>(
-        self,
+        &self,
         span: Span,
         name: A1,
     ) -> SimpleAssignmentTarget<'a>
@@ -2637,7 +2637,7 @@ impl<'a> AstBuilder<'a> {
     /// * `reference_id`: Reference ID
     #[inline]
     pub fn simple_assignment_target_assignment_target_identifier_with_reference_id<A1>(
-        self,
+        &self,
         span: Span,
         name: A1,
         reference_id: ReferenceId,
@@ -2660,7 +2660,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn simple_assignment_target_ts_as_expression(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
         type_annotation: TSType<'a>,
@@ -2682,7 +2682,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`: The type `expression` must satisfy.
     #[inline]
     pub fn simple_assignment_target_ts_satisfies_expression(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
         type_annotation: TSType<'a>,
@@ -2703,7 +2703,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn simple_assignment_target_ts_non_null_expression(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> SimpleAssignmentTarget<'a> {
@@ -2722,7 +2722,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn simple_assignment_target_ts_type_assertion(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
         expression: Expression<'a>,
@@ -2744,7 +2744,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn assignment_target_pattern_array_assignment_target(
-        self,
+        &self,
         span: Span,
         elements: Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>,
         rest: Option<AssignmentTargetRest<'a>>,
@@ -2764,7 +2764,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn assignment_target_pattern_object_assignment_target(
-        self,
+        &self,
         span: Span,
         properties: Vec<'a, AssignmentTargetProperty<'a>>,
         rest: Option<AssignmentTargetRest<'a>>,
@@ -2785,7 +2785,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn array_assignment_target(
-        self,
+        &self,
         span: Span,
         elements: Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>,
         rest: Option<AssignmentTargetRest<'a>>,
@@ -2804,7 +2804,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn alloc_array_assignment_target(
-        self,
+        &self,
         span: Span,
         elements: Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>,
         rest: Option<AssignmentTargetRest<'a>>,
@@ -2823,7 +2823,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn object_assignment_target(
-        self,
+        &self,
         span: Span,
         properties: Vec<'a, AssignmentTargetProperty<'a>>,
         rest: Option<AssignmentTargetRest<'a>>,
@@ -2842,7 +2842,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn alloc_object_assignment_target(
-        self,
+        &self,
         span: Span,
         properties: Vec<'a, AssignmentTargetProperty<'a>>,
         rest: Option<AssignmentTargetRest<'a>>,
@@ -2857,7 +2857,7 @@ impl<'a> AstBuilder<'a> {
     /// * `target`
     #[inline]
     pub fn assignment_target_rest(
-        self,
+        &self,
         span: Span,
         target: AssignmentTarget<'a>,
     ) -> AssignmentTargetRest<'a> {
@@ -2874,7 +2874,7 @@ impl<'a> AstBuilder<'a> {
     /// * `init`
     #[inline]
     pub fn assignment_target_maybe_default_assignment_target_with_default(
-        self,
+        &self,
         span: Span,
         binding: AssignmentTarget<'a>,
         init: Expression<'a>,
@@ -2895,7 +2895,7 @@ impl<'a> AstBuilder<'a> {
     /// * `init`
     #[inline]
     pub fn assignment_target_with_default(
-        self,
+        &self,
         span: Span,
         binding: AssignmentTarget<'a>,
         init: Expression<'a>,
@@ -2914,7 +2914,7 @@ impl<'a> AstBuilder<'a> {
     /// * `init`
     #[inline]
     pub fn alloc_assignment_target_with_default(
-        self,
+        &self,
         span: Span,
         binding: AssignmentTarget<'a>,
         init: Expression<'a>,
@@ -2932,7 +2932,7 @@ impl<'a> AstBuilder<'a> {
     /// * `init`
     #[inline]
     pub fn assignment_target_property_assignment_target_property_identifier(
-        self,
+        &self,
         span: Span,
         binding: IdentifierReference<'a>,
         init: Option<Expression<'a>>,
@@ -2953,7 +2953,7 @@ impl<'a> AstBuilder<'a> {
     /// * `computed`: Property was declared with a computed key
     #[inline]
     pub fn assignment_target_property_assignment_target_property_property(
-        self,
+        &self,
         span: Span,
         name: PropertyKey<'a>,
         binding: AssignmentTargetMaybeDefault<'a>,
@@ -2975,7 +2975,7 @@ impl<'a> AstBuilder<'a> {
     /// * `init`
     #[inline]
     pub fn assignment_target_property_identifier(
-        self,
+        &self,
         span: Span,
         binding: IdentifierReference<'a>,
         init: Option<Expression<'a>>,
@@ -2994,7 +2994,7 @@ impl<'a> AstBuilder<'a> {
     /// * `init`
     #[inline]
     pub fn alloc_assignment_target_property_identifier(
-        self,
+        &self,
         span: Span,
         binding: IdentifierReference<'a>,
         init: Option<Expression<'a>>,
@@ -3014,7 +3014,7 @@ impl<'a> AstBuilder<'a> {
     /// * `computed`: Property was declared with a computed key
     #[inline]
     pub fn assignment_target_property_property(
-        self,
+        &self,
         span: Span,
         name: PropertyKey<'a>,
         binding: AssignmentTargetMaybeDefault<'a>,
@@ -3035,7 +3035,7 @@ impl<'a> AstBuilder<'a> {
     /// * `computed`: Property was declared with a computed key
     #[inline]
     pub fn alloc_assignment_target_property_property(
-        self,
+        &self,
         span: Span,
         name: PropertyKey<'a>,
         binding: AssignmentTargetMaybeDefault<'a>,
@@ -3057,7 +3057,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expressions`
     #[inline]
     pub fn sequence_expression(
-        self,
+        &self,
         span: Span,
         expressions: Vec<'a, Expression<'a>>,
     ) -> SequenceExpression<'a> {
@@ -3074,7 +3074,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expressions`
     #[inline]
     pub fn alloc_sequence_expression(
-        self,
+        &self,
         span: Span,
         expressions: Vec<'a, Expression<'a>>,
     ) -> Box<'a, SequenceExpression<'a>> {
@@ -3089,7 +3089,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn super_(self, span: Span) -> Super {
+    pub fn super_(&self, span: Span) -> Super {
         Super { span }
     }
 
@@ -3101,7 +3101,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_super(self, span: Span) -> Box<'a, Super> {
+    pub fn alloc_super(&self, span: Span) -> Box<'a, Super> {
         Box::new_in(self.super_(span), self.allocator)
     }
 
@@ -3114,7 +3114,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `argument`
     #[inline]
-    pub fn await_expression(self, span: Span, argument: Expression<'a>) -> AwaitExpression<'a> {
+    pub fn await_expression(&self, span: Span, argument: Expression<'a>) -> AwaitExpression<'a> {
         AwaitExpression { span, argument }
     }
 
@@ -3128,7 +3128,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn alloc_await_expression(
-        self,
+        &self,
         span: Span,
         argument: Expression<'a>,
     ) -> Box<'a, AwaitExpression<'a>> {
@@ -3144,7 +3144,11 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
     #[inline]
-    pub fn chain_expression(self, span: Span, expression: ChainElement<'a>) -> ChainExpression<'a> {
+    pub fn chain_expression(
+        &self,
+        span: Span,
+        expression: ChainElement<'a>,
+    ) -> ChainExpression<'a> {
         ChainExpression { span, expression }
     }
 
@@ -3158,7 +3162,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn alloc_chain_expression(
-        self,
+        &self,
         span: Span,
         expression: ChainElement<'a>,
     ) -> Box<'a, ChainExpression<'a>> {
@@ -3177,7 +3181,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn chain_element_call_expression<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -3209,7 +3213,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
     #[inline]
     pub fn chain_element_call_expression_with_pure<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -3239,7 +3243,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn chain_element_ts_non_null_expression(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> ChainElement<'a> {
@@ -3256,7 +3260,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn parenthesized_expression(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> ParenthesizedExpression<'a> {
@@ -3273,7 +3277,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn alloc_parenthesized_expression(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> Box<'a, ParenthesizedExpression<'a>> {
@@ -3288,7 +3292,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `body`
     #[inline]
-    pub fn statement_block(self, span: Span, body: Vec<'a, Statement<'a>>) -> Statement<'a> {
+    pub fn statement_block(&self, span: Span, body: Vec<'a, Statement<'a>>) -> Statement<'a> {
         Statement::BlockStatement(self.alloc_block_statement(span, body))
     }
 
@@ -3302,7 +3306,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn statement_block_with_scope_id(
-        self,
+        &self,
         span: Span,
         body: Vec<'a, Statement<'a>>,
         scope_id: ScopeId,
@@ -3318,7 +3322,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `label`
     #[inline]
-    pub fn statement_break(self, span: Span, label: Option<LabelIdentifier<'a>>) -> Statement<'a> {
+    pub fn statement_break(&self, span: Span, label: Option<LabelIdentifier<'a>>) -> Statement<'a> {
         Statement::BreakStatement(self.alloc_break_statement(span, label))
     }
 
@@ -3331,7 +3335,7 @@ impl<'a> AstBuilder<'a> {
     /// * `label`
     #[inline]
     pub fn statement_continue(
-        self,
+        &self,
         span: Span,
         label: Option<LabelIdentifier<'a>>,
     ) -> Statement<'a> {
@@ -3345,7 +3349,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn statement_debugger(self, span: Span) -> Statement<'a> {
+    pub fn statement_debugger(&self, span: Span) -> Statement<'a> {
         Statement::DebuggerStatement(self.alloc_debugger_statement(span))
     }
 
@@ -3359,7 +3363,7 @@ impl<'a> AstBuilder<'a> {
     /// * `test`
     #[inline]
     pub fn statement_do_while(
-        self,
+        &self,
         span: Span,
         body: Statement<'a>,
         test: Expression<'a>,
@@ -3374,7 +3378,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn statement_empty(self, span: Span) -> Statement<'a> {
+    pub fn statement_empty(&self, span: Span) -> Statement<'a> {
         Statement::EmptyStatement(self.alloc_empty_statement(span))
     }
 
@@ -3386,7 +3390,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
     #[inline]
-    pub fn statement_expression(self, span: Span, expression: Expression<'a>) -> Statement<'a> {
+    pub fn statement_expression(&self, span: Span, expression: Expression<'a>) -> Statement<'a> {
         Statement::ExpressionStatement(self.alloc_expression_statement(span, expression))
     }
 
@@ -3401,7 +3405,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn statement_for_in(
-        self,
+        &self,
         span: Span,
         left: ForStatementLeft<'a>,
         right: Expression<'a>,
@@ -3422,7 +3426,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn statement_for_in_with_scope_id(
-        self,
+        &self,
         span: Span,
         left: ForStatementLeft<'a>,
         right: Expression<'a>,
@@ -3446,7 +3450,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn statement_for_of(
-        self,
+        &self,
         span: Span,
         r#await: bool,
         left: ForStatementLeft<'a>,
@@ -3469,7 +3473,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn statement_for_of_with_scope_id(
-        self,
+        &self,
         span: Span,
         r#await: bool,
         left: ForStatementLeft<'a>,
@@ -3494,7 +3498,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn statement_for(
-        self,
+        &self,
         span: Span,
         init: Option<ForStatementInit<'a>>,
         test: Option<Expression<'a>>,
@@ -3517,7 +3521,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn statement_for_with_scope_id(
-        self,
+        &self,
         span: Span,
         init: Option<ForStatementInit<'a>>,
         test: Option<Expression<'a>>,
@@ -3541,7 +3545,7 @@ impl<'a> AstBuilder<'a> {
     /// * `alternate`
     #[inline]
     pub fn statement_if(
-        self,
+        &self,
         span: Span,
         test: Expression<'a>,
         consequent: Statement<'a>,
@@ -3560,7 +3564,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn statement_labeled(
-        self,
+        &self,
         span: Span,
         label: LabelIdentifier<'a>,
         body: Statement<'a>,
@@ -3576,7 +3580,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `argument`
     #[inline]
-    pub fn statement_return(self, span: Span, argument: Option<Expression<'a>>) -> Statement<'a> {
+    pub fn statement_return(&self, span: Span, argument: Option<Expression<'a>>) -> Statement<'a> {
         Statement::ReturnStatement(self.alloc_return_statement(span, argument))
     }
 
@@ -3590,7 +3594,7 @@ impl<'a> AstBuilder<'a> {
     /// * `cases`
     #[inline]
     pub fn statement_switch(
-        self,
+        &self,
         span: Span,
         discriminant: Expression<'a>,
         cases: Vec<'a, SwitchCase<'a>>,
@@ -3609,7 +3613,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn statement_switch_with_scope_id(
-        self,
+        &self,
         span: Span,
         discriminant: Expression<'a>,
         cases: Vec<'a, SwitchCase<'a>>,
@@ -3631,7 +3635,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `argument`: The expression being thrown, e.g. `err` in `throw err;`
     #[inline]
-    pub fn statement_throw(self, span: Span, argument: Expression<'a>) -> Statement<'a> {
+    pub fn statement_throw(&self, span: Span, argument: Expression<'a>) -> Statement<'a> {
         Statement::ThrowStatement(self.alloc_throw_statement(span, argument))
     }
 
@@ -3646,7 +3650,7 @@ impl<'a> AstBuilder<'a> {
     /// * `finalizer`: The `finally` clause
     #[inline]
     pub fn statement_try<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         block: T1,
         handler: T2,
@@ -3670,7 +3674,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn statement_while(
-        self,
+        &self,
         span: Span,
         test: Expression<'a>,
         body: Statement<'a>,
@@ -3688,7 +3692,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn statement_with(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         body: Statement<'a>,
@@ -3704,7 +3708,7 @@ impl<'a> AstBuilder<'a> {
     /// * `directive`: Raw content of directive as it appears in source, any escapes left as is
     #[inline]
     pub fn directive<A1>(
-        self,
+        &self,
         span: Span,
         expression: StringLiteral<'a>,
         directive: A1,
@@ -3721,7 +3725,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `value`
     #[inline]
-    pub fn hashbang<A1>(self, span: Span, value: A1) -> Hashbang<'a>
+    pub fn hashbang<A1>(&self, span: Span, value: A1) -> Hashbang<'a>
     where
         A1: Into<Atom<'a>>,
     {
@@ -3737,7 +3741,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `body`
     #[inline]
-    pub fn block_statement(self, span: Span, body: Vec<'a, Statement<'a>>) -> BlockStatement<'a> {
+    pub fn block_statement(&self, span: Span, body: Vec<'a, Statement<'a>>) -> BlockStatement<'a> {
         BlockStatement { span, body, scope_id: Default::default() }
     }
 
@@ -3751,7 +3755,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn alloc_block_statement(
-        self,
+        &self,
         span: Span,
         body: Vec<'a, Statement<'a>>,
     ) -> Box<'a, BlockStatement<'a>> {
@@ -3769,7 +3773,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn block_statement_with_scope_id(
-        self,
+        &self,
         span: Span,
         body: Vec<'a, Statement<'a>>,
         scope_id: ScopeId,
@@ -3788,7 +3792,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_block_statement_with_scope_id(
-        self,
+        &self,
         span: Span,
         body: Vec<'a, Statement<'a>>,
         scope_id: ScopeId,
@@ -3807,7 +3811,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn declaration_variable(
-        self,
+        &self,
         span: Span,
         kind: VariableDeclarationKind,
         declarations: Vec<'a, VariableDeclarator<'a>>,
@@ -3839,7 +3843,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`: The function body.
     #[inline]
     pub fn declaration_function<T1, T2, T3, T4, T5>(
-        self,
+        &self,
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
@@ -3894,7 +3898,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     #[inline]
     pub fn declaration_function_with_scope_id_and_pure<T1, T2, T3, T4, T5>(
-        self,
+        &self,
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
@@ -3951,7 +3955,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`: Whether the class was `declare`ed
     #[inline]
     pub fn declaration_class<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#type: ClassType,
         decorators: Vec<'a, Decorator<'a>>,
@@ -4003,7 +4007,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
     #[inline]
     pub fn declaration_class_with_scope_id<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#type: ClassType,
         decorators: Vec<'a, Decorator<'a>>,
@@ -4050,7 +4054,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn declaration_ts_type_alias<T1>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -4082,7 +4086,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn declaration_ts_type_alias_with_scope_id<T1>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -4116,7 +4120,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`: `true` for `declare interface Foo {}`
     #[inline]
     pub fn declaration_ts_interface<T1, T2>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -4152,7 +4156,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn declaration_ts_interface_with_scope_id<T1, T2>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -4188,7 +4192,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn declaration_ts_enum(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         body: TSEnumBody<'a>,
@@ -4213,7 +4217,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn declaration_ts_enum_with_scope_id(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         body: TSEnumBody<'a>,
@@ -4240,7 +4244,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn declaration_ts_module(
-        self,
+        &self,
         span: Span,
         id: TSModuleDeclarationName<'a>,
         body: Option<TSModuleDeclarationBody<'a>>,
@@ -4265,7 +4269,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn declaration_ts_module_with_scope_id(
-        self,
+        &self,
         span: Span,
         id: TSModuleDeclarationName<'a>,
         body: Option<TSModuleDeclarationBody<'a>>,
@@ -4289,7 +4293,7 @@ impl<'a> AstBuilder<'a> {
     /// * `import_kind`
     #[inline]
     pub fn declaration_ts_import_equals(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         module_reference: TSModuleReference<'a>,
@@ -4315,7 +4319,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn variable_declaration(
-        self,
+        &self,
         span: Span,
         kind: VariableDeclarationKind,
         declarations: Vec<'a, VariableDeclarator<'a>>,
@@ -4336,7 +4340,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn alloc_variable_declaration(
-        self,
+        &self,
         span: Span,
         kind: VariableDeclarationKind,
         declarations: Vec<'a, VariableDeclarator<'a>>,
@@ -4355,7 +4359,7 @@ impl<'a> AstBuilder<'a> {
     /// * `definite`
     #[inline]
     pub fn variable_declarator(
-        self,
+        &self,
         span: Span,
         kind: VariableDeclarationKind,
         id: BindingPattern<'a>,
@@ -4373,7 +4377,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn empty_statement(self, span: Span) -> EmptyStatement {
+    pub fn empty_statement(&self, span: Span) -> EmptyStatement {
         EmptyStatement { span }
     }
 
@@ -4385,7 +4389,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_empty_statement(self, span: Span) -> Box<'a, EmptyStatement> {
+    pub fn alloc_empty_statement(&self, span: Span) -> Box<'a, EmptyStatement> {
         Box::new_in(self.empty_statement(span), self.allocator)
     }
 
@@ -4399,7 +4403,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn expression_statement(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> ExpressionStatement<'a> {
@@ -4416,7 +4420,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn alloc_expression_statement(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> Box<'a, ExpressionStatement<'a>> {
@@ -4435,7 +4439,7 @@ impl<'a> AstBuilder<'a> {
     /// * `alternate`
     #[inline]
     pub fn if_statement(
-        self,
+        &self,
         span: Span,
         test: Expression<'a>,
         consequent: Statement<'a>,
@@ -4456,7 +4460,7 @@ impl<'a> AstBuilder<'a> {
     /// * `alternate`
     #[inline]
     pub fn alloc_if_statement(
-        self,
+        &self,
         span: Span,
         test: Expression<'a>,
         consequent: Statement<'a>,
@@ -4476,7 +4480,7 @@ impl<'a> AstBuilder<'a> {
     /// * `test`
     #[inline]
     pub fn do_while_statement(
-        self,
+        &self,
         span: Span,
         body: Statement<'a>,
         test: Expression<'a>,
@@ -4495,7 +4499,7 @@ impl<'a> AstBuilder<'a> {
     /// * `test`
     #[inline]
     pub fn alloc_do_while_statement(
-        self,
+        &self,
         span: Span,
         body: Statement<'a>,
         test: Expression<'a>,
@@ -4514,7 +4518,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn while_statement(
-        self,
+        &self,
         span: Span,
         test: Expression<'a>,
         body: Statement<'a>,
@@ -4533,7 +4537,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn alloc_while_statement(
-        self,
+        &self,
         span: Span,
         test: Expression<'a>,
         body: Statement<'a>,
@@ -4554,7 +4558,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn for_statement(
-        self,
+        &self,
         span: Span,
         init: Option<ForStatementInit<'a>>,
         test: Option<Expression<'a>>,
@@ -4577,7 +4581,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn alloc_for_statement(
-        self,
+        &self,
         span: Span,
         init: Option<ForStatementInit<'a>>,
         test: Option<Expression<'a>>,
@@ -4601,7 +4605,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn for_statement_with_scope_id(
-        self,
+        &self,
         span: Span,
         init: Option<ForStatementInit<'a>>,
         test: Option<Expression<'a>>,
@@ -4626,7 +4630,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_for_statement_with_scope_id(
-        self,
+        &self,
         span: Span,
         init: Option<ForStatementInit<'a>>,
         test: Option<Expression<'a>>,
@@ -4651,7 +4655,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn for_statement_init_variable_declaration(
-        self,
+        &self,
         span: Span,
         kind: VariableDeclarationKind,
         declarations: Vec<'a, VariableDeclarator<'a>>,
@@ -4677,7 +4681,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn for_in_statement(
-        self,
+        &self,
         span: Span,
         left: ForStatementLeft<'a>,
         right: Expression<'a>,
@@ -4698,7 +4702,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn alloc_for_in_statement(
-        self,
+        &self,
         span: Span,
         left: ForStatementLeft<'a>,
         right: Expression<'a>,
@@ -4720,7 +4724,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn for_in_statement_with_scope_id(
-        self,
+        &self,
         span: Span,
         left: ForStatementLeft<'a>,
         right: Expression<'a>,
@@ -4743,7 +4747,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_for_in_statement_with_scope_id(
-        self,
+        &self,
         span: Span,
         left: ForStatementLeft<'a>,
         right: Expression<'a>,
@@ -4767,7 +4771,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn for_statement_left_variable_declaration(
-        self,
+        &self,
         span: Span,
         kind: VariableDeclarationKind,
         declarations: Vec<'a, VariableDeclarator<'a>>,
@@ -4794,7 +4798,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn for_of_statement(
-        self,
+        &self,
         span: Span,
         r#await: bool,
         left: ForStatementLeft<'a>,
@@ -4817,7 +4821,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn alloc_for_of_statement(
-        self,
+        &self,
         span: Span,
         r#await: bool,
         left: ForStatementLeft<'a>,
@@ -4841,7 +4845,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn for_of_statement_with_scope_id(
-        self,
+        &self,
         span: Span,
         r#await: bool,
         left: ForStatementLeft<'a>,
@@ -4866,7 +4870,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_for_of_statement_with_scope_id(
-        self,
+        &self,
         span: Span,
         r#await: bool,
         left: ForStatementLeft<'a>,
@@ -4890,7 +4894,7 @@ impl<'a> AstBuilder<'a> {
     /// * `label`
     #[inline]
     pub fn continue_statement(
-        self,
+        &self,
         span: Span,
         label: Option<LabelIdentifier<'a>>,
     ) -> ContinueStatement<'a> {
@@ -4907,7 +4911,7 @@ impl<'a> AstBuilder<'a> {
     /// * `label`
     #[inline]
     pub fn alloc_continue_statement(
-        self,
+        &self,
         span: Span,
         label: Option<LabelIdentifier<'a>>,
     ) -> Box<'a, ContinueStatement<'a>> {
@@ -4924,7 +4928,7 @@ impl<'a> AstBuilder<'a> {
     /// * `label`
     #[inline]
     pub fn break_statement(
-        self,
+        &self,
         span: Span,
         label: Option<LabelIdentifier<'a>>,
     ) -> BreakStatement<'a> {
@@ -4941,7 +4945,7 @@ impl<'a> AstBuilder<'a> {
     /// * `label`
     #[inline]
     pub fn alloc_break_statement(
-        self,
+        &self,
         span: Span,
         label: Option<LabelIdentifier<'a>>,
     ) -> Box<'a, BreakStatement<'a>> {
@@ -4958,7 +4962,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn return_statement(
-        self,
+        &self,
         span: Span,
         argument: Option<Expression<'a>>,
     ) -> ReturnStatement<'a> {
@@ -4975,7 +4979,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn alloc_return_statement(
-        self,
+        &self,
         span: Span,
         argument: Option<Expression<'a>>,
     ) -> Box<'a, ReturnStatement<'a>> {
@@ -4993,7 +4997,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn with_statement(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         body: Statement<'a>,
@@ -5012,7 +5016,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn alloc_with_statement(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         body: Statement<'a>,
@@ -5031,7 +5035,7 @@ impl<'a> AstBuilder<'a> {
     /// * `cases`
     #[inline]
     pub fn switch_statement(
-        self,
+        &self,
         span: Span,
         discriminant: Expression<'a>,
         cases: Vec<'a, SwitchCase<'a>>,
@@ -5050,7 +5054,7 @@ impl<'a> AstBuilder<'a> {
     /// * `cases`
     #[inline]
     pub fn alloc_switch_statement(
-        self,
+        &self,
         span: Span,
         discriminant: Expression<'a>,
         cases: Vec<'a, SwitchCase<'a>>,
@@ -5070,7 +5074,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn switch_statement_with_scope_id(
-        self,
+        &self,
         span: Span,
         discriminant: Expression<'a>,
         cases: Vec<'a, SwitchCase<'a>>,
@@ -5091,7 +5095,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_switch_statement_with_scope_id(
-        self,
+        &self,
         span: Span,
         discriminant: Expression<'a>,
         cases: Vec<'a, SwitchCase<'a>>,
@@ -5111,7 +5115,7 @@ impl<'a> AstBuilder<'a> {
     /// * `consequent`
     #[inline]
     pub fn switch_case(
-        self,
+        &self,
         span: Span,
         test: Option<Expression<'a>>,
         consequent: Vec<'a, Statement<'a>>,
@@ -5130,7 +5134,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn labeled_statement(
-        self,
+        &self,
         span: Span,
         label: LabelIdentifier<'a>,
         body: Statement<'a>,
@@ -5149,7 +5153,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn alloc_labeled_statement(
-        self,
+        &self,
         span: Span,
         label: LabelIdentifier<'a>,
         body: Statement<'a>,
@@ -5166,7 +5170,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `argument`: The expression being thrown, e.g. `err` in `throw err;`
     #[inline]
-    pub fn throw_statement(self, span: Span, argument: Expression<'a>) -> ThrowStatement<'a> {
+    pub fn throw_statement(&self, span: Span, argument: Expression<'a>) -> ThrowStatement<'a> {
         ThrowStatement { span, argument }
     }
 
@@ -5180,7 +5184,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`: The expression being thrown, e.g. `err` in `throw err;`
     #[inline]
     pub fn alloc_throw_statement(
-        self,
+        &self,
         span: Span,
         argument: Expression<'a>,
     ) -> Box<'a, ThrowStatement<'a>> {
@@ -5199,7 +5203,7 @@ impl<'a> AstBuilder<'a> {
     /// * `finalizer`: The `finally` clause
     #[inline]
     pub fn try_statement<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         block: T1,
         handler: T2,
@@ -5230,7 +5234,7 @@ impl<'a> AstBuilder<'a> {
     /// * `finalizer`: The `finally` clause
     #[inline]
     pub fn alloc_try_statement<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         block: T1,
         handler: T2,
@@ -5255,7 +5259,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`: The statements run when an error is caught
     #[inline]
     pub fn catch_clause<T1>(
-        self,
+        &self,
         span: Span,
         param: Option<CatchParameter<'a>>,
         body: T1,
@@ -5282,7 +5286,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`: The statements run when an error is caught
     #[inline]
     pub fn alloc_catch_clause<T1>(
-        self,
+        &self,
         span: Span,
         param: Option<CatchParameter<'a>>,
         body: T1,
@@ -5305,7 +5309,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn catch_clause_with_scope_id<T1>(
-        self,
+        &self,
         span: Span,
         param: Option<CatchParameter<'a>>,
         body: T1,
@@ -5334,7 +5338,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_catch_clause_with_scope_id<T1>(
-        self,
+        &self,
         span: Span,
         param: Option<CatchParameter<'a>>,
         body: T1,
@@ -5352,7 +5356,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `pattern`: The bound error
     #[inline]
-    pub fn catch_parameter(self, span: Span, pattern: BindingPattern<'a>) -> CatchParameter<'a> {
+    pub fn catch_parameter(&self, span: Span, pattern: BindingPattern<'a>) -> CatchParameter<'a> {
         CatchParameter { span, pattern }
     }
 
@@ -5364,7 +5368,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn debugger_statement(self, span: Span) -> DebuggerStatement {
+    pub fn debugger_statement(&self, span: Span) -> DebuggerStatement {
         DebuggerStatement { span }
     }
 
@@ -5376,7 +5380,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_debugger_statement(self, span: Span) -> Box<'a, DebuggerStatement> {
+    pub fn alloc_debugger_statement(&self, span: Span) -> Box<'a, DebuggerStatement> {
         Box::new_in(self.debugger_statement(span), self.allocator)
     }
 
@@ -5388,7 +5392,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn binding_pattern<T1>(
-        self,
+        &self,
         kind: BindingPatternKind<'a>,
         type_annotation: T1,
         optional: bool,
@@ -5408,7 +5412,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The identifier name being bound.
     #[inline]
     pub fn binding_pattern_kind_binding_identifier<A1>(
-        self,
+        &self,
         span: Span,
         name: A1,
     ) -> BindingPatternKind<'a>
@@ -5428,7 +5432,7 @@ impl<'a> AstBuilder<'a> {
     /// * `symbol_id`: Unique identifier for this binding.
     #[inline]
     pub fn binding_pattern_kind_binding_identifier_with_symbol_id<A1>(
-        self,
+        &self,
         span: Span,
         name: A1,
         symbol_id: SymbolId,
@@ -5451,7 +5455,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn binding_pattern_kind_object_pattern<T1>(
-        self,
+        &self,
         span: Span,
         properties: Vec<'a, BindingProperty<'a>>,
         rest: T1,
@@ -5472,7 +5476,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn binding_pattern_kind_array_pattern<T1>(
-        self,
+        &self,
         span: Span,
         elements: Vec<'a, Option<BindingPattern<'a>>>,
         rest: T1,
@@ -5493,7 +5497,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn binding_pattern_kind_assignment_pattern(
-        self,
+        &self,
         span: Span,
         left: BindingPattern<'a>,
         right: Expression<'a>,
@@ -5512,7 +5516,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn assignment_pattern(
-        self,
+        &self,
         span: Span,
         left: BindingPattern<'a>,
         right: Expression<'a>,
@@ -5531,7 +5535,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn alloc_assignment_pattern(
-        self,
+        &self,
         span: Span,
         left: BindingPattern<'a>,
         right: Expression<'a>,
@@ -5550,7 +5554,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn object_pattern<T1>(
-        self,
+        &self,
         span: Span,
         properties: Vec<'a, BindingProperty<'a>>,
         rest: T1,
@@ -5572,7 +5576,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn alloc_object_pattern<T1>(
-        self,
+        &self,
         span: Span,
         properties: Vec<'a, BindingProperty<'a>>,
         rest: T1,
@@ -5593,7 +5597,7 @@ impl<'a> AstBuilder<'a> {
     /// * `computed`
     #[inline]
     pub fn binding_property(
-        self,
+        &self,
         span: Span,
         key: PropertyKey<'a>,
         value: BindingPattern<'a>,
@@ -5614,7 +5618,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn array_pattern<T1>(
-        self,
+        &self,
         span: Span,
         elements: Vec<'a, Option<BindingPattern<'a>>>,
         rest: T1,
@@ -5636,7 +5640,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn alloc_array_pattern<T1>(
-        self,
+        &self,
         span: Span,
         elements: Vec<'a, Option<BindingPattern<'a>>>,
         rest: T1,
@@ -5657,7 +5661,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn binding_rest_element(
-        self,
+        &self,
         span: Span,
         argument: BindingPattern<'a>,
     ) -> BindingRestElement<'a> {
@@ -5674,7 +5678,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn alloc_binding_rest_element(
-        self,
+        &self,
         span: Span,
         argument: BindingPattern<'a>,
     ) -> Box<'a, BindingRestElement<'a>> {
@@ -5700,7 +5704,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`: The function body.
     #[inline]
     pub fn function<T1, T2, T3, T4, T5>(
-        self,
+        &self,
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
@@ -5756,7 +5760,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`: The function body.
     #[inline]
     pub fn alloc_function<T1, T2, T3, T4, T5>(
-        self,
+        &self,
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
@@ -5815,7 +5819,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     #[inline]
     pub fn function_with_scope_id_and_pure<T1, T2, T3, T4, T5>(
-        self,
+        &self,
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
@@ -5875,7 +5879,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     #[inline]
     pub fn alloc_function_with_scope_id_and_pure<T1, T2, T3, T4, T5>(
-        self,
+        &self,
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
@@ -5929,7 +5933,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn formal_parameters<T1>(
-        self,
+        &self,
         span: Span,
         kind: FormalParameterKind,
         items: Vec<'a, FormalParameter<'a>>,
@@ -5953,7 +5957,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn alloc_formal_parameters<T1>(
-        self,
+        &self,
         span: Span,
         kind: FormalParameterKind,
         items: Vec<'a, FormalParameter<'a>>,
@@ -5976,7 +5980,7 @@ impl<'a> AstBuilder<'a> {
     /// * `override`
     #[inline]
     pub fn formal_parameter(
-        self,
+        &self,
         span: Span,
         decorators: Vec<'a, Decorator<'a>>,
         pattern: BindingPattern<'a>,
@@ -5998,7 +6002,7 @@ impl<'a> AstBuilder<'a> {
     /// * `statements`
     #[inline]
     pub fn function_body(
-        self,
+        &self,
         span: Span,
         directives: Vec<'a, Directive<'a>>,
         statements: Vec<'a, Statement<'a>>,
@@ -6017,7 +6021,7 @@ impl<'a> AstBuilder<'a> {
     /// * `statements`
     #[inline]
     pub fn alloc_function_body(
-        self,
+        &self,
         span: Span,
         directives: Vec<'a, Directive<'a>>,
         statements: Vec<'a, Statement<'a>>,
@@ -6040,7 +6044,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`: See `expression` for whether this arrow expression returns an expression.
     #[inline]
     pub fn arrow_function_expression<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         expression: bool,
         r#async: bool,
@@ -6083,7 +6087,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`: See `expression` for whether this arrow expression returns an expression.
     #[inline]
     pub fn alloc_arrow_function_expression<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         expression: bool,
         r#async: bool,
@@ -6129,7 +6133,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     #[inline]
     pub fn arrow_function_expression_with_scope_id_and_pure<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         expression: bool,
         r#async: bool,
@@ -6176,7 +6180,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     #[inline]
     pub fn alloc_arrow_function_expression_with_scope_id_and_pure<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         expression: bool,
         r#async: bool,
@@ -6220,7 +6224,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn yield_expression(
-        self,
+        &self,
         span: Span,
         delegate: bool,
         argument: Option<Expression<'a>>,
@@ -6239,7 +6243,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn alloc_yield_expression(
-        self,
+        &self,
         span: Span,
         delegate: bool,
         argument: Option<Expression<'a>>,
@@ -6266,7 +6270,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`: Whether the class was `declare`ed
     #[inline]
     pub fn class<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#type: ClassType,
         decorators: Vec<'a, Decorator<'a>>,
@@ -6319,7 +6323,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`: Whether the class was `declare`ed
     #[inline]
     pub fn alloc_class<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#type: ClassType,
         decorators: Vec<'a, Decorator<'a>>,
@@ -6375,7 +6379,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
     #[inline]
     pub fn class_with_scope_id<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#type: ClassType,
         decorators: Vec<'a, Decorator<'a>>,
@@ -6430,7 +6434,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
     #[inline]
     pub fn alloc_class_with_scope_id<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#type: ClassType,
         decorators: Vec<'a, Decorator<'a>>,
@@ -6477,7 +6481,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `body`
     #[inline]
-    pub fn class_body(self, span: Span, body: Vec<'a, ClassElement<'a>>) -> ClassBody<'a> {
+    pub fn class_body(&self, span: Span, body: Vec<'a, ClassElement<'a>>) -> ClassBody<'a> {
         ClassBody { span, body }
     }
 
@@ -6491,7 +6495,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn alloc_class_body(
-        self,
+        &self,
         span: Span,
         body: Vec<'a, ClassElement<'a>>,
     ) -> Box<'a, ClassBody<'a>> {
@@ -6507,7 +6511,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn class_element_static_block(
-        self,
+        &self,
         span: Span,
         body: Vec<'a, Statement<'a>>,
     ) -> ClassElement<'a> {
@@ -6524,7 +6528,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn class_element_static_block_with_scope_id(
-        self,
+        &self,
         span: Span,
         body: Vec<'a, Statement<'a>>,
         scope_id: ScopeId,
@@ -6550,7 +6554,7 @@ impl<'a> AstBuilder<'a> {
     /// * `accessibility`
     #[inline]
     pub fn class_element_method_definition<T1>(
-        self,
+        &self,
         span: Span,
         r#type: MethodDefinitionType,
         decorators: Vec<'a, Decorator<'a>>,
@@ -6602,7 +6606,7 @@ impl<'a> AstBuilder<'a> {
     /// * `accessibility`: Accessibility modifier.
     #[inline]
     pub fn class_element_property_definition<T1>(
-        self,
+        &self,
         span: Span,
         r#type: PropertyDefinitionType,
         decorators: Vec<'a, Decorator<'a>>,
@@ -6657,7 +6661,7 @@ impl<'a> AstBuilder<'a> {
     /// * `accessibility`: Accessibility modifier.
     #[inline]
     pub fn class_element_accessor_property<T1>(
-        self,
+        &self,
         span: Span,
         r#type: AccessorPropertyType,
         decorators: Vec<'a, Decorator<'a>>,
@@ -6700,7 +6704,7 @@ impl<'a> AstBuilder<'a> {
     /// * `static`
     #[inline]
     pub fn class_element_ts_index_signature<T1>(
-        self,
+        &self,
         span: Span,
         parameters: Vec<'a, TSIndexSignatureName<'a>>,
         type_annotation: T1,
@@ -6738,7 +6742,7 @@ impl<'a> AstBuilder<'a> {
     /// * `accessibility`
     #[inline]
     pub fn method_definition<T1>(
-        self,
+        &self,
         span: Span,
         r#type: MethodDefinitionType,
         decorators: Vec<'a, Decorator<'a>>,
@@ -6788,7 +6792,7 @@ impl<'a> AstBuilder<'a> {
     /// * `accessibility`
     #[inline]
     pub fn alloc_method_definition<T1>(
-        self,
+        &self,
         span: Span,
         r#type: MethodDefinitionType,
         decorators: Vec<'a, Decorator<'a>>,
@@ -6844,7 +6848,7 @@ impl<'a> AstBuilder<'a> {
     /// * `accessibility`: Accessibility modifier.
     #[inline]
     pub fn property_definition<T1>(
-        self,
+        &self,
         span: Span,
         r#type: PropertyDefinitionType,
         decorators: Vec<'a, Decorator<'a>>,
@@ -6903,7 +6907,7 @@ impl<'a> AstBuilder<'a> {
     /// * `accessibility`: Accessibility modifier.
     #[inline]
     pub fn alloc_property_definition<T1>(
-        self,
+        &self,
         span: Span,
         r#type: PropertyDefinitionType,
         decorators: Vec<'a, Decorator<'a>>,
@@ -6952,7 +6956,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn private_identifier<A1>(self, span: Span, name: A1) -> PrivateIdentifier<'a>
+    pub fn private_identifier<A1>(&self, span: Span, name: A1) -> PrivateIdentifier<'a>
     where
         A1: Into<Atom<'a>>,
     {
@@ -6969,7 +6973,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`
     #[inline]
     pub fn alloc_private_identifier<A1>(
-        self,
+        &self,
         span: Span,
         name: A1,
     ) -> Box<'a, PrivateIdentifier<'a>>
@@ -6988,7 +6992,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `body`
     #[inline]
-    pub fn static_block(self, span: Span, body: Vec<'a, Statement<'a>>) -> StaticBlock<'a> {
+    pub fn static_block(&self, span: Span, body: Vec<'a, Statement<'a>>) -> StaticBlock<'a> {
         StaticBlock { span, body, scope_id: Default::default() }
     }
 
@@ -7002,7 +7006,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn alloc_static_block(
-        self,
+        &self,
         span: Span,
         body: Vec<'a, Statement<'a>>,
     ) -> Box<'a, StaticBlock<'a>> {
@@ -7020,7 +7024,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn static_block_with_scope_id(
-        self,
+        &self,
         span: Span,
         body: Vec<'a, Statement<'a>>,
         scope_id: ScopeId,
@@ -7039,7 +7043,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_static_block_with_scope_id(
-        self,
+        &self,
         span: Span,
         body: Vec<'a, Statement<'a>>,
         scope_id: ScopeId,
@@ -7060,7 +7064,7 @@ impl<'a> AstBuilder<'a> {
     /// * `import_kind`: `import type { foo } from 'bar'`
     #[inline]
     pub fn module_declaration_import_declaration<T1>(
-        self,
+        &self,
         span: Span,
         specifiers: Option<Vec<'a, ImportDeclarationSpecifier<'a>>>,
         source: StringLiteral<'a>,
@@ -7093,7 +7097,7 @@ impl<'a> AstBuilder<'a> {
     /// * `export_kind`
     #[inline]
     pub fn module_declaration_export_all_declaration<T1>(
-        self,
+        &self,
         span: Span,
         exported: Option<ModuleExportName<'a>>,
         source: StringLiteral<'a>,
@@ -7122,7 +7126,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declaration`
     #[inline]
     pub fn module_declaration_export_default_declaration(
-        self,
+        &self,
         span: Span,
         exported: ModuleExportName<'a>,
         declaration: ExportDefaultDeclarationKind<'a>,
@@ -7147,7 +7151,7 @@ impl<'a> AstBuilder<'a> {
     /// * `with_clause`: Some(vec![]) for empty assertion
     #[inline]
     pub fn module_declaration_export_named_declaration<T1>(
-        self,
+        &self,
         span: Span,
         declaration: Option<Declaration<'a>>,
         specifiers: Vec<'a, ExportSpecifier<'a>>,
@@ -7177,7 +7181,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn module_declaration_ts_export_assignment(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> ModuleDeclaration<'a> {
@@ -7193,7 +7197,7 @@ impl<'a> AstBuilder<'a> {
     /// * `id`
     #[inline]
     pub fn module_declaration_ts_namespace_export_declaration(
-        self,
+        &self,
         span: Span,
         id: IdentifierName<'a>,
     ) -> ModuleDeclaration<'a> {
@@ -7221,7 +7225,7 @@ impl<'a> AstBuilder<'a> {
     /// * `accessibility`: Accessibility modifier.
     #[inline]
     pub fn accessor_property<T1>(
-        self,
+        &self,
         span: Span,
         r#type: AccessorPropertyType,
         decorators: Vec<'a, Decorator<'a>>,
@@ -7271,7 +7275,7 @@ impl<'a> AstBuilder<'a> {
     /// * `accessibility`: Accessibility modifier.
     #[inline]
     pub fn alloc_accessor_property<T1>(
-        self,
+        &self,
         span: Span,
         r#type: AccessorPropertyType,
         decorators: Vec<'a, Decorator<'a>>,
@@ -7317,7 +7321,7 @@ impl<'a> AstBuilder<'a> {
     /// * `phase`
     #[inline]
     pub fn import_expression(
-        self,
+        &self,
         span: Span,
         source: Expression<'a>,
         options: Option<Expression<'a>>,
@@ -7338,7 +7342,7 @@ impl<'a> AstBuilder<'a> {
     /// * `phase`
     #[inline]
     pub fn alloc_import_expression(
-        self,
+        &self,
         span: Span,
         source: Expression<'a>,
         options: Option<Expression<'a>>,
@@ -7361,7 +7365,7 @@ impl<'a> AstBuilder<'a> {
     /// * `import_kind`: `import type { foo } from 'bar'`
     #[inline]
     pub fn import_declaration<T1>(
-        self,
+        &self,
         span: Span,
         specifiers: Option<Vec<'a, ImportDeclarationSpecifier<'a>>>,
         source: StringLiteral<'a>,
@@ -7396,7 +7400,7 @@ impl<'a> AstBuilder<'a> {
     /// * `import_kind`: `import type { foo } from 'bar'`
     #[inline]
     pub fn alloc_import_declaration<T1>(
-        self,
+        &self,
         span: Span,
         specifiers: Option<Vec<'a, ImportDeclarationSpecifier<'a>>>,
         source: StringLiteral<'a>,
@@ -7424,7 +7428,7 @@ impl<'a> AstBuilder<'a> {
     /// * `import_kind`
     #[inline]
     pub fn import_declaration_specifier_import_specifier(
-        self,
+        &self,
         span: Span,
         imported: ModuleExportName<'a>,
         local: BindingIdentifier<'a>,
@@ -7447,7 +7451,7 @@ impl<'a> AstBuilder<'a> {
     /// * `local`: The name of the imported symbol.
     #[inline]
     pub fn import_declaration_specifier_import_default_specifier(
-        self,
+        &self,
         span: Span,
         local: BindingIdentifier<'a>,
     ) -> ImportDeclarationSpecifier<'a> {
@@ -7465,7 +7469,7 @@ impl<'a> AstBuilder<'a> {
     /// * `local`
     #[inline]
     pub fn import_declaration_specifier_import_namespace_specifier(
-        self,
+        &self,
         span: Span,
         local: BindingIdentifier<'a>,
     ) -> ImportDeclarationSpecifier<'a> {
@@ -7486,7 +7490,7 @@ impl<'a> AstBuilder<'a> {
     /// * `import_kind`
     #[inline]
     pub fn import_specifier(
-        self,
+        &self,
         span: Span,
         imported: ModuleExportName<'a>,
         local: BindingIdentifier<'a>,
@@ -7507,7 +7511,7 @@ impl<'a> AstBuilder<'a> {
     /// * `import_kind`
     #[inline]
     pub fn alloc_import_specifier(
-        self,
+        &self,
         span: Span,
         imported: ModuleExportName<'a>,
         local: BindingIdentifier<'a>,
@@ -7526,7 +7530,7 @@ impl<'a> AstBuilder<'a> {
     /// * `local`: The name of the imported symbol.
     #[inline]
     pub fn import_default_specifier(
-        self,
+        &self,
         span: Span,
         local: BindingIdentifier<'a>,
     ) -> ImportDefaultSpecifier<'a> {
@@ -7543,7 +7547,7 @@ impl<'a> AstBuilder<'a> {
     /// * `local`: The name of the imported symbol.
     #[inline]
     pub fn alloc_import_default_specifier(
-        self,
+        &self,
         span: Span,
         local: BindingIdentifier<'a>,
     ) -> Box<'a, ImportDefaultSpecifier<'a>> {
@@ -7560,7 +7564,7 @@ impl<'a> AstBuilder<'a> {
     /// * `local`
     #[inline]
     pub fn import_namespace_specifier(
-        self,
+        &self,
         span: Span,
         local: BindingIdentifier<'a>,
     ) -> ImportNamespaceSpecifier<'a> {
@@ -7577,7 +7581,7 @@ impl<'a> AstBuilder<'a> {
     /// * `local`
     #[inline]
     pub fn alloc_import_namespace_specifier(
-        self,
+        &self,
         span: Span,
         local: BindingIdentifier<'a>,
     ) -> Box<'a, ImportNamespaceSpecifier<'a>> {
@@ -7595,7 +7599,7 @@ impl<'a> AstBuilder<'a> {
     /// * `with_entries`
     #[inline]
     pub fn with_clause(
-        self,
+        &self,
         span: Span,
         attributes_keyword: IdentifierName<'a>,
         with_entries: Vec<'a, ImportAttribute<'a>>,
@@ -7614,7 +7618,7 @@ impl<'a> AstBuilder<'a> {
     /// * `with_entries`
     #[inline]
     pub fn alloc_with_clause(
-        self,
+        &self,
         span: Span,
         attributes_keyword: IdentifierName<'a>,
         with_entries: Vec<'a, ImportAttribute<'a>>,
@@ -7630,7 +7634,7 @@ impl<'a> AstBuilder<'a> {
     /// * `value`
     #[inline]
     pub fn import_attribute(
-        self,
+        &self,
         span: Span,
         key: ImportAttributeKey<'a>,
         value: StringLiteral<'a>,
@@ -7644,7 +7648,11 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn import_attribute_key_identifier<A1>(self, span: Span, name: A1) -> ImportAttributeKey<'a>
+    pub fn import_attribute_key_identifier<A1>(
+        &self,
+        span: Span,
+        name: A1,
+    ) -> ImportAttributeKey<'a>
     where
         A1: Into<Atom<'a>>,
     {
@@ -7659,7 +7667,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
     pub fn import_attribute_key_string_literal<A1>(
-        self,
+        &self,
         span: Span,
         value: A1,
         raw: Option<Atom<'a>>,
@@ -7679,7 +7687,7 @@ impl<'a> AstBuilder<'a> {
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
     pub fn import_attribute_key_string_literal_with_lone_surrogates<A1>(
-        self,
+        &self,
         span: Span,
         value: A1,
         raw: Option<Atom<'a>>,
@@ -7710,7 +7718,7 @@ impl<'a> AstBuilder<'a> {
     /// * `with_clause`: Some(vec![]) for empty assertion
     #[inline]
     pub fn export_named_declaration<T1>(
-        self,
+        &self,
         span: Span,
         declaration: Option<Declaration<'a>>,
         specifiers: Vec<'a, ExportSpecifier<'a>>,
@@ -7745,7 +7753,7 @@ impl<'a> AstBuilder<'a> {
     /// * `with_clause`: Some(vec![]) for empty assertion
     #[inline]
     pub fn alloc_export_named_declaration<T1>(
-        self,
+        &self,
         span: Span,
         declaration: Option<Declaration<'a>>,
         specifiers: Vec<'a, ExportSpecifier<'a>>,
@@ -7780,7 +7788,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declaration`
     #[inline]
     pub fn export_default_declaration(
-        self,
+        &self,
         span: Span,
         exported: ModuleExportName<'a>,
         declaration: ExportDefaultDeclarationKind<'a>,
@@ -7799,7 +7807,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declaration`
     #[inline]
     pub fn alloc_export_default_declaration(
-        self,
+        &self,
         span: Span,
         exported: ModuleExportName<'a>,
         declaration: ExportDefaultDeclarationKind<'a>,
@@ -7820,7 +7828,7 @@ impl<'a> AstBuilder<'a> {
     /// * `export_kind`
     #[inline]
     pub fn export_all_declaration<T1>(
-        self,
+        &self,
         span: Span,
         exported: Option<ModuleExportName<'a>>,
         source: StringLiteral<'a>,
@@ -7852,7 +7860,7 @@ impl<'a> AstBuilder<'a> {
     /// * `export_kind`
     #[inline]
     pub fn alloc_export_all_declaration<T1>(
-        self,
+        &self,
         span: Span,
         exported: Option<ModuleExportName<'a>>,
         source: StringLiteral<'a>,
@@ -7877,7 +7885,7 @@ impl<'a> AstBuilder<'a> {
     /// * `export_kind`
     #[inline]
     pub fn export_specifier(
-        self,
+        &self,
         span: Span,
         local: ModuleExportName<'a>,
         exported: ModuleExportName<'a>,
@@ -7904,7 +7912,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`: The function body.
     #[inline]
     pub fn export_default_declaration_kind_function_declaration<T1, T2, T3, T4, T5>(
-        self,
+        &self,
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
@@ -7965,7 +7973,7 @@ impl<'a> AstBuilder<'a> {
         T4,
         T5,
     >(
-        self,
+        &self,
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
@@ -8024,7 +8032,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`: Whether the class was `declare`ed
     #[inline]
     pub fn export_default_declaration_kind_class_declaration<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#type: ClassType,
         decorators: Vec<'a, Decorator<'a>>,
@@ -8076,7 +8084,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
     #[inline]
     pub fn export_default_declaration_kind_class_declaration_with_scope_id<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#type: ClassType,
         decorators: Vec<'a, Decorator<'a>>,
@@ -8124,7 +8132,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`: `true` for `declare interface Foo {}`
     #[inline]
     pub fn export_default_declaration_kind_ts_interface_declaration<T1, T2>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -8160,7 +8168,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn export_default_declaration_kind_ts_interface_declaration_with_scope_id<T1, T2>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -8193,7 +8201,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`
     #[inline]
     pub fn module_export_name_identifier_name<A1>(
-        self,
+        &self,
         span: Span,
         name: A1,
     ) -> ModuleExportName<'a>
@@ -8210,7 +8218,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The name of the identifier being referenced.
     #[inline]
     pub fn module_export_name_identifier_reference<A1>(
-        self,
+        &self,
         span: Span,
         name: A1,
     ) -> ModuleExportName<'a>
@@ -8228,7 +8236,7 @@ impl<'a> AstBuilder<'a> {
     /// * `reference_id`: Reference ID
     #[inline]
     pub fn module_export_name_identifier_reference_with_reference_id<A1>(
-        self,
+        &self,
         span: Span,
         name: A1,
         reference_id: ReferenceId,
@@ -8251,7 +8259,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
     pub fn module_export_name_string_literal<A1>(
-        self,
+        &self,
         span: Span,
         value: A1,
         raw: Option<Atom<'a>>,
@@ -8271,7 +8279,7 @@ impl<'a> AstBuilder<'a> {
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
     pub fn module_export_name_string_literal_with_lone_surrogates<A1>(
-        self,
+        &self,
         span: Span,
         value: A1,
         raw: Option<Atom<'a>>,
@@ -8299,7 +8307,7 @@ impl<'a> AstBuilder<'a> {
     /// * `arguments`
     #[inline]
     pub fn v_8_intrinsic_expression(
-        self,
+        &self,
         span: Span,
         name: IdentifierName<'a>,
         arguments: Vec<'a, Argument<'a>>,
@@ -8318,7 +8326,7 @@ impl<'a> AstBuilder<'a> {
     /// * `arguments`
     #[inline]
     pub fn alloc_v_8_intrinsic_expression(
-        self,
+        &self,
         span: Span,
         name: IdentifierName<'a>,
         arguments: Vec<'a, Argument<'a>>,
@@ -8335,7 +8343,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code
     /// * `value`: The boolean value itself
     #[inline]
-    pub fn boolean_literal(self, span: Span, value: bool) -> BooleanLiteral {
+    pub fn boolean_literal(&self, span: Span, value: bool) -> BooleanLiteral {
         BooleanLiteral { span, value }
     }
 
@@ -8348,7 +8356,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code
     /// * `value`: The boolean value itself
     #[inline]
-    pub fn alloc_boolean_literal(self, span: Span, value: bool) -> Box<'a, BooleanLiteral> {
+    pub fn alloc_boolean_literal(&self, span: Span, value: bool) -> Box<'a, BooleanLiteral> {
         Box::new_in(self.boolean_literal(span, value), self.allocator)
     }
 
@@ -8360,7 +8368,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     #[inline]
-    pub fn null_literal(self, span: Span) -> NullLiteral {
+    pub fn null_literal(&self, span: Span) -> NullLiteral {
         NullLiteral { span }
     }
 
@@ -8372,7 +8380,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     #[inline]
-    pub fn alloc_null_literal(self, span: Span) -> Box<'a, NullLiteral> {
+    pub fn alloc_null_literal(&self, span: Span) -> Box<'a, NullLiteral> {
         Box::new_in(self.null_literal(span), self.allocator)
     }
 
@@ -8388,7 +8396,7 @@ impl<'a> AstBuilder<'a> {
     /// * `base`: The base representation used by the literal in source code
     #[inline]
     pub fn numeric_literal(
-        self,
+        &self,
         span: Span,
         value: f64,
         raw: Option<Atom<'a>>,
@@ -8409,7 +8417,7 @@ impl<'a> AstBuilder<'a> {
     /// * `base`: The base representation used by the literal in source code
     #[inline]
     pub fn alloc_numeric_literal(
-        self,
+        &self,
         span: Span,
         value: f64,
         raw: Option<Atom<'a>>,
@@ -8429,7 +8437,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
     pub fn string_literal<A1>(
-        self,
+        &self,
         span: Span,
         value: A1,
         raw: Option<Atom<'a>>,
@@ -8451,7 +8459,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
     pub fn alloc_string_literal<A1>(
-        self,
+        &self,
         span: Span,
         value: A1,
         raw: Option<Atom<'a>>,
@@ -8474,7 +8482,7 @@ impl<'a> AstBuilder<'a> {
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
     pub fn string_literal_with_lone_surrogates<A1>(
-        self,
+        &self,
         span: Span,
         value: A1,
         raw: Option<Atom<'a>>,
@@ -8498,7 +8506,7 @@ impl<'a> AstBuilder<'a> {
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
     pub fn alloc_string_literal_with_lone_surrogates<A1>(
-        self,
+        &self,
         span: Span,
         value: A1,
         raw: Option<Atom<'a>>,
@@ -8523,7 +8531,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The bigint as it appears in source code
     /// * `base`: The base representation used by the literal in source code
     #[inline]
-    pub fn big_int_literal<A1>(self, span: Span, raw: A1, base: BigintBase) -> BigIntLiteral<'a>
+    pub fn big_int_literal<A1>(&self, span: Span, raw: A1, base: BigintBase) -> BigIntLiteral<'a>
     where
         A1: Into<Atom<'a>>,
     {
@@ -8541,7 +8549,7 @@ impl<'a> AstBuilder<'a> {
     /// * `base`: The base representation used by the literal in source code
     #[inline]
     pub fn alloc_big_int_literal<A1>(
-        self,
+        &self,
         span: Span,
         raw: A1,
         base: BigintBase,
@@ -8563,7 +8571,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The regular expression as it appears in source code
     #[inline]
     pub fn reg_exp_literal(
-        self,
+        &self,
         span: Span,
         regex: RegExp<'a>,
         raw: Option<Atom<'a>>,
@@ -8582,7 +8590,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The regular expression as it appears in source code
     #[inline]
     pub fn alloc_reg_exp_literal(
-        self,
+        &self,
         span: Span,
         regex: RegExp<'a>,
         raw: Option<Atom<'a>>,
@@ -8602,7 +8610,7 @@ impl<'a> AstBuilder<'a> {
     /// * `closing_element`: Closing tag of the element.
     #[inline]
     pub fn jsx_element<T1, T2>(
-        self,
+        &self,
         span: Span,
         opening_element: T1,
         children: Vec<'a, JSXChild<'a>>,
@@ -8632,7 +8640,7 @@ impl<'a> AstBuilder<'a> {
     /// * `closing_element`: Closing tag of the element.
     #[inline]
     pub fn alloc_jsx_element<T1, T2>(
-        self,
+        &self,
         span: Span,
         opening_element: T1,
         children: Vec<'a, JSXChild<'a>>,
@@ -8660,7 +8668,7 @@ impl<'a> AstBuilder<'a> {
     /// * `attributes`: List of JSX attributes. In React-like applications, these become props.
     #[inline]
     pub fn jsx_opening_element<T1>(
-        self,
+        &self,
         span: Span,
         name: JSXElementName<'a>,
         type_arguments: T1,
@@ -8689,7 +8697,7 @@ impl<'a> AstBuilder<'a> {
     /// * `attributes`: List of JSX attributes. In React-like applications, these become props.
     #[inline]
     pub fn alloc_jsx_opening_element<T1>(
-        self,
+        &self,
         span: Span,
         name: JSXElementName<'a>,
         type_arguments: T1,
@@ -8714,7 +8722,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The tag name, e.g. `Foo` in `</Foo>`.
     #[inline]
     pub fn jsx_closing_element(
-        self,
+        &self,
         span: Span,
         name: JSXElementName<'a>,
     ) -> JSXClosingElement<'a> {
@@ -8731,7 +8739,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The tag name, e.g. `Foo` in `</Foo>`.
     #[inline]
     pub fn alloc_jsx_closing_element(
-        self,
+        &self,
         span: Span,
         name: JSXElementName<'a>,
     ) -> Box<'a, JSXClosingElement<'a>> {
@@ -8750,7 +8758,7 @@ impl<'a> AstBuilder<'a> {
     /// * `closing_fragment`: `</>`
     #[inline]
     pub fn jsx_fragment(
-        self,
+        &self,
         span: Span,
         opening_fragment: JSXOpeningFragment,
         children: Vec<'a, JSXChild<'a>>,
@@ -8771,7 +8779,7 @@ impl<'a> AstBuilder<'a> {
     /// * `closing_fragment`: `</>`
     #[inline]
     pub fn alloc_jsx_fragment(
-        self,
+        &self,
         span: Span,
         opening_fragment: JSXOpeningFragment,
         children: Vec<'a, JSXChild<'a>>,
@@ -8788,7 +8796,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     #[inline]
-    pub fn jsx_opening_fragment(self, span: Span) -> JSXOpeningFragment {
+    pub fn jsx_opening_fragment(&self, span: Span) -> JSXOpeningFragment {
         JSXOpeningFragment { span }
     }
 
@@ -8797,7 +8805,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     #[inline]
-    pub fn jsx_closing_fragment(self, span: Span) -> JSXClosingFragment {
+    pub fn jsx_closing_fragment(&self, span: Span) -> JSXClosingFragment {
         JSXClosingFragment { span }
     }
 
@@ -8809,7 +8817,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code
     /// * `name`: The name of the identifier.
     #[inline]
-    pub fn jsx_element_name_identifier<A1>(self, span: Span, name: A1) -> JSXElementName<'a>
+    pub fn jsx_element_name_identifier<A1>(&self, span: Span, name: A1) -> JSXElementName<'a>
     where
         A1: Into<Atom<'a>>,
     {
@@ -8825,7 +8833,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The name of the identifier being referenced.
     #[inline]
     pub fn jsx_element_name_identifier_reference<A1>(
-        self,
+        &self,
         span: Span,
         name: A1,
     ) -> JSXElementName<'a>
@@ -8845,7 +8853,7 @@ impl<'a> AstBuilder<'a> {
     /// * `reference_id`: Reference ID
     #[inline]
     pub fn jsx_element_name_identifier_reference_with_reference_id<A1>(
-        self,
+        &self,
         span: Span,
         name: A1,
         reference_id: ReferenceId,
@@ -8870,7 +8878,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
     #[inline]
     pub fn jsx_element_name_namespaced_name(
-        self,
+        &self,
         span: Span,
         namespace: JSXIdentifier<'a>,
         name: JSXIdentifier<'a>,
@@ -8888,7 +8896,7 @@ impl<'a> AstBuilder<'a> {
     /// * `property`: The property being accessed. This is everything after the last `.`.
     #[inline]
     pub fn jsx_element_name_member_expression(
-        self,
+        &self,
         span: Span,
         object: JSXMemberExpressionObject<'a>,
         property: JSXIdentifier<'a>,
@@ -8903,7 +8911,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn jsx_element_name_this_expression(self, span: Span) -> JSXElementName<'a> {
+    pub fn jsx_element_name_this_expression(&self, span: Span) -> JSXElementName<'a> {
         JSXElementName::ThisExpression(self.alloc_this_expression(span))
     }
 
@@ -8918,7 +8926,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
     #[inline]
     pub fn jsx_namespaced_name(
-        self,
+        &self,
         span: Span,
         namespace: JSXIdentifier<'a>,
         name: JSXIdentifier<'a>,
@@ -8937,7 +8945,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
     #[inline]
     pub fn alloc_jsx_namespaced_name(
-        self,
+        &self,
         span: Span,
         namespace: JSXIdentifier<'a>,
         name: JSXIdentifier<'a>,
@@ -8956,7 +8964,7 @@ impl<'a> AstBuilder<'a> {
     /// * `property`: The property being accessed. This is everything after the last `.`.
     #[inline]
     pub fn jsx_member_expression(
-        self,
+        &self,
         span: Span,
         object: JSXMemberExpressionObject<'a>,
         property: JSXIdentifier<'a>,
@@ -8975,7 +8983,7 @@ impl<'a> AstBuilder<'a> {
     /// * `property`: The property being accessed. This is everything after the last `.`.
     #[inline]
     pub fn alloc_jsx_member_expression(
-        self,
+        &self,
         span: Span,
         object: JSXMemberExpressionObject<'a>,
         property: JSXIdentifier<'a>,
@@ -8992,7 +9000,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The name of the identifier being referenced.
     #[inline]
     pub fn jsx_member_expression_object_identifier_reference<A1>(
-        self,
+        &self,
         span: Span,
         name: A1,
     ) -> JSXMemberExpressionObject<'a>
@@ -9012,7 +9020,7 @@ impl<'a> AstBuilder<'a> {
     /// * `reference_id`: Reference ID
     #[inline]
     pub fn jsx_member_expression_object_identifier_reference_with_reference_id<A1>(
-        self,
+        &self,
         span: Span,
         name: A1,
         reference_id: ReferenceId,
@@ -9035,7 +9043,7 @@ impl<'a> AstBuilder<'a> {
     /// * `property`: The property being accessed. This is everything after the last `.`.
     #[inline]
     pub fn jsx_member_expression_object_member_expression(
-        self,
+        &self,
         span: Span,
         object: JSXMemberExpressionObject<'a>,
         property: JSXIdentifier<'a>,
@@ -9053,7 +9061,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     #[inline]
     pub fn jsx_member_expression_object_this_expression(
-        self,
+        &self,
         span: Span,
     ) -> JSXMemberExpressionObject<'a> {
         JSXMemberExpressionObject::ThisExpression(self.alloc_this_expression(span))
@@ -9069,7 +9077,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`: The expression inside the container.
     #[inline]
     pub fn jsx_expression_container(
-        self,
+        &self,
         span: Span,
         expression: JSXExpression<'a>,
     ) -> JSXExpressionContainer<'a> {
@@ -9086,7 +9094,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`: The expression inside the container.
     #[inline]
     pub fn alloc_jsx_expression_container(
-        self,
+        &self,
         span: Span,
         expression: JSXExpression<'a>,
     ) -> Box<'a, JSXExpressionContainer<'a>> {
@@ -9098,7 +9106,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     #[inline]
-    pub fn jsx_expression_empty_expression(self, span: Span) -> JSXExpression<'a> {
+    pub fn jsx_expression_empty_expression(&self, span: Span) -> JSXExpression<'a> {
         JSXExpression::EmptyExpression(self.jsx_empty_expression(span))
     }
 
@@ -9107,7 +9115,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     #[inline]
-    pub fn jsx_empty_expression(self, span: Span) -> JSXEmptyExpression {
+    pub fn jsx_empty_expression(&self, span: Span) -> JSXEmptyExpression {
         JSXEmptyExpression { span }
     }
 
@@ -9121,7 +9129,7 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the attribute. This can be a string literal, an expression,
     #[inline]
     pub fn jsx_attribute_item_attribute(
-        self,
+        &self,
         span: Span,
         name: JSXAttributeName<'a>,
         value: Option<JSXAttributeValue<'a>>,
@@ -9138,7 +9146,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`: The expression being spread.
     #[inline]
     pub fn jsx_attribute_item_spread_attribute(
-        self,
+        &self,
         span: Span,
         argument: Expression<'a>,
     ) -> JSXAttributeItem<'a> {
@@ -9156,7 +9164,7 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the attribute. This can be a string literal, an expression,
     #[inline]
     pub fn jsx_attribute(
-        self,
+        &self,
         span: Span,
         name: JSXAttributeName<'a>,
         value: Option<JSXAttributeValue<'a>>,
@@ -9175,7 +9183,7 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the attribute. This can be a string literal, an expression,
     #[inline]
     pub fn alloc_jsx_attribute(
-        self,
+        &self,
         span: Span,
         name: JSXAttributeName<'a>,
         value: Option<JSXAttributeValue<'a>>,
@@ -9193,7 +9201,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`: The expression being spread.
     #[inline]
     pub fn jsx_spread_attribute(
-        self,
+        &self,
         span: Span,
         argument: Expression<'a>,
     ) -> JSXSpreadAttribute<'a> {
@@ -9210,7 +9218,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`: The expression being spread.
     #[inline]
     pub fn alloc_jsx_spread_attribute(
-        self,
+        &self,
         span: Span,
         argument: Expression<'a>,
     ) -> Box<'a, JSXSpreadAttribute<'a>> {
@@ -9225,7 +9233,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code
     /// * `name`: The name of the identifier.
     #[inline]
-    pub fn jsx_attribute_name_identifier<A1>(self, span: Span, name: A1) -> JSXAttributeName<'a>
+    pub fn jsx_attribute_name_identifier<A1>(&self, span: Span, name: A1) -> JSXAttributeName<'a>
     where
         A1: Into<Atom<'a>>,
     {
@@ -9242,7 +9250,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
     #[inline]
     pub fn jsx_attribute_name_namespaced_name(
-        self,
+        &self,
         span: Span,
         namespace: JSXIdentifier<'a>,
         name: JSXIdentifier<'a>,
@@ -9260,7 +9268,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
     pub fn jsx_attribute_value_string_literal<A1>(
-        self,
+        &self,
         span: Span,
         value: A1,
         raw: Option<Atom<'a>>,
@@ -9282,7 +9290,7 @@ impl<'a> AstBuilder<'a> {
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
     pub fn jsx_attribute_value_string_literal_with_lone_surrogates<A1>(
-        self,
+        &self,
         span: Span,
         value: A1,
         raw: Option<Atom<'a>>,
@@ -9308,7 +9316,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`: The expression inside the container.
     #[inline]
     pub fn jsx_attribute_value_expression_container(
-        self,
+        &self,
         span: Span,
         expression: JSXExpression<'a>,
     ) -> JSXAttributeValue<'a> {
@@ -9328,7 +9336,7 @@ impl<'a> AstBuilder<'a> {
     /// * `closing_element`: Closing tag of the element.
     #[inline]
     pub fn jsx_attribute_value_element<T1, T2>(
-        self,
+        &self,
         span: Span,
         opening_element: T1,
         children: Vec<'a, JSXChild<'a>>,
@@ -9357,7 +9365,7 @@ impl<'a> AstBuilder<'a> {
     /// * `closing_fragment`: `</>`
     #[inline]
     pub fn jsx_attribute_value_fragment(
-        self,
+        &self,
         span: Span,
         opening_fragment: JSXOpeningFragment,
         children: Vec<'a, JSXChild<'a>>,
@@ -9380,7 +9388,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code
     /// * `name`: The name of the identifier.
     #[inline]
-    pub fn jsx_identifier<A1>(self, span: Span, name: A1) -> JSXIdentifier<'a>
+    pub fn jsx_identifier<A1>(&self, span: Span, name: A1) -> JSXIdentifier<'a>
     where
         A1: Into<Atom<'a>>,
     {
@@ -9396,7 +9404,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code
     /// * `name`: The name of the identifier.
     #[inline]
-    pub fn alloc_jsx_identifier<A1>(self, span: Span, name: A1) -> Box<'a, JSXIdentifier<'a>>
+    pub fn alloc_jsx_identifier<A1>(&self, span: Span, name: A1) -> Box<'a, JSXIdentifier<'a>>
     where
         A1: Into<Atom<'a>>,
     {
@@ -9412,7 +9420,7 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The text content.
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
-    pub fn jsx_child_text<A1>(self, span: Span, value: A1, raw: Option<Atom<'a>>) -> JSXChild<'a>
+    pub fn jsx_child_text<A1>(&self, span: Span, value: A1, raw: Option<Atom<'a>>) -> JSXChild<'a>
     where
         A1: Into<Atom<'a>>,
     {
@@ -9430,7 +9438,7 @@ impl<'a> AstBuilder<'a> {
     /// * `closing_element`: Closing tag of the element.
     #[inline]
     pub fn jsx_child_element<T1, T2>(
-        self,
+        &self,
         span: Span,
         opening_element: T1,
         children: Vec<'a, JSXChild<'a>>,
@@ -9454,7 +9462,7 @@ impl<'a> AstBuilder<'a> {
     /// * `closing_fragment`: `</>`
     #[inline]
     pub fn jsx_child_fragment(
-        self,
+        &self,
         span: Span,
         opening_fragment: JSXOpeningFragment,
         children: Vec<'a, JSXChild<'a>>,
@@ -9477,7 +9485,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`: The expression inside the container.
     #[inline]
     pub fn jsx_child_expression_container(
-        self,
+        &self,
         span: Span,
         expression: JSXExpression<'a>,
     ) -> JSXChild<'a> {
@@ -9492,7 +9500,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code
     /// * `expression`: The expression being spread.
     #[inline]
-    pub fn jsx_child_spread(self, span: Span, expression: Expression<'a>) -> JSXChild<'a> {
+    pub fn jsx_child_spread(&self, span: Span, expression: Expression<'a>) -> JSXChild<'a> {
         JSXChild::Spread(self.alloc_jsx_spread_child(span, expression))
     }
 
@@ -9505,7 +9513,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code
     /// * `expression`: The expression being spread.
     #[inline]
-    pub fn jsx_spread_child(self, span: Span, expression: Expression<'a>) -> JSXSpreadChild<'a> {
+    pub fn jsx_spread_child(&self, span: Span, expression: Expression<'a>) -> JSXSpreadChild<'a> {
         JSXSpreadChild { span, expression }
     }
 
@@ -9519,7 +9527,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`: The expression being spread.
     #[inline]
     pub fn alloc_jsx_spread_child(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> Box<'a, JSXSpreadChild<'a>> {
@@ -9536,7 +9544,7 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The text content.
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
-    pub fn jsx_text<A1>(self, span: Span, value: A1, raw: Option<Atom<'a>>) -> JSXText<'a>
+    pub fn jsx_text<A1>(&self, span: Span, value: A1, raw: Option<Atom<'a>>) -> JSXText<'a>
     where
         A1: Into<Atom<'a>>,
     {
@@ -9554,7 +9562,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
     pub fn alloc_jsx_text<A1>(
-        self,
+        &self,
         span: Span,
         value: A1,
         raw: Option<Atom<'a>>,
@@ -9576,7 +9584,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`: Type type the `this` keyword will have in the function
     #[inline]
     pub fn ts_this_parameter<T1>(
-        self,
+        &self,
         span: Span,
         this_span: Span,
         type_annotation: T1,
@@ -9602,7 +9610,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`: Type type the `this` keyword will have in the function
     #[inline]
     pub fn alloc_ts_this_parameter<T1>(
-        self,
+        &self,
         span: Span,
         this_span: Span,
         type_annotation: T1,
@@ -9626,7 +9634,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn ts_enum_declaration(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         body: TSEnumBody<'a>,
@@ -9649,7 +9657,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn alloc_ts_enum_declaration(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         body: TSEnumBody<'a>,
@@ -9673,7 +9681,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_enum_declaration_with_scope_id(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         body: TSEnumBody<'a>,
@@ -9698,7 +9706,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_ts_enum_declaration_with_scope_id(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         body: TSEnumBody<'a>,
@@ -9718,7 +9726,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `members`
     #[inline]
-    pub fn ts_enum_body(self, span: Span, members: Vec<'a, TSEnumMember<'a>>) -> TSEnumBody<'a> {
+    pub fn ts_enum_body(&self, span: Span, members: Vec<'a, TSEnumMember<'a>>) -> TSEnumBody<'a> {
         TSEnumBody { span, members }
     }
 
@@ -9730,7 +9738,7 @@ impl<'a> AstBuilder<'a> {
     /// * `initializer`
     #[inline]
     pub fn ts_enum_member(
-        self,
+        &self,
         span: Span,
         id: TSEnumMemberName<'a>,
         initializer: Option<Expression<'a>>,
@@ -9746,7 +9754,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn ts_enum_member_name_identifier<A1>(self, span: Span, name: A1) -> TSEnumMemberName<'a>
+    pub fn ts_enum_member_name_identifier<A1>(&self, span: Span, name: A1) -> TSEnumMemberName<'a>
     where
         A1: Into<Atom<'a>>,
     {
@@ -9763,7 +9771,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
     pub fn ts_enum_member_name_string<A1>(
-        self,
+        &self,
         span: Span,
         value: A1,
         raw: Option<Atom<'a>>,
@@ -9785,7 +9793,7 @@ impl<'a> AstBuilder<'a> {
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
     pub fn ts_enum_member_name_string_with_lone_surrogates<A1>(
-        self,
+        &self,
         span: Span,
         value: A1,
         raw: Option<Atom<'a>>,
@@ -9812,7 +9820,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
     pub fn ts_enum_member_name_computed_string<A1>(
-        self,
+        &self,
         span: Span,
         value: A1,
         raw: Option<Atom<'a>>,
@@ -9834,7 +9842,7 @@ impl<'a> AstBuilder<'a> {
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
     pub fn ts_enum_member_name_computed_string_with_lone_surrogates<A1>(
-        self,
+        &self,
         span: Span,
         value: A1,
         raw: Option<Atom<'a>>,
@@ -9861,7 +9869,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expressions`
     #[inline]
     pub fn ts_enum_member_name_computed_template_string(
-        self,
+        &self,
         span: Span,
         quasis: Vec<'a, TemplateElement<'a>>,
         expressions: Vec<'a, Expression<'a>>,
@@ -9883,7 +9891,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`: The actual type in the annotation
     #[inline]
     pub fn ts_type_annotation(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
     ) -> TSTypeAnnotation<'a> {
@@ -9900,7 +9908,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`: The actual type in the annotation
     #[inline]
     pub fn alloc_ts_type_annotation(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
     ) -> Box<'a, TSTypeAnnotation<'a>> {
@@ -9916,7 +9924,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `literal`
     #[inline]
-    pub fn ts_literal_type(self, span: Span, literal: TSLiteral<'a>) -> TSLiteralType<'a> {
+    pub fn ts_literal_type(&self, span: Span, literal: TSLiteral<'a>) -> TSLiteralType<'a> {
         TSLiteralType { span, literal }
     }
 
@@ -9930,7 +9938,7 @@ impl<'a> AstBuilder<'a> {
     /// * `literal`
     #[inline]
     pub fn alloc_ts_literal_type(
-        self,
+        &self,
         span: Span,
         literal: TSLiteral<'a>,
     ) -> Box<'a, TSLiteralType<'a>> {
@@ -9945,7 +9953,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code
     /// * `value`: The boolean value itself
     #[inline]
-    pub fn ts_literal_boolean_literal(self, span: Span, value: bool) -> TSLiteral<'a> {
+    pub fn ts_literal_boolean_literal(&self, span: Span, value: bool) -> TSLiteral<'a> {
         TSLiteral::BooleanLiteral(self.alloc_boolean_literal(span, value))
     }
 
@@ -9960,7 +9968,7 @@ impl<'a> AstBuilder<'a> {
     /// * `base`: The base representation used by the literal in source code
     #[inline]
     pub fn ts_literal_numeric_literal(
-        self,
+        &self,
         span: Span,
         value: f64,
         raw: Option<Atom<'a>>,
@@ -9979,7 +9987,7 @@ impl<'a> AstBuilder<'a> {
     /// * `base`: The base representation used by the literal in source code
     #[inline]
     pub fn ts_literal_big_int_literal<A1>(
-        self,
+        &self,
         span: Span,
         raw: A1,
         base: BigintBase,
@@ -10000,7 +10008,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
     pub fn ts_literal_string_literal<A1>(
-        self,
+        &self,
         span: Span,
         value: A1,
         raw: Option<Atom<'a>>,
@@ -10022,7 +10030,7 @@ impl<'a> AstBuilder<'a> {
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
     pub fn ts_literal_string_literal_with_lone_surrogates<A1>(
-        self,
+        &self,
         span: Span,
         value: A1,
         raw: Option<Atom<'a>>,
@@ -10049,7 +10057,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expressions`
     #[inline]
     pub fn ts_literal_template_literal(
-        self,
+        &self,
         span: Span,
         quasis: Vec<'a, TemplateElement<'a>>,
         expressions: Vec<'a, Expression<'a>>,
@@ -10067,7 +10075,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn ts_literal_unary_expression(
-        self,
+        &self,
         span: Span,
         operator: UnaryOperator,
         argument: Expression<'a>,
@@ -10082,7 +10090,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_any_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_any_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSAnyKeyword(self.alloc_ts_any_keyword(span))
     }
 
@@ -10093,7 +10101,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_big_int_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_big_int_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSBigIntKeyword(self.alloc_ts_big_int_keyword(span))
     }
 
@@ -10104,7 +10112,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_boolean_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_boolean_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSBooleanKeyword(self.alloc_ts_boolean_keyword(span))
     }
 
@@ -10115,7 +10123,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_intrinsic_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_intrinsic_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSIntrinsicKeyword(self.alloc_ts_intrinsic_keyword(span))
     }
 
@@ -10126,7 +10134,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_never_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_never_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSNeverKeyword(self.alloc_ts_never_keyword(span))
     }
 
@@ -10137,7 +10145,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_null_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_null_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSNullKeyword(self.alloc_ts_null_keyword(span))
     }
 
@@ -10148,7 +10156,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_number_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_number_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSNumberKeyword(self.alloc_ts_number_keyword(span))
     }
 
@@ -10159,7 +10167,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_object_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_object_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSObjectKeyword(self.alloc_ts_object_keyword(span))
     }
 
@@ -10170,7 +10178,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_string_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_string_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSStringKeyword(self.alloc_ts_string_keyword(span))
     }
 
@@ -10181,7 +10189,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_symbol_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_symbol_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSSymbolKeyword(self.alloc_ts_symbol_keyword(span))
     }
 
@@ -10192,7 +10200,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_undefined_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_undefined_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSUndefinedKeyword(self.alloc_ts_undefined_keyword(span))
     }
 
@@ -10203,7 +10211,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_unknown_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_unknown_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSUnknownKeyword(self.alloc_ts_unknown_keyword(span))
     }
 
@@ -10214,7 +10222,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_void_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_void_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSVoidKeyword(self.alloc_ts_void_keyword(span))
     }
 
@@ -10226,7 +10234,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `element_type`
     #[inline]
-    pub fn ts_type_array_type(self, span: Span, element_type: TSType<'a>) -> TSType<'a> {
+    pub fn ts_type_array_type(&self, span: Span, element_type: TSType<'a>) -> TSType<'a> {
         TSType::TSArrayType(self.alloc_ts_array_type(span, element_type))
     }
 
@@ -10242,7 +10250,7 @@ impl<'a> AstBuilder<'a> {
     /// * `false_type`: The type evaluated to if the test is false.
     #[inline]
     pub fn ts_type_conditional_type(
-        self,
+        &self,
         span: Span,
         check_type: TSType<'a>,
         extends_type: TSType<'a>,
@@ -10271,7 +10279,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_type_conditional_type_with_scope_id(
-        self,
+        &self,
         span: Span,
         check_type: TSType<'a>,
         extends_type: TSType<'a>,
@@ -10301,7 +10309,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`
     #[inline]
     pub fn ts_type_constructor_type<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#abstract: bool,
         type_parameters: T1,
@@ -10334,7 +10342,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`: Return type of the function.
     #[inline]
     pub fn ts_type_function_type<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         this_param: T2,
@@ -10369,7 +10377,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_type_function_type_with_scope_id<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         this_param: T2,
@@ -10405,7 +10413,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn ts_type_import_type<T1, T2>(
-        self,
+        &self,
         span: Span,
         argument: TSType<'a>,
         options: T1,
@@ -10435,7 +10443,7 @@ impl<'a> AstBuilder<'a> {
     /// * `index_type`
     #[inline]
     pub fn ts_type_indexed_access_type(
-        self,
+        &self,
         span: Span,
         object_type: TSType<'a>,
         index_type: TSType<'a>,
@@ -10455,7 +10463,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_parameter`: The type bound when the
     #[inline]
-    pub fn ts_type_infer_type<T1>(self, span: Span, type_parameter: T1) -> TSType<'a>
+    pub fn ts_type_infer_type<T1>(&self, span: Span, type_parameter: T1) -> TSType<'a>
     where
         T1: IntoIn<'a, Box<'a, TSTypeParameter<'a>>>,
     {
@@ -10470,7 +10478,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `types`
     #[inline]
-    pub fn ts_type_intersection_type(self, span: Span, types: Vec<'a, TSType<'a>>) -> TSType<'a> {
+    pub fn ts_type_intersection_type(&self, span: Span, types: Vec<'a, TSType<'a>>) -> TSType<'a> {
         TSType::TSIntersectionType(self.alloc_ts_intersection_type(span, types))
     }
 
@@ -10482,7 +10490,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `literal`
     #[inline]
-    pub fn ts_type_literal_type(self, span: Span, literal: TSLiteral<'a>) -> TSType<'a> {
+    pub fn ts_type_literal_type(&self, span: Span, literal: TSLiteral<'a>) -> TSType<'a> {
         TSType::TSLiteralType(self.alloc_ts_literal_type(span, literal))
     }
 
@@ -10499,7 +10507,7 @@ impl<'a> AstBuilder<'a> {
     /// * `readonly`: Readonly modifier before keyed index signature
     #[inline]
     pub fn ts_type_mapped_type<T1>(
-        self,
+        &self,
         span: Span,
         type_parameter: T1,
         name_type: Option<TSType<'a>>,
@@ -10534,7 +10542,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_type_mapped_type_with_scope_id<T1>(
-        self,
+        &self,
         span: Span,
         type_parameter: T1,
         name_type: Option<TSType<'a>>,
@@ -10568,7 +10576,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn ts_type_named_tuple_member(
-        self,
+        &self,
         span: Span,
         label: IdentifierName<'a>,
         element_type: TSTupleElement<'a>,
@@ -10592,7 +10600,7 @@ impl<'a> AstBuilder<'a> {
     /// * `types`: The interpolated expressions in the template literal.
     #[inline]
     pub fn ts_type_template_literal_type(
-        self,
+        &self,
         span: Span,
         quasis: Vec<'a, TemplateElement<'a>>,
         types: Vec<'a, TSType<'a>>,
@@ -10607,7 +10615,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_this_type(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_this_type(&self, span: Span) -> TSType<'a> {
         TSType::TSThisType(self.alloc_ts_this_type(span))
     }
 
@@ -10620,7 +10628,7 @@ impl<'a> AstBuilder<'a> {
     /// * `element_types`
     #[inline]
     pub fn ts_type_tuple_type(
-        self,
+        &self,
         span: Span,
         element_types: Vec<'a, TSTupleElement<'a>>,
     ) -> TSType<'a> {
@@ -10635,7 +10643,11 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `members`
     #[inline]
-    pub fn ts_type_type_literal(self, span: Span, members: Vec<'a, TSSignature<'a>>) -> TSType<'a> {
+    pub fn ts_type_type_literal(
+        &self,
+        span: Span,
+        members: Vec<'a, TSSignature<'a>>,
+    ) -> TSType<'a> {
         TSType::TSTypeLiteral(self.alloc_ts_type_literal(span, members))
     }
 
@@ -10649,7 +10661,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`: The type being operated on
     #[inline]
     pub fn ts_type_type_operator_type(
-        self,
+        &self,
         span: Span,
         operator: TSTypeOperatorOperator,
         type_annotation: TSType<'a>,
@@ -10668,7 +10680,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn ts_type_type_predicate<T1>(
-        self,
+        &self,
         span: Span,
         parameter_name: TSTypePredicateName<'a>,
         asserts: bool,
@@ -10695,7 +10707,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn ts_type_type_query<T1>(
-        self,
+        &self,
         span: Span,
         expr_name: TSTypeQueryExprName<'a>,
         type_arguments: T1,
@@ -10716,7 +10728,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn ts_type_type_reference<T1>(
-        self,
+        &self,
         span: Span,
         type_name: TSTypeName<'a>,
         type_arguments: T1,
@@ -10735,7 +10747,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `types`: The types in the union.
     #[inline]
-    pub fn ts_type_union_type(self, span: Span, types: Vec<'a, TSType<'a>>) -> TSType<'a> {
+    pub fn ts_type_union_type(&self, span: Span, types: Vec<'a, TSType<'a>>) -> TSType<'a> {
         TSType::TSUnionType(self.alloc_ts_union_type(span, types))
     }
 
@@ -10747,7 +10759,11 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
     #[inline]
-    pub fn ts_type_parenthesized_type(self, span: Span, type_annotation: TSType<'a>) -> TSType<'a> {
+    pub fn ts_type_parenthesized_type(
+        &self,
+        span: Span,
+        type_annotation: TSType<'a>,
+    ) -> TSType<'a> {
         TSType::TSParenthesizedType(self.alloc_ts_parenthesized_type(span, type_annotation))
     }
 
@@ -10761,7 +10777,7 @@ impl<'a> AstBuilder<'a> {
     /// * `postfix`: Was `?` after the type annotation?
     #[inline]
     pub fn ts_type_js_doc_nullable_type(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
         postfix: bool,
@@ -10779,7 +10795,7 @@ impl<'a> AstBuilder<'a> {
     /// * `postfix`
     #[inline]
     pub fn ts_type_js_doc_non_nullable_type(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
         postfix: bool,
@@ -10798,7 +10814,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_js_doc_unknown_type(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_js_doc_unknown_type(&self, span: Span) -> TSType<'a> {
         TSType::JSDocUnknownType(self.alloc_js_doc_unknown_type(span))
     }
 
@@ -10815,7 +10831,7 @@ impl<'a> AstBuilder<'a> {
     /// * `false_type`: The type evaluated to if the test is false.
     #[inline]
     pub fn ts_conditional_type(
-        self,
+        &self,
         span: Span,
         check_type: TSType<'a>,
         extends_type: TSType<'a>,
@@ -10845,7 +10861,7 @@ impl<'a> AstBuilder<'a> {
     /// * `false_type`: The type evaluated to if the test is false.
     #[inline]
     pub fn alloc_ts_conditional_type(
-        self,
+        &self,
         span: Span,
         check_type: TSType<'a>,
         extends_type: TSType<'a>,
@@ -10872,7 +10888,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_conditional_type_with_scope_id(
-        self,
+        &self,
         span: Span,
         check_type: TSType<'a>,
         extends_type: TSType<'a>,
@@ -10904,7 +10920,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_ts_conditional_type_with_scope_id(
-        self,
+        &self,
         span: Span,
         check_type: TSType<'a>,
         extends_type: TSType<'a>,
@@ -10934,7 +10950,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `types`: The types in the union.
     #[inline]
-    pub fn ts_union_type(self, span: Span, types: Vec<'a, TSType<'a>>) -> TSUnionType<'a> {
+    pub fn ts_union_type(&self, span: Span, types: Vec<'a, TSType<'a>>) -> TSUnionType<'a> {
         TSUnionType { span, types }
     }
 
@@ -10948,7 +10964,7 @@ impl<'a> AstBuilder<'a> {
     /// * `types`: The types in the union.
     #[inline]
     pub fn alloc_ts_union_type(
-        self,
+        &self,
         span: Span,
         types: Vec<'a, TSType<'a>>,
     ) -> Box<'a, TSUnionType<'a>> {
@@ -10965,7 +10981,7 @@ impl<'a> AstBuilder<'a> {
     /// * `types`
     #[inline]
     pub fn ts_intersection_type(
-        self,
+        &self,
         span: Span,
         types: Vec<'a, TSType<'a>>,
     ) -> TSIntersectionType<'a> {
@@ -10982,7 +10998,7 @@ impl<'a> AstBuilder<'a> {
     /// * `types`
     #[inline]
     pub fn alloc_ts_intersection_type(
-        self,
+        &self,
         span: Span,
         types: Vec<'a, TSType<'a>>,
     ) -> Box<'a, TSIntersectionType<'a>> {
@@ -10999,7 +11015,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn ts_parenthesized_type(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
     ) -> TSParenthesizedType<'a> {
@@ -11016,7 +11032,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn alloc_ts_parenthesized_type(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
     ) -> Box<'a, TSParenthesizedType<'a>> {
@@ -11034,7 +11050,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`: The type being operated on
     #[inline]
     pub fn ts_type_operator(
-        self,
+        &self,
         span: Span,
         operator: TSTypeOperatorOperator,
         type_annotation: TSType<'a>,
@@ -11053,7 +11069,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`: The type being operated on
     #[inline]
     pub fn alloc_ts_type_operator(
-        self,
+        &self,
         span: Span,
         operator: TSTypeOperatorOperator,
         type_annotation: TSType<'a>,
@@ -11070,7 +11086,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `element_type`
     #[inline]
-    pub fn ts_array_type(self, span: Span, element_type: TSType<'a>) -> TSArrayType<'a> {
+    pub fn ts_array_type(&self, span: Span, element_type: TSType<'a>) -> TSArrayType<'a> {
         TSArrayType { span, element_type }
     }
 
@@ -11084,7 +11100,7 @@ impl<'a> AstBuilder<'a> {
     /// * `element_type`
     #[inline]
     pub fn alloc_ts_array_type(
-        self,
+        &self,
         span: Span,
         element_type: TSType<'a>,
     ) -> Box<'a, TSArrayType<'a>> {
@@ -11102,7 +11118,7 @@ impl<'a> AstBuilder<'a> {
     /// * `index_type`
     #[inline]
     pub fn ts_indexed_access_type(
-        self,
+        &self,
         span: Span,
         object_type: TSType<'a>,
         index_type: TSType<'a>,
@@ -11121,7 +11137,7 @@ impl<'a> AstBuilder<'a> {
     /// * `index_type`
     #[inline]
     pub fn alloc_ts_indexed_access_type(
-        self,
+        &self,
         span: Span,
         object_type: TSType<'a>,
         index_type: TSType<'a>,
@@ -11139,7 +11155,7 @@ impl<'a> AstBuilder<'a> {
     /// * `element_types`
     #[inline]
     pub fn ts_tuple_type(
-        self,
+        &self,
         span: Span,
         element_types: Vec<'a, TSTupleElement<'a>>,
     ) -> TSTupleType<'a> {
@@ -11156,7 +11172,7 @@ impl<'a> AstBuilder<'a> {
     /// * `element_types`
     #[inline]
     pub fn alloc_ts_tuple_type(
-        self,
+        &self,
         span: Span,
         element_types: Vec<'a, TSTupleElement<'a>>,
     ) -> Box<'a, TSTupleType<'a>> {
@@ -11175,7 +11191,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn ts_named_tuple_member(
-        self,
+        &self,
         span: Span,
         label: IdentifierName<'a>,
         element_type: TSTupleElement<'a>,
@@ -11196,7 +11212,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn alloc_ts_named_tuple_member(
-        self,
+        &self,
         span: Span,
         label: IdentifierName<'a>,
         element_type: TSTupleElement<'a>,
@@ -11214,7 +11230,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
     #[inline]
-    pub fn ts_optional_type(self, span: Span, type_annotation: TSType<'a>) -> TSOptionalType<'a> {
+    pub fn ts_optional_type(&self, span: Span, type_annotation: TSType<'a>) -> TSOptionalType<'a> {
         TSOptionalType { span, type_annotation }
     }
 
@@ -11228,7 +11244,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn alloc_ts_optional_type(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
     ) -> Box<'a, TSOptionalType<'a>> {
@@ -11244,7 +11260,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
     #[inline]
-    pub fn ts_rest_type(self, span: Span, type_annotation: TSType<'a>) -> TSRestType<'a> {
+    pub fn ts_rest_type(&self, span: Span, type_annotation: TSType<'a>) -> TSRestType<'a> {
         TSRestType { span, type_annotation }
     }
 
@@ -11258,7 +11274,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn alloc_ts_rest_type(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
     ) -> Box<'a, TSRestType<'a>> {
@@ -11274,7 +11290,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn ts_tuple_element_optional_type(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
     ) -> TSTupleElement<'a> {
@@ -11290,7 +11306,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn ts_tuple_element_rest_type(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
     ) -> TSTupleElement<'a> {
@@ -11305,7 +11321,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_any_keyword(self, span: Span) -> TSAnyKeyword {
+    pub fn ts_any_keyword(&self, span: Span) -> TSAnyKeyword {
         TSAnyKeyword { span }
     }
 
@@ -11317,7 +11333,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_any_keyword(self, span: Span) -> Box<'a, TSAnyKeyword> {
+    pub fn alloc_ts_any_keyword(&self, span: Span) -> Box<'a, TSAnyKeyword> {
         Box::new_in(self.ts_any_keyword(span), self.allocator)
     }
 
@@ -11329,7 +11345,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_string_keyword(self, span: Span) -> TSStringKeyword {
+    pub fn ts_string_keyword(&self, span: Span) -> TSStringKeyword {
         TSStringKeyword { span }
     }
 
@@ -11341,7 +11357,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_string_keyword(self, span: Span) -> Box<'a, TSStringKeyword> {
+    pub fn alloc_ts_string_keyword(&self, span: Span) -> Box<'a, TSStringKeyword> {
         Box::new_in(self.ts_string_keyword(span), self.allocator)
     }
 
@@ -11353,7 +11369,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_boolean_keyword(self, span: Span) -> TSBooleanKeyword {
+    pub fn ts_boolean_keyword(&self, span: Span) -> TSBooleanKeyword {
         TSBooleanKeyword { span }
     }
 
@@ -11365,7 +11381,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_boolean_keyword(self, span: Span) -> Box<'a, TSBooleanKeyword> {
+    pub fn alloc_ts_boolean_keyword(&self, span: Span) -> Box<'a, TSBooleanKeyword> {
         Box::new_in(self.ts_boolean_keyword(span), self.allocator)
     }
 
@@ -11377,7 +11393,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_number_keyword(self, span: Span) -> TSNumberKeyword {
+    pub fn ts_number_keyword(&self, span: Span) -> TSNumberKeyword {
         TSNumberKeyword { span }
     }
 
@@ -11389,7 +11405,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_number_keyword(self, span: Span) -> Box<'a, TSNumberKeyword> {
+    pub fn alloc_ts_number_keyword(&self, span: Span) -> Box<'a, TSNumberKeyword> {
         Box::new_in(self.ts_number_keyword(span), self.allocator)
     }
 
@@ -11401,7 +11417,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_never_keyword(self, span: Span) -> TSNeverKeyword {
+    pub fn ts_never_keyword(&self, span: Span) -> TSNeverKeyword {
         TSNeverKeyword { span }
     }
 
@@ -11413,7 +11429,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_never_keyword(self, span: Span) -> Box<'a, TSNeverKeyword> {
+    pub fn alloc_ts_never_keyword(&self, span: Span) -> Box<'a, TSNeverKeyword> {
         Box::new_in(self.ts_never_keyword(span), self.allocator)
     }
 
@@ -11425,7 +11441,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_intrinsic_keyword(self, span: Span) -> TSIntrinsicKeyword {
+    pub fn ts_intrinsic_keyword(&self, span: Span) -> TSIntrinsicKeyword {
         TSIntrinsicKeyword { span }
     }
 
@@ -11437,7 +11453,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_intrinsic_keyword(self, span: Span) -> Box<'a, TSIntrinsicKeyword> {
+    pub fn alloc_ts_intrinsic_keyword(&self, span: Span) -> Box<'a, TSIntrinsicKeyword> {
         Box::new_in(self.ts_intrinsic_keyword(span), self.allocator)
     }
 
@@ -11449,7 +11465,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_unknown_keyword(self, span: Span) -> TSUnknownKeyword {
+    pub fn ts_unknown_keyword(&self, span: Span) -> TSUnknownKeyword {
         TSUnknownKeyword { span }
     }
 
@@ -11461,7 +11477,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_unknown_keyword(self, span: Span) -> Box<'a, TSUnknownKeyword> {
+    pub fn alloc_ts_unknown_keyword(&self, span: Span) -> Box<'a, TSUnknownKeyword> {
         Box::new_in(self.ts_unknown_keyword(span), self.allocator)
     }
 
@@ -11473,7 +11489,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_null_keyword(self, span: Span) -> TSNullKeyword {
+    pub fn ts_null_keyword(&self, span: Span) -> TSNullKeyword {
         TSNullKeyword { span }
     }
 
@@ -11485,7 +11501,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_null_keyword(self, span: Span) -> Box<'a, TSNullKeyword> {
+    pub fn alloc_ts_null_keyword(&self, span: Span) -> Box<'a, TSNullKeyword> {
         Box::new_in(self.ts_null_keyword(span), self.allocator)
     }
 
@@ -11497,7 +11513,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_undefined_keyword(self, span: Span) -> TSUndefinedKeyword {
+    pub fn ts_undefined_keyword(&self, span: Span) -> TSUndefinedKeyword {
         TSUndefinedKeyword { span }
     }
 
@@ -11509,7 +11525,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_undefined_keyword(self, span: Span) -> Box<'a, TSUndefinedKeyword> {
+    pub fn alloc_ts_undefined_keyword(&self, span: Span) -> Box<'a, TSUndefinedKeyword> {
         Box::new_in(self.ts_undefined_keyword(span), self.allocator)
     }
 
@@ -11521,7 +11537,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_void_keyword(self, span: Span) -> TSVoidKeyword {
+    pub fn ts_void_keyword(&self, span: Span) -> TSVoidKeyword {
         TSVoidKeyword { span }
     }
 
@@ -11533,7 +11549,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_void_keyword(self, span: Span) -> Box<'a, TSVoidKeyword> {
+    pub fn alloc_ts_void_keyword(&self, span: Span) -> Box<'a, TSVoidKeyword> {
         Box::new_in(self.ts_void_keyword(span), self.allocator)
     }
 
@@ -11545,7 +11561,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_symbol_keyword(self, span: Span) -> TSSymbolKeyword {
+    pub fn ts_symbol_keyword(&self, span: Span) -> TSSymbolKeyword {
         TSSymbolKeyword { span }
     }
 
@@ -11557,7 +11573,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_symbol_keyword(self, span: Span) -> Box<'a, TSSymbolKeyword> {
+    pub fn alloc_ts_symbol_keyword(&self, span: Span) -> Box<'a, TSSymbolKeyword> {
         Box::new_in(self.ts_symbol_keyword(span), self.allocator)
     }
 
@@ -11569,7 +11585,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_this_type(self, span: Span) -> TSThisType {
+    pub fn ts_this_type(&self, span: Span) -> TSThisType {
         TSThisType { span }
     }
 
@@ -11581,7 +11597,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_this_type(self, span: Span) -> Box<'a, TSThisType> {
+    pub fn alloc_ts_this_type(&self, span: Span) -> Box<'a, TSThisType> {
         Box::new_in(self.ts_this_type(span), self.allocator)
     }
 
@@ -11593,7 +11609,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_object_keyword(self, span: Span) -> TSObjectKeyword {
+    pub fn ts_object_keyword(&self, span: Span) -> TSObjectKeyword {
         TSObjectKeyword { span }
     }
 
@@ -11605,7 +11621,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_object_keyword(self, span: Span) -> Box<'a, TSObjectKeyword> {
+    pub fn alloc_ts_object_keyword(&self, span: Span) -> Box<'a, TSObjectKeyword> {
         Box::new_in(self.ts_object_keyword(span), self.allocator)
     }
 
@@ -11617,7 +11633,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_big_int_keyword(self, span: Span) -> TSBigIntKeyword {
+    pub fn ts_big_int_keyword(&self, span: Span) -> TSBigIntKeyword {
         TSBigIntKeyword { span }
     }
 
@@ -11629,7 +11645,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_big_int_keyword(self, span: Span) -> Box<'a, TSBigIntKeyword> {
+    pub fn alloc_ts_big_int_keyword(&self, span: Span) -> Box<'a, TSBigIntKeyword> {
         Box::new_in(self.ts_big_int_keyword(span), self.allocator)
     }
 
@@ -11644,7 +11660,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn ts_type_reference<T1>(
-        self,
+        &self,
         span: Span,
         type_name: TSTypeName<'a>,
         type_arguments: T1,
@@ -11666,7 +11682,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn alloc_ts_type_reference<T1>(
-        self,
+        &self,
         span: Span,
         type_name: TSTypeName<'a>,
         type_arguments: T1,
@@ -11685,7 +11701,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     #[inline]
-    pub fn ts_type_name_identifier_reference<A1>(self, span: Span, name: A1) -> TSTypeName<'a>
+    pub fn ts_type_name_identifier_reference<A1>(&self, span: Span, name: A1) -> TSTypeName<'a>
     where
         A1: Into<Atom<'a>>,
     {
@@ -11702,7 +11718,7 @@ impl<'a> AstBuilder<'a> {
     /// * `reference_id`: Reference ID
     #[inline]
     pub fn ts_type_name_identifier_reference_with_reference_id<A1>(
-        self,
+        &self,
         span: Span,
         name: A1,
         reference_id: ReferenceId,
@@ -11727,7 +11743,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn ts_type_name_qualified_name(
-        self,
+        &self,
         span: Span,
         left: TSTypeName<'a>,
         right: IdentifierName<'a>,
@@ -11746,7 +11762,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn ts_qualified_name(
-        self,
+        &self,
         span: Span,
         left: TSTypeName<'a>,
         right: IdentifierName<'a>,
@@ -11765,7 +11781,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn alloc_ts_qualified_name(
-        self,
+        &self,
         span: Span,
         left: TSTypeName<'a>,
         right: IdentifierName<'a>,
@@ -11783,7 +11799,7 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     #[inline]
     pub fn ts_type_parameter_instantiation(
-        self,
+        &self,
         span: Span,
         params: Vec<'a, TSType<'a>>,
     ) -> TSTypeParameterInstantiation<'a> {
@@ -11800,7 +11816,7 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     #[inline]
     pub fn alloc_ts_type_parameter_instantiation(
-        self,
+        &self,
         span: Span,
         params: Vec<'a, TSType<'a>>,
     ) -> Box<'a, TSTypeParameterInstantiation<'a>> {
@@ -11822,7 +11838,7 @@ impl<'a> AstBuilder<'a> {
     /// * `const`: Was a `const` modifier keyword present?
     #[inline]
     pub fn ts_type_parameter(
-        self,
+        &self,
         span: Span,
         name: BindingIdentifier<'a>,
         constraint: Option<TSType<'a>>,
@@ -11849,7 +11865,7 @@ impl<'a> AstBuilder<'a> {
     /// * `const`: Was a `const` modifier keyword present?
     #[inline]
     pub fn alloc_ts_type_parameter(
-        self,
+        &self,
         span: Span,
         name: BindingIdentifier<'a>,
         constraint: Option<TSType<'a>>,
@@ -11874,7 +11890,7 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     #[inline]
     pub fn ts_type_parameter_declaration(
-        self,
+        &self,
         span: Span,
         params: Vec<'a, TSTypeParameter<'a>>,
     ) -> TSTypeParameterDeclaration<'a> {
@@ -11891,7 +11907,7 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     #[inline]
     pub fn alloc_ts_type_parameter_declaration(
-        self,
+        &self,
         span: Span,
         params: Vec<'a, TSTypeParameter<'a>>,
     ) -> Box<'a, TSTypeParameterDeclaration<'a>> {
@@ -11911,7 +11927,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn ts_type_alias_declaration<T1>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -11944,7 +11960,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn alloc_ts_type_alias_declaration<T1>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -11974,7 +11990,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_type_alias_declaration_with_scope_id<T1>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -12009,7 +12025,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_ts_type_alias_declaration_with_scope_id<T1>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -12041,7 +12057,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn ts_class_implements<T1>(
-        self,
+        &self,
         span: Span,
         expression: TSTypeName<'a>,
         type_arguments: T1,
@@ -12070,7 +12086,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`: `true` for `declare interface Foo {}`
     #[inline]
     pub fn ts_interface_declaration<T1, T2>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -12107,7 +12123,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`: `true` for `declare interface Foo {}`
     #[inline]
     pub fn alloc_ts_interface_declaration<T1, T2>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -12140,7 +12156,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_interface_declaration_with_scope_id<T1, T2>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -12179,7 +12195,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_ts_interface_declaration_with_scope_id<T1, T2>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -12216,7 +12232,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn ts_interface_body(
-        self,
+        &self,
         span: Span,
         body: Vec<'a, TSSignature<'a>>,
     ) -> TSInterfaceBody<'a> {
@@ -12233,7 +12249,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn alloc_ts_interface_body(
-        self,
+        &self,
         span: Span,
         body: Vec<'a, TSSignature<'a>>,
     ) -> Box<'a, TSInterfaceBody<'a>> {
@@ -12254,7 +12270,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn ts_property_signature<T1>(
-        self,
+        &self,
         span: Span,
         computed: bool,
         optional: bool,
@@ -12289,7 +12305,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn alloc_ts_property_signature<T1>(
-        self,
+        &self,
         span: Span,
         computed: bool,
         optional: bool,
@@ -12318,7 +12334,7 @@ impl<'a> AstBuilder<'a> {
     /// * `static`
     #[inline]
     pub fn ts_signature_index_signature<T1>(
-        self,
+        &self,
         span: Span,
         parameters: Vec<'a, TSIndexSignatureName<'a>>,
         type_annotation: T1,
@@ -12350,7 +12366,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn ts_signature_property_signature<T1>(
-        self,
+        &self,
         span: Span,
         computed: bool,
         optional: bool,
@@ -12383,7 +12399,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`
     #[inline]
     pub fn ts_signature_call_signature_declaration<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         this_param: T2,
@@ -12416,7 +12432,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`
     #[inline]
     pub fn ts_signature_construct_signature_declaration<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         params: T2,
@@ -12447,7 +12463,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_signature_construct_signature_declaration_with_scope_id<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         params: T2,
@@ -12486,7 +12502,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`
     #[inline]
     pub fn ts_signature_method_signature<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         key: PropertyKey<'a>,
         computed: bool,
@@ -12533,7 +12549,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_signature_method_signature_with_scope_id<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         key: PropertyKey<'a>,
         computed: bool,
@@ -12578,7 +12594,7 @@ impl<'a> AstBuilder<'a> {
     /// * `static`
     #[inline]
     pub fn ts_index_signature<T1>(
-        self,
+        &self,
         span: Span,
         parameters: Vec<'a, TSIndexSignatureName<'a>>,
         type_annotation: T1,
@@ -12610,7 +12626,7 @@ impl<'a> AstBuilder<'a> {
     /// * `static`
     #[inline]
     pub fn alloc_ts_index_signature<T1>(
-        self,
+        &self,
         span: Span,
         parameters: Vec<'a, TSIndexSignatureName<'a>>,
         type_annotation: T1,
@@ -12639,7 +12655,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`
     #[inline]
     pub fn ts_call_signature_declaration<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         this_param: T2,
@@ -12674,7 +12690,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`
     #[inline]
     pub fn alloc_ts_call_signature_declaration<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         this_param: T2,
@@ -12716,7 +12732,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`
     #[inline]
     pub fn ts_method_signature<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         key: PropertyKey<'a>,
         computed: bool,
@@ -12764,7 +12780,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`
     #[inline]
     pub fn alloc_ts_method_signature<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         key: PropertyKey<'a>,
         computed: bool,
@@ -12815,7 +12831,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_method_signature_with_scope_id<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         key: PropertyKey<'a>,
         computed: bool,
@@ -12865,7 +12881,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_ts_method_signature_with_scope_id<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         key: PropertyKey<'a>,
         computed: bool,
@@ -12912,7 +12928,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`
     #[inline]
     pub fn ts_construct_signature_declaration<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         params: T2,
@@ -12944,7 +12960,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`
     #[inline]
     pub fn alloc_ts_construct_signature_declaration<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         params: T2,
@@ -12974,7 +12990,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_construct_signature_declaration_with_scope_id<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         params: T2,
@@ -13008,7 +13024,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_ts_construct_signature_declaration_with_scope_id<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         params: T2,
@@ -13040,7 +13056,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn ts_index_signature_name<A1, T1>(
-        self,
+        &self,
         span: Span,
         name: A1,
         type_annotation: T1,
@@ -13064,7 +13080,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn ts_interface_heritage<T1>(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
         type_arguments: T1,
@@ -13091,7 +13107,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn ts_type_predicate<T1>(
-        self,
+        &self,
         span: Span,
         parameter_name: TSTypePredicateName<'a>,
         asserts: bool,
@@ -13120,7 +13136,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn alloc_ts_type_predicate<T1>(
-        self,
+        &self,
         span: Span,
         parameter_name: TSTypePredicateName<'a>,
         asserts: bool,
@@ -13144,7 +13160,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`
     #[inline]
     pub fn ts_type_predicate_name_identifier<A1>(
-        self,
+        &self,
         span: Span,
         name: A1,
     ) -> TSTypePredicateName<'a>
@@ -13159,7 +13175,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_predicate_name_this(self, span: Span) -> TSTypePredicateName<'a> {
+    pub fn ts_type_predicate_name_this(&self, span: Span) -> TSTypePredicateName<'a> {
         TSTypePredicateName::This(self.ts_this_type(span))
     }
 
@@ -13176,7 +13192,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn ts_module_declaration(
-        self,
+        &self,
         span: Span,
         id: TSModuleDeclarationName<'a>,
         body: Option<TSModuleDeclarationBody<'a>>,
@@ -13199,7 +13215,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn alloc_ts_module_declaration(
-        self,
+        &self,
         span: Span,
         id: TSModuleDeclarationName<'a>,
         body: Option<TSModuleDeclarationBody<'a>>,
@@ -13223,7 +13239,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_module_declaration_with_scope_id(
-        self,
+        &self,
         span: Span,
         id: TSModuleDeclarationName<'a>,
         body: Option<TSModuleDeclarationBody<'a>>,
@@ -13248,7 +13264,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_ts_module_declaration_with_scope_id(
-        self,
+        &self,
         span: Span,
         id: TSModuleDeclarationName<'a>,
         body: Option<TSModuleDeclarationBody<'a>>,
@@ -13269,7 +13285,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The identifier name being bound.
     #[inline]
     pub fn ts_module_declaration_name_identifier<A1>(
-        self,
+        &self,
         span: Span,
         name: A1,
     ) -> TSModuleDeclarationName<'a>
@@ -13287,7 +13303,7 @@ impl<'a> AstBuilder<'a> {
     /// * `symbol_id`: Unique identifier for this binding.
     #[inline]
     pub fn ts_module_declaration_name_identifier_with_symbol_id<A1>(
-        self,
+        &self,
         span: Span,
         name: A1,
         symbol_id: SymbolId,
@@ -13308,7 +13324,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
     pub fn ts_module_declaration_name_string_literal<A1>(
-        self,
+        &self,
         span: Span,
         value: A1,
         raw: Option<Atom<'a>>,
@@ -13328,7 +13344,7 @@ impl<'a> AstBuilder<'a> {
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
     pub fn ts_module_declaration_name_string_literal_with_lone_surrogates<A1>(
-        self,
+        &self,
         span: Span,
         value: A1,
         raw: Option<Atom<'a>>,
@@ -13357,7 +13373,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn ts_module_declaration_body_module_declaration(
-        self,
+        &self,
         span: Span,
         id: TSModuleDeclarationName<'a>,
         body: Option<TSModuleDeclarationBody<'a>>,
@@ -13382,7 +13398,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_module_declaration_body_module_declaration_with_scope_id(
-        self,
+        &self,
         span: Span,
         id: TSModuleDeclarationName<'a>,
         body: Option<TSModuleDeclarationBody<'a>>,
@@ -13405,7 +13421,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn ts_module_declaration_body_module_block(
-        self,
+        &self,
         span: Span,
         directives: Vec<'a, Directive<'a>>,
         body: Vec<'a, Statement<'a>>,
@@ -13424,7 +13440,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn ts_module_block(
-        self,
+        &self,
         span: Span,
         directives: Vec<'a, Directive<'a>>,
         body: Vec<'a, Statement<'a>>,
@@ -13443,7 +13459,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn alloc_ts_module_block(
-        self,
+        &self,
         span: Span,
         directives: Vec<'a, Directive<'a>>,
         body: Vec<'a, Statement<'a>>,
@@ -13461,7 +13477,7 @@ impl<'a> AstBuilder<'a> {
     /// * `members`
     #[inline]
     pub fn ts_type_literal(
-        self,
+        &self,
         span: Span,
         members: Vec<'a, TSSignature<'a>>,
     ) -> TSTypeLiteral<'a> {
@@ -13478,7 +13494,7 @@ impl<'a> AstBuilder<'a> {
     /// * `members`
     #[inline]
     pub fn alloc_ts_type_literal(
-        self,
+        &self,
         span: Span,
         members: Vec<'a, TSSignature<'a>>,
     ) -> Box<'a, TSTypeLiteral<'a>> {
@@ -13494,7 +13510,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_parameter`: The type bound when the
     #[inline]
-    pub fn ts_infer_type<T1>(self, span: Span, type_parameter: T1) -> TSInferType<'a>
+    pub fn ts_infer_type<T1>(&self, span: Span, type_parameter: T1) -> TSInferType<'a>
     where
         T1: IntoIn<'a, Box<'a, TSTypeParameter<'a>>>,
     {
@@ -13510,7 +13526,11 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_parameter`: The type bound when the
     #[inline]
-    pub fn alloc_ts_infer_type<T1>(self, span: Span, type_parameter: T1) -> Box<'a, TSInferType<'a>>
+    pub fn alloc_ts_infer_type<T1>(
+        &self,
+        span: Span,
+        type_parameter: T1,
+    ) -> Box<'a, TSInferType<'a>>
     where
         T1: IntoIn<'a, Box<'a, TSTypeParameter<'a>>>,
     {
@@ -13528,7 +13548,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn ts_type_query<T1>(
-        self,
+        &self,
         span: Span,
         expr_name: TSTypeQueryExprName<'a>,
         type_arguments: T1,
@@ -13550,7 +13570,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn alloc_ts_type_query<T1>(
-        self,
+        &self,
         span: Span,
         expr_name: TSTypeQueryExprName<'a>,
         type_arguments: T1,
@@ -13573,7 +13593,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn ts_type_query_expr_name_import_type<T1, T2>(
-        self,
+        &self,
         span: Span,
         argument: TSType<'a>,
         options: T1,
@@ -13606,7 +13626,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn ts_import_type<T1, T2>(
-        self,
+        &self,
         span: Span,
         argument: TSType<'a>,
         options: T1,
@@ -13639,7 +13659,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn alloc_ts_import_type<T1, T2>(
-        self,
+        &self,
         span: Span,
         argument: TSType<'a>,
         options: T1,
@@ -13669,7 +13689,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`: Return type of the function.
     #[inline]
     pub fn ts_function_type<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         this_param: T2,
@@ -13705,7 +13725,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`: Return type of the function.
     #[inline]
     pub fn alloc_ts_function_type<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         this_param: T2,
@@ -13738,7 +13758,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_function_type_with_scope_id<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         this_param: T2,
@@ -13776,7 +13796,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_ts_function_type_with_scope_id<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         this_param: T2,
@@ -13816,7 +13836,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`
     #[inline]
     pub fn ts_constructor_type<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#abstract: bool,
         type_parameters: T1,
@@ -13850,7 +13870,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`
     #[inline]
     pub fn alloc_ts_constructor_type<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#abstract: bool,
         type_parameters: T1,
@@ -13882,7 +13902,7 @@ impl<'a> AstBuilder<'a> {
     /// * `readonly`: Readonly modifier before keyed index signature
     #[inline]
     pub fn ts_mapped_type<T1>(
-        self,
+        &self,
         span: Span,
         type_parameter: T1,
         name_type: Option<TSType<'a>>,
@@ -13918,7 +13938,7 @@ impl<'a> AstBuilder<'a> {
     /// * `readonly`: Readonly modifier before keyed index signature
     #[inline]
     pub fn alloc_ts_mapped_type<T1>(
-        self,
+        &self,
         span: Span,
         type_parameter: T1,
         name_type: Option<TSType<'a>>,
@@ -13957,7 +13977,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_mapped_type_with_scope_id<T1>(
-        self,
+        &self,
         span: Span,
         type_parameter: T1,
         name_type: Option<TSType<'a>>,
@@ -13995,7 +14015,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_ts_mapped_type_with_scope_id<T1>(
-        self,
+        &self,
         span: Span,
         type_parameter: T1,
         name_type: Option<TSType<'a>>,
@@ -14032,7 +14052,7 @@ impl<'a> AstBuilder<'a> {
     /// * `types`: The interpolated expressions in the template literal.
     #[inline]
     pub fn ts_template_literal_type(
-        self,
+        &self,
         span: Span,
         quasis: Vec<'a, TemplateElement<'a>>,
         types: Vec<'a, TSType<'a>>,
@@ -14051,7 +14071,7 @@ impl<'a> AstBuilder<'a> {
     /// * `types`: The interpolated expressions in the template literal.
     #[inline]
     pub fn alloc_ts_template_literal_type(
-        self,
+        &self,
         span: Span,
         quasis: Vec<'a, TemplateElement<'a>>,
         types: Vec<'a, TSType<'a>>,
@@ -14070,7 +14090,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn ts_as_expression(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
         type_annotation: TSType<'a>,
@@ -14089,7 +14109,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn alloc_ts_as_expression(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
         type_annotation: TSType<'a>,
@@ -14108,7 +14128,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`: The type `expression` must satisfy.
     #[inline]
     pub fn ts_satisfies_expression(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
         type_annotation: TSType<'a>,
@@ -14127,7 +14147,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`: The type `expression` must satisfy.
     #[inline]
     pub fn alloc_ts_satisfies_expression(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
         type_annotation: TSType<'a>,
@@ -14146,7 +14166,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn ts_type_assertion(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
         expression: Expression<'a>,
@@ -14165,7 +14185,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn alloc_ts_type_assertion(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
         expression: Expression<'a>,
@@ -14185,7 +14205,7 @@ impl<'a> AstBuilder<'a> {
     /// * `import_kind`
     #[inline]
     pub fn ts_import_equals_declaration(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         module_reference: TSModuleReference<'a>,
@@ -14206,7 +14226,7 @@ impl<'a> AstBuilder<'a> {
     /// * `import_kind`
     #[inline]
     pub fn alloc_ts_import_equals_declaration(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         module_reference: TSModuleReference<'a>,
@@ -14227,7 +14247,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn ts_module_reference_external_module_reference(
-        self,
+        &self,
         span: Span,
         expression: StringLiteral<'a>,
     ) -> TSModuleReference<'a> {
@@ -14246,7 +14266,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn ts_external_module_reference(
-        self,
+        &self,
         span: Span,
         expression: StringLiteral<'a>,
     ) -> TSExternalModuleReference<'a> {
@@ -14263,7 +14283,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn alloc_ts_external_module_reference(
-        self,
+        &self,
         span: Span,
         expression: StringLiteral<'a>,
     ) -> Box<'a, TSExternalModuleReference<'a>> {
@@ -14280,7 +14300,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn ts_non_null_expression(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> TSNonNullExpression<'a> {
@@ -14297,7 +14317,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn alloc_ts_non_null_expression(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> Box<'a, TSNonNullExpression<'a>> {
@@ -14310,7 +14330,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
     #[inline]
-    pub fn decorator(self, span: Span, expression: Expression<'a>) -> Decorator<'a> {
+    pub fn decorator(&self, span: Span, expression: Expression<'a>) -> Decorator<'a> {
         Decorator { span, expression }
     }
 
@@ -14324,7 +14344,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn ts_export_assignment(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> TSExportAssignment<'a> {
@@ -14341,7 +14361,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn alloc_ts_export_assignment(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> Box<'a, TSExportAssignment<'a>> {
@@ -14358,7 +14378,7 @@ impl<'a> AstBuilder<'a> {
     /// * `id`
     #[inline]
     pub fn ts_namespace_export_declaration(
-        self,
+        &self,
         span: Span,
         id: IdentifierName<'a>,
     ) -> TSNamespaceExportDeclaration<'a> {
@@ -14375,7 +14395,7 @@ impl<'a> AstBuilder<'a> {
     /// * `id`
     #[inline]
     pub fn alloc_ts_namespace_export_declaration(
-        self,
+        &self,
         span: Span,
         id: IdentifierName<'a>,
     ) -> Box<'a, TSNamespaceExportDeclaration<'a>> {
@@ -14393,7 +14413,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn ts_instantiation_expression<T1>(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
         type_arguments: T1,
@@ -14419,7 +14439,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn alloc_ts_instantiation_expression<T1>(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
         type_arguments: T1,
@@ -14444,7 +14464,7 @@ impl<'a> AstBuilder<'a> {
     /// * `postfix`: Was `?` after the type annotation?
     #[inline]
     pub fn js_doc_nullable_type(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
         postfix: bool,
@@ -14463,7 +14483,7 @@ impl<'a> AstBuilder<'a> {
     /// * `postfix`: Was `?` after the type annotation?
     #[inline]
     pub fn alloc_js_doc_nullable_type(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
         postfix: bool,
@@ -14482,7 +14502,7 @@ impl<'a> AstBuilder<'a> {
     /// * `postfix`
     #[inline]
     pub fn js_doc_non_nullable_type(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
         postfix: bool,
@@ -14501,7 +14521,7 @@ impl<'a> AstBuilder<'a> {
     /// * `postfix`
     #[inline]
     pub fn alloc_js_doc_non_nullable_type(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
         postfix: bool,
@@ -14517,7 +14537,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn js_doc_unknown_type(self, span: Span) -> JSDocUnknownType {
+    pub fn js_doc_unknown_type(&self, span: Span) -> JSDocUnknownType {
         JSDocUnknownType { span }
     }
 
@@ -14529,7 +14549,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_js_doc_unknown_type(self, span: Span) -> Box<'a, JSDocUnknownType> {
+    pub fn alloc_js_doc_unknown_type(&self, span: Span) -> Box<'a, JSDocUnknownType> {
         Box::new_in(self.js_doc_unknown_type(span), self.allocator)
     }
 }

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -267,7 +267,7 @@ fn generate_builder_methods_for_struct_impl(
         #fn_docs
         #params_docs
         #[inline]
-        pub fn #fn_name #generic_params (self, #fn_params) -> #struct_ty #where_clause {
+        pub fn #fn_name #generic_params (&self, #fn_params) -> #struct_ty #where_clause {
             #struct_ident { #fields }
         }
     };
@@ -291,7 +291,7 @@ fn generate_builder_methods_for_struct_impl(
         #[doc = #alloc_doc2]
         #params_docs
         #[inline]
-        pub fn #alloc_fn_name #generic_params (self, #fn_params) -> Box<'a, #struct_ty> #where_clause {
+        pub fn #alloc_fn_name #generic_params (&self, #fn_params) -> Box<'a, #struct_ty> #where_clause {
             Box::new_in(self.#fn_name(#(#args),*), self.allocator)
         }
     }
@@ -591,7 +591,7 @@ fn generate_builder_method_for_enum_variant_impl(
         #fn_docs
         #params_docs
         #[inline]
-        pub fn #fn_name #generic_params(self, #(#fn_params),*) -> #enum_ty #where_clause {
+        pub fn #fn_name #generic_params(&self, #(#fn_params),*) -> #enum_ty #where_clause {
             #enum_ident::#variant_ident(self.#inner_builder_name(#(#args),*))
         }
     }


### PR DESCRIPTION
Incomplete. This breaks a ton of code.

Remove `#[derive(Clone, Copy)]` from `AstBuilder`, so we can make it stateful. Alter codegen to make all `AstBuilder` methods take `&self` instead of `self`.

We'll need to refactor a lot of code which uses `AstBuilder` methods to work around borrow-checker problems that this change introduces.