### PR TITLE
fix(parser): parse `using()` correctly

### DIFF
--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -438,7 +438,7 @@ impl<'a> ParserImpl<'a> {
         if disallow_of && self.at(Kind::Of) {
             return false;
         }
-        (self.cur_kind().is_binding_identifier() || self.at(Kind::LParen))
+        (self.cur_kind().is_binding_identifier() || self.at(Kind::LCurly))
             && !self.cur_token().is_on_new_line()
     }
 

--- a/tasks/coverage/misc/pass/oxc-11658.js
+++ b/tasks/coverage/misc/pass/oxc-11658.js
@@ -1,0 +1,3 @@
+using();
+using(foo);
+using[a] = b;

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 41/41 (100.00%)
-Positive Passed: 41/41 (100.00%)
+AST Parsed     : 42/42 (100.00%)
+Positive Passed: 42/42 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 41/41 (100.00%)
-Positive Passed: 41/41 (100.00%)
+AST Parsed     : 42/42 (100.00%)
+Positive Passed: 42/42 (100.00%)
 Negative Passed: 45/45 (100.00%)
 
   × Identifier `b` has already been declared

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -29407,14 +29407,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  4 │           c = null;
    ╰────
 
-  × Expected a semicolon or an implicit semicolon after a statement, but found none
-   ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.6.ts:2:10]
+  × Using declarations may not have binding patterns.
+   ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.6.ts:2:11]
  1 │ {
  2 │     using {a} = null;
-   ·          ▲
+   ·           ───
  3 │ }
    ╰────
-  help: Try insert a semicolon here
 
   × Using declarations may not have binding patterns.
    ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.7.ts:3:11]

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 41/41 (100.00%)
-Positive Passed: 25/41 (60.98%)
+AST Parsed     : 42/42 (100.00%)
+Positive Passed: 26/42 (61.90%)
 semantic Error: tasks/coverage/misc/pass/oxc-11593.ts
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 41/41 (100.00%)
-Positive Passed: 41/41 (100.00%)
+AST Parsed     : 42/42 (100.00%)
+Positive Passed: 42/42 (100.00%)


### PR DESCRIPTION
closes #11658