### PR TITLE
feat(parser): produce syntax error for `declare function foo() {}`

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
+++ b/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
@@ -540,8 +540,6 @@ fn test() {
             return _get(target, property, receiver || target);
         }
         "#,
-        "function foo() {}
-        declare function foo() {}",
         r#"
         var validator = function validator(node, key, val) {
             var validator = node.operator === "in" ? inOp : expression;

--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -690,3 +690,8 @@ pub fn parameter_modifiers_in_ts(modifier: &Modifier) -> OxcDiagnostic {
     ts_error("8012", "Parameter modifiers can only be used in TypeScript files.")
         .with_label(modifier.span)
 }
+
+#[cold]
+pub fn implementation_in_ambient(span: Span) -> OxcDiagnostic {
+    ts_error("1183", "An implementation cannot be declared in ambient contexts.").with_label(span)
+}

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -3,7 +3,7 @@ commit: 1d4546bc
 parser_babel Summary:
 AST Parsed     : 2351/2362 (99.53%)
 Positive Passed: 2330/2362 (98.65%)
-Negative Passed: 1587/1698 (93.46%)
+Negative Passed: 1588/1698 (93.52%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/invalid-startindex-and-startline-specified-without-startcolumn/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/startline-and-startcolumn-specified/input.js
@@ -81,8 +81,6 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/ty
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-binding-patterns/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/private-fields-modifier-abstract/input.ts
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/declare/function/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/declare/module-class/input.ts
 
@@ -12447,6 +12445,12 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ declare
  2 │ const { x, y }: { x: number, y: number };
    ·       ──────────────────────────────────
+   ╰────
+
+  × TS(1183): An implementation cannot be declared in ambient contexts.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/declare/function/input.ts:1:24]
+ 1 │ declare function foo() {}
+   ·                        ▲
    ╰────
 
   × Unexpected exponentiation expression

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: 81c95189
 parser_typescript Summary:
 AST Parsed     : 6530/6537 (99.89%)
 Positive Passed: 6519/6537 (99.72%)
-Negative Passed: 1403/5763 (24.34%)
+Negative Passed: 1404/5763 (24.36%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration24.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
@@ -7282,8 +7282,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration2.d.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration4.ts
@@ -12843,6 +12841,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  154 │ }
      ╰────
 
+  × TS(1183): An implementation cannot be declared in ambient contexts.
+   ╭─[typescript/tests/cases/compiler/functionsWithModifiersInBlocks1.ts:2:25]
+ 1 │ {
+ 2 │    declare function f() { }
+   ·                         ▲
+ 3 │    export function f() { }
+   ╰────
+
   × Unexpected token
    ╭─[typescript/tests/cases/compiler/functionsWithModifiersInBlocks1.ts:4:12]
  3 │    export function f() { }
@@ -18382,6 +18388,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·     ─────
  3 │ }
    ╰────
+
+  × TS(1183): An implementation cannot be declared in ambient contexts.
+    ╭─[typescript/tests/cases/conformance/ambient/ambientErrors.ts:20:24]
+ 19 │ // Ambient function with function body
+ 20 │ declare function fn4() { };
+    ·                        ▲
+ 21 │ 
+    ╰────
 
   × TS(1039): Initializers are not allowed in ambient contexts.
    ╭─[typescript/tests/cases/conformance/ambient/ambientErrors.ts:2:17]
@@ -27263,6 +27277,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/Expressions/parserUnaryExpression7.ts:1:4]
  1 │ ++ new Foo();
    ·    ─────────
+   ╰────
+
+  × TS(1183): An implementation cannot be declared in ambient contexts.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration2.ts:1:24]
+ 1 │ declare function Foo() {
+   ·                        ▲
+ 2 │ }
    ╰────
 
   × Unexpected token


### PR DESCRIPTION
closes #11590