### PR TITLE
test(isolated-declarations): fix multiline comment mismatch in windows

### DIFF
--- a/crates/oxc_isolated_declarations/tests/fixtures/class-decorator.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/class-decorator.ts
@@ -1,17 +1,13 @@
 declare const decorator: any;
 
 export class Test1 {
-  /**
-   * This methond will trigger the feature highlight dialog load/show based on dialogId and analyticsId
-   */
+  /** This methond will trigger the feature highlight dialog load/show based on dialogId and analyticsId */
   @decorator
   property: (() => any) | undefined;
 }
 
 export class Test2 {
-  /**
-   * This methond will trigger the feature highlight dialog load/show based on dialogId and analyticsId
-   */
+  /** This methond will trigger the feature highlight dialog load/show based on dialogId and analyticsI */
   @decorator
   property: ((arg: any) => any) | undefined;
 }

--- a/crates/oxc_isolated_declarations/tests/snapshots/class-decorator.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/class-decorator.snap
@@ -6,15 +6,11 @@ input_file: crates/oxc_isolated_declarations/tests/fixtures/class-decorator.ts
 ==================== .D.TS ====================
 
 export declare class Test1 {
-	/**
-	* This methond will trigger the feature highlight dialog load/show based on dialogId and analyticsId
-	*/
+	/** This methond will trigger the feature highlight dialog load/show based on dialogId and analyticsId */
 	property: (() => any) | undefined;
 }
 export declare class Test2 {
-	/**
-	* This methond will trigger the feature highlight dialog load/show based on dialogId and analyticsId
-	*/
+	/** This methond will trigger the feature highlight dialog load/show based on dialogId and analyticsI */
 	property: ((arg: any) => any) | undefined;
 }
 export declare class Test3 {


### PR DESCRIPTION
Fixes https://github.com/oxc-project/oxc/actions/runs/15327109307/job/43124348533

I don't know why it failed in Windows, I just follow the Boshen way to solve the problem.