### PR TITLE
fix(linter): fix message in react/rules-of-hooks diagnostic

### DIFF
--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -66,7 +66,7 @@ mod diagnostics {
 
     pub(super) fn async_component(span: Span, func_name: &str) -> OxcDiagnostic {
         OxcDiagnostic::warn(format!(
-            "message: `React Hook {func_name:?} cannot be called in an async function. "
+            "React Hook {func_name:?} cannot be called in an async function. "
         ))
         .with_label(span)
         .with_error_code_scope(SCOPE)

--- a/crates/oxc_linter/src/snapshots/react_rules_of_hooks.snap
+++ b/crates/oxc_linter/src/snapshots/react_rules_of_hooks.snap
@@ -585,7 +585,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────
    ╰────
 
-  ⚠ eslint-plugin-react-hooks(rules-of-hooks): message: `React Hook "AsyncComponent" cannot be called in an async function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "AsyncComponent" cannot be called in an async function.
    ╭─[rules_of_hooks.tsx:2:32]
  1 │ 
  2 │                 async function AsyncComponent() {
@@ -593,7 +593,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │                     useState();
    ╰────
 
-  ⚠ eslint-plugin-react-hooks(rules-of-hooks): message: `React Hook "Anonymous" cannot be called in an async function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "Anonymous" cannot be called in an async function.
    ╭─[rules_of_hooks.tsx:2:40]
  1 │     
  2 │ ╭─▶                 const AsyncComponent = async () => {
@@ -602,7 +602,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │             
    ╰────
 
-  ⚠ eslint-plugin-react-hooks(rules-of-hooks): message: `React Hook "Page" cannot be called in an async function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "Page" cannot be called in an async function.
    ╭─[rules_of_hooks.tsx:2:32]
  1 │ 
  2 │                 async function Page() {
@@ -610,7 +610,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │                   useId();
    ╰────
 
-  ⚠ eslint-plugin-react-hooks(rules-of-hooks): message: `React Hook "Page" cannot be called in an async function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "Page" cannot be called in an async function.
    ╭─[rules_of_hooks.tsx:2:32]
  1 │ 
  2 │                 async function Page() {
@@ -618,7 +618,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │                   useId();
    ╰────
 
-  ⚠ eslint-plugin-react-hooks(rules-of-hooks): message: `React Hook "useAsyncHook" cannot be called in an async function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useAsyncHook" cannot be called in an async function.
    ╭─[rules_of_hooks.tsx:2:32]
  1 │ 
  2 │                 async function useAsyncHook() {
@@ -682,7 +682,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │                 }
    ╰────
 
-  ⚠ eslint-plugin-react-hooks(rules-of-hooks): message: `React Hook "AsyncComponent" cannot be called in an async function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "AsyncComponent" cannot be called in an async function.
    ╭─[rules_of_hooks.tsx:2:28]
  1 │ 
  2 │             async function AsyncComponent() {


### PR DESCRIPTION
remove redundant `Message: ` from the diagnostic