### PR TITLE
refactor(parser): Remove Lexer peeking for js/class

### DIFF
--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -199,7 +199,7 @@ impl<'a> ParserImpl<'a> {
         );
 
         // static { block }
-        if self.at(Kind::Static) && self.peek_at(Kind::LCurly) {
+        if self.at(Kind::Static) && self.lookahead(Self::next_token_is_open_brace) {
             return self.parse_class_static_block(span);
         }
 
@@ -390,7 +390,12 @@ impl<'a> ParserImpl<'a> {
             let ident = self.parse_identifier_name();
             return Some(PropertyKey::StaticIdentifier(self.alloc(ident)));
         }
-        if self.at(Kind::Str) && self.peek_at(Kind::LParen) {
+        if self.at(Kind::Str)
+            && self.lookahead(|p| {
+                p.bump_any();
+                p.at(Kind::LParen)
+            })
+        {
             return self.try_parse(|p| {
                 let string_literal = p.parse_literal_string();
                 if string_literal.value != "constructor" {

--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -445,7 +445,7 @@ impl<'a> ParserImpl<'a> {
         Some(self.modifier(kind, self.end_span(span)))
     }
 
-    fn next_token_is_open_brace(&mut self) -> bool {
+    pub(crate) fn next_token_is_open_brace(&mut self) -> bool {
         self.bump_any();
         self.at(Kind::LCurly)
     }


### PR DESCRIPTION
Part of #11194 

Just replace, TS does the same thing this time.

> https://github.com/microsoft/TypeScript/blob/b504a1eed45e35b5f54694a1e0a09f35d0a5663c/src/compiler/parser.ts#L7730
> https://github.com/microsoft/TypeScript/blob/b504a1eed45e35b5f54694a1e0a09f35d0a5663c/src/compiler/parser.ts#L8050
