### PR TITLE
refactor(parser): remove lookahead for parsing import declarations and specifiers

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -621,3 +621,8 @@ pub fn unexpected_exponential(x0: &str, span1: Span) -> OxcDiagnostic {
         .with_help(format!("Wrap {x0} expression in parentheses to enforce operator precedence"))
         .with_label(span1)
 }
+
+#[cold]
+pub fn import_equals_can_only_be_used_in_typescript_files(span: Span) -> OxcDiagnostic {
+    ts_error("8002", "'import ... =' can only be used in TypeScript files.").with_label(span)
+}

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -58,70 +58,110 @@ impl<'a> ParserImpl<'a> {
 
     /// Section 16.2.2 Import Declaration
     pub(crate) fn parse_import_declaration(&mut self, span: u32) -> Statement<'a> {
-        // `import something = ...`
-        // `import type something = ...`
-        if self.is_ts
-            && ((self.cur_kind().is_binding_identifier()
-                && self.lookahead(Self::is_next_token_equals))
-                || (self.at(Kind::Type)
-                    && self.lookahead(|p| {
-                        p.bump_any();
-                        if !p.cur_kind().is_binding_identifier() {
-                            return false;
-                        }
-                        p.bump_any();
-                        p.at(Kind::Eq)
-                    })))
-        {
-            let decl = self.parse_ts_import_equals_declaration(span);
-            return Statement::from(decl);
-        }
+        let token_after_import = self.cur_token();
+        let mut identifier_after_import: Option<BindingIdentifier<'_>> =
+            if self.cur_kind().is_binding_identifier() {
+                // `import something ...`
+                Some(self.parse_binding_identifier())
+            } else {
+                // `import ...`
+                None
+            };
+        let mut has_default_specifier = identifier_after_import.is_some();
 
-        // `import type ...`
-        // `import source ...`
-        // `import defer ...`
-        let mut import_kind = ImportOrExportKind::Value;
         let mut phase = None;
-        match self.cur_kind() {
-            Kind::Source => {
-                // `import source something from ...`
-                if self.lookahead(|p| {
-                    p.bump_any();
-                    if !p.cur_kind().is_binding_identifier() {
-                        return false;
+        let mut import_kind = ImportOrExportKind::Value;
+
+        if self.at(Kind::Eq) && identifier_after_import.is_some() {
+            // `import something = ...`
+            let decl = self.parse_ts_import_equals_declaration(
+                ImportOrExportKind::Value,
+                identifier_after_import.unwrap(),
+                span,
+            );
+            return Statement::from(decl);
+        } else if self.is_ts && token_after_import.kind() == Kind::Type {
+            // `import type ...`
+
+            if token_after_import.escaped() {
+                self.error(diagnostics::escaped_keyword(token_after_import.span()));
+            }
+
+            if self.at(Kind::LCurly) || self.at(Kind::Star) {
+                // `import type { ...`
+                // `import type * ...`
+                import_kind = ImportOrExportKind::Type;
+                has_default_specifier = false;
+            } else if self.cur_kind().is_binding_identifier() {
+                // `import type something ...`
+                let token = self.cur_token();
+                let identifier_after_type = self.parse_binding_identifier();
+                if token.kind() == Kind::From && self.at(Kind::Str) {
+                    // `import type from 'source'`
+                    has_default_specifier = true;
+                    import_kind = ImportOrExportKind::Value;
+                } else {
+                    identifier_after_import = Some(identifier_after_type);
+                    import_kind = ImportOrExportKind::Type;
+
+                    if self.at(Kind::Eq) {
+                        // `import type something = ...`
+                        let decl = self.parse_ts_import_equals_declaration(
+                            ImportOrExportKind::Type,
+                            identifier_after_import.unwrap(),
+                            span,
+                        );
+                        return Statement::from(decl);
+                    } else if self.at(Kind::From) {
+                        // `import type something from ...`
+                        has_default_specifier = true;
                     }
-                    p.bump_any();
-                    p.at(Kind::From)
-                }) {
-                    self.bump_any();
-                    phase = Some(ImportPhase::Source);
                 }
             }
-            Kind::Defer
-                if self.lookahead(|p| {
-                    p.bump_any();
-                    p.at(Kind::Star)
-                }) =>
-            {
-                // `import defer * ...`
-                self.bump_any();
-                phase = Some(ImportPhase::Defer);
-            }
-            Kind::Type if self.is_ts => import_kind = self.parse_import_or_export_kind(),
-            _ => {}
+        } else if token_after_import.kind() == Kind::Defer && self.at(Kind::Star) {
+            // `import defer * ...`
+            phase = Some(ImportPhase::Defer);
+            has_default_specifier = false;
+        } else if token_after_import.kind() == Kind::Source
+            && self.cur_kind().is_binding_identifier()
+        {
+            // `import source something`
+            identifier_after_import = Some(self.parse_binding_identifier());
+            phase = Some(ImportPhase::Source);
+            has_default_specifier = true;
         }
 
         let specifiers = if self.at(Kind::Str) {
-            // import "source"
-            None
+            if has_default_specifier
+                && identifier_after_import.as_ref().is_some_and(|s| s.name == "type")
+            {
+                match identifier_after_import {
+                    Some(identifier_after_import) => {
+                        // Special case: `import type from 'source'` where we already consumed `type` and `from`
+                        Some(self.ast.vec1(
+                            self.ast.import_declaration_specifier_import_default_specifier(
+                                identifier_after_import.span,
+                                identifier_after_import,
+                            ),
+                        ))
+                    }
+                    None => unreachable!(),
+                }
+            } else {
+                None
+            }
         } else {
-            Some(self.parse_import_declaration_specifiers(import_kind))
+            let default_specifier =
+                if has_default_specifier { identifier_after_import } else { None };
+
+            Some(self.parse_import_declaration_specifiers(default_specifier, import_kind))
         };
 
         let source = self.parse_literal_string();
         let with_clause = self.parse_import_attributes();
         self.asi();
         let span = self.end_span(span);
+
         self.ast
             .module_declaration_import_declaration(
                 span,
@@ -137,12 +177,23 @@ impl<'a> ParserImpl<'a> {
     // Full Syntax: <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#syntax>
     fn parse_import_declaration_specifiers(
         &mut self,
+        // A default specifier, if we already saw any identifier after `import`
+        default_specifier: Option<BindingIdentifier<'a>>,
         import_kind: ImportOrExportKind,
     ) -> Vec<'a, ImportDeclarationSpecifier<'a>> {
-        let mut specifiers = self.ast.vec();
-        // import defaultExport from "module-name";
-        if self.cur_kind().is_binding_identifier() {
-            specifiers.push(self.parse_import_default_specifier());
+        // If there is a default specifier, create a Vec with the default specifier in it,
+        // otherwise, create an empty Vec.
+        let mut specifiers = if default_specifier.is_some() {
+            self.ast.vec_with_capacity(1)
+        } else {
+            self.ast.vec()
+        };
+
+        if let Some(default_specifier) = default_specifier {
+            specifiers.push(self.ast.import_declaration_specifier_import_default_specifier(
+                default_specifier.span,
+                default_specifier,
+            ));
             if self.eat(Kind::Comma) {
                 match self.cur_kind() {
                     // import defaultExport, * as name from "module-name";
@@ -155,25 +206,27 @@ impl<'a> ParserImpl<'a> {
                     _ => return self.unexpected(),
                 }
             }
-        // import * as name from "module-name";
+
+            // If the default specifiers name was `type`, and it was not a type import
+            // then skip the `from` specifier expect. This is specifically to support an import
+            // like: `import type from 'source'`
+            if import_kind == ImportOrExportKind::Value
+                && specifiers.len() == 1
+                && specifiers[0].name() == "type"
+            {
+                return specifiers;
+            }
         } else if self.at(Kind::Star) {
+            // import * as name from "module-name";
             specifiers.push(self.parse_import_namespace_specifier());
-        // import { export1 , export2 as alias2 , [...] } from "module-name";
         } else if self.at(Kind::LCurly) {
+            // import { export1 , export2 as alias2 , [...] } from "module-name";
             let mut import_specifiers = self.parse_import_specifiers(import_kind);
             specifiers.append(&mut import_specifiers);
         }
 
         self.expect(Kind::From);
         specifiers
-    }
-
-    // import default from "module-name"
-    fn parse_import_default_specifier(&mut self) -> ImportDeclarationSpecifier<'a> {
-        let span = self.start_span();
-        let local = self.parse_binding_identifier();
-        let span = self.end_span(span);
-        self.ast.import_declaration_specifier_import_default_specifier(span, local)
     }
 
     // import * as name from "module-name"
@@ -770,5 +823,271 @@ impl<'a> ParserImpl<'a> {
 
     fn can_parse_module_export_name(&self) -> bool {
         self.cur_kind().is_identifier_name() || self.at(Kind::Str)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use oxc_allocator::Allocator;
+    use oxc_ast::ast::{ImportDeclarationSpecifier, ImportOrExportKind, ImportPhase, Statement};
+    use oxc_span::SourceType;
+
+    use crate::Parser;
+    #[test]
+    fn test_parse_import_declaration() {
+        let src = "import foo from 'bar';";
+        parse_and_assert_import_declarations(src, |declarations| {
+            assert_eq!(declarations.len(), 1);
+            let decl = declarations[0];
+            assert_eq!(decl.import_kind, ImportOrExportKind::Value);
+            let specifiers = decl.specifiers.as_ref().unwrap();
+            assert_eq!(specifiers.len(), 1);
+            assert_eq!(specifiers[0].name(), "foo");
+        });
+
+        let src = "import type foo from 'bar';";
+        parse_and_assert_import_declarations(src, |declarations| {
+            assert_eq!(declarations.len(), 1);
+            let decl = declarations[0];
+            assert_eq!(decl.import_kind, ImportOrExportKind::Type);
+            let specifiers = decl.specifiers.as_ref().unwrap();
+            assert_eq!(specifiers.len(), 1);
+            assert_eq!(specifiers[0].name(), "foo");
+        });
+
+        let src = "import type from 'bar';";
+        parse_and_assert_import_declarations(src, |declarations| {
+            assert_eq!(declarations.len(), 1);
+            let decl = declarations[0];
+            assert_eq!(decl.import_kind, ImportOrExportKind::Value);
+            let specifiers = decl.specifiers.as_ref().unwrap();
+            assert_eq!(specifiers.len(), 1);
+            assert_eq!(specifiers[0].name(), "type");
+        });
+
+        let src = "import type from from 'bar';";
+        parse_and_assert_import_declarations(src, |declarations| {
+            assert_eq!(declarations.len(), 1);
+            let decl = declarations[0];
+            assert_eq!(decl.import_kind, ImportOrExportKind::Type);
+            let specifiers = decl.specifiers.as_ref().unwrap();
+            assert_eq!(specifiers.len(), 1);
+            assert_eq!(specifiers[0].name(), "from");
+            assert!(matches!(specifiers[0], ImportDeclarationSpecifier::ImportDefaultSpecifier(_)));
+        });
+
+        let src = "import type type from 'bar';";
+        parse_and_assert_import_declarations(src, |declarations| {
+            assert_eq!(declarations.len(), 1);
+            let decl = declarations[0];
+            assert_eq!(decl.import_kind, ImportOrExportKind::Type);
+            let specifiers = decl.specifiers.as_ref().unwrap();
+            assert_eq!(specifiers.len(), 1);
+            assert_eq!(specifiers[0].name(), "type");
+            assert!(matches!(specifiers[0], ImportDeclarationSpecifier::ImportDefaultSpecifier(_)));
+        });
+
+        let src = "import type { type } from 'bar';";
+        parse_and_assert_import_declarations(src, |declarations| {
+            assert_eq!(declarations.len(), 1);
+            let decl = declarations[0];
+            assert_eq!(decl.import_kind, ImportOrExportKind::Type);
+            let specifiers = decl.specifiers.as_ref().unwrap();
+            assert_eq!(specifiers.len(), 1);
+            assert_eq!(specifiers[0].name(), "type");
+        });
+
+        let src = "import './a'";
+        parse_and_assert_import_declarations(src, |declarations| {
+            assert_eq!(declarations.len(), 1);
+            let decl = declarations[0];
+            assert_eq!(decl.import_kind, ImportOrExportKind::Value);
+            assert!(decl.specifiers.is_none());
+        });
+
+        let src = "import type, { bar } from 'foo';";
+        parse_and_assert_import_declarations(src, |declarations| {
+            assert_eq!(declarations.len(), 1);
+            let decl = declarations[0];
+            assert_eq!(decl.import_kind, ImportOrExportKind::Value);
+            let specifiers = decl.specifiers.as_ref().unwrap();
+            assert_eq!(specifiers.len(), 2);
+            assert_eq!(specifiers[0].name(), "type");
+            assert_eq!(specifiers[1].name(), "bar");
+        });
+
+        let src = "import { foo, bar } from 'baz';";
+        parse_and_assert_import_declarations(src, |declarations| {
+            assert_eq!(declarations.len(), 1);
+            let decl = declarations[0];
+            assert_eq!(decl.import_kind, ImportOrExportKind::Value);
+            assert!(decl.specifiers.is_some());
+            let specifiers = decl.specifiers.as_ref().unwrap();
+            assert_eq!(specifiers.len(), 2);
+            assert_eq!(specifiers[0].name(), "foo");
+            assert_eq!(specifiers[1].name(), "bar");
+        });
+
+        let src = "import type { foo, bar } from 'baz';";
+        parse_and_assert_import_declarations(src, |declarations| {
+            assert_eq!(declarations.len(), 1);
+            let decl = declarations[0];
+            assert_eq!(decl.import_kind, ImportOrExportKind::Type);
+            assert!(decl.specifiers.is_some());
+            let specifiers = decl.specifiers.as_ref().unwrap();
+            assert_eq!(specifiers.len(), 2);
+            assert_eq!(specifiers[0].name(), "foo");
+            assert_eq!(specifiers[1].name(), "bar");
+        });
+
+        let src = "import type { from, type } from 'baz';";
+        parse_and_assert_import_declarations(src, |declarations| {
+            assert_eq!(declarations.len(), 1);
+            let decl = declarations[0];
+            assert_eq!(decl.import_kind, ImportOrExportKind::Type);
+            assert!(decl.specifiers.is_some());
+            let specifiers = decl.specifiers.as_ref().unwrap();
+            assert_eq!(specifiers.len(), 2);
+            assert_eq!(specifiers[0].name(), "from");
+            assert_eq!(specifiers[1].name(), "type");
+        });
+
+        let src = "import defaultItem, { type from, type } from 'baz';";
+        parse_and_assert_import_declarations(src, |declarations| {
+            assert_eq!(declarations.len(), 1);
+            let decl = declarations[0];
+            assert_eq!(decl.import_kind, ImportOrExportKind::Value);
+            assert!(decl.specifiers.is_some());
+            let specifiers = decl.specifiers.as_ref().unwrap();
+            assert_eq!(specifiers.len(), 3);
+            assert_eq!(specifiers[0].name(), "defaultItem");
+            assert_eq!(specifiers[1].name(), "from");
+            assert_eq!(specifiers[2].name(), "type");
+        });
+
+        let src = "import * as foo from 'bar';";
+        parse_and_assert_import_declarations(src, |declarations| {
+            assert_eq!(declarations.len(), 1);
+            let decl = declarations[0];
+            assert_eq!(decl.import_kind, ImportOrExportKind::Value);
+            let specifiers = decl.specifiers.as_ref().unwrap();
+            assert_eq!(specifiers.len(), 1);
+            assert_eq!(specifiers[0].name(), "foo");
+        });
+
+        let src = "import type * as foo from 'bar';";
+        parse_and_assert_import_declarations(src, |declarations| {
+            assert_eq!(declarations.len(), 1);
+            let decl = declarations[0];
+            assert_eq!(decl.import_kind, ImportOrExportKind::Type);
+            let specifiers = decl.specifiers.as_ref().unwrap();
+            assert_eq!(specifiers.len(), 1);
+            assert_eq!(specifiers[0].name(), "foo");
+        });
+
+        let src = "import defer * as ns from 'x'";
+        parse_and_assert_import_declarations(src, |declarations| {
+            assert_eq!(declarations.len(), 1);
+            let decl = declarations[0];
+            assert_eq!(decl.import_kind, ImportOrExportKind::Value);
+            assert_eq!(decl.phase, Some(ImportPhase::Defer));
+            let specifiers = decl.specifiers.as_ref().unwrap();
+            assert_eq!(specifiers.len(), 1);
+            assert_eq!(specifiers[0].name(), "ns");
+        });
+
+        let src = "import source x from 'source'";
+        parse_and_assert_import_declarations(src, |declarations| {
+            assert_eq!(declarations.len(), 1);
+            let decl = declarations[0];
+            assert_eq!(decl.import_kind, ImportOrExportKind::Value);
+            assert_eq!(decl.phase, Some(ImportPhase::Source));
+            let specifiers = decl.specifiers.as_ref().unwrap();
+            assert_eq!(specifiers.len(), 1);
+            assert_eq!(specifiers[0].name(), "x");
+        });
+
+        let src = "import type foo, { bar } from 'bar';";
+        parse_and_assert_import_declarations(src, |declarations| {
+            assert_eq!(declarations.len(), 1);
+            let decl = declarations[0];
+            assert_eq!(decl.import_kind, ImportOrExportKind::Type);
+            let specifiers = decl.specifiers.as_ref().unwrap();
+            assert_eq!(specifiers.len(), 2);
+            assert_eq!(specifiers[0].name(), "foo");
+            assert_eq!(specifiers[1].name(), "bar");
+        });
+
+        let src = "import foo = bar";
+        parse_and_assert_statements(src, |statements| {
+            if let Statement::TSImportEqualsDeclaration(decl) = statements[0] {
+                assert_eq!(decl.import_kind, ImportOrExportKind::Value);
+                assert_eq!(decl.id.name, "foo");
+            } else {
+                panic!("Expected TSImportEqualsDeclaration, found: {:?}", statements[0]);
+            }
+        });
+
+        let src = "import type foo = bar";
+        parse_and_assert_statements(src, |statements| {
+            if let Statement::TSImportEqualsDeclaration(decl) = statements[0] {
+                assert_eq!(decl.import_kind, ImportOrExportKind::Type);
+                assert_eq!(decl.id.name, "foo");
+            } else {
+                panic!("Expected TSImportEqualsDeclaration, found: {:?}", statements[0]);
+            }
+        });
+
+        let src = "import type from = require('./a')";
+        parse_and_assert_statements(src, |statements| {
+            if let Statement::TSImportEqualsDeclaration(decl) = statements[0] {
+                assert_eq!(decl.import_kind, ImportOrExportKind::Type);
+                assert_eq!(decl.id.name, "from");
+            } else {
+                panic!("Expected TSImportEqualsDeclaration, found: {:?}", statements[0]);
+            }
+        });
+
+        let src = "import from = b";
+        parse_and_assert_statements(src, |statements| {
+            if let Statement::TSImportEqualsDeclaration(decl) = statements[0] {
+                assert_eq!(decl.import_kind, ImportOrExportKind::Value);
+                assert_eq!(decl.id.name, "from");
+            } else {
+                panic!("Expected TSImportEqualsDeclaration, found: {:?}", statements[0]);
+            }
+        });
+    }
+
+    fn parse_and_assert_statements(
+        src: &'static str,
+        // takes a function which accepts the list of statements
+        f: fn(Vec<&oxc_ast::ast::Statement<'_>>) -> (),
+    ) {
+        let source_type = SourceType::default().with_typescript(true);
+        let allocator = Allocator::default();
+        let ret = Parser::new(&allocator, src, source_type).parse();
+        assert!(ret.errors.is_empty(), "Failed to parse source: {src:?}, error: {:?}", ret.errors);
+        f(ret.program.body.iter().collect::<Vec<_>>());
+    }
+
+    fn parse_and_assert_import_declarations(
+        src: &'static str,
+        // takes a function which accepts the list of statements
+        f: fn(Vec<&oxc_allocator::Box<'_, oxc_ast::ast::ImportDeclaration<'_>>>) -> (),
+    ) {
+        let source_type = SourceType::default().with_typescript(true);
+        let allocator = Allocator::default();
+        let ret = Parser::new(&allocator, src, source_type).parse();
+        assert!(ret.errors.is_empty(), "Failed to parse source: {src:?}, error: {:?}", ret.errors);
+        let statements =
+            ret.program
+                .body
+                .iter()
+                .filter_map(|s| {
+                    if let Statement::ImportDeclaration(decl) = s { Some(decl) } else { None }
+                })
+                .collect::<Vec<_>>();
+        f(statements);
     }
 }

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -13433,11 +13433,10 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·               ─
    ╰────
 
-  × Expected `from` but found `=`
-   ╭─[typescript/tests/cases/compiler/jsFileCompilationImportEqualsSyntax.ts:1:10]
+  × TS(8002): 'import ... =' can only be used in TypeScript files.
+   ╭─[typescript/tests/cases/compiler/jsFileCompilationImportEqualsSyntax.ts:1:1]
  1 │ import a = b;
-   ·          ┬
-   ·          ╰── `from` expected
+   · ─────────────
    ╰────
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
@@ -25722,22 +25721,35 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·        ─
    ╰────
 
-  × Expected `from` but found `=`
-   ╭─[typescript/tests/cases/conformance/node/allowJs/nodeModulesAllowJsImportAssignment.ts:2:11]
+  × TS(8002): 'import ... =' can only be used in TypeScript files.
+   ╭─[typescript/tests/cases/conformance/node/allowJs/nodeModulesAllowJsImportAssignment.ts:2:1]
  1 │ // cjs format file
  2 │ import fs = require("fs");
-   ·           ┬
-   ·           ╰── `from` expected
+   · ──────────────────────────
  3 │ fs.readFile;
    ╰────
 
-  × Expected `from` but found `=`
-   ╭─[typescript/tests/cases/conformance/node/allowJs/nodeModulesAllowJsSynchronousCallErrors.ts:3:12]
+  × TS(8002): 'import ... =' can only be used in TypeScript files.
+   ╭─[typescript/tests/cases/conformance/node/allowJs/nodeModulesAllowJsImportAssignment.ts:4:8]
+ 3 │ fs.readFile;
+ 4 │ export import fs2 = require("fs");
+   ·        ───────────────────────────
+   ╰────
+
+  × TS(8002): 'import ... =' can only be used in TypeScript files.
+   ╭─[typescript/tests/cases/conformance/node/allowJs/nodeModulesAllowJsSynchronousCallErrors.ts:3:1]
  2 │ import {h} from "../index.js";
  3 │ import mod = require("../index.js");
-   ·            ┬
-   ·            ╰── `from` expected
+   · ────────────────────────────────────
  4 │ import {f as _f} from "./index.js";
+   ╰────
+
+  × TS(8002): 'import ... =' can only be used in TypeScript files.
+   ╭─[typescript/tests/cases/conformance/node/allowJs/nodeModulesAllowJsSynchronousCallErrors.ts:5:1]
+ 4 │ import {f as _f} from "./index.js";
+ 5 │ import mod2 = require("./index.js");
+   · ────────────────────────────────────
+ 6 │ export async function f() {
    ╰────
 
   × TS(1030): override' modifier already seen.


### PR DESCRIPTION
- towards https://github.com/oxc-project/oxc/issues/11334

Rewrites the parsing for import declarations to not require any lookahead. I've diverged from the TS reference implementation here because it uses a fair amount of `tryParse` and lookahead. The main trick used here is simply parsing as we go and then doing "lookback" to see if the identifier we just parsed was actually a keyword like `defer` or `type`. This allows us to not need to use rewind at all.

Also improves diagnostics slightly by emitting a new diagnostic message for `import ... =`. In the end, this didn't improve conformance at all, but it's a perf win of about 1% on some files.