### PR TITLE
fix(parser): parse `import type from ...` correctly in JS files

### DIFF
--- a/tasks/coverage/misc/pass/oxc-11505.js
+++ b/tasks/coverage/misc/pass/oxc-11505.js
@@ -1,0 +1,1 @@
+import type from 'module'

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 37/37 (100.00%)
-Positive Passed: 37/37 (100.00%)
+AST Parsed     : 38/38 (100.00%)
+Positive Passed: 38/38 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 37/37 (100.00%)
-Positive Passed: 37/37 (100.00%)
+AST Parsed     : 38/38 (100.00%)
+Positive Passed: 38/38 (100.00%)
 Negative Passed: 38/38 (100.00%)
 
   × Identifier `b` has already been declared

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -25332,10 +25332,11 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·                ╰── `,` expected
    ╰────
 
-  × Unexpected token
+  × Expected `from` but found `Identifier`
    ╭─[typescript/tests/cases/conformance/externalModules/typeOnly/grammarErrors.ts:1:13]
  1 │ import type A from './a';
-   ·             ─
+   ·             ┬
+   ·             ╰── `from` expected
  2 │ export type { A };
    ╰────
 

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 37/37 (100.00%)
-Positive Passed: 22/37 (59.46%)
+AST Parsed     : 38/38 (100.00%)
+Positive Passed: 23/38 (60.53%)
 semantic Error: tasks/coverage/misc/pass/oxc-1288.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["from"]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 37/37 (100.00%)
-Positive Passed: 37/37 (100.00%)
+AST Parsed     : 38/38 (100.00%)
+Positive Passed: 38/38 (100.00%)


### PR DESCRIPTION
- fixes https://github.com/oxc-project/oxc/issues/11505

I forgot to add a `self.is_ts` check for parsing `import type from ...`. In JS files, this is just a normal default import. 