### PR TITLE
feat(transformer): expose `shorthand_properties` env option

### DIFF
--- a/crates/oxc_transformer/src/es2015/options.rs
+++ b/crates/oxc_transformer/src/es2015/options.rs
@@ -7,4 +7,7 @@ use super::ArrowFunctionsOptions;
 pub struct ES2015Options {
     #[serde(skip)]
     pub arrow_function: Option<ArrowFunctionsOptions>,
+
+    #[serde(skip)]
+    pub shorthand_properties: bool,
 }

--- a/crates/oxc_transformer/src/options/babel/plugins.rs
+++ b/crates/oxc_transformer/src/options/babel/plugins.rs
@@ -52,6 +52,7 @@ pub struct BabelPlugins {
     pub set_notation: bool,
     // ES2015
     pub arrow_function: Option<ArrowFunctionsOptions>,
+    pub shorthand_properties: bool,
     // ES2016
     pub exponentiation_operator: bool,
     // ES2017
@@ -135,6 +136,7 @@ impl TryFrom<PluginPresetEntries> for BabelPlugins {
                         .map_err(|err| p.errors.push(err))
                         .ok();
                 }
+                "transform-shorthand-properties" => p.shorthand_properties = true,
                 "transform-exponentiation-operator" => p.exponentiation_operator = true,
                 "transform-async-to-generator" => p.async_to_generator = true,
                 "transform-object-rest-spread" => {

--- a/crates/oxc_transformer/src/options/env.rs
+++ b/crates/oxc_transformer/src/options/env.rs
@@ -67,6 +67,7 @@ impl EnvOptions {
                 } else {
                     None
                 },
+                shorthand_properties: true,
             },
             es2016: ES2016Options { exponentiation_operator: true },
             es2017: ES2017Options { async_to_generator: true },
@@ -164,6 +165,7 @@ impl From<EngineTargets> for EnvOptions {
             },
             es2015: ES2015Options {
                 arrow_function: o.has_feature(ES2015ArrowFunctions).then(Default::default),
+                shorthand_properties: o.has_feature(ES2015ShorthandProperties),
             },
             es2016: ES2016Options {
                 exponentiation_operator: o.has_feature(ES2016ExponentiationOperator),

--- a/crates/oxc_transformer/src/options/mod.rs
+++ b/crates/oxc_transformer/src/options/mod.rs
@@ -203,6 +203,8 @@ impl TryFrom<&BabelOptions> for TransformOptions {
 
         let es2015 = ES2015Options {
             arrow_function: options.plugins.arrow_function.or(env.es2015.arrow_function),
+            shorthand_properties: options.plugins.shorthand_properties
+                || env.es2015.shorthand_properties,
         };
 
         let es2016 = ES2016Options {

--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -544,11 +544,16 @@ impl From<ArrowFunctionsOptions> for oxc::transformer::ArrowFunctionsOptions {
 pub struct Es2015Options {
     /// Transform arrow functions into function expressions.
     pub arrow_function: Option<ArrowFunctionsOptions>,
+    // TODO: support it
+    // pub shorthand_properties: bool,
 }
 
 impl From<Es2015Options> for oxc::transformer::ES2015Options {
     fn from(options: Es2015Options) -> Self {
-        oxc::transformer::ES2015Options { arrow_function: options.arrow_function.map(Into::into) }
+        oxc::transformer::ES2015Options {
+            arrow_function: options.arrow_function.map(Into::into),
+            shorthand_properties: false,
+        }
     }
 }
 


### PR DESCRIPTION
closes #11247

Its actual transformation logic has not been implemented. I can try to implement it later.
We can merge it later and wait for its actual logic to be implemented.