### PR TITLE
feat(minifier): annotate more pure constructors

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditions.rs
@@ -1250,14 +1250,14 @@ mod test {
 
     #[test]
     fn test_coercion_substitution_boxed_number_vs_zero() {
-        test_same("var x = new Number(0);\nif (x != 0) throw 'a';\n");
+        test_same("var x = /* @__PURE__ */ new Number(0);\nif (x != 0) throw 'a';\n");
     }
 
     #[test]
     fn test_coercion_substitution_boxed_primitives() {
-        test_same("var x = new Number(); if (x != null) throw 'a';");
-        test_same("var x = new String(); if (x != null) throw 'a';");
-        test_same("var x = new Boolean();\nif (x != null) throw 'a';");
+        test_same("var x = /* @__PURE__ */ new Number(); if (x != null) throw 'a';");
+        test_same("var x = /* @__PURE__ */ new String(); if (x != null) throw 'a';");
+        test_same("var x = /* @__PURE__ */ new Boolean();\nif (x != null) throw 'a';");
     }
 
     #[test]

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -689,6 +689,7 @@ mod test {
         test("new WeakSet([])", "");
         test_same("new WeakSet([x])");
         test_same("new WeakSet(x)");
+        test_same("throw new WeakSet()");
         test("new WeakMap()", "");
         test("new WeakMap(null)", "");
         test("new WeakMap(void 0)", "");


### PR DESCRIPTION
closes https://github.com/rolldown/rolldown/issues/2603

I used the following script to capture what argument throws.

```js
function x(F) {
    try {
    new F(null)
    } catch (e) {
        console.log(F.name)
    }
}
x(Set)
x(Map)
x(WeakSet)
x(WeakMap)
x(AggregateError)
x(Boolean)
x(DataView)
x(Error)
x(EvalError)
x(RangeError)
x(ReferenceError)
x(RegExp)
x(SyntaxError)
x(TypeError)
x(URIError)
x(ArrayBuffer)
x(Date)
x(Number)
x(Object)
x(String)
```