### PR TITLE
test(ast/estree): do not ignore repeated fields in TS-ESTree AST

### DIFF
--- a/tasks/coverage/Cargo.toml
+++ b/tasks/coverage/Cargo.toml
@@ -39,7 +39,7 @@ rayon = { workspace = true }
 rustc-hash = { workspace = true }
 saphyr = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true, features = ["unbounded_depth", "preserve_order"] }
+serde_json = { workspace = true }
 similar = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 walkdir = { workspace = true }

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -1,8 +1,8 @@
 commit: 81c95189
 
 estree_typescript Summary:
-AST Parsed     : 6488/6488 (100.00%)
-Positive Passed: 6485/6488 (99.95%)
+AST Parsed     : 6489/6489 (100.00%)
+Positive Passed: 6486/6489 (99.95%)
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuite.tsx
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitEntities.tsx


### PR DESCRIPTION
#11500 fixed the duplicate fields in TS-ESTree AST. TS-ESTree conformance no longer needs to ignore duplicate fields.