### PR TITLE
fix(linter): improve `jest/no-large-snapshots`

### DIFF
--- a/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
@@ -16,17 +16,18 @@ use crate::{
     utils::{PossibleJestNode, iter_possible_jest_call_node, parse_expect_jest_fn_call},
 };
 
-// TODO: re-word diagnostic messages
-fn no_snapshot(x0: usize, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow large snapshots.")
-        .with_help(format!("`{x0:?}`s should begin with lowercase"))
+fn no_snapshot(line_count: usize, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Snapshot is too long.")
+        .with_help(format!(
+            "Expected to not encounter a Jest snapshot but was found with {line_count} lines long"
+        ))
         .with_label(span)
 }
 
-fn too_long_snapshots(x0: usize, x1: usize, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow large snapshots.")
+fn too_long_snapshot(line_limit: usize, line_count: usize, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Snapshot is too long.")
         .with_help(format!(
-            "Expected Jest snapshot to be smaller than {x0:?} lines but was {x1:?} lines long"
+            "Expected Jest snapshot to be smaller than {line_limit} lines but was {line_count} lines long"
         ))
         .with_label(span)
 }
@@ -63,7 +64,6 @@ declare_oxc_lint!(
     /// important to allow for thorough reviews.
     ///
     /// ### Example
-    ///
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
@@ -121,6 +121,7 @@ declare_oxc_lint!(
     /// line 51
     /// `;
     /// ```
+    ///
     /// Examples of **incorrect** code for this rule:
     /// ```js
     /// exports[`a more manageable and readable snapshot 1`] = `
@@ -143,13 +144,15 @@ impl Rule for NoLargeSnapshots {
             .and_then(|c| c.get("maxSize"))
             .and_then(serde_json::Value::as_number)
             .and_then(serde_json::Number::as_u64)
-            .map_or(50, |v| usize::try_from(v).unwrap_or(50));
+            .and_then(|v| usize::try_from(v).ok())
+            .unwrap_or(50);
 
         let inline_max_size = config
             .and_then(|c| c.get("inlineMaxSize"))
             .and_then(serde_json::Value::as_number)
             .and_then(serde_json::Number::as_u64)
-            .map_or(max_size, |v| usize::try_from(v).unwrap_or(max_size));
+            .and_then(|v| usize::try_from(v).ok())
+            .unwrap_or(max_size);
 
         let allowed_snapshots = config
             .and_then(|c| c.get("allowedSnapshots"))
@@ -236,7 +239,7 @@ impl NoLargeSnapshots {
             if line_count == 0 {
                 ctx.diagnostic(no_snapshot(line_count, expr_stmt.span));
             } else {
-                ctx.diagnostic(too_long_snapshots(self.max_size, line_count, expr_stmt.span));
+                ctx.diagnostic(too_long_snapshot(self.max_size, line_count, expr_stmt.span));
             }
         }
     }
@@ -248,7 +251,7 @@ impl NoLargeSnapshots {
             if self.inline_max_size == 0 {
                 ctx.diagnostic(no_snapshot(line_count, span));
             } else {
-                ctx.diagnostic(too_long_snapshots(self.inline_max_size, line_count, span));
+                ctx.diagnostic(too_long_snapshot(self.inline_max_size, line_count, span));
             }
         }
     }
@@ -341,7 +344,7 @@ fn test() {
     // #[cfg(not(target_os = "windows"))]
     // let another_snap_path = "/another-mock-component.jsx.snap";
 
-    let tow_match_inline_cases = generate_match_inline_snapshot(2);
+    let two_match_inline_cases = generate_match_inline_snapshot(2);
     let two_throw_error_match_cases = generate_throw_error_matching_inline_snapshot(2);
     let twenty_match_inline_cases = generate_match_inline_snapshot(20);
     let sixty_match_inline_cases = generate_match_inline_snapshot(60);
@@ -365,7 +368,7 @@ fn test() {
         ("expect(something).toBe(1)", None, None, None),
         ("expect(something).toMatchInlineSnapshot", None, None, None),
         ("expect(something).toMatchInlineSnapshot()", None, None, None),
-        (tow_match_inline_cases.as_str(), None, None, None),
+        (two_match_inline_cases.as_str(), None, None, None),
         (two_throw_error_match_cases.as_str(), None, None, None),
         (
             twenty_match_inline_cases.as_str(),
@@ -421,6 +424,12 @@ fn test() {
         (
             fifty_throw_error_match_cases.as_str(),
             Some(serde_json::json!([{ "maxSize": 51, "inlineMaxSize": 50 }])),
+            None,
+            None,
+        ),
+        (
+            fifty_throw_error_match_cases.as_str(),
+            Some(serde_json::json!([{ "maxSize": 0 }])),
             None,
             None,
         ),

--- a/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
@@ -19,7 +19,7 @@ use crate::{
 fn no_snapshot(line_count: usize, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Snapshot is too long.")
         .with_help(format!(
-            "Expected to not encounter a Jest snapshot but was found with {line_count} lines long"
+            "Expected to not encounter a Jest snapshot but one was found that is {line_count} lines long"
         ))
         .with_label(span)
 }

--- a/crates/oxc_linter/src/snapshots/jest_no_large_snapshots.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_large_snapshots.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jest(no-large-snapshots): Disallow large snapshots.
+  ⚠ eslint-plugin-jest(no-large-snapshots): Snapshot is too long.
     ╭─[no_large_snapshots.tsx:1:41]
   1 │ ╭─▶ expect(something).toMatchInlineSnapshot(`
   2 │ │   line
@@ -58,7 +58,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Expected Jest snapshot to be smaller than 50 lines but was 51 lines long
 
-  ⚠ eslint-plugin-jest(no-large-snapshots): Disallow large snapshots.
+  ⚠ eslint-plugin-jest(no-large-snapshots): Snapshot is too long.
     ╭─[no_large_snapshots.tsx:1:54]
   1 │ ╭─▶ expect(something).toThrowErrorMatchingInlineSnapshot(`
   2 │ │   line
@@ -115,7 +115,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Expected Jest snapshot to be smaller than 50 lines but was 51 lines long
 
-  ⚠ eslint-plugin-jest(no-large-snapshots): Disallow large snapshots.
+  ⚠ eslint-plugin-jest(no-large-snapshots): Snapshot is too long.
     ╭─[no_large_snapshots.tsx:1:54]
   1 │ ╭─▶ expect(something).toThrowErrorMatchingInlineSnapshot(`
   2 │ │   line
@@ -171,3 +171,60 @@ source: crates/oxc_linter/src/tester.rs
  52 │ ╰─▶ `);
     ╰────
   help: Expected Jest snapshot to be smaller than 50 lines but was 51 lines long
+
+  ⚠ eslint-plugin-jest(no-large-snapshots): Snapshot is too long.
+    ╭─[no_large_snapshots.tsx:1:54]
+  1 │ ╭─▶ expect(something).toThrowErrorMatchingInlineSnapshot(`
+  2 │ │   line
+  3 │ │   line
+  4 │ │   line
+  5 │ │   line
+  6 │ │   line
+  7 │ │   line
+  8 │ │   line
+  9 │ │   line
+ 10 │ │   line
+ 11 │ │   line
+ 12 │ │   line
+ 13 │ │   line
+ 14 │ │   line
+ 15 │ │   line
+ 16 │ │   line
+ 17 │ │   line
+ 18 │ │   line
+ 19 │ │   line
+ 20 │ │   line
+ 21 │ │   line
+ 22 │ │   line
+ 23 │ │   line
+ 24 │ │   line
+ 25 │ │   line
+ 26 │ │   line
+ 27 │ │   line
+ 28 │ │   line
+ 29 │ │   line
+ 30 │ │   line
+ 31 │ │   line
+ 32 │ │   line
+ 33 │ │   line
+ 34 │ │   line
+ 35 │ │   line
+ 36 │ │   line
+ 37 │ │   line
+ 38 │ │   line
+ 39 │ │   line
+ 40 │ │   line
+ 41 │ │   line
+ 42 │ │   line
+ 43 │ │   line
+ 44 │ │   line
+ 45 │ │   line
+ 46 │ │   line
+ 47 │ │   line
+ 48 │ │   line
+ 49 │ │   line
+ 50 │ │   line
+ 51 │ │   line
+ 52 │ ╰─▶ `);
+    ╰────
+  help: Expected to not encounter a Jest snapshot but was found with 51 lines long

--- a/crates/oxc_linter/src/snapshots/jest_no_large_snapshots.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_large_snapshots.snap
@@ -227,4 +227,4 @@ source: crates/oxc_linter/src/tester.rs
  51 │ │   line
  52 │ ╰─▶ `);
     ╰────
-  help: Expected to not encounter a Jest snapshot but was found with 51 lines long
+  help: Expected to not encounter a Jest snapshot but one was found that is 51 lines long


### PR DESCRIPTION
- re-word diagnostic messages ("Disallow large snapshots." => "Snapshot is too long.")
- fix incorrect help message
  - related: https://github.com/jest-community/eslint-plugin-jest/pull/1736
- add test to include `no_snapshot` diagnostic in test snapshot
- minor other code refactorings to improve readability