### PR TITLE
feat(language_server): support `textDocument/diagnostic`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,12 +89,6 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
@@ -110,6 +104,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eeab4423108c5d7c744f4d234de88d18d636100093ae04caf4825134b9c3a32"
 
 [[package]]
 name = "bpaf"
@@ -668,11 +668,12 @@ dependencies = [
 
 [[package]]
 name = "fluent-uri"
-version = "0.1.4"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
 dependencies = [
- "bitflags 1.3.2",
+ "borrow-or-share",
+ "ref-cast",
 ]
 
 [[package]]
@@ -1247,10 +1248,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 [[package]]
 name = "lsp-types"
 version = "0.97.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
+source = "git+https://github.com/tower-lsp-community/lsp-types?rev=7332122ee5572c3f2c247b37cd1af77289b2e1c8#7332122ee5572c3f2c247b37cd1af77289b2e1c8"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "fluent-uri",
  "serde",
  "serde_json",
@@ -1296,7 +1296,7 @@ version = "3.0.0-beta.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c502f122fc89e92c6222810b3144411c6f945da5aa3b713ddfad3bdcae7c9bb4"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "ctor",
  "napi-build",
  "napi-sys",
@@ -1567,7 +1567,7 @@ dependencies = [
 name = "oxc_ast"
 version = "0.73.0"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_data_structures",
@@ -1591,7 +1591,7 @@ dependencies = [
 name = "oxc_ast_tools"
 version = "0.0.0"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "bpaf",
  "convert_case",
  "cow-utils",
@@ -1649,7 +1649,7 @@ dependencies = [
 name = "oxc_cfg"
 version = "0.73.0"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "itertools",
  "nonmax",
  "oxc_index",
@@ -1663,7 +1663,7 @@ name = "oxc_codegen"
 version = "0.73.0"
 dependencies = [
  "base64",
- "bitflags 2.9.1",
+ "bitflags",
  "cow-utils",
  "insta",
  "nonmax",
@@ -1786,7 +1786,7 @@ dependencies = [
 name = "oxc_isolated_declarations"
 version = "0.73.0"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "insta",
  "oxc_allocator",
  "oxc_ast",
@@ -1825,7 +1825,7 @@ dependencies = [
 name = "oxc_linter"
 version = "1.1.0"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "constcat",
  "convert_case",
  "cow-utils",
@@ -1974,7 +1974,7 @@ dependencies = [
 name = "oxc_parser"
 version = "0.73.0"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "cow-utils",
  "memchr",
  "num-bigint",
@@ -2047,7 +2047,7 @@ dependencies = [
 name = "oxc_regular_expression"
 version = "0.73.0"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_diagnostics",
@@ -2146,7 +2146,7 @@ dependencies = [
 name = "oxc_syntax"
 version = "0.73.0"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "cow-utils",
  "nonmax",
  "oxc_allocator",
@@ -2579,7 +2579,27 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2679,7 +2699,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3179,8 +3199,7 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 [[package]]
 name = "tower-lsp-server"
 version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fade4c658b63d11b623ddfa80821901e943a2923a010ae4a038661de42bd377"
+source = "git+https://github.com/tower-lsp-community/tower-lsp-server?rev=27cbe421c6cdc6e9cd607abaf1ece8c060e5cd4e#27cbe421c6cdc6e9cd607abaf1ece8c060e5cd4e"
 dependencies = [
  "bytes",
  "dashmap",
@@ -3703,7 +3722,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -287,3 +287,8 @@ overflow-checks = true # Catch arithmetic overflow errors
 [profile.dev-no-debug-assertions]
 inherits = "dev"
 debug-assertions = false
+
+[patch.crates-io]
+# this patch has the fix for `WorkspaceClientCapabilities`, see tower-lsp-community/tower-lsp-server#50
+lsp-types = { git = "https://github.com/tower-lsp-community/lsp-types", rev = "7332122ee5572c3f2c247b37cd1af77289b2e1c8" }
+tower-lsp-server = { git = "https://github.com/tower-lsp-community/tower-lsp-server", rev = "27cbe421c6cdc6e9cd607abaf1ece8c060e5cd4e" }

--- a/crates/oxc_language_server/src/options.rs
+++ b/crates/oxc_language_server/src/options.rs
@@ -25,10 +25,11 @@ pub enum UnusedDisableDirectives {
 #[derive(Debug, Default, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Options {
-    pub run: Run,
     pub config_path: Option<String>,
     pub unused_disable_directives: UnusedDisableDirectives,
     pub flags: FxHashMap<String, String>,
+    // can only be used when the server is pushing diagnostics
+    pub run: Run,
 }
 
 impl Options {

--- a/crates/oxc_language_server/src/tester.rs
+++ b/crates/oxc_language_server/src/tester.rs
@@ -119,7 +119,7 @@ impl Tester<'_> {
         let reports = tokio::runtime::Runtime::new().unwrap().block_on(async {
             self.create_workspace_worker()
                 .await
-                .lint_file(&uri, None)
+                .lint_file(&uri)
                 .await
                 .expect("lint file is ignored")
         });

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -27,6 +27,7 @@ pub struct WorkspaceWorker {
     root_uri: Uri,
     server_linter: RwLock<Option<ServerLinter>>,
     diagnostics_report_map: Arc<ConcurrentHashMap<String, Vec<DiagnosticReport>>>,
+    document_cache: Arc<ConcurrentHashMap<String, String>>,
     options: Mutex<Options>,
 }
 
@@ -36,6 +37,7 @@ impl WorkspaceWorker {
             root_uri,
             server_linter: RwLock::new(None),
             diagnostics_report_map: Arc::new(ConcurrentHashMap::default()),
+            document_cache: Arc::new(ConcurrentHashMap::default()),
             options: Mutex::new(Options::default()),
         }
     }
@@ -54,6 +56,14 @@ impl WorkspaceWorker {
     pub async fn init_linter(&self, options: &Options) {
         *self.options.lock().await = options.clone();
         *self.server_linter.write().await = Some(ServerLinter::new(&self.root_uri, options));
+    }
+
+    pub fn cache_document(&self, uri: &Uri, content: String) {
+        self.document_cache.pin().insert(uri.to_string(), content);
+    }
+
+    pub fn remove_cached_document(&self, uri: &Uri) {
+        self.document_cache.pin().remove(&uri.to_string());
     }
 
     // WARNING: start all programs (linter, formatter) before calling this function
@@ -136,12 +146,8 @@ impl WorkspaceWorker {
         run_level == current_run
     }
 
-    pub async fn lint_file(
-        &self,
-        uri: &Uri,
-        content: Option<String>,
-    ) -> Option<Vec<DiagnosticReport>> {
-        let diagnostics = self.lint_file_internal(uri, content).await;
+    pub async fn lint_file(&self, uri: &Uri) -> Option<Vec<DiagnosticReport>> {
+        let diagnostics = self.lint_file_internal(uri).await;
 
         if let Some(diagnostics) = &diagnostics {
             self.update_diagnostics(uri, diagnostics);
@@ -150,23 +156,22 @@ impl WorkspaceWorker {
         diagnostics
     }
 
-    async fn lint_file_internal(
-        &self,
-        uri: &Uri,
-        content: Option<String>,
-    ) -> Option<Vec<DiagnosticReport>> {
+    async fn lint_file_internal(&self, uri: &Uri) -> Option<Vec<DiagnosticReport>> {
         let Some(server_linter) = &*self.server_linter.read().await else {
             return None;
         };
 
-        server_linter.run_single(uri, content)
+        let cache = self.document_cache.pin();
+        let content = cache.get(&uri.to_string());
+
+        server_linter.run_single(uri, content.cloned())
     }
 
     fn update_diagnostics(&self, uri: &Uri, diagnostics: &[DiagnosticReport]) {
         self.diagnostics_report_map.pin().insert(uri.to_string(), diagnostics.to_owned());
     }
 
-    async fn revalidate_diagnostics(&self) -> ConcurrentHashMap<String, Vec<DiagnosticReport>> {
+    pub async fn revalidate_diagnostics(&self) -> ConcurrentHashMap<String, Vec<DiagnosticReport>> {
         let diagnostics_map = ConcurrentHashMap::with_capacity_and_hasher(
             self.diagnostics_report_map.len(),
             FxBuildHasher,
@@ -209,7 +214,7 @@ impl WorkspaceWorker {
             Some(value) => value,
             // code actions / commands can be requested without opening the file
             // we just internally lint and provide the code actions / commands without refreshing the diagnostic map.
-            None => &self.lint_file_internal(uri, None).await.unwrap_or_default(),
+            None => &self.lint_file_internal(uri).await.unwrap_or_default(),
         };
 
         if value.is_empty() {
@@ -251,7 +256,7 @@ impl WorkspaceWorker {
             Some(value) => value,
             // code actions / commands can be requested without opening the file
             // we just internally lint and provide the code actions / commands without refreshing the diagnostic map.
-            None => &self.lint_file_internal(uri, None).await.unwrap_or_default(),
+            None => &self.lint_file_internal(uri).await.unwrap_or_default(),
         };
 
         if value.is_empty() {
@@ -280,18 +285,20 @@ impl WorkspaceWorker {
         text_edits
     }
 
-    pub async fn did_change_watched_files(
-        &self,
-        _file_event: &FileEvent,
-    ) -> Option<ConcurrentHashMap<String, Vec<DiagnosticReport>>> {
+    pub async fn did_change_watched_files(&self, _file_event: &FileEvent) {
         self.refresh_server_linter().await;
-        Some(self.revalidate_diagnostics().await)
     }
 
+    /// This function is called when the configuration changes.
+    ///
+    /// # Returns
+    /// A tuple containing:
+    /// - A boolean indicating whether the Client needs new diagnostics.
+    /// - An optional `FileSystemWatcher`, replacing the old one if the config path has changed.
     pub async fn did_change_configuration(
         &self,
         changed_options: &Options,
-    ) -> (Option<ConcurrentHashMap<String, Vec<DiagnosticReport>>>, Option<FileSystemWatcher>) {
+    ) -> (bool, Option<FileSystemWatcher>) {
         // clone the current options to avoid locking the mutex
         let current_option = &self.options.lock().await.clone();
 
@@ -310,7 +317,7 @@ impl WorkspaceWorker {
 
             if current_option.config_path != changed_options.config_path {
                 return (
-                    Some(self.revalidate_diagnostics().await),
+                    true,
                     Some(FileSystemWatcher {
                         glob_pattern: GlobPattern::Relative(RelativePattern {
                             base_uri: OneOf::Right(self.root_uri.clone()),
@@ -325,10 +332,10 @@ impl WorkspaceWorker {
                 );
             }
 
-            return (Some(self.revalidate_diagnostics().await), None);
+            return (true, None);
         }
 
-        (None, None)
+        (false, None)
     }
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -52,8 +52,7 @@ allow = [
   "BSD-3-Clause",
   "ISC",
   "MIT",
-  "MPL-2.0",
-  "OpenSSL",
+  "MIT-0",
   "Unicode-DFS-2016",
   "Unicode-3.0",
   "CDLA-Permissive-2.0",
@@ -194,7 +193,10 @@ unknown-git = "warn"
 # if not specified. If it is specified but empty, no registries are allowed.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
-allow-git = []
+allow-git = [
+  # this patch has the fix for `WorkspaceClientCapabilities`, see tower-lsp-community/tower-lsp-server#50
+  "https://github.com/tower-lsp-community/lsp-types",
+]
 
 [sources.allow-org]
 # 1 or more github.com organizations to allow git sources for

--- a/editors/vscode/client/ConfigService.ts
+++ b/editors/vscode/client/ConfigService.ts
@@ -1,4 +1,5 @@
 import { ConfigurationChangeEvent, Uri, workspace, WorkspaceFolder } from 'vscode';
+import { DiagnosticPullMode } from 'vscode-languageclient';
 import { IDisposable } from './types';
 import { VSCodeConfig } from './VSCodeConfig';
 import { WorkspaceConfig, WorkspaceConfigInterface } from './WorkspaceConfig';
@@ -77,6 +78,24 @@ export class ConfigService implements IDisposable {
     if (isConfigChanged) {
       await this.onConfigChange?.(event);
     }
+  }
+
+  public shouldRequestDiagnostics(
+    textDocumentUri: Uri,
+    diagnosticPullMode: DiagnosticPullMode,
+  ): boolean {
+    if (!this.vsCodeConfig.enable) {
+      return false;
+    }
+
+    const textDocumentPath = textDocumentUri.path;
+
+    for (const [workspaceUri, workspaceConfig] of this.workspaceConfigs.entries()) {
+      if (textDocumentPath.startsWith(workspaceUri)) {
+        return workspaceConfig.shouldRequestDiagnostics(diagnosticPullMode);
+      }
+    }
+    return false;
   }
 
   dispose() {

--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -176,6 +176,12 @@ export async function activate(context: ExtensionContext) {
     initializationOptions: configService.languageServerConfig,
     outputChannel,
     traceOutputChannel: outputChannel,
+    diagnosticPullOptions: {
+      onChange: true,
+      onSave: true,
+      onTabs: false,
+      filter: (document, mode) => !configService.shouldRequestDiagnostics(document.uri, mode),
+    },
     middleware: {
       workspace: {
         configuration: (params: ConfigurationParams) => {

--- a/editors/vscode/tests/WorkspaceConfig.spec.ts
+++ b/editors/vscode/tests/WorkspaceConfig.spec.ts
@@ -1,5 +1,6 @@
 import { deepStrictEqual, strictEqual } from 'assert';
 import { ConfigurationTarget, workspace } from 'vscode';
+import { DiagnosticPullMode } from 'vscode-languageclient';
 import { WorkspaceConfig } from '../client/WorkspaceConfig.js';
 import { WORKSPACE_FOLDER } from './test-helpers.js';
 
@@ -60,7 +61,7 @@ suite('WorkspaceConfig', () => {
     const config = new WorkspaceConfig(WORKSPACE_FOLDER);
 
     await Promise.all([
-      config.updateRunTrigger('onSave'),
+      config.updateRunTrigger(DiagnosticPullMode.onSave),
       config.updateConfigPath('./somewhere'),
       config.updateUnusedDisableDirectives('deny'),
       config.updateFlags({ test: 'value' }),

--- a/editors/vscode/tests/code_actions.spec.ts
+++ b/editors/vscode/tests/code_actions.spec.ts
@@ -15,7 +15,8 @@ import {
   activateExtension,
   fixturesWorkspaceUri,
   loadFixture,
-  sleep
+  sleep,
+  waitForDiagnosticChange
 } from './test-helpers';
 import assert = require('assert');
 
@@ -119,6 +120,7 @@ suite('code actions', () => {
       'fix_kind': 'dangerous_fix',
     });
     await workspace.saveAll();
+    await waitForDiagnosticChange();
 
     const codeActionsWithFix: ProviderResult<Array<CodeAction>> = await commands.executeCommand(
       'vscode.executeCodeActionProvider',


### PR DESCRIPTION
This PR introduces the support for `textDocument/diagnostics`. This will be preferred over the other way around `textDocument/publishDiagnostics`
It is a newer concept between language server and the clients (editors).


> Diagnostics are currently published by the server to the client using a notification. This model has the advantage that for workspace wide diagnostics the server has the freedom to compute them at a server preferred point in time. On the other hand the approach has the disadvantage that the server can’t prioritize the computation for the file in which the user types or which are visible in the editor. Inferring the client’s UI state from the [textDocument/didOpen](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didOpen) and [textDocument/didChange](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didChange) notifications might lead to false positives since these notifications are ownership transfer notifications.

> The specification therefore introduces the concept of diagnostic pull requests to give a client more control over the documents for which diagnostics should be computed and at which point in time.

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_pullDiagnostics

For our server, we need one more feature.

> The [workspace/diagnostic/refresh](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic_refresh) request is sent from the server to the client. Servers can use it to ask clients to refresh all needed document and workspace diagnostics. This is useful if a server detects a project wide configuration change which requires a re-calculation of all diagnostics.

This is needed because in the current implementation we re-lint the opened files when some `.oxlintrc.json` configuration is changed or `fix_kind` server configuration. Instead of re-linting, the server will send this request to the client.

----

This will be a breaking change for other clients which are sending the `run = onType | onSave` configuration, but are supporting all needed specs for the pull diagnostics mode. The client should instead implement their own configuration and sending the `textDocument/diagnostics` to the server when needed.

----

The cargo patches are needed, because of a typo in the `lsp-types` project. The community created a fork and fixed it already for us: https://github.com/tower-lsp-community/lsp-types/commit/71ca29bec6d515d19ef70dd4a8e98f3a0e738fd4
The `tower-lsp-server` needed an update too, or else we could not use the fixed version. I created a PR here: https://github.com/tower-lsp-community/tower-lsp-server/pull/52 and used the commit ID to patch it here.

