### PR TITLE
feat(language_server): add `unusedDisableDirectives` option

### DIFF
--- a/crates/oxc_language_server/README.md
+++ b/crates/oxc_language_server/README.md
@@ -19,11 +19,12 @@ This crate provides an [LSP](https://microsoft.github.io/language-server-protoco
 
 These options can be passed with [initialize](#initialize), [workspace/didChangeConfiguration](#workspace/didChangeConfiguration) and [workspace/configuration](#workspace/configuration).
 
-| Option Key   | Value(s)               | Default    | Description                                                                                          |
-| ------------ | ---------------------- | ---------- | ---------------------------------------------------------------------------------------------------- |
-| `run`        | `"onSave" \| "onType"` | `"onType"` | Should the server lint the files when the user is typing or saving                                   |
-| `configPath` | `<string>` \| `null`   | `null`     | Path to a oxlint configuration file, passing a string will disable nested configuration              |
-| `flags`      | `Map<string, string>`  | `<empty>`  | Special oxc language server flags, currently only one flag key is supported: `disable_nested_config` |
+| Option Key                | Value(s)                       | Default    | Description                                                                                                                                 |
+| ------------------------- | ------------------------------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `run`                     | `"onSave" \| "onType"`         | `"onType"` | Should the server lint the files when the user is typing or saving                                                                          |
+| `configPath`              | `<string>` \| `null`           | `null`     | Path to a oxlint configuration file, passing a string will disable nested configuration                                                     |
+| `unusedDisableDirectives` | `"allow" \| "warn"` \| "deny"` | `"allow"`  | Define how directive comments like `// oxlint-disable-line` should be reported, when no errors would have been reported on that line anyway |
+| `flags`                   | `Map<string, string>`          | `<empty>`  | Special oxc language server flags, currently only one flag key is supported: `disable_nested_config`                                        |
 
 ## Supported LSP Specifications from Server
 
@@ -39,6 +40,7 @@ The client can pass the workspace options like following:
     "options": {
       "run": "onType",
       "configPath": null,
+      "unusedDisableDirectives": "allow",
       "flags": {}
     }
   }]
@@ -72,6 +74,7 @@ The client can pass the workspace options like following:
     "options": {
       "run": "onType",
       "configPath": null,
+      "unusedDisableDirectives": "allow",
       "flags": {}
     }
   }]
@@ -155,11 +158,10 @@ Only will be requested when the `ClientCapabilities` has `workspace.configuratio
 The client can return a response like:
 
 ```json
-{
-    [{
-        "run": "onType",
-        "configPath": null,
-        "flags": {}
-    }]
-}
+[{
+  "run": "onType",
+  "configPath": null,
+  "unusedDisableDirectives": "allow",
+  "flags": {}
+}]
 ```

--- a/crates/oxc_language_server/fixtures/linter/unused_disabled_directives/test.js
+++ b/crates/oxc_language_server/fixtures/linter/unused_disabled_directives/test.js
@@ -1,0 +1,4 @@
+// oxlint-disable-next-line no-debugger -- on wrong line
+(() => {
+  debugger;
+})();

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_unused_disabled_directives@test.js.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_unused_disabled_directives@test.js.snap
@@ -1,0 +1,28 @@
+---
+source: crates/oxc_language_server/src/tester.rs
+input_file: crates/oxc_language_server/fixtures/linter/unused_disabled_directives/test.js
+---
+code: "eslint(no-debugger)"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
+message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"
+range: Range { start: Position { line: 2, character: 2 }, end: Position { line: 2, character: 11 } }
+related_information[0].message: ""
+related_information[0].location.uri: "file://<variable>/fixtures/linter/unused_disabled_directives/test.js"
+related_information[0].location.range: Range { start: Position { line: 2, character: 2 }, end: Position { line: 2, character: 11 } }
+severity: Some(Warning)
+source: Some("oxc")
+tags: None
+fixed: Single(FixedContent { message: Some("Remove the debugger statement"), code: "", range: Range { start: Position { line: 2, character: 2 }, end: Position { line: 2, character: 11 } } })
+
+
+code: ""
+code_description.href: "None"
+message: "Unused eslint-disable directive (no problems were reported from no-debugger)."
+range: Range { start: Position { line: 0, character: 2 }, end: Position { line: 0, character: 56 } }
+related_information[0].message: ""
+related_information[0].location.uri: "file://<variable>/fixtures/linter/unused_disabled_directives/test.js"
+related_information[0].location.range: Range { start: Position { line: 0, character: 2 }, end: Position { line: 0, character: 56 } }
+severity: Some(Error)
+source: Some("oxc")
+tags: None
+fixed: None

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -127,6 +127,7 @@ impl WorkspaceWorker {
         old_options.config_path != new_options.config_path
             || old_options.use_nested_configs() != new_options.use_nested_configs()
             || old_options.fix_kind() != new_options.fix_kind()
+            || old_options.unused_disable_directives != new_options.unused_disable_directives
     }
 
     pub async fn should_lint_on_run_type(&self, current_run: Run) -> bool {

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -37,11 +37,12 @@ Following configuration are supported via `settings.json` and effect the window 
 
 Following configuration are supported via `settings.json` and can be changed for each workspace:
 
-| Key              | Default Value | Possible Values          | Description                                                                 |
-| ---------------- | ------------- | ------------------------ | --------------------------------------------------------------------------- |
-| `oxc.lint.run`   | `onType`      | `onSave` \| `onType`     | Run the linter on save (onSave) or on type (onType)                         |
-| `oxc.configPath` | `null`        | `null`\| `<string>`      | Path to ESlint configuration. Keep it empty to enable nested configuration. |
-| `oxc.flags`      | -             | `Record<string, string>` | Custom flags passed to the language server.                                 |
+| Key                           | Default Value | Possible Values             | Description                                                                                                                                  |
+| ----------------------------- | ------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `oxc.lint.run`                | `onType`      | `onSave` \| `onType`        | Run the linter on save (onSave) or on type (onType)                                                                                          |
+| `oxc.configPath`              | `null`        | `null` \| `<string>`        | Path to ESlint configuration. Keep it empty to enable nested configuration.                                                                  |
+| `oxc.unusedDisableDirectives` | `allow`       | `allow` \| `warn` \| `deny` | Define how directive comments like `// oxlint-disable-line` should be reported, when no errors would have been reported on that line anyway. |
+| `oxc.flags`                   | -             | `Record<string, string>`    | Custom flags passed to the language server.                                                                                                  |
 
 #### Flags
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -110,6 +110,22 @@
           "default": null,
           "description": "Path to ESlint configuration. Keep it empty to enable nested configuration."
         },
+        "oxc.unusedDisableDirectives": {
+          "type": "string",
+          "scope": "resource",
+          "enum": [
+            "allow",
+            "warn",
+            "deny"
+          ],
+          "enumDescriptions": [
+            "Allow",
+            "Warn",
+            "Deny"
+          ],
+          "default": "allow",
+          "description": "Define how directive comments like `// oxlint-disable-line` should be reported, when no errors would have been reported on that line anyway."
+        },
         "oxc.flags": {
           "type": "object",
           "scope": "resource",

--- a/editors/vscode/tests/WorkspaceConfig.spec.ts
+++ b/editors/vscode/tests/WorkspaceConfig.spec.ts
@@ -7,7 +7,7 @@ suite('WorkspaceConfig', () => {
   setup(async () => {
     const workspaceConfig = workspace.getConfiguration('oxc', WORKSPACE_FOLDER);
     const globalConfig = workspace.getConfiguration('oxc');
-    const keys = ['lint.run', 'configPath', 'flags'];
+    const keys = ['lint.run', 'configPath', 'flags', 'unusedDisableDirectives'];
 
     await Promise.all(keys.map(key => workspaceConfig.update(key, undefined, ConfigurationTarget.WorkspaceFolder)));
     // VSCode will not save different workspace configuration inside a `.code-workspace` file.
@@ -18,7 +18,7 @@ suite('WorkspaceConfig', () => {
   teardown(async () => {
     const workspaceConfig = workspace.getConfiguration('oxc', WORKSPACE_FOLDER);
     const globalConfig = workspace.getConfiguration('oxc');
-    const keys = ['lint.run', 'configPath', 'flags'];
+    const keys = ['lint.run', 'configPath', 'flags', 'unusedDisableDirectives'];
 
     await Promise.all(keys.map(key => workspaceConfig.update(key, undefined, ConfigurationTarget.WorkspaceFolder)));
     // VSCode will not save different workspace configuration inside a `.code-workspace` file.
@@ -30,6 +30,7 @@ suite('WorkspaceConfig', () => {
     const config = new WorkspaceConfig(WORKSPACE_FOLDER);
     strictEqual(config.runTrigger, 'onType');
     strictEqual(config.configPath, null);
+    strictEqual(config.unusedDisableDirectives, 'allow');
     deepStrictEqual(config.flags, {});
   });
 
@@ -61,6 +62,7 @@ suite('WorkspaceConfig', () => {
     await Promise.all([
       config.updateRunTrigger('onSave'),
       config.updateConfigPath('./somewhere'),
+      config.updateUnusedDisableDirectives('deny'),
       config.updateFlags({ test: 'value' }),
     ]);
 
@@ -68,6 +70,7 @@ suite('WorkspaceConfig', () => {
 
     strictEqual(wsConfig.get('lint.run'), 'onSave');
     strictEqual(wsConfig.get('configPath'), './somewhere');
+    strictEqual(wsConfig.get('unusedDisableDirectives'), 'deny');
     deepStrictEqual(wsConfig.get('flags'), { test: 'value' });
   });
 });


### PR DESCRIPTION
closes #11618

VSCode users are now able to set the severity of unused disabled directives via `oxc.unusedDisableDirectives`.
Other Clients can use this options too, by passing `unusedDisableDirectives` as a new config key.

![screenshot of vscode editor showing the new reporting error](https://github.com/user-attachments/assets/7581db72-7756-4f55-9df1-e873b3ca0f59)
