### PR TITLE
refactor(parser): speed up and migrate ts errors for parsing ts tuple elements

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -669,3 +669,18 @@ pub fn satisfies_in_ts(span: Span) -> OxcDiagnostic {
     ts_error("8016", "Type satisfaction expressions can only be used in TypeScript files.")
         .with_label(span)
 }
+
+#[cold]
+pub fn optional_and_rest_tuple_member(span: Span) -> OxcDiagnostic {
+    ts_error("5085", "A tuple member cannot be both optional and rest.").with_label(span)
+}
+
+#[cold]
+pub fn optional_after_tuple_member_name(span: Span) -> OxcDiagnostic {
+    ts_error("5086", "A labeled tuple element is declared as optional with a question mark after the name and before the colon, rather than after the type.").with_label(span)
+}
+
+#[cold]
+pub fn rest_after_tuple_member_name(span: Span) -> OxcDiagnostic {
+    ts_error("5087", "A labeled tuple element is declared as rest with a '...' before the name, rather than before the type.").with_label(span)
+}

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -3,7 +3,7 @@ commit: 1d4546bc
 parser_babel Summary:
 AST Parsed     : 2351/2362 (99.53%)
 Positive Passed: 2330/2362 (98.65%)
-Negative Passed: 1586/1698 (93.40%)
+Negative Passed: 1587/1698 (93.46%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/invalid-startindex-and-startline-specified-without-startcolumn/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/startline-and-startcolumn-specified/input.js
@@ -221,8 +221,6 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/ty
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/invalid-import-type-options-with-spread-element/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/invalid-import-type-options-with-trailing-comma/input.ts
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-labeled-invalid-optional/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-optional-invalid/input.ts
 
@@ -13401,6 +13399,12 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ type T = [x<y>: A];
    ·               ┬
    ·               ╰── `,` expected
+   ╰────
+
+  × TS(5086): A labeled tuple element is declared as optional with a question mark after the name and before the colon, rather than after the type.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/tuple-labeled-invalid-optional/input.ts:1:14]
+ 1 │ type T = [x: A?];
+   ·              ──
    ╰────
 
   × TS(1273): 'public' modifier cannot be used on a type parameter.

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: 81c95189
 parser_typescript Summary:
 AST Parsed     : 6530/6537 (99.89%)
 Positive Passed: 6519/6537 (99.72%)
-Negative Passed: 1399/5763 (24.28%)
+Negative Passed: 1400/5763 (24.29%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration24.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
@@ -8365,8 +8365,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tup
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/emptyTuples/emptyTuplesTypeAssertion02.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/indexerWithTuple.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/optionalTupleElements1.ts
 
@@ -31199,6 +31197,46 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
      ·                              ────
  166 │ 
      ╰────
+
+  × TS(5086): A labeled tuple element is declared as optional with a question mark after the name and before the colon, rather than after the type.
+    ╭─[typescript/tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts:10:29]
+  9 │ 
+ 10 │ export type Opt = [element: string?]; // question mark on element disallowed
+    ·                             ───────
+ 11 │ 
+    ╰────
+
+  × TS(5087): A labeled tuple element is declared as rest with a '...' before the name, rather than before the type.
+    ╭─[typescript/tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts:12:46]
+ 11 │ 
+ 12 │ export type Trailing = [first: string, rest: ...string[]]; // dots on element disallowed
+    ·                                              ───────────
+ 13 │ 
+    ╰────
+
+  × TS(5087): A labeled tuple element is declared as rest with a '...' before the name, rather than before the type.
+    ╭─[typescript/tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts:14:49]
+ 13 │ 
+ 14 │ export type OptTrailing = [first: string, rest: ...string[]?]; // dots+question on element disallowed
+    ·                                                 ────────────
+ 15 │ 
+    ╰────
+
+  × TS(5086): A labeled tuple element is declared as optional with a question mark after the name and before the colon, rather than after the type.
+    ╭─[typescript/tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts:14:49]
+ 13 │ 
+ 14 │ export type OptTrailing = [first: string, rest: ...string[]?]; // dots+question on element disallowed
+    ·                                                 ────────────
+ 15 │ 
+    ╰────
+
+  × TS(5085): A tuple member cannot be both optional and rest.
+    ╭─[typescript/tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts:16:39]
+ 15 │ 
+ 16 │ export type OptRest = [first: string, ...rest?: string[]]; // rest+optional disallowed
+    ·                                       ──────────────────
+ 17 │ 
+    ╰────
 
   × TS(1354): 'readonly' type modifier is only permitted on array and tuple literal types.
     ╭─[typescript/tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts:9:12]


### PR DESCRIPTION
- migrate TS errors 5085, 5086, 5087
- avoid expensive lookahead in some cases
- improve code readability