### PR TITLE
refactor(ast_tools/estree): order `type` and `span` fields first by default

### DIFF
--- a/crates/oxc_syntax/src/module_record.rs
+++ b/crates/oxc_syntax/src/module_record.rs
@@ -87,7 +87,7 @@ impl<'a> ModuleRecord<'a> {
 #[ast]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[generate_derive(ESTree)]
-#[estree(no_type, no_ts_def)]
+#[estree(no_type, no_ts_def, field_order(name, span))]
 pub struct NameSpan<'a> {
     /// Name
     #[estree(rename = "value")]

--- a/napi/parser/src/raw_transfer_types.rs
+++ b/napi/parser/src/raw_transfer_types.rs
@@ -83,7 +83,7 @@ impl From<Severity> for ErrorSeverity {
 
 #[ast]
 #[generate_derive(ESTree)]
-#[estree(no_type, no_ts_def)]
+#[estree(no_type, no_ts_def, field_order(message, span))]
 pub struct ErrorLabel<'a> {
     pub message: Option<Atom<'a>>,
     pub span: Span,


### PR DESCRIPTION
Order `type` field 1st, and `span` field 2nd in ESTree and TS-ESTree ASTs.