### PR TITLE
fix(oxc_linter): Make linter file paths clickable within JetBrains terminals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,6 +1736,7 @@ version = "0.75.0"
 dependencies = [
  "cow-utils",
  "oxc-miette",
+ "percent-encoding",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,6 +206,7 @@ nonmax = "0.5.5"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"
 papaya = "0.2.1"
+percent-encoding = "2.3.1"
 petgraph = { version = "0.8.2", default-features = false }
 phf = "0.12.0"
 phf_codegen = "0.12.0"

--- a/crates/oxc_diagnostics/Cargo.toml
+++ b/crates/oxc_diagnostics/Cargo.toml
@@ -21,3 +21,4 @@ doctest = false
 [dependencies]
 cow-utils = { workspace = true }
 miette = { workspace = true }
+percent-encoding = { workspace = true }

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -550,14 +550,14 @@ impl<'l> Runtime<'l> {
 
                         if !messages.is_empty() {
                             let errors = messages.into_iter().map(Into::into).collect();
-                            let path = path.strip_prefix(&me.cwd).unwrap_or(path);
                             let diagnostics = DiagnosticService::wrap_diagnostics(
+                                &me.cwd,
                                 path,
                                 dep.source_text,
                                 section.source.start,
                                 errors,
                             );
-                            tx_error.send(Some(diagnostics)).unwrap();
+                            tx_error.send(Some((path.to_path_buf(), diagnostics))).unwrap();
                         }
                     }
                     // If the new source text is owned, that means it was modified,


### PR DESCRIPTION
JetBrains terminals don't work reliably with relative paths to hyperlink to the file. Outputting the full file URL instead works consistently.

Fixes #8444.

This seems to work, but there is some cleanup that probably needs to be done by somebody more experienced. Left some inline comments for this.

Current
<img width="647" alt="image" src="https://github.com/user-attachments/assets/9981735b-314c-4d35-991b-c28eb415dc29" />

With this change in a JetBrains terminal (IntelliJ in this case)
<img width="998" alt="image" src="https://github.com/user-attachments/assets/6522a14c-4dbc-4481-999e-95d94f3dbaa1" />

With this change in a regular macOS terminal
<img width="621" alt="image" src="https://github.com/user-attachments/assets/132cbe43-9874-4c1c-823e-2b5875b12d78" />