### PR TITLE
refactor(linter): prefer-function-type cleanup

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
@@ -158,8 +158,7 @@ fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext<'_>)
                             }
                         }
 
-                        let has_comments =
-                            ctx.has_comments_between(interface_decl.span);
+                        let has_comments = ctx.has_comments_between(interface_decl.span);
 
                         if has_comments {
                             let comments = ctx
@@ -192,11 +191,7 @@ fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext<'_>)
                                 format!(
                                     "{}{}{} = {};",
                                     comments_text,
-                                    if is_parent_exported {
-                                        "export type "
-                                    } else {
-                                        "type "
-                                    },
+                                    if is_parent_exported { "export type " } else { "type " },
                                     &interface_decl.id.name,
                                     &suggestion
                                 ),
@@ -220,37 +215,37 @@ fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext<'_>)
             }
         }
 
-        AstKind::TSTypeAnnotation(ts_type_annotation) => match &ts_type_annotation
-            .type_annotation
-        {
-            TSType::TSUnionType(union_type) => {
-                union_type.types.iter().for_each(|ts_type| {
-                    if let TSType::TSTypeLiteral(literal) = ts_type {
-                        ctx.diagnostic_with_fix(
-                            prefer_function_type_diagnostic(&suggestion, decl.span),
-                            |fixer| {
-                                fixer
-                                    .replace(literal.span, format!("({suggestion})"))
-                                    .with_message(CONVERT_TO_FUNCTION_TYPE)
-                            },
-                        );
-                    }
-                });
-            }
+        AstKind::TSTypeAnnotation(ts_type_annotation) => {
+            match &ts_type_annotation.type_annotation {
+                TSType::TSUnionType(union_type) => {
+                    union_type.types.iter().for_each(|ts_type| {
+                        if let TSType::TSTypeLiteral(literal) = ts_type {
+                            ctx.diagnostic_with_fix(
+                                prefer_function_type_diagnostic(&suggestion, decl.span),
+                                |fixer| {
+                                    fixer
+                                        .replace(literal.span, format!("({suggestion})"))
+                                        .with_message(CONVERT_TO_FUNCTION_TYPE)
+                                },
+                            );
+                        }
+                    });
+                }
 
-            TSType::TSTypeLiteral(literal) => ctx.diagnostic_with_fix(
-                prefer_function_type_diagnostic(&suggestion, decl.span),
-                |fixer| {
-                    fixer
-                        .replace(literal.span, suggestion)
-                        .with_message(CONVERT_TO_FUNCTION_TYPE)
-                },
-            ),
+                TSType::TSTypeLiteral(literal) => ctx.diagnostic_with_fix(
+                    prefer_function_type_diagnostic(&suggestion, decl.span),
+                    |fixer| {
+                        fixer
+                            .replace(literal.span, suggestion)
+                            .with_message(CONVERT_TO_FUNCTION_TYPE)
+                    },
+                ),
 
-            _ => {
-                ctx.diagnostic(prefer_function_type_diagnostic(&suggestion, decl.span));
+                _ => {
+                    ctx.diagnostic(prefer_function_type_diagnostic(&suggestion, decl.span));
+                }
             }
-        },
+        }
 
         AstKind::TSTypeAliasDeclaration(ts_type_alias_decl) => {
             match &ts_type_alias_decl.type_annotation {
@@ -264,16 +259,10 @@ fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext<'_>)
                             return;
                         }
                         ctx.diagnostic_with_fix(
-                            prefer_function_type_diagnostic(
-                                &suggestion,
-                                decl.span,
-                            ),
+                            prefer_function_type_diagnostic(&suggestion, decl.span),
                             |fixer| {
                                 fixer
-                                    .replace(
-                                        literal.span,
-                                        format!("({suggestion})"),
-                                    )
+                                    .replace(literal.span, format!("({suggestion})"))
                                     .with_message(CONVERT_TO_FUNCTION_TYPE)
                             },
                         );
@@ -290,16 +279,10 @@ fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext<'_>)
                             return;
                         }
                         ctx.diagnostic_with_fix(
-                            prefer_function_type_diagnostic(
-                                &suggestion,
-                                decl.span,
-                            ),
+                            prefer_function_type_diagnostic(&suggestion, decl.span),
                             |fixer| {
                                 fixer
-                                    .replace(
-                                        literal.span,
-                                        format!("({suggestion})"),
-                                    )
+                                    .replace(literal.span, format!("({suggestion})"))
                                     .with_message(CONVERT_TO_FUNCTION_TYPE)
                             },
                         );

--- a/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
@@ -286,22 +286,23 @@ fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext<'_>)
                             return;
                         };
                         let body = &literal.members;
-                        if body.len() == 1 {
-                            ctx.diagnostic_with_fix(
-                                prefer_function_type_diagnostic(
-                                    &suggestion,
-                                    decl.span,
-                                ),
-                                |fixer| {
-                                    fixer
-                                        .replace(
-                                            literal.span,
-                                            format!("({suggestion})"),
-                                        )
-                                        .with_message(CONVERT_TO_FUNCTION_TYPE)
-                                },
-                            );
+                        if body.len() != 1 {
+                            return;
                         }
+                        ctx.diagnostic_with_fix(
+                            prefer_function_type_diagnostic(
+                                &suggestion,
+                                decl.span,
+                            ),
+                            |fixer| {
+                                fixer
+                                    .replace(
+                                        literal.span,
+                                        format!("({suggestion})"),
+                                    )
+                                    .with_message(CONVERT_TO_FUNCTION_TYPE)
+                            },
+                        );
                     });
                 }
 

--- a/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
@@ -282,24 +282,25 @@ fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext<'_>)
 
                 TSType::TSIntersectionType(intersection_type) => {
                     intersection_type.types.iter().for_each(|ts_type| {
-                        if let TSType::TSTypeLiteral(literal) = ts_type {
-                            let body = &literal.members;
-                            if body.len() == 1 {
-                                ctx.diagnostic_with_fix(
-                                    prefer_function_type_diagnostic(
-                                        &suggestion,
-                                        decl.span,
-                                    ),
-                                    |fixer| {
-                                        fixer
-                                            .replace(
-                                                literal.span,
-                                                format!("({suggestion})"),
-                                            )
-                                            .with_message(CONVERT_TO_FUNCTION_TYPE)
-                                    },
-                                );
-                            }
+                        let TSType::TSTypeLiteral(literal) = ts_type else {
+                            return;
+                        };
+                        let body = &literal.members;
+                        if body.len() == 1 {
+                            ctx.diagnostic_with_fix(
+                                prefer_function_type_diagnostic(
+                                    &suggestion,
+                                    decl.span,
+                                ),
+                                |fixer| {
+                                    fixer
+                                        .replace(
+                                            literal.span,
+                                            format!("({suggestion})"),
+                                        )
+                                        .with_message(CONVERT_TO_FUNCTION_TYPE)
+                                },
+                            );
                         }
                     });
                 }

--- a/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
@@ -260,22 +260,23 @@ fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext<'_>)
                             return;
                         };
                         let body = &literal.members;
-                        if body.len() == 1 {
-                            ctx.diagnostic_with_fix(
-                                prefer_function_type_diagnostic(
-                                    &suggestion,
-                                    decl.span,
-                                ),
-                                |fixer| {
-                                    fixer
-                                        .replace(
-                                            literal.span,
-                                            format!("({suggestion})"),
-                                        )
-                                        .with_message(CONVERT_TO_FUNCTION_TYPE)
-                                },
-                            );
+                        if body.len() != 1 {
+                            return;
                         }
+                        ctx.diagnostic_with_fix(
+                            prefer_function_type_diagnostic(
+                                &suggestion,
+                                decl.span,
+                            ),
+                            |fixer| {
+                                fixer
+                                    .replace(
+                                        literal.span,
+                                        format!("({suggestion})"),
+                                    )
+                                    .with_message(CONVERT_TO_FUNCTION_TYPE)
+                            },
+                        );
                     });
                 }
 

--- a/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
@@ -109,130 +109,196 @@ fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext<'_>)
     };
     let start = decl.span.start;
     let end: u32 = decl.span.end;
-    if let Some(type_annotation) = &decl.return_type {
-        let colon_pos = type_annotation.span.start - start;
-        let source_code = &ctx.source_text();
-        let text: &str = &source_code[start as usize..end as usize];
-        let mut suggestion = format!(
-            "{} =>{}",
-            &text[0..colon_pos as usize],
-            &text[(colon_pos + 1) as usize..text.len()]
-        );
+    let Some(type_annotation) = &decl.return_type else {
+        return;
+    };
+    let colon_pos = type_annotation.span.start - start;
+    let source_code = &ctx.source_text();
+    let text: &str = &source_code[start as usize..end as usize];
+    let mut suggestion = format!(
+        "{} =>{}",
+        &text[0..colon_pos as usize],
+        &text[(colon_pos + 1) as usize..text.len()]
+    );
 
-        if suggestion.ends_with(';') {
-            suggestion.pop();
-        }
+    if suggestion.ends_with(';') {
+        suggestion.pop();
+    }
 
-        match node.kind() {
-            AstKind::TSInterfaceDeclaration(interface_decl) => {
-                if let Some(type_parameters) = &interface_decl.type_parameters {
-                    ctx.diagnostic_with_fix(
-                        prefer_function_type_diagnostic(&suggestion, decl.span),
-                        |fixer| {
-                            let mut span = interface_decl.id.span;
-                            span.end = type_parameters.span.end;
-                            let type_name = fixer.source_range(span);
-                            fixer
-                                .replace(
-                                    interface_decl.span,
-                                    format!("type {type_name} = {suggestion};"),
-                                )
-                                .with_message(CONVERT_TO_FUNCTION_TYPE)
-                        },
-                    );
-                } else {
-                    ctx.diagnostic_with_fix(
-                        prefer_function_type_diagnostic(&suggestion, decl.span),
-                        |_| {
-                            let mut is_parent_exported = false;
-                            let mut node_start = interface_decl.span.start;
-                            let mut node_end = interface_decl.span.end;
-                            if let Some(parent_node) = ctx.nodes().parent_node(node.id()) {
-                                if let AstKind::ExportNamedDeclaration(export_name_decl) =
-                                    parent_node.kind()
-                                {
-                                    is_parent_exported = true;
-                                    node_start = export_name_decl.span.start;
-                                    node_end = export_name_decl.span.end;
-                                }
+    match node.kind() {
+        AstKind::TSInterfaceDeclaration(interface_decl) => {
+            if let Some(type_parameters) = &interface_decl.type_parameters {
+                ctx.diagnostic_with_fix(
+                    prefer_function_type_diagnostic(&suggestion, decl.span),
+                    |fixer| {
+                        let mut span = interface_decl.id.span;
+                        span.end = type_parameters.span.end;
+                        let type_name = fixer.source_range(span);
+                        fixer
+                            .replace(
+                                interface_decl.span,
+                                format!("type {type_name} = {suggestion};"),
+                            )
+                            .with_message(CONVERT_TO_FUNCTION_TYPE)
+                    },
+                );
+            } else {
+                ctx.diagnostic_with_fix(
+                    prefer_function_type_diagnostic(&suggestion, decl.span),
+                    |_| {
+                        let mut is_parent_exported = false;
+                        let mut node_start = interface_decl.span.start;
+                        let mut node_end = interface_decl.span.end;
+                        if let Some(parent_node) = ctx.nodes().parent_node(node.id()) {
+                            if let AstKind::ExportNamedDeclaration(export_name_decl) =
+                                parent_node.kind()
+                            {
+                                is_parent_exported = true;
+                                node_start = export_name_decl.span.start;
+                                node_end = export_name_decl.span.end;
                             }
+                        }
 
-                            let has_comments =
-                                ctx.has_comments_between(interface_decl.span);
+                        let has_comments =
+                            ctx.has_comments_between(interface_decl.span);
 
-                            if has_comments {
-                                let comments = ctx
-                                    .comments_range(node_start..node_end)
-                                    .map(|comment| (*comment, comment.content_span()));
+                        if has_comments {
+                            let comments = ctx
+                                .comments_range(node_start..node_end)
+                                .map(|comment| (*comment, comment.content_span()));
 
-                                let comments_text = {
-                                    let mut comments_vec: Vec<String> = vec![];
-                                    comments.for_each(|(comment_interface, span)| {
-                                        let comment = span.source_text(source_code);
+                            let comments_text = {
+                                let mut comments_vec: Vec<String> = vec![];
+                                comments.for_each(|(comment_interface, span)| {
+                                    let comment = span.source_text(source_code);
 
-                                        match comment_interface.kind {
-                                            CommentKind::Line => {
-                                                let single_line_comment: String =
-                                                    format!("//{comment}\n");
-                                                comments_vec.push(single_line_comment);
-                                            }
-                                            CommentKind::Block => {
-                                                let multi_line_comment: String =
-                                                    format!("/*{comment}*/\n");
-                                                comments_vec.push(multi_line_comment);
-                                            }
+                                    match comment_interface.kind {
+                                        CommentKind::Line => {
+                                            let single_line_comment: String =
+                                                format!("//{comment}\n");
+                                            comments_vec.push(single_line_comment);
                                         }
-                                    });
+                                        CommentKind::Block => {
+                                            let multi_line_comment: String =
+                                                format!("/*{comment}*/\n");
+                                            comments_vec.push(multi_line_comment);
+                                        }
+                                    }
+                                });
 
-                                    comments_vec.join("")
-                                };
+                                comments_vec.join("")
+                            };
 
-                                return Fix::new(
-                                    format!(
-                                        "{}{}{} = {};",
-                                        comments_text,
-                                        if is_parent_exported {
-                                            "export type "
-                                        } else {
-                                            "type "
-                                        },
-                                        &interface_decl.id.name,
-                                        &suggestion
-                                    ),
-                                    Span::new(node_start, node_end),
-                                )
-                                .with_message(CONVERT_TO_FUNCTION_TYPE);
-                            }
-
-                            Fix::new(
+                            return Fix::new(
                                 format!(
-                                    "{} {} = {};",
-                                    if is_parent_exported { "export type" } else { "type" },
+                                    "{}{}{} = {};",
+                                    comments_text,
+                                    if is_parent_exported {
+                                        "export type "
+                                    } else {
+                                        "type "
+                                    },
                                     &interface_decl.id.name,
                                     &suggestion
                                 ),
                                 Span::new(node_start, node_end),
                             )
-                            .with_message(CONVERT_TO_FUNCTION_TYPE)
-                        },
-                    );
-                }
+                            .with_message(CONVERT_TO_FUNCTION_TYPE);
+                        }
+
+                        Fix::new(
+                            format!(
+                                "{} {} = {};",
+                                if is_parent_exported { "export type" } else { "type" },
+                                &interface_decl.id.name,
+                                &suggestion
+                            ),
+                            Span::new(node_start, node_end),
+                        )
+                        .with_message(CONVERT_TO_FUNCTION_TYPE)
+                    },
+                );
+            }
+        }
+
+        AstKind::TSTypeAnnotation(ts_type_annotation) => match &ts_type_annotation
+            .type_annotation
+        {
+            TSType::TSUnionType(union_type) => {
+                union_type.types.iter().for_each(|ts_type| {
+                    if let TSType::TSTypeLiteral(literal) = ts_type {
+                        ctx.diagnostic_with_fix(
+                            prefer_function_type_diagnostic(&suggestion, decl.span),
+                            |fixer| {
+                                fixer
+                                    .replace(literal.span, format!("({suggestion})"))
+                                    .with_message(CONVERT_TO_FUNCTION_TYPE)
+                            },
+                        );
+                    }
+                });
             }
 
-            AstKind::TSTypeAnnotation(ts_type_annotation) => match &ts_type_annotation
-                .type_annotation
-            {
+            TSType::TSTypeLiteral(literal) => ctx.diagnostic_with_fix(
+                prefer_function_type_diagnostic(&suggestion, decl.span),
+                |fixer| {
+                    fixer
+                        .replace(literal.span, suggestion)
+                        .with_message(CONVERT_TO_FUNCTION_TYPE)
+                },
+            ),
+
+            _ => {
+                ctx.diagnostic(prefer_function_type_diagnostic(&suggestion, decl.span));
+            }
+        },
+
+        AstKind::TSTypeAliasDeclaration(ts_type_alias_decl) => {
+            match &ts_type_alias_decl.type_annotation {
                 TSType::TSUnionType(union_type) => {
                     union_type.types.iter().for_each(|ts_type| {
                         if let TSType::TSTypeLiteral(literal) = ts_type {
-                            ctx.diagnostic_with_fix(
-                                prefer_function_type_diagnostic(&suggestion, decl.span),
-                                |fixer| {
-                                    fixer
-                                        .replace(literal.span, format!("({suggestion})"))
-                                        .with_message(CONVERT_TO_FUNCTION_TYPE)
-                                },
-                            );
+                            let body = &literal.members;
+                            if body.len() == 1 {
+                                ctx.diagnostic_with_fix(
+                                    prefer_function_type_diagnostic(
+                                        &suggestion,
+                                        decl.span,
+                                    ),
+                                    |fixer| {
+                                        fixer
+                                            .replace(
+                                                literal.span,
+                                                format!("({suggestion})"),
+                                            )
+                                            .with_message(CONVERT_TO_FUNCTION_TYPE)
+                                    },
+                                );
+                            }
+                        }
+                    });
+                }
+
+                TSType::TSIntersectionType(intersection_type) => {
+                    intersection_type.types.iter().for_each(|ts_type| {
+                        if let TSType::TSTypeLiteral(literal) = ts_type {
+                            let body = &literal.members;
+                            if body.len() == 1 {
+                                ctx.diagnostic_with_fix(
+                                    prefer_function_type_diagnostic(
+                                        &suggestion,
+                                        decl.span,
+                                    ),
+                                    |fixer| {
+                                        fixer
+                                            .replace(
+                                                literal.span,
+                                                format!("({suggestion})"),
+                                            )
+                                            .with_message(CONVERT_TO_FUNCTION_TYPE)
+                                    },
+                                );
+                            }
                         }
                     });
                 }
@@ -246,76 +312,11 @@ fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext<'_>)
                     },
                 ),
 
-                _ => {
-                    ctx.diagnostic(prefer_function_type_diagnostic(&suggestion, decl.span));
-                }
-            },
-
-            AstKind::TSTypeAliasDeclaration(ts_type_alias_decl) => {
-                match &ts_type_alias_decl.type_annotation {
-                    TSType::TSUnionType(union_type) => {
-                        union_type.types.iter().for_each(|ts_type| {
-                            if let TSType::TSTypeLiteral(literal) = ts_type {
-                                let body = &literal.members;
-                                if body.len() == 1 {
-                                    ctx.diagnostic_with_fix(
-                                        prefer_function_type_diagnostic(
-                                            &suggestion,
-                                            decl.span,
-                                        ),
-                                        |fixer| {
-                                            fixer
-                                                .replace(
-                                                    literal.span,
-                                                    format!("({suggestion})"),
-                                                )
-                                                .with_message(CONVERT_TO_FUNCTION_TYPE)
-                                        },
-                                    );
-                                }
-                            }
-                        });
-                    }
-
-                    TSType::TSIntersectionType(intersection_type) => {
-                        intersection_type.types.iter().for_each(|ts_type| {
-                            if let TSType::TSTypeLiteral(literal) = ts_type {
-                                let body = &literal.members;
-                                if body.len() == 1 {
-                                    ctx.diagnostic_with_fix(
-                                        prefer_function_type_diagnostic(
-                                            &suggestion,
-                                            decl.span,
-                                        ),
-                                        |fixer| {
-                                            fixer
-                                                .replace(
-                                                    literal.span,
-                                                    format!("({suggestion})"),
-                                                )
-                                                .with_message(CONVERT_TO_FUNCTION_TYPE)
-                                        },
-                                    );
-                                }
-                            }
-                        });
-                    }
-
-                    TSType::TSTypeLiteral(literal) => ctx.diagnostic_with_fix(
-                        prefer_function_type_diagnostic(&suggestion, decl.span),
-                        |fixer| {
-                            fixer
-                                .replace(literal.span, suggestion)
-                                .with_message(CONVERT_TO_FUNCTION_TYPE)
-                        },
-                    ),
-
-                    _ => {}
-                }
+                _ => {}
             }
-
-            _ => ctx.diagnostic(prefer_function_type_diagnostic(&suggestion, decl.span)),
         }
+
+        _ => ctx.diagnostic(prefer_function_type_diagnostic(&suggestion, decl.span)),
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
@@ -104,224 +104,218 @@ fn has_one_super_type(decl: &TSInterfaceDeclaration) -> bool {
 }
 
 fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext<'_>) {
-    match member {
-        TSSignature::TSCallSignatureDeclaration(decl) => {
-            let start = decl.span.start;
-            let end: u32 = decl.span.end;
-            if let Some(type_annotation) = &decl.return_type {
-                let colon_pos = type_annotation.span.start - start;
-                let source_code = &ctx.source_text();
-                let text: &str = &source_code[start as usize..end as usize];
-                let mut suggestion = format!(
-                    "{} =>{}",
-                    &text[0..colon_pos as usize],
-                    &text[(colon_pos + 1) as usize..text.len()]
-                );
+    let TSSignature::TSCallSignatureDeclaration(decl) = member else {
+        return;
+    };
+    let start = decl.span.start;
+    let end: u32 = decl.span.end;
+    if let Some(type_annotation) = &decl.return_type {
+        let colon_pos = type_annotation.span.start - start;
+        let source_code = &ctx.source_text();
+        let text: &str = &source_code[start as usize..end as usize];
+        let mut suggestion = format!(
+            "{} =>{}",
+            &text[0..colon_pos as usize],
+            &text[(colon_pos + 1) as usize..text.len()]
+        );
 
-                if suggestion.ends_with(';') {
-                    suggestion.pop();
+        if suggestion.ends_with(';') {
+            suggestion.pop();
+        }
+
+        match node.kind() {
+            AstKind::TSInterfaceDeclaration(interface_decl) => {
+                if let Some(type_parameters) = &interface_decl.type_parameters {
+                    ctx.diagnostic_with_fix(
+                        prefer_function_type_diagnostic(&suggestion, decl.span),
+                        |fixer| {
+                            let mut span = interface_decl.id.span;
+                            span.end = type_parameters.span.end;
+                            let type_name = fixer.source_range(span);
+                            fixer
+                                .replace(
+                                    interface_decl.span,
+                                    format!("type {type_name} = {suggestion};"),
+                                )
+                                .with_message(CONVERT_TO_FUNCTION_TYPE)
+                        },
+                    );
+                } else {
+                    ctx.diagnostic_with_fix(
+                        prefer_function_type_diagnostic(&suggestion, decl.span),
+                        |_| {
+                            let mut is_parent_exported = false;
+                            let mut node_start = interface_decl.span.start;
+                            let mut node_end = interface_decl.span.end;
+                            if let Some(parent_node) = ctx.nodes().parent_node(node.id()) {
+                                if let AstKind::ExportNamedDeclaration(export_name_decl) =
+                                    parent_node.kind()
+                                {
+                                    is_parent_exported = true;
+                                    node_start = export_name_decl.span.start;
+                                    node_end = export_name_decl.span.end;
+                                }
+                            }
+
+                            let has_comments =
+                                ctx.has_comments_between(interface_decl.span);
+
+                            if has_comments {
+                                let comments = ctx
+                                    .comments_range(node_start..node_end)
+                                    .map(|comment| (*comment, comment.content_span()));
+
+                                let comments_text = {
+                                    let mut comments_vec: Vec<String> = vec![];
+                                    comments.for_each(|(comment_interface, span)| {
+                                        let comment = span.source_text(source_code);
+
+                                        match comment_interface.kind {
+                                            CommentKind::Line => {
+                                                let single_line_comment: String =
+                                                    format!("//{comment}\n");
+                                                comments_vec.push(single_line_comment);
+                                            }
+                                            CommentKind::Block => {
+                                                let multi_line_comment: String =
+                                                    format!("/*{comment}*/\n");
+                                                comments_vec.push(multi_line_comment);
+                                            }
+                                        }
+                                    });
+
+                                    comments_vec.join("")
+                                };
+
+                                return Fix::new(
+                                    format!(
+                                        "{}{}{} = {};",
+                                        comments_text,
+                                        if is_parent_exported {
+                                            "export type "
+                                        } else {
+                                            "type "
+                                        },
+                                        &interface_decl.id.name,
+                                        &suggestion
+                                    ),
+                                    Span::new(node_start, node_end),
+                                )
+                                .with_message(CONVERT_TO_FUNCTION_TYPE);
+                            }
+
+                            Fix::new(
+                                format!(
+                                    "{} {} = {};",
+                                    if is_parent_exported { "export type" } else { "type" },
+                                    &interface_decl.id.name,
+                                    &suggestion
+                                ),
+                                Span::new(node_start, node_end),
+                            )
+                            .with_message(CONVERT_TO_FUNCTION_TYPE)
+                        },
+                    );
                 }
+            }
 
-                match node.kind() {
-                    AstKind::TSInterfaceDeclaration(interface_decl) => {
-                        if let Some(type_parameters) = &interface_decl.type_parameters {
+            AstKind::TSTypeAnnotation(ts_type_annotation) => match &ts_type_annotation
+                .type_annotation
+            {
+                TSType::TSUnionType(union_type) => {
+                    union_type.types.iter().for_each(|ts_type| {
+                        if let TSType::TSTypeLiteral(literal) = ts_type {
                             ctx.diagnostic_with_fix(
                                 prefer_function_type_diagnostic(&suggestion, decl.span),
                                 |fixer| {
-                                    let mut span = interface_decl.id.span;
-                                    span.end = type_parameters.span.end;
-                                    let type_name = fixer.source_range(span);
                                     fixer
-                                        .replace(
-                                            interface_decl.span,
-                                            format!("type {type_name} = {suggestion};"),
-                                        )
+                                        .replace(literal.span, format!("({suggestion})"))
                                         .with_message(CONVERT_TO_FUNCTION_TYPE)
                                 },
                             );
-                        } else {
-                            ctx.diagnostic_with_fix(
-                                prefer_function_type_diagnostic(&suggestion, decl.span),
-                                |_| {
-                                    let mut is_parent_exported = false;
-                                    let mut node_start = interface_decl.span.start;
-                                    let mut node_end = interface_decl.span.end;
-                                    if let Some(parent_node) = ctx.nodes().parent_node(node.id()) {
-                                        if let AstKind::ExportNamedDeclaration(export_name_decl) =
-                                            parent_node.kind()
-                                        {
-                                            is_parent_exported = true;
-                                            node_start = export_name_decl.span.start;
-                                            node_end = export_name_decl.span.end;
-                                        }
-                                    }
-
-                                    let has_comments =
-                                        ctx.has_comments_between(interface_decl.span);
-
-                                    if has_comments {
-                                        let comments = ctx
-                                            .comments_range(node_start..node_end)
-                                            .map(|comment| (*comment, comment.content_span()));
-
-                                        let comments_text = {
-                                            let mut comments_vec: Vec<String> = vec![];
-                                            comments.for_each(|(comment_interface, span)| {
-                                                let comment = span.source_text(source_code);
-
-                                                match comment_interface.kind {
-                                                    CommentKind::Line => {
-                                                        let single_line_comment: String =
-                                                            format!("//{comment}\n");
-                                                        comments_vec.push(single_line_comment);
-                                                    }
-                                                    CommentKind::Block => {
-                                                        let multi_line_comment: String =
-                                                            format!("/*{comment}*/\n");
-                                                        comments_vec.push(multi_line_comment);
-                                                    }
-                                                }
-                                            });
-
-                                            comments_vec.join("")
-                                        };
-
-                                        return Fix::new(
-                                            format!(
-                                                "{}{}{} = {};",
-                                                comments_text,
-                                                if is_parent_exported {
-                                                    "export type "
-                                                } else {
-                                                    "type "
-                                                },
-                                                &interface_decl.id.name,
-                                                &suggestion
-                                            ),
-                                            Span::new(node_start, node_end),
-                                        )
-                                        .with_message(CONVERT_TO_FUNCTION_TYPE);
-                                    }
-
-                                    Fix::new(
-                                        format!(
-                                            "{} {} = {};",
-                                            if is_parent_exported { "export type" } else { "type" },
-                                            &interface_decl.id.name,
-                                            &suggestion
-                                        ),
-                                        Span::new(node_start, node_end),
-                                    )
-                                    .with_message(CONVERT_TO_FUNCTION_TYPE)
-                                },
-                            );
                         }
-                    }
+                    });
+                }
 
-                    AstKind::TSTypeAnnotation(ts_type_annotation) => match &ts_type_annotation
-                        .type_annotation
-                    {
-                        TSType::TSUnionType(union_type) => {
-                            union_type.types.iter().for_each(|ts_type| {
-                                if let TSType::TSTypeLiteral(literal) = ts_type {
+                TSType::TSTypeLiteral(literal) => ctx.diagnostic_with_fix(
+                    prefer_function_type_diagnostic(&suggestion, decl.span),
+                    |fixer| {
+                        fixer
+                            .replace(literal.span, suggestion)
+                            .with_message(CONVERT_TO_FUNCTION_TYPE)
+                    },
+                ),
+
+                _ => {
+                    ctx.diagnostic(prefer_function_type_diagnostic(&suggestion, decl.span));
+                }
+            },
+
+            AstKind::TSTypeAliasDeclaration(ts_type_alias_decl) => {
+                match &ts_type_alias_decl.type_annotation {
+                    TSType::TSUnionType(union_type) => {
+                        union_type.types.iter().for_each(|ts_type| {
+                            if let TSType::TSTypeLiteral(literal) = ts_type {
+                                let body = &literal.members;
+                                if body.len() == 1 {
                                     ctx.diagnostic_with_fix(
-                                        prefer_function_type_diagnostic(&suggestion, decl.span),
+                                        prefer_function_type_diagnostic(
+                                            &suggestion,
+                                            decl.span,
+                                        ),
                                         |fixer| {
                                             fixer
-                                                .replace(literal.span, format!("({suggestion})"))
+                                                .replace(
+                                                    literal.span,
+                                                    format!("({suggestion})"),
+                                                )
                                                 .with_message(CONVERT_TO_FUNCTION_TYPE)
                                         },
                                     );
                                 }
-                            });
-                        }
-
-                        TSType::TSTypeLiteral(literal) => ctx.diagnostic_with_fix(
-                            prefer_function_type_diagnostic(&suggestion, decl.span),
-                            |fixer| {
-                                fixer
-                                    .replace(literal.span, suggestion)
-                                    .with_message(CONVERT_TO_FUNCTION_TYPE)
-                            },
-                        ),
-
-                        _ => {
-                            ctx.diagnostic(prefer_function_type_diagnostic(&suggestion, decl.span));
-                        }
-                    },
-
-                    AstKind::TSTypeAliasDeclaration(ts_type_alias_decl) => {
-                        match &ts_type_alias_decl.type_annotation {
-                            TSType::TSUnionType(union_type) => {
-                                union_type.types.iter().for_each(|ts_type| {
-                                    if let TSType::TSTypeLiteral(literal) = ts_type {
-                                        let body = &literal.members;
-                                        if body.len() == 1 {
-                                            ctx.diagnostic_with_fix(
-                                                prefer_function_type_diagnostic(
-                                                    &suggestion,
-                                                    decl.span,
-                                                ),
-                                                |fixer| {
-                                                    fixer
-                                                        .replace(
-                                                            literal.span,
-                                                            format!("({suggestion})"),
-                                                        )
-                                                        .with_message(CONVERT_TO_FUNCTION_TYPE)
-                                                },
-                                            );
-                                        }
-                                    }
-                                });
                             }
-
-                            TSType::TSIntersectionType(intersection_type) => {
-                                intersection_type.types.iter().for_each(|ts_type| {
-                                    if let TSType::TSTypeLiteral(literal) = ts_type {
-                                        let body = &literal.members;
-                                        if body.len() == 1 {
-                                            ctx.diagnostic_with_fix(
-                                                prefer_function_type_diagnostic(
-                                                    &suggestion,
-                                                    decl.span,
-                                                ),
-                                                |fixer| {
-                                                    fixer
-                                                        .replace(
-                                                            literal.span,
-                                                            format!("({suggestion})"),
-                                                        )
-                                                        .with_message(CONVERT_TO_FUNCTION_TYPE)
-                                                },
-                                            );
-                                        }
-                                    }
-                                });
-                            }
-
-                            TSType::TSTypeLiteral(literal) => ctx.diagnostic_with_fix(
-                                prefer_function_type_diagnostic(&suggestion, decl.span),
-                                |fixer| {
-                                    fixer
-                                        .replace(literal.span, suggestion)
-                                        .with_message(CONVERT_TO_FUNCTION_TYPE)
-                                },
-                            ),
-
-                            _ => {}
-                        }
+                        });
                     }
 
-                    _ => ctx.diagnostic(prefer_function_type_diagnostic(&suggestion, decl.span)),
+                    TSType::TSIntersectionType(intersection_type) => {
+                        intersection_type.types.iter().for_each(|ts_type| {
+                            if let TSType::TSTypeLiteral(literal) = ts_type {
+                                let body = &literal.members;
+                                if body.len() == 1 {
+                                    ctx.diagnostic_with_fix(
+                                        prefer_function_type_diagnostic(
+                                            &suggestion,
+                                            decl.span,
+                                        ),
+                                        |fixer| {
+                                            fixer
+                                                .replace(
+                                                    literal.span,
+                                                    format!("({suggestion})"),
+                                                )
+                                                .with_message(CONVERT_TO_FUNCTION_TYPE)
+                                        },
+                                    );
+                                }
+                            }
+                        });
+                    }
+
+                    TSType::TSTypeLiteral(literal) => ctx.diagnostic_with_fix(
+                        prefer_function_type_diagnostic(&suggestion, decl.span),
+                        |fixer| {
+                            fixer
+                                .replace(literal.span, suggestion)
+                                .with_message(CONVERT_TO_FUNCTION_TYPE)
+                        },
+                    ),
+
+                    _ => {}
                 }
             }
-        }
 
-        TSSignature::TSConstructSignatureDeclaration(_)
-        | TSSignature::TSIndexSignature(_)
-        | TSSignature::TSPropertySignature(_)
-        | TSSignature::TSMethodSignature(_) => {}
+            _ => ctx.diagnostic(prefer_function_type_diagnostic(&suggestion, decl.span)),
+        }
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
@@ -107,8 +107,7 @@ fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext<'_>)
     let TSSignature::TSCallSignatureDeclaration(decl) = member else {
         return;
     };
-    let start = decl.span.start;
-    let end: u32 = decl.span.end;
+    let Span { start, end, .. } = decl.span;
     let Some(type_annotation) = &decl.return_type else {
         return;
     };

--- a/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
@@ -256,24 +256,25 @@ fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext<'_>)
             match &ts_type_alias_decl.type_annotation {
                 TSType::TSUnionType(union_type) => {
                     union_type.types.iter().for_each(|ts_type| {
-                        if let TSType::TSTypeLiteral(literal) = ts_type {
-                            let body = &literal.members;
-                            if body.len() == 1 {
-                                ctx.diagnostic_with_fix(
-                                    prefer_function_type_diagnostic(
-                                        &suggestion,
-                                        decl.span,
-                                    ),
-                                    |fixer| {
-                                        fixer
-                                            .replace(
-                                                literal.span,
-                                                format!("({suggestion})"),
-                                            )
-                                            .with_message(CONVERT_TO_FUNCTION_TYPE)
-                                    },
-                                );
-                            }
+                        let TSType::TSTypeLiteral(literal) = ts_type else {
+                            return;
+                        };
+                        let body = &literal.members;
+                        if body.len() == 1 {
+                            ctx.diagnostic_with_fix(
+                                prefer_function_type_diagnostic(
+                                    &suggestion,
+                                    decl.span,
+                                ),
+                                |fixer| {
+                                    fixer
+                                        .replace(
+                                            literal.span,
+                                            format!("({suggestion})"),
+                                        )
+                                        .with_message(CONVERT_TO_FUNCTION_TYPE)
+                                },
+                            );
                         }
                     });
                 }

--- a/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
@@ -107,10 +107,10 @@ fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext<'_>)
     let TSSignature::TSCallSignatureDeclaration(decl) = member else {
         return;
     };
-    let Span { start, end, .. } = decl.span;
     let Some(type_annotation) = &decl.return_type else {
         return;
     };
+    let Span { start, end, .. } = decl.span;
     let colon_pos = type_annotation.span.start - start;
     let source_code = &ctx.source_text();
     let text: &str = &source_code[start as usize..end as usize];


### PR DESCRIPTION
I started looking into #11668 and as a way of getting familiar with things, I refactored a little bit to better understand what's happening in this file. Mostly, I'm reducing nesting with let-else and early returns. Commit by commit it's super straightforward.

This is my first contribution here, so please let me know what I've missed and how I can fix it! 🙏 