### PR TITLE
refactor(parser): remove lexer lookahead in module parsing

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -69,6 +69,7 @@ impl<'a> ParserImpl<'a> {
 
     /// Peek next kind, returns EOF for final peek
     #[inline]
+    #[expect(dead_code)]
     pub(crate) fn peek_kind(&mut self) -> Kind {
         self.peek_token().kind()
     }
@@ -90,12 +91,14 @@ impl<'a> ParserImpl<'a> {
 
     /// Peek at nth kind
     #[inline]
+    #[expect(dead_code)]
     pub(crate) fn nth_at(&mut self, n: u8, kind: Kind) -> bool {
         self.nth(n).kind() == kind
     }
 
     /// Peek nth kind
     #[inline]
+    #[expect(dead_code)]
     pub(crate) fn nth_kind(&mut self, n: u8) -> Kind {
         self.nth(n).kind()
     }

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -448,7 +448,7 @@ impl<'a> ParserImpl<'a> {
         )
     }
 
-    fn is_next_token_equals(&mut self) -> bool {
+    pub(crate) fn is_next_token_equals(&mut self) -> bool {
         self.bump_any();
         self.at(Kind::Eq)
     }


### PR DESCRIPTION
- part of https://github.com/oxc-project/oxc/issues/11194

Removes the lexer lookahead code for module import/export parsing. There is a minor perf regression in parsing import specifiers (which is fairly hot) related to calling lookahead and doing rewind where before we didn't do it.