### PR TITLE
feat(linter/language_server): add second editor suggestion for `react/forward-ref-uses-ref`

### DIFF
--- a/crates/oxc_language_server/fixtures/linter/multiple_suggestions/.oxlintrc.json
+++ b/crates/oxc_language_server/fixtures/linter/multiple_suggestions/.oxlintrc.json
@@ -1,0 +1,9 @@
+{
+  "plugins": ["react"],
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    "react/forward-ref-uses-ref": "error"
+  }
+}

--- a/crates/oxc_language_server/fixtures/linter/multiple_suggestions/forward_ref.ts
+++ b/crates/oxc_language_server/fixtures/linter/multiple_suggestions/forward_ref.ts
@@ -1,0 +1,1 @@
+forwardRef((props) => {});

--- a/crates/oxc_language_server/fixtures/linter/multiple_suggestions/package.json
+++ b/crates/oxc_language_server/fixtures/linter/multiple_suggestions/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "react": "latest"
+  }
+}

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -350,4 +350,19 @@ mod test {
         Tester::new("fixtures/linter/cross_module_extended_config", None)
             .test_and_snapshot_single_file("dep-a.ts");
     }
+
+    #[test]
+    fn test_multiple_suggestions() {
+        Tester::new(
+            "fixtures/linter/multiple_suggestions",
+            Some(Options {
+                flags: FxHashMap::from_iter([(
+                    "fix_kind".to_string(),
+                    "safe_fix_or_suggestion".to_string(),
+                )]),
+                ..Options::default()
+            }),
+        )
+        .test_and_snapshot_single_file("forward_ref.ts");
+    }
 }

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_multiple_suggestions@forward_ref.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_multiple_suggestions@forward_ref.ts.snap
@@ -1,0 +1,15 @@
+---
+source: crates/oxc_language_server/src/tester.rs
+input_file: crates/oxc_language_server/fixtures/linter/multiple_suggestions/forward_ref.ts
+---
+code: "eslint-plugin-react(forward-ref-uses-ref)"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/react/forward-ref-uses-ref.html"
+message: "Components wrapped with `forwardRef` must have a `ref` parameter\nhelp: Add a `ref` parameter, or remove `forwardRef`"
+range: Range { start: Position { line: 0, character: 11 }, end: Position { line: 0, character: 24 } }
+related_information[0].message: ""
+related_information[0].location.uri: "file://<variable>/fixtures/linter/multiple_suggestions/forward_ref.ts"
+related_information[0].location.range: Range { start: Position { line: 0, character: 11 }, end: Position { line: 0, character: 24 } }
+severity: Some(Error)
+source: Some("oxc")
+tags: None
+fixed: Multiple([FixedContent { message: Some("remove `forwardRef` wrapper"), code: "(props) => {}", range: Range { start: Position { line: 0, character: 0 }, end: Position { line: 0, character: 25 } } }, FixedContent { message: Some("add `ref` parameter"), code: "(props, ref)", range: Range { start: Position { line: 0, character: 11 }, end: Position { line: 0, character: 18 } } }])

--- a/crates/oxc_linter/src/rules/react/forward_ref_uses_ref.rs
+++ b/crates/oxc_linter/src/rules/react/forward_ref_uses_ref.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{AstNode, context::LintContext, fixer::RuleFixer, rule::Rule};
 
 fn forward_ref_uses_ref_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Components wrapped with `forwardRef` must have a `ref` parameter")
@@ -60,9 +60,14 @@ declare_oxc_lint!(
     react,
     correctness,
     suggestion
+    suggestion
 );
 
-fn check_forward_ref_inner(exp: &Expression, call_expr: &CallExpression, ctx: &LintContext) {
+fn check_forward_ref_inner<'a>(
+    exp: &Expression,
+    call_expr: &CallExpression,
+    ctx: &LintContext<'a>,
+) {
     let (params, span) = match exp {
         Expression::ArrowFunctionExpression(f) => (&f.params, f.span),
         Expression::FunctionExpression(f) => (&f.params, f.span),
@@ -71,9 +76,26 @@ fn check_forward_ref_inner(exp: &Expression, call_expr: &CallExpression, ctx: &L
     if params.parameters_count() != 1 || params.rest.is_some() {
         return;
     }
-    ctx.diagnostic_with_suggestion(forward_ref_uses_ref_diagnostic(span), |fixer| {
-        fixer.replace_with(call_expr, exp)
-    });
+
+    ctx.diagnostics_with_multiple_fixes(
+        forward_ref_uses_ref_diagnostic(span),
+        (FixKind::Suggestion, |fixer: RuleFixer<'_, 'a>| {
+            fixer.replace_with(call_expr, exp).with_message("remove `forwardRef` wrapper")
+        }),
+        (FixKind::Suggestion, |fixer: RuleFixer<'_, 'a>| {
+            let fixed = ctx.source_range(params.span);
+            // remove the trailing `)`, `` and `,` if they exist
+            let fixed = fixed.strip_suffix(')').unwrap_or(fixed).trim_end();
+            let mut fixed = fixed.strip_suffix(',').unwrap_or(fixed).to_string();
+
+            if !fixed.starts_with('(') {
+                fixed.insert(0, '(');
+            }
+            fixed.push_str(", ref)");
+
+            fixer.replace(params.span, fixed).with_message("add `ref` parameter")
+        }),
+    );
 }
 
 impl Rule for ForwardRefUsesRef {
@@ -192,11 +214,15 @@ fn test() {
     ];
 
     let fix = vec![
-        ("forwardRef((a) => {})", "(a) => {}"),
-        ("forwardRef(a => {})", "a => {}"),
-        ("forwardRef(function (a) {})", "function (a) {}"),
-        ("forwardRef(function(a,) {})", "function(a,) {}"),
-        ("React.forwardRef(function(a) {})", "function(a) {}"),
+        ("forwardRef((a) => {})", ("(a) => {}", "forwardRef((a, ref) => {})")),
+        ("forwardRef(a => {})", ("a => {}", "forwardRef((a, ref) => {})")),
+        ("forwardRef(function (a) {})", ("function (a) {}", "forwardRef(function (a, ref) {})")),
+        ("forwardRef(function(a,) {})", ("function(a,) {}", "forwardRef(function(a, ref) {})")),
+        ("forwardRef(function(a, ) {})", ("function(a, ) {}", "forwardRef(function(a, ref) {})")),
+        (
+            "React.forwardRef(function(a) {})",
+            ("function(a) {}", "React.forwardRef(function(a, ref) {})"),
+        ),
     ];
 
     Tester::new(ForwardRefUsesRef::NAME, ForwardRefUsesRef::PLUGIN, pass, fail)


### PR DESCRIPTION
![feat-second-editor-suggestion](https://github.com/user-attachments/assets/41db3436-ad31-4aea-ac57-54568f7b326a)

closes #9561

~~blocked by #11379~~