### PR TITLE
feat(parser): produce syntax error for decorators in non-class methods

### DIFF
--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -3,7 +3,7 @@ use oxc_ast::{NONE, ast::*};
 use oxc_span::GetSpan;
 use oxc_syntax::precedence::Precedence;
 
-use super::Tristate;
+use super::{FunctionKind, Tristate};
 use crate::{ParserImpl, diagnostics, lexer::Kind};
 
 struct ArrowFunctionHead<'a> {
@@ -269,8 +269,10 @@ impl<'a> ParserImpl<'a> {
 
         let type_parameters = self.parse_ts_type_parameters();
 
-        let (this_param, params) =
-            self.parse_formal_parameters(FormalParameterKind::ArrowFormalParameters);
+        let (this_param, params) = self.parse_formal_parameters(
+            FunctionKind::Expression,
+            FormalParameterKind::ArrowFormalParameters,
+        );
 
         if let Some(this_param) = this_param {
             // const x = (this: number) => {};

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -9,6 +9,8 @@ use crate::{
     modifiers::{ModifierFlags, ModifierKind, Modifiers},
 };
 
+use super::FunctionKind;
+
 type Extends<'a> =
     Vec<'a, (Expression<'a>, Option<Box<'a, TSTypeParameterInstantiation<'a>>>, Span)>;
 
@@ -364,7 +366,11 @@ impl<'a> ParserImpl<'a> {
         decorators: Vec<'a, Decorator<'a>>,
     ) -> ClassElement<'a> {
         let (name, computed) = self.parse_class_element_name(modifiers);
-        let value = self.parse_method(modifiers.contains(ModifierKind::Async), false);
+        let value = self.parse_method(
+            modifiers.contains(ModifierKind::Async),
+            false,
+            FunctionKind::ClassMethod,
+        );
         let method_definition = self.ast.alloc_method_definition(
             self.end_span(span),
             r#type,
@@ -395,7 +401,11 @@ impl<'a> ParserImpl<'a> {
         modifiers: &Modifiers<'a>,
         decorators: Vec<'a, Decorator<'a>>,
     ) -> ClassElement<'a> {
-        let value = self.parse_method(modifiers.contains(ModifierKind::Async), false);
+        let value = self.parse_method(
+            modifiers.contains(ModifierKind::Async),
+            false,
+            FunctionKind::ClassMethod,
+        );
         let method_definition = self.ast.alloc_method_definition(
             self.end_span(span),
             r#type,
@@ -499,7 +509,11 @@ impl<'a> ParserImpl<'a> {
         modifiers: &Modifiers<'a>,
         decorators: Vec<'a, Decorator<'a>>,
     ) -> ClassElement<'a> {
-        let value = self.parse_method(modifiers.contains(ModifierKind::Async), generator);
+        let value = self.parse_method(
+            modifiers.contains(ModifierKind::Async),
+            generator,
+            FunctionKind::ClassMethod,
+        );
         let method_definition = self.ast.alloc_method_definition(
             self.end_span(span),
             r#type,

--- a/crates/oxc_parser/src/js/mod.rs
+++ b/crates/oxc_parser/src/js/mod.rs
@@ -22,6 +22,8 @@ pub enum Tristate {
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum FunctionKind {
+    ClassMethod,
+    ObjectMethod,
     Declaration,
     Expression,
     DefaultExport,

--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -8,6 +8,8 @@ use crate::{
     modifiers::{ModifierFlags, Modifiers},
 };
 
+use super::FunctionKind;
+
 impl<'a> ParserImpl<'a> {
     /// [Object Expression](https://tc39.es/ecma262/#sec-object-initializer)
     /// `ObjectLiteral`[Yield, Await] :
@@ -65,7 +67,11 @@ impl<'a> ParserImpl<'a> {
                 ModifierFlags::ASYNC,
                 diagnostics::modifier_cannot_be_used_here,
             );
-            let method = self.parse_method(modifiers.contains_async(), asterisk_token);
+            let method = self.parse_method(
+                modifiers.contains_async(),
+                asterisk_token,
+                FunctionKind::ObjectMethod,
+            );
             return self.ast.alloc_object_property(
                 self.end_span(span),
                 PropertyKind::Init,
@@ -196,7 +202,7 @@ impl<'a> ParserImpl<'a> {
         modifiers: &Modifiers<'a>,
     ) -> Box<'a, ObjectProperty<'a>> {
         let (key, computed) = self.parse_property_name();
-        let method = self.parse_method(false, false);
+        let method = self.parse_method(false, false, FunctionKind::ObjectMethod);
         let value = Expression::FunctionExpression(method);
         self.verify_modifiers(
             modifiers,

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -9,7 +9,7 @@ use crate::{
     modifiers::{Modifier, ModifierFlags, ModifierKind, Modifiers},
 };
 
-use super::statement::CallOrConstructorSignature;
+use super::{super::js::FunctionKind, statement::CallOrConstructorSignature};
 
 impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_ts_type(&mut self) -> TSType<'a> {
@@ -55,7 +55,8 @@ impl<'a> ParserImpl<'a> {
         let r#abstract = self.eat(Kind::Abstract);
         let is_constructor_type = self.eat(Kind::New);
         let type_parameters = self.parse_ts_type_parameters();
-        let (this_param, params) = self.parse_formal_parameters(FormalParameterKind::Signature);
+        let (this_param, params) =
+            self.parse_formal_parameters(FunctionKind::Declaration, FormalParameterKind::Signature);
         let return_type = {
             let return_type_span = self.start_span();
             let Some(return_type) = self.parse_return_type(Kind::Arrow, /* is_type */ false) else {
@@ -1098,7 +1099,8 @@ impl<'a> ParserImpl<'a> {
             self.expect(Kind::New);
         }
         let type_parameters = self.parse_ts_type_parameters();
-        let (this_param, params) = self.parse_formal_parameters(FormalParameterKind::Signature);
+        let (this_param, params) =
+            self.parse_formal_parameters(FunctionKind::Declaration, FormalParameterKind::Signature);
         if kind == CallOrConstructorSignature::Constructor {
             if let Some(this_param) = &this_param {
                 // interface Foo { new(this: number): Foo }
@@ -1132,7 +1134,8 @@ impl<'a> ParserImpl<'a> {
         kind: TSMethodSignatureKind,
     ) -> TSSignature<'a> {
         let (key, computed) = self.parse_property_name();
-        let (this_param, params) = self.parse_formal_parameters(FormalParameterKind::Signature);
+        let (this_param, params) =
+            self.parse_formal_parameters(FunctionKind::Declaration, FormalParameterKind::Signature);
         let return_type = self.parse_ts_return_type_annotation(Kind::Colon, false);
         self.parse_type_member_semicolon();
         if kind == TSMethodSignatureKind::Set {
@@ -1165,7 +1168,8 @@ impl<'a> ParserImpl<'a> {
 
         if self.at(Kind::LParen) || self.at(Kind::LAngle) {
             let type_parameters = self.parse_ts_type_parameters();
-            let (this_param, params) = self.parse_formal_parameters(FormalParameterKind::Signature);
+            let (this_param, params) = self
+                .parse_formal_parameters(FunctionKind::Declaration, FormalParameterKind::Signature);
             let return_type = self.parse_ts_return_type_annotation(Kind::Colon, true);
             self.parse_type_member_semicolon();
             self.ast.ts_signature_method_signature(

--- a/tasks/coverage/misc/fail/oxc-11485.ts
+++ b/tasks/coverage/misc/fail/oxc-11485.ts
@@ -1,0 +1,5 @@
+var obj = {
+  method(@foo x) {},
+};
+
+function method(@foo x) {}

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 41/41 (100.00%)
 Positive Passed: 41/41 (100.00%)
-Negative Passed: 43/43 (100.00%)
+Negative Passed: 44/44 (100.00%)
 
   × Identifier `b` has already been declared
    ╭─[misc/fail/oxc-10159.js:1:22]
@@ -52,6 +52,21 @@ Negative Passed: 43/43 (100.00%)
   × Expected `from` but found `EOF`
    ╭─[misc/fail/oxc-11484.ts:2:1]
  1 │ import { type as as }
+   ╰────
+
+  × Decorators are not valid here.
+   ╭─[misc/fail/oxc-11485.ts:2:10]
+ 1 │ var obj = {
+ 2 │   method(@foo x) {},
+   ·          ────
+ 3 │ };
+   ╰────
+
+  × Decorators are not valid here.
+   ╭─[misc/fail/oxc-11485.ts:5:17]
+ 4 │ 
+ 5 │ function method(@foo x) {}
+   ·                 ────
    ╰────
 
   × Unexpected token


### PR DESCRIPTION
part of #11485

I searched around, there are no test cases in babel nor ts.