### PR TITLE
feat(parser): add better debug impl for `Token`

### DIFF
--- a/crates/oxc_parser/src/lexer/token.rs
+++ b/crates/oxc_parser/src/lexer/token.rs
@@ -1,6 +1,6 @@
 //! Token
 
-use std::{mem, ptr};
+use std::{fmt, mem, ptr};
 
 use oxc_span::Span;
 
@@ -40,7 +40,7 @@ const _: () = {
     assert!(is_valid_shift(HAS_SEPARATOR_SHIFT));
 };
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 #[repr(transparent)]
 pub struct Token(u128);
 
@@ -57,6 +57,20 @@ impl Default for Token {
         // has_separator: false,
         const _: () = assert!(Kind::Eof as u8 == 0);
         Self(0)
+    }
+}
+
+impl fmt::Debug for Token {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Token")
+            .field("kind", &self.kind())
+            .field("start", &self.start())
+            .field("end", &self.end())
+            .field("is_on_new_line", &self.is_on_new_line())
+            .field("escaped", &self.escaped())
+            .field("lone_surrogates", &self.lone_surrogates())
+            .field("has_separator", &self.has_separator())
+            .finish()
     }
 }
 


### PR DESCRIPTION
before:
```
[crates/oxc_parser/src/js/expression.rs:467:21] self.cur_token() = Token(
    2951479051875132637200,
)
```

after:
```
[crates/oxc_parser/src/js/expression.rs:467:21] self.cur_token() = Token {
    kind: TemplateTail,
    start: 40,
    end: 45,
    is_on_new_line: false,
    escaped: false,
    lone_surrogates: false,
    has_separator: false,
}
```

