### PR TITLE
fix(linter/no-unused-vars): panic when variable is redeclared as function in same scope

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -204,6 +204,24 @@ fn test_vars_self_use() {
 }
 
 #[test]
+fn test_vars_self_use_js() {
+    let pass = vec![
+        // https://github.com/oxc-project/oxc/issues/11215
+        "export function promisify() { var fn; function fn() {} return fn; }",
+    ];
+
+    let fail = vec![
+        // https://github.com/oxc-project/oxc/issues/11215
+        "export function promisify() { var fn; function fn() { fn() } }",
+    ];
+
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
+        .change_rule_path_extension("js")
+        .intentionally_allow_no_fix_tests()
+        .test();
+}
+
+#[test]
 fn test_vars_discarded_reads() {
     let pass = vec![
         // https://github.com/oxc-project/oxc/pull/4445#issuecomment-2254122889


### PR DESCRIPTION
* close: #11215
* close: https://github.com/oxc-project/oxc/pull/11234

```js
var a;
function a() { a() }
```

The above code is legal; in this case, the symbol_declaration points to `var a` rather than `function a`a because the current implementation handles them in order they declared, thus we need to iterate over `symbol_redeclarations` to find the function's node id.