### PR TITLE
perf(parser): optimize around `eat_decorators`

### DIFF
--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -81,7 +81,9 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_formal_parameter(&mut self) -> FormalParameter<'a> {
         let span = self.start_span();
-        self.eat_decorators();
+        if self.at(Kind::At) {
+            self.eat_decorators();
+        }
         let modifiers = self.parse_parameter_modifiers();
         let pattern = self.parse_binding_pattern_with_initializer();
         let decorators = self.consume_decorators();

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -404,7 +404,9 @@ impl<'a> ParserImpl<'a> {
         let decl_span = self.start_span();
         // For tc39/proposal-decorators
         // For more information, please refer to <https://babeljs.io/docs/babel-plugin-proposal-decorators#decoratorsbeforeexport>
-        self.eat_decorators();
+        if self.at(Kind::At) {
+            self.eat_decorators();
+        }
         let reserved_ctx = self.ctx;
         let modifiers =
             if self.is_ts { self.eat_modifiers_before_declaration() } else { Modifiers::empty() };
@@ -440,7 +442,9 @@ impl<'a> ParserImpl<'a> {
             self.lexer.trivia_builder.previous_token_has_no_side_effects_comment();
         // For tc39/proposal-decorators
         // For more information, please refer to <https://babeljs.io/docs/babel-plugin-proposal-decorators#decoratorsbeforeexport>
-        self.eat_decorators();
+        if self.at(Kind::At) {
+            self.eat_decorators();
+        }
         let declaration = match self.cur_kind() {
             Kind::Class => ExportDefaultDeclarationKind::ClassDeclaration(
                 self.parse_class_declaration(decl_span, /* modifiers */ &Modifiers::empty()),

--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -367,14 +367,13 @@ impl<'a> ParserImpl<'a> {
     ) -> Modifiers<'a> {
         let mut has_seen_static_modifier = false;
         let mut has_leading_modifier = false;
-        let mut has_trailing_decorator = false;
 
         let mut modifiers = self.ast.vec();
         let mut modifier_flags = ModifierFlags::empty();
 
         // parse leading decorators
-        if allow_decorators && matches!(self.cur_kind(), Kind::At) {
-            self.try_parse(Self::eat_decorators);
+        if allow_decorators && self.at(Kind::At) {
+            self.eat_decorators();
         }
 
         // parse leading modifiers
@@ -393,12 +392,12 @@ impl<'a> ParserImpl<'a> {
         }
 
         // parse trailing decorators, but only if we parsed any leading modifiers
-        if allow_decorators && has_leading_modifier && matches!(self.cur_kind(), Kind::At) {
-            has_trailing_decorator = self.try_parse(Self::eat_decorators).is_some();
+        if allow_decorators && has_leading_modifier && self.at(Kind::At) {
+            self.eat_decorators();
         }
 
         // parse trailing modifiers, but only if we parsed any trailing decorators
-        if has_trailing_decorator {
+        if !self.state.decorators.is_empty() {
             while let Some(modifier) = self.try_parse_modifier(
                 has_seen_static_modifier,
                 permit_const_as_modifier,

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -455,7 +455,9 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_ts_this_parameter(&mut self) -> TSThisParameter<'a> {
         let span = self.start_span();
         self.parse_class_element_modifiers(true);
-        self.eat_decorators();
+        if self.at(Kind::At) {
+            self.eat_decorators();
+        }
 
         let this_span = self.start_span();
         self.bump_any();
@@ -466,10 +468,6 @@ impl<'a> ParserImpl<'a> {
     }
 
     pub(crate) fn eat_decorators(&mut self) {
-        if !self.at(Kind::At) {
-            return;
-        }
-
         let mut decorators = self.ast.vec();
         while self.at(Kind::At) {
             let decorator = self.parse_decorator();


### PR DESCRIPTION
- move `Kind::At` check to call site of `eat_decorators` like other calls
- remove surrounding `try_parse` calls surrounding calls of `eat_decorators`

I'm not sure about the removed `try_parse`...
Tests are still green and no diffs in snapshots.
Seems like it didn't break anything 🤞