### PR TITLE
refactor(ast/estree): remove dead code from generated raw transfer deserializer

### DIFF
--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -4091,11 +4091,6 @@ function deserializeVecStatement(pos) {
   return arr;
 }
 
-function deserializeOptionScopeId(pos) {
-  if (uint32[pos >> 2] === 0) return null;
-  return deserializeScopeId(pos);
-}
-
 function deserializeBoxBooleanLiteral(pos) {
   return deserializeBooleanLiteral(uint32[pos >> 2]);
 }
@@ -4254,16 +4249,6 @@ function deserializeBoxTSInstantiationExpression(pos) {
 
 function deserializeBoxV8IntrinsicExpression(pos) {
   return deserializeV8IntrinsicExpression(uint32[pos >> 2]);
-}
-
-function deserializeOptionReferenceId(pos) {
-  if (uint32[pos >> 2] === 0) return null;
-  return deserializeReferenceId(pos);
-}
-
-function deserializeOptionSymbolId(pos) {
-  if (uint32[pos >> 2] === 0) return null;
-  return deserializeSymbolId(pos);
 }
 
 function deserializeVecArrayExpressionElement(pos) {
@@ -4871,15 +4856,6 @@ function deserializeF64(pos) {
   return float64[pos >> 3];
 }
 
-function deserializeBoxPattern(pos) {
-  return deserializePattern(uint32[pos >> 2]);
-}
-
-function deserializeOptionBoxPattern(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxPattern(pos);
-}
-
 function deserializeU8(pos) {
   return uint8[pos];
 }
@@ -5268,74 +5244,6 @@ function deserializeOptionNameSpan(pos) {
   return deserializeNameSpan(pos);
 }
 
-function deserializeVecAlternative(pos) {
-  const arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(deserializeAlternative(pos));
-    pos += 32;
-  }
-  return arr;
-}
-
-function deserializeVecTerm(pos) {
-  const arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(deserializeTerm(pos));
-    pos += 16;
-  }
-  return arr;
-}
-
-function deserializeBoxBoundaryAssertion(pos) {
-  return deserializeBoundaryAssertion(uint32[pos >> 2]);
-}
-
-function deserializeBoxLookAroundAssertion(pos) {
-  return deserializeLookAroundAssertion(uint32[pos >> 2]);
-}
-
-function deserializeBoxQuantifier(pos) {
-  return deserializeQuantifier(uint32[pos >> 2]);
-}
-
-function deserializeBoxCharacter(pos) {
-  return deserializeCharacter(uint32[pos >> 2]);
-}
-
-function deserializeBoxCharacterClassEscape(pos) {
-  return deserializeCharacterClassEscape(uint32[pos >> 2]);
-}
-
-function deserializeBoxUnicodePropertyEscape(pos) {
-  return deserializeUnicodePropertyEscape(uint32[pos >> 2]);
-}
-
-function deserializeBoxCharacterClass(pos) {
-  return deserializeCharacterClass(uint32[pos >> 2]);
-}
-
-function deserializeBoxCapturingGroup(pos) {
-  return deserializeCapturingGroup(uint32[pos >> 2]);
-}
-
-function deserializeBoxIgnoreGroup(pos) {
-  return deserializeIgnoreGroup(uint32[pos >> 2]);
-}
-
-function deserializeBoxIndexedReference(pos) {
-  return deserializeIndexedReference(uint32[pos >> 2]);
-}
-
-function deserializeBoxNamedReference(pos) {
-  return deserializeNamedReference(uint32[pos >> 2]);
-}
-
 function deserializeU64(pos) {
   const pos32 = pos >> 2;
   return uint32[pos32] + uint32[pos32 + 1] * 4294967296;
@@ -5344,55 +5252,6 @@ function deserializeU64(pos) {
 function deserializeOptionU64(pos) {
   if (uint8[pos] === 0) return null;
   return deserializeU64(pos + 8);
-}
-
-function deserializeVecCharacterClassContents(pos) {
-  const arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(deserializeCharacterClassContents(pos));
-    pos += 16;
-  }
-  return arr;
-}
-
-function deserializeBoxCharacterClassRange(pos) {
-  return deserializeCharacterClassRange(uint32[pos >> 2]);
-}
-
-function deserializeBoxClassStringDisjunction(pos) {
-  return deserializeClassStringDisjunction(uint32[pos >> 2]);
-}
-
-function deserializeVecClassString(pos) {
-  const arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(deserializeClassString(pos));
-    pos += 40;
-  }
-  return arr;
-}
-
-function deserializeVecCharacter(pos) {
-  const arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(deserializeCharacter(pos));
-    pos += 16;
-  }
-  return arr;
-}
-
-function deserializeOptionModifiers(pos) {
-  if (uint8[pos] === 0) return null;
-  return deserializeModifiers(pos + 8);
 }
 
 function deserializeVecError(pos) {

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -4235,11 +4235,6 @@ function deserializeVecStatement(pos) {
   return arr;
 }
 
-function deserializeOptionScopeId(pos) {
-  if (uint32[pos >> 2] === 0) return null;
-  return deserializeScopeId(pos);
-}
-
 function deserializeBoxBooleanLiteral(pos) {
   return deserializeBooleanLiteral(uint32[pos >> 2]);
 }
@@ -4398,16 +4393,6 @@ function deserializeBoxTSInstantiationExpression(pos) {
 
 function deserializeBoxV8IntrinsicExpression(pos) {
   return deserializeV8IntrinsicExpression(uint32[pos >> 2]);
-}
-
-function deserializeOptionReferenceId(pos) {
-  if (uint32[pos >> 2] === 0) return null;
-  return deserializeReferenceId(pos);
-}
-
-function deserializeOptionSymbolId(pos) {
-  if (uint32[pos >> 2] === 0) return null;
-  return deserializeSymbolId(pos);
 }
 
 function deserializeVecArrayExpressionElement(pos) {
@@ -5015,15 +5000,6 @@ function deserializeF64(pos) {
   return float64[pos >> 3];
 }
 
-function deserializeBoxPattern(pos) {
-  return deserializePattern(uint32[pos >> 2]);
-}
-
-function deserializeOptionBoxPattern(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxPattern(pos);
-}
-
 function deserializeU8(pos) {
   return uint8[pos];
 }
@@ -5412,74 +5388,6 @@ function deserializeOptionNameSpan(pos) {
   return deserializeNameSpan(pos);
 }
 
-function deserializeVecAlternative(pos) {
-  const arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(deserializeAlternative(pos));
-    pos += 32;
-  }
-  return arr;
-}
-
-function deserializeVecTerm(pos) {
-  const arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(deserializeTerm(pos));
-    pos += 16;
-  }
-  return arr;
-}
-
-function deserializeBoxBoundaryAssertion(pos) {
-  return deserializeBoundaryAssertion(uint32[pos >> 2]);
-}
-
-function deserializeBoxLookAroundAssertion(pos) {
-  return deserializeLookAroundAssertion(uint32[pos >> 2]);
-}
-
-function deserializeBoxQuantifier(pos) {
-  return deserializeQuantifier(uint32[pos >> 2]);
-}
-
-function deserializeBoxCharacter(pos) {
-  return deserializeCharacter(uint32[pos >> 2]);
-}
-
-function deserializeBoxCharacterClassEscape(pos) {
-  return deserializeCharacterClassEscape(uint32[pos >> 2]);
-}
-
-function deserializeBoxUnicodePropertyEscape(pos) {
-  return deserializeUnicodePropertyEscape(uint32[pos >> 2]);
-}
-
-function deserializeBoxCharacterClass(pos) {
-  return deserializeCharacterClass(uint32[pos >> 2]);
-}
-
-function deserializeBoxCapturingGroup(pos) {
-  return deserializeCapturingGroup(uint32[pos >> 2]);
-}
-
-function deserializeBoxIgnoreGroup(pos) {
-  return deserializeIgnoreGroup(uint32[pos >> 2]);
-}
-
-function deserializeBoxIndexedReference(pos) {
-  return deserializeIndexedReference(uint32[pos >> 2]);
-}
-
-function deserializeBoxNamedReference(pos) {
-  return deserializeNamedReference(uint32[pos >> 2]);
-}
-
 function deserializeU64(pos) {
   const pos32 = pos >> 2;
   return uint32[pos32] + uint32[pos32 + 1] * 4294967296;
@@ -5488,55 +5396,6 @@ function deserializeU64(pos) {
 function deserializeOptionU64(pos) {
   if (uint8[pos] === 0) return null;
   return deserializeU64(pos + 8);
-}
-
-function deserializeVecCharacterClassContents(pos) {
-  const arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(deserializeCharacterClassContents(pos));
-    pos += 16;
-  }
-  return arr;
-}
-
-function deserializeBoxCharacterClassRange(pos) {
-  return deserializeCharacterClassRange(uint32[pos >> 2]);
-}
-
-function deserializeBoxClassStringDisjunction(pos) {
-  return deserializeClassStringDisjunction(uint32[pos >> 2]);
-}
-
-function deserializeVecClassString(pos) {
-  const arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(deserializeClassString(pos));
-    pos += 40;
-  }
-  return arr;
-}
-
-function deserializeVecCharacter(pos) {
-  const arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(deserializeCharacter(pos));
-    pos += 16;
-  }
-  return arr;
-}
-
-function deserializeOptionModifiers(pos) {
-  if (uint8[pos] === 0) return null;
-  return deserializeModifiers(pos + 8);
 }
 
 function deserializeVecError(pos) {

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -112,13 +112,13 @@ fn generate_deserializers(schema: &Schema, codegen: &Codegen) -> Codes {
                 generate_primitive(primitive_def, &mut codes.both, schema);
             }
             TypeDef::Option(option_def) => {
-                generate_option(option_def, &mut codes.both, schema);
+                generate_option(option_def, &mut codes.both, estree_derive_id, schema);
             }
             TypeDef::Box(box_def) => {
-                generate_box(box_def, &mut codes.both, schema);
+                generate_box(box_def, &mut codes.both, estree_derive_id, schema);
             }
             TypeDef::Vec(vec_def) => {
-                generate_vec(vec_def, &mut codes.both, schema);
+                generate_vec(vec_def, &mut codes.both, estree_derive_id, schema);
             }
             TypeDef::Cell(_cell_def) => {
                 // No deserializers for `Cell`s - use inner type's deserializer
@@ -533,9 +533,18 @@ static STR_DESERIALIZER_BODY: &str = "
 ";
 
 /// Generate deserialize function for an `Option`.
-fn generate_option(option_def: &OptionDef, code: &mut String, schema: &Schema) {
-    let fn_name = option_def.deser_name(schema);
+fn generate_option(
+    option_def: &OptionDef,
+    code: &mut String,
+    estree_derive_id: DeriveId,
+    schema: &Schema,
+) {
     let inner_type = option_def.inner_type(schema);
+    if should_skip_innermost_type(inner_type, estree_derive_id, schema) {
+        return;
+    }
+
+    let fn_name = option_def.deser_name(schema);
     let inner_fn_name = inner_type.deser_name(schema);
     let inner_layout = inner_type.layout_64();
 
@@ -574,9 +583,14 @@ fn generate_option(option_def: &OptionDef, code: &mut String, schema: &Schema) {
 }
 
 /// Generate deserialize function for a `Box`.
-fn generate_box(box_def: &BoxDef, code: &mut String, schema: &Schema) {
+fn generate_box(box_def: &BoxDef, code: &mut String, estree_derive_id: DeriveId, schema: &Schema) {
+    let inner_type = box_def.inner_type(schema);
+    if should_skip_innermost_type(inner_type, estree_derive_id, schema) {
+        return;
+    }
+
     let fn_name = box_def.deser_name(schema);
-    let inner_fn_name = box_def.inner_type(schema).deser_name(schema);
+    let inner_fn_name = inner_type.deser_name(schema);
 
     #[rustfmt::skip]
     write_it!(code, "
@@ -587,9 +601,13 @@ fn generate_box(box_def: &BoxDef, code: &mut String, schema: &Schema) {
 }
 
 /// Generate deserialize function for a `Vec`.
-fn generate_vec(vec_def: &VecDef, code: &mut String, schema: &Schema) {
-    let fn_name = vec_def.deser_name(schema);
+fn generate_vec(vec_def: &VecDef, code: &mut String, estree_derive_id: DeriveId, schema: &Schema) {
     let inner_type = vec_def.inner_type(schema);
+    if should_skip_innermost_type(inner_type, estree_derive_id, schema) {
+        return;
+    }
+
+    let fn_name = vec_def.deser_name(schema);
     let inner_fn_name = inner_type.deser_name(schema);
     let inner_type_size = inner_type.layout_64().size;
 
@@ -610,6 +628,23 @@ fn generate_vec(vec_def: &VecDef, code: &mut String, schema: &Schema) {
             return arr;
         }}
     ");
+}
+
+/// Check if innermost type does not require a deserializer.
+fn should_skip_innermost_type(
+    type_def: &TypeDef,
+    estree_derive_id: DeriveId,
+    schema: &Schema,
+) -> bool {
+    match type_def.innermost_type(schema) {
+        TypeDef::Struct(struct_def) => {
+            !struct_def.generates_derive(estree_derive_id) || struct_def.estree.skip
+        }
+        TypeDef::Enum(enum_def) => {
+            !enum_def.generates_derive(estree_derive_id) || enum_def.estree.skip
+        }
+        _ => false,
+    }
 }
 
 /// Generate pos offset string.


### PR DESCRIPTION
Remove dead code for deserializing `Option`s, `Box`es and `Vec`s of types which are not included in ESTree AST (e.g. `oxc_regular_expression` types).
