### PR TITLE
refactor(linter): simplify accessing span of NameSpan

### DIFF
--- a/crates/oxc_linter/src/module_record.rs
+++ b/crates/oxc_linter/src/module_record.rs
@@ -116,7 +116,7 @@ impl fmt::Debug for ModuleRecord {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NameSpan {
     pub name: CompactStr,
-    span: Span,
+    pub span: Span,
 }
 
 impl NameSpan {
@@ -126,10 +126,6 @@ impl NameSpan {
 
     pub fn name(&self) -> &str {
         self.name.as_str()
-    }
-
-    pub fn span(&self) -> Span {
-        self.span
     }
 }
 
@@ -392,7 +388,7 @@ impl ExportExportName {
     /// Attempt to get the [`Span`] of this export name.
     pub fn span(&self) -> Option<Span> {
         match self {
-            Self::Name(name) => Some(name.span()),
+            Self::Name(name) => Some(name.span),
             Self::Default(span) => Some(*span),
             Self::Null => None,
         }

--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
@@ -137,7 +137,7 @@ impl Rule for NoDuplicateImports {
 
         for entry in &module_record.import_entries {
             let source = &entry.module_request.name;
-            let span = entry.module_request.span();
+            let span = entry.module_request.span;
 
             let same_statement = if let Some(curr_span) = current_span {
                 curr_span == span

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
@@ -1295,14 +1295,14 @@ fn get_diagnostic_from_import_name_result_path(
         },
         ImportNameResult::NameDisallowed(name_span) => match &path.allow_import_names {
             Some(allow_import_names) => diagnostic_allowed_import_name(
-                name_span.clone().span(),
+                name_span.span,
                 path.message.clone(),
                 name_span.name(),
                 source,
                 allow_import_names.join(", ").as_str(),
             ),
             _ => diagnostic_import_name(
-                name_span.clone().span(),
+                name_span.span,
                 path.message.clone(),
                 name_span.name(),
                 source,
@@ -1363,7 +1363,7 @@ fn get_diagnostic_from_import_name_result_pattern(
         }
         ImportNameResult::NameDisallowed(name_span) => match &pattern.allow_import_names {
             Some(allow_import_names) => diagnostic_allowed_import_name(
-                name_span.clone().span(),
+                name_span.span,
                 pattern.message.clone(),
                 name_span.name(),
                 source,
@@ -1371,14 +1371,14 @@ fn get_diagnostic_from_import_name_result_pattern(
             ),
             _ => match &pattern.allow_import_name_pattern {
                 Some(allow_import_name_pattern) => diagnostic_allowed_import_name_pattern(
-                    name_span.clone().span(),
+                    name_span.span,
                     pattern.message.clone(),
                     name_span.name(),
                     source,
                     allow_import_name_pattern.as_str(),
                 ),
                 _ => diagnostic_pattern_and_import_name(
-                    name_span.clone().span(),
+                    name_span.span,
                     pattern.message.clone(),
                     name_span.name(),
                     source,

--- a/crates/oxc_linter/src/rules/import/export.rs
+++ b/crates/oxc_linter/src/rules/import/export.rs
@@ -74,7 +74,7 @@ impl Rule for Export {
             walk_exported_recursive(remote_module_record, &mut export_names, &mut visited);
 
             if export_names.is_empty() {
-                ctx.diagnostic(no_named_export(module_request.name(), module_request.span()));
+                ctx.diagnostic(no_named_export(module_request.name(), module_request.span));
             } else {
                 all_export_names.insert(star_export_entry.span, export_names);
             }

--- a/crates/oxc_linter/src/rules/import/max_dependencies.rs
+++ b/crates/oxc_linter/src/rules/import/max_dependencies.rs
@@ -119,7 +119,7 @@ impl Rule for MaxDependencies {
             "File has too many dependencies ({}). Maximum allowed is {}.",
             module_count, self.max,
         );
-        ctx.diagnostic(max_dependencies_diagnostic(error, entry.module_request.span()));
+        ctx.diagnostic(max_dependencies_diagnostic(error, entry.module_request.span));
     }
 }
 

--- a/crates/oxc_linter/src/rules/import/named.rs
+++ b/crates/oxc_linter/src/rules/import/named.rs
@@ -105,7 +105,7 @@ impl Rule for Named {
             if !remote_module_record.has_module_syntax {
                 continue;
             }
-            let import_span = import_name.span();
+            let import_span = import_name.span;
             let name = import_name.name();
             // Check `import { default as foo } from 'bar'`
             if name == "default" && remote_module_record.export_default.is_some() {
@@ -152,7 +152,7 @@ impl Rule for Named {
             if remote_module_record.exported_bindings.contains_key(name) {
                 continue;
             }
-            ctx.diagnostic(named_diagnostic(name, specifier, import_name.span()));
+            ctx.diagnostic(named_diagnostic(name, specifier, import_name.span));
         }
     }
 }

--- a/crates/oxc_linter/src/rules/import/no_duplicates.rs
+++ b/crates/oxc_linter/src/rules/import/no_duplicates.rs
@@ -118,7 +118,7 @@ impl Rule for NoDuplicates {
                 let imports = module_record
                     .import_entries
                     .iter()
-                    .filter(|entry| entry.module_request.span() == requested_module.span)
+                    .filter(|entry| entry.module_request.span == requested_module.span)
                     .collect::<Vec<_>>();
                 if imports.is_empty() {
                     import_entries_maps.entry(0).or_default().push(requested_module);

--- a/crates/oxc_linter/src/rules/import/no_named_default.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_default.rs
@@ -48,7 +48,7 @@ impl Rule for NoNamedDefault {
                 return;
             };
             if import_name.name() == "default" && !entry.is_type {
-                ctx.diagnostic(no_named_default_diagnostic(import_name.span()));
+                ctx.diagnostic(no_named_default_diagnostic(import_name.span));
             }
         });
     }

--- a/crates/oxc_linter/src/rules/import/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/import/no_namespace.rs
@@ -108,7 +108,7 @@ impl Rule for NoNamespace {
                 let source = entry.module_request.name();
 
                 if self.ignore.is_empty() {
-                    ctx.diagnostic(no_namespace_diagnostic(entry.local_name.span()));
+                    ctx.diagnostic(no_namespace_diagnostic(entry.local_name.span));
                 } else {
                     if !source.contains('.') {
                         return;
@@ -120,7 +120,7 @@ impl Rule for NoNamespace {
                         return;
                     }
 
-                    ctx.diagnostic(no_namespace_diagnostic(entry.local_name.span()));
+                    ctx.diagnostic(no_namespace_diagnostic(entry.local_name.span));
                 }
             }
             ImportImportName::Name(_) | ImportImportName::Default(_) => {}

--- a/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
+++ b/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
@@ -51,7 +51,7 @@ impl Rule for NoMocksImport {
         for import_entry in &module_records.import_entries {
             let module_specifier = import_entry.module_request.name();
             if contains_mocks_dir(module_specifier) {
-                ctx.diagnostic(no_mocks_import_diagnostic(import_entry.module_request.span()));
+                ctx.diagnostic(no_mocks_import_diagnostic(import_entry.module_request.span));
             }
         }
 

--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -101,7 +101,7 @@ impl Rule for NoBarrelFile {
             {
                 if let Some(count) = count_loaded_modules(remote_module) {
                     total += count;
-                    labels.push(module_request.span().label(format!("{count} modules")));
+                    labels.push(module_request.span.label(format!("{count} modules")));
                 }
             }
         }


### PR DESCRIPTION
Make span of NameSpan public like it already is in oxc_syntax::module_record::NameSpan to make code shorter and more explicit.

Also found five unnecessary clones while working on this.