### PR TITLE
perf(ecmascript): faster parsing integers

### DIFF
--- a/crates/oxc_ecmascript/src/string_to_number.rs
+++ b/crates/oxc_ecmascript/src/string_to_number.rs
@@ -32,10 +32,13 @@ impl StringToNumber for &str {
         let mut bytes = s.bytes();
 
         if s.len() > 2 && bytes.next() == Some(b'0') {
-            let radix: u32 = match bytes.next() {
-                Some(b'x' | b'X') => 16,
-                Some(b'o' | b'O') => 8,
-                Some(b'b' | b'B') => 2,
+            // `| 32` converts upper case ASCII letters to lower case.
+            // A bit more efficient than testing for `b'x' | b'X'`.
+            // https://godbolt.org/z/Korrhd4TE
+            let radix: u32 = match bytes.next().unwrap() | 32 {
+                b'x' => 16,
+                b'o' => 8,
+                b'b' => 2,
                 _ => 0,
             };
 

--- a/crates/oxc_ecmascript/src/to_big_int.rs
+++ b/crates/oxc_ecmascript/src/to_big_int.rs
@@ -1,5 +1,5 @@
 use num_bigint::BigInt;
-use num_traits::{One, Zero};
+use num_traits::{Num, One, Zero};
 
 use oxc_ast::ast::{BigIntLiteral, Expression};
 use oxc_syntax::operator::UnaryOperator;
@@ -59,7 +59,8 @@ impl<'a> ToBigInt<'a> for Expression<'a> {
 
 impl<'a> ToBigInt<'a> for BigIntLiteral<'a> {
     fn to_big_int(&self, _is_global_reference: &impl IsGlobalReference) -> Option<BigInt> {
-        let value = self.value.as_str().string_to_big_int();
+        // No need to use `StringToBigInt::string_to_big_int`, because `value` is always base 10
+        let value = BigInt::from_str_radix(&self.value, 10).ok();
         debug_assert!(value.is_some(), "Failed to parse {}n", self.value);
         value
     }


### PR DESCRIPTION
Small optimizations to integer conversions in `oxc_ecmascript`:

* Use `BigInt::from_str_radix` instead of `BigInt::parse_bytes` to skip unnecessary UTF-8 validation.
* Faster matching `0x` etc prefixes.
