### PR TITLE
refactor(language_server): introduce helper `path_to_uri`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1798,6 +1798,7 @@ dependencies = [
 name = "oxc_language_server"
 version = "0.17.0"
 dependencies = [
+ "cow-utils",
  "env_logger",
  "futures",
  "globset",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1808,6 +1808,7 @@ dependencies = [
  "oxc_diagnostics",
  "oxc_linter",
  "papaya",
+ "percent-encoding",
  "rustc-hash",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,6 +204,7 @@ nonmax = "0.5.5"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"
 papaya = "0.2.1"
+percent-encoding = "2.3.1"
 petgraph = { version = "0.8.1", default-features = false }
 phf = "0.11.3"
 phf_codegen = "0.11.3"

--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -27,6 +27,7 @@ oxc_diagnostics = { workspace = true }
 oxc_linter = { workspace = true, features = ["language_server"] }
 
 #
+cow-utils = { workspace = true }
 env_logger = { workspace = true, features = ["humantime"] }
 futures = { workspace = true }
 globset = { workspace = true }

--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -33,6 +33,7 @@ globset = { workspace = true }
 ignore = { workspace = true, features = ["simd-accel"] }
 log = { workspace = true }
 papaya = { workspace = true }
+percent-encoding = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/oxc_language_server/fixtures/linter/nextjs/[[...rest]]/debugger.ts
+++ b/crates/oxc_language_server/fixtures/linter/nextjs/[[...rest]]/debugger.ts
@@ -1,0 +1,1 @@
+debugger;

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -316,8 +316,8 @@ mod test {
         Tester::new("fixtures/linter/vue", None).test_and_snapshot_single_file("debugger.vue");
         Tester::new("fixtures/linter/svelte", None)
             .test_and_snapshot_single_file("debugger.svelte");
-        // ToDo: fix Tester to work only with Uris and do not access the file system
-        // Tester::new("fixtures/linter/nextjs").test_and_snapshot_single_file("%5B%5B..rest%5D%5D/debugger.ts");
+        Tester::new("fixtures/linter/nextjs", None)
+            .test_and_snapshot_single_file("[[...rest]]/debugger.ts");
     }
 
     #[test]

--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -30,6 +30,7 @@ mod linter;
 mod options;
 #[cfg(test)]
 mod tester;
+mod uri_ext;
 mod worker;
 
 type ConcurrentHashMap<K, V> = papaya::HashMap<K, V, FxBuildHasher>;

--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -30,6 +30,7 @@ mod linter;
 mod options;
 #[cfg(test)]
 mod tester;
+#[cfg(test)]
 mod uri_ext;
 mod worker;
 

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_nextjs@[[...rest]]_debugger.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_nextjs@[[...rest]]_debugger.ts.snap
@@ -1,0 +1,15 @@
+---
+source: crates/oxc_language_server/src/tester.rs
+input_file: "crates/oxc_language_server/fixtures/linter/nextjs/[[...rest]]/debugger.ts"
+---
+code: "eslint(no-debugger)"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
+message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"
+range: Range { start: Position { line: 0, character: 0 }, end: Position { line: 0, character: 9 } }
+related_information[0].message: ""
+related_information[0].location.uri: "file://<variable>/fixtures/linter/nextjs/%5B%5B...rest%5D%5D/debugger.ts"
+related_information[0].location.range: Range { start: Position { line: 0, character: 0 }, end: Position { line: 0, character: 9 } }
+severity: Some(Warning)
+source: Some("oxc")
+tags: None
+fixed: Single(FixedContent { message: Some("Remove the debugger statement"), code: "", range: Range { start: Position { line: 0, character: 0 }, end: Position { line: 0, character: 9 } } })

--- a/crates/oxc_language_server/src/tester.rs
+++ b/crates/oxc_language_server/src/tester.rs
@@ -5,7 +5,7 @@ use tower_lsp_server::{
     lsp_types::{CodeDescription, NumberOrString, Uri},
 };
 
-use crate::{Options, worker::WorkspaceWorker};
+use crate::{Options, uri_ext::path_to_uri, worker::WorkspaceWorker};
 
 use super::linter::error_with_position::DiagnosticReport;
 
@@ -13,7 +13,7 @@ use super::linter::error_with_position::DiagnosticReport;
 pub fn get_file_uri(relative_file_path: &str) -> Uri {
     let absolute_file_path =
         std::env::current_dir().expect("could not get current dir").join(relative_file_path);
-    Uri::from_file_path(absolute_file_path).expect("failed to convert file path to URL")
+    path_to_uri(&absolute_file_path)
 }
 
 fn get_snapshot_from_report(report: &DiagnosticReport) -> String {

--- a/crates/oxc_language_server/src/uri_ext.rs
+++ b/crates/oxc_language_server/src/uri_ext.rs
@@ -1,0 +1,67 @@
+use std::{path::{Path, PathBuf}, str::FromStr};
+
+use percent_encoding::AsciiSet;
+use tower_lsp_server::lsp_types::Uri;
+
+fn path_to_uri(path: &PathBuf) -> Uri {
+    let path_str = normalize_path_with_utf8_percent_encode(path);
+    Uri::from_str(&format!("file://{}", path_str.to_string_lossy())).expect("Failed to create URI from path")
+}
+
+const ASCII_SET: AsciiSet = percent_encoding::NON_ALPHANUMERIC.remove(b'.');
+
+/// Normalize a path by removing `.` and resolving `..` components,
+/// without touching the filesystem.
+pub fn normalize_path_with_utf8_percent_encode<P: AsRef<Path>>(path: P) -> PathBuf {
+    let mut result = PathBuf::new();
+    let components = path.as_ref().components();
+
+    for component in components {
+        match component {
+            std::path::Component::Prefix(_) => {
+                // Keep the prefix (e.g., drive letter on Windows)
+                result.push(component.as_os_str());
+            }
+            std::path::Component::RootDir => {
+                // Keep the root directory
+                result.push(component.as_os_str());
+            }
+            std::path::Component::Normal(part) => {
+                // Normal components are added to the path
+                result.push(percent_encoding::utf8_percent_encode(&part.to_str().unwrap(), &ASCII_SET).to_string());
+            }
+            _ => {}
+        }
+    }
+
+    result
+}
+#[cfg(test)]
+mod test {
+    use std::path::PathBuf;
+
+    use crate::uri_ext::path_to_uri;
+
+
+    #[test]
+    fn test_path_to_uri() {
+        let path = PathBuf::from("/some/path/to/file.txt");
+        let uri = path_to_uri(&path);
+        assert_eq!(uri.to_string(), "file:///some/path/to/file.txt");
+    }
+
+    #[test]
+    fn test_path_to_uri_with_spaces() {
+        let path = PathBuf::from("/some/path/to/file with spaces.txt");
+        let uri = path_to_uri(&path);
+        assert_eq!(uri.to_string(), "file:///some/path/to/file%20with%20spaces.txt");
+    }
+
+    #[test]
+
+    fn test_path_to_uri_with_special_characters() {
+        let path = PathBuf::from("/some/path/[[...rest]]/file.txt");
+        let uri = path_to_uri(&path);
+        assert_eq!(uri.to_string(), "file:///some/path/%5B%5B...rest%5D%5D/file.txt");
+    }
+}

--- a/crates/oxc_language_server/src/uri_ext.rs
+++ b/crates/oxc_language_server/src/uri_ext.rs
@@ -1,67 +1,96 @@
-use std::{path::{Path, PathBuf}, str::FromStr};
+use std::{path::Path, str::FromStr};
 
+use cow_utils::CowUtils;
 use percent_encoding::AsciiSet;
 use tower_lsp_server::lsp_types::Uri;
 
-fn path_to_uri(path: &PathBuf) -> Uri {
-    let path_str = normalize_path_with_utf8_percent_encode(path);
-    Uri::from_str(&format!("file://{}", path_str.to_string_lossy())).expect("Failed to create URI from path")
+pub fn path_to_uri(path: &Path) -> Uri {
+    let path = if cfg!(target_os = "windows") {
+        // On Windows, we need to replace backslashes with forward slashes.
+        // Tripleslash is a shorthand for `file://localhost/C:/Windows` with the `localhost` omitted.
+        // We encode the driver Letter `C:` as well. LSP Specification allows it.
+        // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#uri
+        format!(
+            "file:///{}",
+            percent_encoding::utf8_percent_encode(
+                &path.to_string_lossy().cow_replace('\\', "/"),
+                &ASCII_SET
+            )
+        )
+    } else {
+        // For Unix-like systems, just convert to a file URI directly
+        format!(
+            "file://{}",
+            percent_encoding::utf8_percent_encode(&path.to_string_lossy(), &ASCII_SET)
+        )
+    };
+    Uri::from_str(&path).expect("Failed to create URI from path")
 }
 
-const ASCII_SET: AsciiSet = percent_encoding::NON_ALPHANUMERIC.remove(b'.');
+const ASCII_SET: AsciiSet =
+    // RFC3986 allows only alphanumeric characters, `-`, `.`, `_`, and `~` in the path.
+    percent_encoding::NON_ALPHANUMERIC
+        .remove(b'-')
+        .remove(b'.')
+        .remove(b'_')
+        .remove(b'~')
+        // we do not want path separators to be percent-encoded
+        .remove(b'/');
 
-/// Normalize a path by removing `.` and resolving `..` components,
-/// without touching the filesystem.
-pub fn normalize_path_with_utf8_percent_encode<P: AsRef<Path>>(path: P) -> PathBuf {
-    let mut result = PathBuf::new();
-    let components = path.as_ref().components();
-
-    for component in components {
-        match component {
-            std::path::Component::Prefix(_) => {
-                // Keep the prefix (e.g., drive letter on Windows)
-                result.push(component.as_os_str());
-            }
-            std::path::Component::RootDir => {
-                // Keep the root directory
-                result.push(component.as_os_str());
-            }
-            std::path::Component::Normal(part) => {
-                // Normal components are added to the path
-                result.push(percent_encoding::utf8_percent_encode(&part.to_str().unwrap(), &ASCII_SET).to_string());
-            }
-            _ => {}
-        }
-    }
-
-    result
-}
 #[cfg(test)]
 mod test {
     use std::path::PathBuf;
 
     use crate::uri_ext::path_to_uri;
 
+    const EXPECTED_SCHEMA: &str = if cfg!(target_os = "windows") { "file:///" } else { "file://" };
+
+    fn with_schema(path: &str) -> String {
+        format!("{EXPECTED_SCHEMA}{path}")
+    }
 
     #[test]
     fn test_path_to_uri() {
         let path = PathBuf::from("/some/path/to/file.txt");
         let uri = path_to_uri(&path);
-        assert_eq!(uri.to_string(), "file:///some/path/to/file.txt");
+        assert_eq!(uri.to_string(), with_schema("/some/path/to/file.txt"));
     }
 
     #[test]
     fn test_path_to_uri_with_spaces() {
         let path = PathBuf::from("/some/path/to/file with spaces.txt");
         let uri = path_to_uri(&path);
-        assert_eq!(uri.to_string(), "file:///some/path/to/file%20with%20spaces.txt");
+        assert_eq!(uri.to_string(), with_schema("/some/path/to/file%20with%20spaces.txt"));
     }
 
     #[test]
-
     fn test_path_to_uri_with_special_characters() {
         let path = PathBuf::from("/some/path/[[...rest]]/file.txt");
         let uri = path_to_uri(&path);
-        assert_eq!(uri.to_string(), "file:///some/path/%5B%5B...rest%5D%5D/file.txt");
+        assert_eq!(uri.to_string(), with_schema("/some/path/%5B%5B...rest%5D%5D/file.txt"));
+    }
+
+    #[test]
+    fn test_path_to_uri_non_ascii() {
+        let path = PathBuf::from("/some/path/to/файл.txt");
+        let uri = path_to_uri(&path);
+        assert_eq!(uri.to_string(), with_schema("/some/path/to/%D1%84%D0%B0%D0%B9%D0%BB.txt"));
+    }
+
+    #[test]
+    fn test_path_to_uri_with_unicode() {
+        let path = PathBuf::from("/some/path/to/文件.txt");
+        let uri = path_to_uri(&path);
+        assert_eq!(uri.to_string(), with_schema("/some/path/to/%E6%96%87%E4%BB%B6.txt"));
+    }
+
+    #[cfg(all(test, target_os = "windows"))]
+    #[test]
+    fn test_path_to_uri_windows() {
+        let path = PathBuf::from("C:\\some\\path\\to\\file.txt");
+        let uri = path_to_uri(&path);
+        // yes we encode `:` too, LSP allows it
+        // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#uri
+        assert_eq!(uri.to_string(), with_schema("C%3A/some/path/to/file.txt"));
     }
 }


### PR DESCRIPTION
Currently only used for the test. The plan is to convert paths back to URI when we implement workspace wide diagnostics.
The client will not send us URIs, we need to create them on our own.

The current implementation from `Uri::from_file_path` is broken because of the escape characters.
I see someone from `tower-lsp-server` wants to implement something similar:
https://github.com/tower-lsp-community/tower-lsp-server/pull/46