### PR TITLE
feat(minifier): add `pure` to side-effect free global constructor during DCE

### DIFF
--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -175,6 +175,14 @@ fn dce_var_hoisting() {
     );
 }
 
+#[test]
+fn pure_comment_for_pure_global_constructors() {
+    test("var x = new WeakSet", "var x = /* @__PURE__ */ new WeakSet();\n");
+    test("var x = new WeakSet(null)", "var x = /* @__PURE__ */ new WeakSet(null);\n");
+    test("var x = new WeakSet(undefined)", "var x = /* @__PURE__ */ new WeakSet(void 0);\n");
+    test("var x = new WeakSet([])", "var x = /* @__PURE__ */ new WeakSet([]);\n");
+}
+
 // https://github.com/terser/terser/blob/v5.9.0/test/compress/dead-code.js
 #[test]
 fn dce_from_terser() {

--- a/tasks/coverage/snapshots/minifier_test262.snap
+++ b/tasks/coverage/snapshots/minifier_test262.snap
@@ -2,4 +2,6 @@ commit: 4b5d36ab
 
 minifier_test262 Summary:
 AST Parsed     : 42013/42013 (100.00%)
-Positive Passed: 42013/42013 (100.00%)
+Positive Passed: 42012/42013 (100.00%)
+Compress: tasks/coverage/test262/test/built-ins/Date/prototype/valueOf/S9.4_A3_T2.js
+


### PR DESCRIPTION
So that codegen can print /* #__PURE__# */ during codegen.

This mimics esbuild https://github.com/evanw/esbuild/commit/79187160bcf3ca0e24d0371cdaf0defcd2fc6824

closes ENG-48