### PR TITLE
fix(linter/exhaustive-deps): handle destructuring inside hooks

### DIFF
--- a/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
@@ -1189,12 +1189,9 @@ impl<'a> Visit<'a> for ExhaustiveDepsVisitor<'a, '_> {
                                 if let Cow::Borrowed(id) = id {
                                     if id == "current" {
                                         did_see_ref = true;
-                                        if is_inside_effect_cleanup(&self.stack) {
-                                            // don't report `current` in effect cleanups
-                                            // self.refs_inside_cleanups.push(...);
-                                        }
+                                    } else {
+                                        destructured_props.push(id.into());
                                     }
-                                    destructured_props.push(id.into());
                                 } else {
                                     // todo
                                 }
@@ -1254,15 +1251,11 @@ impl<'a> Visit<'a> for ExhaustiveDepsVisitor<'a, '_> {
                 if let Cow::Borrowed(id) = id {
                     if id == "current" {
                         did_see_ref = true;
-                        if is_inside_effect_cleanup(&self.stack) {
-                            // don't report `current` in effect cleanups
-                            // self.refs_inside_cleanups.push(ident.to_static_member_expression());
-                        }
-                        return;
+                    } else {
+                        destructured_props.push(id.into());
                     }
-                    destructured_props.push(id.into());
                 } else {
-                    // todo: arena-allocate
+                    // todo: arena allocate
                 }
             })
             .unwrap_or(true);

--- a/crates/oxc_linter/src/snapshots/react_exhaustive_deps.snap
+++ b/crates/oxc_linter/src/snapshots/react_exhaustive_deps.snap
@@ -541,6 +541,51 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'props.foo'
+   ╭─[exhaustive_deps.tsx:5:14]
+ 4 │             console.log(foo);
+ 5 │           }, [props.bar]);
+   ·              ───────────
+ 6 │         }
+   ╰────
+  help: Either include it or remove the dependency array.
+
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.bar
+   ╭─[exhaustive_deps.tsx:5:14]
+ 4 │             console.log(foo);
+ 5 │           }, [props.bar]);
+   ·              ───────────
+ 6 │         }
+   ╰────
+  help: Either include it or remove the dependency array.
+
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'props.foo'
+   ╭─[exhaustive_deps.tsx:5:14]
+ 4 │             console.log(bar);
+ 5 │           }, [props.foo.bar]);
+   ·              ───────────────
+ 6 │         }
+   ╰────
+  help: Either include it or remove the dependency array.
+
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo.bar
+   ╭─[exhaustive_deps.tsx:5:14]
+ 4 │             console.log(bar);
+ 5 │           }, [props.foo.bar]);
+   ·              ───────────────
+ 6 │         }
+   ╰────
+  help: Either include it or remove the dependency array.
+
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'foo.bar'
+   ╭─[exhaustive_deps.tsx:6:14]
+ 5 │             console.log(bar);
+ 6 │           }, [props.foo.bar]);
+   ·              ───────────────
+ 7 │         }
+   ╰────
+  help: Either include it or remove the dependency array.
+
   ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             console.log(local);


### PR DESCRIPTION
## What This PR Does

Updates `react-hooks/exhaustive-deps` to handle object/array destructuring within hooks.

Before, this rule would report `props.foo` as an unnecessary dependency
```ts
function MyComponent(props) {
  useEffect(() => {
    const { foo } = props;
    console.log(foo);
  }, [props.foo]);
}
```