### PR TITLE
refactor(parser): Add some is_ts fast checks before doing lookaheads

### DIFF
--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -477,11 +477,18 @@ impl<'a> ParserImpl<'a> {
     }
 
     pub(crate) fn at_start_of_ts_declaration(&mut self) -> bool {
+        if !self.is_ts {
+            return false;
+        }
         self.lookahead(Self::at_start_of_ts_declaration_worker)
     }
 
     /// Check if the parser is at a start of a ts declaration
     fn at_start_of_ts_declaration_worker(&mut self) -> bool {
+        if !self.is_ts {
+            return false;
+        }
+
         loop {
             match self.cur_kind() {
                 Kind::Var | Kind::Let | Kind::Const | Kind::Function | Kind::Class | Kind::Enum => {

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -81,6 +81,9 @@ impl<'a> ParserImpl<'a> {
     }
 
     fn is_start_of_function_type_or_constructor_type(&mut self) -> bool {
+        if !self.is_ts {
+            return false;
+        }
         if self.at(Kind::LAngle) {
             return true;
         }
@@ -483,6 +486,10 @@ impl<'a> ParserImpl<'a> {
     }
 
     fn is_start_of_type(&mut self, in_start_of_parameter: bool) -> bool {
+        if !self.is_ts {
+            return false;
+        }
+
         match self.cur_kind() {
             kind if kind.is_number() => true,
             Kind::Any
@@ -530,6 +537,10 @@ impl<'a> ParserImpl<'a> {
     }
 
     fn is_start_of_mapped_type(&mut self) -> bool {
+        if !self.is_ts {
+            return false;
+        }
+
         self.bump_any();
         if self.at(Kind::Plus) || self.at(Kind::Minus) {
             self.bump_any();
@@ -552,6 +563,10 @@ impl<'a> ParserImpl<'a> {
     }
 
     fn is_start_of_parenthesized_or_function_type(&mut self) -> bool {
+        if !self.is_ts {
+            return false;
+        }
+
         self.bump_any();
         self.at(Kind::RParen)
             || self.is_start_of_parameter(/* is_js_doc_parameter */ false)

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1094,6 +1094,9 @@ impl<'a> ParserImpl<'a> {
     }
 
     pub(crate) fn is_next_at_type_member_name(&mut self) -> bool {
+        if !self.is_ts {
+            return false;
+        }
         self.lookahead(Self::is_next_at_type_member_name_worker)
     }
 
@@ -1321,6 +1324,10 @@ impl<'a> ParserImpl<'a> {
     }
 
     fn is_at_modifier(&mut self, is_constructor_parameter: bool) -> bool {
+        if !self.is_ts {
+            return false;
+        }
+
         if !matches!(
             self.cur_kind(),
             Kind::Public
@@ -1415,6 +1422,10 @@ impl<'a> ParserImpl<'a> {
     }
 
     fn is_start_of_left_hand_side_expression(&mut self) -> bool {
+        if !self.is_ts {
+            return false;
+        }
+
         match self.cur_kind() {
             kind if kind.is_literal() => true,
             kind if kind.is_template_start_of_tagged_template() => true,


### PR DESCRIPTION
Add some is_ts fast checks before doing lookaheads.

Relates to #11334 .