### PR TITLE
refactor(parser): Reduce backtracking for assertion signature parsing

### DIFF
--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -422,7 +422,7 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    fn is_token_identifier_or_keyword_on_same_line(&mut self) -> bool {
+    fn is_token_identifier_or_keyword_on_same_line(&self) -> bool {
         self.cur_kind().is_identifier_name() && !self.cur_token().is_on_new_line()
     }
 

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -406,9 +406,18 @@ impl<'a> ParserImpl<'a> {
             Kind::LParen => self.parse_parenthesized_type(),
             Kind::Import => TSType::TSImportType(self.parse_ts_import_type()),
             Kind::Asserts => {
-                if self.lookahead(Self::is_next_token_identifier_or_keyword_on_same_line) {
+                let checkpoint = self.checkpoint();
+                self.bump_any(); // bump `asserts`
+
+                // Is token after the `asserts` an identifier or keyword that
+                // is on the same line?
+                let same_line_id_or_keyword= self.is_next_token_identifier_or_keyword_on_same_line();
+                if same_line_id_or_keyword {
+                    self.rewind(checkpoint);
+
                     self.parse_asserts_type_predicate()
                 } else {
+                    self.rewind(checkpoint);
                     self.parse_type_reference()
                 }
             }
@@ -418,7 +427,7 @@ impl<'a> ParserImpl<'a> {
     }
 
     fn is_next_token_identifier_or_keyword_on_same_line(&mut self) -> bool {
-        self.bump_any();
+        // self.bump_any();
         self.cur_kind().is_identifier_name() && !self.cur_token().is_on_new_line()
     }
 


### PR DESCRIPTION
- Replace use of `lookahead` when parsing assertion signatures in favour of checkpoint and rewinds.
- Remove unnecessary backtracking when parsing assertion signatures for one of the code paths.

Relates to #11334 as part of reducing unnecessary backtracking from the parser.