### PR TITLE
feat(linter): add auto-fix to unicorn/no-static-only-class

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
@@ -321,7 +321,7 @@ fn test() {
         (
             "class A { static foo = 2; static bar = 3; static baz() { return 2; } }",
             "const A = { foo: 2, bar: 3, baz() { return 2; }, }",
-        )
+        ),
     ];
 
     Tester::new(NoStaticOnlyClass::NAME, NoStaticOnlyClass::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
@@ -1,7 +1,7 @@
 use oxc_ast::{AstKind, ast::ClassElement};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::Span;
+use oxc_span::{GetSpan, Span};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -54,7 +54,7 @@ declare_oxc_lint!(
     NoStaticOnlyClass,
     unicorn,
     pedantic,
-    pending
+    fix_dangerous
 );
 
 impl Rule for NoStaticOnlyClass {
@@ -72,6 +72,8 @@ impl Rule for NoStaticOnlyClass {
         if class.body.body.is_empty() {
             return;
         }
+        let mut ele_arr: Vec<&ClassElement> = vec![];
+        let mut with_type_annotation = false;
         if class.body.body.iter().any(|node| {
             match node {
                 ClassElement::MethodDefinition(v) => {
@@ -86,10 +88,17 @@ impl Rule for NoStaticOnlyClass {
                 }
                 ClassElement::AccessorProperty(_)
                 | ClassElement::StaticBlock(_)
-                | ClassElement::TSIndexSignature(_) => {}
+                | ClassElement::TSIndexSignature(_)
+                 => {
+                    return true;
+                }
             }
 
             if node.r#static() {
+                ele_arr.push(node);
+                if !with_type_annotation && matches!(node, ClassElement::PropertyDefinition(v) if v.type_annotation.is_some()) {
+                    with_type_annotation = true;
+                }
                 if let Some(k) = node.property_key() {
                     return k.is_private_identifier();
                 }
@@ -99,8 +108,120 @@ impl Rule for NoStaticOnlyClass {
         }) {
             return;
         }
+        #[expect(clippy::cast_possible_truncation)]
+        ctx.diagnostic_with_dangerous_fix(no_static_only_class_diagnostic(class.span), |fixer| {
+            if with_type_annotation
+                || class.is_typescript_syntax()
+                || (class.is_expression() && class.id.is_some())
+                || !class.implements.is_empty()
+            {
+                return fixer.noop();
+            }
 
-        ctx.diagnostic(no_static_only_class_diagnostic(class.span));
+            let Some(parent) = ctx.nodes().parent_kind(node.id()) else {
+                return fixer.noop();
+            };
+
+            if (matches!(
+                parent,
+                AstKind::ExportDefaultDeclaration(_) | AstKind::ReturnStatement(_)
+            ) && class.id.is_some())
+            {
+                return fixer.noop();
+            }
+
+            let fixer = fixer.for_multifix();
+            let len = ele_arr.len();
+            let mut rule_fixes = fixer.new_fix_with_capacity(len);
+            for (idx, item) in ele_arr.iter().enumerate() {
+                match item {
+                    ClassElement::MethodDefinition(v) => {
+                        let not_last = idx != len - 1;
+                        let (key, value) = (&v.key, &v.value);
+                        let name = if v.computed {
+                            format!("[{}]", ctx.source_range(key.span()))
+                        } else {
+                            key.static_name().unwrap().to_string()
+                        };
+
+                        // we need to check is there have a trailing semicolon
+                        // ```javascript
+                        // class A {
+                        //     static a() {}; // <-- trailing semicolon
+                        // }
+                        // ```
+                        let next_start = if not_last {
+                            ele_arr[idx + 1].span().start
+                        } else {
+                            class.body.span.end
+                        };
+                        let mut search_start = item.span().end;
+                        let mut target_semicolon_pos = None;
+                        while search_start < next_start {
+                            if let Some(pos) = ctx
+                                .source_range(Span::new(search_start, next_start))
+                                .find(';')
+                                .map(|p| search_start + (p as u32))
+                            {
+                                let comments = ctx.comments_range(item.span().end..next_start);
+                                let mut is_in_comment = false;
+                                for comment in comments {
+                                    if comment.span.start < pos && comment.span.end > pos {
+                                        is_in_comment = true;
+                                        break;
+                                    }
+                                }
+                                if !is_in_comment {
+                                    target_semicolon_pos = Some(pos);
+                                    break;
+                                }
+                                search_start = pos + 1;
+                            } else {
+                                break;
+                            }
+                        }
+                        if let Some(pos) = target_semicolon_pos {
+                            rule_fixes.push(fixer.delete_range(Span::new(pos, pos + 1)));
+                        }
+                        let replacement = format!("{name}{},", ctx.source_range(value.span()));
+                        rule_fixes.push(fixer.replace(v.span, replacement));
+                    }
+                    ClassElement::PropertyDefinition(v) => {
+                        if v.type_annotation.is_some() {
+                            return fixer.noop();
+                        }
+                        let (key, value) = (&v.key, &v.value);
+                        let name = if v.computed {
+                            format!("[{}]", ctx.source_range(key.span()))
+                        } else {
+                            key.static_name().unwrap().to_string()
+                        };
+                        let value_str = if value.is_none() {
+                            "undefined"
+                        } else {
+                            ctx.source_range(value.as_ref().unwrap().span())
+                        };
+
+                        let replacement = format!("{name}: {value_str},");
+                        rule_fixes.push(fixer.replace(v.span, replacement));
+                    }
+                    _ => {}
+                }
+            }
+
+            let start = class.span.start;
+            if class.id.is_none() {
+                // just remove the class keyword
+                rule_fixes.push(fixer.delete_range(Span::new(start, start + 5)));
+            } else {
+                let id = class.id.as_ref().unwrap();
+                let target = Span::new(start, id.span.end);
+                let replacement = format!("const {} =", id.name.as_str());
+                rule_fixes.push(fixer.replace(target, replacement));
+            }
+            rule_fixes
+                .with_message("Convert to an object instead of a class with only static members.")
+        });
     }
 }
 
@@ -137,6 +258,8 @@ fn test() {
         r"const A2 = class { static #a() {}; }",
         r"const A2 = class { static #a = 1; }",
         r"class A2 { static {}; }",
+        r"class X { static foo = 2; accessor y: string = 'hello'; }",
+        r"class X { static foo = 2; static { } }",
     ];
 
     let fail = vec![
@@ -152,5 +275,51 @@ fn test() {
         r"class A { static a() {} }",
     ];
 
-    Tester::new(NoStaticOnlyClass::NAME, NoStaticOnlyClass::PLUGIN, pass, fail).test_and_snapshot();
+    let fix = vec![
+        ("class A { static a() {}; }", "const A = { a() {}, }"),
+        ("class A { static a() {} }", "const A = { a() {}, }"),
+        ("const A = class A { static a() {}; }", "const A = class A { static a() {}; }"),
+        ("class A { static constructor() {}; }", "const A = { constructor() {}, }"),
+        ("export default class A { static a() {}; }", "export default class A { static a() {}; }"),
+        ("export default class{ static a() {}; }", "export default { a() {}, }"),
+        ("export class A { static a() {}; }", "export const A = { a() {}, }"),
+        ("class A {static foo = 1}", "const A = {foo: 1,}"),
+        ("class A {static [this.a] = 1}", "const A = {[this.a]: 1,}"),
+        ("class A { static a: string; }", "class A { static a: string; }"),
+        (
+            "class A { static a() {} /** comment ;;;; */ ;}",
+            "const A = { a() {}, /** comment ;;;; */ }",
+        ),
+        (
+            "class A { static a() {}; /** comment; */ static b() {}; }",
+            "const A = { a() {}, /** comment; */ b() {}, }",
+        ),
+        (
+            "class A { static a() {} /** comment; */ ;static b() {}; }",
+            "const A = { a() {}, /** comment; */ b() {}, }",
+        ),
+        (
+            "class A { static a() {}; /** comment; */ static b() {}; /** ;comment; */ static v = 2; }",
+            "const A = { a() {}, /** comment; */ b() {}, /** ;comment; */ v: 2, }",
+        ),
+        (
+            "class A { static a() {} /** comment; */ static b() {} /** ;comment; */ static v = 2 }",
+            "const A = { a() {}, /** comment; */ b() {}, /** ;comment; */ v: 2, }",
+        ),
+        (
+            "class A { static a() {}; /** comment ;;;; */ }",
+            "const A = { a() {}, /** comment ;;;; */ }",
+        ),
+        ("function a() { return class{ static b = 2 }; }", "function a() { return { b: 2, }; }"),
+        (
+            "function a() { return class A { static b = 2 }; }",
+            "function a() { return class A { static b = 2 }; }",
+        ),
+        ("(class { static A = 2 })", "( { A: 2, })"),
+        ("(class A { static B = 2 })", "(class A { static B = 2 })"),
+    ];
+
+    Tester::new(NoStaticOnlyClass::NAME, NoStaticOnlyClass::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
@@ -278,6 +278,7 @@ fn test() {
     let fix = vec![
         ("class A { static a() {}; }", "const A = { a() {}, }"),
         ("class A { static a() {} }", "const A = { a() {}, }"),
+        ("const a = class { static bar = 2; static baz() {} }", "const a =  { bar: 2, baz() {}, }"),
         ("const A = class A { static a() {}; }", "const A = class A { static a() {}; }"),
         ("class A { static constructor() {}; }", "const A = { constructor() {}, }"),
         ("export default class A { static a() {}; }", "export default class A { static a() {}; }"),
@@ -317,6 +318,10 @@ fn test() {
         ),
         ("(class { static A = 2 })", "( { A: 2, })"),
         ("(class A { static B = 2 })", "(class A { static B = 2 })"),
+        (
+            "class A { static foo = 2; static bar = 3; static baz() { return 2; } }",
+            "const A = { foo: 2, bar: 3, baz() { return 2; }, }",
+        )
     ];
 
     Tester::new(NoStaticOnlyClass::NAME, NoStaticOnlyClass::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
@@ -322,6 +322,7 @@ fn test() {
             "class A { static foo = 2; static bar = 3; static baz() { return 2; } }",
             "const A = { foo: 2, bar: 3, baz() { return 2; }, }",
         ),
+        ("class A { static foo; }", "const A = { foo: undefined, }"),
     ];
 
     Tester::new(NoStaticOnlyClass::NAME, NoStaticOnlyClass::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/unicorn_no_static_only_class.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_static_only_class.snap
@@ -6,12 +6,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ class A { static a() {}; }
    · ──────────────────────────
    ╰────
+  help: Convert to an object instead of a class with only static members.
 
   ⚠ eslint-plugin-unicorn(no-static-only-class): Use an object instead of a class with only static members.
    ╭─[no_static_only_class.tsx:1:1]
  1 │ class A { static a() {} }
    · ─────────────────────────
    ╰────
+  help: Convert to an object instead of a class with only static members.
 
   ⚠ eslint-plugin-unicorn(no-static-only-class): Use an object instead of a class with only static members.
    ╭─[no_static_only_class.tsx:1:11]
@@ -24,12 +26,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const A = class { static a() {}; }
    ·           ────────────────────────
    ╰────
+  help: Convert to an object instead of a class with only static members.
 
   ⚠ eslint-plugin-unicorn(no-static-only-class): Use an object instead of a class with only static members.
    ╭─[no_static_only_class.tsx:1:1]
  1 │ class A { static constructor() {}; }
    · ────────────────────────────────────
    ╰────
+  help: Convert to an object instead of a class with only static members.
 
   ⚠ eslint-plugin-unicorn(no-static-only-class): Use an object instead of a class with only static members.
    ╭─[no_static_only_class.tsx:1:16]
@@ -42,21 +46,25 @@ source: crates/oxc_linter/src/tester.rs
  1 │ export default class { static a() {}; }
    ·                ────────────────────────
    ╰────
+  help: Convert to an object instead of a class with only static members.
 
   ⚠ eslint-plugin-unicorn(no-static-only-class): Use an object instead of a class with only static members.
    ╭─[no_static_only_class.tsx:1:8]
  1 │ export class A { static a() {}; }
    ·        ──────────────────────────
    ╰────
+  help: Convert to an object instead of a class with only static members.
 
   ⚠ eslint-plugin-unicorn(no-static-only-class): Use an object instead of a class with only static members.
    ╭─[no_static_only_class.tsx:1:1]
  1 │ class A {static [this.a] = 1}
    · ─────────────────────────────
    ╰────
+  help: Convert to an object instead of a class with only static members.
 
   ⚠ eslint-plugin-unicorn(no-static-only-class): Use an object instead of a class with only static members.
    ╭─[no_static_only_class.tsx:1:1]
  1 │ class A { static a() {} }
    · ─────────────────────────
    ╰────
+  help: Convert to an object instead of a class with only static members.


### PR DESCRIPTION
### Auto-fix Example
```js
class A { static a() {}; }
// const A = { a() {}, }
```

```js
export class A { static a() {}; }
// export const A = { a() {}, }
```

```js
class A {static foo = 1; static bar; }
// const A = {foo: 1, bar: undefined, }
```

```js
class A { static a() {}; /** comment ;;;; */ }
// const A = { a() {}, /** comment ;;;; */ }
```

```js
function a() { return class{ static b = 2 }; }
// function a() { return { b: 2, }; }
```