### PR TITLE
refactor(parser): Reduce backtracking for literal type node parsing

### DIFF
--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -366,11 +366,12 @@ impl<'a> ParserImpl<'a> {
             }
             Kind::Minus => {
                 let checkpoint = self.checkpoint();
-                self.bump_any();
+                let minus_start_span = self.start_span();
+
+                self.bump_any(); // bump `-`
 
                 if self.cur_kind().is_number() {
-                    self.rewind(checkpoint);
-                    self.parse_literal_type_node(/* negative */ true)
+                    self.parse_rest_of_literal_type_node(minus_start_span, /* negative */ true)
                 } else {
                     self.rewind(checkpoint);
                     self.parse_type_reference()
@@ -944,10 +945,10 @@ impl<'a> ParserImpl<'a> {
             self.bump_any(); // bump `-`
         }
 
-        self.parse_thing(span, negative)
+        self.parse_rest_of_literal_type_node(span, negative)
     }
 
-    fn parse_thing(&mut self, span: u32, negative: bool) -> TSType<'a> {
+    fn parse_rest_of_literal_type_node(&mut self, span: u32, negative: bool) -> TSType<'a> {
         let expression = if self.at(Kind::NoSubstitutionTemplate) {
             self.parse_template_literal_expression(false)
         } else {

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -365,9 +365,14 @@ impl<'a> ParserImpl<'a> {
                 self.parse_literal_type_node(/* negative */ false)
             }
             Kind::Minus => {
-                if self.lookahead(Self::is_next_token_number) {
+                let checkpoint = self.checkpoint();
+                self.bump_any();
+
+                if self.cur_kind().is_number() {
+                    self.rewind(checkpoint);
                     self.parse_literal_type_node(/* negative */ true)
                 } else {
+                    self.rewind(checkpoint);
                     self.parse_type_reference()
                 }
             }
@@ -939,6 +944,10 @@ impl<'a> ParserImpl<'a> {
             self.bump_any(); // bump `-`
         }
 
+        self.parse_thing(span, negative)
+    }
+
+    fn parse_thing(&mut self, span: u32, negative: bool) -> TSType<'a> {
         let expression = if self.at(Kind::NoSubstitutionTemplate) {
             self.parse_template_literal_expression(false)
         } else {


### PR DESCRIPTION
- Replace use of `lookahead` when parsing assertion signatures in favour of checkpoint and rewinds.
- Remove unnecessary backtracking when parsing literal type nodes.

Relates to #11334  as part of reducing unnecessary backtracking from the parser.