### PR TITLE
chore(napi)!: drop support for NodeJS before v20 in `oxc-parser`

### DIFF
--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -16,7 +16,7 @@
     "bench": "vitest bench --run ./bench.bench.mjs"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=20.0.0"
   },
   "description": "Oxc Parser Node API",
   "keywords": [


### PR DESCRIPTION
Drop support for NodeJS before v20 in `oxc-parser` NPM package.

All versions of NodeJS earlier than v20 are now EOL. I don't think we need to support them.

https://nodejs.org/en/about/previous-releases

I would like to use `FinalizationRegistry`, which is not available in Node v14 (our current lowest supported version).
