### PR TITLE
test(napi/parser): run raw transfer tests on multiple threads

### DIFF
--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -63,8 +63,9 @@
     "@vitest/browser": "3.2.2",
     "esbuild": "^0.25.0",
     "playwright": "^1.51.0",
-    "vitest": "catalog:",
-    "typescript": "catalog:"
+    "tinypool": "^1.1.0",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "napi": {
     "binaryName": "parser",

--- a/napi/parser/test/parse-raw-common.mjs
+++ b/napi/parser/test/parse-raw-common.mjs
@@ -1,0 +1,28 @@
+// Constants used in both main thread and worker in raw transfer tests.
+
+import { join as pathJoin } from 'node:path';
+
+export const TEST_TYPE_TEST262 = 0;
+export const TEST_TYPE_JSX = 1;
+export const TEST_TYPE_TS = 2;
+export const TEST_TYPE_FIXTURE = 3;
+export const TEST_TYPE_INLINE_FIXTURE = 4;
+
+export const TEST_TYPE_MAIN_MASK = 7;
+export const TEST_TYPE_LAZY = 8;
+export const TEST_TYPE_PRETTY = 16;
+
+export const ROOT_DIR_PATH = pathJoin(import.meta.dirname, '../../..');
+export const TARGET_DIR_PATH = pathJoin(ROOT_DIR_PATH, 'target');
+export const TEST262_SHORT_DIR_PATH = 'tasks/coverage/test262/test';
+export const TEST262_DIR_PATH = pathJoin(ROOT_DIR_PATH, TEST262_SHORT_DIR_PATH);
+export const TS_SHORT_DIR_PATH = 'tasks/coverage/typescript';
+export const TS_DIR_PATH = pathJoin(ROOT_DIR_PATH, TS_SHORT_DIR_PATH);
+export const ACORN_TEST262_DIR_PATH = pathJoin(ROOT_DIR_PATH, 'tasks/coverage/acorn-test262/tests/test262/test');
+export const JSX_SHORT_DIR_PATH = 'tasks/coverage/acorn-test262/tests/acorn-jsx/pass';
+export const JSX_DIR_PATH = pathJoin(ROOT_DIR_PATH, JSX_SHORT_DIR_PATH);
+const TS_ESTREE_SHORT_DIR_PATH = 'tasks/coverage/acorn-test262/tests/typescript';
+export const TS_ESTREE_DIR_PATH = pathJoin(ROOT_DIR_PATH, TS_ESTREE_SHORT_DIR_PATH);
+export const TEST262_SNAPSHOT_PATH = pathJoin(ROOT_DIR_PATH, 'tasks/coverage/snapshots/estree_test262.snap');
+export const JSX_SNAPSHOT_PATH = pathJoin(ROOT_DIR_PATH, 'tasks/coverage/snapshots/estree_acorn_jsx.snap');
+export const TS_SNAPSHOT_PATH = pathJoin(ROOT_DIR_PATH, 'tasks/coverage/snapshots/estree_typescript.snap');

--- a/napi/parser/test/parse-raw-worker.mjs
+++ b/napi/parser/test/parse-raw-worker.mjs
@@ -1,0 +1,280 @@
+// Worker for raw transfer tests.
+
+import { readFile } from 'node:fs/promises';
+import { basename, join as pathJoin } from 'node:path';
+
+import { parseSync } from '../index.js';
+import {
+  ACORN_TEST262_DIR_PATH,
+  JSX_DIR_PATH,
+  ROOT_DIR_PATH,
+  TEST262_DIR_PATH,
+  TEST_TYPE_FIXTURE,
+  TEST_TYPE_INLINE_FIXTURE,
+  TEST_TYPE_JSX,
+  TEST_TYPE_LAZY,
+  TEST_TYPE_MAIN_MASK,
+  TEST_TYPE_PRETTY,
+  TEST_TYPE_TEST262,
+  TEST_TYPE_TS,
+  TS_DIR_PATH,
+  TS_ESTREE_DIR_PATH,
+} from './parse-raw-common.mjs';
+import { makeUnitsFromTest } from './typescript-make-units-from-test.cjs';
+
+// Run test case and return whether it passes.
+// This is the entry point when run as a worker.
+export default async function(data) {
+  try {
+    await runCase(data, simpleExpect);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Run test case with specified `expect` implementation.
+// If test fails, will throw an error.
+// Can be called from main thread.
+export async function runCase({ type, props }, expect) {
+  const lazy = (type & TEST_TYPE_LAZY) !== 0,
+    pretty = (type & TEST_TYPE_PRETTY) !== 0;
+  type &= TEST_TYPE_MAIN_MASK;
+
+  switch (type) {
+    case TEST_TYPE_TEST262:
+      await runTest262Case(props, lazy, expect);
+      break;
+    case TEST_TYPE_JSX:
+      await runJsxCase(props, lazy, expect);
+      break;
+    case TEST_TYPE_TS:
+      await runTsCase(props, lazy, expect);
+      break;
+    case TEST_TYPE_FIXTURE:
+      await runFixture(props, lazy, pretty, expect);
+      break;
+    case TEST_TYPE_INLINE_FIXTURE:
+      await runInlineFixture(props, lazy, pretty, expect);
+      break;
+    default:
+      throw new Error('Unexpected test type');
+  }
+}
+
+// Run Test262 test case
+async function runTest262Case(path, lazy, expect) {
+  const filename = basename(path);
+  const [sourceText, acornJson] = await Promise.all([
+    readFile(pathJoin(TEST262_DIR_PATH, path), 'utf8'),
+    readFile(pathJoin(ACORN_TEST262_DIR_PATH, `${path}on`), 'utf8'),
+  ]);
+
+  const sourceType = getSourceTypeFromJSON(acornJson);
+
+  if (lazy) return testLazy(filename, sourceText, { sourceType });
+
+  // @ts-ignore
+  const { program } = parseSync(filename, sourceText, { sourceType, experimentalRawTransfer: true });
+  const json = stringifyAcornTest262Style(program);
+  expect(json).toEqual(acornJson);
+}
+
+// Run JSX test case
+async function runJsxCase(filename, lazy, expect) {
+  const sourcePath = pathJoin(JSX_DIR_PATH, filename),
+    jsonPath = sourcePath.slice(0, -1) + 'on'; // `.jsx` -> `.json`
+  const [sourceText, acornJson] = await Promise.all([
+    readFile(sourcePath, 'utf8'),
+    readFile(jsonPath, 'utf8'),
+  ]);
+
+  const sourceType = getSourceTypeFromJSON(acornJson);
+
+  if (lazy) return testLazy(filename, sourceText, { sourceType });
+
+  // @ts-ignore
+  const { program } = parseSync(filename, sourceText, { sourceType, experimentalRawTransfer: true });
+  const json = stringifyAcornTest262Style(program);
+  expect(json).toEqual(acornJson);
+}
+
+// Run TypeScript test case
+const TS_CASE_HEADER = '__ESTREE_TEST__:PASS:\n```json\n';
+const TS_CASE_FOOTER = '\n```\n';
+const TS_CASE_FOOTER_LEN = TS_CASE_FOOTER.length;
+
+async function runTsCase(path, lazy, expect) {
+  const tsPath = path.slice(0, -3); // Trim off `.md`
+  let [sourceText, casesJson] = await Promise.all([
+    readFile(pathJoin(TS_DIR_PATH, tsPath), 'utf8'),
+    readFile(pathJoin(TS_ESTREE_DIR_PATH, path), 'utf8'),
+  ]);
+
+  // Trim off UTF-8 BOM
+  if (sourceText.charCodeAt(0) === 0xFEFF) sourceText = sourceText.slice(1);
+
+  const { tests } = makeUnitsFromTest(tsPath, sourceText);
+  const estreeJsons = casesJson.split(TS_CASE_HEADER)
+    .slice(1)
+    .map(part => part.slice(0, -TS_CASE_FOOTER_LEN));
+  expect(estreeJsons.length).toEqual(tests.length);
+
+  for (let i = 0; i < tests.length; i++) {
+    const { name: filename, content: code, sourceType } = tests[i];
+
+    const options = {
+      sourceType: sourceType.module ? 'module' : 'unambiguous',
+      astType: 'ts',
+      preserveParens: false,
+      experimentalRawTransfer: true,
+    };
+
+    if (lazy) {
+      testLazy(filename, sourceText, options);
+      continue;
+    }
+
+    // @ts-ignore
+    const { program, errors } = parseSync(filename, code, options);
+    const oxcJson = stringifyAcornTest262Style(program);
+
+    const estreeJson = estreeJsons[i];
+
+    try {
+      expect(oxcJson).toEqual(estreeJson);
+    } catch (err) {
+      // Fall back to comparing to AST parsed via JSON transfer.
+      // We can fail to match the TS-ESLint snapshots where there are syntax errors,
+      // because our parser is not recoverable.
+      // @ts-ignore
+      const standard = parseSync(filename, code, { ...options, experimentalRawTransfer: false });
+      const standardJson = stringifyAcornTest262Style(standard.program);
+      const errorsStandard = standard.errors;
+
+      expect(oxcJson).toEqual(standardJson);
+
+      const errorsRawJson = JSON.stringify(removeNullProperties(errors), null, 2);
+      const errorsStandardJson = JSON.stringify(errorsStandard, null, 2);
+      expect(errorsRawJson).toEqual(errorsStandardJson);
+    }
+  }
+}
+
+// Test raw transfer output matches standard (via JSON) output for a fixture file
+async function runFixture(path, lazy, pretty, expect) {
+  const filename = basename(path);
+  const sourceText = await readFile(pathJoin(ROOT_DIR_PATH, path), 'utf8');
+
+  if (lazy) {
+    testLazy(filename, sourceText);
+  } else {
+    assertRawAndStandardMatch(filename, sourceText, pretty, expect);
+  }
+}
+
+// Test raw transfer output matches standard (via JSON) output for a fixture, with provided source text
+async function runInlineFixture({ filename, sourceText }, lazy, pretty, expect) {
+  if (lazy) {
+    testLazy(filename, sourceText);
+  } else {
+    assertRawAndStandardMatch(filename, sourceText, pretty, expect);
+  }
+}
+
+// Test lazy deserialization does not throw an error.
+// We don't test the correctness of the output.
+function testLazy(filename, sourceText, options) {
+  // @ts-ignore
+  const ret = parseSync(filename, sourceText, {
+    ...options,
+    experimentalRawTransfer: false,
+    experimentalLazy: true,
+  });
+  JSON.stringify(ret.program);
+  JSON.stringify(ret.comments);
+  JSON.stringify(ret.errors);
+  JSON.stringify(ret.module);
+}
+
+// Assert raw transfer output matches standard (via JSON) output
+function assertRawAndStandardMatch(filename, sourceText, pretty, expect) {
+  const retStandard = parseSync(filename, sourceText);
+  const { program: programStandard, comments: commentsStandard, module: moduleStandard, errors: errorsStandard } =
+    retStandard;
+
+  // @ts-ignore
+  const retRaw = parseSync(filename, sourceText, { experimentalRawTransfer: true });
+  const { program: programRaw, comments: commentsRaw } = retRaw;
+  // Remove `null` values, to match what NAPI-RS does
+  const moduleRaw = removeNullProperties(retRaw.module);
+  const errorsRaw = removeNullProperties(retRaw.errors);
+
+  // Compare as JSON (to ensure same field order)
+  const jsonStandard = stringify(
+    { program: programStandard, comments: commentsStandard, module: moduleStandard, errors: errorsStandard },
+    pretty,
+  );
+  const jsonRaw = stringify(
+    { program: programRaw, comments: commentsRaw, module: moduleRaw, errors: errorsRaw },
+    pretty,
+  );
+  expect(jsonRaw).toEqual(jsonStandard);
+}
+
+// Acorn JSON files always end with:
+// ```
+//   "sourceType": "script",
+//   "hashbang": null
+// }
+// ```
+// For speed, extract `sourceType` with a slice, rather than parsing the JSON.
+function getSourceTypeFromJSON(json) {
+  return json.slice(-29, -23);
+}
+
+// Stringify to JSON, replacing values which are invalid in JSON.
+// If `pretty === true`, JSON is pretty-printed.
+function stringify(obj, pretty) {
+  return JSON.stringify(obj, (_key, value) => {
+    if (typeof value === 'bigint') return `__BIGINT__: ${value}`;
+    if (typeof value === 'object' && value instanceof RegExp) return `__REGEXP__: ${value}`;
+    if (value === Infinity) return `__INFINITY__`;
+    return value;
+  }, pretty ? 2 : undefined);
+}
+
+// Stringify to JSON, removing values which are invalid in JSON,
+// matching `acorn-test262` fixtures.
+const INFINITY_PLACEHOLDER = '__INFINITY__INFINITY__INFINITY__';
+const INFINITY_REGEXP = new RegExp(`"${INFINITY_PLACEHOLDER}"`, 'g');
+
+function stringifyAcornTest262Style(obj) {
+  let containsInfinity = false;
+  const json = JSON.stringify(obj, (_key, value) => {
+    if (typeof value === 'bigint' || (typeof value === 'object' && value instanceof RegExp)) return null;
+    if (value === Infinity) {
+      containsInfinity = true;
+      return INFINITY_PLACEHOLDER;
+    }
+    return value;
+  }, 2);
+
+  return containsInfinity ? json.replace(INFINITY_REGEXP, '1e+400') : json;
+}
+
+// Remove `null` values, to match what NAPI-RS does
+function removeNullProperties(obj) {
+  return JSON.parse(JSON.stringify(obj, (_key, value) => value === null ? undefined : value));
+}
+
+// Very simple `expect` implementation.
+// Only supports `expect(x).toEqual(y)`, and uses only a simple `===` comparison.
+// Therefore, only works for primitive values e.g. strings.
+function simpleExpect(value) {
+  return {
+    toEqual(expected) {
+      if (value !== expected) throw new Error('Mismatch');
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       playwright:
         specifier: ^1.51.0
         version: 1.52.0
+      tinypool:
+        specifier: ^1.1.0
+        version: 1.1.0
       typescript:
         specifier: 'catalog:'
         version: 5.8.3


### PR DESCRIPTION
Fix #10519.

Run raw transfer tests across multiple threads. Vitest can run multiple test *files* in parallel on separate threads, but it doesn't have ability to run test *cases* in the same file in parallel.

So create a worker pool and send details of each test case to the workers, which then run them in parallel.

On my machine, this cuts down the time to run `napi/parser` tests by a factor of 3 - from 19s to 6s.

Also: Fix `parseAsync` tests: `Promise`s weren't being `await`-ed, and cut down number of iterations on `parseAsync` test from 100,000 to 10,000 so it completes in a reasonable amount of time.