### PR TITLE
fix(napi/parser): lazy deserializer locally cache all `Vec`s and strings

### DIFF
--- a/napi/parser/generated/deserialize/lazy.js
+++ b/napi/parser/generated/deserialize/lazy.js
@@ -5544,7 +5544,7 @@ class ImportDeclaration {
     const cached = nodes.get(pos);
     if (cached !== void 0) return cached;
 
-    this.#internal = { $pos: pos, $ast: ast };
+    this.#internal = { $pos: pos, $ast: ast, specifiers: void 0 };
     nodes.set(pos, this);
   }
 
@@ -5559,8 +5559,10 @@ class ImportDeclaration {
   }
 
   get specifiers() {
-    const internal = this.#internal;
-    return constructOptionVecImportDeclarationSpecifier(internal.$pos + 8, internal.$ast);
+    const internal = this.#internal,
+      cached = internal.specifiers;
+    if (cached !== void 0) return cached;
+    return internal.specifiers = constructOptionVecImportDeclarationSpecifier(internal.$pos + 8, internal.$ast);
   }
 
   get source() {


### PR DESCRIPTION
Fix a bug in lazy deserializer where `Vec`s were not getting cached because they were wrapped in `Option`. When determining if a node's field needs to be locally cached, drill down through any wrapping `Option`s / `Box`es / `Cell`s / enums.
