### PR TITLE
style(ast): import `Span` at top level

### DIFF
--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -1,7 +1,7 @@
 use oxc_ast::AstKind;
 use oxc_cfg::BlockNodeId;
 use oxc_index::IndexVec;
-use oxc_span::GetSpan;
+use oxc_span::{GetSpan, Span};
 use oxc_syntax::{
     node::{NodeFlags, NodeId},
     scope::ScopeId,
@@ -80,7 +80,7 @@ impl<'a> AstNode<'a> {
 
 impl GetSpan for AstNode<'_> {
     #[inline]
-    fn span(&self) -> oxc_span::Span {
+    fn span(&self) -> Span {
         self.kind.span()
     }
 }


### PR DESCRIPTION
Style nit. It's odd to import `GetSpan` but not `Span`.
