### PR TITLE
fix(linter)!: remove react from default plugin set

### DIFF
--- a/apps/oxlint/src/snapshots/_--ignore-path fixtures__linter__.customignore --no-ignore fixtures__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-path fixtures__linter__.customignore --no-ignore fixtures__linter__nan.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Use the isNaN function to compare with NaN.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 87 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--ignore-pattern _____.js --ignore-pattern _____.vue fixtures__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-pattern _____.js --ignore-pattern _____.vue fixtures__linter@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --ignore-pattern **/*.js --ignore-pattern **/*.vue fixtures/linter
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 101 rules using 1 threads.
+Finished in <variable>ms on 0 files with 87 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--import-plugin -A all -D no-cycle fixtures__flow__@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--import-plugin -A all -D no-cycle fixtures__flow__@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --import-plugin -A all -D no-cycle fixtures/flow/
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 2 files with 103 rules using 1 threads.
+Finished in <variable>ms on 2 files with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--import-plugin fixtures__flow__index.mjs@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--import-plugin fixtures__flow__index.mjs@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --import-plugin fixtures/flow/index.mjs
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 103 rules using 1 threads.
+Finished in <variable>ms on 1 file with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
@@ -23,7 +23,7 @@ working directory:
   help: Remove the appending `.skip`
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 113 rules using 1 threads.
+Finished in <variable>ms on 1 file with 99 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-A all --print-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-A all --print-config@oxlint.snap
@@ -7,7 +7,6 @@ working directory:
 ----------
 {
   "plugins": [
-    "react",
     "unicorn",
     "typescript",
     "oxc"

--- a/apps/oxlint/src/snapshots/_-D correctness fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-D correctness fixtures__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 87 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-W correctness -A no-debugger fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W correctness -A no-debugger fixtures__linter__debugger.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -W correctness -A no-debugger fixtures/linter/debugger.js
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 100 rules using 1 threads.
+Finished in <variable>ms on 1 file with 86 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__eslintrc_env__eslintrc_no_env.json fixtures__eslintrc_env__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__eslintrc_env__eslintrc_no_env.json fixtures__eslintrc_env__test.js@oxlint.snap
@@ -13,7 +13,7 @@ working directory:
    `----
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 102 rules using 1 threads.
+Finished in <variable>ms on 1 file with 88 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__no_undef__eslintrc.json fixtures__no_undef__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__no_undef__eslintrc.json fixtures__no_undef__test.js@oxlint.snap
@@ -13,7 +13,7 @@ working directory:
    `----
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 102 rules using 1 threads.
+Finished in <variable>ms on 1 file with 88 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension@oxlint.snap
@@ -12,7 +12,7 @@ working directory:
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 87 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_env__eslintrc_env_browser.json fixtures__eslintrc_env__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_env__eslintrc_env_browser.json fixtures__eslintrc_env__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/eslintrc_env/eslintrc_env_browser.json fixtures/eslintrc_
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 102 rules using 1 threads.
+Finished in <variable>ms on 1 file with 88 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_off__eslintrc.json fixtures__eslintrc_off__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_off__eslintrc.json fixtures__eslintrc_off__test.js@oxlint.snap
@@ -12,7 +12,7 @@ working directory:
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 87 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/eslintrc_vitest_replace/eslintrc.json fixtures/eslintrc_v
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 87 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__linter__eslintrc.json fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__linter__eslintrc.json fixtures__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 87 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_console_off__eslintrc.json fixtures__no_console_off__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_console_off__eslintrc.json fixtures__no_console_off__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/no_console_off/eslintrc.json fixtures/no_console_off/test
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 87 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_empty_allow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_allow_empty_catch__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_empty_allow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_allow_empty_catch__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/no_empty_allow_empty_catch/eslintrc.json -W no-empty fixt
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 102 rules using 1 threads.
+Finished in <variable>ms on 1 file with 88 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_empty_disallow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_disallow_empty_catch__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_empty_disallow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_disallow_empty_catch__test.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove this block or add a comment inside it
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 102 rules using 1 threads.
+Finished in <variable>ms on 1 file with 88 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.js -c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.ts -c fixtures__overrides__.oxlintrc.json fixtures__overrides__other.jsx@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.js -c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.ts -c fixtures__overrides__.oxlintrc.json fixtures__overrides__other.jsx@oxlint.snap
@@ -15,7 +15,7 @@ working directory:
   help: Replace var with let or const
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 103 rules using 1 threads.
+Finished in <variable>ms on 1 file with 89 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------
@@ -42,7 +42,7 @@ working directory:
   help: Delete this console statement.
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 103 rules using 1 threads.
+Finished in <variable>ms on 1 file with 89 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------
@@ -61,7 +61,7 @@ working directory:
   help: Replace var with let or const
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 103 rules using 1 threads.
+Finished in <variable>ms on 1 file with 89 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__overrides__directories-config.json fixtures__overrides@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__overrides__directories-config.json fixtures__overrides@oxlint.snap
@@ -35,7 +35,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 2 warnings and 2 errors.
-Finished in <variable>ms on 7 files with 100 rules using 1 threads.
+Finished in <variable>ms on 7 files with 86 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__print_config__ban_rules__eslintrc.json -A all -D eqeqeq --print-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__print_config__ban_rules__eslintrc.json -A all -D eqeqeq --print-config@oxlint.snap
@@ -7,7 +7,6 @@ working directory:
 ----------
 {
   "plugins": [
-    "react",
     "unicorn",
     "typescript",
     "oxc"

--- a/apps/oxlint/src/snapshots/_fixtures__astro__debugger.astro@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__astro__debugger.astro@oxlint.snap
@@ -43,7 +43,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 4 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 87 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter@oxlint.snap
@@ -36,7 +36,7 @@ working directory:
   help: Use the isNaN function to compare with NaN.
 
 Found 4 warnings and 0 errors.
-Finished in <variable>ms on 4 files with 101 rules using 1 threads.
+Finished in <variable>ms on 4 files with 87 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js fixtures__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js fixtures__linter__nan.js@oxlint.snap
@@ -21,7 +21,7 @@ working directory:
   help: Use the isNaN function to compare with NaN.
 
 Found 2 warnings and 0 errors.
-Finished in <variable>ms on 2 files with 101 rules using 1 threads.
+Finished in <variable>ms on 2 files with 87 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 87 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter__js_as_jsx.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__js_as_jsx.js@oxlint.snap
@@ -15,7 +15,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 87 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__svelte__debugger.svelte@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__svelte__debugger.svelte@oxlint.snap
@@ -16,7 +16,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 87 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__vue__debugger.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__vue__debugger.vue@oxlint.snap
@@ -25,7 +25,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 2 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 87 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__vue__empty.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__vue__empty.vue@oxlint.snap
@@ -6,7 +6,7 @@ arguments: fixtures/vue/empty.vue
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 87 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_foo.asdf@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_foo.asdf@oxlint.snap
@@ -6,7 +6,7 @@ arguments: foo.asdf
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 101 rules using 1 threads.
+Finished in <variable>ms on 0 files with 87 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__ignore_directory_-c eslintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__ignore_directory_-c eslintrc.json@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/config_ignore_patterns/ignore_directory
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 87 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__with_oxlintrc_-c .__test__eslintrc.json --ignore-pattern _.ts .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__with_oxlintrc_-c .__test__eslintrc.json --ignore-pattern _.ts .@oxlint.snap
@@ -12,7 +12,7 @@ working directory: fixtures/config_ignore_patterns/with_oxlintrc
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 87 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--config extends_rules_config.json console.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--config extends_rules_config.json console.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/extends_config
   help: Delete this console statement.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 102 rules using 1 threads.
+Finished in <variable>ms on 1 file with 88 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--config relative_paths__extends_extends_config.json console.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--config relative_paths__extends_extends_config.json console.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/extends_config
   help: Delete this console statement.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 102 rules using 1 threads.
+Finished in <variable>ms on 1 file with 88 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--disable-nested-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--disable-nested-config@oxlint.snap
@@ -31,7 +31,7 @@ working directory: fixtures/extends_config
   help: Remove the debugger statement
 
 Found 3 warnings and 0 errors.
-Finished in <variable>ms on 4 files with 101 rules using 1 threads.
+Finished in <variable>ms on 4 files with 87 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__ignore_file_current_dir_ .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__ignore_file_current_dir_ .@oxlint.snap
@@ -6,7 +6,7 @@ arguments:
 working directory: fixtures/ignore_file_current_dir
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 101 rules using 1 threads.
+Finished in <variable>ms on 0 files with 87 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------
@@ -16,7 +16,7 @@ arguments: .
 working directory: fixtures/ignore_file_current_dir
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 101 rules using 1 threads.
+Finished in <variable>ms on 0 files with 87 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__import-cycle_--import-plugin -D import__no-cycle@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__import-cycle_--import-plugin -D import__no-cycle@oxlint.snap
@@ -27,7 +27,7 @@ working directory: fixtures/import-cycle
         -> ./b - fixtures/import-cycle/b.ts
 
 Found 0 warnings and 2 errors.
-Finished in <variable>ms on 2 files with 104 rules using 1 threads.
+Finished in <variable>ms on 2 files with 90 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__issue_11054_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__issue_11054_-c .oxlintrc.json@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c .oxlintrc.json
 working directory: fixtures/issue_11054
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 87 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__linter_debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__linter_debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/linter
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 87 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__overrides_env_globals_-c .oxlintrc.json .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__overrides_env_globals_-c .oxlintrc.json .@oxlint.snap
@@ -51,7 +51,7 @@ working directory: fixtures/overrides_env_globals
    `----
 
 Found 5 warnings and 0 errors.
-Finished in <variable>ms on 3 files with 101 rules using 1 threads.
+Finished in <variable>ms on 3 files with 87 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__overrides_with_plugin_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__overrides_with_plugin_-c .oxlintrc.json@oxlint.snap
@@ -32,7 +32,7 @@ working directory: fixtures/overrides_with_plugin
   help: "Write a meaningful title for your test"
 
 Found 1 warning and 2 errors.
-Finished in <variable>ms on 2 files with 101 rules using 1 threads.
+Finished in <variable>ms on 2 files with 87 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__report_unused_directives_-c .oxlintrc.json --report-unused-disable-directives test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__report_unused_directives_-c .oxlintrc.json --report-unused-disable-directives test.js@oxlint.snap
@@ -39,7 +39,7 @@ working directory: fixtures/report_unused_directives
     `----
 
 Found 4 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 102 rules using 1 threads.
+Finished in <variable>ms on 1 file with 88 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/crates/oxc_linter/src/config/plugins.rs
+++ b/crates/oxc_linter/src/config/plugins.rs
@@ -43,7 +43,7 @@ bitflags! {
 impl Default for LintPlugins {
     #[inline]
     fn default() -> Self {
-        LintPlugins::REACT | LintPlugins::UNICORN | LintPlugins::TYPESCRIPT | LintPlugins::OXC
+        LintPlugins::UNICORN | LintPlugins::TYPESCRIPT | LintPlugins::OXC
     }
 }
 
@@ -267,7 +267,7 @@ pub struct LintPluginOptions {
 impl Default for LintPluginOptions {
     fn default() -> Self {
         Self {
-            react: true,
+            react: false,
             unicorn: true,
             typescript: true,
             oxc: true,


### PR DESCRIPTION
This is a breaking change, but currently, how we check whether a react rule should run is opaque and unclear.

For example, the `react/forward-ref-uses-ref` rule checks whether the framework flags `FrameworkFlags::React` is enabled, however this is never set to true meaning that this rule can never run.

https://github.com/oxc-project/oxc/blob/bbb7eb1a27ac280febc3702bc5e7eb131dcc005a/crates/oxc_linter/src/rules/react/forward_ref_uses_ref.rs#L99-L101

This PR removes the react rule group from the default plugins, if users which to use the react plugin, they just have to add it to the plugins array.

I have made thie change before 1.0, so hopefully the fact that it's breaking is ok.