### PR TITLE
fix(minifier): fix incorrect span when performing collapse variable declarations

### DIFF
--- a/crates/oxc_minifier/examples/minifier.rs
+++ b/crates/oxc_minifier/examples/minifier.rs
@@ -58,7 +58,7 @@ fn minify(
             minify: nospace,
             comments: false,
             annotation_comments: false,
-            legal_comments: oxc_codegen::LegalComment::Eof,
+            legal_comments: oxc_codegen::LegalComment::Inline,
             ..CodegenOptions::default()
         })
         .with_scoping(ret.scoping)

--- a/crates/oxc_minifier/src/peephole/collapse_variable_declarations.rs
+++ b/crates/oxc_minifier/src/peephole/collapse_variable_declarations.rs
@@ -30,6 +30,8 @@ mod test {
                 "var x = 2; foo(x); x = 3; x = 1; var y = 2; var z = 4; x = 5",
                 "var x = 2; foo(x), x = 3, x = 1; var y = 2, z = 4; x = 5",
             );
+
+            test("/* comment */const a = 1; const b = 2", "/* comment */const a = 1, b = 2");
         }
 
         #[test]

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -375,9 +375,9 @@ impl<'a> PeepholeOptimizations {
     ) {
         if let Some(Statement::VariableDeclaration(prev_var_decl)) = result.last_mut() {
             if var_decl.kind == prev_var_decl.kind {
-                var_decl.declarations.splice(0..0, prev_var_decl.declarations.drain(..));
-                result.pop();
+                prev_var_decl.declarations.extend(var_decl.declarations.drain(..));
                 state.changed = true;
+                return;
             }
         }
         result.push(Statement::VariableDeclaration(var_decl));


### PR DESCRIPTION
fixes https://github.com/rolldown/rolldown/issues/4796

Incorrect span causes comments not being preserved.