### PR TITLE
refactor(parser): rewrite decorator parsing

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -759,10 +759,7 @@ impl Gen for FunctionBody<'_> {
 
 impl Gen for FormalParameter<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
-        for decorator in &self.decorators {
-            decorator.print(p, ctx);
-            p.print_soft_space();
-        }
+        p.print_decorators(&self.decorators, ctx);
         if let Some(accessibility) = self.accessibility {
             p.print_space_before_identifier();
             p.print_str(accessibility.as_str());
@@ -2245,10 +2242,7 @@ impl Gen for Class<'_> {
         let n = p.code_len();
         let wrap = self.is_expression() && (p.start_of_stmt == n || p.start_of_default_export == n);
         p.wrap(wrap, |p| {
-            for decorator in &self.decorators {
-                decorator.print(p, ctx);
-                p.print_hard_space();
-            }
+            p.print_decorators(&self.decorators, ctx);
             p.print_space_before_identifier();
             p.add_source_mapping(self.span);
             if self.declare {
@@ -2552,10 +2546,7 @@ impl Gen for StaticBlock<'_> {
 impl Gen for MethodDefinition<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
-        for decorator in &self.decorators {
-            decorator.print(p, ctx);
-            p.print_soft_space();
-        }
+        p.print_decorators(&self.decorators, ctx);
         if let Some(accessibility) = &self.accessibility {
             p.print_space_before_identifier();
             p.print_str(accessibility.as_str());
@@ -2637,10 +2628,7 @@ impl Gen for MethodDefinition<'_> {
 impl Gen for PropertyDefinition<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
-        for decorator in &self.decorators {
-            decorator.print(p, ctx);
-            p.print_soft_space();
-        }
+        p.print_decorators(&self.decorators, ctx);
         if self.declare {
             p.print_space_before_identifier();
             p.print_str("declare");
@@ -2694,10 +2682,7 @@ impl Gen for PropertyDefinition<'_> {
 impl Gen for AccessorProperty<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
-        for decorator in &self.decorators {
-            decorator.print(p, ctx);
-            p.print_soft_space();
-        }
+        p.print_decorators(&self.decorators, ctx);
         if self.r#type.is_abstract() {
             p.print_space_before_identifier();
             p.add_source_mapping(self.span);

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -628,6 +628,13 @@ impl<'a> Codegen<'a> {
         }
     }
 
+    fn print_decorators(&mut self, decorators: &[Decorator<'_>], ctx: Context) {
+        for decorator in decorators {
+            decorator.print(self, ctx);
+            self.print_hard_space();
+        }
+    }
+
     // `get_minified_number` from terser
     // https://github.com/terser/terser/blob/c5315c3fd6321d6b2e076af35a70ef532f498505/lib/output.js#L2418
     #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_possible_wrap)]

--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -1,7 +1,7 @@
 //! Code related to navigating `Token`s from the lexer
 
-use oxc_allocator::{TakeIn, Vec};
-use oxc_ast::ast::{BindingRestElement, Decorator, RegExpFlags};
+use oxc_allocator::Vec;
+use oxc_ast::ast::{BindingRestElement, RegExpFlags};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{GetSpan, Span};
 
@@ -293,32 +293,6 @@ impl<'a> ParserImpl<'a> {
         let result = cb(self);
         self.ctx = ctx;
         result
-    }
-
-    /// Consume all decorators.
-    pub(crate) fn consume_decorators(&mut self) -> Vec<'a, Decorator<'a>> {
-        self.state.decorators.take_in(self.ast)
-    }
-
-    /// Parse and save all decorators.
-    pub(crate) fn parse_and_save_decorators(&mut self) {
-        // For `@dec1 export default @dec2 class {}`
-        for decorator in &mut self.state.decorators {
-            self.errors.push(diagnostics::decorators_in_export_and_class(decorator.span));
-        }
-        while self.at(Kind::At) {
-            let decorator = self.parse_decorator();
-            self.state.decorators.push(decorator);
-        }
-    }
-
-    /// Check for unconsumed decorators.
-    pub(crate) fn check_unconsumed_decorators(&mut self) {
-        if !self.state.decorators.is_empty() {
-            for decorator in self.consume_decorators() {
-                self.error(diagnostics::decorators_are_not_valid_here(decorator.span));
-            }
-        }
     }
 
     pub(crate) fn parse_normal_list<F, T>(&mut self, open: Kind, close: Kind, f: F) -> Vec<'a, T>

--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -540,7 +540,7 @@ pub fn accessibility_modifier_already_seen(modifier: &Modifier) -> OxcDiagnostic
 
 #[cold]
 pub fn modifier_already_seen(modifier: &Modifier) -> OxcDiagnostic {
-    ts_error("1030", format!("{}' modifier already seen.", modifier.kind))
+    ts_error("1030", format!("'{}' modifier already seen.", modifier.kind))
         .with_label(modifier.span)
         .with_help("Remove the duplicate modifier.")
 }
@@ -683,4 +683,10 @@ pub fn optional_after_tuple_member_name(span: Span) -> OxcDiagnostic {
 #[cold]
 pub fn rest_after_tuple_member_name(span: Span) -> OxcDiagnostic {
     ts_error("5087", "A labeled tuple element is declared as rest with a '...' before the name, rather than before the type.").with_label(span)
+}
+
+#[cold]
+pub fn parameter_modifiers_in_ts(modifier: &Modifier) -> OxcDiagnostic {
+    ts_error("8012", "Parameter modifiers can only be used in TypeScript files.")
+        .with_label(modifier.span)
 }

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -1,5 +1,5 @@
 use cow_utils::CowUtils;
-use oxc_allocator::{Box, TakeIn};
+use oxc_allocator::{Box, TakeIn, Vec};
 use oxc_ast::ast::*;
 #[cfg(feature = "regular_expression")]
 use oxc_regular_expression::ast::Pattern;
@@ -19,6 +19,7 @@ use super::{
 use crate::{
     Context, ParserImpl, diagnostics,
     lexer::{Kind, parse_big_int, parse_float, parse_int},
+    modifiers::Modifiers,
 };
 
 impl<'a> ParserImpl<'a> {
@@ -156,15 +157,10 @@ impl<'a> ParserImpl<'a> {
     ///     `TemplateLiteral`[?Yield, ?Await, ~Tagged]
     ///     `CoverParenthesizedExpressionAndArrowParameterList`[?Yield, ?Await]
     fn parse_primary_expression(&mut self) -> Expression<'a> {
-        let span = self.start_span();
-
-        if self.at(Kind::At) {
-            self.parse_and_save_decorators();
-        }
-
         // FunctionExpression, GeneratorExpression
         // AsyncFunctionExpression, AsyncGeneratorExpression
         if self.at_function_with_async() {
+            let span = self.start_span();
             let r#async = self.eat(Kind::Async);
             return self.parse_function_expression(span, r#async);
         }
@@ -176,7 +172,9 @@ impl<'a> ParserImpl<'a> {
             // ObjectLiteral
             Kind::LCurly => Expression::ObjectExpression(self.parse_object_expression()),
             // ClassExpression
-            Kind::Class => self.parse_class_expression(),
+            Kind::Class => {
+                self.parse_class_expression(self.start_span(), &Modifiers::empty(), self.ast.vec())
+            }
             // This
             Kind::This => self.parse_this_expression(),
             // TemplateLiteral
@@ -187,19 +185,21 @@ impl<'a> ParserImpl<'a> {
             Kind::New => self.parse_new_expression(),
             Kind::Super => self.parse_super(),
             Kind::Import => self.parse_import_meta_or_call(),
-            Kind::LParen => self.parse_parenthesized_expression(span),
+            Kind::LParen => self.parse_parenthesized_expression(),
             Kind::Slash | Kind::SlashEq => {
                 let literal = self.parse_literal_regexp();
                 Expression::RegExpLiteral(self.alloc(literal))
             }
+            Kind::At => self.parse_decorated_expression(),
             // Literal, RegularExpressionLiteral
             kind if kind.is_literal() => self.parse_literal_expression(),
             _ => self.parse_identifier_expression(),
         }
     }
 
-    fn parse_parenthesized_expression(&mut self, span: u32) -> Expression<'a> {
-        self.expect(Kind::LParen);
+    fn parse_parenthesized_expression(&mut self) -> Expression<'a> {
+        let span = self.start_span();
+        self.bump_any(); // `bump` `(`
         let expr_span = self.start_span();
         let (mut expressions, comma_span) = self.context(Context::In, Context::Decorator, |p| {
             p.parse_delimited_list(
@@ -1378,6 +1378,29 @@ impl<'a> ParserImpl<'a> {
             p.parse_simple_unary_expression(lhs_span)
         });
         self.ast.expression_await(self.end_span(span), argument)
+    }
+
+    fn parse_decorated_expression(&mut self) -> Expression<'a> {
+        let span = self.start_span();
+        let decorators = self.parse_decorators();
+        let modifiers = self.parse_modifiers(false, false);
+        if self.at(Kind::Class) {
+            self.parse_class_expression(span, &modifiers, decorators)
+        } else {
+            self.unexpected()
+        }
+    }
+
+    pub(crate) fn parse_decorators(&mut self) -> Vec<'a, Decorator<'a>> {
+        if self.at(Kind::At) {
+            let mut decorators = self.ast.vec_with_capacity(1);
+            while self.at(Kind::At) {
+                decorators.push(self.parse_decorator());
+            }
+            decorators
+        } else {
+            self.ast.vec()
+        }
     }
 
     /// `Decorator`[Yield, Await]:

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -67,25 +67,25 @@ impl<'a> ParserImpl<'a> {
         (this_param, formal_parameters)
     }
 
-    fn parse_parameter_modifiers(&mut self) -> Modifiers<'a> {
-        let modifiers = self.parse_class_element_modifiers(true);
-        self.verify_modifiers(
-            &modifiers,
-            ModifierFlags::ACCESSIBILITY
-                .union(ModifierFlags::READONLY)
-                .union(ModifierFlags::OVERRIDE),
-            diagnostics::cannot_appear_on_a_parameter,
-        );
-        modifiers
-    }
-
     fn parse_formal_parameter(&mut self) -> FormalParameter<'a> {
         let span = self.start_span();
-        if self.at(Kind::At) {
-            self.parse_and_save_decorators();
+        let decorators = self.parse_decorators();
+        let modifiers = self.parse_modifiers(false, false);
+        if self.is_ts {
+            self.verify_modifiers(
+                &modifiers,
+                ModifierFlags::ACCESSIBILITY
+                    .union(ModifierFlags::READONLY)
+                    .union(ModifierFlags::OVERRIDE),
+                diagnostics::cannot_appear_on_a_parameter,
+            );
+        } else {
+            self.verify_modifiers(
+                &modifiers,
+                ModifierFlags::empty(),
+                diagnostics::parameter_modifiers_in_ts,
+            );
         }
-        let decorators = self.consume_decorators();
-        let modifiers = self.parse_parameter_modifiers();
         let pattern = self.parse_binding_pattern_with_initializer();
         self.ast.formal_parameter(
             self.end_span(span),

--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -41,7 +41,7 @@ impl<'a> ParserImpl<'a> {
         let span = self.start_span();
 
         let modifiers = self.parse_modifiers(
-            /* allow_decorators */ true, /* permit_const_as_modifier */ false,
+            /* permit_const_as_modifier */ false,
             /* stop_on_start_of_class_static_block */ false,
         );
 

--- a/crates/oxc_parser/src/lexer/kind.rs
+++ b/crates/oxc_parser/src/lexer/kind.rs
@@ -398,8 +398,8 @@ impl Kind {
     #[rustfmt::skip]
     #[inline]
     pub fn is_modifier_kind(self) -> bool {
-        matches!(self, Abstract | Accessor | Async | Const | Declare | Default
-          | Export | In | Out | Public | Private | Protected | Readonly | Static | Override)
+        matches!(self, Abstract | Accessor | Async | Const | Declare
+          | In | Out | Public | Private | Protected | Readonly | Static | Override)
     }
 
     #[inline]

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -415,7 +415,7 @@ impl<'a> ParserImpl<'a> {
             fatal_error: None,
             token: Token::default(),
             prev_token_end: 0,
-            state: ParserState::new(allocator),
+            state: ParserState::new(),
             ctx: Self::default_context(source_type, options),
             ast: AstBuilder::new(allocator),
             module_record_builder: ModuleRecordBuilder::new(allocator),

--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -30,6 +30,7 @@ bitflags! {
       const DEFAULT       = 1 << 13;
       const ACCESSOR      = 1 << 14;
       const ACCESSIBILITY = Self::PRIVATE.bits() | Self::PROTECTED.bits() | Self::PUBLIC.bits();
+      // NOTE: `export` and `default` are not handled here, they are parsed explicitly in the parser.
   }
 }
 
@@ -51,8 +52,6 @@ impl From<Kind> for ModifierFlags {
             Kind::Const => Self::CONST,
             Kind::In => Self::IN,
             Kind::Out => Self::OUT,
-            Kind::Export => Self::EXPORT,
-            Kind::Default => Self::DEFAULT,
             Kind::Accessor => Self::ACCESSOR,
             _ => unreachable!(),
         }
@@ -74,8 +73,6 @@ impl From<ModifierKind> for ModifierFlags {
             ModifierKind::Const => Self::CONST,
             ModifierKind::In => Self::IN,
             ModifierKind::Out => Self::OUT,
-            ModifierKind::Export => Self::EXPORT,
-            ModifierKind::Default => Self::DEFAULT,
             ModifierKind::Accessor => Self::ACCESSOR,
         }
     }
@@ -135,7 +132,7 @@ impl TryFrom<Token> for Modifier {
 /// // ^^^ This also counts as a modifier, but is also recorded separately as a
 /// // named export declaration
 /// ```
-#[derive(Debug, Hash)]
+#[derive(Debug)]
 pub struct Modifiers<'a> {
     /// May contain duplicates.
     modifiers: Option<Vec<'a, Modifier>>,
@@ -158,12 +155,12 @@ impl<'a> Modifiers<'a> {
     /// `flags` must correctly reflect the [`ModifierKind`]s within
     ///  `modifiers`. E.g., if `modifiers` is empty, then so is `flags``.
     #[must_use]
-    pub(crate) fn new(modifiers: Vec<'a, Modifier>, flags: ModifierFlags) -> Self {
-        if modifiers.is_empty() {
-            debug_assert!(flags.is_empty());
-            Self::empty()
-        } else {
+    pub(crate) fn new(modifiers: Option<Vec<'a, Modifier>>, flags: ModifierFlags) -> Self {
+        if let Some(modifiers) = modifiers {
             Self { modifiers: Some(modifiers), flags }
+        } else {
+            debug_assert!(flags.is_empty());
+            Self { modifiers: None, flags: ModifierFlags::empty() }
         }
     }
 
@@ -231,8 +228,6 @@ pub enum ModifierKind {
     Async,
     Const,
     Declare,
-    Default,
-    Export,
     In,
     Public,
     Private,
@@ -251,8 +246,6 @@ impl ModifierKind {
             Self::Async => "async",
             Self::Const => "const",
             Self::Declare => "declare",
-            Self::Default => "default",
-            Self::Export => "export",
             Self::In => "in",
             Self::Public => "public",
             Self::Private => "private",
@@ -281,8 +274,6 @@ impl TryFrom<Kind> for ModifierKind {
             Kind::Const => Ok(Self::Const),
             Kind::In => Ok(Self::In),
             Kind::Out => Ok(Self::Out),
-            Kind::Export => Ok(Self::Export),
-            Kind::Default => Ok(Self::Default),
             Kind::Accessor => Ok(Self::Accessor),
             _ => Err(()),
         }
@@ -309,7 +300,7 @@ impl<'a> ParserImpl<'a> {
             flags.set(modifier_flags, true);
             modifiers.push(modifier);
         }
-        Modifiers::new(modifiers, flags)
+        Modifiers::new(Some(modifiers), flags)
     }
 
     fn at_modifier(&mut self) -> bool {
@@ -326,18 +317,6 @@ impl<'a> ParserImpl<'a> {
                 self.bump_any();
                 self.at(Kind::Enum)
             }
-            Kind::Export => {
-                self.bump_any();
-                match self.cur_kind() {
-                    Kind::Default => self.next_token_can_follow_default_keyword(),
-                    Kind::Type => {
-                        self.bump_any();
-                        self.can_follow_export_modifier()
-                    }
-                    _ => self.can_follow_modifier(),
-                }
-            }
-            Kind::Default => self.next_token_can_follow_default_keyword(),
             Kind::Accessor | Kind::Static | Kind::Get | Kind::Set => {
                 // These modifiers can cross line.
                 self.bump_any();
@@ -361,22 +340,14 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn parse_modifiers(
         &mut self,
-        allow_decorators: bool,
         permit_const_as_modifier: bool,
         stop_on_start_of_class_static_block: bool,
     ) -> Modifiers<'a> {
         let mut has_seen_static_modifier = false;
-        let mut has_leading_modifier = false;
 
-        let mut modifiers = self.ast.vec();
+        let mut modifiers = None;
         let mut modifier_flags = ModifierFlags::empty();
 
-        // parse leading decorators
-        if allow_decorators && self.at(Kind::At) {
-            self.parse_and_save_decorators();
-        }
-
-        // parse leading modifiers
         while let Some(modifier) = self.try_parse_modifier(
             has_seen_static_modifier,
             permit_const_as_modifier,
@@ -387,29 +358,7 @@ impl<'a> ParserImpl<'a> {
             }
             self.check_for_duplicate_modifiers(modifier_flags, &modifier);
             modifier_flags.set(modifier.kind.into(), true);
-            modifiers.push(modifier);
-            has_leading_modifier = true;
-        }
-
-        // parse trailing decorators, but only if we parsed any leading modifiers
-        if allow_decorators && has_leading_modifier && self.at(Kind::At) {
-            self.parse_and_save_decorators();
-        }
-
-        // parse trailing modifiers, but only if we parsed any trailing decorators
-        if !self.state.decorators.is_empty() {
-            while let Some(modifier) = self.try_parse_modifier(
-                has_seen_static_modifier,
-                permit_const_as_modifier,
-                stop_on_start_of_class_static_block,
-            ) {
-                if modifier.is_static() {
-                    has_seen_static_modifier = true;
-                }
-                self.check_for_duplicate_modifiers(modifier_flags, &modifier);
-                modifier_flags.set(modifier.kind.into(), true);
-                modifiers.push(modifier);
-            }
+            modifiers.get_or_insert_with(|| self.ast.vec()).push(modifier);
         }
 
         Modifiers::new(modifiers, modifier_flags)
@@ -468,15 +417,6 @@ impl<'a> ParserImpl<'a> {
                 self.bump_any();
                 self.at(Kind::Enum)
             }
-            Kind::Export => {
-                self.bump_any();
-                match self.cur_kind() {
-                    Kind::Default => self.lookahead(Self::next_token_can_follow_default_keyword),
-                    Kind::Type => self.lookahead(Self::next_token_can_follow_export_modifier),
-                    _ => self.can_follow_export_modifier(),
-                }
-            }
-            Kind::Default => self.next_token_can_follow_default_keyword(),
             Kind::Static => {
                 self.bump_any();
                 self.can_follow_modifier()
@@ -506,34 +446,6 @@ impl<'a> ParserImpl<'a> {
         self.can_follow_modifier()
     }
 
-    fn next_token_can_follow_default_keyword(&mut self) -> bool {
-        self.bump_any();
-        match self.cur_kind() {
-            Kind::Class | Kind::Function | Kind::Interface | Kind::At => true,
-            Kind::Abstract if self.lookahead(Self::next_token_is_class_keyword_on_same_line) => {
-                true
-            }
-            Kind::Async if self.lookahead(Self::next_token_is_function_keyword_on_same_line) => {
-                true
-            }
-            _ => false,
-        }
-    }
-
-    fn next_token_can_follow_export_modifier(&mut self) -> bool {
-        self.bump_any();
-        self.can_follow_export_modifier()
-    }
-
-    fn can_follow_export_modifier(&self) -> bool {
-        let kind = self.cur_kind();
-        kind == Kind::At
-            && kind != Kind::Star
-            && kind != Kind::As
-            && kind != Kind::LCurly
-            && self.can_follow_modifier()
-    }
-
     fn can_follow_modifier(&self) -> bool {
         match self.cur_kind() {
             Kind::PrivateIdentifier | Kind::LBrack | Kind::LCurly | Kind::Star | Kind::Dot3 => true,
@@ -544,16 +456,6 @@ impl<'a> ParserImpl<'a> {
     fn can_follow_get_or_set_keyword(&self) -> bool {
         let kind = self.cur_kind();
         kind == Kind::LBrack || kind == Kind::PrivateIdentifier || kind.is_literal_property_name()
-    }
-
-    fn next_token_is_class_keyword_on_same_line(&mut self) -> bool {
-        self.bump_any();
-        self.cur_kind() == Kind::Class && !self.cur_token().is_on_new_line()
-    }
-
-    fn next_token_is_function_keyword_on_same_line(&mut self) -> bool {
-        self.bump_any();
-        self.cur_kind() == Kind::Function && !self.cur_token().is_on_new_line()
     }
 
     fn check_for_duplicate_modifiers(&mut self, seen_flags: ModifierFlags, modifier: &Modifier) {

--- a/crates/oxc_parser/src/state.rs
+++ b/crates/oxc_parser/src/state.rs
@@ -1,13 +1,10 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use oxc_allocator::{Allocator, Vec as ArenaVec};
-use oxc_ast::ast::{AssignmentExpression, Decorator};
+use oxc_ast::ast::AssignmentExpression;
 use oxc_span::Span;
 
 pub struct ParserState<'a> {
     pub not_parenthesized_arrow: FxHashSet<u32>,
-
-    pub decorators: ArenaVec<'a, Decorator<'a>>,
 
     /// Temporary storage for `CoverInitializedName` `({ foo = bar })`.
     /// Keyed by `ObjectProperty`'s span.start.
@@ -20,12 +17,10 @@ pub struct ParserState<'a> {
     pub trailing_commas: FxHashMap<u32, Span>,
 }
 
-impl<'a> ParserState<'a> {
-    pub fn new(allocator: &'a Allocator) -> Self {
+impl ParserState<'_> {
+    pub fn new() -> Self {
         Self {
             not_parenthesized_arrow: FxHashSet::default(),
-            // Create a large enough buffer for most cases.
-            decorators: ArenaVec::with_capacity_in(4, allocator),
             cover_initialized_name: FxHashMap::default(),
             trailing_commas: FxHashMap::default(),
         }

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -124,7 +124,7 @@ impl<'a> ParserImpl<'a> {
     fn skip_parameter_start(&mut self) -> bool {
         // Skip modifiers
         if self.cur_kind().is_modifier_kind() {
-            self.parse_modifiers(false, false, false);
+            self.parse_modifiers(false, false);
         }
         if self.cur_kind().is_identifier() || self.at(Kind::This) {
             self.bump_any();
@@ -170,7 +170,7 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_ts_type_parameter(&mut self) -> TSTypeParameter<'a> {
         let span = self.start_span();
 
-        let modifiers = self.parse_modifiers(false, true, false);
+        let modifiers = self.parse_modifiers(true, false);
         self.verify_modifiers(
             &modifiers,
             ModifierFlags::IN | ModifierFlags::OUT | ModifierFlags::CONST,
@@ -1264,7 +1264,7 @@ impl<'a> ParserImpl<'a> {
         }
 
         let mut flags = ModifierFlags::empty();
-        let mut modifiers: Vec<Modifier> = self.ast.vec();
+        let mut modifiers = None;
 
         loop {
             if !self.is_at_modifier(is_constructor_parameter) {
@@ -1278,7 +1278,7 @@ impl<'a> ParserImpl<'a> {
                     self.error(diagnostics::accessibility_modifier_already_seen(&modifier));
                 } else {
                     flags.insert(new_flag);
-                    modifiers.push(modifier);
+                    modifiers.get_or_insert_with(|| self.ast.vec()).push(modifier);
                 }
             } else {
                 break;

--- a/tasks/coverage/misc/pass/oxc-11593.ts
+++ b/tasks/coverage/misc/pass/oxc-11593.ts
@@ -1,0 +1,19 @@
+export class C extends B {
+  @convert(val => {
+    if (['rect', 'triangle'].includes(val)) {
+      return val;
+    }
+
+    return 'rect';
+  })
+  @derive(val => {
+    if (val === 'triangle') {
+      return {
+        rotate: 0,
+      };
+    }
+    return {};
+  })
+  @field()
+  accessor shapeType: 'rect' | 'triangle' = 'rect';
+}

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 40/40 (100.00%)
-Positive Passed: 40/40 (100.00%)
+AST Parsed     : 41/41 (100.00%)
+Positive Passed: 41/41 (100.00%)

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -12111,7 +12111,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Try insert a semicolon here
 
-  × TS(1030): declare' modifier already seen.
+  × TS(1030): 'declare' modifier already seen.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/duplicate-modifier-1/input.ts:2:18]
  1 │ class A {
  2 │   declare public declare foo;
@@ -12120,7 +12120,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Remove the duplicate modifier.
 
-  × TS(1030): declare' modifier already seen.
+  × TS(1030): 'declare' modifier already seen.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/duplicate-modifier-2/input.ts:2:25]
  1 │ class A {
  2 │   declare public static declare foo;
@@ -12129,7 +12129,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Remove the duplicate modifier.
 
-  × TS(1030): public' modifier already seen.
+  × TS(1030): 'public' modifier already seen.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/duplicates-accessibility/input.ts:2:10]
  1 │ class Foo {
  2 │   public public a;
@@ -12469,7 +12469,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·                ───
    ╰────
 
-  × TS(1030): declare' modifier already seen.
+  × TS(1030): 'declare' modifier already seen.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/export/double-declare/input.ts:1:16]
  1 │ export declare declare var name;
    ·                ───────
@@ -13415,7 +13415,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  96 │ type T21<in out in T> = T;  // Error
     ╰────
 
-  × TS(1030): in' modifier already seen.
+  × TS(1030): 'in' modifier already seen.
     ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/variance-annotations/input.ts:96:17]
  95 │ type T20<public T> = T;  // Error
  96 │ type T21<in out in T> = T;  // Error
@@ -13424,7 +13424,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
     ╰────
   help: Remove the duplicate modifier.
 
-  × TS(1030): out' modifier already seen.
+  × TS(1030): 'out' modifier already seen.
     ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/variance-annotations/input.ts:97:17]
  96 │ type T21<in out in T> = T;  // Error
  97 │ type T22<in out out T> = T;  // Error
@@ -13441,7 +13441,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  96 │ type T21<in out in T> = T;  // Error
     ╰────
 
-  × TS(1030): in' modifier already seen.
+  × TS(1030): 'in' modifier already seen.
     ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/variance-annotations-babel-7/input.ts:96:17]
  95 │ type T20<public T> = T;  // Error
  96 │ type T21<in out in T> = T;  // Error
@@ -13450,7 +13450,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
     ╰────
   help: Remove the duplicate modifier.
 
-  × TS(1030): out' modifier already seen.
+  × TS(1030): 'out' modifier already seen.
     ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/variance-annotations-babel-7/input.ts:97:17]
  96 │ type T21<in out in T> = T;  // Error
  97 │ type T22<in out out T> = T;  // Error

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 40/40 (100.00%)
-Positive Passed: 40/40 (100.00%)
+AST Parsed     : 41/41 (100.00%)
+Positive Passed: 41/41 (100.00%)
 Negative Passed: 40/40 (100.00%)
 
   × Identifier `b` has already been declared
@@ -36,13 +36,13 @@ Negative Passed: 40/40 (100.00%)
    ╰────
 
   × Decorators may not appear after 'export' or 'export default' if they also appear before 'export'.
-   ╭─[misc/fail/oxc-11472.js:1:1]
+   ╭─[misc/fail/oxc-11472.js:1:14]
  1 │ @dec1 export @dec2 class C {}
-   · ─────
+   ·              ─────
  2 │ 
    ╰────
 
-  × Decorators may not appear after 'export' or 'export default' if they also appear before 'export'.
+  × Decorators are not valid here.
    ╭─[misc/fail/oxc-11472.js:3:1]
  2 │ 
  3 │ @dec1 export default @dec2 class {}

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: 81c95189
 parser_typescript Summary:
 AST Parsed     : 6530/6537 (99.89%)
 Positive Passed: 6519/6537 (99.72%)
-Negative Passed: 1400/5763 (24.29%)
+Negative Passed: 1403/5763 (24.34%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration24.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
@@ -2017,10 +2017,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importDeclRe
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importDeclTypes.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importDeclWithClassModifiers.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importDeclWithDeclareModifier.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importDeclWithDeclareModifierInAmbientContext.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importDeclWithExportModifier.ts
 
@@ -5875,8 +5871,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/esDecorat
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.9.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-arguments.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-decoratorExpression.3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-emitDecoratorMetadata.ts
 
@@ -11284,7 +11278,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │     }
    ╰────
 
-  × TS(1028): Accessibility modifier already seen.
+  × TS(1030): 'public' modifier already seen.
    ╭─[typescript/tests/cases/compiler/constructorArgsErrors3.ts:2:25]
  1 │ class foo {
  2 │     constructor (public public a: number) {
@@ -11293,7 +11287,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╰────
   help: Remove the duplicate modifier.
 
-  × TS(1090): 'export' modifier cannot appear on a parameter.
+  × Identifier expected. 'export' is a reserved word that cannot be used here.
    ╭─[typescript/tests/cases/compiler/constructorArgsErrors5.ts:2:18]
  1 │ class foo {
  2 │     constructor (export a: number) {
@@ -11486,7 +11480,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  2 │ export default Foo
    ╰────
 
-  × TS(1030): declare' modifier already seen.
+  × TS(1030): 'declare' modifier already seen.
    ╭─[typescript/tests/cases/compiler/declareAlreadySeen.ts:2:13]
  1 │ module M {
  2 │     declare declare var x;
@@ -11495,7 +11489,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╰────
   help: Remove the duplicate modifier.
 
-  × TS(1030): declare' modifier already seen.
+  × TS(1030): 'declare' modifier already seen.
    ╭─[typescript/tests/cases/compiler/declareAlreadySeen.ts:3:13]
  2 │     declare declare var x;
  3 │     declare declare function f();
@@ -11504,7 +11498,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╰────
   help: Remove the duplicate modifier.
 
-  × TS(1030): declare' modifier already seen.
+  × TS(1030): 'declare' modifier already seen.
    ╭─[typescript/tests/cases/compiler/declareAlreadySeen.ts:5:13]
  4 │ 
  5 │     declare declare module N { }  
@@ -11513,7 +11507,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╰────
   help: Remove the duplicate modifier.
 
-  × TS(1030): declare' modifier already seen.
+  × TS(1030): 'declare' modifier already seen.
    ╭─[typescript/tests/cases/compiler/declareAlreadySeen.ts:7:13]
  6 │ 
  7 │     declare declare class C { }
@@ -12490,85 +12484,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·        ────────────────
    ╰────
 
-  × 'export' modifier cannot be used here.
+  × Unexpected token
    ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:2:12]
  1 │ module M {
  2 │     export export var x = 1;
    ·            ──────
  3 │     export export function f() { }
    ╰────
-
-  × 'export' modifier cannot be used here.
-   ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:3:12]
- 2 │     export export var x = 1;
- 3 │     export export function f() { }
-   ·            ──────
- 4 │ 
-   ╰────
-
-  × 'export' modifier cannot be used here.
-   ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:6:16]
- 5 │     export export module N {
- 6 │         export export class C { }
-   ·                ──────
- 7 │         export export interface I { }
-   ╰────
-
-  × 'export' modifier cannot be used here.
-   ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:7:16]
- 6 │         export export class C { }
- 7 │         export export interface I { }
-   ·                ──────
- 8 │     }  
-   ╰────
-
-  × 'export' modifier cannot be used here.
-   ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:5:12]
- 4 │ 
- 5 │     export export module N {
-   ·            ──────
- 6 │         export export class C { }
-   ╰────
-
-  × 'export' modifier cannot be used here.
-    ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:12:12]
- 11 │ declare module A {
- 12 │     export export var x;
-    ·            ──────
- 13 │     export export function f()
-    ╰────
-
-  × 'export' modifier cannot be used here.
-    ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:13:12]
- 12 │     export export var x;
- 13 │     export export function f()
-    ·            ──────
- 14 │ 
-    ╰────
-
-  × 'export' modifier cannot be used here.
-    ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:16:16]
- 15 │     export export module N {
- 16 │         export export class C { }
-    ·                ──────
- 17 │         export export interface I { }
-    ╰────
-
-  × 'export' modifier cannot be used here.
-    ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:17:16]
- 16 │         export export class C { }
- 17 │         export export interface I { }
-    ·                ──────
- 18 │     }
-    ╰────
-
-  × 'export' modifier cannot be used here.
-    ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:15:12]
- 14 │ 
- 15 │     export export module N {
-    ·            ──────
- 16 │         export export class C { }
-    ╰────
 
   × Unexpected token
    ╭─[typescript/tests/cases/compiler/exportAssignmentWithDeclareAndExportModifiers.ts:2:16]
@@ -12921,7 +12843,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  154 │ }
      ╰────
 
-  × 'export' modifier cannot be used here.
+  × Unexpected token
    ╭─[typescript/tests/cases/compiler/functionsWithModifiersInBlocks1.ts:4:12]
  3 │    export function f() { }
  4 │    declare export function f() { }
@@ -13035,6 +12957,22 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  1 │ import * as thing1 from "./mod.mjs" assert {field: 0};
    ·                                                    ─
  2 │ 
+   ╰────
+
+  × Unexpected token
+   ╭─[typescript/tests/cases/compiler/importDeclWithDeclareModifier.ts:5:9]
+ 4 │ }
+ 5 │ declare export import a = x.c;
+   ·         ──────
+ 6 │ var b: a;
+   ╰────
+
+  × Unexpected token
+   ╭─[typescript/tests/cases/compiler/importDeclWithDeclareModifierInAmbientContext.ts:6:13]
+ 5 │     }
+ 6 │     declare export import a = x.c;
+   ·             ──────
+ 7 │     var b: a;
    ╰────
 
   × Cannot use import statement outside a module
@@ -13492,11 +13430,10 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·             ╰── `,` expected
    ╰────
 
-  × Expected `,` but found `Identifier`
-   ╭─[typescript/tests/cases/compiler/jsFileCompilationPublicParameterModifier.ts:1:30]
+  × TS(8012): Parameter modifiers can only be used in TypeScript files.
+   ╭─[typescript/tests/cases/compiler/jsFileCompilationPublicParameterModifier.ts:1:23]
  1 │ class C { constructor(public x) { }}
-   ·                              ┬
-   ·                              ╰── `,` expected
+   ·                       ──────
    ╰────
 
   × Unexpected token
@@ -14606,7 +14543,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  2 │     .then((role: Role) =>
    ╰────
 
-  × TS(1030): public' modifier already seen.
+  × TS(1030): 'public' modifier already seen.
    ╭─[typescript/tests/cases/compiler/multipleClassPropertyModifiersErrors.ts:2:9]
  1 │ class C {
  2 │     public public p1;
@@ -14615,7 +14552,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╰────
   help: Remove the duplicate modifier.
 
-  × TS(1030): private' modifier already seen.
+  × TS(1030): 'private' modifier already seen.
    ╭─[typescript/tests/cases/compiler/multipleClassPropertyModifiersErrors.ts:3:10]
  2 │     public public p1;
  3 │     private private p2;
@@ -15843,7 +15780,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  1 │ if (true) {
    ╰────
 
-  × 'export' modifier cannot be used here.
+  × Unexpected token
      ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:326:9]
  325 │ 
  326 │ declare export module "anotherParseError2" {
@@ -19495,7 +19432,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  4 │ }
    ╰────
 
-  × TS(1030): readonly' modifier already seen.
+  × TS(1030): 'readonly' modifier already seen.
    ╭─[typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/readonlyReadonly.ts:2:14]
  1 │ class C {
  2 │     readonly readonly x: number;
@@ -19504,7 +19441,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╰────
   help: Remove the duplicate modifier.
 
-  × TS(1028): Accessibility modifier already seen.
+  × TS(1030): 'readonly' modifier already seen.
    ╭─[typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/readonlyReadonly.ts:3:26]
  2 │     readonly readonly x: number;
  3 │     constructor(readonly readonly y: number) {}
@@ -20577,7 +20514,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │ }
    ╰────
 
-  × TS(1030): public' modifier already seen.
+  × TS(1030): 'public' modifier already seen.
     ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessibilityModifiers.ts:42:12]
  41 │     private protected get getter() { return 0; }
  42 │     public public set setter(a: number) { }
@@ -20609,7 +20546,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  10 │     c
     ╰────
 
-  × TS(1030): accessor' modifier already seen.
+  × TS(1030): 'accessor' modifier already seen.
    ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorDisallowedModifiers.ts:2:14]
  1 │ abstract class C1 {
  2 │     accessor accessor a: any;
@@ -21032,12 +20969,12 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  4 │ }
    ╰────
 
-  × Decorators are not valid here.
-   ╭─[typescript/tests/cases/conformance/decorators/invalid/decoratorOnEnum.ts:3:1]
- 2 │ 
+  × Unexpected token
+   ╭─[typescript/tests/cases/conformance/decorators/invalid/decoratorOnEnum.ts:4:1]
  3 │ @dec
-   · ────
  4 │ enum E {
+   · ────
+ 5 │ }
    ╰────
 
   × Unexpected token
@@ -21048,19 +20985,19 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  5 │ }
    ╰────
 
-  × Decorators are not valid here.
-   ╭─[typescript/tests/cases/conformance/decorators/invalid/decoratorOnFunctionDeclaration.ts:3:1]
- 2 │ 
+  × Unexpected token
+   ╭─[typescript/tests/cases/conformance/decorators/invalid/decoratorOnFunctionDeclaration.ts:4:1]
  3 │ @dec
-   · ────
  4 │ function F() {
+   · ────────
+ 5 │ }
    ╰────
 
-  × Decorators are not valid here.
-   ╭─[typescript/tests/cases/conformance/decorators/invalid/decoratorOnFunctionExpression.ts:3:9]
+  × Unexpected token
+   ╭─[typescript/tests/cases/conformance/decorators/invalid/decoratorOnFunctionExpression.ts:3:14]
  2 │ 
  3 │ var F = @dec function () {
-   ·         ────
+   ·              ────────
  4 │ }
    ╰────
 
@@ -21072,51 +21009,50 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  6 │ function called(@dec() this: C) { return this.n; }
    ╰────
 
-  × Decorators are not valid here.
-   ╭─[typescript/tests/cases/conformance/decorators/invalid/decoratorOnImportEquals1.ts:8:5]
- 7 │ module M2 {
- 8 │     @dec
-   ·     ────
- 9 │     import X = M1.X;
-   ╰────
+  × Unexpected token
+    ╭─[typescript/tests/cases/conformance/decorators/invalid/decoratorOnImportEquals1.ts:9:5]
+  8 │     @dec
+  9 │     import X = M1.X;
+    ·     ──────
+ 10 │ }
+    ╰────
 
-  × Decorators are not valid here.
-   ╭─[typescript/tests/cases/conformance/decorators/invalid/decoratorOnImportEquals2.ts:1:1]
+  × Unexpected token
+   ╭─[typescript/tests/cases/conformance/decorators/invalid/decoratorOnImportEquals2.ts:2:1]
  1 │ @dec
-   · ────
  2 │ import lib = require('./decoratorOnImportEquals2_0');
+   · ──────
+ 3 │ 
    ╰────
 
-  × Decorators are not valid here.
-   ╭─[typescript/tests/cases/conformance/decorators/invalid/decoratorOnInterface.ts:3:1]
- 2 │ 
+  × Unexpected token
+   ╭─[typescript/tests/cases/conformance/decorators/invalid/decoratorOnInterface.ts:4:1]
  3 │ @dec
-   · ────
  4 │ interface I {
+   · ─────────
+ 5 │ }
    ╰────
 
-  × Decorators are not valid here.
-   ╭─[typescript/tests/cases/conformance/decorators/invalid/decoratorOnInternalModule.ts:3:1]
- 2 │ 
+  × Unexpected token
+   ╭─[typescript/tests/cases/conformance/decorators/invalid/decoratorOnInternalModule.ts:4:1]
  3 │ @dec
-   · ────
  4 │ module M {
+   · ──────
+ 5 │     
    ╰────
 
-  × Decorators are not valid here.
-   ╭─[typescript/tests/cases/conformance/decorators/invalid/decoratorOnTypeAlias.ts:3:1]
- 2 │ 
+  × Unexpected token
+   ╭─[typescript/tests/cases/conformance/decorators/invalid/decoratorOnTypeAlias.ts:4:1]
  3 │ @dec
-   · ────
  4 │ type T = number;
+   · ────
    ╰────
 
-  × Decorators are not valid here.
-   ╭─[typescript/tests/cases/conformance/decorators/invalid/decoratorOnVar.ts:3:1]
- 2 │ 
+  × Unexpected token
+   ╭─[typescript/tests/cases/conformance/decorators/invalid/decoratorOnVar.ts:4:1]
  3 │ @dec
-   · ────
  4 │ var x: number;
+   · ───
    ╰────
 
   × Unexpected token
@@ -24310,18 +24246,20 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  12 │ }
     ╰────
 
-  × 'default' modifier cannot be used here.
-   ╭─[typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-exportModifier.2.ts:2:13]
+  × Expected `{` but found `class`
+   ╭─[typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-exportModifier.2.ts:2:21]
  1 │ // error
  2 │ export @dec default class C3 {}
-   ·             ───────
+   ·                     ──┬──
+   ·                       ╰── `{` expected
    ╰────
 
-  × Unexpected token
-   ╭─[typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-exportModifier.ts:2:13]
+  × Expected `{` but found `class`
+   ╭─[typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-exportModifier.ts:2:21]
  1 │ // error
  2 │ export @dec default class C3 {}
-   ·             ───────
+   ·                     ──┬──
+   ·                       ╰── `{` expected
    ╰────
 
   × TS(1249): A decorator can only decorate a method implementation, not an overload.
@@ -24411,6 +24349,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
     ·              ─────
  38 │ 
     ╰────
+
+  × Unexpected token
+   ╭─[typescript/tests/cases/conformance/esDecorators/esDecorators-decoratorExpression.3.ts:5:5]
+ 4 │ 
+ 5 │ { @g<number> class C {} }
+   ·     ─
+ 6 │ 
+   ╰────
 
   × Private identifier '#foo' is not allowed outside class bodies
    ╭─[typescript/tests/cases/conformance/esDecorators/esDecorators-privateFieldAccess.ts:3:13]
@@ -25353,10 +25299,10 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╰────
 
   × Unexpected token
-   ╭─[typescript/tests/cases/conformance/externalModules/umd-errors.ts:3:15]
+   ╭─[typescript/tests/cases/conformance/externalModules/umd-errors.ts:3:8]
  2 │ export var p;
  3 │ static export as namespace oo1;
-   ·               ──
+   ·        ──────
  4 │ declare export as namespace oo2;
    ╰────
 
@@ -26298,7 +26244,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  4 │     & import("pkg", [ {"resolution-mode": "import"} ]).ImportInterface;
    ╰────
 
-  × TS(1030): override' modifier already seen.
+  × TS(1030): 'override' modifier already seen.
     ╭─[typescript/tests/cases/conformance/override/override5.ts:22:14]
  21 │ 
  22 │     override override oop: number;
@@ -26307,7 +26253,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
     ╰────
   help: Remove the duplicate modifier.
 
-  × TS(1030): override' modifier already seen.
+  × TS(1030): 'override' modifier already seen.
     ╭─[typescript/tests/cases/conformance/override/override7.ts:19:14]
  18 │ 
  19 │     override override oop: number;
@@ -26692,7 +26638,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │ }
    ╰────
 
-  × TS(1030): public' modifier already seen.
+  × TS(1030): 'public' modifier already seen.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration6.ts:2:10]
  1 │ class C {
  2 │   public public constructor() { }
@@ -27609,7 +27555,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  2 │ }
    ╰────
 
-  × 'export' modifier cannot be used here.
+  × Unexpected token
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/InterfaceDeclarations/parserInterfaceDeclaration6.ts:1:8]
  1 │ export export interface I {
    ·        ──────
@@ -27665,7 +27611,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │ }
    ╰────
 
-  × TS(1030): public' modifier already seen.
+  × TS(1030): 'public' modifier already seen.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration7.ts:2:12]
  1 │ class C {
  2 │     public public get Foo() { }
@@ -27683,7 +27629,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │ }
    ╰────
 
-  × TS(1030): public' modifier already seen.
+  × TS(1030): 'public' modifier already seen.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/MemberFunctionDeclarations/parserMemberFunctionDeclaration1.ts:2:12]
  1 │ class C {
  2 │     public public Foo() { }
@@ -27766,7 +27712,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  13 │ }
     ╰────
 
-  × TS(1030): public' modifier already seen.
+  × TS(1030): 'public' modifier already seen.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/MemberVariableDeclarations/parserMemberVariableDeclaration1.ts:2:10]
  1 │ class C {
  2 │   public public Foo;
@@ -28061,7 +28007,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │ }
    ╰────
 
-  × 'export' modifier cannot be used here.
+  × Unexpected token
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser618973.ts:1:8]
  1 │ export export class Foo {
    ·        ──────
@@ -31317,7 +31263,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  96 │ type T21<in out in T> = T;  // Error
     ╰────
 
-  × TS(1030): in' modifier already seen.
+  × TS(1030): 'in' modifier already seen.
     ╭─[typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotations.ts:96:17]
  95 │ type T20<public T> = T;  // Error
  96 │ type T21<in out in T> = T;  // Error
@@ -31326,7 +31272,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
     ╰────
   help: Remove the duplicate modifier.
 
-  × TS(1030): out' modifier already seen.
+  × TS(1030): 'out' modifier already seen.
     ╭─[typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotations.ts:97:17]
  96 │ type T21<in out in T> = T;  // Error
  97 │ type T22<in out out T> = T;  // Error

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,23 @@
 semantic_misc Summary:
-AST Parsed     : 40/40 (100.00%)
-Positive Passed: 25/40 (62.50%)
+AST Parsed     : 41/41 (100.00%)
+Positive Passed: 25/41 (60.98%)
+semantic Error: tasks/coverage/misc/pass/oxc-11593.ts
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(4)]
+rebuilt        : ScopeId(1): []
+Scope parent mismatch:
+after transform: ScopeId(2): Some(ScopeId(1))
+rebuilt        : ScopeId(2): Some(ScopeId(0))
+Scope parent mismatch:
+after transform: ScopeId(4): Some(ScopeId(1))
+rebuilt        : ScopeId(4): Some(ScopeId(0))
+Unresolved reference IDs mismatch for "String":
+after transform: [ReferenceId(7), ReferenceId(8)]
+rebuilt        : [ReferenceId(9)]
+
 semantic Error: tasks/coverage/misc/pass/oxc-1288.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["from"]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 40/40 (100.00%)
-Positive Passed: 40/40 (100.00%)
+AST Parsed     : 41/41 (100.00%)
+Positive Passed: 41/41 (100.00%)

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -545,13 +545,12 @@ rebuilt        : ["Object", "babelHelpers", "console", "dec"]
 
 * oxc/metadata/typescript-syntax/input.ts
 
-  x TS(1249): A decorator can only decorate a method implementation, not an
-  | overload.
-   ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/typescript-syntax/input.ts:6:3]
- 5 | class B {
- 6 |   @m
-   :   ^^
- 7 |   method();
+  x Unexpected token
+   ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/typescript-syntax/input.ts:2:1]
+ 1 | @dec
+ 2 | declare class A {}
+   : ^^^^^^^
+ 3 | 
    `----
 
 


### PR DESCRIPTION
fixes #11593

Parse decorators and pass them around explicitly instead of using a state to store them.