### PR TITLE
feat(napi/minify): `preserve_parens: false` when parsing

### DIFF
--- a/napi/minify/src/lib.rs
+++ b/napi/minify/src/lib.rs
@@ -17,7 +17,7 @@ use napi_derive::napi;
 use oxc_allocator::Allocator;
 use oxc_codegen::{Codegen, CodegenOptions};
 use oxc_minifier::Minifier;
-use oxc_parser::Parser;
+use oxc_parser::{ParseOptions, Parser};
 use oxc_span::SourceType;
 
 use crate::options::{MinifyOptions, MinifyResult};
@@ -40,7 +40,10 @@ pub fn minify(
 
     let source_type = SourceType::from_path(&filename).unwrap_or_default();
 
-    let mut program = Parser::new(&allocator, &source_text, source_type).parse().program;
+    let mut program = Parser::new(&allocator, &source_text, source_type)
+        .with_options(ParseOptions { preserve_parens: false, ..ParseOptions::default() })
+        .parse()
+        .program;
 
     let scoping = Minifier::new(minifier_options).build(&allocator, &mut program).scoping;
 

--- a/tasks/benchmark/benches/minifier.rs
+++ b/tasks/benchmark/benches/minifier.rs
@@ -4,7 +4,7 @@ use oxc_allocator::Allocator;
 use oxc_benchmark::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use oxc_mangler::Mangler;
 use oxc_minifier::{CompressOptions, Compressor};
-use oxc_parser::Parser;
+use oxc_parser::{ParseOptions, Parser};
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 use oxc_tasks_common::TestFiles;
@@ -28,7 +28,13 @@ fn bench_minifier(criterion: &mut Criterion) {
                 allocator.reset();
 
                 // Create fresh AST + semantic data for each iteration
-                let mut program = Parser::new(&allocator, source_text, source_type).parse().program;
+                let mut program = Parser::new(&allocator, source_text, source_type)
+                    .with_options(ParseOptions {
+                        preserve_parens: false,
+                        ..ParseOptions::default()
+                    })
+                    .parse()
+                    .program;
                 let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
 
                 // Minifier only works on esnext.


### PR DESCRIPTION
Parser with `preserve_parens: false` now works correctly for the
minification pipeline.