### PR TITLE
refactor(parser): Remove lookahead from assertion signature parsing

### DIFF
--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -413,13 +413,15 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_assertion_signature(&mut self) -> TSType<'a> {
         let checkpoint = self.checkpoint();
+        let asserts_start_span = self.start_span();
+
         self.bump_any(); // bump `asserts`
         let token = self.cur_token();
         if token.kind().is_identifier_name() && !token.is_on_new_line() {
             self.parse_asserts_type_predicate()
         } else {
             self.rewind(checkpoint);
-            self.parse_type_reference()
+            self.parse_type_reference(asserts_start_span)
         }
     }
 
@@ -752,11 +754,10 @@ impl<'a> ParserImpl<'a> {
         )
     }
 
-    fn parse_type_reference(&mut self) -> TSType<'a> {
-        let span = self.start_span();
+    fn parse_type_reference(&mut self, start_span: u32) -> TSType<'a> {
         let type_name = self.parse_ts_type_name();
         let type_parameters = self.parse_type_arguments_of_type_reference();
-        self.ast.ts_type_type_reference(self.end_span(span), type_name, type_parameters)
+        self.ast.ts_type_type_reference(self.end_span(start_span), type_name, type_parameters)
     }
 
     fn parse_ts_implement_name(&mut self) -> TSClassImplements<'a> {

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -406,7 +406,7 @@ impl<'a> ParserImpl<'a> {
             Kind::LParen => self.parse_parenthesized_type(),
             Kind::Import => TSType::TSImportType(self.parse_ts_import_type()),
             Kind::Asserts => 
-               self.parse_thing(),
+               self.parse_asserts(),
                // if self.lookahead(Self::is_next_token_identifier_or_keyword_on_same_line) {
                //     self.parse_asserts_type_predicate()
                // } else {
@@ -417,36 +417,19 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    fn parse_thing(&mut self) -> TSType<'a> {
+    fn parse_asserts(&mut self) -> TSType<'a> {
     
     //self.checkpoint();
       // let checkpoint = self.checkpoint();
         let token = self.cur_token(); // these are the bits to remove now
         self.bump_any();
-       // self.rewind(checkpoint);  // these are the bits to remove now
-       let is_next_token_identifier_or_keyword_on_same_line =  token.kind().is_identifier_name() && !token.is_on_new_line();
-        if is_next_token_identifier_or_keyword_on_same_line {
+        // self.rewind(checkpoint);  // these are the bits to remove now
+       //let is_next_token_identifier_or_keyword_on_same_line =  token.kind().is_identifier_name() && !token.is_on_new_line();
+       //let is_cur_token_identifier_or_keyword_on_same_line = token.kind().is_identifier_name() && !token.is_on_new_line() ;
+
+       if token.kind().is_identifier_name() && !token.is_on_new_line() {
             //self.parse_asserts_type_predicate()
-            let span = self.start_span();
-        //    self.bump_any(); // bump `asserts`
-            let parameter_name = if self.at(Kind::This) {
-                TSTypePredicateName::This(self.parse_this_type_node())
-            } else {
-                let ident_name = self.parse_identifier_name();
-                TSTypePredicateName::Identifier(self.alloc(ident_name))
-            };
-            let mut type_annotation = None;
-            if self.eat(Kind::Is) {
-                let type_span = self.start_span();
-                let ty = self.parse_ts_type();
-                type_annotation = Some(self.ast.ts_type_annotation(self.end_span(type_span), ty));
-            }
-            self.ast.ts_type_type_predicate(
-                self.end_span(span),
-                parameter_name,
-                /* asserts */ true,
-                type_annotation,
-            )
+            self.parse_asserts_type_predicate()
         } else {
             // self.parse_type_reference()
             let span = self.start_span();
@@ -456,10 +439,9 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    fn is_next_token_identifier_or_keyword_on_same_line(&mut self) -> bool {
-        self.bump_any();
-        self.cur_kind().is_identifier_name() && !self.cur_token().is_on_new_line()
-    }
+    //fn is_cur_token_identifier_or_keyword_on_same_line(&mut self) -> bool {
+    //    self.cur_kind().is_identifier_name() && !self.cur_token().is_on_new_line()
+    //}
 
     fn is_next_token_number(&mut self) -> bool {
         self.bump_any();
@@ -770,7 +752,6 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_asserts_type_predicate(&mut self) -> TSType<'a> {
         let span = self.start_span();
-        self.bump_any(); // bump `asserts`
         let parameter_name = if self.at(Kind::This) {
             TSTypePredicateName::This(self.parse_this_type_node())
         } else {

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -412,12 +412,13 @@ impl<'a> ParserImpl<'a> {
     }
 
     fn parse_assertion_signature(&mut self) -> TSType<'a> {
+        let checkpoint = self.checkpoint();
         self.bump_any(); // bump `asserts`
         let token = self.cur_token();
-
         if token.kind().is_identifier_name() && !token.is_on_new_line() {
             self.parse_asserts_type_predicate()
         } else {
+            self.rewind(checkpoint);
             self.parse_type_reference()
         }
     }

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -405,15 +405,23 @@ impl<'a> ParserImpl<'a> {
             Kind::LBrack => self.parse_tuple_type(),
             Kind::LParen => self.parse_parenthesized_type(),
             Kind::Import => TSType::TSImportType(self.parse_ts_import_type()),
-            Kind::Asserts => {
-                if self.lookahead(Self::is_next_token_identifier_or_keyword_on_same_line) {
-                    self.parse_asserts_type_predicate()
-                } else {
-                    self.parse_type_reference()
-                }
-            }
+            Kind::Asserts => 
+               self.parse_thing(),
+               // if self.lookahead(Self::is_next_token_identifier_or_keyword_on_same_line) {
+               //     self.parse_asserts_type_predicate()
+               // } else {
+               //     self.parse_type_reference()
+               // }
             Kind::TemplateHead => self.parse_template_type(false),
             _ => self.parse_type_reference(),
+        }
+    }
+
+    fn parse_thing(&mut self) -> TSType<'a> {
+        if self.lookahead(Self::is_next_token_identifier_or_keyword_on_same_line) {
+            self.parse_asserts_type_predicate()
+        } else {
+            self.parse_type_reference()
         }
     }
 

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -418,7 +418,14 @@ impl<'a> ParserImpl<'a> {
     }
 
     fn parse_thing(&mut self) -> TSType<'a> {
-        if self.lookahead(Self::is_next_token_identifier_or_keyword_on_same_line) {
+    
+    self.checkpoint();
+        let checkpoint = self.checkpoint();
+        //let token = self.cur_token();
+        self.bump_any();
+        self.rewind(checkpoint);
+       let is_next_token_identifier_or_keyword_on_same_line =  self.cur_kind().is_identifier_name() && !self.cur_token().is_on_new_line();
+        if is_next_token_identifier_or_keyword_on_same_line {
             //self.parse_asserts_type_predicate()
             let span = self.start_span();
             self.bump_any(); // bump `asserts`

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -413,7 +413,7 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_assertion_signature(&mut self) -> TSType<'a> {
         let token = self.cur_token();
-        self.bump_any();
+        self.bump_any(); // bump `asserts`
 
         if token.kind().is_identifier_name() && !token.is_on_new_line() {
             self.parse_asserts_type_predicate()

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -339,7 +339,8 @@ impl<'a> ParserImpl<'a> {
                 if let Some(ty) = self.try_parse(Self::parse_keyword_and_no_dot) {
                     ty
                 } else {
-                    self.parse_type_reference()
+                    let span = self.start_span();
+                    self.parse_type_reference(span)
                 }
             }
             // TODO: js doc types: `JSDocAllType`, `JSDocFunctionType`
@@ -368,7 +369,8 @@ impl<'a> ParserImpl<'a> {
                 if self.lookahead(Self::is_next_token_number) {
                     self.parse_literal_type_node(/* negative */ true)
                 } else {
-                    self.parse_type_reference()
+                    let span = self.start_span();
+                    self.parse_type_reference(span)
                 }
             }
             Kind::Void => {
@@ -407,7 +409,10 @@ impl<'a> ParserImpl<'a> {
             Kind::Import => TSType::TSImportType(self.parse_ts_import_type()),
             Kind::Asserts => self.parse_assertion_signature(),
             Kind::TemplateHead => self.parse_template_type(false),
-            _ => self.parse_type_reference(),
+            _ => {
+                let span = self.start_span();
+                self.parse_type_reference(span)
+            },
         }
     }
 

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -415,7 +415,7 @@ impl<'a> ParserImpl<'a> {
         let token = self.cur_token();
         self.bump_any(); // bump `asserts`
 
-        if token.kind().is_identifier_name() && !token.is_on_new_line() {
+        if self.cur_kind().is_identifier_name() && !self.cur_token().is_on_new_line() {
             self.parse_asserts_type_predicate()
         } else {
             self.parse_type_reference()

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -405,43 +405,22 @@ impl<'a> ParserImpl<'a> {
             Kind::LBrack => self.parse_tuple_type(),
             Kind::LParen => self.parse_parenthesized_type(),
             Kind::Import => TSType::TSImportType(self.parse_ts_import_type()),
-            Kind::Asserts => 
-               self.parse_asserts(),
-               // if self.lookahead(Self::is_next_token_identifier_or_keyword_on_same_line) {
-               //     self.parse_asserts_type_predicate()
-               // } else {
-               //     self.parse_type_reference()
-               // }
+            Kind::Asserts => self.parse_assertion_signature(),
             Kind::TemplateHead => self.parse_template_type(false),
             _ => self.parse_type_reference(),
         }
     }
 
-    fn parse_asserts(&mut self) -> TSType<'a> {
-    
-    //self.checkpoint();
-      // let checkpoint = self.checkpoint();
-        let token = self.cur_token(); // these are the bits to remove now
+    fn parse_assertion_signature(&mut self) -> TSType<'a> {
+        let token = self.cur_token();
         self.bump_any();
-        // self.rewind(checkpoint);  // these are the bits to remove now
-       //let is_next_token_identifier_or_keyword_on_same_line =  token.kind().is_identifier_name() && !token.is_on_new_line();
-       //let is_cur_token_identifier_or_keyword_on_same_line = token.kind().is_identifier_name() && !token.is_on_new_line() ;
 
-       if token.kind().is_identifier_name() && !token.is_on_new_line() {
-            //self.parse_asserts_type_predicate()
+        if token.kind().is_identifier_name() && !token.is_on_new_line() {
             self.parse_asserts_type_predicate()
         } else {
-            // self.parse_type_reference()
-            let span = self.start_span();
-            let type_name = self.parse_ts_type_name();
-            let type_parameters = self.parse_type_arguments_of_type_reference();
-            self.ast.ts_type_type_reference(self.end_span(span), type_name, type_parameters)
+            self.parse_type_reference()
         }
     }
-
-    //fn is_cur_token_identifier_or_keyword_on_same_line(&mut self) -> bool {
-    //    self.cur_kind().is_identifier_name() && !self.cur_token().is_on_new_line()
-    //}
 
     fn is_next_token_number(&mut self) -> bool {
         self.bump_any();

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -412,10 +412,10 @@ impl<'a> ParserImpl<'a> {
     }
 
     fn parse_assertion_signature(&mut self) -> TSType<'a> {
-        let token = self.cur_token();
         self.bump_any(); // bump `asserts`
+        let token = self.cur_token();
 
-        if self.cur_kind().is_identifier_name() && !self.cur_token().is_on_new_line() {
+        if token.kind().is_identifier_name() && !token.is_on_new_line() {
             self.parse_asserts_type_predicate()
         } else {
             self.parse_type_reference()

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -419,7 +419,7 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_thing(&mut self) -> TSType<'a> {
     
-    self.checkpoint();
+    //self.checkpoint();
       // let checkpoint = self.checkpoint();
         let token = self.cur_token(); // these are the bits to remove now
         self.bump_any();

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -420,15 +420,15 @@ impl<'a> ParserImpl<'a> {
     fn parse_thing(&mut self) -> TSType<'a> {
     
     self.checkpoint();
-        let checkpoint = self.checkpoint();
-        //let token = self.cur_token();
+      // let checkpoint = self.checkpoint();
+        let token = self.cur_token(); // these are the bits to remove now
         self.bump_any();
-        self.rewind(checkpoint);
-       let is_next_token_identifier_or_keyword_on_same_line =  self.cur_kind().is_identifier_name() && !self.cur_token().is_on_new_line();
+       // self.rewind(checkpoint);  // these are the bits to remove now
+       let is_next_token_identifier_or_keyword_on_same_line =  token.kind().is_identifier_name() && !token.is_on_new_line();
         if is_next_token_identifier_or_keyword_on_same_line {
             //self.parse_asserts_type_predicate()
             let span = self.start_span();
-            self.bump_any(); // bump `asserts`
+        //    self.bump_any(); // bump `asserts`
             let parameter_name = if self.at(Kind::This) {
                 TSTypePredicateName::This(self.parse_this_type_node())
             } else {


### PR DESCRIPTION
Remove use of `lookahead` when parsing assertion signatures.

Relates to #11334 as part of reducing unnecessary backtracking from the parser.