### PR TITLE
perf(ast/estree): convert `NumericLiteral` `raw` field to JSON without escaping

### DIFF
--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -56,6 +56,7 @@ pub struct NumericLiteral<'a> {
     ///
     /// `None` when this ast node is not constructed from the parser.
     #[content_eq(skip)]
+    #[estree(json_safe)]
     pub raw: Option<Atom<'a>>,
     /// The base representation used by the literal in source code
     #[content_eq(skip)]

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1917,7 +1917,7 @@ impl ESTree for NumericLiteral<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &self.value);
-        state.serialize_field("raw", &self.raw);
+        state.serialize_field("raw", &self.raw.map(|s| JsonSafeString(s.as_str())));
         state.end();
     }
 }


### PR DESCRIPTION
Small optimization in serializing `NumericLiteral`s to JSON. `raw` field cannot contain characters which need escaping in JSON, so skip escaping.

Add support for `#[estree(json_safe)]` on `Option<Atom>` and `Option<&str>` fields to enable this.