### PR TITLE
fix(justfile): `just fmt` doesn't work on `Windows`

### DIFF
--- a/justfile
+++ b/justfile
@@ -83,7 +83,7 @@ lint:
 
 # Format all files
 fmt:
-  cargo shear --fix || true # remove all unused dependencies
+  -cargo shear --fix # remove all unused dependencies
   cargo fmt --all
   dprint fmt
 


### PR DESCRIPTION
```bash
+ cargo shear --fix || true
+                   ~~
标记“||”不是此版本中的有效语句分隔符。
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : InvalidEndOfLine
```