### PR TITLE
fix(linter/block-scoped-var): better diagnostic messages

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/block_scoped_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/block_scoped_var.rs
@@ -1,14 +1,25 @@
 use oxc_ast::{AstKind, ast::VariableDeclarationKind};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::Span;
+use oxc_span::{GetSpan, Span};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
-fn block_scoped_var_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
+fn redeclaration_diagnostic(decl_span: Span, redecl_span: Span, name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("'{name}' is used outside of binding context."))
         .with_help(format!("Variable '{name}' is used outside its declaration block. Declare it outside the block or use 'let'/'const'."))
-        .with_label(span)
+        .with_labels([
+            redecl_span.label("it is redeclared here"),
+            decl_span.label(format!("'{name}' is first declared here")),
+        ])
+}
+fn use_outside_scope_diagnostic(decl_span: Span, used_span: Span, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("'{name}' is used outside of binding context."))
+        .with_help(format!("Variable '{name}' is used outside its declaration block. Declare it outside the block or use 'let'/'const'."))
+        .with_labels([
+            used_span.label(format!("'{name}' is used here")),
+            decl_span.label("It is declared in a different scope here"),
+        ])
 }
 
 #[derive(Debug, Default, Clone)]
@@ -84,7 +95,11 @@ impl Rule for BlockScopedVar {
                 for redeclaration in ctx.scoping().symbol_redeclarations(symbol_id) {
                     let re_scope_id = ctx.nodes().get_node(redeclaration.declaration).scope_id();
                     if !scope_arr.contains(&re_scope_id) && re_scope_id != cur_node_scope_id {
-                        ctx.diagnostic(block_scoped_var_diagnostic(redeclaration.span, name));
+                        ctx.diagnostic(redeclaration_diagnostic(
+                            item.id.span(),
+                            redeclaration.span,
+                            name,
+                        ));
                     }
                 }
                 // e.g. "var a = 4; console.log(a);"
@@ -93,7 +108,8 @@ impl Rule for BlockScopedVar {
                     if !scope_arr.contains(&reference_scope_id)
                         && reference_scope_id != cur_node_scope_id
                     {
-                        ctx.diagnostic(block_scoped_var_diagnostic(
+                        ctx.diagnostic(use_outside_scope_diagnostic(
+                            item.id.span(),
                             ctx.reference_span(reference),
                             name,
                         ));

--- a/crates/oxc_linter/src/snapshots/eslint_block_scoped_var.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_block_scoped_var.snap
@@ -2,28 +2,48 @@
 source: crates/oxc_linter/src/tester.rs
 ---
   ⚠ eslint(block-scoped-var): 'a' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:6:21]
+   ╭─[block_scoped_var.tsx:3:21]
+ 2 │             if (true) {
+ 3 │                 var a = 3;
+   ·                     ┬
+   ·                     ╰── 'a' is first declared here
+ 4 │             } else {
  5 │                 var b = 4;
  6 │                 var a = 4;
-   ·                     ─
+   ·                     ┬
+   ·                     ╰── it is redeclared here
  7 │             }
    ╰────
   help: Variable 'a' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'a' is used outside of binding context.
+   ╭─[block_scoped_var.tsx:3:21]
+ 2 │             if (true) {
+ 3 │                 var a = 3;
+   ·                     ┬
+   ·                     ╰── It is declared in a different scope here
+ 4 │             } else {
+   ╰────
    ╭─[block_scoped_var.tsx:8:25]
  7 │             }
  8 │             console.log(a, b);
-   ·                         ─
+   ·                         ┬
+   ·                         ╰── 'a' is used here
  9 │         
    ╰────
   help: Variable 'a' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'b' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:8:28]
+   ╭─[block_scoped_var.tsx:5:21]
+ 4 │             } else {
+ 5 │                 var b = 4;
+   ·                     ┬
+   ·                     ╰── It is declared in a different scope here
+ 6 │                 var a = 4;
  7 │             }
  8 │             console.log(a, b);
-   ·                            ─
+   ·                            ┬
+   ·                            ╰── 'b' is used here
  9 │         
    ╰────
   help: Variable 'b' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
@@ -32,61 +52,97 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[block_scoped_var.tsx:3:21]
  2 │             if (true) {
  3 │                 var a = 3;
-   ·                     ─
+   ·                     ┬
+   ·                     ╰── it is redeclared here
  4 │             } else {
+ 5 │                 var b = 4;
+ 6 │                 var a = 4;
+   ·                     ┬
+   ·                     ╰── 'a' is first declared here
+ 7 │             }
    ╰────
   help: Variable 'a' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'a' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:8:25]
+   ╭─[block_scoped_var.tsx:6:21]
+ 5 │                 var b = 4;
+ 6 │                 var a = 4;
+   ·                     ┬
+   ·                     ╰── It is declared in a different scope here
  7 │             }
  8 │             console.log(a, b);
-   ·                         ─
+   ·                         ┬
+   ·                         ╰── 'a' is used here
  9 │         
    ╰────
   help: Variable 'a' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'a' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:5:25]
+   ╭─[block_scoped_var.tsx:3:21]
+ 2 │             if (true) {
+ 3 │                 var [a, b] = [1, 2];
+   ·                     ───┬──
+   ·                        ╰── It is declared in a different scope here
  4 │             }
  5 │             console.log(a, b);
-   ·                         ─
+   ·                         ┬
+   ·                         ╰── 'a' is used here
  6 │         
    ╰────
   help: Variable 'a' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'b' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:5:28]
+   ╭─[block_scoped_var.tsx:3:21]
+ 2 │             if (true) {
+ 3 │                 var [a, b] = [1, 2];
+   ·                     ───┬──
+   ·                        ╰── It is declared in a different scope here
  4 │             }
  5 │             console.log(a, b);
-   ·                            ─
+   ·                            ┬
+   ·                            ╰── 'b' is used here
  6 │         
    ╰────
   help: Variable 'b' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'a' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:5:25]
+   ╭─[block_scoped_var.tsx:3:21]
+ 2 │             if (true) {
+ 3 │                 var a = 4, b = 3;
+   ·                     ┬
+   ·                     ╰── It is declared in a different scope here
  4 │             }
  5 │             console.log(a, b);
-   ·                         ─
+   ·                         ┬
+   ·                         ╰── 'a' is used here
  6 │         
    ╰────
   help: Variable 'a' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'b' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:5:28]
+   ╭─[block_scoped_var.tsx:3:28]
+ 2 │             if (true) {
+ 3 │                 var a = 4, b = 3;
+   ·                            ┬
+   ·                            ╰── It is declared in a different scope here
  4 │             }
  5 │             console.log(a, b);
-   ·                            ─
+   ·                            ┬
+   ·                            ╰── 'b' is used here
  6 │         
    ╰────
   help: Variable 'b' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'a' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:6:21]
+   ╭─[block_scoped_var.tsx:4:25]
+ 3 │                 {
+ 4 │                     var a = 4, b = 3;
+   ·                         ┬
+   ·                         ╰── 'a' is first declared here
  5 │                 }
  6 │                 var a = 4;
-   ·                     ─
+   ·                     ┬
+   ·                     ╰── it is redeclared here
  7 │             }
    ╰────
   help: Variable 'a' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
@@ -94,203 +150,278 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint(block-scoped-var): 'x' is used outside of binding context.
    ╭─[block_scoped_var.tsx:1:15]
  1 │ function f(){ x; { var x; } }
-   ·               ─
+   ·               ┬        ┬
+   ·               │        ╰── It is declared in a different scope here
+   ·               ╰── 'x' is used here
    ╰────
   help: Variable 'x' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'x' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:1:26]
+   ╭─[block_scoped_var.tsx:1:21]
  1 │ function f(){ { var x; } x; }
-   ·                          ─
+   ·                     ┬    ┬
+   ·                     │    ╰── 'x' is used here
+   ·                     ╰── It is declared in a different scope here
    ╰────
   help: Variable 'x' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'b' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:1:42]
+   ╭─[block_scoped_var.tsx:1:29]
  1 │ function f() { var a; { var b = 0; } a = b; }
-   ·                                          ─
+   ·                             ┬            ┬
+   ·                             │            ╰── 'b' is used here
+   ·                             ╰── It is declared in a different scope here
    ╰────
   help: Variable 'b' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'a' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:1:55]
+   ╭─[block_scoped_var.tsx:1:26]
  1 │ function f() { try { var a = 0; } catch (e) { var b = a; } }
-   ·                                                       ─
+   ·                          ┬                            ┬
+   ·                          │                            ╰── 'a' is used here
+   ·                          ╰── It is declared in a different scope here
    ╰────
   help: Variable 'a' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'c' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:1:48]
+   ╭─[block_scoped_var.tsx:1:39]
  1 │ function a() { for(var b in {}) { var c = b; } c; }
-   ·                                                ─
+   ·                                       ┬        ┬
+   ·                                       │        ╰── 'c' is used here
+   ·                                       ╰── It is declared in a different scope here
    ╰────
   help: Variable 'c' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'c' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:1:48]
+   ╭─[block_scoped_var.tsx:1:39]
  1 │ function a() { for(var b of {}) { var c = b; } c; }
-   ·                                                ─
+   ·                                       ┬        ┬
+   ·                                       │        ╰── 'c' is used here
+   ·                                       ╰── It is declared in a different scope here
    ╰────
   help: Variable 'c' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'b' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:1:76]
+   ╭─[block_scoped_var.tsx:1:39]
  1 │ function f(){ switch(2) { case 1: var b = 2; b; break; default: b; break;} b; }
-   ·                                                                            ─
+   ·                                       ┬                                    ┬
+   ·                                       │                                    ╰── 'b' is used here
+   ·                                       ╰── It is declared in a different scope here
    ╰────
   help: Variable 'b' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'a' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:1:22]
+   ╭─[block_scoped_var.tsx:1:10]
  1 │ for (var a = 0;;) {} a;
-   ·                      ─
+   ·          ┬           ┬
+   ·          │           ╰── 'a' is used here
+   ·          ╰── It is declared in a different scope here
    ╰────
   help: Variable 'a' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'a' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:1:22]
+   ╭─[block_scoped_var.tsx:1:10]
  1 │ for (var a in []) {} a;
-   ·                      ─
+   ·          ┬           ┬
+   ·          │           ╰── 'a' is used here
+   ·          ╰── It is declared in a different scope here
    ╰────
   help: Variable 'a' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'a' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:1:22]
+   ╭─[block_scoped_var.tsx:1:10]
  1 │ for (var a of []) {} a;
-   ·                      ─
+   ·          ┬           ┬
+   ·          │           ╰── 'a' is used here
+   ·          ╰── It is declared in a different scope here
    ╰────
   help: Variable 'a' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'a' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:1:16]
+   ╭─[block_scoped_var.tsx:1:7]
  1 │ { var a = 0; } a;
-   ·                ─
+   ·       ┬        ┬
+   ·       │        ╰── 'a' is used here
+   ·       ╰── It is declared in a different scope here
    ╰────
   help: Variable 'a' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'a' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:1:22]
+   ╭─[block_scoped_var.tsx:1:17]
  1 │ if (true) { var a; } a;
-   ·                      ─
-   ╰────
-  help: Variable 'a' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
-
-  ⚠ eslint(block-scoped-var): 'a' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:1:37]
- 1 │ if (true) { var a = 1; } else { var a = 2; }
-   ·                                     ─
+   ·                 ┬    ┬
+   ·                 │    ╰── 'a' is used here
+   ·                 ╰── It is declared in a different scope here
    ╰────
   help: Variable 'a' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'a' is used outside of binding context.
    ╭─[block_scoped_var.tsx:1:17]
  1 │ if (true) { var a = 1; } else { var a = 2; }
-   ·                 ─
+   ·                 ┬                   ┬
+   ·                 │                   ╰── it is redeclared here
+   ·                 ╰── 'a' is first declared here
+   ╰────
+  help: Variable 'a' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
+
+  ⚠ eslint(block-scoped-var): 'a' is used outside of binding context.
+   ╭─[block_scoped_var.tsx:1:17]
+ 1 │ if (true) { var a = 1; } else { var a = 2; }
+   ·                 ┬                   ┬
+   ·                 │                   ╰── 'a' is first declared here
+   ·                 ╰── it is redeclared here
    ╰────
   help: Variable 'a' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'i' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:1:30]
+   ╭─[block_scoped_var.tsx:1:10]
  1 │ for (var i = 0;;) {} for(var i = 0;;) {}
-   ·                              ─
+   ·          ┬                   ┬
+   ·          │                   ╰── it is redeclared here
+   ·          ╰── 'i' is first declared here
    ╰────
   help: Variable 'i' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'i' is used outside of binding context.
    ╭─[block_scoped_var.tsx:1:10]
  1 │ for (var i = 0;;) {} for(var i = 0;;) {}
-   ·          ─
+   ·          ┬                   ┬
+   ·          │                   ╰── 'i' is first declared here
+   ·          ╰── it is redeclared here
    ╰────
   help: Variable 'i' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'foo' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:1:42]
+   ╭─[block_scoped_var.tsx:1:35]
  1 │ class C { static { if (bar) { var foo; } foo; } }
-   ·                                          ───
+   ·                                   ─┬─    ─┬─
+   ·                                    │      ╰── 'foo' is used here
+   ·                                    ╰── It is declared in a different scope here
    ╰────
   help: Variable 'foo' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'bar' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:1:20]
+   ╭─[block_scoped_var.tsx:1:13]
  1 │ { var foo,  bar; } bar;
-   ·                    ───
+   ·             ─┬─    ─┬─
+   ·              │      ╰── 'bar' is used here
+   ·              ╰── It is declared in a different scope here
    ╰────
   help: Variable 'bar' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'a' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:1:45]
+   ╭─[block_scoped_var.tsx:1:16]
  1 │ if (foo) { var a = 1; } else if (bar) { var a = 2; } else { var a = 3; }
-   ·                                             ─
-   ╰────
-  help: Variable 'a' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
-
-  ⚠ eslint(block-scoped-var): 'a' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:1:65]
- 1 │ if (foo) { var a = 1; } else if (bar) { var a = 2; } else { var a = 3; }
-   ·                                                                 ─
+   ·                ┬                            ┬
+   ·                │                            ╰── it is redeclared here
+   ·                ╰── 'a' is first declared here
    ╰────
   help: Variable 'a' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'a' is used outside of binding context.
    ╭─[block_scoped_var.tsx:1:16]
  1 │ if (foo) { var a = 1; } else if (bar) { var a = 2; } else { var a = 3; }
-   ·                ─
-   ╰────
-  help: Variable 'a' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
-
-  ⚠ eslint(block-scoped-var): 'a' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:1:65]
- 1 │ if (foo) { var a = 1; } else if (bar) { var a = 2; } else { var a = 3; }
-   ·                                                                 ─
+   ·                ┬                                                ┬
+   ·                │                                                ╰── it is redeclared here
+   ·                ╰── 'a' is first declared here
    ╰────
   help: Variable 'a' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'a' is used outside of binding context.
    ╭─[block_scoped_var.tsx:1:16]
  1 │ if (foo) { var a = 1; } else if (bar) { var a = 2; } else { var a = 3; }
-   ·                ─
+   ·                ┬                            ┬
+   ·                │                            ╰── 'a' is first declared here
+   ·                ╰── it is redeclared here
    ╰────
   help: Variable 'a' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'a' is used outside of binding context.
    ╭─[block_scoped_var.tsx:1:45]
  1 │ if (foo) { var a = 1; } else if (bar) { var a = 2; } else { var a = 3; }
-   ·                                             ─
+   ·                                             ┬                   ┬
+   ·                                             │                   ╰── it is redeclared here
+   ·                                             ╰── 'a' is first declared here
+   ╰────
+  help: Variable 'a' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
+
+  ⚠ eslint(block-scoped-var): 'a' is used outside of binding context.
+   ╭─[block_scoped_var.tsx:1:16]
+ 1 │ if (foo) { var a = 1; } else if (bar) { var a = 2; } else { var a = 3; }
+   ·                ┬                                                ┬
+   ·                │                                                ╰── 'a' is first declared here
+   ·                ╰── it is redeclared here
+   ╰────
+  help: Variable 'a' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
+
+  ⚠ eslint(block-scoped-var): 'a' is used outside of binding context.
+   ╭─[block_scoped_var.tsx:1:45]
+ 1 │ if (foo) { var a = 1; } else if (bar) { var a = 2; } else { var a = 3; }
+   ·                                             ┬                   ┬
+   ·                                             │                   ╰── 'a' is first declared here
+   ·                                             ╰── it is redeclared here
    ╰────
   help: Variable 'a' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'build' is used outside of binding context.
+   ╭─[block_scoped_var.tsx:3:21]
+ 2 │             if (true) {
+ 3 │                 var build = true;
+   ·                     ──┬──
+   ·                       ╰── It is declared in a different scope here
+ 4 │                 console.log(build);
+   ╰────
     ╭─[block_scoped_var.tsx:12:25]
  11 │             }
  12 │             console.log(build);
-    ·                         ─────
+    ·                         ──┬──
+    ·                           ╰── 'build' is used here
  13 │             let t = build;
     ╰────
   help: Variable 'build' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'build' is used outside of binding context.
+   ╭─[block_scoped_var.tsx:3:21]
+ 2 │             if (true) {
+ 3 │                 var build = true;
+   ·                     ──┬──
+   ·                       ╰── It is declared in a different scope here
+ 4 │                 console.log(build);
+   ╰────
     ╭─[block_scoped_var.tsx:13:21]
  12 │             console.log(build);
  13 │             let t = build;
-    ·                     ─────
+    ·                     ──┬──
+    ·                       ╰── 'build' is used here
  14 │         
     ╰────
   help: Variable 'build' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'build' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:7:29]
+   ╭─[block_scoped_var.tsx:4:25]
+ 3 │                 if (true) {
+ 4 │                     var build = true;
+   ·                         ──┬──
+   ·                           ╰── It is declared in a different scope here
+ 5 │                 }
  6 │ 
  7 │                 console.log(build);
-   ·                             ─────
+   ·                             ──┬──
+   ·                               ╰── 'build' is used here
  8 │             }
    ╰────
   help: Variable 'build' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'build' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:6:25]
+   ╭─[block_scoped_var.tsx:4:25]
+ 3 │                 if (true) {
+ 4 │                     var build = true;
+   ·                         ──┬──
+   ·                           ╰── 'build' is first declared here
  5 │                 } else {
  6 │                     var build = false;
-   ·                         ─────
+   ·                         ──┬──
+   ·                           ╰── it is redeclared here
  7 │                 }
    ╰────
   help: Variable 'build' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
@@ -299,34 +430,54 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[block_scoped_var.tsx:4:25]
  3 │                 if (true) {
  4 │                     var build = true;
-   ·                         ─────
+   ·                         ──┬──
+   ·                           ╰── it is redeclared here
  5 │                 } else {
+ 6 │                     var build = false;
+   ·                         ──┬──
+   ·                           ╰── 'build' is first declared here
+ 7 │                 }
    ╰────
   help: Variable 'build' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'build' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:6:29]
+   ╭─[block_scoped_var.tsx:4:25]
+ 3 │                 try {
+ 4 │                     var build = 1;
+   ·                         ──┬──
+   ·                           ╰── It is declared in a different scope here
  5 │                 } catch (e) {
  6 │                     var f = build;
-   ·                             ─────
+   ·                             ──┬──
+   ·                               ╰── 'build' is used here
  7 │                 }
    ╰────
   help: Variable 'build' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'y' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:6:29]
+   ╭─[block_scoped_var.tsx:4:25]
+ 3 │                 for (var x = 1; x < 10; x++) {
+ 4 │                     var y = f(x);
+   ·                         ┬
+   ·                         ╰── It is declared in a different scope here
  5 │                 }
  6 │                 console.log(y);
-   ·                             ─
+   ·                             ┬
+   ·                             ╰── 'y' is used here
  7 │             }
    ╰────
   help: Variable 'y' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.
 
   ⚠ eslint(block-scoped-var): 'build' is used outside of binding context.
-   ╭─[block_scoped_var.tsx:7:21]
+   ╭─[block_scoped_var.tsx:5:29]
+ 4 │                     if (something) {
+ 5 │                         var build = true;
+   ·                             ──┬──
+   ·                               ╰── It is declared in a different scope here
  6 │                     }
  7 │                     build = false;
-   ·                     ─────
+   ·                     ──┬──
+   ·                       ╰── 'build' is used here
  8 │                 }
    ╰────
   help: Variable 'build' is used outside its declaration block. Declare it outside the block or use 'let'/'const'.


### PR DESCRIPTION
## What This PR Does

Updates diagnostics for `eslint/block-scoped-var` to provide better information, particularly better labels