### PR TITLE
perf(linter): change `Arc<OsStr>` to `Box<OsStr>` in linter runtime

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -4,7 +4,6 @@ use std::{
     fs,
     io::{ErrorKind, Write},
     path::{Path, PathBuf, absolute},
-    sync::Arc,
     time::Instant,
 };
 
@@ -383,7 +382,7 @@ impl LintRunner {
         stdout: &mut dyn Write,
         handler: &GraphicalReportHandler,
         filters: &Vec<LintFilter>,
-        paths: &Vec<Arc<OsStr>>,
+        paths: &Vec<Box<OsStr>>,
     ) -> Result<FxHashMap<PathBuf, Config>, CliRunResult> {
         // TODO(perf): benchmark whether or not it is worth it to store the configurations on a
         // per-file or per-directory basis, to avoid calling `.parent()` on every path.

--- a/apps/oxlint/src/walk.rs
+++ b/apps/oxlint/src/walk.rs
@@ -1,4 +1,4 @@
-use std::{ffi::OsStr, path::PathBuf, sync::Arc, sync::mpsc};
+use std::{ffi::OsStr, path::PathBuf, sync::mpsc};
 
 use ignore::{DirEntry, overrides::Override};
 use oxc_linter::LINTABLE_EXTENSIONS;
@@ -21,7 +21,7 @@ pub struct Walk {
 }
 
 struct WalkBuilder {
-    sender: mpsc::Sender<Vec<Arc<OsStr>>>,
+    sender: mpsc::Sender<Vec<Box<OsStr>>>,
     extensions: Extensions,
 }
 
@@ -36,8 +36,8 @@ impl<'s> ignore::ParallelVisitorBuilder<'s> for WalkBuilder {
 }
 
 struct WalkCollector {
-    paths: Vec<Arc<OsStr>>,
-    sender: mpsc::Sender<Vec<Arc<OsStr>>>,
+    paths: Vec<Box<OsStr>>,
+    sender: mpsc::Sender<Vec<Box<OsStr>>>,
     extensions: Extensions,
 }
 
@@ -100,8 +100,8 @@ impl Walk {
         Self { inner, extensions: Extensions::default() }
     }
 
-    pub fn paths(self) -> Vec<Arc<OsStr>> {
-        let (sender, receiver) = mpsc::channel::<Vec<Arc<OsStr>>>();
+    pub fn paths(self) -> Vec<Box<OsStr>> {
+        let (sender, receiver) = mpsc::channel::<Vec<Box<OsStr>>>();
         let mut builder = WalkBuilder { sender, extensions: self.extensions };
         self.inner.visit(&mut builder);
         drop(builder);

--- a/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
+++ b/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
@@ -1,6 +1,6 @@
 use std::{
     path::{Path, PathBuf},
-    sync::{Arc, OnceLock},
+    sync::OnceLock,
 };
 
 use log::debug;
@@ -132,11 +132,9 @@ impl IsolatedLintHandler {
 
         debug!("lint {}", path.display());
 
-        let lint_service_options = LintServiceOptions::new(
-            self.options.root_path.clone(),
-            vec![Arc::from(path.as_os_str())],
-        )
-        .with_cross_module(self.options.use_cross_module);
+        let lint_service_options =
+            LintServiceOptions::new(self.options.root_path.clone(), vec![path.as_os_str().into()])
+                .with_cross_module(self.options.use_cross_module);
 
         let mut lint_service =
             LintService::new(&self.linter, lint_service_options).with_file_system(Box::new(

--- a/crates/oxc_linter/src/service/mod.rs
+++ b/crates/oxc_linter/src/service/mod.rs
@@ -1,7 +1,6 @@
 use std::{
     ffi::OsStr,
     path::{Path, PathBuf},
-    sync::Arc,
 };
 
 use oxc_diagnostics::DiagnosticSender;
@@ -20,7 +19,7 @@ pub struct LintServiceOptions {
     cwd: Box<Path>,
 
     /// All paths to lint
-    paths: Vec<Arc<OsStr>>,
+    paths: Vec<Box<OsStr>>,
 
     /// TypeScript `tsconfig.json` path for reading path alias and project references
     tsconfig: Option<PathBuf>,
@@ -30,7 +29,7 @@ pub struct LintServiceOptions {
 
 impl LintServiceOptions {
     #[must_use]
-    pub fn new<T>(cwd: T, paths: Vec<Arc<OsStr>>) -> Self
+    pub fn new<T>(cwd: T, paths: Vec<Box<OsStr>>) -> Self
     where
         T: Into<Box<Path>>,
     {

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -1,8 +1,6 @@
 use std::{
     env,
-    ffi::OsStr,
     path::{Path, PathBuf},
-    sync::Arc,
     sync::mpsc,
 };
 
@@ -511,7 +509,7 @@ impl Tester {
         };
 
         let cwd = self.current_working_directory.clone();
-        let paths = vec![Arc::<OsStr>::from(path_to_lint.as_os_str())];
+        let paths = vec![path_to_lint.as_os_str().into()];
         let options =
             LintServiceOptions::new(cwd, paths).with_cross_module(self.plugins.has_import());
         let mut lint_service = LintService::new(&linter, options).with_file_system(Box::new(


### PR DESCRIPTION
Given our conditions:

* Paths are relatively small strings
* There's about 1k - 10k paths in total for most apps
* mimalloc is used

`Arc::clone` + `Arc::drop` should be slower than `String::clone` + `String::drop`.