### PR TITLE
fix(linter/no-magic-numbers): fix typo in error message

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_magic_numbers.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_magic_numbers.rs
@@ -276,7 +276,7 @@ impl InternConfig<'_> {
             }
             _ => {
                 unreachable!(
-                    "expected AstKind BingIntLiteral or NumericLiteral, got {:?}",
+                    "expected AstKind BigIntLiteral or NumericLiteral, got {:?}",
                     node.kind().debug_name()
                 )
             }


### PR DESCRIPTION
"BigIntLiteral" not "BingIntLiteral".