### PR TITLE
test(ast/estree): bump `acorn-test262` dependency

### DIFF
--- a/.github/actions/clone-submodules/action.yml
+++ b/.github/actions/clone-submodules/action.yml
@@ -38,4 +38,4 @@ runs:
         show-progress: false
         repository: oxc-project/acorn-test262
         path: tasks/coverage/acorn-test262
-        ref: 359faaadce848c92efcf19dcaf7446740f8e27f4 # Latest main at 30/5/25
+        ref: 4027b2de44e02e8d492f6e8fa2671bbc266b7856 # Latest main at 2/6/25

--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ submodules:
   just clone-submodule tasks/coverage/babel https://github.com/babel/babel.git 1d4546bcb80009303aab386b59f4df1fd335c1d5
   just clone-submodule tasks/coverage/typescript https://github.com/microsoft/TypeScript.git 81c951894e93bdc37c6916f18adcd80de76679bc
   just clone-submodule tasks/prettier_conformance/prettier https://github.com/prettier/prettier.git 7584432401a47a26943dd7a9ca9a8e032ead7285
-  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 359faaadce848c92efcf19dcaf7446740f8e27f4
+  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 4027b2de44e02e8d492f6e8fa2671bbc266b7856
   just update-transformer-fixtures
 
 # Install git pre-commit to format files

--- a/tasks/coverage/snapshots/estree_acorn_jsx.snap
+++ b/tasks/coverage/snapshots/estree_acorn_jsx.snap
@@ -1,4 +1,4 @@
-commit: 359faaad
+commit: 4027b2de
 
 estree_acorn_jsx Summary:
 AST Parsed     : 39/39 (100.00%)


### PR DESCRIPTION
Bump `acorn-test262` submodule, to integrate https://github.com/oxc-project/acorn-test262/pull/44 and https://github.com/oxc-project/acorn-test262/pull/45 which fix the field order in TS snapshots of `TemplateElement` and regexp `Literal`s.