### PR TITLE
feat(parser): syntax errors for decorators appearing in conflicting places

### DIFF
--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -84,6 +84,8 @@ fn class() {
         "export class Test2 {\n@decorator\nproperty: ((arg: any) => any) | undefined;\n}",
         "export class Test2 {\n\t@decorator property: ((arg: any) => any) | undefined;\n}\n",
     );
+    test_same("export @dec1 @dec2 class C {}\n");
+    test_same("export default @dec1 @dec2 class {}\n");
     test_minify("class { static [computed] }", "class{static[computed]}");
 }
 

--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -295,8 +295,21 @@ impl<'a> ParserImpl<'a> {
         result
     }
 
+    /// Consume all decorators.
     pub(crate) fn consume_decorators(&mut self) -> Vec<'a, Decorator<'a>> {
         self.state.decorators.take_in(self.ast)
+    }
+
+    /// Parse and save all decorators.
+    pub(crate) fn parse_and_save_decorators(&mut self) {
+        // For `@dec1 export default @dec2 class {}`
+        for decorator in &mut self.state.decorators {
+            self.errors.push(diagnostics::decorators_in_export_and_class(decorator.span));
+        }
+        while self.at(Kind::At) {
+            let decorator = self.parse_decorator();
+            self.state.decorators.push(decorator);
+        }
     }
 
     pub(crate) fn parse_normal_list<F, T>(&mut self, open: Kind, close: Kind, f: F) -> Vec<'a, T>

--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -641,3 +641,8 @@ pub fn index_signature_type_annotation(span: Span) -> OxcDiagnostic {
 pub fn unexpected_export(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Unexpected export.").with_label(span)
 }
+
+#[cold]
+pub fn decorators_in_export_and_class(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Decorators may not appear after 'export' or 'export default' if they also appear before 'export'.").with_label(span)
+}

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -159,7 +159,7 @@ impl<'a> ParserImpl<'a> {
         let span = self.start_span();
 
         if self.at(Kind::At) {
-            self.eat_decorators();
+            self.parse_and_save_decorators();
         }
 
         // FunctionExpression, GeneratorExpression

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -82,7 +82,7 @@ impl<'a> ParserImpl<'a> {
     fn parse_formal_parameter(&mut self) -> FormalParameter<'a> {
         let span = self.start_span();
         if self.at(Kind::At) {
-            self.eat_decorators();
+            self.parse_and_save_decorators();
         }
         let decorators = self.consume_decorators();
         let modifiers = self.parse_parameter_modifiers();

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -472,7 +472,7 @@ impl<'a> ParserImpl<'a> {
         // For tc39/proposal-decorators
         // For more information, please refer to <https://babeljs.io/docs/babel-plugin-proposal-decorators#decoratorsbeforeexport>
         if self.at(Kind::At) {
-            self.eat_decorators();
+            self.parse_and_save_decorators();
         }
         let reserved_ctx = self.ctx;
         let modifiers =
@@ -510,7 +510,7 @@ impl<'a> ParserImpl<'a> {
         // For tc39/proposal-decorators
         // For more information, please refer to <https://babeljs.io/docs/babel-plugin-proposal-decorators#decoratorsbeforeexport>
         if self.at(Kind::At) {
-            self.eat_decorators();
+            self.parse_and_save_decorators();
         }
         let declaration = match self.cur_kind() {
             Kind::Class => ExportDefaultDeclarationKind::ClassDeclaration(

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -87,7 +87,7 @@ impl<'a> ParserImpl<'a> {
             self.lexer.trivia_builder.previous_token_has_no_side_effects_comment();
 
         if self.at(Kind::At) {
-            self.eat_decorators();
+            self.parse_and_save_decorators();
         }
 
         let mut stmt = match self.cur_kind() {

--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -373,7 +373,7 @@ impl<'a> ParserImpl<'a> {
 
         // parse leading decorators
         if allow_decorators && self.at(Kind::At) {
-            self.eat_decorators();
+            self.parse_and_save_decorators();
         }
 
         // parse leading modifiers
@@ -393,7 +393,7 @@ impl<'a> ParserImpl<'a> {
 
         // parse trailing decorators, but only if we parsed any leading modifiers
         if allow_decorators && has_leading_modifier && self.at(Kind::At) {
-            self.eat_decorators();
+            self.parse_and_save_decorators();
         }
 
         // parse trailing modifiers, but only if we parsed any trailing decorators

--- a/crates/oxc_parser/src/state.rs
+++ b/crates/oxc_parser/src/state.rs
@@ -24,7 +24,8 @@ impl<'a> ParserState<'a> {
     pub fn new(allocator: &'a Allocator) -> Self {
         Self {
             not_parenthesized_arrow: FxHashSet::default(),
-            decorators: ArenaVec::new_in(allocator),
+            // Create a large enough buffer for most cases.
+            decorators: ArenaVec::with_capacity_in(4, allocator),
             cover_initialized_name: FxHashMap::default(),
             trailing_commas: FxHashMap::default(),
         }

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -480,7 +480,7 @@ impl<'a> ParserImpl<'a> {
         let span = self.start_span();
         self.parse_class_element_modifiers(true);
         if self.at(Kind::At) {
-            self.eat_decorators();
+            self.parse_and_save_decorators();
         }
 
         let this_span = self.start_span();
@@ -489,16 +489,6 @@ impl<'a> ParserImpl<'a> {
 
         let type_annotation = self.parse_ts_type_annotation();
         self.ast.ts_this_parameter(self.end_span(span), this, type_annotation)
-    }
-
-    pub(crate) fn eat_decorators(&mut self) {
-        let mut decorators = self.ast.vec();
-        while self.at(Kind::At) {
-            let decorator = self.parse_decorator();
-            decorators.push(decorator);
-        }
-
-        self.state.decorators = decorators;
     }
 
     pub(crate) fn at_start_of_ts_declaration(&mut self) -> bool {

--- a/tasks/coverage/misc/fail/oxc-11472.js
+++ b/tasks/coverage/misc/fail/oxc-11472.js
@@ -1,0 +1,3 @@
+@dec1 export @dec2 class C {}
+
+@dec1 export default @dec2 class {}

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 36/36 (100.00%)
 Positive Passed: 36/36 (100.00%)
-Negative Passed: 35/35 (100.00%)
+Negative Passed: 36/36 (100.00%)
 
   × Identifier `b` has already been declared
    ╭─[misc/fail/oxc-10159.js:1:22]
@@ -33,6 +33,20 @@ Negative Passed: 35/35 (100.00%)
   × Expected `from` but found `EOF`
    ╭─[misc/fail/oxc-11453.js:2:1]
  1 │ export import
+   ╰────
+
+  × Decorators may not appear after 'export' or 'export default' if they also appear before 'export'.
+   ╭─[misc/fail/oxc-11472.js:1:1]
+ 1 │ @dec1 export @dec2 class C {}
+   · ─────
+ 2 │ 
+   ╰────
+
+  × Decorators may not appear after 'export' or 'export default' if they also appear before 'export'.
+   ╭─[misc/fail/oxc-11472.js:3:1]
+ 2 │ 
+ 3 │ @dec1 export default @dec2 class {}
+   · ─────
    ╰────
 
   × Unexpected token


### PR DESCRIPTION
fixes #11472

e.g.

```
@dec1 export @dec2 class C {}

@dec1 export default @dec2 class {}
```