### PR TITLE
refactor(parser): remove lexer lookahead in JS statement parsing

### DIFF
--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -32,6 +32,20 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
+    pub(crate) fn is_using_statement(&mut self) -> bool {
+        self.lookahead(Self::is_next_token_using_keyword_then_binding_identifier)
+    }
+
+    fn is_next_token_using_keyword_then_binding_identifier(&mut self) -> bool {
+        self.bump_any();
+        if self.at(Kind::Using) && !self.cur_token().is_on_new_line() {
+            self.bump_any();
+            self.cur_kind().is_binding_identifier() && !self.cur_token().is_on_new_line()
+        } else {
+            false
+        }
+    }
+
     pub(crate) fn parse_using_statement(&mut self) -> Statement<'a> {
         let mut decl = self.parse_using_declaration(StatementContext::StatementList);
         self.asi();


### PR DESCRIPTION
- part of https://github.com/oxc-project/oxc/issues/11194

Removes more usage of lexer lookahead methods in favor of using the parser lookahead. This is all pretty much 1:1 conversions based on the existing code and the TS parser.