### PR TITLE
refactor(ast/estree): re-order fields in visitation order

### DIFF
--- a/.github/actions/clone-submodules/action.yml
+++ b/.github/actions/clone-submodules/action.yml
@@ -38,4 +38,4 @@ runs:
         show-progress: false
         repository: oxc-project/acorn-test262
         path: tasks/coverage/acorn-test262
-        ref: bf1f5de027151b5e2e671cba0a6085907be3ab37 # Latest main at 20/5/25
+        ref: e6d4a8915d6825132e03b4e517b51f97a1536a3a # Latest main at 28/5/25

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -214,7 +214,8 @@ pub use match_expression;
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(
     rename = "Identifier",
-    add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull)
+    add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
+    field_order(span, decorators, name, optional, typeAnnotation),
 )]
 pub struct IdentifierName<'a> {
     pub span: Span,
@@ -232,7 +233,8 @@ pub struct IdentifierName<'a> {
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(
     rename = "Identifier",
-    add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull)
+    add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
+    field_order(span, decorators, name, optional, typeAnnotation),
 )]
 pub struct IdentifierReference<'a> {
     pub span: Span,
@@ -258,7 +260,8 @@ pub struct IdentifierReference<'a> {
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(
     rename = "Identifier",
-    add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull)
+    add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
+    field_order(span, decorators, name, optional, typeAnnotation),
 )]
 pub struct BindingIdentifier<'a> {
     pub span: Span,
@@ -285,6 +288,7 @@ pub struct BindingIdentifier<'a> {
 #[estree(
     rename = "Identifier",
     add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
+    field_order(span, decorators, name, optional, typeAnnotation),
 )]
 pub struct LabelIdentifier<'a> {
     pub span: Span,
@@ -376,11 +380,7 @@ pub enum ObjectPropertyKind<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(
-    rename = "Property",
-    add_fields(optional = TsFalse),
-    field_order(span, method, shorthand, computed, key, value, kind, optional),
-)]
+#[estree(rename = "Property", add_fields(optional = TsFalse))]
 pub struct ObjectProperty<'a> {
     pub span: Span,
     pub kind: PropertyKind,
@@ -429,7 +429,6 @@ pub enum PropertyKind {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(field_order(span, expressions, quasis))]
 pub struct TemplateLiteral<'a> {
     pub span: Span,
     pub quasis: Vec<'a, TemplateElement<'a>>,
@@ -524,11 +523,7 @@ pub use match_member_expression;
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(
-    rename = "MemberExpression",
-    add_fields(computed = True),
-    field_order(span, object, expression, computed, optional),
-)]
+#[estree(rename = "MemberExpression", add_fields(computed = True))]
 pub struct ComputedMemberExpression<'a> {
     pub span: Span,
     pub object: Expression<'a>,
@@ -543,11 +538,7 @@ pub struct ComputedMemberExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(
-    rename = "MemberExpression",
-    add_fields(computed = False),
-    field_order(span, object, property, computed, optional),
-)]
+#[estree(rename = "MemberExpression", add_fields(computed = False))]
 pub struct StaticMemberExpression<'a> {
     pub span: Span,
     pub object: Expression<'a>,
@@ -561,11 +552,7 @@ pub struct StaticMemberExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(
-    rename = "MemberExpression",
-    add_fields(computed = False),
-    field_order(span, object, field, computed, optional),
-)]
+#[estree(rename = "MemberExpression", add_fields(computed = False))]
 pub struct PrivateFieldExpression<'a> {
     pub span: Span,
     pub object: Expression<'a>,
@@ -695,7 +682,7 @@ pub struct UpdateExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(add_fields(prefix = True), field_order(span, operator, prefix, argument))]
+#[estree(add_fields(prefix = True))]
 pub struct UnaryExpression<'a> {
     pub span: Span,
     pub operator: UnaryOperator,
@@ -719,11 +706,7 @@ pub struct BinaryExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(
-    rename = "BinaryExpression",
-    add_fields(operator = In),
-    field_order(span, left, operator, right),
-)]
+#[estree(rename = "BinaryExpression", add_fields(operator = In), field_order(span, left, operator, right))]
 pub struct PrivateInExpression<'a> {
     pub span: Span,
     pub left: PrivateIdentifier<'a>,
@@ -870,6 +853,7 @@ pub use match_assignment_target_pattern;
 #[estree(
     rename = "ArrayPattern",
     add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
+    field_order(span, decorators, elements, optional, typeAnnotation),
 )]
 pub struct ArrayAssignmentTarget<'a> {
     pub span: Span,
@@ -887,6 +871,7 @@ pub struct ArrayAssignmentTarget<'a> {
 #[estree(
     rename = "ObjectPattern",
     add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
+    field_order(span, decorators, properties, optional, typeAnnotation),
 )]
 pub struct ObjectAssignmentTarget<'a> {
     pub span: Span,
@@ -904,6 +889,7 @@ pub struct ObjectAssignmentTarget<'a> {
 #[estree(
     rename = "RestElement",
     add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull, value = TsNull),
+    field_order(span, decorators, target, optional, typeAnnotation, value),
 )]
 pub struct AssignmentTargetRest<'a> {
     pub span: Span,
@@ -932,7 +918,8 @@ pub enum AssignmentTargetMaybeDefault<'a> {
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(
     rename = "AssignmentPattern",
-    add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull)
+    add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
+    field_order(span, decorators, binding, init, optional, typeAnnotation),
 )]
 pub struct AssignmentTargetWithDefault<'a> {
     pub span: Span,
@@ -959,8 +946,8 @@ pub enum AssignmentTargetProperty<'a> {
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(
     rename = "Property",
-    add_fields(method = False, shorthand = True, computed = False, kind = Init, optional = TsFalse),
-    field_order(span, method, shorthand, computed, binding, init, kind, optional),
+    add_fields(kind = Init, method = False, shorthand = True, computed = False, optional = TsFalse),
+    field_order(span, kind, binding, init, method, shorthand, computed, optional),
 )]
 pub struct AssignmentTargetPropertyIdentifier<'a> {
     pub span: Span,
@@ -978,8 +965,8 @@ pub struct AssignmentTargetPropertyIdentifier<'a> {
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(
     rename = "Property",
-    add_fields(method = False, shorthand = False, kind = Init, optional = TsFalse),
-    field_order(span, method, shorthand, computed, name, binding, kind, optional),
+    add_fields(kind = Init, method = False, shorthand = False, optional = TsFalse),
+    field_order(span, kind, name, binding, method, shorthand, computed, optional),
 )]
 pub struct AssignmentTargetPropertyProperty<'a> {
     pub span: Span,
@@ -1188,7 +1175,6 @@ pub use match_declaration;
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(field_order(span, declarations, kind, declare))]
 pub struct VariableDeclaration<'a> {
     pub span: Span,
     pub kind: VariableDeclarationKind,
@@ -1405,7 +1391,6 @@ pub struct SwitchStatement<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(field_order(span, consequent, test))]
 pub struct SwitchCase<'a> {
     pub span: Span,
     pub test: Option<Expression<'a>>,
@@ -1416,7 +1401,6 @@ pub struct SwitchCase<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(field_order(span, body, label))]
 pub struct LabeledStatement<'a> {
     pub span: Span,
     pub label: LabelIdentifier<'a>,
@@ -1571,7 +1555,10 @@ pub enum BindingPatternKind<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull))]
+#[estree(
+    add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
+    field_order(span, decorators, left, right, optional, typeAnnotation),
+)]
 pub struct AssignmentPattern<'a> {
     pub span: Span,
     pub left: BindingPattern<'a>,
@@ -1581,7 +1568,10 @@ pub struct AssignmentPattern<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull))]
+#[estree(
+    add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
+    field_order(span, decorators, properties, optional, typeAnnotation),
+)]
 pub struct ObjectPattern<'a> {
     pub span: Span,
     pub properties: Vec<'a, BindingProperty<'a>>,
@@ -1594,8 +1584,8 @@ pub struct ObjectPattern<'a> {
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(
     rename = "Property",
-    add_fields(method = False, kind = Init, optional = TsFalse),
-    field_order(span, method, shorthand, computed, key, value, kind, optional),
+    add_fields(kind = Init, method = False, optional = TsFalse),
+    field_order(span, kind, key, value, method, shorthand, computed, optional),
 )]
 pub struct BindingProperty<'a> {
     pub span: Span,
@@ -1608,7 +1598,10 @@ pub struct BindingProperty<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull))]
+#[estree(
+    add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
+    field_order(span, decorators, elements, optional, typeAnnotation),
+)]
 pub struct ArrayPattern<'a> {
     pub span: Span,
     pub elements: Vec<'a, Option<BindingPattern<'a>>>,
@@ -1631,6 +1624,7 @@ pub struct ArrayPattern<'a> {
 #[estree(
     rename = "RestElement",
     add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull, value = TsNull),
+    field_order(span, decorators, argument, optional, typeAnnotation, value),
 )]
 pub struct BindingRestElement<'a> {
     pub span: Span,
@@ -1686,10 +1680,6 @@ pub struct BindingRestElement<'a> {
 #[estree(
     add_ts_def = "type ParamPattern = FormalParameter | TSParameterProperty | FormalParameterRest",
     add_fields(expression = False),
-    field_order(
-        r#type, span, id, expression, generator, r#async, params, body,
-        declare, type_parameters, return_type,
-    ),
 )]
 pub struct Function<'a> {
     pub span: Span,
@@ -1873,10 +1863,7 @@ pub struct FunctionBody<'a> {
 )]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(
-    add_fields(id = Null, generator = False),
-    field_order(span, id, expression, generator, r#async, params, body, type_parameters, return_type),
-)]
+#[estree(add_fields(id = Null, generator = False))]
 pub struct ArrowFunctionExpression<'a> {
     pub span: Span,
     /// Is the function body an arrow expression? i.e. `() => expr` instead of `() => {}`
@@ -1913,11 +1900,6 @@ pub struct YieldExpression<'a> {
 #[scope(flags = ScopeFlags::StrictMode)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[rustfmt::skip]
-#[estree(field_order(
-    r#type, span, id, super_class, body,
-    decorators, type_parameters, super_type_arguments, implements, r#abstract, declare,
-))]
 pub struct Class<'a> {
     pub span: Span,
     pub r#type: ClassType,
@@ -2057,11 +2039,6 @@ pub enum ClassElement<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[rustfmt::skip]
-#[estree(field_order(
-    r#type, span, r#static, computed, key, kind, value,
-    decorators, r#override, optional, accessibility
-))]
 pub struct MethodDefinition<'a> {
     pub span: Span,
     /// Method definition type
@@ -2102,11 +2079,6 @@ pub enum MethodDefinitionType {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[rustfmt::skip]
-#[estree(field_order(
-    r#type, span, r#static, computed, key, value,
-    decorators, declare, r#override, optional, definite, readonly, type_annotation, accessibility,
-))]
 pub struct PropertyDefinition<'a> {
     pub span: Span,
     pub r#type: PropertyDefinitionType,
@@ -2329,14 +2301,7 @@ pub enum AccessorPropertyType {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[rustfmt::skip]
-#[estree(
-    add_fields(declare = TsFalse, optional = TsFalse, readonly = TsFalse),
-    field_order(
-        r#type, span, key, type_annotation, value, computed, r#static, decorators, definite,
-        accessibility, optional, r#override, readonly, declare
-    )
-)]
+#[estree(add_fields(declare = TsFalse, optional = TsFalse, readonly = TsFalse))]
 pub struct AccessorProperty<'a> {
     pub span: Span,
     pub r#type: AccessorPropertyType,
@@ -2395,7 +2360,6 @@ pub struct ImportExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(field_order(span, specifiers, source, with_clause, phase, import_kind))]
 pub struct ImportDeclaration<'a> {
     pub span: Span,
     /// `None` for `import 'foo'`, `Some([])` for `import {} from 'foo'`

--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -33,7 +33,6 @@ use super::{inherit_variants, js::*, literal::*, ts::*};
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(field_order(span, opening_element, closing_element, children))]
 pub struct JSXElement<'a> {
     /// Node location in source code
     pub span: Span,
@@ -66,10 +65,7 @@ pub struct JSXElement<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(
-    add_fields(selfClosing = JSXOpeningElementSelfClosing),
-    field_order(span, attributes, name, selfClosing, type_arguments),
-)]
+#[estree(add_fields(selfClosing = JSXOpeningElementSelfClosing))]
 pub struct JSXOpeningElement<'a> {
     /// Node location in source code
     pub span: Span,
@@ -114,7 +110,6 @@ pub struct JSXClosingElement<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(field_order(span, opening_fragment, closing_fragment, children))]
 pub struct JSXFragment<'a> {
     /// Node location in source code
     pub span: Span,

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -37,7 +37,7 @@ use super::{inherit_variants, js::*, literal::*};
 #[estree(
     rename = "Identifier",
     add_fields(name = This, decorators = EmptyArray, optional = False),
-    field_order(span, name, decorators, optional, type_annotation),
+    field_order(span, decorators, name, optional, type_annotation),
 )]
 pub struct TSThisParameter<'a> {
     pub span: Span,
@@ -122,10 +122,7 @@ pub struct TSEnumBody<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(
-    add_fields(computed = TSEnumMemberComputed),
-    field_order(span, id, computed, initializer),
-)]
+#[estree(add_fields(computed = TSEnumMemberComputed))]
 pub struct TSEnumMember<'a> {
     pub span: Span,
     pub id: TSEnumMemberName<'a>,
@@ -1087,7 +1084,7 @@ pub struct TSConstructSignatureDeclaration<'a> {
 #[estree(
     rename = "Identifier",
     add_fields(decorators = EmptyArray, optional = False),
-    field_order(span, name, decorators, optional, type_annotation),
+    field_order(span, decorators, name, optional, type_annotation),
 )]
 pub struct TSIndexSignatureName<'a> {
     pub span: Span,
@@ -1439,7 +1436,10 @@ pub struct TSConstructorType<'a> {
 #[scope]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(add_fields(key = TSMappedTypeKey, constraint = TSMappedTypeConstraint))]
+#[estree(
+    add_fields(key = TSMappedTypeKey, constraint = TSMappedTypeConstraint),
+    field_order(span, key, constraint, name_type, type_annotation, optional, readonly),
+)]
 pub struct TSMappedType<'a> {
     pub span: Span,
     /// Key type parameter, e.g. `P` in `[P in keyof T]`.

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -75,8 +75,8 @@ impl ESTree for IdentifierName<'_> {
         state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
+        state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
         state.end();
@@ -89,8 +89,8 @@ impl ESTree for IdentifierReference<'_> {
         state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
+        state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
         state.end();
@@ -103,8 +103,8 @@ impl ESTree for BindingIdentifier<'_> {
         state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
+        state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
         state.end();
@@ -117,8 +117,8 @@ impl ESTree for LabelIdentifier<'_> {
         state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
+        state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
         state.end();
@@ -230,12 +230,12 @@ impl ESTree for ObjectProperty<'_> {
         state.serialize_field("type", &JsonSafeString("Property"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
+        state.serialize_field("kind", &self.kind);
+        state.serialize_field("key", &self.key);
+        state.serialize_field("value", &self.value);
         state.serialize_field("method", &self.method);
         state.serialize_field("shorthand", &self.shorthand);
         state.serialize_field("computed", &self.computed);
-        state.serialize_field("key", &self.key);
-        state.serialize_field("value", &self.value);
-        state.serialize_field("kind", &self.kind);
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.end();
     }
@@ -309,8 +309,8 @@ impl ESTree for TemplateLiteral<'_> {
         state.serialize_field("type", &JsonSafeString("TemplateLiteral"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("expressions", &self.expressions);
         state.serialize_field("quasis", &self.quasis);
+        state.serialize_field("expressions", &self.expressions);
         state.end();
     }
 }
@@ -361,8 +361,8 @@ impl ESTree for ComputedMemberExpression<'_> {
         state.serialize_field("end", &self.span.end);
         state.serialize_field("object", &self.object);
         state.serialize_field("property", &self.expression);
-        state.serialize_field("computed", &crate::serialize::basic::True(self));
         state.serialize_field("optional", &self.optional);
+        state.serialize_field("computed", &crate::serialize::basic::True(self));
         state.end();
     }
 }
@@ -375,8 +375,8 @@ impl ESTree for StaticMemberExpression<'_> {
         state.serialize_field("end", &self.span.end);
         state.serialize_field("object", &self.object);
         state.serialize_field("property", &self.property);
-        state.serialize_field("computed", &crate::serialize::basic::False(self));
         state.serialize_field("optional", &self.optional);
+        state.serialize_field("computed", &crate::serialize::basic::False(self));
         state.end();
     }
 }
@@ -389,8 +389,8 @@ impl ESTree for PrivateFieldExpression<'_> {
         state.serialize_field("end", &self.span.end);
         state.serialize_field("object", &self.object);
         state.serialize_field("property", &self.field);
-        state.serialize_field("computed", &crate::serialize::basic::False(self));
         state.serialize_field("optional", &self.optional);
+        state.serialize_field("computed", &crate::serialize::basic::False(self));
         state.end();
     }
 }
@@ -516,8 +516,8 @@ impl ESTree for UnaryExpression<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("operator", &self.operator);
-        state.serialize_field("prefix", &crate::serialize::basic::True(self));
         state.serialize_field("argument", &self.argument);
+        state.serialize_field("prefix", &crate::serialize::basic::True(self));
         state.end();
     }
 }
@@ -634,8 +634,8 @@ impl ESTree for ArrayAssignmentTarget<'_> {
         state.serialize_field("type", &JsonSafeString("ArrayPattern"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("elements", &Concat2(&self.elements, &self.rest));
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
+        state.serialize_field("elements", &Concat2(&self.elements, &self.rest));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
         state.end();
@@ -648,8 +648,8 @@ impl ESTree for ObjectAssignmentTarget<'_> {
         state.serialize_field("type", &JsonSafeString("ObjectPattern"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("properties", &Concat2(&self.properties, &self.rest));
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
+        state.serialize_field("properties", &Concat2(&self.properties, &self.rest));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
         state.end();
@@ -662,8 +662,8 @@ impl ESTree for AssignmentTargetRest<'_> {
         state.serialize_field("type", &JsonSafeString("RestElement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("argument", &self.target);
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
+        state.serialize_field("argument", &self.target);
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
         state.serialize_ts_field("value", &crate::serialize::basic::TsNull(self));
@@ -695,9 +695,9 @@ impl ESTree for AssignmentTargetWithDefault<'_> {
         state.serialize_field("type", &JsonSafeString("AssignmentPattern"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
+        state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
         state.serialize_field("left", &self.binding);
         state.serialize_field("right", &self.init);
-        state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
         state.end();
@@ -719,15 +719,15 @@ impl ESTree for AssignmentTargetPropertyIdentifier<'_> {
         state.serialize_field("type", &JsonSafeString("Property"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("method", &crate::serialize::basic::False(self));
-        state.serialize_field("shorthand", &crate::serialize::basic::True(self));
-        state.serialize_field("computed", &crate::serialize::basic::False(self));
+        state.serialize_field("kind", &crate::serialize::basic::Init(self));
         state.serialize_field("key", &self.binding);
         state.serialize_field(
             "value",
             &crate::serialize::js::AssignmentTargetPropertyIdentifierInit(self),
         );
-        state.serialize_field("kind", &crate::serialize::basic::Init(self));
+        state.serialize_field("method", &crate::serialize::basic::False(self));
+        state.serialize_field("shorthand", &crate::serialize::basic::True(self));
+        state.serialize_field("computed", &crate::serialize::basic::False(self));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.end();
     }
@@ -739,12 +739,12 @@ impl ESTree for AssignmentTargetPropertyProperty<'_> {
         state.serialize_field("type", &JsonSafeString("Property"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
+        state.serialize_field("kind", &crate::serialize::basic::Init(self));
+        state.serialize_field("key", &self.name);
+        state.serialize_field("value", &self.binding);
         state.serialize_field("method", &crate::serialize::basic::False(self));
         state.serialize_field("shorthand", &crate::serialize::basic::False(self));
         state.serialize_field("computed", &self.computed);
-        state.serialize_field("key", &self.name);
-        state.serialize_field("value", &self.binding);
-        state.serialize_field("kind", &crate::serialize::basic::Init(self));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.end();
     }
@@ -910,8 +910,8 @@ impl ESTree for VariableDeclaration<'_> {
         state.serialize_field("type", &JsonSafeString("VariableDeclaration"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("declarations", &self.declarations);
         state.serialize_field("kind", &self.kind);
+        state.serialize_field("declarations", &self.declarations);
         state.serialize_ts_field("declare", &self.declare);
         state.end();
     }
@@ -1177,8 +1177,8 @@ impl ESTree for SwitchCase<'_> {
         state.serialize_field("type", &JsonSafeString("SwitchCase"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("consequent", &self.consequent);
         state.serialize_field("test", &self.test);
+        state.serialize_field("consequent", &self.consequent);
         state.end();
     }
 }
@@ -1189,8 +1189,8 @@ impl ESTree for LabeledStatement<'_> {
         state.serialize_field("type", &JsonSafeString("LabeledStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("body", &self.body);
         state.serialize_field("label", &self.label);
+        state.serialize_field("body", &self.body);
         state.end();
     }
 }
@@ -1278,9 +1278,9 @@ impl ESTree for AssignmentPattern<'_> {
         state.serialize_field("type", &JsonSafeString("AssignmentPattern"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
+        state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
         state.serialize_field("left", &self.left);
         state.serialize_field("right", &self.right);
-        state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
         state.end();
@@ -1293,8 +1293,8 @@ impl ESTree for ObjectPattern<'_> {
         state.serialize_field("type", &JsonSafeString("ObjectPattern"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("properties", &Concat2(&self.properties, &self.rest));
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
+        state.serialize_field("properties", &Concat2(&self.properties, &self.rest));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
         state.end();
@@ -1307,12 +1307,12 @@ impl ESTree for BindingProperty<'_> {
         state.serialize_field("type", &JsonSafeString("Property"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
+        state.serialize_field("kind", &crate::serialize::basic::Init(self));
+        state.serialize_field("key", &self.key);
+        state.serialize_field("value", &self.value);
         state.serialize_field("method", &crate::serialize::basic::False(self));
         state.serialize_field("shorthand", &self.shorthand);
         state.serialize_field("computed", &self.computed);
-        state.serialize_field("key", &self.key);
-        state.serialize_field("value", &self.value);
-        state.serialize_field("kind", &crate::serialize::basic::Init(self));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.end();
     }
@@ -1324,8 +1324,8 @@ impl ESTree for ArrayPattern<'_> {
         state.serialize_field("type", &JsonSafeString("ArrayPattern"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("elements", &Concat2(&self.elements, &self.rest));
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
+        state.serialize_field("elements", &Concat2(&self.elements, &self.rest));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
         state.end();
@@ -1338,8 +1338,8 @@ impl ESTree for BindingRestElement<'_> {
         state.serialize_field("type", &JsonSafeString("RestElement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("argument", &self.argument);
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
+        state.serialize_field("argument", &self.argument);
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
         state.serialize_ts_field("value", &crate::serialize::basic::TsNull(self));
@@ -1354,14 +1354,14 @@ impl ESTree for Function<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("id", &self.id);
-        state.serialize_field("expression", &crate::serialize::basic::False(self));
         state.serialize_field("generator", &self.generator);
         state.serialize_field("async", &self.r#async);
-        state.serialize_field("params", &crate::serialize::js::FunctionParams(self));
-        state.serialize_field("body", &self.body);
         state.serialize_ts_field("declare", &self.declare);
         state.serialize_ts_field("typeParameters", &self.type_parameters);
+        state.serialize_field("params", &crate::serialize::js::FunctionParams(self));
         state.serialize_ts_field("returnType", &self.return_type);
+        state.serialize_field("body", &self.body);
+        state.serialize_field("expression", &crate::serialize::basic::False(self));
         state.end();
     }
 }
@@ -1425,14 +1425,14 @@ impl ESTree for ArrowFunctionExpression<'_> {
         state.serialize_field("type", &JsonSafeString("ArrowFunctionExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("id", &crate::serialize::basic::Null(self));
         state.serialize_field("expression", &self.expression);
-        state.serialize_field("generator", &crate::serialize::basic::False(self));
         state.serialize_field("async", &self.r#async);
-        state.serialize_field("params", &self.params);
-        state.serialize_field("body", &crate::serialize::js::ArrowFunctionExpressionBody(self));
         state.serialize_ts_field("typeParameters", &self.type_parameters);
+        state.serialize_field("params", &self.params);
         state.serialize_ts_field("returnType", &self.return_type);
+        state.serialize_field("body", &crate::serialize::js::ArrowFunctionExpressionBody(self));
+        state.serialize_field("id", &crate::serialize::basic::Null(self));
+        state.serialize_field("generator", &crate::serialize::basic::False(self));
         state.end();
     }
 }
@@ -1455,13 +1455,13 @@ impl ESTree for Class<'_> {
         state.serialize_field("type", &self.r#type);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("id", &self.id);
-        state.serialize_field("superClass", &self.super_class);
-        state.serialize_field("body", &self.body);
         state.serialize_ts_field("decorators", &self.decorators);
+        state.serialize_field("id", &self.id);
         state.serialize_ts_field("typeParameters", &self.type_parameters);
+        state.serialize_field("superClass", &self.super_class);
         state.serialize_ts_field("superTypeArguments", &self.super_type_arguments);
         state.serialize_ts_field("implements", &self.implements);
+        state.serialize_field("body", &self.body);
         state.serialize_ts_field("abstract", &self.r#abstract);
         state.serialize_ts_field("declare", &self.declare);
         state.end();
@@ -1506,12 +1506,12 @@ impl ESTree for MethodDefinition<'_> {
         state.serialize_field("type", &self.r#type);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("static", &self.r#static);
-        state.serialize_field("computed", &self.computed);
-        state.serialize_field("key", &crate::serialize::js::MethodDefinitionKey(self));
-        state.serialize_field("kind", &self.kind);
-        state.serialize_field("value", &self.value);
         state.serialize_ts_field("decorators", &self.decorators);
+        state.serialize_field("key", &crate::serialize::js::MethodDefinitionKey(self));
+        state.serialize_field("value", &self.value);
+        state.serialize_field("kind", &self.kind);
+        state.serialize_field("computed", &self.computed);
+        state.serialize_field("static", &self.r#static);
         state.serialize_ts_field("override", &self.r#override);
         state.serialize_ts_field("optional", &self.optional);
         state.serialize_ts_field("accessibility", &self.accessibility);
@@ -1536,17 +1536,17 @@ impl ESTree for PropertyDefinition<'_> {
         state.serialize_field("type", &self.r#type);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("static", &self.r#static);
-        state.serialize_field("computed", &self.computed);
-        state.serialize_field("key", &self.key);
-        state.serialize_field("value", &self.value);
         state.serialize_ts_field("decorators", &self.decorators);
+        state.serialize_field("key", &self.key);
+        state.serialize_ts_field("typeAnnotation", &self.type_annotation);
+        state.serialize_field("value", &self.value);
+        state.serialize_field("computed", &self.computed);
+        state.serialize_field("static", &self.r#static);
         state.serialize_ts_field("declare", &self.declare);
         state.serialize_ts_field("override", &self.r#override);
         state.serialize_ts_field("optional", &self.optional);
         state.serialize_ts_field("definite", &self.definite);
         state.serialize_ts_field("readonly", &self.readonly);
-        state.serialize_ts_field("typeAnnotation", &self.type_annotation);
         state.serialize_ts_field("accessibility", &self.accessibility);
         state.end();
     }
@@ -1626,18 +1626,18 @@ impl ESTree for AccessorProperty<'_> {
         state.serialize_field("type", &self.r#type);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
+        state.serialize_ts_field("decorators", &self.decorators);
         state.serialize_field("key", &self.key);
         state.serialize_ts_field("typeAnnotation", &self.type_annotation);
         state.serialize_field("value", &self.value);
         state.serialize_field("computed", &self.computed);
         state.serialize_field("static", &self.r#static);
-        state.serialize_ts_field("decorators", &self.decorators);
+        state.serialize_ts_field("override", &self.r#override);
         state.serialize_ts_field("definite", &self.definite);
         state.serialize_ts_field("accessibility", &self.accessibility);
-        state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
-        state.serialize_ts_field("override", &self.r#override);
-        state.serialize_ts_field("readonly", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("declare", &crate::serialize::basic::TsFalse(self));
+        state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
+        state.serialize_ts_field("readonly", &crate::serialize::basic::TsFalse(self));
         state.end();
     }
 }
@@ -1666,11 +1666,11 @@ impl ESTree for ImportDeclaration<'_> {
             &crate::serialize::js::ImportDeclarationSpecifiers(self),
         );
         state.serialize_field("source", &self.source);
+        state.serialize_field("phase", &self.phase);
         state.serialize_field(
             "attributes",
             &crate::serialize::js::ImportDeclarationWithClause(self),
         );
-        state.serialize_field("phase", &self.phase);
         state.serialize_ts_field("importKind", &self.import_kind);
         state.end();
     }
@@ -2001,8 +2001,8 @@ impl ESTree for JSXElement<'_> {
             "openingElement",
             &crate::serialize::jsx::JSXElementOpeningElement(self),
         );
-        state.serialize_field("closingElement", &self.closing_element);
         state.serialize_field("children", &self.children);
+        state.serialize_field("closingElement", &self.closing_element);
         state.end();
     }
 }
@@ -2013,13 +2013,13 @@ impl ESTree for JSXOpeningElement<'_> {
         state.serialize_field("type", &JsonSafeString("JSXOpeningElement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("attributes", &self.attributes);
         state.serialize_field("name", &self.name);
+        state.serialize_ts_field("typeArguments", &self.type_arguments);
+        state.serialize_field("attributes", &self.attributes);
         state.serialize_field(
             "selfClosing",
             &crate::serialize::jsx::JSXOpeningElementSelfClosing(self),
         );
-        state.serialize_ts_field("typeArguments", &self.type_arguments);
         state.end();
     }
 }
@@ -2042,8 +2042,8 @@ impl ESTree for JSXFragment<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("openingFragment", &self.opening_fragment);
-        state.serialize_field("closingFragment", &self.closing_fragment);
         state.serialize_field("children", &self.children);
+        state.serialize_field("closingFragment", &self.closing_fragment);
         state.end();
     }
 }
@@ -2300,8 +2300,8 @@ impl ESTree for TSThisParameter<'_> {
         state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("name", &crate::serialize::basic::This(self));
         state.serialize_field("decorators", &crate::serialize::basic::EmptyArray(self));
+        state.serialize_field("name", &crate::serialize::basic::This(self));
         state.serialize_field("optional", &crate::serialize::basic::False(self));
         state.serialize_field("typeAnnotation", &self.type_annotation);
         state.end();
@@ -2340,8 +2340,8 @@ impl ESTree for TSEnumMember<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("id", &self.id);
-        state.serialize_field("computed", &crate::serialize::ts::TSEnumMemberComputed(self));
         state.serialize_field("initializer", &self.initializer);
+        state.serialize_field("computed", &crate::serialize::ts::TSEnumMemberComputed(self));
         state.end();
     }
 }
@@ -3007,8 +3007,8 @@ impl ESTree for TSIndexSignatureName<'_> {
         state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.serialize_field("decorators", &crate::serialize::basic::EmptyArray(self));
+        state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.serialize_field("optional", &crate::serialize::basic::False(self));
         state.serialize_field("typeAnnotation", &self.type_annotation);
         state.end();
@@ -3187,12 +3187,12 @@ impl ESTree for TSMappedType<'_> {
         state.serialize_field("type", &JsonSafeString("TSMappedType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
+        state.serialize_field("key", &crate::serialize::ts::TSMappedTypeKey(self));
+        state.serialize_field("constraint", &crate::serialize::ts::TSMappedTypeConstraint(self));
         state.serialize_field("nameType", &self.name_type);
         state.serialize_field("typeAnnotation", &self.type_annotation);
         state.serialize_field("optional", &crate::serialize::ts::TSMappedTypeOptional(self));
         state.serialize_field("readonly", &self.readonly);
-        state.serialize_field("key", &crate::serialize::ts::TSMappedTypeKey(self));
-        state.serialize_field("constraint", &crate::serialize::ts::TSMappedTypeConstraint(self));
         state.end();
     }
 }

--- a/crates/oxc_ast/src/serialize/jsx.rs
+++ b/crates/oxc_ast/src/serialize/jsx.rs
@@ -26,10 +26,10 @@ impl ESTree for JSXElementOpeningElement<'_, '_> {
         state.serialize_field("type", &JsonSafeString("JSXOpeningElement"));
         state.serialize_field("start", &opening_element.span.start);
         state.serialize_field("end", &opening_element.span.end);
-        state.serialize_field("attributes", &opening_element.attributes);
         state.serialize_field("name", &opening_element.name);
-        state.serialize_field("selfClosing", &element.closing_element.is_none());
         state.serialize_ts_field("typeArguments", &opening_element.type_arguments);
+        state.serialize_field("attributes", &opening_element.attributes);
+        state.serialize_field("selfClosing", &element.closing_element.is_none());
         state.end();
     }
 }

--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ submodules:
   just clone-submodule tasks/coverage/babel https://github.com/babel/babel.git 1d4546bcb80009303aab386b59f4df1fd335c1d5
   just clone-submodule tasks/coverage/typescript https://github.com/microsoft/TypeScript.git 81c951894e93bdc37c6916f18adcd80de76679bc
   just clone-submodule tasks/prettier_conformance/prettier https://github.com/prettier/prettier.git 7584432401a47a26943dd7a9ca9a8e032ead7285
-  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 bf1f5de027151b5e2e671cba0a6085907be3ab37
+  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 e6d4a8915d6825132e03b4e517b51f97a1536a3a
   just update-transformer-fixtures
 
 # Install git pre-commit to format files

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -123,12 +123,12 @@ function deserializeObjectProperty(pos) {
     type: 'Property',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
+    kind: deserializePropertyKind(pos + 40),
+    key: deserializePropertyKey(pos + 8),
+    value: deserializeExpression(pos + 24),
     method: deserializeBool(pos + 41),
     shorthand: deserializeBool(pos + 42),
     computed: deserializeBool(pos + 43),
-    key: deserializePropertyKey(pos + 8),
-    value: deserializeExpression(pos + 24),
-    kind: deserializePropertyKind(pos + 40),
   };
 }
 
@@ -137,8 +137,8 @@ function deserializeTemplateLiteral(pos) {
     type: 'TemplateLiteral',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expressions: deserializeVecExpression(pos + 32),
     quasis: deserializeVecTemplateElement(pos + 8),
+    expressions: deserializeVecExpression(pos + 32),
   };
 }
 
@@ -178,8 +178,8 @@ function deserializeComputedMemberExpression(pos) {
     end: deserializeU32(pos + 4),
     object: deserializeExpression(pos + 8),
     property: deserializeExpression(pos + 24),
-    computed: true,
     optional: deserializeBool(pos + 40),
+    computed: true,
   };
 }
 
@@ -190,8 +190,8 @@ function deserializeStaticMemberExpression(pos) {
     end: deserializeU32(pos + 4),
     object: deserializeExpression(pos + 8),
     property: deserializeIdentifierName(pos + 24),
-    computed: false,
     optional: deserializeBool(pos + 48),
+    computed: false,
   };
 }
 
@@ -202,8 +202,8 @@ function deserializePrivateFieldExpression(pos) {
     end: deserializeU32(pos + 4),
     object: deserializeExpression(pos + 8),
     property: deserializePrivateIdentifier(pos + 24),
-    computed: false,
     optional: deserializeBool(pos + 48),
+    computed: false,
   };
 }
 
@@ -264,8 +264,8 @@ function deserializeUnaryExpression(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     operator: deserializeUnaryOperator(pos + 24),
-    prefix: true,
     argument: deserializeExpression(pos + 8),
+    prefix: true,
   };
 }
 
@@ -386,12 +386,12 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     type: 'Property',
     start,
     end,
+    kind: 'init',
+    key,
+    value,
     method: false,
     shorthand: true,
     computed: false,
-    key,
-    value,
-    kind: 'init',
   };
 }
 
@@ -400,12 +400,12 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
     type: 'Property',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
+    kind: 'init',
+    key: deserializePropertyKey(pos + 8),
+    value: deserializeAssignmentTargetMaybeDefault(pos + 24),
     method: false,
     shorthand: false,
     computed: deserializeBool(pos + 40),
-    key: deserializePropertyKey(pos + 8),
-    value: deserializeAssignmentTargetMaybeDefault(pos + 24),
-    kind: 'init',
   };
 }
 
@@ -486,8 +486,8 @@ function deserializeVariableDeclaration(pos) {
     type: 'VariableDeclaration',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    declarations: deserializeVecVariableDeclarator(pos + 8),
     kind: deserializeVariableDeclarationKind(pos + 32),
+    declarations: deserializeVecVariableDeclarator(pos + 8),
   };
 }
 
@@ -636,8 +636,8 @@ function deserializeSwitchCase(pos) {
     type: 'SwitchCase',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    consequent: deserializeVecStatement(pos + 24),
     test: deserializeOptionExpression(pos + 8),
+    consequent: deserializeVecStatement(pos + 24),
   };
 }
 
@@ -646,8 +646,8 @@ function deserializeLabeledStatement(pos) {
     type: 'LabeledStatement',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    body: deserializeStatement(pos + 32),
     label: deserializeLabelIdentifier(pos + 8),
+    body: deserializeStatement(pos + 32),
   };
 }
 
@@ -728,12 +728,12 @@ function deserializeBindingProperty(pos) {
     type: 'Property',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
+    kind: 'init',
+    key: deserializePropertyKey(pos + 8),
+    value: deserializeBindingPattern(pos + 24),
     method: false,
     shorthand: deserializeBool(pos + 56),
     computed: deserializeBool(pos + 57),
-    key: deserializePropertyKey(pos + 8),
-    value: deserializeBindingPattern(pos + 24),
-    kind: 'init',
   };
 }
 
@@ -765,11 +765,11 @@ function deserializeFunction(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     id: deserializeOptionBindingIdentifier(pos + 8),
-    expression: false,
     generator: deserializeBool(pos + 85),
     async: deserializeBool(pos + 86),
     params,
     body: deserializeOptionBoxFunctionBody(pos + 72),
+    expression: false,
   };
 }
 
@@ -809,12 +809,12 @@ function deserializeArrowFunctionExpression(pos) {
     type: 'ArrowFunctionExpression',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    id: null,
     expression,
-    generator: false,
     async: deserializeBool(pos + 45),
     params: deserializeBoxFormalParameters(pos + 16),
     body: expression ? body.body[0].expression : body,
+    id: null,
+    generator: false,
   };
 }
 
@@ -853,11 +853,11 @@ function deserializeMethodDefinition(pos) {
     type: deserializeMethodDefinitionType(pos + 56),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    static: deserializeBool(pos + 59),
-    computed: deserializeBool(pos + 58),
     key: deserializePropertyKey(pos + 32),
-    kind: deserializeMethodDefinitionKind(pos + 57),
     value: deserializeBoxFunction(pos + 48),
+    kind: deserializeMethodDefinitionKind(pos + 57),
+    computed: deserializeBool(pos + 58),
+    static: deserializeBool(pos + 59),
   };
 }
 
@@ -866,10 +866,10 @@ function deserializePropertyDefinition(pos) {
     type: deserializePropertyDefinitionType(pos + 72),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    static: deserializeBool(pos + 74),
-    computed: deserializeBool(pos + 73),
     key: deserializePropertyKey(pos + 32),
     value: deserializeOptionExpression(pos + 56),
+    computed: deserializeBool(pos + 73),
+    static: deserializeBool(pos + 74),
   };
 }
 
@@ -924,8 +924,8 @@ function deserializeImportDeclaration(pos) {
     end: deserializeU32(pos + 4),
     specifiers,
     source: deserializeStringLiteral(pos + 32),
-    attributes: withClause === null ? [] : withClause.attributes,
     phase: deserializeOptionImportPhase(pos + 88),
+    attributes: withClause === null ? [] : withClause.attributes,
   };
 }
 
@@ -1142,8 +1142,8 @@ function deserializeJSXElement(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     openingElement,
-    closingElement,
     children: deserializeVecJSXChild(pos + 16),
+    closingElement,
   };
 }
 
@@ -1152,8 +1152,8 @@ function deserializeJSXOpeningElement(pos) {
     type: 'JSXOpeningElement',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    attributes: deserializeVecJSXAttributeItem(pos + 32),
     name: deserializeJSXElementName(pos + 8),
+    attributes: deserializeVecJSXAttributeItem(pos + 32),
     selfClosing: false,
   };
 }
@@ -1173,8 +1173,8 @@ function deserializeJSXFragment(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     openingFragment: deserializeJSXOpeningFragment(pos + 8),
-    closingFragment: deserializeJSXClosingFragment(pos + 40),
     children: deserializeVecJSXChild(pos + 16),
+    closingFragment: deserializeJSXClosingFragment(pos + 40),
   };
 }
 
@@ -1285,8 +1285,8 @@ function deserializeTSThisParameter(pos) {
     type: 'Identifier',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    name: 'this',
     decorators: [],
+    name: 'this',
     optional: false,
     typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 16),
   };
@@ -1319,8 +1319,8 @@ function deserializeTSEnumMember(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     id: deserializeTSEnumMemberName(pos + 8),
-    computed: deserializeU8(pos + 8) > 1,
     initializer: deserializeOptionExpression(pos + 24),
+    computed: deserializeU8(pos + 8) > 1,
   };
 }
 
@@ -1760,8 +1760,8 @@ function deserializeTSIndexSignatureName(pos) {
     type: 'Identifier',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    name: deserializeStr(pos + 8),
     decorators: [],
+    name: deserializeStr(pos + 8),
     optional: false,
     typeAnnotation: deserializeBoxTSTypeAnnotation(pos + 24),
   };
@@ -1913,19 +1913,19 @@ function deserializeTSConstructorType(pos) {
 }
 
 function deserializeTSMappedType(pos) {
+  const typeParameter = deserializeBoxTSTypeParameter(pos + 8);
   let optional = deserializeOptionTSMappedTypeModifierOperator(pos + 52);
   if (optional === null) optional = false;
-  const typeParameter = deserializeBoxTSTypeParameter(pos + 8);
   return {
     type: 'TSMappedType',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
+    key: typeParameter.name,
+    constraint: typeParameter.constraint,
     nameType: deserializeOptionTSType(pos + 16),
     typeAnnotation: deserializeOptionTSType(pos + 32),
     optional,
     readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 53),
-    key: typeParameter.name,
-    constraint: typeParameter.constraint,
   };
 }
 

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -73,8 +73,8 @@ function deserializeIdentifierName(pos) {
     type: 'Identifier',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    name: deserializeStr(pos + 8),
     decorators: [],
+    name: deserializeStr(pos + 8),
     optional: false,
     typeAnnotation: null,
   };
@@ -85,8 +85,8 @@ function deserializeIdentifierReference(pos) {
     type: 'Identifier',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    name: deserializeStr(pos + 8),
     decorators: [],
+    name: deserializeStr(pos + 8),
     optional: false,
     typeAnnotation: null,
   };
@@ -97,8 +97,8 @@ function deserializeBindingIdentifier(pos) {
     type: 'Identifier',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    name: deserializeStr(pos + 8),
     decorators: [],
+    name: deserializeStr(pos + 8),
     optional: false,
     typeAnnotation: null,
   };
@@ -109,8 +109,8 @@ function deserializeLabelIdentifier(pos) {
     type: 'Identifier',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    name: deserializeStr(pos + 8),
     decorators: [],
+    name: deserializeStr(pos + 8),
     optional: false,
     typeAnnotation: null,
   };
@@ -151,12 +151,12 @@ function deserializeObjectProperty(pos) {
     type: 'Property',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
+    kind: deserializePropertyKind(pos + 40),
+    key: deserializePropertyKey(pos + 8),
+    value: deserializeExpression(pos + 24),
     method: deserializeBool(pos + 41),
     shorthand: deserializeBool(pos + 42),
     computed: deserializeBool(pos + 43),
-    key: deserializePropertyKey(pos + 8),
-    value: deserializeExpression(pos + 24),
-    kind: deserializePropertyKind(pos + 40),
     optional: false,
   };
 }
@@ -166,8 +166,8 @@ function deserializeTemplateLiteral(pos) {
     type: 'TemplateLiteral',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expressions: deserializeVecExpression(pos + 32),
     quasis: deserializeVecTemplateElement(pos + 8),
+    expressions: deserializeVecExpression(pos + 32),
   };
 }
 
@@ -208,8 +208,8 @@ function deserializeComputedMemberExpression(pos) {
     end: deserializeU32(pos + 4),
     object: deserializeExpression(pos + 8),
     property: deserializeExpression(pos + 24),
-    computed: true,
     optional: deserializeBool(pos + 40),
+    computed: true,
   };
 }
 
@@ -220,8 +220,8 @@ function deserializeStaticMemberExpression(pos) {
     end: deserializeU32(pos + 4),
     object: deserializeExpression(pos + 8),
     property: deserializeIdentifierName(pos + 24),
-    computed: false,
     optional: deserializeBool(pos + 48),
+    computed: false,
   };
 }
 
@@ -232,8 +232,8 @@ function deserializePrivateFieldExpression(pos) {
     end: deserializeU32(pos + 4),
     object: deserializeExpression(pos + 8),
     property: deserializePrivateIdentifier(pos + 24),
-    computed: false,
     optional: deserializeBool(pos + 48),
+    computed: false,
   };
 }
 
@@ -296,8 +296,8 @@ function deserializeUnaryExpression(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     operator: deserializeUnaryOperator(pos + 24),
-    prefix: true,
     argument: deserializeExpression(pos + 8),
+    prefix: true,
   };
 }
 
@@ -364,8 +364,8 @@ function deserializeArrayAssignmentTarget(pos) {
     type: 'ArrayPattern',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    elements,
     decorators: [],
+    elements,
     optional: false,
     typeAnnotation: null,
   };
@@ -379,8 +379,8 @@ function deserializeObjectAssignmentTarget(pos) {
     type: 'ObjectPattern',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    properties,
     decorators: [],
+    properties,
     optional: false,
     typeAnnotation: null,
   };
@@ -391,8 +391,8 @@ function deserializeAssignmentTargetRest(pos) {
     type: 'RestElement',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    argument: deserializeAssignmentTarget(pos + 8),
     decorators: [],
+    argument: deserializeAssignmentTarget(pos + 8),
     optional: false,
     typeAnnotation: null,
     value: null,
@@ -404,9 +404,9 @@ function deserializeAssignmentTargetWithDefault(pos) {
     type: 'AssignmentPattern',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
+    decorators: [],
     left: deserializeAssignmentTarget(pos + 8),
     right: deserializeExpression(pos + 24),
-    decorators: [],
     optional: false,
     typeAnnotation: null,
   };
@@ -434,12 +434,12 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     type: 'Property',
     start,
     end,
+    kind: 'init',
+    key,
+    value,
     method: false,
     shorthand: true,
     computed: false,
-    key,
-    value,
-    kind: 'init',
     optional: false,
   };
 }
@@ -449,12 +449,12 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
     type: 'Property',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
+    kind: 'init',
+    key: deserializePropertyKey(pos + 8),
+    value: deserializeAssignmentTargetMaybeDefault(pos + 24),
     method: false,
     shorthand: false,
     computed: deserializeBool(pos + 40),
-    key: deserializePropertyKey(pos + 8),
-    value: deserializeAssignmentTargetMaybeDefault(pos + 24),
-    kind: 'init',
     optional: false,
   };
 }
@@ -536,8 +536,8 @@ function deserializeVariableDeclaration(pos) {
     type: 'VariableDeclaration',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    declarations: deserializeVecVariableDeclarator(pos + 8),
     kind: deserializeVariableDeclarationKind(pos + 32),
+    declarations: deserializeVecVariableDeclarator(pos + 8),
     declare: deserializeBool(pos + 33),
   };
 }
@@ -689,8 +689,8 @@ function deserializeSwitchCase(pos) {
     type: 'SwitchCase',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    consequent: deserializeVecStatement(pos + 24),
     test: deserializeOptionExpression(pos + 8),
+    consequent: deserializeVecStatement(pos + 24),
   };
 }
 
@@ -699,8 +699,8 @@ function deserializeLabeledStatement(pos) {
     type: 'LabeledStatement',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    body: deserializeStatement(pos + 32),
     label: deserializeLabelIdentifier(pos + 8),
+    body: deserializeStatement(pos + 32),
   };
 }
 
@@ -763,9 +763,9 @@ function deserializeAssignmentPattern(pos) {
     type: 'AssignmentPattern',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
+    decorators: [],
     left: deserializeBindingPattern(pos + 8),
     right: deserializeExpression(pos + 40),
-    decorators: [],
     optional: false,
     typeAnnotation: null,
   };
@@ -779,8 +779,8 @@ function deserializeObjectPattern(pos) {
     type: 'ObjectPattern',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    properties,
     decorators: [],
+    properties,
     optional: false,
     typeAnnotation: null,
   };
@@ -791,12 +791,12 @@ function deserializeBindingProperty(pos) {
     type: 'Property',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
+    kind: 'init',
+    key: deserializePropertyKey(pos + 8),
+    value: deserializeBindingPattern(pos + 24),
     method: false,
     shorthand: deserializeBool(pos + 56),
     computed: deserializeBool(pos + 57),
-    key: deserializePropertyKey(pos + 8),
-    value: deserializeBindingPattern(pos + 24),
-    kind: 'init',
     optional: false,
   };
 }
@@ -809,8 +809,8 @@ function deserializeArrayPattern(pos) {
     type: 'ArrayPattern',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    elements,
     decorators: [],
+    elements,
     optional: false,
     typeAnnotation: null,
   };
@@ -821,8 +821,8 @@ function deserializeBindingRestElement(pos) {
     type: 'RestElement',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    argument: deserializeBindingPattern(pos + 8),
     decorators: [],
+    argument: deserializeBindingPattern(pos + 8),
     optional: false,
     typeAnnotation: null,
     value: null,
@@ -838,14 +838,14 @@ function deserializeFunction(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     id: deserializeOptionBindingIdentifier(pos + 8),
-    expression: false,
     generator: deserializeBool(pos + 85),
     async: deserializeBool(pos + 86),
-    params,
-    body: deserializeOptionBoxFunctionBody(pos + 72),
     declare: deserializeBool(pos + 87),
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 40),
+    params,
     returnType: deserializeOptionBoxTSTypeAnnotation(pos + 64),
+    body: deserializeOptionBoxFunctionBody(pos + 72),
+    expression: false,
   };
 }
 
@@ -915,14 +915,14 @@ function deserializeArrowFunctionExpression(pos) {
     type: 'ArrowFunctionExpression',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    id: null,
     expression,
-    generator: false,
     async: deserializeBool(pos + 45),
-    params: deserializeBoxFormalParameters(pos + 16),
-    body: expression ? body.body[0].expression : body,
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 8),
+    params: deserializeBoxFormalParameters(pos + 16),
     returnType: deserializeOptionBoxTSTypeAnnotation(pos + 24),
+    body: expression ? body.body[0].expression : body,
+    id: null,
+    generator: false,
   };
 }
 
@@ -941,13 +941,13 @@ function deserializeClass(pos) {
     type: deserializeClassType(pos + 132),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    id: deserializeOptionBindingIdentifier(pos + 32),
-    superClass: deserializeOptionExpression(pos + 72),
-    body: deserializeBoxClassBody(pos + 120),
     decorators: deserializeVecDecorator(pos + 8),
+    id: deserializeOptionBindingIdentifier(pos + 32),
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 64),
+    superClass: deserializeOptionExpression(pos + 72),
     superTypeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 88),
     implements: deserializeVecTSClassImplements(pos + 96),
+    body: deserializeBoxClassBody(pos + 120),
     abstract: deserializeBool(pos + 133),
     declare: deserializeBool(pos + 134),
   };
@@ -980,12 +980,12 @@ function deserializeMethodDefinition(pos) {
     type: deserializeMethodDefinitionType(pos + 56),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    static: deserializeBool(pos + 59),
-    computed: deserializeBool(pos + 58),
-    key,
-    kind,
-    value: deserializeBoxFunction(pos + 48),
     decorators: deserializeVecDecorator(pos + 8),
+    key,
+    value: deserializeBoxFunction(pos + 48),
+    kind,
+    computed: deserializeBool(pos + 58),
+    static: deserializeBool(pos + 59),
     override: deserializeBool(pos + 60),
     optional: deserializeBool(pos + 61),
     accessibility: deserializeOptionTSAccessibility(pos + 62),
@@ -997,17 +997,17 @@ function deserializePropertyDefinition(pos) {
     type: deserializePropertyDefinitionType(pos + 72),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    static: deserializeBool(pos + 74),
-    computed: deserializeBool(pos + 73),
-    key: deserializePropertyKey(pos + 32),
-    value: deserializeOptionExpression(pos + 56),
     decorators: deserializeVecDecorator(pos + 8),
+    key: deserializePropertyKey(pos + 32),
+    typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 48),
+    value: deserializeOptionExpression(pos + 56),
+    computed: deserializeBool(pos + 73),
+    static: deserializeBool(pos + 74),
     declare: deserializeBool(pos + 75),
     override: deserializeBool(pos + 76),
     optional: deserializeBool(pos + 77),
     definite: deserializeBool(pos + 78),
     readonly: deserializeBool(pos + 79),
-    typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 48),
     accessibility: deserializeOptionTSAccessibility(pos + 80),
   };
 }
@@ -1035,18 +1035,18 @@ function deserializeAccessorProperty(pos) {
     type: deserializeAccessorPropertyType(pos + 72),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
+    decorators: deserializeVecDecorator(pos + 8),
     key: deserializePropertyKey(pos + 32),
     typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 48),
     value: deserializeOptionExpression(pos + 56),
     computed: deserializeBool(pos + 73),
     static: deserializeBool(pos + 74),
-    decorators: deserializeVecDecorator(pos + 8),
+    override: deserializeBool(pos + 75),
     definite: deserializeBool(pos + 76),
     accessibility: deserializeOptionTSAccessibility(pos + 77),
-    optional: false,
-    override: deserializeBool(pos + 75),
-    readonly: false,
     declare: false,
+    optional: false,
+    readonly: false,
   };
 }
 
@@ -1071,8 +1071,8 @@ function deserializeImportDeclaration(pos) {
     end: deserializeU32(pos + 4),
     specifiers,
     source: deserializeStringLiteral(pos + 32),
-    attributes: withClause === null ? [] : withClause.attributes,
     phase: deserializeOptionImportPhase(pos + 88),
+    attributes: withClause === null ? [] : withClause.attributes,
     importKind: deserializeImportOrExportKind(pos + 89),
   };
 }
@@ -1295,8 +1295,8 @@ function deserializeJSXElement(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     openingElement,
-    closingElement,
     children: deserializeVecJSXChild(pos + 16),
+    closingElement,
   };
 }
 
@@ -1305,10 +1305,10 @@ function deserializeJSXOpeningElement(pos) {
     type: 'JSXOpeningElement',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    attributes: deserializeVecJSXAttributeItem(pos + 32),
     name: deserializeJSXElementName(pos + 8),
-    selfClosing: false,
     typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
+    attributes: deserializeVecJSXAttributeItem(pos + 32),
+    selfClosing: false,
   };
 }
 
@@ -1327,8 +1327,8 @@ function deserializeJSXFragment(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     openingFragment: deserializeJSXOpeningFragment(pos + 8),
-    closingFragment: deserializeJSXClosingFragment(pos + 40),
     children: deserializeVecJSXChild(pos + 16),
+    closingFragment: deserializeJSXClosingFragment(pos + 40),
   };
 }
 
@@ -1437,8 +1437,8 @@ function deserializeTSThisParameter(pos) {
     type: 'Identifier',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    name: 'this',
     decorators: [],
+    name: 'this',
     optional: false,
     typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 16),
   };
@@ -1471,8 +1471,8 @@ function deserializeTSEnumMember(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     id: deserializeTSEnumMemberName(pos + 8),
-    computed: deserializeU8(pos + 8) > 1,
     initializer: deserializeOptionExpression(pos + 24),
+    computed: deserializeU8(pos + 8) > 1,
   };
 }
 
@@ -1912,8 +1912,8 @@ function deserializeTSIndexSignatureName(pos) {
     type: 'Identifier',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    name: deserializeStr(pos + 8),
     decorators: [],
+    name: deserializeStr(pos + 8),
     optional: false,
     typeAnnotation: deserializeBoxTSTypeAnnotation(pos + 24),
   };
@@ -2065,19 +2065,19 @@ function deserializeTSConstructorType(pos) {
 }
 
 function deserializeTSMappedType(pos) {
+  const typeParameter = deserializeBoxTSTypeParameter(pos + 8);
   let optional = deserializeOptionTSMappedTypeModifierOperator(pos + 52);
   if (optional === null) optional = false;
-  const typeParameter = deserializeBoxTSTypeParameter(pos + 8);
   return {
     type: 'TSMappedType',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
+    key: typeParameter.name,
+    constraint: typeParameter.constraint,
     nameType: deserializeOptionTSType(pos + 16),
     typeAnnotation: deserializeOptionTSType(pos + 32),
     optional,
     readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 53),
-    key: typeParameter.name,
-    constraint: typeParameter.constraint,
   };
 }
 

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -53,32 +53,32 @@ export type Expression =
 
 export interface IdentifierName extends Span {
   type: 'Identifier';
-  name: string;
   decorators?: [];
+  name: string;
   optional?: false;
   typeAnnotation?: null;
 }
 
 export interface IdentifierReference extends Span {
   type: 'Identifier';
-  name: string;
   decorators?: [];
+  name: string;
   optional?: false;
   typeAnnotation?: null;
 }
 
 export interface BindingIdentifier extends Span {
   type: 'Identifier';
-  name: string;
   decorators?: [];
+  name: string;
   optional?: false;
   typeAnnotation?: null;
 }
 
 export interface LabelIdentifier extends Span {
   type: 'Identifier';
-  name: string;
   decorators?: [];
+  name: string;
   optional?: false;
   typeAnnotation?: null;
 }
@@ -103,12 +103,12 @@ export type ObjectPropertyKind = ObjectProperty | SpreadElement;
 
 export interface ObjectProperty extends Span {
   type: 'Property';
+  kind: PropertyKind;
+  key: PropertyKey;
+  value: Expression;
   method: boolean;
   shorthand: boolean;
   computed: boolean;
-  key: PropertyKey;
-  value: Expression;
-  kind: PropertyKind;
   optional?: false;
 }
 
@@ -118,8 +118,8 @@ export type PropertyKind = 'init' | 'get' | 'set';
 
 export interface TemplateLiteral extends Span {
   type: 'TemplateLiteral';
-  expressions: Array<Expression>;
   quasis: Array<TemplateElement>;
+  expressions: Array<Expression>;
 }
 
 export interface TaggedTemplateExpression extends Span {
@@ -146,24 +146,24 @@ export interface ComputedMemberExpression extends Span {
   type: 'MemberExpression';
   object: Expression;
   property: Expression;
-  computed: true;
   optional: boolean;
+  computed: true;
 }
 
 export interface StaticMemberExpression extends Span {
   type: 'MemberExpression';
   object: Expression;
   property: IdentifierName;
-  computed: false;
   optional: boolean;
+  computed: false;
 }
 
 export interface PrivateFieldExpression extends Span {
   type: 'MemberExpression';
   object: Expression;
   property: PrivateIdentifier;
-  computed: false;
   optional: boolean;
+  computed: false;
 }
 
 export interface CallExpression extends Span {
@@ -204,8 +204,8 @@ export interface UpdateExpression extends Span {
 export interface UnaryExpression extends Span {
   type: 'UnaryExpression';
   operator: UnaryOperator;
-  prefix: true;
   argument: Expression;
+  prefix: true;
 }
 
 export interface BinaryExpression extends Span {
@@ -257,24 +257,24 @@ export type AssignmentTargetPattern = ArrayAssignmentTarget | ObjectAssignmentTa
 
 export interface ArrayAssignmentTarget extends Span {
   type: 'ArrayPattern';
-  elements: Array<AssignmentTargetMaybeDefault | AssignmentTargetRest | null>;
   decorators?: [];
+  elements: Array<AssignmentTargetMaybeDefault | AssignmentTargetRest | null>;
   optional?: false;
   typeAnnotation?: null;
 }
 
 export interface ObjectAssignmentTarget extends Span {
   type: 'ObjectPattern';
-  properties: Array<AssignmentTargetProperty | AssignmentTargetRest>;
   decorators?: [];
+  properties: Array<AssignmentTargetProperty | AssignmentTargetRest>;
   optional?: false;
   typeAnnotation?: null;
 }
 
 export interface AssignmentTargetRest extends Span {
   type: 'RestElement';
-  argument: AssignmentTarget;
   decorators?: [];
+  argument: AssignmentTarget;
   optional?: false;
   typeAnnotation?: null;
   value?: null;
@@ -284,9 +284,9 @@ export type AssignmentTargetMaybeDefault = AssignmentTargetWithDefault | Assignm
 
 export interface AssignmentTargetWithDefault extends Span {
   type: 'AssignmentPattern';
+  decorators?: [];
   left: AssignmentTarget;
   right: Expression;
-  decorators?: [];
   optional?: false;
   typeAnnotation?: null;
 }
@@ -295,23 +295,23 @@ export type AssignmentTargetProperty = AssignmentTargetPropertyIdentifier | Assi
 
 export interface AssignmentTargetPropertyIdentifier extends Span {
   type: 'Property';
+  kind: 'init';
+  key: IdentifierReference;
+  value: IdentifierReference | AssignmentTargetWithDefault;
   method: false;
   shorthand: true;
   computed: false;
-  key: IdentifierReference;
-  value: IdentifierReference | AssignmentTargetWithDefault;
-  kind: 'init';
   optional?: false;
 }
 
 export interface AssignmentTargetPropertyProperty extends Span {
   type: 'Property';
+  kind: 'init';
+  key: PropertyKey;
+  value: AssignmentTargetMaybeDefault;
   method: false;
   shorthand: false;
   computed: boolean;
-  key: PropertyKey;
-  value: AssignmentTargetMaybeDefault;
-  kind: 'init';
   optional?: false;
 }
 
@@ -391,8 +391,8 @@ export type Declaration =
 
 export interface VariableDeclaration extends Span {
   type: 'VariableDeclaration';
-  declarations: Array<VariableDeclarator>;
   kind: VariableDeclarationKind;
+  declarations: Array<VariableDeclarator>;
   declare?: boolean;
 }
 
@@ -490,14 +490,14 @@ export interface SwitchStatement extends Span {
 
 export interface SwitchCase extends Span {
   type: 'SwitchCase';
-  consequent: Array<Statement>;
   test: Expression | null;
+  consequent: Array<Statement>;
 }
 
 export interface LabeledStatement extends Span {
   type: 'LabeledStatement';
-  body: Statement;
   label: LabelIdentifier;
+  body: Statement;
 }
 
 export interface ThrowStatement extends Span {
@@ -533,44 +533,44 @@ export type BindingPatternKind = BindingIdentifier | ObjectPattern | ArrayPatter
 
 export interface AssignmentPattern extends Span {
   type: 'AssignmentPattern';
+  decorators?: [];
   left: BindingPattern;
   right: Expression;
-  decorators?: [];
   optional?: false;
   typeAnnotation?: null;
 }
 
 export interface ObjectPattern extends Span {
   type: 'ObjectPattern';
-  properties: Array<BindingProperty | BindingRestElement>;
   decorators?: [];
+  properties: Array<BindingProperty | BindingRestElement>;
   optional?: false;
   typeAnnotation?: null;
 }
 
 export interface BindingProperty extends Span {
   type: 'Property';
+  kind: 'init';
+  key: PropertyKey;
+  value: BindingPattern;
   method: false;
   shorthand: boolean;
   computed: boolean;
-  key: PropertyKey;
-  value: BindingPattern;
-  kind: 'init';
   optional?: false;
 }
 
 export interface ArrayPattern extends Span {
   type: 'ArrayPattern';
-  elements: Array<BindingPattern | BindingRestElement | null>;
   decorators?: [];
+  elements: Array<BindingPattern | BindingRestElement | null>;
   optional?: false;
   typeAnnotation?: null;
 }
 
 export interface BindingRestElement extends Span {
   type: 'RestElement';
-  argument: BindingPattern;
   decorators?: [];
+  argument: BindingPattern;
   optional?: false;
   typeAnnotation?: null;
   value?: null;
@@ -579,14 +579,14 @@ export interface BindingRestElement extends Span {
 export interface Function extends Span {
   type: FunctionType;
   id: BindingIdentifier | null;
-  expression: false;
   generator: boolean;
   async: boolean;
-  params: ParamPattern[];
-  body: FunctionBody | null;
   declare?: boolean;
   typeParameters?: TSTypeParameterDeclaration | null;
+  params: ParamPattern[];
   returnType?: TSTypeAnnotation | null;
+  body: FunctionBody | null;
+  expression: false;
 }
 
 export type ParamPattern = FormalParameter | TSParameterProperty | FormalParameterRest;
@@ -629,14 +629,14 @@ export interface FunctionBody extends Span {
 
 export interface ArrowFunctionExpression extends Span {
   type: 'ArrowFunctionExpression';
-  id: null;
   expression: boolean;
-  generator: false;
   async: boolean;
-  params: ParamPattern[];
-  body: FunctionBody | Expression;
   typeParameters?: TSTypeParameterDeclaration | null;
+  params: ParamPattern[];
   returnType?: TSTypeAnnotation | null;
+  body: FunctionBody | Expression;
+  id: null;
+  generator: false;
 }
 
 export interface YieldExpression extends Span {
@@ -647,13 +647,13 @@ export interface YieldExpression extends Span {
 
 export interface Class extends Span {
   type: ClassType;
-  id: BindingIdentifier | null;
-  superClass: Expression | null;
-  body: ClassBody;
   decorators?: Array<Decorator>;
+  id: BindingIdentifier | null;
   typeParameters?: TSTypeParameterDeclaration | null;
+  superClass: Expression | null;
   superTypeArguments?: TSTypeParameterInstantiation | null;
   implements?: Array<TSClassImplements>;
+  body: ClassBody;
   abstract?: boolean;
   declare?: boolean;
 }
@@ -669,12 +669,12 @@ export type ClassElement = StaticBlock | MethodDefinition | PropertyDefinition |
 
 export interface MethodDefinition extends Span {
   type: MethodDefinitionType;
-  static: boolean;
-  computed: boolean;
-  key: PropertyKey;
-  kind: MethodDefinitionKind;
-  value: Function;
   decorators?: Array<Decorator>;
+  key: PropertyKey;
+  value: Function;
+  kind: MethodDefinitionKind;
+  computed: boolean;
+  static: boolean;
   override?: boolean;
   optional?: boolean;
   accessibility?: TSAccessibility | null;
@@ -684,17 +684,17 @@ export type MethodDefinitionType = 'MethodDefinition' | 'TSAbstractMethodDefinit
 
 export interface PropertyDefinition extends Span {
   type: PropertyDefinitionType;
-  static: boolean;
-  computed: boolean;
-  key: PropertyKey;
-  value: Expression | null;
   decorators?: Array<Decorator>;
+  key: PropertyKey;
+  typeAnnotation?: TSTypeAnnotation | null;
+  value: Expression | null;
+  computed: boolean;
+  static: boolean;
   declare?: boolean;
   override?: boolean;
   optional?: boolean;
   definite?: boolean;
   readonly?: boolean;
-  typeAnnotation?: TSTypeAnnotation | null;
   accessibility?: TSAccessibility | null;
 }
 
@@ -724,18 +724,18 @@ export type AccessorPropertyType = 'AccessorProperty' | 'TSAbstractAccessorPrope
 
 export interface AccessorProperty extends Span {
   type: AccessorPropertyType;
+  decorators?: Array<Decorator>;
   key: PropertyKey;
   typeAnnotation?: TSTypeAnnotation | null;
   value: Expression | null;
   computed: boolean;
   static: boolean;
-  decorators?: Array<Decorator>;
+  override?: boolean;
   definite?: boolean;
   accessibility?: TSAccessibility | null;
-  optional?: false;
-  override?: boolean;
-  readonly?: false;
   declare?: false;
+  optional?: false;
+  readonly?: false;
 }
 
 export interface ImportExpression extends Span {
@@ -749,8 +749,8 @@ export interface ImportDeclaration extends Span {
   type: 'ImportDeclaration';
   specifiers: Array<ImportDeclarationSpecifier>;
   source: StringLiteral;
-  attributes: Array<ImportAttribute>;
   phase: ImportPhase | null;
+  attributes: Array<ImportAttribute>;
   importKind?: ImportOrExportKind;
 }
 
@@ -864,16 +864,16 @@ export interface RegExpLiteral extends Span {
 export interface JSXElement extends Span {
   type: 'JSXElement';
   openingElement: JSXOpeningElement;
-  closingElement: JSXClosingElement | null;
   children: Array<JSXChild>;
+  closingElement: JSXClosingElement | null;
 }
 
 export interface JSXOpeningElement extends Span {
   type: 'JSXOpeningElement';
-  attributes: Array<JSXAttributeItem>;
   name: JSXElementName;
-  selfClosing: boolean;
   typeArguments?: TSTypeParameterInstantiation | null;
+  attributes: Array<JSXAttributeItem>;
+  selfClosing: boolean;
 }
 
 export interface JSXClosingElement extends Span {
@@ -884,8 +884,8 @@ export interface JSXClosingElement extends Span {
 export interface JSXFragment extends Span {
   type: 'JSXFragment';
   openingFragment: JSXOpeningFragment;
-  closingFragment: JSXClosingFragment;
   children: Array<JSXChild>;
+  closingFragment: JSXClosingFragment;
 }
 
 export interface JSXOpeningFragment extends Span {
@@ -962,8 +962,8 @@ export interface JSXText extends Span {
 
 export interface TSThisParameter extends Span {
   type: 'Identifier';
-  name: 'this';
   decorators: [];
+  name: 'this';
   optional: false;
   typeAnnotation: TSTypeAnnotation | null;
 }
@@ -984,8 +984,8 @@ export interface TSEnumBody extends Span {
 export interface TSEnumMember extends Span {
   type: 'TSEnumMember';
   id: TSEnumMemberName;
-  computed: boolean;
   initializer: Expression | null;
+  computed: boolean;
 }
 
 export type TSEnumMemberName = IdentifierName | StringLiteral | TemplateLiteral;
@@ -1292,8 +1292,8 @@ export interface TSConstructSignatureDeclaration extends Span {
 
 export interface TSIndexSignatureName extends Span {
   type: 'Identifier';
-  name: string;
   decorators: [];
+  name: string;
   optional: false;
   typeAnnotation: TSTypeAnnotation;
 }
@@ -1372,12 +1372,12 @@ export interface TSConstructorType extends Span {
 
 export interface TSMappedType extends Span {
   type: 'TSMappedType';
+  key: TSTypeParameter['name'];
+  constraint: TSTypeParameter['constraint'];
   nameType: TSType | null;
   typeAnnotation: TSType | null;
   optional: TSMappedTypeModifierOperator | false;
   readonly: TSMappedTypeModifierOperator | null;
-  key: TSTypeParameter['name'];
-  constraint: TSTypeParameter['constraint'];
 }
 
 export type TSMappedTypeModifierOperator = true | '+' | '-';

--- a/tasks/coverage/snapshots/estree_acorn_jsx.snap
+++ b/tasks/coverage/snapshots/estree_acorn_jsx.snap
@@ -1,4 +1,4 @@
-commit: bf1f5de0
+commit: e6d4a891
 
 estree_acorn_jsx Summary:
 AST Parsed     : 39/39 (100.00%)


### PR DESCRIPTION
Re-order fields in ESTree and TS-ESTree ASTs to be in visitation order (which is the order in which they're defined in Rust types).

This does not align with either Acorn or TS-ESLint, but for the reasons discussed in https://github.com/oxc-project/oxc/issues/9705#issuecomment-2859250834, I feel this isn't a concern. The field order doesn't matter much per se, only that it's consistent, and this change has other benefits - it will make it simpler to build a visitor which visits fields in the correct order, and allows adding other parsers to `acorn-test262` in order to produce test cases for decorators.

Visitation order aligns with TS-ESLint except for the following types:

* `ExportSpecifier`
* `TSImportType`
* `TSIndexedAccessType`
* `TSMethodSignature`
* `TSPropertySignature`
* `TSTypePredicate`

In these 6 cases, TS-ESLint's `visitorKeys` has the wrong visitation order, because it does not visit fields in source order. I will open an issue and hopefully they can fix.

This PR also bumps `acorn-test262` to include https://github.com/oxc-project/acorn-test262/pull/37 which re-orders the fields in fixture snapshots to match the new field order here.