### PR TITLE
fix(linter): make `jest/no-large-snapshots` error easier to comprehend

### DIFF
--- a/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
@@ -27,7 +27,7 @@ fn no_snapshot(line_count: usize, span: Span) -> OxcDiagnostic {
 fn too_long_snapshot(line_limit: usize, line_count: usize, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Snapshot is too long.")
         .with_help(format!(
-            "Expected Jest snapshot to not be longer than {line_limit} lines but was {line_count} lines long"
+            "Expected Jest snapshot to be no longer than {line_limit} lines but it was {line_count} lines long"
         ))
         .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
@@ -27,7 +27,7 @@ fn no_snapshot(line_count: usize, span: Span) -> OxcDiagnostic {
 fn too_long_snapshot(line_limit: usize, line_count: usize, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Snapshot is too long.")
         .with_help(format!(
-            "Expected Jest snapshot to be smaller than {line_limit} lines but was {line_count} lines long"
+            "Expected Jest snapshot to not be longer than {line_limit} lines but was {line_count} lines long"
         ))
         .with_label(span)
 }

--- a/crates/oxc_linter/src/snapshots/jest_no_large_snapshots.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_large_snapshots.snap
@@ -7,7 +7,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ─────────────────────
  2 │ line
    ╰────
-  help: Expected Jest snapshot to not be longer than 50 lines but was 51 lines long
+  help: Expected Jest snapshot to be no longer than 50 lines but it was 51 lines long
 
   ⚠ eslint-plugin-jest(no-large-snapshots): Snapshot is too long.
    ╭─[no_large_snapshots.tsx:1:19]
@@ -15,7 +15,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ──────────────────────────────────
  2 │ line
    ╰────
-  help: Expected Jest snapshot to not be longer than 50 lines but was 51 lines long
+  help: Expected Jest snapshot to be no longer than 50 lines but it was 51 lines long
 
   ⚠ eslint-plugin-jest(no-large-snapshots): Snapshot is too long.
    ╭─[no_large_snapshots.tsx:1:19]
@@ -23,7 +23,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ──────────────────────────────────
  2 │ line
    ╰────
-  help: Expected Jest snapshot to not be longer than 50 lines but was 51 lines long
+  help: Expected Jest snapshot to be no longer than 50 lines but it was 51 lines long
 
   ⚠ eslint-plugin-jest(no-large-snapshots): Snapshot is too long.
    ╭─[no_large_snapshots.tsx:1:19]

--- a/crates/oxc_linter/src/snapshots/jest_no_large_snapshots.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_large_snapshots.snap
@@ -7,7 +7,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ─────────────────────
  2 │ line
    ╰────
-  help: Expected Jest snapshot to be smaller than 50 lines but was 51 lines long
+  help: Expected Jest snapshot to not be longer than 50 lines but was 51 lines long
 
   ⚠ eslint-plugin-jest(no-large-snapshots): Snapshot is too long.
    ╭─[no_large_snapshots.tsx:1:19]
@@ -15,7 +15,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ──────────────────────────────────
  2 │ line
    ╰────
-  help: Expected Jest snapshot to be smaller than 50 lines but was 51 lines long
+  help: Expected Jest snapshot to not be longer than 50 lines but was 51 lines long
 
   ⚠ eslint-plugin-jest(no-large-snapshots): Snapshot is too long.
    ╭─[no_large_snapshots.tsx:1:19]
@@ -23,7 +23,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ──────────────────────────────────
  2 │ line
    ╰────
-  help: Expected Jest snapshot to be smaller than 50 lines but was 51 lines long
+  help: Expected Jest snapshot to not be longer than 50 lines but was 51 lines long
 
   ⚠ eslint-plugin-jest(no-large-snapshots): Snapshot is too long.
    ╭─[no_large_snapshots.tsx:1:19]

--- a/crates/oxc_linter/src/snapshots/jest_no_large_snapshots.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_large_snapshots.snap
@@ -2,229 +2,33 @@
 source: crates/oxc_linter/src/tester.rs
 ---
   ⚠ eslint-plugin-jest(no-large-snapshots): Snapshot is too long.
-    ╭─[no_large_snapshots.tsx:1:41]
-  1 │ ╭─▶ expect(something).toMatchInlineSnapshot(`
-  2 │ │   line
-  3 │ │   line
-  4 │ │   line
-  5 │ │   line
-  6 │ │   line
-  7 │ │   line
-  8 │ │   line
-  9 │ │   line
- 10 │ │   line
- 11 │ │   line
- 12 │ │   line
- 13 │ │   line
- 14 │ │   line
- 15 │ │   line
- 16 │ │   line
- 17 │ │   line
- 18 │ │   line
- 19 │ │   line
- 20 │ │   line
- 21 │ │   line
- 22 │ │   line
- 23 │ │   line
- 24 │ │   line
- 25 │ │   line
- 26 │ │   line
- 27 │ │   line
- 28 │ │   line
- 29 │ │   line
- 30 │ │   line
- 31 │ │   line
- 32 │ │   line
- 33 │ │   line
- 34 │ │   line
- 35 │ │   line
- 36 │ │   line
- 37 │ │   line
- 38 │ │   line
- 39 │ │   line
- 40 │ │   line
- 41 │ │   line
- 42 │ │   line
- 43 │ │   line
- 44 │ │   line
- 45 │ │   line
- 46 │ │   line
- 47 │ │   line
- 48 │ │   line
- 49 │ │   line
- 50 │ │   line
- 51 │ │   line
- 52 │ ╰─▶ `);
-    ╰────
+   ╭─[no_large_snapshots.tsx:1:19]
+ 1 │ expect(something).toMatchInlineSnapshot(`
+   ·                   ─────────────────────
+ 2 │ line
+   ╰────
   help: Expected Jest snapshot to be smaller than 50 lines but was 51 lines long
 
   ⚠ eslint-plugin-jest(no-large-snapshots): Snapshot is too long.
-    ╭─[no_large_snapshots.tsx:1:54]
-  1 │ ╭─▶ expect(something).toThrowErrorMatchingInlineSnapshot(`
-  2 │ │   line
-  3 │ │   line
-  4 │ │   line
-  5 │ │   line
-  6 │ │   line
-  7 │ │   line
-  8 │ │   line
-  9 │ │   line
- 10 │ │   line
- 11 │ │   line
- 12 │ │   line
- 13 │ │   line
- 14 │ │   line
- 15 │ │   line
- 16 │ │   line
- 17 │ │   line
- 18 │ │   line
- 19 │ │   line
- 20 │ │   line
- 21 │ │   line
- 22 │ │   line
- 23 │ │   line
- 24 │ │   line
- 25 │ │   line
- 26 │ │   line
- 27 │ │   line
- 28 │ │   line
- 29 │ │   line
- 30 │ │   line
- 31 │ │   line
- 32 │ │   line
- 33 │ │   line
- 34 │ │   line
- 35 │ │   line
- 36 │ │   line
- 37 │ │   line
- 38 │ │   line
- 39 │ │   line
- 40 │ │   line
- 41 │ │   line
- 42 │ │   line
- 43 │ │   line
- 44 │ │   line
- 45 │ │   line
- 46 │ │   line
- 47 │ │   line
- 48 │ │   line
- 49 │ │   line
- 50 │ │   line
- 51 │ │   line
- 52 │ ╰─▶ `);
-    ╰────
+   ╭─[no_large_snapshots.tsx:1:19]
+ 1 │ expect(something).toThrowErrorMatchingInlineSnapshot(`
+   ·                   ──────────────────────────────────
+ 2 │ line
+   ╰────
   help: Expected Jest snapshot to be smaller than 50 lines but was 51 lines long
 
   ⚠ eslint-plugin-jest(no-large-snapshots): Snapshot is too long.
-    ╭─[no_large_snapshots.tsx:1:54]
-  1 │ ╭─▶ expect(something).toThrowErrorMatchingInlineSnapshot(`
-  2 │ │   line
-  3 │ │   line
-  4 │ │   line
-  5 │ │   line
-  6 │ │   line
-  7 │ │   line
-  8 │ │   line
-  9 │ │   line
- 10 │ │   line
- 11 │ │   line
- 12 │ │   line
- 13 │ │   line
- 14 │ │   line
- 15 │ │   line
- 16 │ │   line
- 17 │ │   line
- 18 │ │   line
- 19 │ │   line
- 20 │ │   line
- 21 │ │   line
- 22 │ │   line
- 23 │ │   line
- 24 │ │   line
- 25 │ │   line
- 26 │ │   line
- 27 │ │   line
- 28 │ │   line
- 29 │ │   line
- 30 │ │   line
- 31 │ │   line
- 32 │ │   line
- 33 │ │   line
- 34 │ │   line
- 35 │ │   line
- 36 │ │   line
- 37 │ │   line
- 38 │ │   line
- 39 │ │   line
- 40 │ │   line
- 41 │ │   line
- 42 │ │   line
- 43 │ │   line
- 44 │ │   line
- 45 │ │   line
- 46 │ │   line
- 47 │ │   line
- 48 │ │   line
- 49 │ │   line
- 50 │ │   line
- 51 │ │   line
- 52 │ ╰─▶ `);
-    ╰────
+   ╭─[no_large_snapshots.tsx:1:19]
+ 1 │ expect(something).toThrowErrorMatchingInlineSnapshot(`
+   ·                   ──────────────────────────────────
+ 2 │ line
+   ╰────
   help: Expected Jest snapshot to be smaller than 50 lines but was 51 lines long
 
   ⚠ eslint-plugin-jest(no-large-snapshots): Snapshot is too long.
-    ╭─[no_large_snapshots.tsx:1:54]
-  1 │ ╭─▶ expect(something).toThrowErrorMatchingInlineSnapshot(`
-  2 │ │   line
-  3 │ │   line
-  4 │ │   line
-  5 │ │   line
-  6 │ │   line
-  7 │ │   line
-  8 │ │   line
-  9 │ │   line
- 10 │ │   line
- 11 │ │   line
- 12 │ │   line
- 13 │ │   line
- 14 │ │   line
- 15 │ │   line
- 16 │ │   line
- 17 │ │   line
- 18 │ │   line
- 19 │ │   line
- 20 │ │   line
- 21 │ │   line
- 22 │ │   line
- 23 │ │   line
- 24 │ │   line
- 25 │ │   line
- 26 │ │   line
- 27 │ │   line
- 28 │ │   line
- 29 │ │   line
- 30 │ │   line
- 31 │ │   line
- 32 │ │   line
- 33 │ │   line
- 34 │ │   line
- 35 │ │   line
- 36 │ │   line
- 37 │ │   line
- 38 │ │   line
- 39 │ │   line
- 40 │ │   line
- 41 │ │   line
- 42 │ │   line
- 43 │ │   line
- 44 │ │   line
- 45 │ │   line
- 46 │ │   line
- 47 │ │   line
- 48 │ │   line
- 49 │ │   line
- 50 │ │   line
- 51 │ │   line
- 52 │ ╰─▶ `);
-    ╰────
+   ╭─[no_large_snapshots.tsx:1:19]
+ 1 │ expect(something).toThrowErrorMatchingInlineSnapshot(`
+   ·                   ──────────────────────────────────
+ 2 │ line
+   ╰────
   help: Expected to not encounter a Jest snapshot but one was found that is 51 lines long


### PR DESCRIPTION
> @camc314 as a followup, we could change the span to perhaps just point to toThrowErrorMatchingInlineSnapshot rather than the whole snapshot to help the error be more comprehensible

https://github.com/oxc-project/oxc/pull/11291#discussion_r2106288733