### PR TITLE
refactor(parser): Avoid peek in parse_delimited_list

### DIFF
--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -180,13 +180,10 @@ impl<'a> ParserImpl<'a> {
         import_kind: ImportOrExportKind,
     ) -> Vec<'a, ImportDeclarationSpecifier<'a>> {
         self.expect(Kind::LCurly);
-        let list = self.context(Context::empty(), self.ctx, |p| {
-            p.parse_delimited_list(
-                Kind::RCurly,
-                Kind::Comma,
-                /* trailing_separator */ true,
-                |parser| parser.parse_import_specifier(import_kind),
-            )
+        let (list, _) = self.context(Context::empty(), self.ctx, |p| {
+            p.parse_delimited_list(Kind::RCurly, Kind::Comma, |parser| {
+                parser.parse_import_specifier(import_kind)
+            })
         });
         self.expect(Kind::RCurly);
         list
@@ -203,13 +200,8 @@ impl<'a> ParserImpl<'a> {
         };
         let span = self.start_span();
         self.expect(Kind::LCurly);
-        let with_entries = self.context(Context::empty(), self.ctx, |p| {
-            p.parse_delimited_list(
-                Kind::RCurly,
-                Kind::Comma,
-                /*trailing_separator*/ true,
-                Self::parse_import_attribute,
-            )
+        let (with_entries, _) = self.context(Context::empty(), self.ctx, |p| {
+            p.parse_delimited_list(Kind::RCurly, Kind::Comma, Self::parse_import_attribute)
         });
         self.expect(Kind::RCurly);
 
@@ -327,13 +319,10 @@ impl<'a> ParserImpl<'a> {
     fn parse_export_named_specifiers(&mut self, span: u32) -> Box<'a, ExportNamedDeclaration<'a>> {
         let export_kind = self.parse_import_or_export_kind();
         self.expect(Kind::LCurly);
-        let mut specifiers = self.context(Context::empty(), self.ctx, |p| {
-            p.parse_delimited_list(
-                Kind::RCurly,
-                Kind::Comma,
-                /* trailing_separator */ true,
-                |parser| parser.parse_export_named_specifier(export_kind),
-            )
+        let (mut specifiers, _) = self.context(Context::empty(), self.ctx, |p| {
+            p.parse_delimited_list(Kind::RCurly, Kind::Comma, |parser| {
+                parser.parse_export_named_specifier(export_kind)
+            })
         });
         self.expect(Kind::RCurly);
         let (source, with_clause) = if self.eat(Kind::From) && self.cur_kind().is_literal() {

--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -13,11 +13,10 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_object_expression(&mut self) -> Box<'a, ObjectExpression<'a>> {
         let span = self.start_span();
         self.expect(Kind::LCurly);
-        let object_expression_properties = self.context(Context::In, Context::empty(), |p| {
+        let (object_expression_properties, _) = self.context(Context::In, Context::empty(), |p| {
             p.parse_delimited_list(
                 Kind::RCurly,
                 Kind::Comma,
-                /* trailing_separator */ false,
                 Self::parse_object_expression_property,
             )
         });

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -38,12 +38,8 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_ts_enum_body(&mut self) -> TSEnumBody<'a> {
         let span = self.start_span();
         self.expect(Kind::LCurly);
-        let members = self.parse_delimited_list(
-            Kind::RCurly,
-            Kind::Comma,
-            /* trailing_separator */ true,
-            Self::parse_ts_enum_member,
-        );
+        let (members, _) =
+            self.parse_delimited_list(Kind::RCurly, Kind::Comma, Self::parse_ts_enum_member);
         self.expect(Kind::RCurly);
         self.ast.ts_enum_body(self.end_span(span), members)
     }

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -13042,6 +13042,24 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │ };
    ╰────
 
+  × Expected `]` but found `,`
+   ╭─[typescript/tests/cases/compiler/indexSignatureWithTrailingComma.ts:6:17]
+ 5 │ interface B {
+ 6 │     [key: string,]: string;
+   ·                 ┬
+   ·                 ╰── `]` expected
+ 7 │ }
+   ╰────
+
+  × Expected `]` but found `,`
+    ╭─[typescript/tests/cases/compiler/indexSignatureWithTrailingComma.ts:10:17]
+  9 │ class C {
+ 10 │     [key: string,]: null;
+    ·                 ┬
+    ·                 ╰── `]` expected
+ 11 │ }
+    ╰────
+
   × Unexpected token
    ╭─[typescript/tests/cases/compiler/indexSignatureWithoutTypeAnnotation1.ts:2:14]
  1 │ class C {


### PR DESCRIPTION
Out of curiosity, I've just deleted the peeking in `parse_delimited_list`.

Then, coverage errors show me there are only a few places missing error report for invalid trailing comma after rest element, etc.

So I added those checks manually.

In TSC, these checks seem to be done at checker, not parser. But we need this in parser for JS.

---

(Sorry, I have PASSED the test, but I am not very confident that this change is intrinsically sound.)