### PR TITLE
perf(parser): simplify getting span of identifiers and literals

### DIFF
--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -433,15 +433,10 @@ impl<'a> ParserImpl<'a> {
     }
 
     fn parse_jsx_text(&mut self) -> Box<'a, JSXText<'a>> {
-        let span = self.start_span();
+        let span = self.cur_token().span();
+        let raw = Atom::from(self.cur_src());
         let value = Atom::from(self.cur_string());
         self.bump_any();
-        let span = self.end_span(span);
-        // SAFETY:
-        // range comes from the lexer, which are ensured to meeting the criteria of `get_unchecked`.
-        let raw = Atom::from(unsafe {
-            self.source_text.get_unchecked(span.start as usize..span.end as usize)
-        });
         self.ast.alloc_jsx_text(span, value, Some(raw))
     }
 


### PR DESCRIPTION
Small optimization. For identifiers and literals, the span of the AST node is the same as the span of the `Token`. So just get the whole span from the `Token` in one access, and avoid the dance of assembling the span by calling `start_span` and then `end_span`.
