### PR TITLE
chore(Cargo.toml): compile tests faster with `[profile.test] debug = false`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,6 +238,11 @@ ignored = ["napi", "oxc_transform_napi", "oxc_parser_napi", "prettyplease", "laz
 # and we don't rely on it for debugging that much.
 debug = false
 
+[profile.test]
+# Disabling debug info speeds up local and CI builds,
+# and we don't rely on it for debugging that much.
+debug = false
+
 [profile.dev.package]
 # Compile macros with some optimizations to make consuming crates build faster
 oxc_macros.opt-level = 1


### PR DESCRIPTION
Make tests compile faster.

We seldom use debug symbols in `cargo test`.