### PR TITLE
perf(parser): use const generics to speed up parsing

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -19,7 +19,7 @@ pub struct ParserCheckpoint<'a> {
     fatal_error: Option<FatalError>,
 }
 
-impl<'a> ParserImpl<'a> {
+impl<'a, const IS_TS: bool> ParserImpl<'a, IS_TS> {
     #[inline]
     pub(crate) fn start_span(&self) -> u32 {
         self.token.start()
@@ -261,7 +261,7 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn try_parse<T>(
         &mut self,
-        func: impl FnOnce(&mut ParserImpl<'a>) -> T,
+        func: impl FnOnce(&mut ParserImpl<'a, IS_TS>) -> T,
     ) -> Option<T> {
         let checkpoint = self.checkpoint();
         let ctx = self.ctx;
@@ -275,7 +275,10 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    pub(crate) fn lookahead<U>(&mut self, predicate: impl Fn(&mut ParserImpl<'a>) -> U) -> U {
+    pub(crate) fn lookahead<U>(
+        &mut self,
+        predicate: impl Fn(&mut ParserImpl<'a, IS_TS>) -> U,
+    ) -> U {
         let checkpoint = self.checkpoint();
         let answer = predicate(self);
         self.rewind(checkpoint);

--- a/crates/oxc_parser/src/error_handler.rs
+++ b/crates/oxc_parser/src/error_handler.rs
@@ -14,7 +14,7 @@ pub struct FatalError {
     pub errors_len: usize,
 }
 
-impl<'a> ParserImpl<'a> {
+impl<'a, const IS_TS: bool> ParserImpl<'a, IS_TS> {
     pub(crate) fn set_unexpected(&mut self) {
         // The lexer should have reported a more meaningful diagnostic
         // when it is a undetermined kind.

--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -15,7 +15,7 @@ struct ArrowFunctionHead<'a> {
     has_return_colon: bool,
 }
 
-impl<'a> ParserImpl<'a> {
+impl<'a, const IS_TS: bool> ParserImpl<'a, IS_TS> {
     pub(super) fn try_parse_parenthesized_arrow_function_expression(
         &mut self,
         allow_return_type_in_arrow_function: bool,
@@ -86,7 +86,7 @@ impl<'a> ParserImpl<'a> {
                         self.bump_any();
                         let third = self.cur_kind();
                         match third {
-                            Kind::Colon if self.is_ts => Tristate::Maybe,
+                            Kind::Colon if IS_TS => Tristate::Maybe,
                             Kind::Arrow | Kind::LCurly => Tristate::True,
                             _ => Tristate::False,
                         }
@@ -287,7 +287,7 @@ impl<'a> ParserImpl<'a> {
             self.error(diagnostics::ts_arrow_function_this_parameter(this_param.span));
         }
 
-        let has_return_colon = self.is_ts && self.at(Kind::Colon);
+        let has_return_colon = IS_TS && self.at(Kind::Colon);
         let return_type = self.parse_ts_return_type_annotation(Kind::Arrow, false);
 
         self.ctx = self.ctx.and_await(has_await);

--- a/crates/oxc_parser/src/js/binding.rs
+++ b/crates/oxc_parser/src/js/binding.rs
@@ -3,7 +3,7 @@ use oxc_span::GetSpan;
 
 use crate::{Context, ParserImpl, diagnostics, lexer::Kind};
 
-impl<'a> ParserImpl<'a> {
+impl<'a, const IS_TS: bool> ParserImpl<'a, IS_TS> {
     /// `BindingElement`
     ///     `SingleNameBinding`
     ///     `BindingPattern`[?Yield, ?Await] `Initializer`[+In, ?Yield, ?Await]opt
@@ -15,7 +15,7 @@ impl<'a> ParserImpl<'a> {
 
     pub(super) fn parse_binding_pattern(&mut self, allow_question: bool) -> BindingPattern<'a> {
         let mut kind = self.parse_binding_pattern_kind();
-        let optional = if allow_question && self.is_ts { self.eat(Kind::Question) } else { false };
+        let optional = if allow_question && IS_TS { self.eat(Kind::Question) } else { false };
         let type_annotation = self.parse_ts_type_annotation();
         if let Some(type_annotation) = &type_annotation {
             Self::extend_binding_pattern_span_end(type_annotation.span.end, &mut kind);
@@ -116,7 +116,7 @@ impl<'a> ParserImpl<'a> {
 
         let kind = self.parse_binding_pattern_kind();
         // Rest element does not allow `?`, checked in checker/typescript.rs
-        if self.at(Kind::Question) && self.is_ts {
+        if self.at(Kind::Question) && IS_TS {
             let span = self.cur_token().span();
             self.bump_any();
             self.error(diagnostics::a_rest_parameter_cannot_be_optional(span));

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -13,7 +13,7 @@ type Extends<'a> =
     Vec<'a, (Expression<'a>, Option<Box<'a, TSTypeParameterInstantiation<'a>>>, Span)>;
 
 /// Section 15.7 Class Definitions
-impl<'a> ParserImpl<'a> {
+impl<'a, const IS_TS: bool> ParserImpl<'a, IS_TS> {
     // `start_span` points at the start of all decoractors and `class` keyword.
     pub(crate) fn parse_class_statement(
         &mut self,
@@ -78,7 +78,7 @@ impl<'a> ParserImpl<'a> {
             None
         };
 
-        let type_parameters = if self.is_ts { self.parse_ts_type_parameters() } else { None };
+        let type_parameters = if IS_TS { self.parse_ts_type_parameters() } else { None };
         let (extends, implements) = self.parse_heritage_clause();
         let mut super_class = None;
         let mut super_type_parameters = None;
@@ -261,7 +261,7 @@ impl<'a> ParserImpl<'a> {
             Kind::PrivateIdentifier => {
                 let private_ident = self.parse_private_identifier();
                 // `private #foo`, etc. is illegal
-                if self.is_ts {
+                if IS_TS {
                     self.verify_modifiers(
                         modifiers,
                         ModifierFlags::all() - ModifierFlags::ACCESSIBILITY,
@@ -295,7 +295,7 @@ impl<'a> ParserImpl<'a> {
         definite: bool,
         modifiers: &Modifiers<'a>,
     ) -> ClassElement<'a> {
-        let type_annotation = if self.is_ts { self.parse_ts_type_annotation() } else { None };
+        let type_annotation = if IS_TS { self.parse_ts_type_annotation() } else { None };
         let value = self.eat(Kind::Eq).then(|| self.parse_assignment_expression_or_higher());
         self.asi();
         let r#type = if modifiers.contains(ModifierKind::Abstract) {
@@ -517,7 +517,7 @@ impl<'a> ParserImpl<'a> {
         modifiers: &Modifiers,
     ) -> ClassElement<'a> {
         let decorators = self.consume_decorators();
-        let type_annotation = if self.is_ts { self.parse_ts_type_annotation() } else { None };
+        let type_annotation = if IS_TS { self.parse_ts_type_annotation() } else { None };
         // Initializer[+In, ?Yield, ?Await]opt
         let initializer = self
             .eat(Kind::Eq)

--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -9,7 +9,7 @@ use crate::{
     modifiers::{ModifierFlags, Modifiers},
 };
 
-impl<'a> ParserImpl<'a> {
+impl<'a, const IS_TS: bool> ParserImpl<'a, IS_TS> {
     pub(crate) fn parse_let(&mut self, stmt_ctx: StatementContext) -> Statement<'a> {
         let span = self.start_span();
         let checkpoint = self.checkpoint();
@@ -106,7 +106,7 @@ impl<'a> ParserImpl<'a> {
 
         let mut binding_kind = self.parse_binding_pattern_kind();
 
-        let (id, definite) = if self.is_ts {
+        let (id, definite) = if IS_TS {
             // const x!: number = 1
             //        ^ definite
             let mut definite = false;

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -19,7 +19,7 @@ impl FunctionKind {
     }
 }
 
-impl<'a> ParserImpl<'a> {
+impl<'a, const IS_TS: bool> ParserImpl<'a, IS_TS> {
     pub(crate) fn at_function_with_async(&mut self) -> bool {
         self.at(Kind::Function)
             || self.at(Kind::Async)
@@ -47,7 +47,7 @@ impl<'a> ParserImpl<'a> {
     ) -> (Option<TSThisParameter<'a>>, Box<'a, FormalParameters<'a>>) {
         let span = self.start_span();
         self.expect(Kind::LParen);
-        let this_param = if self.is_ts && self.at(Kind::This) {
+        let this_param = if IS_TS && self.at(Kind::This) {
             let param = self.parse_ts_this_parameter();
             if !self.at(Kind::RParen) {
                 self.expect(Kind::Comma);
@@ -139,7 +139,7 @@ impl<'a> ParserImpl<'a> {
         self.ctx =
             self.ctx.and_in(ctx.has_in()).and_await(ctx.has_await()).and_yield(ctx.has_yield());
 
-        if !self.is_ts && body.is_none() {
+        if !IS_TS && body.is_none() {
             return self.unexpected();
         }
 

--- a/crates/oxc_parser/src/js/grammar.rs
+++ b/crates/oxc_parser/src/js/grammar.rs
@@ -6,11 +6,11 @@ use oxc_span::GetSpan;
 use crate::{ParserImpl, diagnostics};
 
 pub trait CoverGrammar<'a, T>: Sized {
-    fn cover(value: T, p: &mut ParserImpl<'a>) -> Self;
+    fn cover<const IS_TS: bool>(value: T, p: &mut ParserImpl<'a, IS_TS>) -> Self;
 }
 
 impl<'a> CoverGrammar<'a, Expression<'a>> for AssignmentTarget<'a> {
-    fn cover(expr: Expression<'a>, p: &mut ParserImpl<'a>) -> Self {
+    fn cover<const IS_TS: bool>(expr: Expression<'a>, p: &mut ParserImpl<'a, IS_TS>) -> Self {
         match expr {
             Expression::ArrayExpression(array_expr) => {
                 let pat = ArrayAssignmentTarget::cover(array_expr.unbox(), p);
@@ -26,7 +26,7 @@ impl<'a> CoverGrammar<'a, Expression<'a>> for AssignmentTarget<'a> {
 }
 
 impl<'a> CoverGrammar<'a, Expression<'a>> for SimpleAssignmentTarget<'a> {
-    fn cover(expr: Expression<'a>, p: &mut ParserImpl<'a>) -> Self {
+    fn cover<const IS_TS: bool>(expr: Expression<'a>, p: &mut ParserImpl<'a, IS_TS>) -> Self {
         match expr {
             Expression::Identifier(ident) => {
                 SimpleAssignmentTarget::AssignmentTargetIdentifier(ident)
@@ -61,7 +61,7 @@ impl<'a> CoverGrammar<'a, Expression<'a>> for SimpleAssignmentTarget<'a> {
 }
 
 impl<'a> CoverGrammar<'a, ArrayExpression<'a>> for ArrayAssignmentTarget<'a> {
-    fn cover(expr: ArrayExpression<'a>, p: &mut ParserImpl<'a>) -> Self {
+    fn cover<const IS_TS: bool>(expr: ArrayExpression<'a>, p: &mut ParserImpl<'a, IS_TS>) -> Self {
         let mut elements = p.ast.vec();
         let mut rest = None;
 
@@ -96,7 +96,7 @@ impl<'a> CoverGrammar<'a, ArrayExpression<'a>> for ArrayAssignmentTarget<'a> {
 }
 
 impl<'a> CoverGrammar<'a, Expression<'a>> for AssignmentTargetMaybeDefault<'a> {
-    fn cover(expr: Expression<'a>, p: &mut ParserImpl<'a>) -> Self {
+    fn cover<const IS_TS: bool>(expr: Expression<'a>, p: &mut ParserImpl<'a, IS_TS>) -> Self {
         match expr {
             Expression::AssignmentExpression(assignment_expr) => {
                 let target = AssignmentTargetWithDefault::cover(assignment_expr.unbox(), p);
@@ -111,13 +111,16 @@ impl<'a> CoverGrammar<'a, Expression<'a>> for AssignmentTargetMaybeDefault<'a> {
 }
 
 impl<'a> CoverGrammar<'a, AssignmentExpression<'a>> for AssignmentTargetWithDefault<'a> {
-    fn cover(expr: AssignmentExpression<'a>, p: &mut ParserImpl<'a>) -> Self {
+    fn cover<const IS_TS: bool>(
+        expr: AssignmentExpression<'a>,
+        p: &mut ParserImpl<'a, IS_TS>,
+    ) -> Self {
         p.ast.assignment_target_with_default(expr.span, expr.left, expr.right)
     }
 }
 
 impl<'a> CoverGrammar<'a, ObjectExpression<'a>> for ObjectAssignmentTarget<'a> {
-    fn cover(expr: ObjectExpression<'a>, p: &mut ParserImpl<'a>) -> Self {
+    fn cover<const IS_TS: bool>(expr: ObjectExpression<'a>, p: &mut ParserImpl<'a, IS_TS>) -> Self {
         let mut properties = p.ast.vec();
         let mut rest = None;
 
@@ -146,7 +149,10 @@ impl<'a> CoverGrammar<'a, ObjectExpression<'a>> for ObjectAssignmentTarget<'a> {
 }
 
 impl<'a> CoverGrammar<'a, ObjectProperty<'a>> for AssignmentTargetProperty<'a> {
-    fn cover(property: ObjectProperty<'a>, p: &mut ParserImpl<'a>) -> Self {
+    fn cover<const IS_TS: bool>(
+        property: ObjectProperty<'a>,
+        p: &mut ParserImpl<'a, IS_TS>,
+    ) -> Self {
         if property.shorthand {
             let binding = match property.key {
                 PropertyKey::StaticIdentifier(ident) => {

--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -4,7 +4,7 @@ use oxc_syntax::operator::AssignmentOperator;
 
 use crate::{Context, ParserImpl, diagnostics, lexer::Kind, modifiers::Modifier};
 
-impl<'a> ParserImpl<'a> {
+impl<'a, const IS_TS: bool> ParserImpl<'a, IS_TS> {
     /// [Object Expression](https://tc39.es/ecma262/#sec-object-initializer)
     /// `ObjectLiteral`[Yield, Await] :
     ///     { }
@@ -58,7 +58,7 @@ impl<'a> ParserImpl<'a> {
             // Report and handle illegal modifiers
             // e.g. const x = { public foo() {} }
             modifier_kind
-                if self.is_ts
+                if IS_TS
                     && modifier_kind.is_modifier_kind()
                     && peek_kind.is_identifier_or_keyword() =>
             {

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -7,7 +7,7 @@ use crate::{
     Context, ParserImpl, StatementContext, diagnostics, lexer::Kind, modifiers::Modifiers,
 };
 
-impl<'a> ParserImpl<'a> {
+impl<'a, const IS_TS: bool> ParserImpl<'a, IS_TS> {
     // Section 12
     // The InputElementHashbangOrRegExp goal is used at the start of a Script
     // or Module.
@@ -133,7 +133,7 @@ impl<'a> ParserImpl<'a> {
                 self.parse_import_declaration()
             }
             // Check we are not at a `const enum` in TypeScript
-            Kind::Const if !(self.is_ts && self.lookahead(|p| {
+            Kind::Const if !(IS_TS && self.lookahead(|p| {
                 p.bump_any();
                 p.at(Kind::Enum)
             })) =>
@@ -160,7 +160,7 @@ impl<'a> ParserImpl<'a> {
             | Kind::Static
             | Kind::Readonly
             | Kind::Global
-                if self.is_ts && self.at_start_of_ts_declaration() =>
+                if IS_TS && self.at_start_of_ts_declaration() =>
             {
                 self.parse_ts_declaration_statement(start_span)
             }

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -6,7 +6,7 @@ use oxc_span::{Atom, GetSpan, Span};
 
 use crate::{Context, ParserImpl, diagnostics, lexer::Kind};
 
-impl<'a> ParserImpl<'a> {
+impl<'a, const IS_TS: bool> ParserImpl<'a, IS_TS> {
     pub(crate) fn parse_jsx_expression(&mut self) -> Expression<'a> {
         if self.lookahead(|s| {
             s.bump_any();
@@ -92,7 +92,7 @@ impl<'a> ParserImpl<'a> {
         self.expect(Kind::LAngle);
         let name = self.parse_jsx_element_name();
         // <Component<TsType> for tsx
-        let type_arguments = if self.is_ts { self.try_parse_type_arguments() } else { None };
+        let type_arguments = if IS_TS { self.try_parse_type_arguments() } else { None };
         let attributes = self.parse_jsx_attributes();
         let self_closing = self.eat(Kind::Slash);
         if !self_closing || in_jsx_child {

--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -291,7 +291,7 @@ impl std::fmt::Display for ModifierKind {
     }
 }
 
-impl<'a> ParserImpl<'a> {
+impl<'a, const IS_TS: bool> ParserImpl<'a, IS_TS> {
     pub(crate) fn eat_modifiers_before_declaration(&mut self) -> Modifiers<'a> {
         let mut flags = ModifierFlags::empty();
         let mut modifiers = self.ast.vec();

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -9,7 +9,7 @@ use crate::{
     modifiers::{ModifierFlags, ModifierKind, Modifiers},
 };
 
-impl<'a> ParserImpl<'a> {
+impl<'a, const IS_TS: bool> ParserImpl<'a, IS_TS> {
     /* ------------------- Enum ------------------ */
     /// `https://www.typescriptlang.org/docs/handbook/enums.html`
     pub(crate) fn parse_ts_enum_declaration(
@@ -97,7 +97,7 @@ impl<'a> ParserImpl<'a> {
     /* ------------------- Annotation ----------------- */
 
     pub(crate) fn parse_ts_type_annotation(&mut self) -> Option<Box<'a, TSTypeAnnotation<'a>>> {
-        if !self.is_ts {
+        if !IS_TS {
             return None;
         }
         if !self.at(Kind::Colon) {
@@ -363,7 +363,7 @@ impl<'a> ParserImpl<'a> {
                 if declare {
                     let decl = self.parse_ts_declare_function(start_span, modifiers);
                     Declaration::FunctionDeclaration(decl)
-                } else if self.is_ts {
+                } else if IS_TS {
                     let decl = self.parse_ts_function_impl(
                         start_span,
                         FunctionKind::Declaration,

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -9,7 +9,7 @@ use crate::{
     modifiers::{Modifier, ModifierFlags, ModifierKind, Modifiers},
 };
 
-impl<'a> ParserImpl<'a> {
+impl<'a, const IS_TS: bool> ParserImpl<'a, IS_TS> {
     pub(crate) fn parse_ts_type(&mut self) -> TSType<'a> {
         if self.is_start_of_function_type_or_constructor_type() {
             return self.parse_function_or_constructor_type();
@@ -141,7 +141,7 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_ts_type_parameters(
         &mut self,
     ) -> Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
-        if !self.is_ts {
+        if !IS_TS {
             return None;
         }
         if !self.at(Kind::LAngle) {
@@ -813,7 +813,7 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_type_arguments_in_expression(
         &mut self,
     ) -> Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
-        if !self.is_ts {
+        if !IS_TS {
             return None;
         }
         let span = self.start_span();
@@ -1007,7 +1007,7 @@ impl<'a> ParserImpl<'a> {
         kind: Kind,
         is_type: bool,
     ) -> Option<Box<'a, TSTypeAnnotation<'a>>> {
-        if !self.is_ts {
+        if !IS_TS {
             return None;
         }
         if !self.at(Kind::Colon) {
@@ -1274,7 +1274,7 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         is_constructor_parameter: bool,
     ) -> Modifiers<'a> {
-        if !self.is_ts {
+        if !IS_TS {
             return Modifiers::empty();
         }
 


### PR DESCRIPTION
Since `is_ts` never changes during parsing, we can convert it into a const generic parameter to test for potential speed improvements.