### PR TITLE
refactor(ast/estree): do not put TS struct fields last

### DIFF
--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -322,8 +322,8 @@ impl ESTree for TaggedTemplateExpression<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("tag", &self.tag);
-        state.serialize_field("quasi", &self.quasi);
         state.serialize_ts_field("typeArguments", &self.type_arguments);
+        state.serialize_field("quasi", &self.quasi);
         state.end();
     }
 }
@@ -402,9 +402,9 @@ impl ESTree for CallExpression<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("callee", &self.callee);
+        state.serialize_ts_field("typeArguments", &self.type_arguments);
         state.serialize_field("arguments", &self.arguments);
         state.serialize_field("optional", &self.optional);
-        state.serialize_ts_field("typeArguments", &self.type_arguments);
         state.end();
     }
 }
@@ -416,8 +416,8 @@ impl ESTree for NewExpression<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("callee", &self.callee);
-        state.serialize_field("arguments", &self.arguments);
         state.serialize_ts_field("typeArguments", &self.type_arguments);
+        state.serialize_field("arguments", &self.arguments);
         state.end();
     }
 }
@@ -1768,11 +1768,11 @@ impl ESTree for ExportNamedDeclaration<'_> {
         state.serialize_field("declaration", &self.declaration);
         state.serialize_field("specifiers", &self.specifiers);
         state.serialize_field("source", &self.source);
+        state.serialize_ts_field("exportKind", &self.export_kind);
         state.serialize_field(
             "attributes",
             &crate::serialize::js::ExportNamedDeclarationWithClause(self),
         );
-        state.serialize_ts_field("exportKind", &self.export_kind);
         state.end();
     }
 }

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -177,8 +177,8 @@ function deserializeTaggedTemplateExpression(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     tag: deserializeExpression(pos + 8),
-    quasi: deserializeTemplateLiteral(pos + 32),
     typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
+    quasi: deserializeTemplateLiteral(pos + 32),
   };
 }
 
@@ -243,9 +243,9 @@ function deserializeCallExpression(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     callee: deserializeExpression(pos + 8),
+    typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
     arguments: deserializeVecArgument(pos + 32),
     optional: deserializeBool(pos + 56),
-    typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
   };
 }
 
@@ -255,8 +255,8 @@ function deserializeNewExpression(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     callee: deserializeExpression(pos + 8),
-    arguments: deserializeVecArgument(pos + 32),
     typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
+    arguments: deserializeVecArgument(pos + 32),
   };
 }
 
@@ -1131,8 +1131,8 @@ function deserializeExportNamedDeclaration(pos) {
     declaration: deserializeOptionDeclaration(pos + 8),
     specifiers: deserializeVecExportSpecifier(pos + 24),
     source: deserializeOptionStringLiteral(pos + 48),
-    attributes: withClause === null ? [] : withClause.attributes,
     exportKind: deserializeImportOrExportKind(pos + 104),
+    attributes: withClause === null ? [] : withClause.attributes,
   };
 }
 

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -125,8 +125,8 @@ export interface TemplateLiteral extends Span {
 export interface TaggedTemplateExpression extends Span {
   type: 'TaggedTemplateExpression';
   tag: Expression;
-  quasi: TemplateLiteral;
   typeArguments?: TSTypeParameterInstantiation | null;
+  quasi: TemplateLiteral;
 }
 
 export interface TemplateElement extends Span {
@@ -169,16 +169,16 @@ export interface PrivateFieldExpression extends Span {
 export interface CallExpression extends Span {
   type: 'CallExpression';
   callee: Expression;
+  typeArguments?: TSTypeParameterInstantiation | null;
   arguments: Array<Argument>;
   optional: boolean;
-  typeArguments?: TSTypeParameterInstantiation | null;
 }
 
 export interface NewExpression extends Span {
   type: 'NewExpression';
   callee: Expression;
-  arguments: Array<Argument>;
   typeArguments?: TSTypeParameterInstantiation | null;
+  arguments: Array<Argument>;
 }
 
 export interface MetaProperty extends Span {
@@ -788,8 +788,8 @@ export interface ExportNamedDeclaration extends Span {
   declaration: Declaration | null;
   specifiers: Array<ExportSpecifier>;
   source: StringLiteral | null;
-  attributes: Array<ImportAttribute>;
   exportKind?: ImportOrExportKind;
+  attributes: Array<ImportAttribute>;
 }
 
 export interface ExportDefaultDeclaration extends Span {


### PR DESCRIPTION
Previously we automatically re-ordered fields to put TS-only fields last. Don't do that - use definition order, unless a field order is specified with `#[estree(field_order(...))]`.