### PR TITLE
test(editor): remove useless test + improve speed

### DIFF
--- a/editors/vscode/fixtures/cross_module/.oxlintrc.json
+++ b/editors/vscode/fixtures/cross_module/.oxlintrc.json
@@ -1,8 +1,0 @@
-{
-  "plugins": [
-    "import"
-  ],
-  "rules": {
-    "import/no-cycle": "error"
-  }
-}

--- a/editors/vscode/fixtures/cross_module/debugger.ts
+++ b/editors/vscode/fixtures/cross_module/debugger.ts
@@ -1,2 +1,0 @@
-// Debugger should be shown as a warning
-debugger;

--- a/editors/vscode/fixtures/cross_module/dep-a.ts
+++ b/editors/vscode/fixtures/cross_module/dep-a.ts
@@ -1,4 +1,0 @@
-// should report cycle detected
-import { b } from './dep-b.ts';
-
-b();

--- a/editors/vscode/fixtures/cross_module/dep-b.ts
+++ b/editors/vscode/fixtures/cross_module/dep-b.ts
@@ -1,4 +1,0 @@
-// this file is also included in dep-a.ts and dep-a.ts should report a no-cycle diagnostic
-import './dep-a.ts';
-
-export function b() { /* ... */ }

--- a/editors/vscode/fixtures/cross_module_extended_config/.oxlintrc.json
+++ b/editors/vscode/fixtures/cross_module_extended_config/.oxlintrc.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "./config/.oxlintrc.json"
-  ]
-}

--- a/editors/vscode/fixtures/cross_module_extended_config/config/.oxlintrc.json
+++ b/editors/vscode/fixtures/cross_module_extended_config/config/.oxlintrc.json
@@ -1,8 +1,0 @@
-{
-  "plugins": [
-    "import"
-  ],
-  "rules": {
-    "import/no-cycle": "error"
-  }
-}

--- a/editors/vscode/fixtures/cross_module_extended_config/dep-a.ts
+++ b/editors/vscode/fixtures/cross_module_extended_config/dep-a.ts
@@ -1,4 +1,0 @@
-// should report cycle detected
-import { b } from './dep-b.ts';
-
-b();

--- a/editors/vscode/fixtures/cross_module_extended_config/dep-b.ts
+++ b/editors/vscode/fixtures/cross_module_extended_config/dep-b.ts
@@ -1,4 +1,0 @@
-// this file is also included in dep-a.ts and dep-a.ts should report a no-cycle diagnostic
-import './dep-a.ts';
-
-export function b() { /* ... */ }

--- a/editors/vscode/fixtures/cross_module_nested_config/dep-a.ts
+++ b/editors/vscode/fixtures/cross_module_nested_config/dep-a.ts
@@ -1,4 +1,0 @@
-// should report cycle detected
-import { b } from './dep-b.ts';
-
-b();

--- a/editors/vscode/fixtures/cross_module_nested_config/dep-b.ts
+++ b/editors/vscode/fixtures/cross_module_nested_config/dep-b.ts
@@ -1,4 +1,0 @@
-// this file is also included in dep-a.ts and dep-a.ts should report a no-cycle diagnostic
-import './dep-a.ts';
-
-export function b() { /* ... */ }

--- a/editors/vscode/fixtures/cross_module_nested_config/folder/.oxlintrc.json
+++ b/editors/vscode/fixtures/cross_module_nested_config/folder/.oxlintrc.json
@@ -1,8 +1,0 @@
-{
-  "plugins": [
-    "import"
-  ],
-  "rules": {
-    "import/no-cycle": "error"
-  }
-}

--- a/editors/vscode/fixtures/cross_module_nested_config/folder/folder-dep-a.ts
+++ b/editors/vscode/fixtures/cross_module_nested_config/folder/folder-dep-a.ts
@@ -1,4 +1,0 @@
-// should report cycle detected
-import { b } from './folder-dep-b.ts';
-
-b();

--- a/editors/vscode/fixtures/cross_module_nested_config/folder/folder-dep-b.ts
+++ b/editors/vscode/fixtures/cross_module_nested_config/folder/folder-dep-b.ts
@@ -1,4 +1,0 @@
-// this file is also included in folder-dep-a.ts and folder-dep-a.ts should report a no-cycle diagnostic
-import './folder-dep-a.ts';
-
-export function b() { /* ... */ }

--- a/editors/vscode/fixtures/nested_config/.oxlintrc.json
+++ b/editors/vscode/fixtures/nested_config/.oxlintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "no-debugger": "warn"
-  }
-}

--- a/editors/vscode/fixtures/nested_config/folder/.oxlintrc.json
+++ b/editors/vscode/fixtures/nested_config/folder/.oxlintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "no-debugger": "error"
-  }
-}

--- a/editors/vscode/fixtures/nested_config/folder/index.ts
+++ b/editors/vscode/fixtures/nested_config/folder/index.ts
@@ -1,1 +1,0 @@
-debugger;

--- a/editors/vscode/fixtures/nested_config/index.ts
+++ b/editors/vscode/fixtures/nested_config/index.ts
@@ -1,1 +1,0 @@
-debugger;

--- a/editors/vscode/tests/e2e_server.spec.ts
+++ b/editors/vscode/tests/e2e_server.spec.ts
@@ -155,30 +155,17 @@ suite('E2E Diagnostics', () => {
     strictEqual(contentWithFixAll.toString(), 'if (foo === null) { bar();}');
   });
 
-  test('nested configs severity', async () => {
-    await loadFixture('nested_config');
-    const rootDiagnostics = await getDiagnostics('index.ts');
-    const nestedDiagnostics = await getDiagnostics('folder/index.ts');
-
-    assert(typeof rootDiagnostics[0].code == 'object');
-    strictEqual(rootDiagnostics[0].code.target.authority, 'oxc.rs');
-    strictEqual(rootDiagnostics[0].severity, DiagnosticSeverity.Warning);
-
-    assert(typeof nestedDiagnostics[0].code == 'object');
-    strictEqual(nestedDiagnostics[0].code.target.authority, 'oxc.rs');
-    strictEqual(nestedDiagnostics[0].severity, DiagnosticSeverity.Error);
-  });
-
   testMultiFolderMode('different diagnostic severity', async () => {
     await loadFixture('debugger', WORKSPACE_DIR);
-    await loadFixture('debugger_error', WORKSPACE_SECOND_DIR);
-
     const firstDiagnostics = await getDiagnostics('debugger.js', WORKSPACE_DIR);
-    const secondDiagnostics = await getDiagnostics('debugger.js', WORKSPACE_SECOND_DIR);
 
     assert(typeof firstDiagnostics[0].code == 'object');
     strictEqual(firstDiagnostics[0].code.target.authority, 'oxc.rs');
     strictEqual(firstDiagnostics[0].severity, DiagnosticSeverity.Warning);
+
+    await loadFixture('debugger_error', WORKSPACE_SECOND_DIR);
+    await sleep(500);
+    const secondDiagnostics = await getDiagnostics('debugger.js', WORKSPACE_SECOND_DIR);
 
     assert(typeof secondDiagnostics[0].code == 'object');
     strictEqual(secondDiagnostics[0].code.target.authority, 'oxc.rs');
@@ -217,55 +204,5 @@ suite('E2E Diagnostics', () => {
     assert(typeof secondDiagnostics[0].code == 'object');
     strictEqual(secondDiagnostics[0].code.target.authority, 'oxc.rs');
     strictEqual(secondDiagnostics[0].severity, DiagnosticSeverity.Error);
-  });
-
-  test('cross module', async () => {
-    await loadFixture('cross_module');
-    const diagnostics = await getDiagnostics('dep-a.ts');
-
-    strictEqual(diagnostics.length, 1);
-    assert(typeof diagnostics[0].code == 'object');
-    strictEqual(diagnostics[0].code.target.authority, 'oxc.rs');
-    assert(
-      diagnostics[0].message.startsWith("Dependency cycle detected"),
-    );
-    strictEqual(diagnostics[0].severity, DiagnosticSeverity.Error);
-    strictEqual(diagnostics[0].range.start.line, 1);
-    strictEqual(diagnostics[0].range.start.character, 18);
-    strictEqual(diagnostics[0].range.end.line, 1);
-    strictEqual(diagnostics[0].range.end.character, 30);
-  });
-
-  test('cross module with nested config', async () => {
-    await loadFixture('cross_module_nested_config');
-    const diagnostics = await getDiagnostics('folder/folder-dep-a.ts');
-
-    strictEqual(diagnostics.length, 1);
-    assert(typeof diagnostics[0].code == 'object');
-    strictEqual(diagnostics[0].code.target.authority, 'oxc.rs');
-    assert(
-      diagnostics[0].message.startsWith("Dependency cycle detected"),
-    );
-    strictEqual(diagnostics[0].severity, DiagnosticSeverity.Error);
-    strictEqual(diagnostics[0].range.start.line, 1);
-    strictEqual(diagnostics[0].range.start.character, 18);
-    strictEqual(diagnostics[0].range.end.line, 1);
-    strictEqual(diagnostics[0].range.end.character, 37);
-  });
-
-  test('cross module with extended config', async () => {
-    await loadFixture('cross_module_extended_config');
-    const diagnostics = await getDiagnostics('dep-a.ts');
-
-    assert(typeof diagnostics[0].code == 'object');
-    strictEqual(diagnostics[0].code.target.authority, 'oxc.rs');
-    assert(
-      diagnostics[0].message.startsWith("Dependency cycle detected"),
-    );
-    strictEqual(diagnostics[0].severity, DiagnosticSeverity.Error);
-    strictEqual(diagnostics[0].range.start.line, 1);
-    strictEqual(diagnostics[0].range.start.character, 18);
-    strictEqual(diagnostics[0].range.end.line, 1);
-    strictEqual(diagnostics[0].range.end.character, 30);
   });
 });

--- a/editors/vscode/tests/test-helpers.ts
+++ b/editors/vscode/tests/test-helpers.ts
@@ -103,7 +103,6 @@ export async function loadFixture(fixture: string, workspaceDir: Uri = fixturesW
 export async function getDiagnostics(file: string, workspaceDir: Uri = fixturesWorkspaceUri()): Promise<Diagnostic[]> {
   const fileUri = Uri.joinPath(workspaceDir, 'fixtures', file);
   await window.showTextDocument(fileUri);
-  await sleep(500);
   const diagnostics = languages.getDiagnostics(fileUri);
   await commands.executeCommand('workbench.action.closeActiveEditor');
   return diagnostics;


### PR DESCRIPTION
Because VSCode supports the Pull Diagnostics Mode, some tests are now 100% Linter logic and not need to be in the editor. 
These tests are already existing on the language server side.