### PR TITLE
fix(linter/no-inner-declarations): flag `var` statement as body of `for` loop

### DIFF
--- a/crates/oxc_linter/src/snapshots/eslint_no_inner_declarations.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_inner_declarations.snap
@@ -175,3 +175,24 @@ source: crates/oxc_linter/src/tester.rs
    ·                                  ───
    ╰────
   help: Move variable declaration to program root
+
+  ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
+   ╭─[no_inner_declarations.tsx:1:21]
+ 1 │ for (const x in {}) var y = 5;
+   ·                     ───
+   ╰────
+  help: Move variable declaration to program root
+
+  ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
+   ╭─[no_inner_declarations.tsx:1:21]
+ 1 │ for (const x of []) var y = 5;
+   ·                     ───
+   ╰────
+  help: Move variable declaration to program root
+
+  ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
+   ╭─[no_inner_declarations.tsx:1:32]
+ 1 │ for (const x = 1; a < 10; a++) var y = 5;
+   ·                                ───
+   ╰────
+  help: Move variable declaration to program root


### PR DESCRIPTION
Follow-on after #11617. That change broke the rule (failed to report errors) in these cases:

```js
for (const x in {}) var y = 5;
for (const x of []) var y = 5;
for (const x = 1; a < 10; a++) var y = 5;
```

We need to check that parent is a `for` statement *and* that the declaration is its `init` / `left`.
