### PR TITLE
refactor(parser): Remove Lexer peeking for js/expression

### DIFF
--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -5078,11 +5078,11 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  3 │ }
    ╰────
 
-  × Cannot use `yield` as an identifier in a generator context
-   ╭─[babel/packages/babel-parser/test/fixtures/es2015/yield/parameter-name-arrow-no-parens-inside-generator/input.js:2:3]
+  × Unexpected token
+   ╭─[babel/packages/babel-parser/test/fixtures/es2015/yield/parameter-name-arrow-no-parens-inside-generator/input.js:2:9]
  1 │ function* fn() {
  2 │   yield => {};
-   ·   ─────
+   ·         ──
  3 │ }
    ╰────
 

--- a/tasks/coverage/snapshots/parser_test262.snap
+++ b/tasks/coverage/snapshots/parser_test262.snap
@@ -3474,11 +3474,11 @@ Negative Passed: 4519/4519 (100.00%)
  56 │   
     ╰────
 
-  × Cannot use `await` as an identifier in an async context
-    ╭─[test262/test/language/expressions/arrow-function/static-init-await-binding.js:17:6]
+  × Unexpected token
+    ╭─[test262/test/language/expressions/arrow-function/static-init-await-binding.js:17:12]
  16 │   static {
  17 │     (await => 0);
-    ·      ─────
+    ·            ──
  18 │   }
     ╰────
 
@@ -6599,12 +6599,13 @@ Negative Passed: 4519/4519 (100.00%)
  35 │ }
     ╰────
 
-  × Cannot use `await` as an identifier in an async context
-    ╭─[test262/test/language/expressions/async-arrow-function/await-as-param-ident-nested-arrow-parameter-position.js:17:11]
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+    ╭─[test262/test/language/expressions/async-arrow-function/await-as-param-ident-nested-arrow-parameter-position.js:17:23]
  16 │ 
  17 │ async(a = await => {}) => {};
-    ·           ─────
+    ·                       ▲
     ╰────
+  help: Try insert a semicolon here
 
   × await expression not allowed in formal parameter
     ╭─[test262/test/language/expressions/async-arrow-function/await-as-param-nested-arrow-body-position.js:17:19]

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -18323,12 +18323,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │ }
    ╰────
 
-  × Cannot use `await` as an identifier in an async context
-   ╭─[typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction9_es2017.ts:1:22]
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction9_es2017.ts:1:37]
  1 │ var foo = async (a = await => await): Promise<void> => {
-   ·                      ─────
+   ·                                     ▲
  2 │ }
    ╰────
+  help: Try insert a semicolon here
 
   × Cannot assign to this expression
    ╭─[typescript/tests/cases/conformance/async/es2017/await_unaryExpression_es2017_3.ts:2:7]
@@ -18338,10 +18339,10 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │ }
    ╰────
 
-  × Cannot use `await` as an identifier in an async context
-   ╭─[typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts:1:24]
+  × Unexpected token
+   ╭─[typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts:1:30]
  1 │ async function foo(a = await => await): Promise<void> {
-   ·                        ─────
+   ·                              ──
  2 │ }
    ╰────
 
@@ -18412,12 +18413,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │ }
    ╰────
 
-  × Cannot use `await` as an identifier in an async context
-   ╭─[typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction9_es5.ts:1:22]
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction9_es5.ts:1:37]
  1 │ var foo = async (a = await => await): Promise<void> => {
-   ·                      ─────
+   ·                                     ▲
  2 │ }
    ╰────
+  help: Try insert a semicolon here
 
   × 'async' modifier cannot be used here.
    ╭─[typescript/tests/cases/conformance/async/es5/asyncClass_es5.ts:1:1]
@@ -18478,10 +18480,10 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │   }
    ╰────
 
-  × Cannot use `await` as an identifier in an async context
-   ╭─[typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts:1:24]
+  × Unexpected token
+   ╭─[typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts:1:30]
  1 │ async function foo(a = await => await): Promise<void> {
-   ·                        ─────
+   ·                              ──
  2 │ }
    ╰────
 
@@ -18552,12 +18554,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │ }
    ╰────
 
-  × Cannot use `await` as an identifier in an async context
-   ╭─[typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction9_es6.ts:1:22]
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction9_es6.ts:1:37]
  1 │ var foo = async (a = await => await): Promise<void> => {
-   ·                      ─────
+   ·                                     ▲
  2 │ }
    ╰────
+  help: Try insert a semicolon here
 
   × 'async' modifier cannot be used here.
    ╭─[typescript/tests/cases/conformance/async/es6/asyncClass_es6.ts:1:1]
@@ -18626,10 +18629,10 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │ }
    ╰────
 
-  × Cannot use `await` as an identifier in an async context
-   ╭─[typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts:1:24]
+  × Unexpected token
+   ╭─[typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts:1:30]
  1 │ async function foo(a = await => await): Promise<void> {
-   ·                        ─────
+   ·                              ──
  2 │ }
    ╰────
 
@@ -21647,10 +21650,10 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │ }
    ╰────
 
-  × Cannot use `yield` as an identifier in a generator context
-   ╭─[typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration10_es6.ts:1:20]
+  × Unexpected token
+   ╭─[typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration10_es6.ts:1:26]
  1 │ function * foo(a = yield => yield) {
-   ·                    ─────
+   ·                          ──
  2 │ }
    ╰────
 


### PR DESCRIPTION
Part of #11194 

- Snapshot diffs closer to TS
- `next_token_is_identifier_or_keyword_or_literal_on_same_line` is based on:
  - https://github.com/microsoft/TypeScript/blob/main/src/compiler/parser.ts#L7150
