### PR TITLE
fix(linter): remove use of `FrameworkFlags::React` to decide whether rules should run

### DIFF
--- a/crates/oxc_linter/src/rules/react/forward_ref_uses_ref.rs
+++ b/crates/oxc_linter/src/rules/react/forward_ref_uses_ref.rs
@@ -1,4 +1,3 @@
-use crate::{ContextHost, FrameworkFlags};
 use oxc_ast::{
     AstKind,
     ast::{CallExpression, Expression},
@@ -95,15 +94,10 @@ impl Rule for ForwardRefUsesRef {
 
         check_forward_ref_inner(first_arg_as_exp, call_expr, ctx);
     }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.frameworks().contains(FrameworkFlags::React)
-    }
 }
 
 #[test]
 fn test() {
-    use crate::LintOptions;
     use crate::tester::Tester;
 
     let pass = vec![
@@ -206,10 +200,6 @@ fn test() {
     ];
 
     Tester::new(ForwardRefUsesRef::NAME, ForwardRefUsesRef::PLUGIN, pass, fail)
-        .with_lint_options(LintOptions {
-            framework_hints: FrameworkFlags::React,
-            ..LintOptions::default()
-        })
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/no_children_prop.rs
+++ b/crates/oxc_linter/src/rules/react/no_children_prop.rs
@@ -6,12 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{
-    AstNode, FrameworkFlags,
-    context::{ContextHost, LintContext},
-    rule::Rule,
-    utils::is_create_element_call,
-};
+use crate::{AstNode, context::LintContext, rule::Rule, utils::is_create_element_call};
 
 fn no_children_prop_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Avoid passing children using a prop.")
@@ -93,17 +88,10 @@ impl Rule for NoChildrenProp {
             _ => {}
         }
     }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        // Only is JSX Context
-        // Only when React is installed, others frameworks can use JSX too
-        ctx.source_type().is_jsx() && ctx.frameworks().contains(FrameworkFlags::React)
-    }
 }
 
 #[test]
 fn test() {
-    use crate::LintOptions;
     use crate::tester::Tester;
 
     #[rustfmt::skip]
@@ -167,10 +155,5 @@ fn test() {
         (r#"React.createElement(MyComponent, {...props, children: "Children"})"#, None),
     ];
 
-    Tester::new(NoChildrenProp::NAME, NoChildrenProp::PLUGIN, pass, fail)
-        .with_lint_options(LintOptions {
-            framework_hints: FrameworkFlags::React,
-            ..LintOptions::default()
-        })
-        .test_and_snapshot();
+    Tester::new(NoChildrenProp::NAME, NoChildrenProp::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -319,11 +319,6 @@ impl Tester {
         self
     }
 
-    pub fn with_lint_options(mut self, lint_options: LintOptions) -> Self {
-        self.lint_options = lint_options;
-        self
-    }
-
     /// Add cases that should fix problems found in the source code.
     ///
     /// These cases will fail if no fixes are produced or if the fixed source


### PR DESCRIPTION
As mentioned in the PR above this in the stack, we never populate this value, so rules relying on framework flags that aren't the `Jest`/`Vitest` just don't work.