### PR TITLE
fix(parser): parse `new (import("x"))` with `preserveParens: false`

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -849,6 +849,7 @@ impl<'a> ParserImpl<'a> {
         }
 
         let rhs_span = self.start_span();
+        let is_import = self.at(Kind::Import); // Syntax Error for `new import('mod')` but not `new (import('mod'))`.
         let mut optional = false;
         let mut callee = {
             let lhs = self.parse_primary_expression();
@@ -890,7 +891,7 @@ impl<'a> ParserImpl<'a> {
             self.ast.vec()
         };
 
-        if matches!(callee, Expression::ImportExpression(_)) {
+        if is_import && matches!(callee, Expression::ImportExpression(_)) {
             self.error(diagnostics::new_dynamic_import(self.end_span(rhs_span)));
         }
 


### PR DESCRIPTION
fixes #11183

No unit tests added, I will enable `preserveParens: false` in
the conformance test in the near future.