### PR TITLE
perf(parser): remove lexer lookahead

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -61,49 +61,6 @@ impl<'a> ParserImpl<'a> {
         self.lexer.get_template_string(self.token.start())
     }
 
-    /// Peek next token, returns EOF for final peek
-    #[inline]
-    pub(crate) fn peek_token(&mut self) -> Token {
-        self.lexer.lookahead(1)
-    }
-
-    /// Peek next kind, returns EOF for final peek
-    #[inline]
-    #[expect(dead_code)]
-    pub(crate) fn peek_kind(&mut self) -> Kind {
-        self.peek_token().kind()
-    }
-
-    /// Peek at kind
-    #[inline]
-    #[expect(dead_code)]
-    pub(crate) fn peek_at(&mut self, kind: Kind) -> bool {
-        self.peek_token().kind() == kind
-    }
-
-    /// Peek nth token
-    #[inline]
-    pub(crate) fn nth(&mut self, n: u8) -> Token {
-        if n == 0 {
-            return self.cur_token();
-        }
-        self.lexer.lookahead(n)
-    }
-
-    /// Peek at nth kind
-    #[inline]
-    #[expect(dead_code)]
-    pub(crate) fn nth_at(&mut self, n: u8, kind: Kind) -> bool {
-        self.nth(n).kind() == kind
-    }
-
-    /// Peek nth kind
-    #[inline]
-    #[expect(dead_code)]
-    pub(crate) fn nth_kind(&mut self, n: u8) -> Kind {
-        self.nth(n).kind()
-    }
-
     /// Checks if the current index has token `Kind`
     #[inline]
     pub(crate) fn at(&self, kind: Kind) -> bool {

--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -76,6 +76,7 @@ impl<'a> ParserImpl<'a> {
 
     /// Peek at kind
     #[inline]
+    #[expect(dead_code)]
     pub(crate) fn peek_at(&mut self, kind: Kind) -> bool {
         self.peek_token().kind() == kind
     }

--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -384,7 +384,13 @@ impl<'a> ParserImpl<'a> {
             if first {
                 first = false;
             } else {
-                if !trailing_separator && self.at(separator) && self.peek_at(close) {
+                if !trailing_separator
+                    && self.at(separator)
+                    && self.lookahead(|p| {
+                        p.bump_any();
+                        p.at(close)
+                    })
+                {
                     break;
                 }
                 self.expect(separator);

--- a/crates/oxc_parser/src/lexer/jsx.rs
+++ b/crates/oxc_parser/src/lexer/jsx.rs
@@ -116,9 +116,6 @@ impl Lexer<'_> {
         }
         self.consume_char();
 
-        // Clear the current lookahead `Minus` Token
-        self.lookahead.clear();
-
         // Consume bytes which are part of identifier tail
         let next_byte = byte_search! {
             lexer: self,

--- a/crates/oxc_parser/src/lexer/punctuation.rs
+++ b/crates/oxc_parser/src/lexer/punctuation.rs
@@ -61,9 +61,6 @@ impl Lexer<'_> {
     pub(crate) fn re_lex_right_angle(&mut self) -> Token {
         self.token.set_start(self.offset());
         let kind = self.read_right_angle();
-        if kind != Kind::RAngle {
-            self.lookahead.clear();
-        }
         self.finish_next(kind)
     }
 

--- a/crates/oxc_parser/src/lexer/regex.rs
+++ b/crates/oxc_parser/src/lexer/regex.rs
@@ -21,7 +21,6 @@ impl Lexer<'_> {
                 },
         );
         let (pattern_end, flags, flags_error) = self.read_regex();
-        self.lookahead.clear();
         let token = self.finish_next(Kind::RegExp);
         (token, pattern_end, flags, flags_error)
     }

--- a/crates/oxc_parser/src/lexer/template.rs
+++ b/crates/oxc_parser/src/lexer/template.rs
@@ -389,7 +389,6 @@ impl<'a> Lexer<'a> {
     pub(crate) fn next_template_substitution_tail(&mut self) -> Token {
         self.token.set_start(self.offset() - 1);
         let kind = self.read_template_literal(Kind::TemplateMiddle, Kind::TemplateTail);
-        self.lookahead.clear();
         self.finish_next(kind)
     }
 

--- a/crates/oxc_parser/src/lexer/typescript.rs
+++ b/crates/oxc_parser/src/lexer/typescript.rs
@@ -11,7 +11,6 @@ impl Lexer<'_> {
         self.token.set_start(self.offset() - offset);
         self.source.back(offset as usize - 1);
         let kind = Kind::LAngle;
-        self.lookahead.clear();
         self.finish_next(kind)
     }
 
@@ -25,7 +24,6 @@ impl Lexer<'_> {
         self.token.set_start(self.offset() - offset);
         self.source.back(offset as usize - 1);
         let kind = Kind::RAngle;
-        self.lookahead.clear();
         self.finish_next(kind)
     }
 }


### PR DESCRIPTION
- Closes #11194 

Removes the lookahead `VecDeque` in the lexer and all of the bookkeeping code depending on it.