### PR TITLE
feat(parser): produce syntax error for `interface A implements B {}`

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -695,3 +695,8 @@ pub fn parameter_modifiers_in_ts(modifier: &Modifier) -> OxcDiagnostic {
 pub fn implementation_in_ambient(span: Span) -> OxcDiagnostic {
     ts_error("1183", "An implementation cannot be declared in ambient contexts.").with_label(span)
 }
+
+#[cold]
+pub fn interface_implements(span: Span) -> OxcDiagnostic {
+    ts_error("1176", "Interface declaration cannot have 'implements' clause.").with_label(span)
+}

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -170,17 +170,21 @@ impl<'a> ParserImpl<'a> {
         self.expect(Kind::Interface); // bump interface
         let id = self.parse_binding_identifier();
         let type_parameters = self.parse_ts_type_parameters();
-        let (extends, _) = self.parse_heritage_clause();
+        let (extends, implements) = self.parse_heritage_clause();
         let body = self.parse_ts_interface_body();
         let extends =
             extends.map_or_else(|| self.ast.vec(), |e| self.ast.ts_interface_heritages(e));
-
         self.verify_modifiers(
             modifiers,
             ModifierFlags::DECLARE,
             diagnostics::modifier_cannot_be_used_here,
         );
-
+        if !implements.is_empty() {
+            self.error(diagnostics::interface_implements(Span::new(
+                implements.first().unwrap().span.start,
+                implements.last().unwrap().span.end,
+            )));
+        }
         self.ast.declaration_ts_interface(
             self.end_span(span),
             id,

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: 81c95189
 parser_typescript Summary:
 AST Parsed     : 6530/6537 (99.89%)
 Positive Passed: 6519/6537 (99.72%)
-Negative Passed: 1404/5763 (24.36%)
+Negative Passed: 1407/5763 (24.41%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration24.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
@@ -2275,8 +2275,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/interfaceNam
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/interfacePropertiesWithSameName2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/interfacePropertiesWithSameName3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/interfaceWithImplements1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/interfaceWithMultipleDeclarations.ts
 
@@ -6464,8 +6462,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/interface
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceThatIndirectlyInheritsFromItself.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceThatInheritsFromItself.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithAccessibilityModifiers.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithMultipleBaseTypes.ts
@@ -7339,8 +7335,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexSignatures/parserIndexSignature4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexSignatures/parserIndexSignature5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/InterfaceDeclarations/parserInterfaceDeclaration2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/InterfaceDeclarations/parserInterfaceDeclaration8.ts
 
@@ -13206,6 +13200,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  2 │ interface interface{ }
    ╰────
   help: Try insert a semicolon here
+
+  × TS(1176): Interface declaration cannot have 'implements' clause.
+   ╭─[typescript/tests/cases/compiler/interfaceWithImplements1.ts:3:27]
+ 2 │ 
+ 3 │ interface IBar implements IFoo {
+   ·                           ────
+ 4 │ }
+   ╰────
 
   × Illegal continue statement: no surrounding iteration statement
    ╭─[typescript/tests/cases/compiler/invalidContinueInDownlevelAsync.ts:3:9]
@@ -25476,6 +25478,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·                      ────────
    ╰────
 
+  × TS(1176): Interface declaration cannot have 'implements' clause.
+    ╭─[typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceThatInheritsFromItself.ts:10:26]
+  9 │ 
+ 10 │ interface Bar implements Bar { // error
+    ·                          ───
+ 11 │ }
+    ╰────
+
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfacesWithPredefinedTypesAsNames.ts:5:10]
  4 │ interface boolean { }
@@ -27513,6 +27523,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/InterfaceDeclarations/parserInterfaceDeclaration1.ts:1:23]
  1 │ interface I extends A extends B {
    ·                       ───────
+ 2 │ }
+   ╰────
+
+  × TS(1176): Interface declaration cannot have 'implements' clause.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/InterfaceDeclarations/parserInterfaceDeclaration2.ts:1:24]
+ 1 │ interface I implements A {
+   ·                        ─
  2 │ }
    ╰────
 


### PR DESCRIPTION
fixes #11591