### PR TITLE
fix(parser): fix "Enum member must have initializer." false positive

### DIFF
--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -286,7 +286,7 @@ pub fn check_ts_enum_declaration<'a>(decl: &TSEnumDeclaration<'a>, ctx: &Semanti
         #[expect(clippy::unnested_or_patterns)]
         if let Some(initializer) = &member.initializer {
             need_initializer = !matches!(
-                initializer,
+                initializer.without_parentheses(),
                 // A = 1
                 Expression::NumericLiteral(_)
                     // B = A

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -2,7 +2,7 @@ commit: 81c95189
 
 parser_typescript Summary:
 AST Parsed     : 6530/6537 (99.89%)
-Positive Passed: 6518/6537 (99.71%)
+Positive Passed: 6519/6537 (99.72%)
 Negative Passed: 1324/5763 (22.97%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration24.ts
 
@@ -9118,16 +9118,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/prope
      ·                ─────────
  291 │         prototype() {} // ok
      ╰────
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum1.ts
-
-  × Enum member must have initializer.
-    ╭─[typescript/tests/cases/conformance/constEnums/constEnum1.ts:9:5]
-  8 │     c = (a+1),
-  9 │     e,
-    ·     ─
- 10 │     d = ~e,
-    ╰────
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInScriptContext1.ts
 

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -35088,7 +35088,15 @@ after transform: ["const"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum1.ts
-Enum member must have initializer.
+Bindings mismatch:
+after transform: ScopeId(1): ["E", "a", "b", "c", "d", "e", "f", "g", "h"]
+rebuilt        : ScopeId(1): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "E":
+after transform: SymbolId(0): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum3.ts
 Scope children mismatch:


### PR DESCRIPTION
when parens are encountered in enum member value.