### PR TITLE
perf(semantic): make cfg const generic

### DIFF
--- a/crates/oxc/README.md
+++ b/crates/oxc/README.md
@@ -99,7 +99,7 @@ if panicked {
 let SemanticBuilderReturn {
     semantic,
     errors: semantic_errors,
-} = SemanticBuilder::new()
+} = SemanticBuilder::<false>::new()
     .with_check_syntax_error(true) // Enable extra syntax error checking
     .with_build_jsdoc(true)        // Enable JSDoc parsing
     .with_cfg(true)                // Build a Control Flow Graph

--- a/crates/oxc/src/compiler.rs
+++ b/crates/oxc/src/compiler.rs
@@ -175,8 +175,11 @@ pub trait CompilerInterface {
 
         // Symbols and scopes are out of sync.
         if inject_options.is_some() || define_options.is_some() {
-            scoping =
-                SemanticBuilder::new().with_stats(stats).build(&program).semantic.into_scoping();
+            scoping = SemanticBuilder::<false>::new()
+                .with_stats(stats)
+                .build(&program)
+                .semantic
+                .into_scoping();
         }
 
         if let Some(options) = inject_options {
@@ -190,7 +193,7 @@ pub trait CompilerInterface {
             if self.compress_options().is_none() {
                 // Rebuild semantic because define plugin changed the AST.
                 // DCE assumes semantic data to be correct, it will crash otherwise.
-                scoping = SemanticBuilder::new()
+                scoping = SemanticBuilder::<false>::new()
                     .with_stats(stats)
                     .build(&program)
                     .semantic
@@ -228,7 +231,7 @@ pub trait CompilerInterface {
     }
 
     fn semantic<'a>(&self, program: &'a Program<'a>) -> SemanticBuilderReturn<'a> {
-        let mut builder = SemanticBuilder::new();
+        let mut builder = SemanticBuilder::<false>::new();
 
         if self.transform_options().is_some() {
             // Estimate transformer will triple scopes, symbols, references

--- a/crates/oxc_linter/examples/linter.rs
+++ b/crates/oxc_linter/examples/linter.rs
@@ -29,7 +29,7 @@ fn main() -> std::io::Result<()> {
         return Ok(());
     }
 
-    let semantic_ret = SemanticBuilder::new().build(&ret.program);
+    let semantic_ret = SemanticBuilder::<false>::new().build(&ret.program);
 
     let mut errors: Vec<OxcDiagnostic> = vec![];
 

--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -715,7 +715,8 @@ mod tests {
     fn process_source<'a>(allocator: &'a Allocator, source_text: &'a str) -> Semantic<'a> {
         let source_type = SourceType::default();
         let parser_ret = Parser::new(allocator, source_text, source_type).parse();
-        let semantic_ret = SemanticBuilder::new().build(allocator.alloc(parser_ret.program));
+        let semantic_ret =
+            SemanticBuilder::<false>::new().build(allocator.alloc(parser_ret.program));
         semantic_ret.semantic
     }
 

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -865,7 +865,7 @@ impl<'l> Runtime<'l> {
             return Err(if ret.is_flow_language { vec![] } else { ret.errors });
         }
 
-        let semantic_ret = SemanticBuilder::new()
+        let semantic_ret = SemanticBuilder::<true>::new()
             .with_cfg(true)
             .with_scope_tree_child_ids(true)
             .with_build_jsdoc(true)

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -324,7 +324,7 @@ mod test {
         let source_type = SourceType::default();
         let parser_ret = Parser::new(&allocator, "", source_type).parse();
         let semantic_ret =
-            SemanticBuilder::new().with_cfg(true).build(&parser_ret.program).semantic;
+            SemanticBuilder::<false>::new().with_cfg(true).build(&parser_ret.program).semantic;
         let semantic_ret = Rc::new(semantic_ret);
 
         let build_ctx = |path: &'static str| {

--- a/crates/oxc_mangler/src/keep_names.rs
+++ b/crates/oxc_mangler/src/keep_names.rs
@@ -250,7 +250,7 @@ mod test {
         let ret = Parser::new(&allocator, source_text, SourceType::mjs()).parse();
         assert!(!ret.panicked, "{source_text}");
         assert!(ret.errors.is_empty(), "{source_text}");
-        let ret = SemanticBuilder::new().build(&ret.program);
+        let ret = SemanticBuilder::<false>::new().build(&ret.program);
         assert!(ret.errors.is_empty(), "{source_text}");
         let semantic = ret.semantic;
         let symbols = collect_name_symbols(opts, semantic.scoping(), semantic.nodes());

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -177,7 +177,7 @@ impl Mangler {
     #[must_use]
     pub fn build(self, program: &Program<'_>) -> Scoping {
         let mut semantic =
-            SemanticBuilder::new().with_scope_tree_child_ids(true).build(program).semantic;
+            SemanticBuilder::<false>::new().with_scope_tree_child_ids(true).build(program).semantic;
         self.build_with_semantic(&mut semantic, program);
         semantic.into_scoping()
     }

--- a/crates/oxc_minifier/src/compressor.rs
+++ b/crates/oxc_minifier/src/compressor.rs
@@ -22,7 +22,7 @@ impl<'a> Compressor<'a> {
     }
 
     pub fn build(self, program: &mut Program<'a>) {
-        let scoping = SemanticBuilder::new().build(program).semantic.into_scoping();
+        let scoping = SemanticBuilder::<false>::new().build(program).semantic.into_scoping();
         self.build_with_scoping(scoping, program);
     }
 
@@ -37,7 +37,7 @@ impl<'a> Compressor<'a> {
     }
 
     pub fn dead_code_elimination(self, program: &mut Program<'a>) {
-        let scoping = SemanticBuilder::new().build(program).semantic.into_scoping();
+        let scoping = SemanticBuilder::<false>::new().build(program).semantic.into_scoping();
         self.dead_code_elimination_with_scoping(scoping, program);
     }
 

--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -49,7 +49,7 @@ impl Minifier {
 
     pub fn build<'a>(self, allocator: &'a Allocator, program: &mut Program<'a>) -> MinifierReturn {
         let stats = if let Some(compress) = self.options.compress {
-            let semantic = SemanticBuilder::new().build(program).semantic;
+            let semantic = SemanticBuilder::<false>::new().build(program).semantic;
             let stats = semantic.stats();
             let scoping = semantic.into_scoping();
             Compressor::new(allocator, compress).build_with_scoping(scoping, program);
@@ -58,7 +58,7 @@ impl Minifier {
             Stats::default()
         };
         let scoping = self.options.mangle.map(|options| {
-            let mut semantic = SemanticBuilder::new()
+            let mut semantic = SemanticBuilder::<false>::new()
                 .with_stats(stats)
                 .with_scope_tree_child_ids(true)
                 .build(program)

--- a/crates/oxc_semantic/examples/cfg.rs
+++ b/crates/oxc_semantic/examples/cfg.rs
@@ -56,7 +56,7 @@ fn main() -> std::io::Result<()> {
     println!("Wrote AST to: {}", &ast_file_name);
 
     let semantic =
-        SemanticBuilder::new().with_check_syntax_error(true).with_cfg(true).build(&program);
+        SemanticBuilder::<false>::new().with_check_syntax_error(true).with_cfg(true).build(&program);
 
     if !semantic.errors.is_empty() {
         let error_message: String = semantic

--- a/crates/oxc_semantic/examples/cfg.rs
+++ b/crates/oxc_semantic/examples/cfg.rs
@@ -55,8 +55,10 @@ fn main() -> std::io::Result<()> {
     std::fs::write(ast_file_path, format!("{:#?}", &program))?;
     println!("Wrote AST to: {}", &ast_file_name);
 
-    let semantic =
-        SemanticBuilder::<false>::new().with_check_syntax_error(true).with_cfg(true).build(&program);
+    let semantic = SemanticBuilder::<false>::new()
+        .with_check_syntax_error(true)
+        .with_cfg(true)
+        .build(&program);
 
     if !semantic.errors.is_empty() {
         let error_message: String = semantic

--- a/crates/oxc_semantic/examples/semantic.rs
+++ b/crates/oxc_semantic/examples/semantic.rs
@@ -34,7 +34,7 @@ fn main() -> std::io::Result<()> {
 
     let program = parser_ret.program;
 
-    let semantic = SemanticBuilder::new()
+    let semantic = SemanticBuilder::<false>::new()
         // Enable additional syntax checks not performed by the parser
         .with_check_syntax_error(true)
         .build(&program);

--- a/crates/oxc_semantic/src/checker/mod.rs
+++ b/crates/oxc_semantic/src/checker/mod.rs
@@ -13,7 +13,7 @@ use typescript as ts;
 
 use crate::{AstNode, builder::SemanticBuilder};
 
-pub fn check<'a>(node: &AstNode<'a>, ctx: &SemanticBuilder<'a>) {
+pub fn check<'a, const WITH_CFG: bool>(node: &AstNode<'a>, ctx: &SemanticBuilder<'a, WITH_CFG>) {
     let kind = node.kind();
 
     let is_typescript = ctx.source_type.is_typescript();
@@ -140,7 +140,7 @@ fn undefined_export(x0: &str, span1: Span) -> OxcDiagnostic {
 
 /// It is a Syntax Error if any element of the ExportedBindings of ModuleItemList
 /// does not also occur in either the VarDeclaredNames of ModuleItemList, or the LexicallyDeclaredNames of ModuleItemList.
-pub fn check_unresolved_exports(ctx: &SemanticBuilder<'_>) {
+pub fn check_unresolved_exports<const WITH_CFG: bool>(ctx: &SemanticBuilder<'_, WITH_CFG>) {
     for reference_ids in ctx.unresolved_references.root().values() {
         for reference_id in reference_ids {
             let reference = ctx.scoping.get_reference(*reference_id);

--- a/crates/oxc_semantic/src/jsdoc/builder.rs
+++ b/crates/oxc_semantic/src/jsdoc/builder.rs
@@ -207,7 +207,10 @@ mod test {
     ) -> Semantic<'a> {
         let source_type = source_type.unwrap_or_default();
         let ret = Parser::new(allocator, source_text, source_type).parse();
-        SemanticBuilder::<false>::new().with_build_jsdoc(true).build(allocator.alloc(ret.program)).semantic
+        SemanticBuilder::<false>::new()
+            .with_build_jsdoc(true)
+            .build(allocator.alloc(ret.program))
+            .semantic
     }
 
     fn get_jsdocs<'a>(

--- a/crates/oxc_semantic/src/jsdoc/builder.rs
+++ b/crates/oxc_semantic/src/jsdoc/builder.rs
@@ -207,7 +207,7 @@ mod test {
     ) -> Semantic<'a> {
         let source_type = source_type.unwrap_or_default();
         let ret = Parser::new(allocator, source_text, source_type).parse();
-        SemanticBuilder::new().with_build_jsdoc(true).build(allocator.alloc(ret.program)).semantic
+        SemanticBuilder::<false>::new().with_build_jsdoc(true).build(allocator.alloc(ret.program)).semantic
     }
 
     fn get_jsdocs<'a>(

--- a/crates/oxc_semantic/src/jsdoc/parser/jsdoc.rs
+++ b/crates/oxc_semantic/src/jsdoc/parser/jsdoc.rs
@@ -45,7 +45,10 @@ mod test {
     fn build_semantic<'a>(allocator: &'a Allocator, source_text: &'a str) -> Semantic<'a> {
         let source_type = SourceType::default();
         let ret = Parser::new(allocator, source_text, source_type).parse();
-        SemanticBuilder::new().with_build_jsdoc(true).build(allocator.alloc(ret.program)).semantic
+        SemanticBuilder::<false>::new()
+            .with_build_jsdoc(true)
+            .build(allocator.alloc(ret.program))
+            .semantic
     }
 
     #[test]

--- a/crates/oxc_semantic/src/jsdoc/parser/jsdoc_tag.rs
+++ b/crates/oxc_semantic/src/jsdoc/parser/jsdoc_tag.rs
@@ -194,7 +194,10 @@ mod test {
     fn build_semantic<'a>(allocator: &'a Allocator, source_text: &'a str) -> Semantic<'a> {
         let source_type = SourceType::default();
         let ret = Parser::new(allocator, source_text, source_type).parse();
-        SemanticBuilder::new().with_build_jsdoc(true).build(allocator.alloc(ret.program)).semantic
+        SemanticBuilder::<false>::new()
+            .with_build_jsdoc(true)
+            .build(allocator.alloc(ret.program))
+            .semantic
     }
 
     #[test]

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -237,7 +237,7 @@ mod tests {
     ) -> Semantic<'s> {
         let parse = oxc_parser::Parser::new(allocator, source, source_type).parse();
         assert!(parse.errors.is_empty());
-        let semantic = SemanticBuilder::new().build(allocator.alloc(parse.program));
+        let semantic = SemanticBuilder::<false>::new().build(allocator.alloc(parse.program));
         assert!(semantic.errors.is_empty(), "Parse error: {}", semantic.errors[0]);
         semantic.semantic
     }

--- a/crates/oxc_semantic/tests/integration/util/mod.rs
+++ b/crates/oxc_semantic/tests/integration/util/mod.rs
@@ -167,7 +167,7 @@ impl<'a> SemanticTester<'a> {
                 .collect::<String>()
         );
 
-        SemanticBuilder::new()
+        SemanticBuilder::<false>::new()
             .with_check_syntax_error(true)
             .with_cfg(self.cfg)
             .with_scope_tree_child_ids(self.scope_tree_child_ids)

--- a/crates/oxc_semantic/tests/main.rs
+++ b/crates/oxc_semantic/tests/main.rs
@@ -125,7 +125,7 @@ fn analyze(
     let source_type = SourceType::from_path(path).unwrap();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let semantic =
-        SemanticBuilder::new().with_check_syntax_error(true).build(&ret.program).semantic;
+        SemanticBuilder::<false>::new().with_check_syntax_error(true).build(&ret.program).semantic;
     let ctx = TestContext { path, semantic };
     let scope_snapshot = run_scope_snapshot_test(&ctx);
     let conformance_snapshot = conformance_suite.run_on_source(&ctx);

--- a/crates/oxc_transformer/examples/transformer.rs
+++ b/crates/oxc_transformer/examples/transformer.rs
@@ -42,7 +42,7 @@ fn main() {
 
     let mut program = ret.program;
 
-    let ret = SemanticBuilder::new()
+    let ret = SemanticBuilder::<false>::new()
         // Estimate transformer will triple scopes, symbols, references
         .with_excess_capacity(2.0)
         .build(&program);

--- a/crates/oxc_transformer/tests/integrations/main.rs
+++ b/crates/oxc_transformer/tests/integrations/main.rs
@@ -28,7 +28,7 @@ pub(crate) fn test(
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let mut program = ret.program;
-    let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+    let scoping = SemanticBuilder::<false>::new().build(&program).semantic.into_scoping();
     let ret = Transformer::new(&allocator, Path::new(""), options)
         .build_with_scoping(scoping, &mut program);
     if !ret.errors.is_empty() {

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -871,7 +871,7 @@ mod test {
         let allocator = Allocator::default();
         let ret = Parser::new(&allocator, source_text, source_type).parse();
         let mut program = ret.program;
-        let mut scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+        let mut scoping = SemanticBuilder::<false>::new().build(&program).semantic.into_scoping();
         if is_jsx {
             let mut options = TransformOptions::default();
             options.jsx.runtime = JsxRuntime::Classic;

--- a/crates/oxc_transformer_plugins/tests/integrations/inject_global_variables.rs
+++ b/crates/oxc_transformer_plugins/tests/integrations/inject_global_variables.rs
@@ -17,7 +17,7 @@ fn test(source_text: &str, expected: &str, config: InjectGlobalVariablesConfig) 
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let mut program = ret.program;
-    let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+    let scoping = SemanticBuilder::<false>::new().build(&program).semantic.into_scoping();
     let _ = InjectGlobalVariables::new(&allocator, config).build(scoping, &mut program);
     let result = Codegen::new()
         .with_options(CodegenOptions { single_quote: true, ..CodegenOptions::default() })

--- a/crates/oxc_transformer_plugins/tests/integrations/replace_global_defines.rs
+++ b/crates/oxc_transformer_plugins/tests/integrations/replace_global_defines.rs
@@ -14,10 +14,10 @@ pub fn test(source_text: &str, expected: &str, config: ReplaceGlobalDefinesConfi
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let mut program = ret.program;
-    let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+    let scoping = SemanticBuilder::<false>::new().build(&program).semantic.into_scoping();
     let _ = ReplaceGlobalDefines::new(&allocator, config).build(scoping, &mut program);
     // Run DCE, to align pipeline in crates/oxc/src/compiler.rs
-    let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+    let scoping = SemanticBuilder::<false>::new().build(&program).semantic.into_scoping();
     Compressor::new(&allocator, CompressOptions::default())
         .dead_code_elimination_with_scoping(scoping, &mut program);
     let result = Codegen::new()
@@ -277,7 +277,7 @@ log(__MEMBER__);
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let mut program = ret.program;
-    let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+    let scoping = SemanticBuilder::<false>::new().build(&program).semantic.into_scoping();
     let _ = ReplaceGlobalDefines::new(&allocator, config).build(scoping, &mut program);
     let result = Codegen::new()
         .with_options(CodegenOptions {

--- a/napi/parser/src/lib.rs
+++ b/napi/parser/src/lib.rs
@@ -82,7 +82,8 @@ fn parse_with_return(filename: &str, source_text: String, options: &ParserOption
     let mut diagnostics = ret.errors;
 
     if options.show_semantic_errors == Some(true) {
-        let semantic_ret = SemanticBuilder::new().with_check_syntax_error(true).build(&program);
+        let semantic_ret =
+            SemanticBuilder::<false>::new().with_check_syntax_error(true).build(&program);
         diagnostics.extend(semantic_ret.errors);
     }
 

--- a/napi/parser/src/raw_transfer.rs
+++ b/napi/parser/src/raw_transfer.rs
@@ -238,7 +238,8 @@ unsafe fn parse_raw_impl(
         // Note: Avoid calling `Error::from_diagnostics_in` unless there are some errors,
         // because it's fairly expensive (it copies whole of source text into a `String`).
         let mut errors = if options.show_semantic_errors == Some(true) {
-            let semantic_ret = SemanticBuilder::new().with_check_syntax_error(true).build(&program);
+            let semantic_ret =
+                SemanticBuilder::<false>::new().with_check_syntax_error(true).build(&program);
 
             if !ret.errors.is_empty() || !semantic_ret.errors.is_empty() {
                 Error::from_diagnostics_in(

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -131,7 +131,7 @@ impl Oxc {
                 .parse();
         self.diagnostics.extend(errors);
 
-        let mut semantic_builder = SemanticBuilder::new();
+        let mut semantic_builder = SemanticBuilder::<false>::new();
         if run_options.transform.unwrap_or_default() {
             // Estimate transformer will triple scopes, symbols, references
             semantic_builder = semantic_builder.with_excess_capacity(2.0);
@@ -283,7 +283,7 @@ impl Oxc {
     ) {
         // Only lint if there are no syntax errors
         if run_options.lint.unwrap_or_default() && self.diagnostics.is_empty() {
-            let semantic_ret = SemanticBuilder::new().with_cfg(true).build(program);
+            let semantic_ret = SemanticBuilder::<false>::new().with_cfg(true).build(program);
             let semantic = Rc::new(semantic_ret.semantic);
             let lint_config = ConfigStoreBuilder::default().build();
             let linter_ret = Linter::new(

--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -865,7 +865,7 @@ pub fn module_runner_transform(
     let mut program = parser_ret.program;
 
     let SemanticBuilderReturn { semantic, errors } =
-        SemanticBuilder::new().with_check_syntax_error(true).build(&program);
+        SemanticBuilder::<false>::new().with_check_syntax_error(true).build(&program);
     parser_ret.errors.extend(errors);
 
     let scoping = semantic.into_scoping();

--- a/tasks/benchmark/benches/codegen.rs
+++ b/tasks/benchmark/benches/codegen.rs
@@ -19,7 +19,7 @@ fn bench_codegen(criterion: &mut Criterion) {
         assert!(parser_ret.errors.is_empty());
         let mut program = parser_ret.program;
 
-        let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+        let scoping = SemanticBuilder::<false>::new().build(&program).semantic.into_scoping();
 
         let transform_options = TransformOptions::enable_all();
         let transformer_ret =

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -19,7 +19,7 @@ fn bench_linter(criterion: &mut Criterion) {
         let allocator = Allocator::default();
         let ret = Parser::new(&allocator, source_text, source_type).parse();
         let path = Path::new("");
-        let semantic_ret = SemanticBuilder::new()
+        let semantic_ret = SemanticBuilder::<false>::new()
             .with_build_jsdoc(true)
             .with_scope_tree_child_ids(true)
             .with_cfg(true)

--- a/tasks/benchmark/benches/minifier.rs
+++ b/tasks/benchmark/benches/minifier.rs
@@ -29,7 +29,8 @@ fn bench_minifier(criterion: &mut Criterion) {
 
                 // Create fresh AST + semantic data for each iteration
                 let mut program = Parser::new(&allocator, source_text, source_type).parse().program;
-                let scoping = SemanticBuilder::<false>::new().build(&program).semantic.into_scoping();
+                let scoping =
+                    SemanticBuilder::<false>::new().build(&program).semantic.into_scoping();
 
                 // Minifier only works on esnext.
                 let transform_options = TransformOptions::from_target("esnext").unwrap();
@@ -37,7 +38,8 @@ fn bench_minifier(criterion: &mut Criterion) {
                     Transformer::new(&allocator, Path::new(&file.file_name), &transform_options)
                         .build_with_scoping(scoping, &mut program);
                 assert!(transformer_ret.errors.is_empty());
-                let scoping = SemanticBuilder::<false>::new().build(&program).semantic.into_scoping();
+                let scoping =
+                    SemanticBuilder::<false>::new().build(&program).semantic.into_scoping();
 
                 let options = CompressOptions::smallest();
                 runner.run(|| {
@@ -61,8 +63,10 @@ fn bench_mangler(criterion: &mut Criterion) {
             b.iter_with_setup_wrapper(|runner| {
                 allocator.reset();
                 let program = Parser::new(&allocator, source_text, source_type).parse().program;
-                let mut semantic =
-                    SemanticBuilder::<false>::new().with_scope_tree_child_ids(true).build(&program).semantic;
+                let mut semantic = SemanticBuilder::<false>::new()
+                    .with_scope_tree_child_ids(true)
+                    .build(&program)
+                    .semantic;
                 runner.run(|| {
                     Mangler::new().build_with_semantic(&mut semantic, &program);
                 });

--- a/tasks/benchmark/benches/minifier.rs
+++ b/tasks/benchmark/benches/minifier.rs
@@ -29,7 +29,7 @@ fn bench_minifier(criterion: &mut Criterion) {
 
                 // Create fresh AST + semantic data for each iteration
                 let mut program = Parser::new(&allocator, source_text, source_type).parse().program;
-                let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+                let scoping = SemanticBuilder::<false>::new().build(&program).semantic.into_scoping();
 
                 // Minifier only works on esnext.
                 let transform_options = TransformOptions::from_target("esnext").unwrap();
@@ -37,7 +37,7 @@ fn bench_minifier(criterion: &mut Criterion) {
                     Transformer::new(&allocator, Path::new(&file.file_name), &transform_options)
                         .build_with_scoping(scoping, &mut program);
                 assert!(transformer_ret.errors.is_empty());
-                let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+                let scoping = SemanticBuilder::<false>::new().build(&program).semantic.into_scoping();
 
                 let options = CompressOptions::smallest();
                 runner.run(|| {
@@ -62,7 +62,7 @@ fn bench_mangler(criterion: &mut Criterion) {
                 allocator.reset();
                 let program = Parser::new(&allocator, source_text, source_type).parse().program;
                 let mut semantic =
-                    SemanticBuilder::new().with_scope_tree_child_ids(true).build(&program).semantic;
+                    SemanticBuilder::<false>::new().with_scope_tree_child_ids(true).build(&program).semantic;
                 runner.run(|| {
                     Mangler::new().build_with_semantic(&mut semantic, &program);
                 });

--- a/tasks/benchmark/benches/semantic.rs
+++ b/tasks/benchmark/benches/semantic.rs
@@ -29,7 +29,8 @@ fn bench_semantic(criterion: &mut Criterion) {
                     // We return `errors` to be dropped outside of the measured section, as usually
                     // code would have no errors. One of our benchmarks `cal.com.tsx` has a lot of errors,
                     // but that's atypical, so don't want to include it in benchmark time.
-                    let ret = SemanticBuilder::<false>::new().with_build_jsdoc(true).build(&program);
+                    let ret =
+                        SemanticBuilder::<false>::new().with_build_jsdoc(true).build(&program);
                     let ret = black_box(ret);
                     ret.errors
                 });

--- a/tasks/benchmark/benches/semantic.rs
+++ b/tasks/benchmark/benches/semantic.rs
@@ -29,7 +29,7 @@ fn bench_semantic(criterion: &mut Criterion) {
                     // We return `errors` to be dropped outside of the measured section, as usually
                     // code would have no errors. One of our benchmarks `cal.com.tsx` has a lot of errors,
                     // but that's atypical, so don't want to include it in benchmark time.
-                    let ret = SemanticBuilder::new().with_build_jsdoc(true).build(&program);
+                    let ret = SemanticBuilder::<false>::new().with_build_jsdoc(true).build(&program);
                     let ret = black_box(ret);
                     ret.errors
                 });

--- a/tasks/benchmark/benches/transformer.rs
+++ b/tasks/benchmark/benches/transformer.rs
@@ -33,7 +33,7 @@ fn bench_transformer(criterion: &mut Criterion) {
                 // Create fresh AST + semantic data for each iteration
                 let ParserReturn { mut program, .. } =
                     Parser::new(&allocator, source_text, source_type).parse();
-                let scoping = SemanticBuilder::new()
+                let scoping = SemanticBuilder::<false>::new()
                     // Estimate transformer will triple scopes, symbols, references
                     .with_excess_capacity(2.0)
                     .build(&program)

--- a/tasks/coverage/src/runtime/mod.rs
+++ b/tasks/coverage/src/runtime/mod.rs
@@ -183,7 +183,7 @@ impl Test262RuntimeCase {
         let mut program = Parser::new(&allocator, source_text, source_type).parse().program;
 
         if transform {
-            let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+            let scoping = SemanticBuilder::<false>::new().build(&program).semantic.into_scoping();
             let mut options = TransformOptions::enable_all();
             options.jsx.refresh = None;
             options.helper_loader.mode = HelperLoaderMode::External;

--- a/tasks/minsize/src/lib.rs
+++ b/tasks/minsize/src/lib.rs
@@ -142,7 +142,7 @@ fn minify(source_text: &str, source_type: SourceType) -> String {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let mut program = ret.program;
-    let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+    let scoping = SemanticBuilder::<false>::new().build(&program).semantic.into_scoping();
     let _ = ReplaceGlobalDefines::new(
         &allocator,
         ReplaceGlobalDefinesConfig::new(&[("process.env.NODE_ENV", "'development'")]).unwrap(),

--- a/tasks/transform_checker/src/lib.rs
+++ b/tasks/transform_checker/src/lib.rs
@@ -134,7 +134,7 @@ pub fn check_semantic_after_transform(
     // so the cloned AST will be "clean" of all semantic data, as if it had come fresh from the parser.
     let allocator = Allocator::default();
     let program = program.clone_in(&allocator);
-    let scoping_rebuilt = SemanticBuilder::new()
+    let scoping_rebuilt = SemanticBuilder::<false>::new()
         .with_scope_tree_child_ids(scoping_after_transform.has_scope_child_ids())
         .build(&program)
         .semantic


### PR DESCRIPTION
cfg is only used by linter, we can (hopefully) speed up semantic by skipping the cfg stuff at compile time