### PR TITLE
fix(linter): improve message in react/prefer-es6-class diagnostic

### DIFF
--- a/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
@@ -15,7 +15,7 @@ fn unexpected_es6_class_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 fn expected_es6_class_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Components should use es6 class instead of createClass.").with_label(span)
+    OxcDiagnostic::warn("Components should use ES6 class instead of createClass.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/snapshots/react_prefer_es6_class.snap
+++ b/crates/oxc_linter/src/snapshots/react_prefer_es6_class.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-react(prefer-es6-class): Components should use es6 class instead of createClass.
+  ⚠ eslint-plugin-react(prefer-es6-class): Components should use ES6 class instead of createClass.
    ╭─[prefer_es6_class.tsx:2:25]
  1 │ 
  2 │             var Hello = createReactClass({
@@ -9,7 +9,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │               displayName: 'Hello',
    ╰────
 
-  ⚠ eslint-plugin-react(prefer-es6-class): Components should use es6 class instead of createClass.
+  ⚠ eslint-plugin-react(prefer-es6-class): Components should use ES6 class instead of createClass.
    ╭─[prefer_es6_class.tsx:2:25]
  1 │ 
  2 │             var Hello = createReactClass({


### PR DESCRIPTION
this PR makes the `es6` casing consistent between both class diagnostics