### PR TITLE
feat(parser): produce syntax error for `satisfies` and `as` in js files

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -657,3 +657,15 @@ pub fn decorator_on_overload(span: Span) -> OxcDiagnostic {
     ts_error("1249", "A decorator can only decorate a method implementation, not an overload.")
         .with_label(span)
 }
+
+#[cold]
+pub fn as_in_ts(span: Span) -> OxcDiagnostic {
+    ts_error("8037", "Type assertion expressions can only be used in TypeScript files.")
+        .with_label(span)
+}
+
+#[cold]
+pub fn satisfies_in_ts(span: Span) -> OxcDiagnostic {
+    ts_error("8016", "Type satisfaction expressions can only be used in TypeScript files.")
+        .with_label(span)
+}

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -1086,7 +1086,7 @@ impl<'a> ParserImpl<'a> {
             // This is need for jsx `<div>=</div>` case
             let kind = self.re_lex_right_angle();
 
-            let Some(left_precedence) = kind_to_precedence(kind, self.is_ts) else { break };
+            let Some(left_precedence) = kind_to_precedence(kind) else { break };
 
             let stop = if left_precedence.is_right_associative() {
                 left_precedence < min_precedence
@@ -1105,7 +1105,7 @@ impl<'a> ParserImpl<'a> {
                 break;
             }
 
-            if self.is_ts && matches!(kind, Kind::As | Kind::Satisfies) {
+            if matches!(kind, Kind::As | Kind::Satisfies) {
                 if self.cur_token().is_on_new_line() {
                     break;
                 }
@@ -1113,8 +1113,14 @@ impl<'a> ParserImpl<'a> {
                 let type_annotation = self.parse_ts_type();
                 let span = self.end_span(lhs_span);
                 lhs = if kind == Kind::As {
+                    if !self.is_ts {
+                        self.error(diagnostics::as_in_ts(span));
+                    }
                     self.ast.expression_ts_as(span, lhs, type_annotation)
                 } else {
+                    if !self.is_ts {
+                        self.error(diagnostics::satisfies_in_ts(span));
+                    }
                     self.ast.expression_ts_satisfies(span, lhs, type_annotation)
                 };
                 continue;

--- a/crates/oxc_parser/src/js/operator.rs
+++ b/crates/oxc_parser/src/js/operator.rs
@@ -7,7 +7,7 @@ use oxc_syntax::{
 
 use crate::lexer::Kind;
 
-pub fn kind_to_precedence(kind: Kind, is_typescript: bool) -> Option<Precedence> {
+pub fn kind_to_precedence(kind: Kind) -> Option<Precedence> {
     match kind {
         Kind::Question2 => Some(Precedence::NullishCoalescing),
         Kind::Pipe2 => Some(Precedence::LogicalOr),
@@ -23,7 +23,7 @@ pub fn kind_to_precedence(kind: Kind, is_typescript: bool) -> Option<Precedence>
         Kind::Plus | Kind::Minus => Some(Precedence::Add),
         Kind::Star | Kind::Slash | Kind::Percent => Some(Precedence::Multiply),
         Kind::Star2 => Some(Precedence::Exponentiation),
-        Kind::As | Kind::Satisfies if is_typescript => Some(Precedence::Compare),
+        Kind::As | Kind::Satisfies => Some(Precedence::Compare),
         _ => None,
     }
 }

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -219,10 +219,16 @@ Negative Passed: 38/38 (100.00%)
  9 │ }
    ╰────
 
-  × Expected a semicolon or an implicit semicolon after a statement, but found none
-   ╭─[misc/fail/oxc-4111-1.js:1:18]
+  × TS(8037): Type assertion expressions can only be used in TypeScript files.
+   ╭─[misc/fail/oxc-4111-1.js:1:1]
  1 │ funtransientction as longciiConÞr>ol(cde) {
-   ·                  ▲
+   · ─────────────────────────────────
+   ╰────
+
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[misc/fail/oxc-4111-1.js:1:43]
+ 1 │ funtransientction as longciiConÞr>ol(cde) {
+   ·                                          ▲
    ╰────
   help: Try insert a semicolon here
 

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -13521,13 +13521,19 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  2 │ Foo<number>(1);
    ╰────
 
-  × Expected a semicolon or an implicit semicolon after a statement, but found none
-   ╭─[typescript/tests/cases/compiler/jsFileCompilationTypeAssertions.ts:1:2]
+  × TS(8037): Type assertion expressions can only be used in TypeScript files.
+   ╭─[typescript/tests/cases/compiler/jsFileCompilationTypeAssertions.ts:1:1]
  1 │ 0 as number;
-   ·  ▲
+   · ───────────
  2 │ var v = <string>undefined;
    ╰────
-  help: Try insert a semicolon here
+
+  × Unexpected token
+   ╭─[typescript/tests/cases/compiler/jsFileCompilationTypeAssertions.ts:2:9]
+ 1 │ 0 as number;
+ 2 │ var v = <string>undefined;
+   ·         ─
+   ╰────
 
   × Expected `,` but found `:`
    ╭─[typescript/tests/cases/compiler/jsFileCompilationTypeOfParameter.ts:1:13]
@@ -24841,12 +24847,11 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╰────
   help: Try insert a semicolon here
 
-  × Expected a semicolon or an implicit semicolon after a statement, but found none
-   ╭─[typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_js.ts:1:18]
+  × TS(8016): Type satisfaction expressions can only be used in TypeScript files.
+   ╭─[typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_js.ts:1:9]
  1 │ var v = undefined satisfies 1;
-   ·                  ▲
+   ·         ─────────────────────
    ╰────
-  help: Try insert a semicolon here
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[typescript/tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorInvalidOperations.ts:5:10]


### PR DESCRIPTION
fixes #11313