### PR TITLE
refactor(parser): use `StringBuilder` instead of `String`

### DIFF
--- a/crates/oxc_parser/src/lexer/identifier.rs
+++ b/crates/oxc_parser/src/lexer/identifier.rs
@@ -1,6 +1,6 @@
 use std::cmp::max;
 
-use oxc_allocator::String;
+use oxc_allocator::StringBuilder;
 use oxc_span::Span;
 use oxc_syntax::identifier::{
     is_identifier_part, is_identifier_part_unicode, is_identifier_start_unicode,
@@ -136,7 +136,7 @@ impl<'a> Lexer<'a> {
     pub fn identifier_backslash_handler(&mut self) -> Kind {
         // Create arena string to hold unescaped identifier.
         // We don't know how long identifier will end up being, so guess.
-        let str = String::with_capacity_in(MIN_ESCAPED_STR_LEN, self.allocator);
+        let str = StringBuilder::with_capacity_in(MIN_ESCAPED_STR_LEN, self.allocator);
 
         // Process escape and get rest of identifier
         let id = self.identifier_on_backslash(str, true);
@@ -153,7 +153,7 @@ impl<'a> Lexer<'a> {
         // will be double what we've seen so far, or `MIN_ESCAPED_STR_LEN` minimum.
         let so_far = self.source.str_from_pos_to_current(start_pos);
         let capacity = max(so_far.len() * 2, MIN_ESCAPED_STR_LEN);
-        let mut str = String::with_capacity_in(capacity, self.allocator);
+        let mut str = StringBuilder::with_capacity_in(capacity, self.allocator);
 
         // Push identifier up this point into `str`
         str.push_str(so_far);
@@ -167,7 +167,11 @@ impl<'a> Lexer<'a> {
     /// `self.source` should be positioned *on* the `\` (i.e. `\` has not been consumed yet).
     /// `str` should contain the identifier up to before the escape.
     /// `is_start` should be `true` if this is first char in the identifier, `false` otherwise.
-    fn identifier_on_backslash(&mut self, mut str: String<'a>, mut is_start: bool) -> &'a str {
+    fn identifier_on_backslash(
+        &mut self,
+        mut str: StringBuilder<'a>,
+        mut is_start: bool,
+    ) -> &'a str {
         'outer: loop {
             // Consume `\`
             self.consume_char();
@@ -201,7 +205,7 @@ impl<'a> Lexer<'a> {
         }
 
         // Convert `str` to arena slice and save to `escaped_strings`
-        let id = str.into_bump_str();
+        let id = str.into_str();
         self.save_string(true, id);
         id
     }

--- a/crates/oxc_parser/src/lexer/string.rs
+++ b/crates/oxc_parser/src/lexer/string.rs
@@ -1,6 +1,6 @@
 use std::cmp::max;
 
-use oxc_allocator::String;
+use oxc_allocator::StringBuilder;
 
 use crate::diagnostics;
 
@@ -107,7 +107,7 @@ macro_rules! handle_string_literal_escape {
         // will be double what we've seen so far, or `MIN_ESCAPED_STR_LEN` minimum.
         let so_far = $lexer.source.str_from_pos_to_current($after_opening_quote);
         let capacity = max(so_far.len() * 2, MIN_ESCAPED_STR_LEN);
-        let mut str = String::with_capacity_in(capacity, $lexer.allocator);
+        let mut str = StringBuilder::with_capacity_in(capacity, $lexer.allocator);
 
         // Push chunk before `\` into `str`.
         str.push_str(so_far);
@@ -193,7 +193,7 @@ macro_rules! handle_string_literal_escape {
         }
 
         // Convert `str` to arena slice and save to `escaped_strings`
-        $lexer.save_string(true, str.into_bump_str());
+        $lexer.save_string(true, str.into_str());
 
         Kind::Str
     }};

--- a/crates/oxc_parser/src/lexer/template.rs
+++ b/crates/oxc_parser/src/lexer/template.rs
@@ -1,6 +1,6 @@
 use std::{cmp::max, str};
 
-use oxc_allocator::String;
+use oxc_allocator::StringBuilder;
 
 use crate::diagnostics;
 
@@ -194,14 +194,14 @@ impl<'a> Lexer<'a> {
     ///
     /// # SAFETY
     /// `pos` must not be before `self.source.position()`
-    unsafe fn template_literal_create_string(&self, pos: SourcePosition<'a>) -> String<'a> {
+    unsafe fn template_literal_create_string(&self, pos: SourcePosition<'a>) -> StringBuilder<'a> {
         // Create arena string to hold modified template literal.
         // We don't know how long template literal will end up being. Take a guess that total length
         // will be double what we've seen so far, or `MIN_ESCAPED_TEMPLATE_LIT_LEN` minimum.
         // SAFETY: Caller guarantees `pos` is not before `self.source.position()`.
         let so_far = unsafe { self.source.str_from_current_to_pos_unchecked(pos) };
         let capacity = max(so_far.len() * 2, MIN_ESCAPED_TEMPLATE_LIT_LEN);
-        let mut str = String::with_capacity_in(capacity, self.allocator);
+        let mut str = StringBuilder::with_capacity_in(capacity, self.allocator);
         str.push_str(so_far);
         str
     }
@@ -212,7 +212,7 @@ impl<'a> Lexer<'a> {
     /// `chunk_start` must not be after `pos`.
     unsafe fn template_literal_escaped(
         &mut self,
-        mut str: String<'a>,
+        mut str: StringBuilder<'a>,
         pos: SourcePosition<'a>,
         mut chunk_start: SourcePosition<'a>,
         mut is_valid_escape_sequence: bool,
@@ -379,7 +379,7 @@ impl<'a> Lexer<'a> {
             },
         };
 
-        self.save_template_string(is_valid_escape_sequence, str.into_bump_str());
+        self.save_template_string(is_valid_escape_sequence, str.into_str());
 
         ret
     }


### PR DESCRIPTION
Replace usage of `String` with `StringBuilder` (introduced in #11257) in parser.