### PR TITLE
test(linter): explicitly disable correctness for clarity

### DIFF
--- a/apps/oxlint/fixtures/nested_config/.oxlintrc.json
+++ b/apps/oxlint/fixtures/nested_config/.oxlintrc.json
@@ -1,4 +1,5 @@
 {
+  "categories": { "correctness": "off"},
   "rules": {
     "no-console": "error",
     "no-debugger": "error"

--- a/apps/oxlint/fixtures/nested_config/oxlint-no-console.json
+++ b/apps/oxlint/fixtures/nested_config/oxlint-no-console.json
@@ -1,4 +1,5 @@
 {
+  "categories": { "correctness": "off" },
   "rules": {
     "no-console": "error",
     "no-debugger": "off"

--- a/apps/oxlint/fixtures/nested_config/package1-empty-config/.oxlintrc.json
+++ b/apps/oxlint/fixtures/nested_config/package1-empty-config/.oxlintrc.json
@@ -1,3 +1,4 @@
 {
+  "categories": { "correctness": "off"},
   "rules": {}
 }

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_--config oxlint-no-console.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_--config oxlint-no-console.json@oxlint.snap
@@ -37,7 +37,7 @@ working directory: fixtures/nested_config
   help: Delete this console statement.
 
 Found 0 warnings and 4 errors.
-Finished in <variable>ms on 7 files with 101 rules using 1 threads.
+Finished in <variable>ms on 7 files with 1 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_-A no-console --config oxlint-no-console.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_-A no-console --config oxlint-no-console.json@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -A no-console --config oxlint-no-console.json
 working directory: fixtures/nested_config
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 7 files with 100 rules using 1 threads.
+Finished in <variable>ms on 7 files with 0 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_-A no-console@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_-A no-console@oxlint.snap
@@ -13,13 +13,6 @@ working directory: fixtures/nested_config
    `----
   help: Remove the debugger statement
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
-   ,-[package1-empty-config/debugger.js:1:1]
- 1 | debugger;
-   : ^^^^^^^^^
-   `----
-  help: Remove the debugger statement
-
   x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
    ,-[package2-no-config/debugger.js:1:1]
  1 | debugger;
@@ -27,7 +20,7 @@ working directory: fixtures/nested_config
    `----
   help: Remove the debugger statement
 
-Found 1 warning and 2 errors.
+Found 0 warnings and 2 errors.
 Finished in <variable>ms on 7 files using 1 threads.
 ----------
 CLI result: LintFoundErrors

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_@oxlint.snap
@@ -20,13 +20,6 @@ working directory: fixtures/nested_config
    `----
   help: Remove the debugger statement
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
-   ,-[package1-empty-config/debugger.js:1:1]
- 1 | debugger;
-   : ^^^^^^^^^
-   `----
-  help: Remove the debugger statement
-
   x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: Unexpected console statement.
    ,-[package2-no-config/console.ts:1:1]
  1 | console.log("test");
@@ -50,7 +43,7 @@ working directory: fixtures/nested_config
    `----
   help: Delete this console statement.
 
-Found 1 warning and 5 errors.
+Found 0 warnings and 5 errors.
 Finished in <variable>ms on 7 files using 1 threads.
 ----------
 CLI result: LintFoundErrors


### PR DESCRIPTION
previously it was unclear why some rules were enabled (perf is impliclty enabled when categories is unconfigured)