### PR TITLE
feat(ast): add parenthesized info to `AssignmentExpression` and `UpdateExpression`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -686,6 +686,8 @@ pub struct UpdateExpression<'a> {
     pub operator: UpdateOperator,
     pub prefix: bool,
     pub argument: SimpleAssignmentTarget<'a>,
+    #[estree(skip)]
+    pub argument_parenthesized: Option<Span>,
 }
 
 /// `typeof` in `typeof a === "string"`
@@ -768,6 +770,8 @@ pub struct AssignmentExpression<'a> {
     pub operator: AssignmentOperator,
     pub left: AssignmentTarget<'a>,
     pub right: Expression<'a>,
+    #[estree(skip)]
+    pub left_parenthesized: Option<Span>,
 }
 
 inherit_variants! {

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -187,12 +187,13 @@ const _: () = {
     assert!(align_of::<Argument>() == 8);
 
     // Padding: 6 bytes
-    assert!(size_of::<UpdateExpression>() == 32);
+    assert!(size_of::<UpdateExpression>() == 48);
     assert!(align_of::<UpdateExpression>() == 8);
     assert!(offset_of!(UpdateExpression, span) == 0);
-    assert!(offset_of!(UpdateExpression, operator) == 24);
-    assert!(offset_of!(UpdateExpression, prefix) == 25);
+    assert!(offset_of!(UpdateExpression, operator) == 40);
+    assert!(offset_of!(UpdateExpression, prefix) == 41);
     assert!(offset_of!(UpdateExpression, argument) == 8);
+    assert!(offset_of!(UpdateExpression, argument_parenthesized) == 24);
 
     // Padding: 7 bytes
     assert!(size_of::<UnaryExpression>() == 32);
@@ -233,12 +234,13 @@ const _: () = {
     assert!(offset_of!(ConditionalExpression, alternate) == 40);
 
     // Padding: 7 bytes
-    assert!(size_of::<AssignmentExpression>() == 48);
+    assert!(size_of::<AssignmentExpression>() == 64);
     assert!(align_of::<AssignmentExpression>() == 8);
     assert!(offset_of!(AssignmentExpression, span) == 0);
-    assert!(offset_of!(AssignmentExpression, operator) == 40);
+    assert!(offset_of!(AssignmentExpression, operator) == 56);
     assert!(offset_of!(AssignmentExpression, left) == 8);
     assert!(offset_of!(AssignmentExpression, right) == 24);
+    assert!(offset_of!(AssignmentExpression, left_parenthesized) == 40);
 
     assert!(size_of::<AssignmentTarget>() == 16);
     assert!(align_of::<AssignmentTarget>() == 8);
@@ -1776,12 +1778,13 @@ const _: () = {
     assert!(align_of::<Argument>() == 4);
 
     // Padding: 2 bytes
-    assert!(size_of::<UpdateExpression>() == 20);
+    assert!(size_of::<UpdateExpression>() == 32);
     assert!(align_of::<UpdateExpression>() == 4);
     assert!(offset_of!(UpdateExpression, span) == 0);
-    assert!(offset_of!(UpdateExpression, operator) == 16);
-    assert!(offset_of!(UpdateExpression, prefix) == 17);
+    assert!(offset_of!(UpdateExpression, operator) == 28);
+    assert!(offset_of!(UpdateExpression, prefix) == 29);
     assert!(offset_of!(UpdateExpression, argument) == 8);
+    assert!(offset_of!(UpdateExpression, argument_parenthesized) == 16);
 
     // Padding: 3 bytes
     assert!(size_of::<UnaryExpression>() == 20);
@@ -1822,12 +1825,13 @@ const _: () = {
     assert!(offset_of!(ConditionalExpression, alternate) == 24);
 
     // Padding: 3 bytes
-    assert!(size_of::<AssignmentExpression>() == 28);
+    assert!(size_of::<AssignmentExpression>() == 40);
     assert!(align_of::<AssignmentExpression>() == 4);
     assert!(offset_of!(AssignmentExpression, span) == 0);
-    assert!(offset_of!(AssignmentExpression, operator) == 24);
+    assert!(offset_of!(AssignmentExpression, operator) == 36);
     assert!(offset_of!(AssignmentExpression, left) == 8);
     assert!(offset_of!(AssignmentExpression, right) == 16);
+    assert!(offset_of!(AssignmentExpression, left_parenthesized) == 24);
 
     assert!(size_of::<AssignmentTarget>() == 8);
     assert!(align_of::<AssignmentTarget>() == 4);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -423,6 +423,7 @@ impl<'a> AstBuilder<'a> {
     /// * `operator`
     /// * `left`
     /// * `right`
+    /// * `left_parenthesized`
     #[inline]
     pub fn expression_assignment(
         self,
@@ -430,10 +431,15 @@ impl<'a> AstBuilder<'a> {
         operator: AssignmentOperator,
         left: AssignmentTarget<'a>,
         right: Expression<'a>,
+        left_parenthesized: Option<Span>,
     ) -> Expression<'a> {
-        Expression::AssignmentExpression(
-            self.alloc_assignment_expression(span, operator, left, right),
-        )
+        Expression::AssignmentExpression(self.alloc_assignment_expression(
+            span,
+            operator,
+            left,
+            right,
+            left_parenthesized,
+        ))
     }
 
     /// Build an [`Expression::AwaitExpression`].
@@ -997,6 +1003,7 @@ impl<'a> AstBuilder<'a> {
     /// * `operator`
     /// * `prefix`
     /// * `argument`
+    /// * `argument_parenthesized`
     #[inline]
     pub fn expression_update(
         self,
@@ -1004,8 +1011,15 @@ impl<'a> AstBuilder<'a> {
         operator: UpdateOperator,
         prefix: bool,
         argument: SimpleAssignmentTarget<'a>,
+        argument_parenthesized: Option<Span>,
     ) -> Expression<'a> {
-        Expression::UpdateExpression(self.alloc_update_expression(span, operator, prefix, argument))
+        Expression::UpdateExpression(self.alloc_update_expression(
+            span,
+            operator,
+            prefix,
+            argument,
+            argument_parenthesized,
+        ))
     }
 
     /// Build an [`Expression::YieldExpression`].
@@ -2334,6 +2348,7 @@ impl<'a> AstBuilder<'a> {
     /// * `operator`
     /// * `prefix`
     /// * `argument`
+    /// * `argument_parenthesized`
     #[inline]
     pub fn update_expression(
         self,
@@ -2341,8 +2356,9 @@ impl<'a> AstBuilder<'a> {
         operator: UpdateOperator,
         prefix: bool,
         argument: SimpleAssignmentTarget<'a>,
+        argument_parenthesized: Option<Span>,
     ) -> UpdateExpression<'a> {
-        UpdateExpression { span, operator, prefix, argument }
+        UpdateExpression { span, operator, prefix, argument, argument_parenthesized }
     }
 
     /// Build an [`UpdateExpression`], and store it in the memory arena.
@@ -2355,6 +2371,7 @@ impl<'a> AstBuilder<'a> {
     /// * `operator`
     /// * `prefix`
     /// * `argument`
+    /// * `argument_parenthesized`
     #[inline]
     pub fn alloc_update_expression(
         self,
@@ -2362,8 +2379,12 @@ impl<'a> AstBuilder<'a> {
         operator: UpdateOperator,
         prefix: bool,
         argument: SimpleAssignmentTarget<'a>,
+        argument_parenthesized: Option<Span>,
     ) -> Box<'a, UpdateExpression<'a>> {
-        Box::new_in(self.update_expression(span, operator, prefix, argument), self.allocator)
+        Box::new_in(
+            self.update_expression(span, operator, prefix, argument, argument_parenthesized),
+            self.allocator,
+        )
     }
 
     /// Build an [`UnaryExpression`].
@@ -2578,6 +2599,7 @@ impl<'a> AstBuilder<'a> {
     /// * `operator`
     /// * `left`
     /// * `right`
+    /// * `left_parenthesized`
     #[inline]
     pub fn assignment_expression(
         self,
@@ -2585,8 +2607,9 @@ impl<'a> AstBuilder<'a> {
         operator: AssignmentOperator,
         left: AssignmentTarget<'a>,
         right: Expression<'a>,
+        left_parenthesized: Option<Span>,
     ) -> AssignmentExpression<'a> {
-        AssignmentExpression { span, operator, left, right }
+        AssignmentExpression { span, operator, left, right, left_parenthesized }
     }
 
     /// Build an [`AssignmentExpression`], and store it in the memory arena.
@@ -2599,6 +2622,7 @@ impl<'a> AstBuilder<'a> {
     /// * `operator`
     /// * `left`
     /// * `right`
+    /// * `left_parenthesized`
     #[inline]
     pub fn alloc_assignment_expression(
         self,
@@ -2606,8 +2630,12 @@ impl<'a> AstBuilder<'a> {
         operator: AssignmentOperator,
         left: AssignmentTarget<'a>,
         right: Expression<'a>,
+        left_parenthesized: Option<Span>,
     ) -> Box<'a, AssignmentExpression<'a>> {
-        Box::new_in(self.assignment_expression(span, operator, left, right), self.allocator)
+        Box::new_in(
+            self.assignment_expression(span, operator, left, right, left_parenthesized),
+            self.allocator,
+        )
     }
 
     /// Build a [`SimpleAssignmentTarget::AssignmentTargetIdentifier`].

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -1564,6 +1564,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for UpdateExpression<'_> {
             operator: CloneIn::clone_in(&self.operator, allocator),
             prefix: CloneIn::clone_in(&self.prefix, allocator),
             argument: CloneIn::clone_in(&self.argument, allocator),
+            argument_parenthesized: CloneIn::clone_in(&self.argument_parenthesized, allocator),
         }
     }
 
@@ -1573,6 +1574,10 @@ impl<'new_alloc> CloneIn<'new_alloc> for UpdateExpression<'_> {
             operator: CloneIn::clone_in_with_semantic_ids(&self.operator, allocator),
             prefix: CloneIn::clone_in_with_semantic_ids(&self.prefix, allocator),
             argument: CloneIn::clone_in_with_semantic_ids(&self.argument, allocator),
+            argument_parenthesized: CloneIn::clone_in_with_semantic_ids(
+                &self.argument_parenthesized,
+                allocator,
+            ),
         }
     }
 }
@@ -1692,6 +1697,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentExpression<'_> {
             operator: CloneIn::clone_in(&self.operator, allocator),
             left: CloneIn::clone_in(&self.left, allocator),
             right: CloneIn::clone_in(&self.right, allocator),
+            left_parenthesized: CloneIn::clone_in(&self.left_parenthesized, allocator),
         }
     }
 
@@ -1701,6 +1707,10 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentExpression<'_> {
             operator: CloneIn::clone_in_with_semantic_ids(&self.operator, allocator),
             left: CloneIn::clone_in_with_semantic_ids(&self.left, allocator),
             right: CloneIn::clone_in_with_semantic_ids(&self.right, allocator),
+            left_parenthesized: CloneIn::clone_in_with_semantic_ids(
+                &self.left_parenthesized,
+                allocator,
+            ),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_dummy.rs
+++ b/crates/oxc_ast/src/generated/derive_dummy.rs
@@ -344,6 +344,7 @@ impl<'a> Dummy<'a> for UpdateExpression<'a> {
             operator: Dummy::dummy(allocator),
             prefix: Dummy::dummy(allocator),
             argument: Dummy::dummy(allocator),
+            argument_parenthesized: Dummy::dummy(allocator),
         }
     }
 }
@@ -426,6 +427,7 @@ impl<'a> Dummy<'a> for AssignmentExpression<'a> {
             operator: Dummy::dummy(allocator),
             left: Dummy::dummy(allocator),
             right: Dummy::dummy(allocator),
+            left_parenthesized: Dummy::dummy(allocator),
         }
     }
 }

--- a/crates/oxc_ast_macros/src/generated/structs.rs
+++ b/crates/oxc_ast_macros/src/generated/structs.rs
@@ -150,7 +150,7 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
         ("JSXElement", StructDetails { field_order: None }),
         ("FunctionBody", StructDetails { field_order: None }),
         ("RegExpFlags", StructDetails { field_order: None }),
-        ("UpdateExpression", StructDetails { field_order: Some(&[0, 2, 3, 1]) }),
+        ("UpdateExpression", StructDetails { field_order: Some(&[0, 3, 4, 1, 2]) }),
         (
             "PropertyDefinition",
             StructDetails { field_order: Some(&[0, 5, 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13]) },
@@ -165,7 +165,7 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
         ("BindingRestElement", StructDetails { field_order: None }),
         ("IdentifierName", StructDetails { field_order: None }),
         ("Disjunction", StructDetails { field_order: None }),
-        ("AssignmentExpression", StructDetails { field_order: Some(&[0, 3, 1, 2]) }),
+        ("AssignmentExpression", StructDetails { field_order: Some(&[0, 4, 1, 2, 3]) }),
         ("AssignmentTargetRest", StructDetails { field_order: None }),
         ("TSTypeQuery", StructDetails { field_order: None }),
         ("WithClause", StructDetails { field_order: None }),

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -1681,6 +1681,9 @@ pub mod walk {
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
         visitor.visit_simple_assignment_target(&it.argument);
+        if let Some(argument_parenthesized) = &it.argument_parenthesized {
+            visitor.visit_span(argument_parenthesized);
+        }
         visitor.leave_node(kind);
     }
 
@@ -1750,6 +1753,9 @@ pub mod walk {
         visitor.visit_span(&it.span);
         visitor.visit_assignment_target(&it.left);
         visitor.visit_expression(&it.right);
+        if let Some(left_parenthesized) = &it.left_parenthesized {
+            visitor.visit_span(left_parenthesized);
+        }
         visitor.leave_node(kind);
     }
 

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -1700,6 +1700,9 @@ pub mod walk_mut {
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
         visitor.visit_simple_assignment_target(&mut it.argument);
+        if let Some(argument_parenthesized) = &mut it.argument_parenthesized {
+            visitor.visit_span(argument_parenthesized);
+        }
         visitor.leave_node(kind);
     }
 
@@ -1778,6 +1781,9 @@ pub mod walk_mut {
         visitor.visit_span(&mut it.span);
         visitor.visit_assignment_target(&mut it.left);
         visitor.visit_expression(&mut it.right);
+        if let Some(left_parenthesized) = &mut it.left_parenthesized {
+            visitor.visit_span(left_parenthesized);
+        }
         visitor.leave_node(kind);
     }
 

--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -135,6 +135,7 @@ impl<'a> ParserImpl<'a> {
                 AssignmentOperator::Assign,
                 left,
                 right,
+                None,
             );
             self.state.cover_initialized_name.insert(span, expr);
         }

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -3643,6 +3643,8 @@ pub(crate) const OFFSET_UPDATE_EXPRESSION_SPAN: usize = offset_of!(UpdateExpress
 pub(crate) const OFFSET_UPDATE_EXPRESSION_OPERATOR: usize = offset_of!(UpdateExpression, operator);
 pub(crate) const OFFSET_UPDATE_EXPRESSION_PREFIX: usize = offset_of!(UpdateExpression, prefix);
 pub(crate) const OFFSET_UPDATE_EXPRESSION_ARGUMENT: usize = offset_of!(UpdateExpression, argument);
+pub(crate) const OFFSET_UPDATE_EXPRESSION_ARGUMENT_PARENTHESIZED: usize =
+    offset_of!(UpdateExpression, argument_parenthesized);
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -3668,6 +3670,14 @@ impl<'a, 't> UpdateExpressionWithoutArgument<'a, 't> {
     #[inline]
     pub fn prefix(self) -> &'t bool {
         unsafe { &*((self.0 as *const u8).add(OFFSET_UPDATE_EXPRESSION_PREFIX) as *const bool) }
+    }
+
+    #[inline]
+    pub fn argument_parenthesized(self) -> &'t Option<Span> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_UPDATE_EXPRESSION_ARGUMENT_PARENTHESIZED)
+                as *const Option<Span>)
+        }
     }
 }
 
@@ -4053,6 +4063,8 @@ pub(crate) const OFFSET_ASSIGNMENT_EXPRESSION_OPERATOR: usize =
 pub(crate) const OFFSET_ASSIGNMENT_EXPRESSION_LEFT: usize = offset_of!(AssignmentExpression, left);
 pub(crate) const OFFSET_ASSIGNMENT_EXPRESSION_RIGHT: usize =
     offset_of!(AssignmentExpression, right);
+pub(crate) const OFFSET_ASSIGNMENT_EXPRESSION_LEFT_PARENTHESIZED: usize =
+    offset_of!(AssignmentExpression, left_parenthesized);
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -4080,6 +4092,14 @@ impl<'a, 't> AssignmentExpressionWithoutLeft<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ASSIGNMENT_EXPRESSION_RIGHT)
                 as *const Expression<'a>)
+        }
+    }
+
+    #[inline]
+    pub fn left_parenthesized(self) -> &'t Option<Span> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_ASSIGNMENT_EXPRESSION_LEFT_PARENTHESIZED)
+                as *const Option<Span>)
         }
     }
 }
@@ -4117,6 +4137,14 @@ impl<'a, 't> AssignmentExpressionWithoutRight<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ASSIGNMENT_EXPRESSION_LEFT)
                 as *const AssignmentTarget<'a>)
+        }
+    }
+
+    #[inline]
+    pub fn left_parenthesized(self) -> &'t Option<Span> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_ASSIGNMENT_EXPRESSION_LEFT_PARENTHESIZED)
+                as *const Option<Span>)
         }
     }
 }

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -252,8 +252,8 @@ function deserializeUpdateExpression(pos) {
     type: 'UpdateExpression',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    operator: deserializeUpdateOperator(pos + 24),
-    prefix: deserializeBool(pos + 25),
+    operator: deserializeUpdateOperator(pos + 40),
+    prefix: deserializeBool(pos + 41),
     argument: deserializeSimpleAssignmentTarget(pos + 8),
   };
 }
@@ -318,7 +318,7 @@ function deserializeAssignmentExpression(pos) {
     type: 'AssignmentExpression',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    operator: deserializeAssignmentOperator(pos + 40),
+    operator: deserializeAssignmentOperator(pos + 56),
     left: deserializeAssignmentTarget(pos + 8),
     right: deserializeExpression(pos + 24),
   };
@@ -4369,6 +4369,11 @@ function deserializeVecArgument(pos) {
     pos += 16;
   }
   return arr;
+}
+
+function deserializeOptionSpan(pos) {
+  if (uint8[pos] === 0) return null;
+  return deserializeSpan(pos + 8);
 }
 
 function deserializeBoxArrayAssignmentTarget(pos) {

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -284,8 +284,8 @@ function deserializeUpdateExpression(pos) {
     type: 'UpdateExpression',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    operator: deserializeUpdateOperator(pos + 24),
-    prefix: deserializeBool(pos + 25),
+    operator: deserializeUpdateOperator(pos + 40),
+    prefix: deserializeBool(pos + 41),
     argument: deserializeSimpleAssignmentTarget(pos + 8),
   };
 }
@@ -350,7 +350,7 @@ function deserializeAssignmentExpression(pos) {
     type: 'AssignmentExpression',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    operator: deserializeAssignmentOperator(pos + 40),
+    operator: deserializeAssignmentOperator(pos + 56),
     left: deserializeAssignmentTarget(pos + 8),
     right: deserializeExpression(pos + 24),
   };
@@ -4521,6 +4521,11 @@ function deserializeVecArgument(pos) {
     pos += 16;
   }
   return arr;
+}
+
+function deserializeOptionSpan(pos) {
+  if (uint8[pos] === 0) return null;
+  return deserializeSpan(pos + 8);
 }
 
 function deserializeBoxArrayAssignmentTarget(pos) {


### PR DESCRIPTION
fixes #10899
fixes #10939

To allow

* `(a)++`
* `({}) = {}`
* `(fn) = function () {};` See https://oxc.rs/docs/learn/ecmascript/grammar.html#parenthesized-expression

in codegen and formatter.