### PR TITLE
refactor(ast/estree): simplify TS type def for `BindingPattern`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1522,11 +1522,7 @@ pub struct DebuggerStatement {
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(no_type)]
 pub struct BindingPattern<'a> {
-    // estree(flatten) the attributes because estree has no `BindingPattern`
-    #[estree(
-        flatten,
-        ts_type = "(BindingIdentifier | ObjectPattern | ArrayPattern | AssignmentPattern)"
-    )]
+    #[estree(flatten)]
     #[span]
     pub kind: BindingPatternKind<'a>,
     #[ts]

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -522,12 +522,10 @@ export interface DebuggerStatement extends Span {
   type: 'DebuggerStatement';
 }
 
-export type BindingPattern =
-  & ({
-    typeAnnotation?: TSTypeAnnotation | null;
-    optional?: boolean;
-  })
-  & (BindingIdentifier | ObjectPattern | ArrayPattern | AssignmentPattern);
+export interface BindingPattern extends BindingPatternKind {
+  typeAnnotation?: TSTypeAnnotation | null;
+  optional?: boolean;
+}
 
 export type BindingPatternKind = BindingIdentifier | ObjectPattern | ArrayPattern | AssignmentPattern;
 


### PR DESCRIPTION
Simplify TS type def for `BindingPattern`.

I'm not sure, but think this may also fix the type def, as maybe `typeAnnotation?: null; optional?: false;` fields on `BindingIdentifier` etc were taking priority over `typeAnnotation?: TSTypeAnnotation | null; optional?: boolean;` defined inline.

This also removes some noise from the Rust type definition by removing the over-complicated `#[estree]` attr.
