### PR TITLE
test(ast/estree): bump `acorn-test262` submodule

### DIFF
--- a/.github/actions/clone-submodules/action.yml
+++ b/.github/actions/clone-submodules/action.yml
@@ -38,4 +38,4 @@ runs:
         show-progress: false
         repository: oxc-project/acorn-test262
         path: tasks/coverage/acorn-test262
-        ref: 4027b2de44e02e8d492f6e8fa2671bbc266b7856 # Latest main at 2/6/25
+        ref: 9bfb9ab035c3df785284d27004a80824fb8a2dd6 # Latest main at 8/6/25

--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ submodules:
   just clone-submodule tasks/coverage/babel https://github.com/babel/babel.git 1d4546bcb80009303aab386b59f4df1fd335c1d5
   just clone-submodule tasks/coverage/typescript https://github.com/microsoft/TypeScript.git 81c951894e93bdc37c6916f18adcd80de76679bc
   just clone-submodule tasks/prettier_conformance/prettier https://github.com/prettier/prettier.git 7584432401a47a26943dd7a9ca9a8e032ead7285
-  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 4027b2de44e02e8d492f6e8fa2671bbc266b7856
+  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 9bfb9ab035c3df785284d27004a80824fb8a2dd6
   just update-transformer-fixtures
 
 # Install git pre-commit to format files

--- a/tasks/coverage/snapshots/estree_acorn_jsx.snap
+++ b/tasks/coverage/snapshots/estree_acorn_jsx.snap
@@ -1,4 +1,4 @@
-commit: 4027b2de
+commit: 9bfb9ab0
 
 estree_acorn_jsx Summary:
 AST Parsed     : 39/39 (100.00%)

--- a/tasks/coverage/snapshots/estree_test262.snap
+++ b/tasks/coverage/snapshots/estree_test262.snap
@@ -1,19 +1,167 @@
 commit: 4b5d36ab
 
 estree_test262 Summary:
-AST Parsed     : 44201/44201 (100.00%)
-Positive Passed: 44192/44201 (99.98%)
+AST Parsed     : 44203/44203 (100.00%)
+Positive Passed: 44120/44203 (99.81%)
+Mismatch: tasks/coverage/test262/test/built-ins/Atomics/and/bigint/good-views.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/Atomics/or/bigint/good-views.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-store.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/Atomics/waitAsync/bigint/no-spurious-wakeup-on-store.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/Atomics/xor/bigint/good-views.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/BigInt/asIntN/arithmetic.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/BigInt/asUintN/arithmetic.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigInt64/return-values-custom-offset.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigInt64/return-values.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigInt64/to-boolean-littleendian.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigInt64/toindex-byteoffset-toprimitive.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigInt64/toindex-byteoffset-wrapped-values.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigInt64/toindex-byteoffset.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigUint64/return-values-custom-offset.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigUint64/return-values.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigUint64/to-boolean-littleendian.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigUint64/toindex-byteoffset-toprimitive.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigUint64/toindex-byteoffset-wrapped-values.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigUint64/toindex-byteoffset.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/setBigInt64/set-values-little-endian-order.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/setBigInt64/to-boolean-littleendian.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/addition/bigint-arithmetic.js
+
 Mismatch: tasks/coverage/test262/test/language/expressions/assignment/fn-name-lhs-cover.js
 
 Mismatch: tasks/coverage/test262/test/language/expressions/assignment/target-cover-id.js
 
+Mismatch: tasks/coverage/test262/test/language/expressions/bitwise-and/bigint-non-primitive.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/bitwise-and/bigint.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/bitwise-not/bigint.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/bitwise-or/bigint-non-primitive.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/bitwise-or/bigint.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/bitwise-xor/bigint-non-primitive.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/bitwise-xor/bigint.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/division/bigint-arithmetic.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/does-not-equals/bigint-and-bigint.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/does-not-equals/bigint-and-number-extremes.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/equals/bigint-and-bigint.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/equals/bigint-and-number-extremes.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/exponentiation/bigint-arithmetic.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/greater-than/bigint-and-bigint.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/greater-than/bigint-and-number-extremes.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/greater-than-or-equal/bigint-and-bigint.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/greater-than-or-equal/bigint-and-number-extremes.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/left-shift/bigint-non-primitive.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/left-shift/bigint.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/less-than/bigint-and-bigint.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/less-than/bigint-and-number-extremes.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/less-than-or-equal/bigint-and-bigint.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/less-than-or-equal/bigint-and-number-extremes.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/modulus/bigint-arithmetic.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/multiplication/bigint-arithmetic.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/postfix-decrement/bigint.js
+
 Mismatch: tasks/coverage/test262/test/language/expressions/postfix-decrement/target-cover-id.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/postfix-increment/bigint.js
 
 Mismatch: tasks/coverage/test262/test/language/expressions/postfix-increment/target-cover-id.js
 
+Mismatch: tasks/coverage/test262/test/language/expressions/prefix-decrement/bigint.js
+
 Mismatch: tasks/coverage/test262/test/language/expressions/prefix-decrement/target-cover-id.js
 
+Mismatch: tasks/coverage/test262/test/language/expressions/prefix-increment/bigint.js
+
 Mismatch: tasks/coverage/test262/test/language/expressions/prefix-increment/target-cover-id.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/right-shift/bigint-non-primitive.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/right-shift/bigint.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/strict-does-not-equals/bigint-and-bigint.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/strict-does-not-equals/bigint-and-number-extremes.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/strict-equals/bigint-and-bigint.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/strict-equals/bigint-and-number-extremes.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/subtraction/bigint-arithmetic.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/unary-minus/bigint.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/unsigned-right-shift/bigint-non-primitive.js
+
+Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-bil-bd-nsl-bd.js
+
+Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-bil-bd-nsl-bds.js
+
+Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-bil-bds-nsl-bd.js
+
+Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-bil-bds-nsl-bds.js
+
+Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-hil-hd-nsl-hd.js
+
+Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-hil-hd-nsl-hds.js
+
+Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-hil-hds-nsl-hd.js
+
+Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-hil-hds-nsl-hds.js
+
+Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-hil-od-nsl-od-one-of.js
+
+Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-oil-od-nsl-od-one-of.js
+
+Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-oil-od-nsl-od.js
+
+Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-oil-od-nsl-ods.js
+
+Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-oil-ods-nsl-od.js
+
+Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-oil-ods-nsl-ods.js
 
 Mismatch: tasks/coverage/test262/test/language/statements/for-in/head-lhs-cover.js
 


### PR DESCRIPTION
Bump `acorn-test262` submodule to include https://github.com/oxc-project/acorn-test262/pull/47, which bumps Acorn dependency.

Acorn v8.15.0 fixes the formatting of the `bigint` field of `Literal`s to align with ESTree spec. Currently we are failing those test cases as our behavior is incorrect. Will fix it in following PR.