### PR TITLE
feat(ast)!: add `value` field to `BigIntLiteral`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1568,7 +1568,6 @@ name = "oxc_ast"
 version = "0.72.3"
 dependencies = [
  "bitflags 2.9.1",
- "cow-utils",
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_data_structures",
@@ -1742,7 +1741,6 @@ dependencies = [
 name = "oxc_ecmascript"
 version = "0.72.3"
 dependencies = [
- "cow-utils",
  "num-bigint",
  "num-traits",
  "oxc_ast",

--- a/crates/oxc_ast/Cargo.toml
+++ b/crates/oxc_ast/Cargo.toml
@@ -28,7 +28,6 @@ oxc_span = { workspace = true }
 oxc_syntax = { workspace = true }
 
 bitflags = { workspace = true }
-cow-utils = { workspace = true }
 
 [features]
 default = []

--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -102,15 +102,19 @@ pub struct StringLiteral<'a> {
 #[generate_derive(CloneIn, Dummy, TakeIn, ContentEq, GetSpan, GetSpanMut, ESTree)]
 #[estree(
     rename = "Literal",
-    add_fields(value = BigIntLiteralValue, bigint = BigIntLiteralBigint),
+    add_fields(bigint = BigIntLiteralBigint),
     field_order(span, value, raw, bigint),
 )]
 pub struct BigIntLiteral<'a> {
     /// Node location in source code
     pub span: Span,
+    /// Bigint value in base 10 with no underscores
+    #[estree(via = BigIntLiteralValue)]
+    pub value: Atom<'a>,
     /// The bigint as it appears in source code
-    #[estree(ts_type = "string | null")]
-    pub raw: Atom<'a>,
+    #[content_eq(skip)]
+    #[estree(json_safe)]
+    pub raw: Option<Atom<'a>>,
     /// The base representation used by the literal in source code
     #[content_eq(skip)]
     #[estree(skip)]

--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -439,7 +439,7 @@ impl<'a> PropertyKey<'a> {
             Self::StringLiteral(lit) => Some(Cow::Borrowed(lit.value.as_str())),
             Self::RegExpLiteral(lit) => Some(Cow::Owned(lit.regex.to_string())),
             Self::NumericLiteral(lit) => Some(Cow::Owned(lit.value.to_string())),
-            Self::BigIntLiteral(lit) => Some(Cow::Borrowed(lit.raw.as_str())),
+            Self::BigIntLiteral(lit) => Some(Cow::Borrowed(lit.value.as_str())),
             Self::NullLiteral(_) => Some(Cow::Borrowed("null")),
             Self::TemplateLiteral(lit) => {
                 lit.expressions.is_empty().then(|| lit.quasi()).flatten().map(Into::into)

--- a/crates/oxc_ast/src/ast_impl/literal.rs
+++ b/crates/oxc_ast/src/ast_impl/literal.rs
@@ -115,18 +115,18 @@ impl Display for StringLiteral<'_> {
 impl BigIntLiteral<'_> {
     /// Is this BigInt literal zero? (`0n`).
     pub fn is_zero(&self) -> bool {
-        self.raw == "0n"
+        self.value == "0"
     }
 
     /// Is this BigInt literal negative? (e.g. `-1n`).
     pub fn is_negative(&self) -> bool {
-        self.raw.starts_with('-')
+        self.value.starts_with('-')
     }
 }
 
 impl Display for BigIntLiteral<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.raw.fmt(f)
+        write!(f, "{}n", self.value)
     }
 }
 

--- a/crates/oxc_ast/src/ast_kind_impl.rs
+++ b/crates/oxc_ast/src/ast_kind_impl.rs
@@ -207,7 +207,7 @@ impl AstKind<'_> {
             Self::StringLiteral(s) => format!("StringLiteral({})", s.value).into(),
             Self::BooleanLiteral(b) => format!("BooleanLiteral({})", b.value).into(),
             Self::NullLiteral(_) => "NullLiteral".into(),
-            Self::BigIntLiteral(b) => format!("BigIntLiteral({})", b.raw).into(),
+            Self::BigIntLiteral(b) => format!("BigIntLiteral({})", b.value).into(),
             Self::RegExpLiteral(r) => format!("RegExpLiteral({})", r.regex).into(),
             Self::TemplateLiteral(t) => format!(
                 "TemplateLiteral({})",

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -877,11 +877,12 @@ const _: () = {
     assert!(offset_of!(StringLiteral, lone_surrogates) == 40);
 
     // Padding: 7 bytes
-    assert!(size_of::<BigIntLiteral>() == 32);
+    assert!(size_of::<BigIntLiteral>() == 48);
     assert!(align_of::<BigIntLiteral>() == 8);
     assert!(offset_of!(BigIntLiteral, span) == 0);
-    assert!(offset_of!(BigIntLiteral, raw) == 8);
-    assert!(offset_of!(BigIntLiteral, base) == 24);
+    assert!(offset_of!(BigIntLiteral, value) == 8);
+    assert!(offset_of!(BigIntLiteral, raw) == 24);
+    assert!(offset_of!(BigIntLiteral, base) == 40);
 
     // Padding: 0 bytes
     assert!(size_of::<RegExpLiteral>() == 56);
@@ -2466,11 +2467,12 @@ const _: () = {
     assert!(offset_of!(StringLiteral, lone_surrogates) == 24);
 
     // Padding: 3 bytes
-    assert!(size_of::<BigIntLiteral>() == 20);
+    assert!(size_of::<BigIntLiteral>() == 28);
     assert!(align_of::<BigIntLiteral>() == 4);
     assert!(offset_of!(BigIntLiteral, span) == 0);
-    assert!(offset_of!(BigIntLiteral, raw) == 8);
-    assert!(offset_of!(BigIntLiteral, base) == 16);
+    assert!(offset_of!(BigIntLiteral, value) == 8);
+    assert!(offset_of!(BigIntLiteral, raw) == 16);
+    assert!(offset_of!(BigIntLiteral, base) == 24);
 
     // Padding: 0 bytes
     assert!(size_of::<RegExpLiteral>() == 32);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -137,19 +137,21 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
+    /// * `value`: Bigint value in base 10 with no underscores
     /// * `raw`: The bigint as it appears in source code
     /// * `base`: The base representation used by the literal in source code
     #[inline]
     pub fn expression_big_int_literal<A1>(
         self,
         span: Span,
-        raw: A1,
+        value: A1,
+        raw: Option<Atom<'a>>,
         base: BigintBase,
     ) -> Expression<'a>
     where
         A1: Into<Atom<'a>>,
     {
-        Expression::BigIntLiteral(self.alloc_big_int_literal(span, raw, base))
+        Expression::BigIntLiteral(self.alloc_big_int_literal(span, value, raw, base))
     }
 
     /// Build an [`Expression::RegExpLiteral`].
@@ -8520,14 +8522,21 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
+    /// * `value`: Bigint value in base 10 with no underscores
     /// * `raw`: The bigint as it appears in source code
     /// * `base`: The base representation used by the literal in source code
     #[inline]
-    pub fn big_int_literal<A1>(self, span: Span, raw: A1, base: BigintBase) -> BigIntLiteral<'a>
+    pub fn big_int_literal<A1>(
+        self,
+        span: Span,
+        value: A1,
+        raw: Option<Atom<'a>>,
+        base: BigintBase,
+    ) -> BigIntLiteral<'a>
     where
         A1: Into<Atom<'a>>,
     {
-        BigIntLiteral { span, raw: raw.into(), base }
+        BigIntLiteral { span, value: value.into(), raw, base }
     }
 
     /// Build a [`BigIntLiteral`], and store it in the memory arena.
@@ -8537,19 +8546,21 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
+    /// * `value`: Bigint value in base 10 with no underscores
     /// * `raw`: The bigint as it appears in source code
     /// * `base`: The base representation used by the literal in source code
     #[inline]
     pub fn alloc_big_int_literal<A1>(
         self,
         span: Span,
-        raw: A1,
+        value: A1,
+        raw: Option<Atom<'a>>,
         base: BigintBase,
     ) -> Box<'a, BigIntLiteral<'a>>
     where
         A1: Into<Atom<'a>>,
     {
-        Box::new_in(self.big_int_literal(span, raw, base), self.allocator)
+        Box::new_in(self.big_int_literal(span, value, raw, base), self.allocator)
     }
 
     /// Build a [`RegExpLiteral`].
@@ -9975,19 +9986,21 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
+    /// * `value`: Bigint value in base 10 with no underscores
     /// * `raw`: The bigint as it appears in source code
     /// * `base`: The base representation used by the literal in source code
     #[inline]
     pub fn ts_literal_big_int_literal<A1>(
         self,
         span: Span,
-        raw: A1,
+        value: A1,
+        raw: Option<Atom<'a>>,
         base: BigintBase,
     ) -> TSLiteral<'a>
     where
         A1: Into<Atom<'a>>,
     {
-        TSLiteral::BigIntLiteral(self.alloc_big_int_literal(span, raw, base))
+        TSLiteral::BigIntLiteral(self.alloc_big_int_literal(span, value, raw, base))
     }
 
     /// Build a [`TSLiteral::StringLiteral`].

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -4861,6 +4861,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BigIntLiteral<'_> {
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BigIntLiteral {
             span: CloneIn::clone_in(&self.span, allocator),
+            value: CloneIn::clone_in(&self.value, allocator),
             raw: CloneIn::clone_in(&self.raw, allocator),
             base: CloneIn::clone_in(&self.base, allocator),
         }
@@ -4869,6 +4870,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BigIntLiteral<'_> {
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BigIntLiteral {
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
+            value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
             raw: CloneIn::clone_in_with_semantic_ids(&self.raw, allocator),
             base: CloneIn::clone_in_with_semantic_ids(&self.base, allocator),
         }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -1479,7 +1479,7 @@ impl ContentEq for StringLiteral<'_> {
 
 impl ContentEq for BigIntLiteral<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.raw, &other.raw)
+        ContentEq::content_eq(&self.value, &other.value)
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_dummy.rs
+++ b/crates/oxc_ast/src/generated/derive_dummy.rs
@@ -1602,6 +1602,7 @@ impl<'a> Dummy<'a> for BigIntLiteral<'a> {
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
             span: Dummy::dummy(allocator),
+            value: Dummy::dummy(allocator),
             raw: Dummy::dummy(allocator),
             base: Dummy::dummy(allocator),
         }

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1941,7 +1941,7 @@ impl ESTree for BigIntLiteral<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &crate::serialize::literal::BigIntLiteralValue(self));
-        state.serialize_field("raw", &self.raw);
+        state.serialize_field("raw", &self.raw.map(|s| JsonSafeString(s.as_str())));
         state.serialize_field("bigint", &crate::serialize::literal::BigIntLiteralBigint(self));
         state.end();
     }

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1284,15 +1284,14 @@ impl GenExpr for BigIntLiteral<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, _ctx: Context) {
         p.print_space_before_identifier();
         p.add_source_mapping(self.span);
-        let raw = self.raw.as_str().cow_replace('_', "");
-        if !raw.starts_with('-') {
-            p.print_str(&raw);
-        } else if precedence >= Precedence::Prefix {
+        let value = self.value.as_str();
+        if value.starts_with('-') && precedence >= Precedence::Prefix {
             p.print_ascii_byte(b'(');
-            p.print_str(&raw);
-            p.print_ascii_byte(b')');
+            p.print_str(value);
+            p.print_str("n)");
         } else {
-            p.print_str(&raw);
+            p.print_str(value);
+            p.print_ascii_byte(b'n');
         }
     }
 }

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -451,21 +451,21 @@ fn big_int() {
     test("+0n;", "+0n;\n");
     test("-0n;", "-0n;\n");
 
-    test("0x1_0n;", "0x10n;\n");
-    test("0x10n;", "0x10n;\n");
+    test("0x1_0n;", "16n;\n");
+    test("0x10n;", "16n;\n");
 
-    test("0b1_01n;", "0b101n;\n");
-    test("0b101n;", "0b101n;\n");
-    test("0b101_101n;", "0b101101n;\n");
-    test("0b10_1n", "0b101n;\n");
+    test("0b1_01n;", "5n;\n");
+    test("0b101n;", "5n;\n");
+    test("0b101_101n;", "45n;\n");
+    test("0b10_1n", "5n;\n");
 
-    test("0o13n;", "0o13n;\n");
-    test("0o7n", "0o7n;\n");
+    test("0o13n;", "11n;\n");
+    test("0o7n", "7n;\n");
 
-    test("0x2_0n", "0x20n;\n");
-    test("0xfabn", "0xfabn;\n");
-    test("0xaef_en;", "0xaefen;\n");
-    test("0xaefen;", "0xaefen;\n");
+    test("0x2_0n", "32n;\n");
+    test("0xfabn", "4011n;\n");
+    test("0xaef_en;", "44798n;\n");
+    test("0xaefen;", "44798n;\n");
 
     test("return 1n", "return 1n;\n");
     test_minify("return 1n", "return 1n;");

--- a/crates/oxc_ecmascript/Cargo.toml
+++ b/crates/oxc_ecmascript/Cargo.toml
@@ -25,6 +25,5 @@ oxc_ast = { workspace = true }
 oxc_span = { workspace = true }
 oxc_syntax = { workspace = true, features = ["to_js_string"] }
 
-cow-utils = { workspace = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }

--- a/crates/oxc_ecmascript/src/to_big_int.rs
+++ b/crates/oxc_ecmascript/src/to_big_int.rs
@@ -59,8 +59,8 @@ impl<'a> ToBigInt<'a> for Expression<'a> {
 
 impl<'a> ToBigInt<'a> for BigIntLiteral<'a> {
     fn to_big_int(&self, _is_global_reference: &impl IsGlobalReference) -> Option<BigInt> {
-        let value = self.raw.as_str().trim_end_matches('n').string_to_big_int();
-        debug_assert!(value.is_some(), "Failed to parse {}", self.raw);
+        let value = self.value.as_str().string_to_big_int();
+        debug_assert!(value.is_some(), "Failed to parse {}n", self.value);
         value
     }
 }

--- a/crates/oxc_ecmascript/src/to_string.rs
+++ b/crates/oxc_ecmascript/src/to_string.rs
@@ -1,4 +1,3 @@
-use cow_utils::CowUtils;
 use std::borrow::Cow;
 
 use oxc_ast::ast::*;
@@ -97,9 +96,7 @@ impl<'a> ToJsString<'a> for NumericLiteral<'a> {
 /// <https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-bigint.prototype.tostring>
 impl<'a> ToJsString<'a> for BigIntLiteral<'a> {
     fn to_js_string(&self, _is_global_reference: &impl IsGlobalReference) -> Option<Cow<'a, str>> {
-        self.base
-            .is_base_10()
-            .then(|| Cow::Owned(self.raw.trim_end_matches('n').cow_replace('_', "").to_string()))
+        Some(Cow::Borrowed(self.value.as_str()))
     }
 }
 

--- a/crates/oxc_formatter/src/write/mod.rs
+++ b/crates/oxc_formatter/src/write/mod.rs
@@ -1961,7 +1961,7 @@ impl<'a> FormatWrite<'a> for StringLiteral<'a> {
 
 impl<'a> FormatWrite<'a> for BigIntLiteral<'a> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, dynamic_text(&self.raw.as_str().cow_to_ascii_lowercase(), self.span.start))
+        write!(f, dynamic_text(&self.raw.unwrap().cow_to_ascii_lowercase(), self.span.start))
     }
 }
 

--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -787,7 +787,7 @@ pub fn get_static_property_name<'a>(parent_node: &AstNode<'a>) -> Option<Cow<'a,
 
     match key {
         PropertyKey::RegExpLiteral(regex) => Some(Cow::Owned(regex.regex.to_string())),
-        PropertyKey::BigIntLiteral(bigint) => Some(Cow::Borrowed(bigint.raw.as_str())),
+        PropertyKey::BigIntLiteral(bigint) => Some(Cow::Borrowed(bigint.value.as_str())),
         PropertyKey::TemplateLiteral(template) => {
             if template.expressions.is_empty() && template.quasis.len() == 1 {
                 if let Some(cooked) = &template.quasis[0].value.cooked {

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
@@ -133,8 +133,6 @@ fn test() {
         "class A { get foo() {} get bar() {} get baz() {} }",
         "class A { 1() {} 2() {} }",
         "class Foo { foo(a: string): string; foo(a: number): number; foo(a: any): any {} }",
-        // NOTE: This should fail when we get read the big int value
-        "class A { [123n]() {} 123() {} }",
     ];
 
     let fail = vec![
@@ -158,6 +156,7 @@ fn test() {
         "class A { [0x10]() {} 16() {} }",
         "class A { [100]() {} [1e2]() {} }",
         "class A { [123.00]() {} [`123`]() {} }",
+        "class A { [123n]() {} 123() {} }",
         "class A { static '65'() {} static [0o101]() {} }",
         "class A { [null]() {} 'null'() {} }",
         "class A { foo() {} foo() {} foo() {} }",

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_keys.rs
@@ -128,8 +128,6 @@ fn test() {
         // Syntax:error: the '0' prefixed octal literals is not allowed.
         // ("var x = { 012: 1, 12: 2 };", None),
         ("var x = { 1_0: 1, 1: 2 };", None),
-        // NOTE: This should fail when we get read the big int value
-        ("var x = { 1n: 1, 1: 2 };", None),
     ];
 
     let fail = vec![
@@ -142,6 +140,7 @@ fn test() {
         ("var x = { 0b1: 1, 1: 2 };", None),
         ("var x = { 0o1: 1, 1: 2 };", None),
         ("var x = { 1_0: 1, 10: 2 };", None),
+        ("var x = { 1n: 1, 1: 2 };", None),
         ("var x = { \"z\": 1, z: 2 };", None),
         ("var foo = {\n  bar: 1,\n  bar: 1,\n}", None),
         ("var x = { a: 1, get a() {} };", None),

--- a/crates/oxc_linter/src/rules/eslint/no_magic_numbers.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_magic_numbers.rs
@@ -257,20 +257,19 @@ impl InternConfig<'_> {
                 }
             }
             AstKind::BigIntLiteral(bigint) => {
-                let big_int_string = bigint.raw.into_string();
                 if is_negative {
-                    let raw = format!("-{big_int_string}");
-
+                    let big_int_string = format!("-{}n", bigint.value);
                     InternConfig {
                         node: parent_node,
-                        value: NoMagicNumbersNumber::BigInt(raw.clone()),
-                        raw,
+                        value: NoMagicNumbersNumber::BigInt(big_int_string),
+                        raw: format!("-{}", bigint.raw.unwrap()),
                     }
                 } else {
+                    let big_int_string = format!("{}n", bigint.value);
                     InternConfig {
                         node: if is_unary { parent_node } else { node },
-                        value: NoMagicNumbersNumber::BigInt(big_int_string.clone()),
-                        raw: big_int_string,
+                        value: NoMagicNumbersNumber::BigInt(big_int_string),
+                        raw: bigint.raw.unwrap().into_string(),
                     }
                 }
             }

--- a/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
+++ b/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
@@ -109,11 +109,12 @@ impl Rule for NumericSeparatorsStyle {
                 }
             }
             AstKind::BigIntLiteral(number) => {
-                if self.only_if_contains_separator && !number.raw.contains('_') {
+                let raw = number.raw.unwrap().as_str();
+                if self.only_if_contains_separator && !raw.contains('_') {
                     return;
                 }
 
-                let formatted = self.format_bigint(number, &number.raw);
+                let formatted = self.format_bigint(number, raw);
 
                 if formatted.len() != number.span.size() as usize {
                     ctx.diagnostic_with_fix(

--- a/crates/oxc_linter/src/snapshots/eslint_no_dupe_class_members.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_dupe_class_members.snap
@@ -181,6 +181,15 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: The last declaration overwrites previous ones, remove one of them or rename if both should be retained
 
+  ⚠ eslint(no-dupe-class-members): Duplicate class member: "123"
+   ╭─[no_dupe_class_members.tsx:1:12]
+ 1 │ class A { [123n]() {} 123() {} }
+   ·            ──┬─       ─┬─
+   ·              │         ╰── "123" is re-declared here
+   ·              ╰── "123" is previously declared here
+   ╰────
+  help: The last declaration overwrites previous ones, remove one of them or rename if both should be retained
+
   ⚠ eslint(no-dupe-class-members): Duplicate class member: "65"
    ╭─[no_dupe_class_members.tsx:1:18]
  1 │ class A { static '65'() {} static [0o101]() {} }

--- a/crates/oxc_linter/src/snapshots/eslint_no_dupe_keys.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_dupe_keys.snap
@@ -82,6 +82,15 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing the duplicated key
 
+  ⚠ eslint(no-dupe-keys): Duplicate key '1'
+   ╭─[no_dupe_keys.tsx:1:11]
+ 1 │ var x = { 1n: 1, 1: 2 };
+   ·           ─┬     ┬
+   ·            │     ╰── and duplicated here
+   ·            ╰── Key is first defined here
+   ╰────
+  help: Consider removing the duplicated key
+
   ⚠ eslint(no-dupe-keys): Duplicate key 'z'
    ╭─[no_dupe_keys.tsx:1:11]
  1 │ var x = { "z": 1, z: 2 };

--- a/crates/oxc_minifier/src/ctx.rs
+++ b/crates/oxc_minifier/src/ctx.rs
@@ -88,8 +88,8 @@ impl<'a> Ctx<'a, '_> {
                 self.ast.expression_numeric_literal(span, n, None, number_base)
             }
             ConstantValue::BigInt(bigint) => {
-                let raw = format_atom!(self.ast.allocator, "{bigint}n");
-                self.ast.expression_big_int_literal(span, raw, BigintBase::Decimal)
+                let value = format_atom!(self.ast.allocator, "{bigint}");
+                self.ast.expression_big_int_literal(span, value, None, BigintBase::Decimal)
             }
             ConstantValue::String(s) => {
                 self.ast.expression_string_literal(span, self.ast.atom_from_cow(&s), None)

--- a/crates/oxc_minifier/tests/ecmascript/array_join.rs
+++ b/crates/oxc_minifier/tests/ecmascript/array_join.rs
@@ -23,7 +23,8 @@ fn test() {
         .push(ArrayExpressionElement::BooleanLiteral(ast.alloc(ast.boolean_literal(SPAN, true))));
     elements.push(ArrayExpressionElement::BigIntLiteral(ast.alloc(ast.big_int_literal(
         SPAN,
-        "42n",
+        "42",
+        Some(Atom::from("42n")),
         BigintBase::Decimal,
     ))));
     let array = ast.array_expression(SPAN, elements.clone_in(&allocator));

--- a/crates/oxc_minifier/tests/ecmascript/to_string.rs
+++ b/crates/oxc_minifier/tests/ecmascript/to_string.rs
@@ -44,7 +44,8 @@ fn test() {
     let object_with_to_string_string =
         object_with_to_string.to_js_string(&WithoutGlobalReferenceInformation {});
 
-    let bigint_with_separators = ast.expression_big_int_literal(SPAN, "1_0n", BigintBase::Decimal);
+    let bigint_with_separators =
+        ast.expression_big_int_literal(SPAN, "10", Some(Atom::from("1_0n")), BigintBase::Decimal);
     let bigint_with_separators_string =
         bigint_with_separators.to_js_string(&WithoutGlobalReferenceInformation {});
 

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -338,10 +338,10 @@ impl<'a> ParserImpl<'a> {
         let span = token.span();
         let raw = self.cur_src();
         let src = raw.strip_suffix('n').unwrap();
-        let _value = parse_big_int(src, token.kind(), token.has_separator())
-            .map_err(|err| diagnostics::invalid_number(err, span));
+        let value = parse_big_int(src, token.kind(), token.has_separator(), self.ast.allocator);
+
         self.bump_any();
-        self.ast.big_int_literal(span, raw, base)
+        self.ast.big_int_literal(span, value, Some(Atom::from(raw)), base)
     }
 
     pub(crate) fn parse_literal_regexp(&mut self) -> RegExpLiteral<'a> {

--- a/crates/oxc_semantic/src/dot.rs
+++ b/crates/oxc_semantic/src/dot.rs
@@ -45,7 +45,7 @@ impl DebugDotContext<'_, '_> {
             AstKind::NumericLiteral(lit) => Some(lit.value.to_string()),
             AstKind::BooleanLiteral(lit) => Some(lit.value.to_string()),
             AstKind::StringLiteral(lit) => Some(lit.value.to_string()),
-            AstKind::BigIntLiteral(lit) => Some(lit.raw.to_string()),
+            AstKind::BigIntLiteral(lit) => Some(lit.value.to_string()),
             AstKind::NullLiteral(_) => Some("null".to_string()),
             _ => None,
         }

--- a/crates/oxc_traverse/src/ast_operations/gather_node_parts.rs
+++ b/crates/oxc_traverse/src/ast_operations/gather_node_parts.rs
@@ -482,7 +482,7 @@ impl GatherNodeParts<'_> for BooleanLiteral {
 
 impl<'a> GatherNodeParts<'a> for BigIntLiteral<'a> {
     fn gather<F: FnMut(&str)>(&self, f: &mut F) {
-        f(self.raw.as_str());
+        f(self.value.as_str());
     }
 }
 

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -1078,14 +1078,13 @@ function deserializeStringLiteral(pos) {
 }
 
 function deserializeBigIntLiteral(pos) {
-  const raw = deserializeStr(pos + 8),
-    bigint = raw.slice(0, -1).replace(/_/g, '');
+  const bigint = deserializeStr(pos + 8);
   return {
     type: 'Literal',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     value: BigInt(bigint),
-    raw,
+    raw: deserializeOptionStr(pos + 24),
     bigint,
   };
 }

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -1223,14 +1223,13 @@ function deserializeStringLiteral(pos) {
 }
 
 function deserializeBigIntLiteral(pos) {
-  const raw = deserializeStr(pos + 8),
-    bigint = raw.slice(0, -1).replace(/_/g, '');
+  const bigint = deserializeStr(pos + 8);
   return {
     type: 'Literal',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     value: BigInt(bigint),
-    raw,
+    raw: deserializeOptionStr(pos + 24),
     bigint,
   };
 }

--- a/tasks/coverage/snapshots/estree_test262.snap
+++ b/tasks/coverage/snapshots/estree_test262.snap
@@ -2,166 +2,18 @@ commit: 4b5d36ab
 
 estree_test262 Summary:
 AST Parsed     : 44203/44203 (100.00%)
-Positive Passed: 44120/44203 (99.81%)
-Mismatch: tasks/coverage/test262/test/built-ins/Atomics/and/bigint/good-views.js
-
-Mismatch: tasks/coverage/test262/test/built-ins/Atomics/or/bigint/good-views.js
-
-Mismatch: tasks/coverage/test262/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-store.js
-
-Mismatch: tasks/coverage/test262/test/built-ins/Atomics/waitAsync/bigint/no-spurious-wakeup-on-store.js
-
-Mismatch: tasks/coverage/test262/test/built-ins/Atomics/xor/bigint/good-views.js
-
-Mismatch: tasks/coverage/test262/test/built-ins/BigInt/asIntN/arithmetic.js
-
-Mismatch: tasks/coverage/test262/test/built-ins/BigInt/asUintN/arithmetic.js
-
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigInt64/return-values-custom-offset.js
-
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigInt64/return-values.js
-
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigInt64/to-boolean-littleendian.js
-
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigInt64/toindex-byteoffset-toprimitive.js
-
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigInt64/toindex-byteoffset-wrapped-values.js
-
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigInt64/toindex-byteoffset.js
-
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigUint64/return-values-custom-offset.js
-
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigUint64/return-values.js
-
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigUint64/to-boolean-littleendian.js
-
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigUint64/toindex-byteoffset-toprimitive.js
-
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigUint64/toindex-byteoffset-wrapped-values.js
-
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigUint64/toindex-byteoffset.js
-
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/setBigInt64/set-values-little-endian-order.js
-
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/setBigInt64/to-boolean-littleendian.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/addition/bigint-arithmetic.js
-
+Positive Passed: 44194/44203 (99.98%)
 Mismatch: tasks/coverage/test262/test/language/expressions/assignment/fn-name-lhs-cover.js
 
 Mismatch: tasks/coverage/test262/test/language/expressions/assignment/target-cover-id.js
 
-Mismatch: tasks/coverage/test262/test/language/expressions/bitwise-and/bigint-non-primitive.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/bitwise-and/bigint.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/bitwise-not/bigint.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/bitwise-or/bigint-non-primitive.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/bitwise-or/bigint.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/bitwise-xor/bigint-non-primitive.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/bitwise-xor/bigint.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/division/bigint-arithmetic.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/does-not-equals/bigint-and-bigint.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/does-not-equals/bigint-and-number-extremes.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/equals/bigint-and-bigint.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/equals/bigint-and-number-extremes.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/exponentiation/bigint-arithmetic.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/greater-than/bigint-and-bigint.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/greater-than/bigint-and-number-extremes.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/greater-than-or-equal/bigint-and-bigint.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/greater-than-or-equal/bigint-and-number-extremes.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/left-shift/bigint-non-primitive.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/left-shift/bigint.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/less-than/bigint-and-bigint.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/less-than/bigint-and-number-extremes.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/less-than-or-equal/bigint-and-bigint.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/less-than-or-equal/bigint-and-number-extremes.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/modulus/bigint-arithmetic.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/multiplication/bigint-arithmetic.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/postfix-decrement/bigint.js
-
 Mismatch: tasks/coverage/test262/test/language/expressions/postfix-decrement/target-cover-id.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/postfix-increment/bigint.js
 
 Mismatch: tasks/coverage/test262/test/language/expressions/postfix-increment/target-cover-id.js
 
-Mismatch: tasks/coverage/test262/test/language/expressions/prefix-decrement/bigint.js
-
 Mismatch: tasks/coverage/test262/test/language/expressions/prefix-decrement/target-cover-id.js
 
-Mismatch: tasks/coverage/test262/test/language/expressions/prefix-increment/bigint.js
-
 Mismatch: tasks/coverage/test262/test/language/expressions/prefix-increment/target-cover-id.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/right-shift/bigint-non-primitive.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/right-shift/bigint.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/strict-does-not-equals/bigint-and-bigint.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/strict-does-not-equals/bigint-and-number-extremes.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/strict-equals/bigint-and-bigint.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/strict-equals/bigint-and-number-extremes.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/subtraction/bigint-arithmetic.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/unary-minus/bigint.js
-
-Mismatch: tasks/coverage/test262/test/language/expressions/unsigned-right-shift/bigint-non-primitive.js
-
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-bil-bd-nsl-bd.js
-
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-bil-bd-nsl-bds.js
-
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-bil-bds-nsl-bd.js
-
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-bil-bds-nsl-bds.js
-
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-hil-hd-nsl-hd.js
-
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-hil-hd-nsl-hds.js
-
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-hil-hds-nsl-hd.js
-
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-hil-hds-nsl-hds.js
-
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-hil-od-nsl-od-one-of.js
-
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-oil-od-nsl-od-one-of.js
-
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-oil-od-nsl-od.js
-
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-oil-od-nsl-ods.js
-
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-oil-ods-nsl-od.js
-
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-oil-ods-nsl-ods.js
 
 Mismatch: tasks/coverage/test262/test/language/statements/for-in/head-lhs-cover.js
 


### PR DESCRIPTION
Add `value` field to `BigIntLiteral`, same as the other literal types.

Once upon a time, we stored the value as a `BigInt` which normalized the representation (removing `_`s, and converting e.g. `0xFF` to `255`). But we had to remove it because `BigInt` owns a heap allocation, and this caused a memory leak.

https://github.com/oxc-project/oxc/commit/50fe0fef73027f10740e68a65a78216933b5d8a0

This PR brings back the `value` field, but avoids memory leak by storing the normalized value as a string (`Atom`).

This has effects in various places in the codebase:

* Brings our JS-side AST into line with ESTree (fixing the test cases broken by #11563).
* Fixes edge cases in a couple of lint rules.
* Codegen now prints bigints in normalized form e.g. `0xFFn` is printed as `255n`.
* Changes behavior of 1 function in `oxc_ecmascript`.

I've made comments below on the parts I'm not so sure about. Review would be very welcome!