### PR TITLE
chore(benchmark): set `.with_check_syntax_error(true)` to semantic benchmark

### DIFF
--- a/tasks/benchmark/benches/semantic.rs
+++ b/tasks/benchmark/benches/semantic.rs
@@ -29,7 +29,10 @@ fn bench_semantic(criterion: &mut Criterion) {
                     // We return `errors` to be dropped outside of the measured section, as usually
                     // code would have no errors. One of our benchmarks `cal.com.tsx` has a lot of errors,
                     // but that's atypical, so don't want to include it in benchmark time.
-                    let ret = SemanticBuilder::new().with_build_jsdoc(true).build(&program);
+                    let ret = SemanticBuilder::new()
+                        .with_build_jsdoc(true)
+                        .with_check_syntax_error(true)
+                        .build(&program);
                     let ret = black_box(ret);
                     ret.errors
                 });


### PR DESCRIPTION
There were no measurements for checking syntax errors in semantic.