### PR TITLE
fix(parser): fix decorator placed incorrectly in initializers

### DIFF
--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -5,6 +5,12 @@ use crate::tester::{
 };
 
 #[test]
+fn cases() {
+    test_same("class C {\n\t@foo static accessor A = @bar class {};\n}\n");
+    test_same("function foo(@foo x = @bar class {}) {}\n");
+}
+
+#[test]
 fn decl() {
     test_minify("const [foo] = bar", "const[foo]=bar;");
     test_minify("const {foo} = bar", "const{foo}=bar;");

--- a/crates/oxc_codegen/tests/integration/main.rs
+++ b/crates/oxc_codegen/tests/integration/main.rs
@@ -1,9 +1,9 @@
 #![expect(clippy::missing_panics_doc, clippy::literal_string_with_formatting_args)]
 pub mod comments;
 pub mod esbuild;
+pub mod js;
 pub mod tester;
 pub mod ts;
-pub mod unit;
 
 use oxc_allocator::Allocator;
 use oxc_codegen::{Codegen, CodegenOptions, CodegenReturn};

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -302,6 +302,7 @@ impl<'a> ParserImpl<'a> {
         definite: bool,
         modifiers: &Modifiers<'a>,
     ) -> ClassElement<'a> {
+        let decorators = self.consume_decorators();
         let type_annotation = if self.is_ts { self.parse_ts_type_annotation() } else { None };
         let value = self.eat(Kind::Eq).then(|| self.parse_assignment_expression_or_higher());
         self.asi();
@@ -322,7 +323,7 @@ impl<'a> ParserImpl<'a> {
         self.ast.class_element_accessor_property(
             self.end_span(span),
             r#type,
-            self.consume_decorators(),
+            decorators,
             key,
             type_annotation,
             value,
@@ -341,8 +342,8 @@ impl<'a> ParserImpl<'a> {
         kind: MethodDefinitionKind,
         modifiers: &Modifiers<'a>,
     ) -> ClassElement<'a> {
-        let (name, computed) = self.parse_class_element_name(modifiers);
         let decorators = self.consume_decorators();
+        let (name, computed) = self.parse_class_element_name(modifiers);
         let value = self.parse_method(modifiers.contains(ModifierKind::Async), false);
         let method_definition = self.ast.alloc_method_definition(
             self.end_span(span),
@@ -372,8 +373,8 @@ impl<'a> ParserImpl<'a> {
         r#type: MethodDefinitionType,
         modifiers: &Modifiers<'a>,
     ) -> Option<ClassElement<'a>> {
-        let name = self.parse_constructor_name()?;
         let decorators = self.consume_decorators();
+        let name = self.parse_constructor_name()?;
         let value = self.parse_method(modifiers.contains(ModifierKind::Async), false);
         let method_definition = self.ast.alloc_method_definition(
             self.end_span(span),

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -84,9 +84,9 @@ impl<'a> ParserImpl<'a> {
         if self.at(Kind::At) {
             self.eat_decorators();
         }
+        let decorators = self.consume_decorators();
         let modifiers = self.parse_parameter_modifiers();
         let pattern = self.parse_binding_pattern_with_initializer();
-        let decorators = self.consume_decorators();
         self.ast.formal_parameter(
             self.end_span(span),
             decorators,


### PR DESCRIPTION
fixes #11452

cases:

```
class C { @foo static accessor A0 = @bar class {} }
function foo(@foo x = @bar class {}) {}
```