### PR TITLE
perf(napi/parser): re-use `TypedArray` objects in raw transfer

### DIFF
--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -13,8 +13,8 @@ const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
 
 function deserialize(buffer, sourceTextInput, sourceLenInput) {
   uint8 = buffer;
-  uint32 = new Uint32Array(buffer.buffer, buffer.byteOffset);
-  float64 = new Float64Array(buffer.buffer, buffer.byteOffset);
+  uint32 = buffer.uint32;
+  float64 = buffer.float64;
 
   sourceText = sourceTextInput;
   sourceLen = sourceLenInput;

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -13,8 +13,8 @@ const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
 
 function deserialize(buffer, sourceTextInput, sourceLenInput) {
   uint8 = buffer;
-  uint32 = new Uint32Array(buffer.buffer, buffer.byteOffset);
-  float64 = new Float64Array(buffer.buffer, buffer.byteOffset);
+  uint32 = buffer.uint32;
+  float64 = buffer.float64;
 
   sourceText = sourceTextInput;
   sourceLen = sourceLenInput;

--- a/napi/parser/raw-transfer/index.js
+++ b/napi/parser/raw-transfer/index.js
@@ -249,7 +249,10 @@ function clearBuffersCache() {
 function createBuffer() {
   const arrayBuffer = new ArrayBuffer(SIX_GIB);
   const offset = bindings.getBufferOffset(new Uint8Array(arrayBuffer));
-  return new Uint8Array(arrayBuffer, offset, TWO_GIB);
+  const buffer = new Uint8Array(arrayBuffer, offset, TWO_GIB);
+  buffer.uint32 = new Uint32Array(arrayBuffer, offset, TWO_GIB / 4);
+  buffer.float64 = new Float64Array(arrayBuffer, offset, TWO_GIB / 8);
+  return buffer;
 }
 
 let rawTransferIsSupported = null;

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -65,8 +65,8 @@ static PRELUDE: &str = "
 
     function deserialize(buffer, sourceTextInput, sourceLenInput) {
         uint8 = buffer;
-        uint32 = new Uint32Array(buffer.buffer, buffer.byteOffset);
-        float64 = new Float64Array(buffer.buffer, buffer.byteOffset);
+        uint32 = buffer.uint32;
+        float64 = buffer.float64;
 
         sourceText = sourceTextInput;
         sourceLen = sourceLenInput;


### PR DESCRIPTION
Small optimization to raw transfer. Reuse the same `Uint32Array` and `Float64Array`, rather than re-creating them for each file.