### PR TITLE
refactor(parser): rewrite arrow function parsing to remove rewind in hot paths

### DIFF
--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -44,9 +44,12 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_formal_parameters(
         &mut self,
         params_kind: FormalParameterKind,
+        after_paren: bool,
     ) -> (Option<TSThisParameter<'a>>, Box<'a, FormalParameters<'a>>) {
         let span = self.start_span();
-        self.expect(Kind::LParen);
+        if !after_paren {
+            self.expect(Kind::LParen);
+        }
         let this_param = if self.is_ts && self.at(Kind::This) {
             let param = self.parse_ts_this_parameter();
             if !self.at(Kind::RParen) {
@@ -112,7 +115,7 @@ impl<'a> ParserImpl<'a> {
 
         let type_parameters = self.parse_ts_type_parameters();
 
-        let (this_param, params) = self.parse_formal_parameters(param_kind);
+        let (this_param, params) = self.parse_formal_parameters(param_kind, false);
 
         let return_type =
             self.parse_ts_return_type_annotation(Kind::Colon, /* is_type */ true);

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -55,7 +55,8 @@ impl<'a> ParserImpl<'a> {
         let r#abstract = self.eat(Kind::Abstract);
         let is_constructor_type = self.eat(Kind::New);
         let type_parameters = self.parse_ts_type_parameters();
-        let (this_param, params) = self.parse_formal_parameters(FormalParameterKind::Signature);
+        let (this_param, params) =
+            self.parse_formal_parameters(FormalParameterKind::Signature, false);
         let return_type = {
             let return_type_span = self.start_span();
             let Some(return_type) = self.parse_return_type(Kind::Arrow, /* is_type */ false) else {
@@ -1101,7 +1102,8 @@ impl<'a> ParserImpl<'a> {
             self.expect(Kind::New);
         }
         let type_parameters = self.parse_ts_type_parameters();
-        let (this_param, params) = self.parse_formal_parameters(FormalParameterKind::Signature);
+        let (this_param, params) =
+            self.parse_formal_parameters(FormalParameterKind::Signature, false);
         if kind == CallOrConstructorSignature::Constructor {
             if let Some(this_param) = &this_param {
                 // interface Foo { new(this: number): Foo }
@@ -1135,7 +1137,8 @@ impl<'a> ParserImpl<'a> {
         kind: TSMethodSignatureKind,
     ) -> TSSignature<'a> {
         let (key, computed) = self.parse_property_name();
-        let (this_param, params) = self.parse_formal_parameters(FormalParameterKind::Signature);
+        let (this_param, params) =
+            self.parse_formal_parameters(FormalParameterKind::Signature, false);
         let return_type = self.parse_ts_return_type_annotation(Kind::Colon, false);
         self.parse_type_member_semicolon();
         if kind == TSMethodSignatureKind::Set {
@@ -1168,7 +1171,8 @@ impl<'a> ParserImpl<'a> {
 
         if self.at(Kind::LParen) || self.at(Kind::LAngle) {
             let type_parameters = self.parse_ts_type_parameters();
-            let (this_param, params) = self.parse_formal_parameters(FormalParameterKind::Signature);
+            let (this_param, params) =
+                self.parse_formal_parameters(FormalParameterKind::Signature, false);
             let return_type = self.parse_ts_return_type_annotation(Kind::Colon, true);
             self.parse_type_member_semicolon();
             self.ast.ts_signature_method_signature(

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -5378,11 +5378,10 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Did you mean to use a ':'? An '=' can only follow a property name when the containing object literal is part of a destructuring pattern.
 
-  × Expected `,` but found `?`
-   ╭─[babel/packages/babel-parser/test/fixtures/es2017/async-call/with-optional-operator/input.js:1:8]
+  × Unexpected token
+   ╭─[babel/packages/babel-parser/test/fixtures/es2017/async-call/with-optional-operator/input.js:1:9]
  1 │ async(x?)
-   ·        ┬
-   ·        ╰── `,` expected
+   ·         ─
    ╰────
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
@@ -8923,11 +8922,10 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·     ───
    ╰────
 
-  × Expected `=>` but found `+`
-   ╭─[babel/packages/babel-parser/test/fixtures/esprima/es2015-arrow-function/rest-without-arrow/input.js:1:8]
+  × Unexpected token
+   ╭─[babel/packages/babel-parser/test/fixtures/esprima/es2015-arrow-function/rest-without-arrow/input.js:1:2]
  1 │ (...a) + 1
-   ·        ┬
-   ·        ╰── `=>` expected
+   ·  ───
    ╰────
 
   × Cannot assign to 'eval' in strict mode
@@ -11844,9 +11842,10 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    · ────
    ╰────
 
-  × Expected `=>` but found `EOF`
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/async-call/with-optional-parameter/input.ts:1:10]
+  × Unexpected token
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/async-call/with-optional-parameter/input.ts:1:9]
  1 │ async(x?)
+   ·         ─
    ╰────
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
@@ -11907,11 +11906,11 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·      ───────
    ╰────
 
-  × Expected `=>` but found `;`
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/cast/invalid/input.ts:1:6]
+  × Expected `,` but found `:`
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/cast/invalid/input.ts:1:3]
  1 │ (a:b);
-   ·      ┬
-   ·      ╰── `=>` expected
+   ·   ┬
+   ·   ╰── `,` expected
  2 │ (a:b,c:d);
    ╰────
 

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -11579,12 +11579,12 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  7 │ 
    ╰────
 
-  × Expected `=>` but found `.`
-    ╭─[typescript/tests/cases/compiler/destructuringControlFlowNoCrash.ts:11:28]
+  × Expected `,` but found `:`
+    ╭─[typescript/tests/cases/compiler/destructuringControlFlowNoCrash.ts:11:22]
  10 │   date2,
  11 │ } = (inspectedElement: any).props;
-    ·                            ┬
-    ·                            ╰── `=>` expected
+    ·                      ┬
+    ·                      ╰── `,` expected
  12 │ 
     ╰────
 
@@ -26826,10 +26826,11 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·                                                      ╰── `,` expected
    ╰────
 
-  × Unexpected token
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ArrowFunctions/ArrowFunction1.ts:1:13]
+  × Expected `,` but found `:`
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ArrowFunctions/ArrowFunction1.ts:1:11]
  1 │ var v = (a: ) => {
-   ·             ─
+   ·           ┬
+   ·           ╰── `,` expected
  2 │    
    ╰────
 
@@ -26841,10 +26842,11 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╰────
   help: Try insert a semicolon here
 
-  × Unexpected token
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ArrowFunctions/parserX_ArrowFunction1.ts:1:13]
+  × Expected `,` but found `:`
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ArrowFunctions/parserX_ArrowFunction1.ts:1:11]
  1 │ var v = (a: ) => {
-   ·             ─
+   ·           ┬
+   ·           ╰── `,` expected
  2 │    
    ╰────
 
@@ -27102,11 +27104,11 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  2 │ }
    ╰────
 
-  × Expected `,` but found `=>`
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ParameterLists/parserErrorRecovery_ParameterList5.ts:1:11]
+  × Expected `,` but found `:`
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ParameterLists/parserErrorRecovery_ParameterList5.ts:1:3]
  1 │ (a:number => { }
-   ·           ─┬
-   ·            ╰── `,` expected
+   ·   ┬
+   ·   ╰── `,` expected
    ╰────
 
   × Unexpected token
@@ -27992,11 +27994,12 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  4 │ }
    ╰────
 
-  × Empty parenthesized expression
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509669.ts:2:9]
+  × Expected `=>` but found `{`
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509669.ts:2:17]
  1 │ function foo():any {
  2 │  return ():void {};
-   ·         ──
+   ·                 ┬
+   ·                 ╰── `=>` expected
  3 │ }
    ╰────
 


### PR DESCRIPTION
This is a major work-in-progress. May not even be merged.