### PR TITLE
test(ast/estree): conformance tests check field order in TS-ESTree AST

### DIFF
--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -1,8 +1,8 @@
 commit: 81c95189
 
 estree_typescript Summary:
-AST Parsed     : 6489/6489 (100.00%)
-Positive Passed: 6486/6489 (99.95%)
+AST Parsed     : 6488/6488 (100.00%)
+Positive Passed: 6485/6488 (99.95%)
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuite.tsx
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitEntities.tsx


### PR DESCRIPTION
ESTree conformance tests check field order is correct in TS-ESTree ASTs.

This revealed some mismatches, but they were fixed by #11449.

Need to skip 1 test which is only failing due to rounding errors in floating point numbers in the `serde_json` round-trip conversion JSON -> value -> JSON.
