### PR TITLE
fix(linter): add missing `additional_hooks` option to exhaustive-deps

### DIFF
--- a/crates/oxc_linter/src/snapshots/react_exhaustive_deps.snap
+++ b/crates/oxc_linter/src/snapshots/react_exhaustive_deps.snap
@@ -2313,3 +2313,12 @@ source: crates/oxc_linter/src/tester.rs
  10 │         }
     ╰────
   help: Either include it or remove the dependency array.
+
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useSpecialEffect has a missing dependency: 'state'
+   ╭─[exhaustive_deps.tsx:7:14]
+ 6 │             setState(prevState => prevState + someNumber + state);
+ 7 │           }, [])
+   ·              ──
+ 8 │         }
+   ╰────
+  help: Either include it or remove the dependency array.


### PR DESCRIPTION
fixes #11601