### PR TITLE
feat(parser): produce syntax error for decorators on overload

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -651,3 +651,9 @@ pub fn decorators_in_export_and_class(span: Span) -> OxcDiagnostic {
 pub fn decorators_are_not_valid_here(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Decorators are not valid here.").with_label(span)
 }
+
+#[cold]
+pub fn decorator_on_overload(span: Span) -> OxcDiagnostic {
+    ts_error("1249", "A decorator can only decorate a method implementation, not an overload.")
+        .with_label(span)
+}

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -192,6 +192,13 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_class_element(&mut self) -> ClassElement<'a> {
         let elem = self.parse_class_element_impl();
+        if let ClassElement::MethodDefinition(def) = &elem {
+            if def.value.body.is_none() && !def.decorators.is_empty() {
+                for decorator in &def.decorators {
+                    self.error(diagnostics::decorator_on_overload(decorator.span));
+                }
+            }
+        }
         self.check_unconsumed_decorators();
         elem
     }

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: 81c95189
 parser_typescript Summary:
 AST Parsed     : 6530/6537 (99.89%)
 Positive Passed: 6519/6537 (99.72%)
-Negative Passed: 1396/5763 (24.22%)
+Negative Passed: 1399/5763 (24.28%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration24.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
@@ -5016,8 +5016,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/decorator
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod8.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethodOverload1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty11.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty6.ts
@@ -5796,8 +5794,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es7/expon
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndValidOperands.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/accessors/esDecorators-classDeclaration-accessors-nonStaticAbstract.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-classDecorator.1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-classDecorator.2.ts
@@ -5843,8 +5839,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/esDecorat
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-nonStaticAmbient.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-staticAmbient.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/methods/esDecorators-classDeclaration-methods-nonStaticAbstract.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.1.ts
 
@@ -20984,6 +20978,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  5 │ }
    ╰────
 
+  × TS(1249): A decorator can only decorate a method implementation, not an overload.
+   ╭─[typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethodOverload1.ts:4:5]
+ 3 │ class C {
+ 4 │     @dec
+   ·     ────
+ 5 │     method()
+   ╰────
+
   × await expression not allowed in formal parameter
    ╭─[typescript/tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodParameter3.ts:5:23]
  4 │   class Class {
@@ -24256,6 +24258,54 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │ }
    ╰────
 
+  × TS(1249): A decorator can only decorate a method implementation, not an overload.
+   ╭─[typescript/tests/cases/conformance/esDecorators/classDeclaration/accessors/esDecorators-classDeclaration-accessors-nonStaticAbstract.ts:6:5]
+ 5 │ abstract class C {
+ 6 │     @dec(11) abstract get method1(): number;
+   ·     ────────
+ 7 │     @dec(12) abstract set method1(value);
+   ╰────
+
+  × TS(1249): A decorator can only decorate a method implementation, not an overload.
+   ╭─[typescript/tests/cases/conformance/esDecorators/classDeclaration/accessors/esDecorators-classDeclaration-accessors-nonStaticAbstract.ts:7:5]
+ 6 │     @dec(11) abstract get method1(): number;
+ 7 │     @dec(12) abstract set method1(value);
+   ·     ────────
+ 8 │     @dec(21) abstract get ["method2"](): number;
+   ╰────
+
+  × TS(1249): A decorator can only decorate a method implementation, not an overload.
+   ╭─[typescript/tests/cases/conformance/esDecorators/classDeclaration/accessors/esDecorators-classDeclaration-accessors-nonStaticAbstract.ts:8:5]
+ 7 │     @dec(12) abstract set method1(value);
+ 8 │     @dec(21) abstract get ["method2"](): number;
+   ·     ────────
+ 9 │     @dec(22) abstract set ["method2"](value);
+   ╰────
+
+  × TS(1249): A decorator can only decorate a method implementation, not an overload.
+    ╭─[typescript/tests/cases/conformance/esDecorators/classDeclaration/accessors/esDecorators-classDeclaration-accessors-nonStaticAbstract.ts:9:5]
+  8 │     @dec(21) abstract get ["method2"](): number;
+  9 │     @dec(22) abstract set ["method2"](value);
+    ·     ────────
+ 10 │     @dec(31) abstract get [method3](): number;
+    ╰────
+
+  × TS(1249): A decorator can only decorate a method implementation, not an overload.
+    ╭─[typescript/tests/cases/conformance/esDecorators/classDeclaration/accessors/esDecorators-classDeclaration-accessors-nonStaticAbstract.ts:10:5]
+  9 │     @dec(22) abstract set ["method2"](value);
+ 10 │     @dec(31) abstract get [method3](): number;
+    ·     ────────
+ 11 │     @dec(32) abstract set [method3](value);
+    ╰────
+
+  × TS(1249): A decorator can only decorate a method implementation, not an overload.
+    ╭─[typescript/tests/cases/conformance/esDecorators/classDeclaration/accessors/esDecorators-classDeclaration-accessors-nonStaticAbstract.ts:11:5]
+ 10 │     @dec(31) abstract get [method3](): number;
+ 11 │     @dec(32) abstract set [method3](value);
+    ·     ────────
+ 12 │ }
+    ╰────
+
   × 'default' modifier cannot be used here.
    ╭─[typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-exportModifier.2.ts:2:13]
  1 │ // error
@@ -24268,6 +24318,30 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  1 │ // error
  2 │ export @dec default class C3 {}
    ·             ───────
+   ╰────
+
+  × TS(1249): A decorator can only decorate a method implementation, not an overload.
+   ╭─[typescript/tests/cases/conformance/esDecorators/classDeclaration/methods/esDecorators-classDeclaration-methods-nonStaticAbstract.ts:6:5]
+ 5 │ abstract class C {
+ 6 │     @dec(1) abstract method1(): void;
+   ·     ───────
+ 7 │     @dec(2) abstract ["method2"](): void;
+   ╰────
+
+  × TS(1249): A decorator can only decorate a method implementation, not an overload.
+   ╭─[typescript/tests/cases/conformance/esDecorators/classDeclaration/methods/esDecorators-classDeclaration-methods-nonStaticAbstract.ts:7:5]
+ 6 │     @dec(1) abstract method1(): void;
+ 7 │     @dec(2) abstract ["method2"](): void;
+   ·     ───────
+ 8 │     @dec(3) abstract [method3](): void;
+   ╰────
+
+  × TS(1249): A decorator can only decorate a method implementation, not an overload.
+   ╭─[typescript/tests/cases/conformance/esDecorators/classDeclaration/methods/esDecorators-classDeclaration-methods-nonStaticAbstract.ts:8:5]
+ 7 │     @dec(2) abstract ["method2"](): void;
+ 8 │     @dec(3) abstract [method3](): void;
+   ·     ───────
+ 9 │ }
    ╰────
 
   × Expression must be enclosed in parentheses to be used as a decorator.

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -544,18 +544,16 @@ after transform: ["Object", "PropertyDescriptor", "babelHelpers", "console"]
 rebuilt        : ["Object", "babelHelpers", "console", "dec"]
 
 * oxc/metadata/typescript-syntax/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "B"]
-rebuilt        : ScopeId(0): ["B"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-Unresolved references mismatch:
-after transform: ["dec", "m"]
-rebuilt        : []
+
+  x TS(1249): A decorator can only decorate a method implementation, not an
+  | overload.
+   ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/typescript-syntax/input.ts:6:3]
+ 5 | class B {
+ 6 |   @m
+   :   ^^
+ 7 |   method();
+   `----
+
 
 * oxc/metadata/unbound-type-reference/input.ts
 Symbol span mismatch for "Example":
@@ -1213,18 +1211,16 @@ after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 * typescript/method/decoratorOnClassMethodOverload1/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["C", "dec"]
-rebuilt        : ScopeId(0): ["C"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor"]
-rebuilt        : []
+
+  x TS(1249): A decorator can only decorate a method implementation, not an
+  | overload.
+   ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethodOverload1/input.ts:6:5]
+ 5 | class C {
+ 6 |     @dec
+   :     ^^^^
+ 7 |     method()
+   `----
+
 
 * typescript/method/decoratorOnClassMethodOverload2/input.ts
 Bindings mismatch:


### PR DESCRIPTION
fixes #11029

```ts
class A {
    @decorator()
    method(): Array<string>
}
```