### PR TITLE
docs(oxlint): remove incorrect doc comment

### DIFF
--- a/apps/oxlint/fixtures/nested_config/package1-empty-config/.oxlintrc.json
+++ b/apps/oxlint/fixtures/nested_config/package1-empty-config/.oxlintrc.json
@@ -1,5 +1,3 @@
 {
-  // this is a nested config file, but it should use the default config which
-  // is implicitly merged with this
   "rules": {}
 }


### PR DESCRIPTION
as per our docs

> Configuration files are not automatically merged, and the configuration in a child configuration file will not affect the parent configuration. However, options passed in the command-line will override any configuration file, regardless of whether it is in the parent or child directory. In addition, using the --config option to specify a singular file for configuration will disable the use of nested configuration files.


https://oxc.rs/docs/guide/usage/linter/nested-config.html