### PR TITLE
perf(parser): Skip `try_parse` when current token is not an identifier

### DIFF
--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1058,7 +1058,12 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_type_or_type_predicate(&mut self) -> TSType<'a> {
         let span = self.start_span();
-        let type_predicate_variable = self.try_parse(Self::parse_type_predicate_prefix);
+        let type_predicate_variable = if self.cur_kind().is_identifier_name() {
+            self.try_parse(Self::parse_type_predicate_prefix)
+        } else {
+            None
+        };
+
         let ty = self.parse_ts_type();
         if let Some(parameter_name) = type_predicate_variable {
             let type_annotation = Some(self.ast.ts_type_annotation(ty.span(), ty));


### PR DESCRIPTION
Part of #11334

Check if it is worth doing `try_parse()` for the 8️⃣th hot path.

TSC: https://github.com/microsoft/TypeScript/blob/44d46714c81e0cadf9067cc32b649c63d2a4f436/src/compiler/parser.ts#L4912