### PR TITLE
fix(linter): add missing menuitemradio and menutitemcheckbox roles

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/role_has_required_aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/role_has_required_aria_props.rs
@@ -47,6 +47,8 @@ declare_oxc_lint!(
 static ROLE_TO_REQUIRED_ARIA_PROPS: phf::Map<&'static str, phf::Set<&'static str>> = phf_map! {
     "checkbox" => phf_set!{"aria-checked"},
     "radio" => phf_set!{"aria-checked"},
+    "menuitemcheckbox" => phf_set!{"aria-checked"},
+    "menuitemradio" => phf_set!{"aria-checked"},
     "combobox" => phf_set!{"aria-controls", "aria-expanded"},
     "tab" => phf_set!{"aria-selected"},
     "slider" => phf_set!{"aria-valuemax", "aria-valuemin", "aria-valuenow"},
@@ -121,6 +123,8 @@ fn test() {
             None,
             Some(settings()),
         ),
+        ("<div role='menuitemradio' aria-checked='false' />", None, None),
+        ("<div role='menuitemcheckbox' aria-checked='false' />", None, None),
     ];
 
     let fail = vec![
@@ -141,6 +145,8 @@ fn test() {
         ("<div role='scrollbar' aria-valuemin aria-valuenow />", None, None),
         ("<div role='heading' />", None, None),
         ("<div role='option' />", None, None),
+        ("<div role='menuitemradio' />", None, None),
+        ("<div role='menuitemcheckbox' />", None, None),
         ("<MyComponent role='combobox' />", None, Some(settings())),
     ];
 

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_role_has_required_aria_props.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_role_has_required_aria_props.snap
@@ -253,6 +253,20 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add missing aria props `aria-selected` to the element with `option` role.
 
+  ⚠ eslint-plugin-jsx-a11y(role-has-required-aria-props): `menuitemradio` role is missing required aria props `aria-checked`.
+   ╭─[role_has_required_aria_props.tsx:1:6]
+ 1 │ <div role='menuitemradio' />
+   ·      ────────────────────
+   ╰────
+  help: Add missing aria props `aria-checked` to the element with `menuitemradio` role.
+
+  ⚠ eslint-plugin-jsx-a11y(role-has-required-aria-props): `menuitemcheckbox` role is missing required aria props `aria-checked`.
+   ╭─[role_has_required_aria_props.tsx:1:6]
+ 1 │ <div role='menuitemcheckbox' />
+   ·      ───────────────────────
+   ╰────
+  help: Add missing aria props `aria-checked` to the element with `menuitemcheckbox` role.
+
   ⚠ eslint-plugin-jsx-a11y(role-has-required-aria-props): `combobox` role is missing required aria props `aria-controls`.
    ╭─[role_has_required_aria_props.tsx:1:14]
  1 │ <MyComponent role='combobox' />


### PR DESCRIPTION
# Why?

In testing `oxlint` in a few repositories, I noticed that this rule was missing two roles to check for in the required section. This has been working in the ESLint version due to its use of `aria-query` to help ensure all roles and required aria props were met.

## Short-term

This patches the missing instances and ensures the rule is working correctly.

## Long-term

I'm putting a PoC together to refactor `globals.rs` and the `jsx_a11y` rules to be fully compliant with WAI-ARIA 1.2 and present a possible _tiny_ speed boost that will help me also write the remaining rules I depend on preventing me from adopting `oxlint` at this time.