### PR TITLE
fix(ast/estree): remove repeat fields from `BindingPattern` in TS-ESTree AST

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1494,7 +1494,7 @@ pub struct CatchClause<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(no_type, ts_alias = "BindingPattern")]
+#[estree(no_type, via = CatchParameterConverter)]
 pub struct CatchParameter<'a> {
     #[estree(skip)]
     pub span: Span,
@@ -1528,7 +1528,7 @@ pub struct DebuggerStatement {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(no_type)]
+#[estree(no_type, via = BindingPatternConverter, field_order(kind, optional, type_annotation))]
 pub struct BindingPattern<'a> {
     // estree(flatten) the attributes because estree has no `BindingPattern`
     #[estree(

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1233,11 +1233,7 @@ impl ESTree for CatchClause<'_> {
 
 impl ESTree for CatchParameter<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let mut state = serializer.serialize_struct();
-        self.pattern.kind.serialize(FlatStructSerializer(&mut state));
-        state.serialize_ts_field("typeAnnotation", &self.pattern.type_annotation);
-        state.serialize_ts_field("optional", &self.pattern.optional);
-        state.end();
+        crate::serialize::js::CatchParameterConverter(self).serialize(serializer)
     }
 }
 
@@ -1253,11 +1249,7 @@ impl ESTree for DebuggerStatement {
 
 impl ESTree for BindingPattern<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let mut state = serializer.serialize_struct();
-        self.kind.serialize(FlatStructSerializer(&mut state));
-        state.serialize_ts_field("typeAnnotation", &self.type_annotation);
-        state.serialize_ts_field("optional", &self.optional);
-        state.end();
+        crate::serialize::js::BindingPatternConverter(self).serialize(serializer)
     }
 }
 

--- a/crates/oxc_ast/src/serialize/js.rs
+++ b/crates/oxc_ast/src/serialize/js.rs
@@ -1,7 +1,7 @@
 use oxc_ast_macros::ast_meta;
 use oxc_estree::{
-    Concat2, ConcatElement, ESTree, FlatStructSerializer, JsonSafeString, SequenceSerializer,
-    Serializer, StructSerializer,
+    Concat2, ConcatElement, ESTree, JsonSafeString, SequenceSerializer, Serializer,
+    StructSerializer,
 };
 use oxc_span::GetSpan;
 
@@ -9,9 +9,108 @@ use crate::ast::*;
 
 use super::{EmptyArray, Null};
 
-// --------------------
-// Function params
-// --------------------
+// ----------------------------------------
+// Binding patterns and function params
+// ----------------------------------------
+
+/// Converter for [`BindingPattern`].
+///
+/// Take `typeAnnotation` and `optional` fields from `BindingPattern`,
+/// remaining fields from flattening `BindingPatternKind`.
+#[ast_meta]
+#[estree(raw_deser = "
+    const pattern = DESER[BindingPatternKind](POS_OFFSET.kind);
+    /* IF_TS */
+    pattern.optional = DESER[bool](POS_OFFSET.optional);
+    pattern.typeAnnotation = DESER[Option<Box<TSTypeAnnotation>>](POS_OFFSET.type_annotation);
+    /* END_IF_TS */
+    pattern
+")]
+pub struct BindingPatternConverter<'a, 'b>(pub &'b BindingPattern<'a>);
+
+impl ESTree for BindingPatternConverter<'_, '_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let pattern = self.0;
+
+        if S::INCLUDE_TS_FIELDS {
+            BindingPatternKindAndTsFields {
+                kind: &pattern.kind,
+                decorators: &[],
+                optional: pattern.optional,
+                type_annotation: pattern.type_annotation.as_deref(),
+            }
+            .serialize(serializer);
+        } else {
+            pattern.kind.serialize(serializer);
+        }
+    }
+}
+
+struct BindingPatternKindAndTsFields<'a, 'b> {
+    kind: &'b BindingPatternKind<'a>,
+    decorators: &'b [Decorator<'a>],
+    optional: bool,
+    type_annotation: Option<&'b TSTypeAnnotation<'a>>,
+}
+
+impl ESTree for BindingPatternKindAndTsFields<'_, '_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+
+        match &self.kind {
+            BindingPatternKind::BindingIdentifier(ident) => {
+                state.serialize_field("type", &JsonSafeString("Identifier"));
+                state.serialize_field("start", &ident.span.start);
+                state.serialize_field("end", &ident.span.end);
+                state.serialize_field("decorators", &self.decorators);
+                state.serialize_field("name", &JsonSafeString(ident.name.as_str()));
+            }
+            BindingPatternKind::ObjectPattern(object) => {
+                state.serialize_field("type", &JsonSafeString("ObjectPattern"));
+                state.serialize_field("start", &object.span.start);
+                state.serialize_field("end", &object.span.end);
+                state.serialize_field("decorators", &self.decorators);
+                state.serialize_field("properties", &Concat2(&object.properties, &object.rest));
+            }
+            BindingPatternKind::ArrayPattern(array) => {
+                state.serialize_field("type", &JsonSafeString("ArrayPattern"));
+                state.serialize_field("start", &array.span.start);
+                state.serialize_field("end", &array.span.end);
+                state.serialize_field("decorators", &self.decorators);
+                state.serialize_field("elements", &Concat2(&array.elements, &array.rest));
+            }
+            BindingPatternKind::AssignmentPattern(assignment) => {
+                state.serialize_field("type", &JsonSafeString("AssignmentPattern"));
+                state.serialize_field("start", &assignment.span.start);
+                state.serialize_field("end", &assignment.span.end);
+                state.serialize_field("decorators", &self.decorators);
+                state.serialize_field("left", &assignment.left);
+                state.serialize_field("right", &assignment.right);
+            }
+        }
+
+        state.serialize_field("optional", &self.optional);
+        state.serialize_field("typeAnnotation", &self.type_annotation);
+
+        state.end();
+    }
+}
+
+/// Converter for [`CatchParameter`].
+///
+/// Just delegate to [`BindingPattern`] serializer, ignoring `span` field.
+///
+/// We could do this just with `#[estree(skip)]` and `#[estree(flatten)]` on the Rust type def.
+/// This converter only exists to generate more efficient raw deser code.
+#[ast_meta]
+#[estree(ts_type = "BindingPattern", raw_deser = "DESER[BindingPattern](POS_OFFSET.pattern)")]
+pub struct CatchParameterConverter<'a, 'b>(pub &'b CatchParameter<'a>);
+
+impl ESTree for CatchParameterConverter<'_, '_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        self.0.pattern.serialize(serializer);
+    }
+}
 
 /// Converter for `FormalParameters`.
 ///
@@ -98,12 +197,10 @@ impl ESTree for FormalParametersRest<'_, '_> {
             override = DESER[bool](POS_OFFSET.override);
         let param;
         if (accessibility === null && !readonly && !override) {
-            param = {
-                ...DESER[BindingPatternKind](POS_OFFSET.pattern.kind),
-                decorators: DESER[Vec<Decorator>](POS_OFFSET.decorators),
-                optional: DESER[bool](POS_OFFSET.pattern.optional),
-                typeAnnotation: DESER[Option<Box<TSTypeAnnotation>>](POS_OFFSET.pattern.type_annotation),
-            };
+            param = DESER[BindingPatternKind](POS_OFFSET.pattern.kind);
+            param.decorators = DESER[Vec<Decorator>](POS_OFFSET.decorators);
+            param.optional = DESER[bool](POS_OFFSET.pattern.optional);
+            param.typeAnnotation = DESER[Option<Box<TSTypeAnnotation>>](POS_OFFSET.pattern.type_annotation);
         } else {
             param = {
                 type: 'TSParameterProperty',
@@ -141,12 +238,13 @@ impl ESTree for FormalParameterConverter<'_, '_> {
                 state.serialize_field("static", &false);
                 state.end();
             } else {
-                let mut state = serializer.serialize_struct();
-                param.pattern.kind.serialize(FlatStructSerializer(&mut state));
-                state.serialize_field("decorators", &param.decorators);
-                state.serialize_field("optional", &param.pattern.optional);
-                state.serialize_field("typeAnnotation", &param.pattern.type_annotation);
-                state.end();
+                BindingPatternKindAndTsFields {
+                    kind: &param.pattern.kind,
+                    decorators: &param.decorators,
+                    optional: param.pattern.optional,
+                    type_annotation: param.pattern.type_annotation.as_deref(),
+                }
+                .serialize(serializer);
             }
         } else {
             param.pattern.kind.serialize(serializer);
@@ -182,9 +280,9 @@ impl ESTree for FunctionParams<'_, '_> {
     }
 }
 
-// --------------------
+// ----------------------------------------
 // Import / export
-// --------------------
+// ----------------------------------------
 
 /// Serializer for `specifiers` field of `ImportDeclaration`.
 ///
@@ -278,9 +376,9 @@ impl ESTree for ExportAllDeclarationWithClause<'_, '_> {
     }
 }
 
-// --------------------
+// ----------------------------------------
 // Misc
-// --------------------
+// ----------------------------------------
 
 /// Serializer for `key` field of `MethodDefinition`.
 ///

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -682,9 +682,7 @@ function deserializeCatchClause(pos) {
 }
 
 function deserializeCatchParameter(pos) {
-  return {
-    ...deserializeBindingPatternKind(pos + 8),
-  };
+  return deserializeBindingPattern(pos + 8);
 }
 
 function deserializeDebuggerStatement(pos) {
@@ -696,9 +694,8 @@ function deserializeDebuggerStatement(pos) {
 }
 
 function deserializeBindingPattern(pos) {
-  return {
-    ...deserializeBindingPatternKind(pos),
-  };
+  const pattern = deserializeBindingPatternKind(pos);
+  return pattern;
 }
 
 function deserializeAssignmentPattern(pos) {

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -735,11 +735,7 @@ function deserializeCatchClause(pos) {
 }
 
 function deserializeCatchParameter(pos) {
-  return {
-    ...deserializeBindingPatternKind(pos + 8),
-    typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 24),
-    optional: deserializeBool(pos + 32),
-  };
+  return deserializeBindingPattern(pos + 8);
 }
 
 function deserializeDebuggerStatement(pos) {
@@ -751,11 +747,10 @@ function deserializeDebuggerStatement(pos) {
 }
 
 function deserializeBindingPattern(pos) {
-  return {
-    ...deserializeBindingPatternKind(pos),
-    typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 16),
-    optional: deserializeBool(pos + 24),
-  };
+  const pattern = deserializeBindingPatternKind(pos);
+  pattern.optional = deserializeBool(pos + 24);
+  pattern.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 16);
+  return pattern;
 }
 
 function deserializeAssignmentPattern(pos) {
@@ -875,12 +870,10 @@ function deserializeFormalParameter(pos) {
     override = deserializeBool(pos + 66);
   let param;
   if (accessibility === null && !readonly && !override) {
-    param = {
-      ...deserializeBindingPatternKind(pos + 32),
-      decorators: deserializeVecDecorator(pos + 8),
-      optional: deserializeBool(pos + 56),
-      typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 48),
-    };
+    param = deserializeBindingPatternKind(pos + 32);
+    param.decorators = deserializeVecDecorator(pos + 8);
+    param.optional = deserializeBool(pos + 56);
+    param.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 48);
   } else {
     param = {
       type: 'TSParameterProperty',

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -524,8 +524,8 @@ export interface DebuggerStatement extends Span {
 
 export type BindingPattern =
   & ({
-    typeAnnotation?: TSTypeAnnotation | null;
     optional?: boolean;
+    typeAnnotation?: TSTypeAnnotation | null;
   })
   & (BindingIdentifier | ObjectPattern | ArrayPattern | AssignmentPattern);
 


### PR DESCRIPTION
Related to #11489.

Remove the duplicate properties from TS-ESTree JSON for `BindingPattern` by using custom serializers.

This isn't the ideal solution, but it does solve the immediate problem.
