### PR TITLE
fix(ast): restore `#[ts]` attribute to `FormalParameter` `decorators` field

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1812,6 +1812,7 @@ pub struct FormalParameters<'a> {
 pub struct FormalParameter<'a> {
     #[estree(skip)]
     pub span: Span,
+    #[ts]
     pub decorators: Vec<'a, Decorator<'a>>,
     #[estree(flatten)]
     pub pattern: BindingPattern<'a>,


### PR DESCRIPTION
Revert #11494.

As discussed in https://github.com/oxc-project/oxc/issues/11485#issuecomment-2943276060, whether the `#[ts]` attribute is present or not does not affect the code for generating these nodes in ESTree AST, because `FormalParameter` has a custom serializer and custom type def.

So the purpose of the `#[ts]` attribute here is more of a comment that this field is not present in the plain JS ESTree AST. That field is not present, so it's preferable to keep the attribute to signal that.
