### PR TITLE
fix(parser): correct `TemplateTail::to_str` from `$}` to `}`

### DIFF
--- a/crates/oxc_parser/src/lexer/kind.rs
+++ b/crates/oxc_parser/src/lexer/kind.rs
@@ -518,6 +518,7 @@ impl Kind {
     }
 
     pub fn to_str(self) -> &'static str {
+        #[expect(clippy::match_same_arms)]
         match self {
             Undetermined => "Unknown",
             Eof => "EOF",
@@ -655,7 +656,7 @@ impl Kind {
             NoSubstitutionTemplate => "${}",
             TemplateHead => "${",
             TemplateMiddle => "${expr}",
-            TemplateTail => "$}",
+            TemplateTail => "}",
             PrivateIdentifier => "#identifier",
             JSXText => "jsx",
             At => "@",

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -4454,7 +4454,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·           ╰── `(` expected
    ╰────
 
-  × Expected `$}` but found `EOF`
+  × Expected `}` but found `EOF`
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/266/input.js:1:19]
  1 │ `hello ${10 `test`
    ╰────
@@ -9522,7 +9522,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·            ─
    ╰────
 
-  × Expected `$}` but found `EOF`
+  × Expected `}` but found `EOF`
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/es2015-template-literals/unclosed-nested/input.js:2:1]
  1 │ `hello ${10 `test`
    ╰────

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -17766,7 +17766,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·                  ─
    ╰────
 
-  × Expected `$}` but found `EOF`
+  × Expected `}` but found `EOF`
    ╭─[typescript/tests/cases/compiler/taggedTemplatesWithIncompleteTemplateExpressions3.ts:5:23]
  4 │ // Incomplete call, not enough parameters.
  5 │ f `123qdawdrqw${ 1 }${
@@ -17786,13 +17786,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·                        ─
    ╰────
 
-  × Expected `$}` but found `EOF`
+  × Expected `}` but found `EOF`
    ╭─[typescript/tests/cases/compiler/taggedTemplatesWithIncompleteTemplateExpressions5.ts:5:30]
  4 │ // Incomplete call, but too many parameters.
  5 │ f `123qdawdrqw${ 1 }${ 2 }${ 
    ╰────
 
-  × Expected `$}` but found `EOF`
+  × Expected `}` but found `EOF`
    ╭─[typescript/tests/cases/compiler/taggedTemplatesWithIncompleteTemplateExpressions6.ts:5:23]
  4 │ // Incomplete call, not enough parameters, at EOF.
  5 │ f `123qdawdrqw${ 1 }${
@@ -22237,7 +22237,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  11 │     };
     ╰────
 
-  × Expected `$}` but found `EOF`
+  × Expected `}` but found `EOF`
    ╭─[typescript/tests/cases/conformance/es6/templates/TemplateExpression1.ts:1:19]
  1 │ var v = `foo ${ a 
    ╰────


### PR DESCRIPTION
not 100% sure this is correct