### PR TITLE
feat(span): add `Atom::from_cow_in` method

### DIFF
--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -118,10 +118,7 @@ impl<'a> AstBuilder<'a> {
     /// If the `Cow` is owned, allocates the string into arena to generate a new `Atom`.
     #[inline]
     pub fn atom_from_cow(self, value: &Cow<'a, str>) -> Atom<'a> {
-        match value {
-            Cow::Borrowed(s) => Atom::from(*s),
-            Cow::Owned(s) => self.atom(s),
-        }
+        Atom::from_cow_in(value, self.allocator)
     }
 
     /// `0`

--- a/crates/oxc_span/src/atom.rs
+++ b/crates/oxc_span/src/atom.rs
@@ -88,6 +88,20 @@ impl<'a> Atom<'a> {
     ) -> Atom<'a> {
         Self::from(allocator.alloc_concat_strs_array(strings))
     }
+
+    /// Convert a [`Cow<'a, str>`] to an [`Atom<'a>`].
+    ///
+    /// If the `Cow` borrows a string from arena, returns an `Atom` which references that same string,
+    /// without allocating a new one.
+    ///
+    /// If the `Cow` is owned, allocates the string into arena to generate a new `Atom`.
+    #[inline]
+    pub fn from_cow_in(value: &Cow<'a, str>, allocator: &'a Allocator) -> Atom<'a> {
+        match value {
+            Cow::Borrowed(s) => Atom::from(*s),
+            Cow::Owned(s) => Atom::from_in(s, allocator),
+        }
+    }
 }
 
 impl<'new_alloc> CloneIn<'new_alloc> for Atom<'_> {


### PR DESCRIPTION
Move the functionality of `AstBuilder::atom_from_cow` into new method `Atom::from_cow_in`. This allows efficiently converting a `Cow<'a, str>` to `Atom<'a>` in places where you don't have access to an `AstBuilder`.