### PR TITLE
test(linter): `eslint/no-duplicate-imports` shouldn't report the same span

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
@@ -487,6 +487,13 @@ fn test() {
         export * from "os";"#,
             Some(serde_json::json!([{ "includeExports": true }])),
         ),
+        (
+            // Verifies that the error for the second line appears only once in the test snapshot.
+            // https://github.com/oxc-project/oxc/pull/11320#issuecomment-2912286528
+            r#"import type { PriorityDialogCustomClassNames, WeightDialogCustomClassNames } from "./HostEditDialogs";
+            import { PriorityDialog, WeightDialog } from "./HostEditDialogs";"#,
+            None,
+        ),
     ];
 
     Tester::new(NoDuplicateImports::NAME, NoDuplicateImports::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/eslint_no_duplicate_imports.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_duplicate_imports.snap
@@ -158,3 +158,14 @@ source: crates/oxc_linter/src/tester.rs
    ·                  ╰── This export is duplicated
    ╰────
   help: Merge the duplicated exports into a single export statement
+
+  ⚠ eslint(no-duplicate-imports): './HostEditDialogs' import is duplicated
+   ╭─[no_duplicate_imports.tsx:1:83]
+ 1 │ import type { PriorityDialogCustomClassNames, WeightDialogCustomClassNames } from "./HostEditDialogs";
+   ·                                                                                   ─────────┬─────────
+   ·                                                                                            ╰── Can be merged with this import
+ 2 │             import { PriorityDialog, WeightDialog } from "./HostEditDialogs";
+   ·                                                          ─────────┬─────────
+   ·                                                                   ╰── This import is duplicated
+   ╰────
+  help: Merge the duplicated import into a single import statement


### PR DESCRIPTION
Adds a test for a bug that was unintentionally fixed by #11320.
I also confirmed that the test would have failed before my original PR.

Context: https://github.com/oxc-project/oxc/pull/11320#issuecomment-2912286528