### PR TITLE
refactor(parser): align jsx parsing to tsc

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -192,8 +192,6 @@ impl<'a> ParserImpl<'a> {
             }
             // Literal, RegularExpressionLiteral
             kind if kind.is_literal() => self.parse_literal_expression(),
-            // JSXElement, JSXFragment
-            Kind::LAngle if self.source_type.is_jsx() => self.parse_jsx_expression(),
             _ => self.parse_identifier_expression(),
         }
     }
@@ -1017,7 +1015,7 @@ impl<'a> ParserImpl<'a> {
             && kind == Kind::LAngle
             && self.lookahead(|p| {
                 p.bump_any();
-                p.cur_kind().is_identifier_or_keyword()
+                p.at(Kind::RAngle) || p.cur_kind().is_identifier_or_keyword()
             })
         {
             return self.parse_jsx_expression();

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -406,16 +406,11 @@ impl<'a> ParserImpl<'a> {
                 let expr = self.parse_jsx_expression_container(/* in_jsx_child */ false);
                 JSXAttributeValue::ExpressionContainer(expr)
             }
-            Kind::LAngle => {
-                if self.lookahead(|s| {
-                    s.bump_any();
-                    s.at(Kind::RAngle)
-                }) {
-                    JSXAttributeValue::Fragment(self.parse_jsx_fragment(false))
-                } else {
-                    JSXAttributeValue::Element(self.parse_jsx_element(false))
-                }
-            }
+            Kind::LAngle => match self.parse_jsx_expression() {
+                Expression::JSXFragment(fragment) => JSXAttributeValue::Fragment(fragment),
+                Expression::JSXElement(element) => JSXAttributeValue::Element(element),
+                _ => unreachable!(),
+            },
             _ => self.unexpected(),
         }
     }

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -25412,10 +25412,10 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
     ╰────
 
   × Unexpected token
-   ╭─[typescript/tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx:3:2]
+   ╭─[typescript/tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx:3:1]
  2 │ 
  3 │ </>;
-   ·  ─
+   · ─
    ╰────
 
   × TS(18007): JSX expressions may not use the comma operator
@@ -25466,25 +25466,25 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
     ╰────
 
   × Unexpected token
-   ╭─[typescript/tests/cases/conformance/jsx/tsxErrorRecovery1.tsx:4:20]
+   ╭─[typescript/tests/cases/conformance/jsx/tsxErrorRecovery1.tsx:4:19]
  3 │ function foo() {
  4 │     var x = <div>  { </div>
-   ·                       ─
+   ·                      ─
  5 │ }
    ╰────
 
   × Unexpected token
-   ╭─[typescript/tests/cases/conformance/jsx/tsxErrorRecovery2.tsx:4:7]
+   ╭─[typescript/tests/cases/conformance/jsx/tsxErrorRecovery2.tsx:4:6]
  3 │ <div></div>
  4 │ <div></div>
-   ·       ─
+   ·      ─
    ╰────
 
   × Unexpected token
-   ╭─[typescript/tests/cases/conformance/jsx/tsxErrorRecovery3.tsx:4:7]
+   ╭─[typescript/tests/cases/conformance/jsx/tsxErrorRecovery3.tsx:4:6]
  3 │ <div></div>
  4 │ <div></div>
-   ·       ─
+   ·      ─
    ╰────
 
   × Expected `>` but found `Identifier`


### PR DESCRIPTION
My original plan was to rework the JSX parser from the entry point, as I had found in #11232.

However, when I read through all the TSC JSX parser code, I found that what we are doing is not much different.

---

As for perf perspective, the OXC currently requires rewind in 3 places for JSX:

- 1: `parse_jsx_expression()` - `lookahead`
  - To determine if it is a `JSXElement`(`<C`) OR `JSXFragment`(`<>`) at the entry point
- 2: `parse_jsx_child()` - `checkpoint+rewind`
  - The same above OR breaking list(`</`)
- 3: `parse_jsx_child()` - `checkpoint+rewind`
  - To determine if it is `JSXChild::Spread`(`{...Expression}`) OR `JSXChild::ExpressionContainer`(`{JSXExpression}`)

These don't exist in TSC, they just use union type or loose ASTs.

But we have different and explicit ASTs in Rust, it seems they can't be easily eliminated.

And unfortunately, I tried, but there was no remarkable improvement.

- For 1, 3045952596c7201348b26ef347bdd99e110384e4 => Minifier +3%, but no effect for parser
- For 2, I wish we had `Kind::LessThanSlash`...
- For 3, a12ff218e6d93be84a90ba1f8bcff25181b4b384 => No effect for parser

As a result, I think it would be better to keep the current clean and explicit code.