### PR TITLE
chore(linter): mark react/exhaustive-deps as correctness

### DIFF
--- a/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
@@ -190,7 +190,7 @@ declare_oxc_lint!(
     /// ```
     ExhaustiveDeps,
     react,
-    nursery
+    correctness
 );
 
 const HOOKS_USELESS_WITHOUT_DEPENDENCIES: [&str; 2] = ["useCallback", "useMemo"];


### PR DESCRIPTION
this rule has been around for several months, and all bugs regarding it have been fixed.

lets mark it as correctness and address any issues as they appear