### PR TITLE
fix(estree): Update `add_ts_def` types in oxc-types

### DIFF
--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1700,4 +1700,4 @@ export type Node =
   | JSDocNullableType
   | JSDocNonNullableType
   | JSDocUnknownType
-  | FormalParameterRest;
+  | ParamPattern;

--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -35,10 +35,11 @@ impl Generator for TypescriptGenerator {
             }
         }
 
-        // Manually append `FormalParameterRest`, which is generated via `add_ts_def`.
+        // Manually append `ParamPattern`, which is generated via `add_ts_def`.
+        // `ParamPattern` is a union type of other `add_ts_def`ed types.
         // TODO: Should not be hard-coded here.
         let ast_node_union = ast_node_names.join(" | ");
-        write_it!(code, "export type Node = {ast_node_union} | FormalParameterRest;\n\n");
+        write_it!(code, "export type Node = {ast_node_union} | ParamPattern;\n\n");
 
         Output::Javascript { path: TYPESCRIPT_DEFINITIONS_PATH.to_string(), code }
     }


### PR DESCRIPTION
Fixes #11415 

Currently, there are 3 places using `add_ts_def`.

https://github.com/oxc-project/oxc/blob/d0cc3315fd6a3280008e18b34fda70adecfbf9fe/crates/oxc_ast/src/ast/js.rs#L1681
https://github.com/oxc-project/oxc/blob/d0cc3315fd6a3280008e18b34fda70adecfbf9fe/crates/oxc_ast/src/ast/js.rs#L1766-L1767
https://github.com/oxc-project/oxc/blob/d0cc3315fd6a3280008e18b34fda70adecfbf9fe/crates/oxc_ast/src/ast/js.rs#L1794-L1795

Adding `ParamPattern` to the list causes all other types to be listed as well.