### PR TITLE
fix(ast/estree): make error objects via raw transfer match standard transfer

### DIFF
--- a/crates/oxc_ast_macros/src/generated/structs.rs
+++ b/crates/oxc_ast_macros/src/generated/structs.rs
@@ -280,7 +280,7 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
         ("ExportAllDeclaration", StructDetails { field_order: None }),
         ("TSBooleanKeyword", StructDetails { field_order: None }),
         ("ImportAttribute", StructDetails { field_order: None }),
-        ("Error", StructDetails { field_order: Some(&[3, 0, 1, 2]) }),
+        ("Error", StructDetails { field_order: Some(&[4, 0, 1, 2, 3]) }),
         ("RawTransferData", StructDetails { field_order: None }),
         ("RegExpFlags", StructDetails { field_order: None }),
         ("RegExpLiteral", StructDetails { field_order: None }),

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -2140,10 +2140,11 @@ function deserializeRawTransferData(pos) {
 
 function deserializeError(pos) {
   return {
-    severity: deserializeErrorSeverity(pos + 56),
+    severity: deserializeErrorSeverity(pos + 72),
     message: deserializeStr(pos),
     labels: deserializeVecErrorLabel(pos + 16),
     helpMessage: deserializeOptionStr(pos + 40),
+    codeframe: deserializeStr(pos + 56),
   };
 }
 
@@ -5405,7 +5406,7 @@ function deserializeVecError(pos) {
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeError(pos));
-    pos += 64;
+    pos += 80;
   }
   return arr;
 }

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -2288,10 +2288,11 @@ function deserializeRawTransferData(pos) {
 
 function deserializeError(pos) {
   return {
-    severity: deserializeErrorSeverity(pos + 56),
+    severity: deserializeErrorSeverity(pos + 72),
     message: deserializeStr(pos),
     labels: deserializeVecErrorLabel(pos + 16),
     helpMessage: deserializeOptionStr(pos + 40),
+    codeframe: deserializeStr(pos + 56),
   };
 }
 
@@ -5553,7 +5554,7 @@ function deserializeVecError(pos) {
   pos = uint32[pos32];
   for (let i = 0; i < len; i++) {
     arr.push(deserializeError(pos));
-    pos += 64;
+    pos += 80;
   }
   return arr;
 }

--- a/napi/parser/src/generated/assert_layouts.rs
+++ b/napi/parser/src/generated/assert_layouts.rs
@@ -18,12 +18,13 @@ const _: () = {
     assert!(offset_of!(RawTransferData, errors) == 256);
 
     // Padding: 7 bytes
-    assert!(size_of::<Error>() == 64);
+    assert!(size_of::<Error>() == 80);
     assert!(align_of::<Error>() == 8);
-    assert!(offset_of!(Error, severity) == 56);
+    assert!(offset_of!(Error, severity) == 72);
     assert!(offset_of!(Error, message) == 0);
     assert!(offset_of!(Error, labels) == 16);
     assert!(offset_of!(Error, help_message) == 40);
+    assert!(offset_of!(Error, codeframe) == 56);
 
     assert!(size_of::<ErrorSeverity>() == 1);
     assert!(align_of::<ErrorSeverity>() == 1);
@@ -68,12 +69,13 @@ const _: () = {
     assert!(offset_of!(RawTransferData, errors) == 172);
 
     // Padding: 3 bytes
-    assert!(size_of::<Error>() == 36);
+    assert!(size_of::<Error>() == 44);
     assert!(align_of::<Error>() == 4);
-    assert!(offset_of!(Error, severity) == 32);
+    assert!(offset_of!(Error, severity) == 40);
     assert!(offset_of!(Error, message) == 0);
     assert!(offset_of!(Error, labels) == 8);
     assert!(offset_of!(Error, help_message) == 24);
+    assert!(offset_of!(Error, codeframe) == 32);
 
     assert!(size_of::<ErrorSeverity>() == 1);
     assert!(align_of::<ErrorSeverity>() == 1);

--- a/napi/parser/src/generated/derive_estree.rs
+++ b/napi/parser/src/generated/derive_estree.rs
@@ -27,6 +27,7 @@ impl ESTree for Error<'_> {
         state.serialize_field("message", &self.message);
         state.serialize_field("labels", &self.labels);
         state.serialize_field("helpMessage", &self.help_message);
+        state.serialize_field("codeframe", &self.codeframe);
         state.end();
     }
 }

--- a/napi/parser/src/raw_transfer_types.rs
+++ b/napi/parser/src/raw_transfer_types.rs
@@ -1,10 +1,12 @@
+use std::sync::Arc;
+
 use rustc_hash::FxHashMap;
 
 use oxc::{
     allocator::{Allocator, FromIn, Vec},
     ast::ast::{Comment, Program},
-    diagnostics::{LabeledSpan, OxcDiagnostic, Severity},
-    span::{Atom, Span},
+    diagnostics::{LabeledSpan, NamedSource, OxcDiagnostic, Severity},
+    span::{Atom, Span, format_atom},
     syntax::module_record::{DynamicImport, ExportEntry, ImportEntry, ModuleRecord, NameSpan},
 };
 use oxc_ast_macros::ast;
@@ -35,10 +37,31 @@ pub struct Error<'a> {
     pub message: Atom<'a>,
     pub labels: Vec<'a, ErrorLabel<'a>>,
     pub help_message: Option<Atom<'a>>,
+    pub codeframe: Atom<'a>,
 }
 
-impl<'a> FromIn<'a, &OxcDiagnostic> for Error<'a> {
-    fn from_in(diagnostic: &OxcDiagnostic, allocator: &'a Allocator) -> Self {
+impl<'a> Error<'a> {
+    pub(crate) fn from_diagnostics_in(
+        diagnostics: impl IntoIterator<Item = OxcDiagnostic>,
+        source_text: &str,
+        filename: &str,
+        allocator: &'a Allocator,
+    ) -> Vec<'a, Self> {
+        let named_source = Arc::new(NamedSource::new(filename, source_text.to_string()));
+
+        Vec::from_iter_in(
+            diagnostics
+                .into_iter()
+                .map(|diagnostic| Self::from_diagnostic_in(diagnostic, &named_source, allocator)),
+            allocator,
+        )
+    }
+
+    fn from_diagnostic_in(
+        diagnostic: OxcDiagnostic,
+        named_source: &Arc<NamedSource<String>>,
+        allocator: &'a Allocator,
+    ) -> Self {
         let labels = diagnostic.labels.as_ref().map_or_else(
             || Vec::new_in(allocator),
             |labels| {
@@ -49,15 +72,15 @@ impl<'a> FromIn<'a, &OxcDiagnostic> for Error<'a> {
             },
         );
 
-        Self {
-            severity: ErrorSeverity::from(diagnostic.severity),
-            message: Atom::from_in(diagnostic.message.as_ref(), allocator),
-            labels,
-            help_message: diagnostic
-                .help
-                .as_ref()
-                .map(|help| Atom::from_in(help.as_ref(), allocator)),
-        }
+        let severity = ErrorSeverity::from(diagnostic.severity);
+        let message = Atom::from_in(diagnostic.message.as_ref(), allocator);
+        let help_message =
+            diagnostic.help.as_ref().map(|help| Atom::from_in(help.as_ref(), allocator));
+        let report = diagnostic.with_source_code(Arc::clone(named_source));
+        let codeframe = format_atom!(allocator, "{report:?}");
+
+        #[expect(clippy::inconsistent_struct_constructor)] // `#[ast]` macro re-orders struct fields
+        Self { severity, message, labels, help_message, codeframe }
     }
 }
 
@@ -90,10 +113,10 @@ pub struct ErrorLabel<'a> {
 }
 
 impl<'a> FromIn<'a, &LabeledSpan> for ErrorLabel<'a> {
-    #[expect(clippy::cast_possible_truncation)]
     fn from_in(label: &LabeledSpan, allocator: &'a Allocator) -> Self {
         Self {
             message: label.label().map(|message| Atom::from_in(message, allocator)),
+            #[expect(clippy::cast_possible_truncation)]
             span: Span::new(label.offset() as u32, (label.offset() + label.len()) as u32),
         }
     }

--- a/napi/parser/test/parse-raw.test.ts
+++ b/napi/parser/test/parse-raw.test.ts
@@ -184,8 +184,10 @@ describe('TypeScript', () => {
         const errorsStandard = standard.errors;
 
         expect(oxcJson).toEqual(standardJson);
-        expect(errors.length).toEqual(errorsStandard.length);
-        // expect(errors).toEqual(errorsStandard); // TODO
+
+        const errorsRawJson = JSON.stringify(clean(errors), null, 2);
+        const errorsStandardJson = JSON.stringify(errorsStandard, null, 2);
+        expect(errorsRawJson).toEqual(errorsStandardJson);
       }
     }
   });


### PR DESCRIPTION
Add `codeframe` property to errors returned by `parseSync` / `parseAsync` when using raw transfer. This matches the shape of error objects without raw transfer.