### PR TITLE
refactor(linter/no-unused-vars): avoid unnecessary memory allocation in `get_unused_var_name`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,6 +1828,7 @@ dependencies = [
  "indexmap",
  "insta",
  "itertools",
+ "itoa",
  "javascript-globals",
  "json-strip-comments",
  "language-tags",

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -25,6 +25,7 @@ workspace = true
 doctest = true
 
 [dependencies]
+itoa = { workspace = true }
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }


### PR DESCRIPTION
To avoid unnecessary memory allocations, `itoa` is introduced to optimize integer-to-str conversions.