### PR TITLE
fix(parser): handle `import {type as as}` correctly

### DIFF
--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -15,6 +15,7 @@ fn cases() {
         "class Foo {\n\t#name: string;\n\tf() {\n\t\t#name in other && this.#name === other.#name;\n\t}\n}\n",
     );
     test_same("class B {\n\tconstructor(override readonly a: number) {}\n}\n");
+    test_same("export { type as as };\n");
 }
 
 #[test]

--- a/tasks/coverage/misc/fail/oxc-11484.ts
+++ b/tasks/coverage/misc/fail/oxc-11484.ts
@@ -1,0 +1,1 @@
+import { type as as }

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 37/37 (100.00%)
 Positive Passed: 37/37 (100.00%)
-Negative Passed: 37/37 (100.00%)
+Negative Passed: 38/38 (100.00%)
 
   × Identifier `b` has already been declared
    ╭─[misc/fail/oxc-10159.js:1:22]
@@ -47,6 +47,11 @@ Negative Passed: 37/37 (100.00%)
  2 │ 
  3 │ @dec1 export default @dec2 class {}
    · ─────
+   ╰────
+
+  × Expected `from` but found `EOF`
+   ╭─[misc/fail/oxc-11484.ts:2:1]
+ 1 │ import { type as as }
    ╰────
 
   × Unexpected token


### PR DESCRIPTION
- closes https://github.com/oxc-project/oxc/issues/11484