### PR TITLE
fix(linter): correct labels for redundant comparisons

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/const_comparisons.rs
+++ b/crates/oxc_linter/src/rules/oxc/const_comparisons.rs
@@ -16,8 +16,8 @@ fn redundant_left_hand_side(left_span: Span, right_span: Span, help: String) -> 
     OxcDiagnostic::warn("Left-hand side of `&&` operator has no effect.")
         .with_help(help)
         .with_labels([
-            left_span.label("If this evaluates to `true`"),
-            right_span.label("This will always evaluate to true."),
+            right_span.label("If this evaluates to `true`"),
+            left_span.label("This will always evaluate to true."),
         ])
 }
 
@@ -25,8 +25,8 @@ fn redundant_right_hand_side(right_span: Span, left_span: Span, help: String) ->
     OxcDiagnostic::warn("Right-hand side of `&&` operator has no effect.")
         .with_help(help)
         .with_labels([
-            right_span.label("If this evaluates to `true`"),
-            left_span.label("This will always evaluate to true."),
+            left_span.label("If this evaluates to `true`"),
+            right_span.label("This will always evaluate to true."),
         ])
 }
 

--- a/crates/oxc_linter/src/snapshots/oxc_const_comparisons.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_const_comparisons.snap
@@ -68,8 +68,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[const_comparisons.tsx:1:1]
  1 │ status_code < 200 && status_code <= 299;
    · ────────┬────────    ─────────┬────────
-   ·         │                     ╰── If this evaluates to `true`
-   ·         ╰── This will always evaluate to true.
+   ·         │                     ╰── This will always evaluate to true.
+   ·         ╰── If this evaluates to `true`
    ╰────
   help: if `status_code < 200` evaluates to true, `status_code <= 299` will always evaluate to true as well
 
@@ -77,8 +77,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[const_comparisons.tsx:1:1]
  1 │ status_code > 200 && status_code >= 299;
    · ────────┬────────    ─────────┬────────
-   ·         │                     ╰── This will always evaluate to true.
-   ·         ╰── If this evaluates to `true`
+   ·         │                     ╰── If this evaluates to `true`
+   ·         ╰── This will always evaluate to true.
    ╰────
   help: if `status_code >= 299` evaluates to true, `status_code > 200` will always evaluate to true as well
 
@@ -86,8 +86,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[const_comparisons.tsx:1:1]
  1 │ status_code >= 500 && status_code > 500;
    · ─────────┬────────    ────────┬────────
-   ·          │                    ╰── This will always evaluate to true.
-   ·          ╰── If this evaluates to `true`
+   ·          │                    ╰── If this evaluates to `true`
+   ·          ╰── This will always evaluate to true.
    ╰────
   help: if `status_code > 500` evaluates to true, `status_code >= 500` will always evaluate to true as well
 
@@ -95,8 +95,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[const_comparisons.tsx:1:1]
  1 │ status_code > 500 && status_code >= 500;
    · ────────┬────────    ─────────┬────────
-   ·         │                     ╰── If this evaluates to `true`
-   ·         ╰── This will always evaluate to true.
+   ·         │                     ╰── This will always evaluate to true.
+   ·         ╰── If this evaluates to `true`
    ╰────
   help: if `status_code > 500` evaluates to true, `status_code >= 500` will always evaluate to true as well
 
@@ -104,8 +104,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[const_comparisons.tsx:1:1]
  1 │ status_code <= 500 && status_code < 500;
    · ─────────┬────────    ────────┬────────
-   ·          │                    ╰── This will always evaluate to true.
-   ·          ╰── If this evaluates to `true`
+   ·          │                    ╰── If this evaluates to `true`
+   ·          ╰── This will always evaluate to true.
    ╰────
   help: if `status_code < 500` evaluates to true, `status_code <= 500` will always evaluate to true as well
 
@@ -113,8 +113,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[const_comparisons.tsx:1:1]
  1 │ status_code < 500 && status_code <= 500;
    · ────────┬────────    ─────────┬────────
-   ·         │                     ╰── If this evaluates to `true`
-   ·         ╰── This will always evaluate to true.
+   ·         │                     ╰── This will always evaluate to true.
+   ·         ╰── If this evaluates to `true`
    ╰────
   help: if `status_code < 500` evaluates to true, `status_code <= 500` will always evaluate to true as well
 
@@ -185,8 +185,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[const_comparisons.tsx:1:10]
  1 │ foo() && status_code >= 500 && status_code > 500;
    ·          ─────────┬────────    ────────┬────────
-   ·                   │                    ╰── This will always evaluate to true.
-   ·                   ╰── If this evaluates to `true`
+   ·                   │                    ╰── If this evaluates to `true`
+   ·                   ╰── This will always evaluate to true.
    ╰────
   help: if `status_code > 500` evaluates to true, `status_code >= 500` will always evaluate to true as well
 
@@ -194,8 +194,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[const_comparisons.tsx:1:1]
  1 │ status_code <= 500 && foo() && status_code < 500;
    · ─────────┬────────             ────────┬────────
-   ·          │                             ╰── This will always evaluate to true.
-   ·          ╰── If this evaluates to `true`
+   ·          │                             ╰── If this evaluates to `true`
+   ·          ╰── This will always evaluate to true.
    ╰────
   help: if `status_code < 500` evaluates to true, `status_code <= 500` will always evaluate to true as well
 
@@ -203,8 +203,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[const_comparisons.tsx:1:1]
  1 │ status_code >= 500 && response && status_code > 500;
    · ─────────┬────────                ────────┬────────
-   ·          │                                ╰── This will always evaluate to true.
-   ·          ╰── If this evaluates to `true`
+   ·          │                                ╰── If this evaluates to `true`
+   ·          ╰── This will always evaluate to true.
    ╰────
   help: if `status_code > 500` evaluates to true, `status_code >= 500` will always evaluate to true as well
 
@@ -212,8 +212,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[const_comparisons.tsx:1:13]
  1 │ response && status_code > 500 && status_code >= 500;
    ·             ────────┬────────    ─────────┬────────
-   ·                     │                     ╰── If this evaluates to `true`
-   ·                     ╰── This will always evaluate to true.
+   ·                     │                     ╰── This will always evaluate to true.
+   ·                     ╰── If this evaluates to `true`
    ╰────
   help: if `status_code > 500` evaluates to true, `status_code >= 500` will always evaluate to true as well
 
@@ -221,8 +221,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[const_comparisons.tsx:1:1]
  1 │ status_code <= 500 && response && status_code < 500;
    · ─────────┬────────                ────────┬────────
-   ·          │                                ╰── This will always evaluate to true.
-   ·          ╰── If this evaluates to `true`
+   ·          │                                ╰── If this evaluates to `true`
+   ·          ╰── This will always evaluate to true.
    ╰────
   help: if `status_code < 500` evaluates to true, `status_code <= 500` will always evaluate to true as well
 
@@ -230,8 +230,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[const_comparisons.tsx:1:1]
  1 │ status_code < 500 && response && status_code <= 500;
    · ────────┬────────                ─────────┬────────
-   ·         │                                 ╰── If this evaluates to `true`
-   ·         ╰── This will always evaluate to true.
+   ·         │                                 ╰── This will always evaluate to true.
+   ·         ╰── If this evaluates to `true`
    ╰────
   help: if `status_code < 500` evaluates to true, `status_code <= 500` will always evaluate to true as well
 


### PR DESCRIPTION
The labels were displayed in an opposite order.