### PR TITLE
perf(parser): optimize around `parse_type_arguments_in_expression`

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -757,14 +757,14 @@ impl<'a> ParserImpl<'a> {
                 continue;
             }
 
-            if !question_dot {
-                if self.is_ts && !self.cur_token().is_on_new_line() && self.eat(Kind::Bang) {
+            if !question_dot && self.is_ts {
+                if !self.cur_token().is_on_new_line() && self.eat(Kind::Bang) {
                     lhs = self.ast.expression_ts_non_null(self.end_span(lhs_span), lhs);
                     continue;
                 }
 
                 if matches!(self.cur_kind(), Kind::LAngle | Kind::ShiftLeft) {
-                    if let Some(Some(arguments)) =
+                    if let Some(arguments) =
                         self.try_parse(Self::parse_type_arguments_in_expression)
                     {
                         lhs = self.ast.expression_ts_instantiation(
@@ -908,8 +908,10 @@ impl<'a> ParserImpl<'a> {
 
             let mut type_arguments = None;
             if question_dot {
-                if let Some(Some(args)) = self.try_parse(Self::parse_type_arguments_in_expression) {
-                    type_arguments = Some(args);
+                if self.is_ts {
+                    if let Some(args) = self.try_parse(Self::parse_type_arguments_in_expression) {
+                        type_arguments = Some(args);
+                    }
                 }
                 if self.cur_kind().is_template_start_of_tagged_template() {
                     lhs = self.parse_tagged_template(lhs_span, lhs, question_dot, type_arguments);

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -812,13 +812,10 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn parse_type_arguments_in_expression(
         &mut self,
-    ) -> Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
-        if !self.is_ts {
-            return None;
-        }
+    ) -> Box<'a, TSTypeParameterInstantiation<'a>> {
         let span = self.start_span();
         if self.re_lex_l_angle() != Kind::LAngle {
-            return None;
+            return self.unexpected();
         }
         self.expect(Kind::LAngle);
         let (params, _) = self.parse_delimited_list(Kind::RAngle, Kind::Comma, Self::parse_ts_type);
@@ -828,11 +825,10 @@ impl<'a> ParserImpl<'a> {
         }
         self.re_lex_ts_r_angle();
         self.expect(Kind::RAngle);
-        if self.can_follow_type_arguments_in_expr() {
-            Some(self.ast.alloc_ts_type_parameter_instantiation(self.end_span(span), params))
-        } else {
-            self.unexpected()
+        if !self.can_follow_type_arguments_in_expr() {
+            return self.unexpected();
         }
+        self.ast.alloc_ts_type_parameter_instantiation(self.end_span(span), params)
     }
 
     fn can_follow_type_arguments_in_expr(&mut self) -> bool {


### PR DESCRIPTION
- move `is_ts` to call site to avoid expensive `try_parse` call
- refactor `parse_type_arguments_in_expression` to not return `Option` to avoid one level of indirection when calling it in `try_parse`