### PR TITLE
docs(linter): clarify jsdoc/check-tag-names configuration

### DIFF
--- a/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
@@ -43,6 +43,40 @@ declare_oxc_lint!(
     /// ```javascript
     /// /** @param */
     /// ```
+    ///
+    /// ### Options
+    ///
+    /// Configuration for allowed tags is done via [`settings.jsdoc.tagNamePreference`](/docs/guide/usage/linter/config-file-reference.html#settings-jsdoc-tagnamepreference). 
+    /// There is no CLI-only parameter for this rule.
+    /// 
+    /// You can add custom tags by adding a key-value pair where both match the name of the tag you want to add, like so:
+    /// 
+    /// ::: code-group
+    /// 
+    /// ```json [Config (.oxlintrc.json)]
+    /// {
+    ///   "plugins": ["jsdoc"],
+    ///   "rules": {
+    ///     "jsdoc/check-tag-names": "error"
+    ///   },
+    ///   "settings": { // [!code highlight:7]
+    ///     "jsdoc": {
+    ///       "tagNamePreference": {
+    ///         "customTagName": "customTagName"
+    ///       }
+    ///     }
+    ///   }
+    /// }
+    /// ```
+    /// :::
+    /// 
+    /// Examples of correct code for the is rule with the above configuration, adding the `customTagName` tag :
+    /// 
+    /// ```js
+    /// /**
+    ///  * @customTagName
+    ///  */
+    /// ```
     CheckTagNames,
     jsdoc,
     correctness

--- a/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
@@ -46,13 +46,13 @@ declare_oxc_lint!(
     ///
     /// ### Options
     ///
-    /// Configuration for allowed tags is done via [`settings.jsdoc.tagNamePreference`](/docs/guide/usage/linter/config-file-reference.html#settings-jsdoc-tagnamepreference). 
+    /// Configuration for allowed tags is done via [`settings.jsdoc.tagNamePreference`](/docs/guide/usage/linter/config-file-reference.html#settings-jsdoc-tagnamepreference).
     /// There is no CLI-only parameter for this rule.
-    /// 
+    ///
     /// You can add custom tags by adding a key-value pair where both match the name of the tag you want to add, like so:
-    /// 
+    ///
     /// ::: code-group
-    /// 
+    ///
     /// ```json [Config (.oxlintrc.json)]
     /// {
     ///   "plugins": ["jsdoc"],
@@ -69,9 +69,9 @@ declare_oxc_lint!(
     /// }
     /// ```
     /// :::
-    /// 
+    ///
     /// Examples of correct code for this rule with the above configuration, adding the `customTagName` tag:
-    /// 
+    ///
     /// ```js
     /// /**
     ///  * @customTagName

--- a/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
@@ -70,7 +70,7 @@ declare_oxc_lint!(
     /// ```
     /// :::
     /// 
-    /// Examples of correct code for the is rule with the above configuration, adding the `customTagName` tag :
+    /// Examples of correct code for this rule with the above configuration, adding the `customTagName` tag :
     /// 
     /// ```js
     /// /**

--- a/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
@@ -70,7 +70,7 @@ declare_oxc_lint!(
     /// ```
     /// :::
     /// 
-    /// Examples of correct code for this rule with the above configuration, adding the `customTagName` tag :
+    /// Examples of correct code for this rule with the above configuration, adding the `customTagName` tag:
     /// 
     /// ```js
     /// /**


### PR DESCRIPTION
Explain how custom tags can be registered to avoid false positives when using them in comments.

related issue #11392