### PR TITLE
fix(estree): Use consistent field order in serialization

### DIFF
--- a/crates/oxc_ast/src/serialize/js.rs
+++ b/crates/oxc_ast/src/serialize/js.rs
@@ -27,9 +27,11 @@ use super::{EmptyArray, Null};
                 type: 'RestElement',
                 start: DESER[u32]( POS_OFFSET<BindingRestElement>.span.start ),
                 end: DESER[u32]( POS_OFFSET<BindingRestElement>.span.end ),
-                argument: DESER[BindingPatternKind]( POS_OFFSET<BindingRestElement>.argument.kind ),
                 /* IF_TS */
                 decorators: [],
+                /* END_IF_TS */
+                argument: DESER[BindingPatternKind]( POS_OFFSET<BindingRestElement>.argument.kind ),
+                /* IF_TS */
                 optional: DESER[bool]( POS_OFFSET<BindingRestElement>.argument.optional ),
                 typeAnnotation: DESER[Option<Box<TSTypeAnnotation>>](
                     POS_OFFSET<BindingRestElement>.argument.type_annotation
@@ -69,8 +71,8 @@ impl ESTree for FormalParametersRest<'_, '_> {
         state.serialize_field("type", &JsonSafeString("RestElement"));
         state.serialize_field("start", &rest.span.start);
         state.serialize_field("end", &rest.span.end);
-        state.serialize_field("argument", &rest.argument.kind);
         state.serialize_ts_field("decorators", &EmptyArray(()));
+        state.serialize_field("argument", &rest.argument.kind);
         state.serialize_ts_field("optional", &rest.argument.optional);
         state.serialize_ts_field("typeAnnotation", &rest.argument.type_annotation);
         state.serialize_ts_field("value", &Null(()));
@@ -364,10 +366,12 @@ impl ESTree for ArrowFunctionExpressionBody<'_> {
                     type: 'AssignmentPattern',
                     start: THIS.start,
                     end: THIS.end,
+                    /* IF_TS */
+                    decorators: [],
+                    /* END_IF_TS */
                     left: keyCopy,
                     right: init,
                     /* IF_TS */
-                    decorators: [],
                     optional: false,
                     typeAnnotation: null,
                     /* END_IF_TS */
@@ -386,9 +390,9 @@ impl ESTree for AssignmentTargetPropertyIdentifierInit<'_> {
             state.serialize_field("type", &JsonSafeString("AssignmentPattern"));
             state.serialize_field("start", &self.0.span.start);
             state.serialize_field("end", &self.0.span.end);
+            state.serialize_ts_field("decorators", &EmptyArray(()));
             state.serialize_field("left", &self.0.binding);
             state.serialize_field("right", init);
-            state.serialize_ts_field("decorators", &EmptyArray(()));
             state.serialize_ts_field("optional", &false);
             state.serialize_ts_field("typeAnnotation", &Null(()));
             state.end();

--- a/crates/oxc_ast/src/serialize/ts.rs
+++ b/crates/oxc_ast/src/serialize/ts.rs
@@ -301,8 +301,8 @@ impl ESTree for TSTypeNameIdentifierReference<'_, '_> {
                 end: expression.end,
                 object: expression.left,
                 property: expression.right,
-                computed: false,
                 optional: false,
+                computed: false,
             };
 
             while (parent.object.type === 'TSQualifiedName') {
@@ -313,8 +313,8 @@ impl ESTree for TSTypeNameIdentifierReference<'_, '_> {
                     end: object.end,
                     object: object.left,
                     property: object.right,
-                    computed: false,
                     optional: false,
+                    computed: false,
                 };
             }
         }
@@ -347,8 +347,8 @@ impl ESTree for TSTypeNameAsMemberExpression<'_, '_> {
                 state.serialize_field("end", &name.span.end);
                 state.serialize_field("object", &TSTypeNameAsMemberExpression(&name.left));
                 state.serialize_field("property", &name.right);
-                state.serialize_field("computed", &false);
                 state.serialize_field("optional", &false);
+                state.serialize_field("computed", &false);
                 state.end();
             }
         }

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -1633,8 +1633,8 @@ function deserializeTSClassImplements(pos) {
       end: expression.end,
       object: expression.left,
       property: expression.right,
-      computed: false,
       optional: false,
+      computed: false,
     };
 
     while (parent.object.type === 'TSQualifiedName') {
@@ -1645,8 +1645,8 @@ function deserializeTSClassImplements(pos) {
         end: object.end,
         object: object.left,
         property: object.right,
-        computed: false,
         optional: false,
+        computed: false,
       };
     }
   }

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -424,9 +424,9 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
         type: 'AssignmentPattern',
         start: start,
         end: end,
+        decorators: [],
         left: keyCopy,
         right: init,
-        decorators: [],
         optional: false,
         typeAnnotation: null,
       };
@@ -857,8 +857,8 @@ function deserializeFormalParameters(pos) {
       type: 'RestElement',
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
-      argument: deserializeBindingPatternKind(pos + 8),
       decorators: [],
+      argument: deserializeBindingPatternKind(pos + 8),
       optional: deserializeBool(pos + 32),
       typeAnnotation: deserializeOptionBoxTSTypeAnnotation(
         pos + 24,
@@ -1785,8 +1785,8 @@ function deserializeTSClassImplements(pos) {
       end: expression.end,
       object: expression.left,
       property: expression.right,
-      computed: false,
       optional: false,
+      computed: false,
     };
 
     while (parent.object.type === 'TSQualifiedName') {
@@ -1797,8 +1797,8 @@ function deserializeTSClassImplements(pos) {
         end: object.end,
         object: object.left,
         property: object.right,
-        computed: false,
         optional: false,
+        computed: false,
       };
     }
   }


### PR DESCRIPTION
Part of #9705 , follow up #11362 

This change will generate the same AST shapes in all locations, regardless of `visitor-keys`.