### PR TITLE
fix(parser): parse `@x() @y() export default abstract class {}`

### DIFF
--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -16,7 +16,12 @@ fn cases() {
     );
     test_same("class B {\n\tconstructor(override readonly a: number) {}\n}\n");
     test_same("export { type as as };\n");
-    test_same("@Decorator() abstract class C {}\n");
+}
+
+#[test]
+fn decorators() {
+    test_same("@a abstract class C {}\n");
+    test_tsx("@a @b export default abstract class {}", "export default @a @b abstract class {}\n");
 }
 
 #[test]

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -181,7 +181,6 @@ impl<'a> ParserImpl<'a> {
         span: u32,
         modifiers: &Modifiers<'a>,
     ) -> Declaration<'a> {
-        self.expect(Kind::Interface); // bump interface
         let id = self.parse_binding_identifier();
         let type_parameters = self.parse_ts_type_parameters();
         let (extends, implements) = self.parse_heritage_clause();
@@ -430,7 +429,10 @@ impl<'a> ParserImpl<'a> {
             }
             Kind::Type => self.parse_ts_type_alias_declaration(start_span, modifiers),
             Kind::Enum => self.parse_ts_enum_declaration(start_span, modifiers),
-            Kind::Interface => self.parse_ts_interface_declaration(start_span, modifiers),
+            Kind::Interface => {
+                self.bump_any();
+                self.parse_ts_interface_declaration(start_span, modifiers)
+            }
             Kind::Class => {
                 let decl = self.parse_class_declaration(start_span, modifiers, decorators);
                 Declaration::ClassDeclaration(decl)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -42,11 +42,11 @@ Negative Passed: 45/45 (100.00%)
  2 │ 
    ╰────
 
-  × Decorators are not valid here.
-   ╭─[misc/fail/oxc-11472.js:3:1]
+  × Decorators may not appear after 'export' or 'export default' if they also appear before 'export'.
+   ╭─[misc/fail/oxc-11472.js:3:22]
  2 │ 
  3 │ @dec1 export default @dec2 class {}
-   · ─────
+   ·                      ─────
    ╰────
 
   × Expected `from` but found `EOF`


### PR DESCRIPTION
Also took the opportunity to reduce a rewind on `export default interface`.