### PR TITLE
fix(linter/switch-case-braces): align the logic with `unicorn`

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -5,23 +5,22 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{AstNode, ast_util::get_preceding_indent_str, context::LintContext, rule::Rule};
 
-#[derive(Clone, Copy)]
-enum Diagnostic {
-    EmptyClause,
-    MissingBraces,
-    UnnecessaryBraces,
+fn switch_case_braces_diagnostic_empty_clause(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unexpected braces in empty case clause.")
+        .with_help("Remove braces in empty case clause.")
+        .with_label(span)
 }
 
-fn switch_case_braces_diagnostic(span: Span, diagnostic_type: Diagnostic) -> OxcDiagnostic {
-    (match diagnostic_type {
-        Diagnostic::EmptyClause => OxcDiagnostic::warn("Unexpected braces in empty case clause.")
-            .with_help("Remove braces in empty case clause."),
-        Diagnostic::MissingBraces => OxcDiagnostic::warn("Missing braces in case clause.")
-            .with_help("Add Braces for case clause."),
-        Diagnostic::UnnecessaryBraces => OxcDiagnostic::warn("Unnecessary braces in case clause.")
-            .with_help("Remove Braces for case clause."),
-    })
-    .with_label(span)
+fn switch_case_braces_diagnostic_missing_braces(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Missing braces in case clause.")
+        .with_help("Add Braces for case clause.")
+        .with_label(span)
+}
+
+fn switch_case_braces_diagnostic_unnecessary_braces(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unnecessary braces in case clause.")
+        .with_help("Remove Braces for case clause.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -76,9 +75,8 @@ declare_oxc_lint!(
 
 impl Rule for SwitchCaseBraces {
     fn from_configuration(value: serde_json::Value) -> Self {
-        let always = value.get(0).is_none_or(|v| v.as_str() != Some("avoid"));
-
-        Self { always_braces: always }
+        let always_braces = value.get(0).is_none_or(|v| v.as_str() != Some("avoid"));
+        Self { always_braces }
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -91,130 +89,70 @@ impl Rule for SwitchCaseBraces {
         }
 
         for case in &switch.cases {
-            for case_consequent in &case.consequent {
-                match case_consequent {
-                    Statement::BlockStatement(case_block) => {
-                        if case_block.body.is_empty() {
-                            ctx.diagnostic_with_fix(
-                                switch_case_braces_diagnostic(
-                                    case_block.span,
-                                    Diagnostic::EmptyClause,
-                                ),
-                                |fixer| fixer.delete_range(case_block.span),
-                            );
-                        }
-
-                        if !self.always_braces
-                            && !case_block.body.iter().any(|stmt| {
-                                matches!(
-                                    stmt,
-                                    Statement::VariableDeclaration(_)
-                                        | Statement::FunctionDeclaration(_)
-                                )
-                            })
-                        {
-                            ctx.diagnostic_with_fix(
-                                switch_case_braces_diagnostic(
-                                    case_block.span(),
-                                    Diagnostic::UnnecessaryBraces,
-                                ),
-                                |fixer| {
-                                    fixer.replace(
-                                        case_block.span,
-                                        fixer.source_range(Span::new(
-                                            case_block.span.start + 1,
-                                            case_block.span.end - 1,
-                                        )),
-                                    )
-                                },
-                            );
-                        }
-                    }
-                    Statement::EmptyStatement(_) => {}
-                    _ => {
-                        if !self.always_braces
-                            && !&case.consequent.iter().any(|stmt| {
-                                matches!(
-                                    stmt,
-                                    Statement::VariableDeclaration(_)
-                                        | Statement::FunctionDeclaration(_)
-                                )
-                            })
-                        {
-                            return;
-                        }
-
-                        let Some(first_statement) = &case.consequent.first() else {
-                            return;
-                        };
-                        let Some(last_statement) = &case.consequent.last() else {
-                            return;
-                        };
-
-                        let case_body_span =
-                            Span::new(first_statement.span().start, last_statement.span().end);
-
+            if case.consequent.is_empty() {
+                continue;
+            }
+            let missing_braces = match &case.consequent[0] {
+                Statement::BlockStatement(block_stmt) if case.consequent.len() == 1 => {
+                    if block_stmt.body.is_empty() {
                         ctx.diagnostic_with_fix(
-                            switch_case_braces_diagnostic(
-                                case_body_span,
-                                Diagnostic::MissingBraces,
-                            ),
+                            switch_case_braces_diagnostic_empty_clause(block_stmt.span),
+                            |fixer| fixer.delete_range(block_stmt.span),
+                        );
+                        continue;
+                    }
+                    if !self.always_braces
+                        && !block_stmt.body.iter().any(|stmt| {
+                            matches!(
+                                stmt,
+                                Statement::VariableDeclaration(_)
+                                    | Statement::FunctionDeclaration(_)
+                            )
+                        })
+                    {
+                        ctx.diagnostic_with_fix(
+                            switch_case_braces_diagnostic_unnecessary_braces(block_stmt.span()),
                             |fixer| {
-                                let modified_code = {
-                                    let mut formatter = fixer.codegen();
-
-                                    if let Some(case_test) = &case.test {
-                                        formatter.print_str("case ");
-                                        formatter.print_expression(case_test);
-                                    } else {
-                                        formatter.print_str("default");
-                                    }
-
-                                    formatter.print_ascii_byte(b':');
-                                    formatter.print_ascii_byte(b' ');
-                                    formatter.print_ascii_byte(b'{');
-
-                                    let source_text = ctx.source_text();
-
-                                    for x in &case.consequent {
-                                        if matches!(
-                                            x,
-                                            Statement::ExpressionStatement(_)
-                                                | Statement::BreakStatement(_)
-                                        ) {
-                                            // indent the statement in the case consequent, if needed
-                                            if let Some(indent_str) =
-                                                get_preceding_indent_str(source_text, x.span())
-                                            {
-                                                formatter.print_ascii_byte(b'\n');
-                                                formatter.print_str(indent_str);
-                                            }
-                                        }
-
-                                        formatter.print_str(x.span().source_text(source_text));
-                                    }
-
-                                    // indent the closing case bracket, if needed
-                                    if let Some(case_indent_str) =
-                                        get_preceding_indent_str(source_text, case.span())
-                                    {
-                                        formatter.print_ascii_byte(b'\n');
-                                        formatter.print_str(case_indent_str);
-                                    }
-
-                                    formatter.print_ascii_byte(b'}');
-
-                                    formatter.into_source_text()
-                                };
-
-                                fixer.replace(case.span, modified_code)
+                                fixer.replace(
+                                    block_stmt.span,
+                                    fixer.source_range(block_stmt.span.shrink(1)),
+                                )
                             },
                         );
-
-                        // After first incorrect consequent we have to break to not repeat the work
-                        break;
+                        continue;
                     }
+                    false
                 }
+                _ => true,
+            };
+
+            if self.always_braces && missing_braces {
+                let colon = u32::try_from(ctx.source_range(case.span).find(':').unwrap()).unwrap();
+                let span = Span::new(case.span.start, case.span.start + colon + 1);
+                ctx.diagnostic_with_fix(
+                    switch_case_braces_diagnostic_missing_braces(span),
+                    |fixer| {
+                        let fixer = fixer.for_multifix();
+                        let mut fix = fixer.new_fix_with_capacity(2);
+
+                        fix.push(fixer.insert_text_after_range(span, " {"));
+
+                        // Indent the closing case bracket, if needed
+                        let code = match get_preceding_indent_str(fixer.source_text(), case.span) {
+                            Some(indent) => {
+                                let mut code = String::with_capacity(2 + indent.len());
+                                code.push('\n');
+                                code.push_str(indent);
+                                code.push('}');
+                                code
+                            }
+                            None => String::from('}'),
+                        };
+
+                        fix.push(fixer.insert_text_after_range(case.span, code));
+                        fix.with_message("Add Braces for case clause.")
+                    },
+                );
             }
         }
     }
@@ -243,6 +181,7 @@ fn test() {
         "switch(foo) { case 1: { doSomething(); } break; /* <-- This should be between braces */ }",
         "switch(foo) { default: label: {} }",
         "switch(something) { case 1: case 2: { console.log('something'); break; } case 3: console.log('something else'); }",
+        "switch(foo){ case 1: {}; break; }",
     ];
 
     let fix = vec![
@@ -253,15 +192,15 @@ fn test() {
         ),
         (
             "switch(something) { case 1: {} case 2: console.log('something'); break;}",
-            "switch(something) { case 1:  case 2: {console.log('something');break;}}",
+            "switch(something) { case 1:  case 2: { console.log('something'); break;}}",
             None,
         ),
         (
             "switch(foo) { default: doSomething(); }",
-            "switch(foo) { default: {doSomething();} }",
+            "switch(foo) { default: { doSomething();} }",
             None,
         ),
-        ("switch(s){case'':/]/}", "switch(s){case '': {/]/}}", None),
+        ("switch(s){case'':/]/}", "switch(s){case'': {/]/}}", None),
         (
             "switch(foo) { default: {doSomething();} }",
             "switch(foo) { default: doSomething(); }",
@@ -275,7 +214,7 @@ fn test() {
                 let gamma = 0
 
                 switch (alpha) {
-                    case 1: 
+                    case 1:
                         beta = 'one'
                         gamma = 1
                         break
@@ -296,6 +235,7 @@ fn test() {
             ",
             None,
         ),
+        ("switch(foo){ case 1: {}; break; }", "switch(foo){ case 1: { {}; break;} }", None),
     ];
 
     Tester::new(SwitchCaseBraces::NAME, SwitchCaseBraces::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/unicorn_switch_case_braces.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_switch_case_braces.snap
@@ -2,9 +2,9 @@
 source: crates/oxc_linter/src/tester.rs
 ---
   ⚠ eslint-plugin-unicorn(switch-case-braces): Missing braces in case clause.
-   ╭─[switch_case_braces.tsx:1:18]
+   ╭─[switch_case_braces.tsx:1:11]
  1 │ switch(s){case'':/]/}
-   ·                  ───
+   ·           ───────
    ╰────
   help: Add Braces for case clause.
 
@@ -16,9 +16,9 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove braces in empty case clause.
 
   ⚠ eslint-plugin-unicorn(switch-case-braces): Missing braces in case clause.
-   ╭─[switch_case_braces.tsx:1:37]
+   ╭─[switch_case_braces.tsx:1:29]
  1 │ switch(something) { case 1: case 2: console.log('something'); break;}
-   ·                                     ────────────────────────────────
+   ·                             ───────
    ╰────
   help: Add Braces for case clause.
 
@@ -51,29 +51,36 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove braces in empty case clause.
 
   ⚠ eslint-plugin-unicorn(switch-case-braces): Missing braces in case clause.
-   ╭─[switch_case_braces.tsx:1:24]
+   ╭─[switch_case_braces.tsx:1:15]
  1 │ switch(foo) { default: doSomething(); }
-   ·                        ──────────────
+   ·               ────────
    ╰────
   help: Add Braces for case clause.
 
   ⚠ eslint-plugin-unicorn(switch-case-braces): Missing braces in case clause.
-   ╭─[switch_case_braces.tsx:1:23]
+   ╭─[switch_case_braces.tsx:1:15]
  1 │ switch(foo) { case 1: { doSomething(); } break; /* <-- This should be between braces */ }
-   ·                       ─────────────────────────
+   ·               ───────
    ╰────
   help: Add Braces for case clause.
 
   ⚠ eslint-plugin-unicorn(switch-case-braces): Missing braces in case clause.
-   ╭─[switch_case_braces.tsx:1:24]
+   ╭─[switch_case_braces.tsx:1:15]
  1 │ switch(foo) { default: label: {} }
-   ·                        ─────────
+   ·               ────────
    ╰────
   help: Add Braces for case clause.
 
   ⚠ eslint-plugin-unicorn(switch-case-braces): Missing braces in case clause.
-   ╭─[switch_case_braces.tsx:1:82]
+   ╭─[switch_case_braces.tsx:1:74]
  1 │ switch(something) { case 1: case 2: { console.log('something'); break; } case 3: console.log('something else'); }
-   ·                                                                                  ──────────────────────────────
+   ·                                                                          ───────
+   ╰────
+  help: Add Braces for case clause.
+
+  ⚠ eslint-plugin-unicorn(switch-case-braces): Missing braces in case clause.
+   ╭─[switch_case_braces.tsx:1:14]
+ 1 │ switch(foo){ case 1: {}; break; }
+   ·              ───────
    ╰────
   help: Add Braces for case clause.


### PR DESCRIPTION
In the case of `switch(foo){ case 1: {}; break; }`, only a "Missing braces in case clause" diagnostic should be reported.

However, the current behavior incorrectly reports below:

```bash
  ⚠ eslint-plugin-unicorn(switch-case-braces): Unexpected braces in empty case clause.
   ╭─[switch_case_braces.tsx:1:22]
 1 │ switch(foo){ case 1: {}; break; }
   ·                      ──
   ╰────
  help: Remove braces in empty case clause.

  ⚠ eslint-plugin-unicorn(switch-case-braces): Missing braces in case clause.
   ╭─[switch_case_braces.tsx:1:22]
 1 │ switch(foo){ case 1: {}; break; }
   ·                      ──────────
   ╰────
  help: Add Braces for case clause.
```