### PR TITLE
fix(ast): emit parameter decorators in js estree

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1812,7 +1812,6 @@ pub struct FormalParameters<'a> {
 pub struct FormalParameter<'a> {
     #[estree(skip)]
     pub span: Span,
-    #[ts]
     pub decorators: Vec<'a, Decorator<'a>>,
     #[estree(flatten)]
     pub pattern: BindingPattern<'a>,


### PR DESCRIPTION
fixes #11485

Stage 3 parameter decorator is not in the spec, it is a possible future
extension: https://github.com/tc39/proposal-decorators/blob/master/EXTENSIONS.md#parameter-decorators-and-annotations

```js
var obj = {
  method(@foo x) {},
};

function method(@foo x) {}
```

BUT, it's adopted in the ecosystem, and babel can process and produce an AST.

There shouldn't be any conformance changes because this is invalid syntax :-)