### PR TITLE
perf(parser): `check_identifier` match on `Kind` not `&str`

### DIFF
--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -338,17 +338,15 @@ impl<'a> ParserImpl<'a> {
         r#async: bool,
         generator: bool,
     ) -> Option<BindingIdentifier<'a>> {
-        if self.cur_kind().is_binding_identifier() {
-            let ctx = self.ctx;
+        let kind = self.cur_kind();
+        if kind.is_binding_identifier() {
+            let mut ctx = self.ctx;
             if func_kind.is_expression() {
-                self.ctx = self.ctx.and_await(r#async).and_yield(generator);
+                ctx = ctx.and_await(r#async).and_yield(generator);
             }
+            self.check_identifier(kind, ctx);
 
             let (span, name) = self.parse_identifier_kind(Kind::Ident);
-            self.check_identifier(span, &name);
-
-            self.ctx = ctx;
-
             Some(self.ast.binding_identifier(span, name))
         } else {
             if func_kind.is_id_required() {


### PR DESCRIPTION
Small optimization. `ParserImpl::check_identifier` check if the identifier is `async` or `yield` by comparing `kind == Kind::Async` instead of `name == "async"`. Comparing `Kind`s is cheaper than string comparison.

Also:

* Receive `ctx` as a parameter, to avoid `parse_function_id` having to temporarily overwrite `self.ctx` and then set it back again.
* Don't take `span` as a parameter, because it can be obtained from `self.cur_token().span()`, and this is on a cold path.
