### PR TITLE
perf(napi/parser): lazily deserialize `Vec`s

### DIFF
--- a/napi/parser/generated/deserialize/lazy.js
+++ b/napi/parser/generated/deserialize/lazy.js
@@ -3,9 +3,7 @@
 
 'use strict';
 
-// Unique token which is not exposed publicly.
-// Used to prevent user calling class constructors.
-const TOKEN = {};
+const { NodeArray, TOKEN } = require('../../raw-transfer/node-array.js');
 
 module.exports = { construct, TOKEN };
 
@@ -12517,15 +12515,18 @@ function constructStr(pos, ast) {
 
 function constructVecComment(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(new Comment(pos, ast));
-    pos += 16;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    16,
+    constructComment,
+    ast,
+  );
+}
+
+function constructComment(pos, ast) {
+  return new Comment(pos, ast);
 }
 
 function constructOptionHashbang(pos, ast) {
@@ -12535,28 +12536,30 @@ function constructOptionHashbang(pos, ast) {
 
 function constructVecDirective(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(new Directive(pos, ast));
-    pos += 72;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    72,
+    constructDirective,
+    ast,
+  );
+}
+
+function constructDirective(pos, ast) {
+  return new Directive(pos, ast);
 }
 
 function constructVecStatement(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(constructStatement(pos, ast));
-    pos += 16;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    16,
+    constructStatement,
+    ast,
+  );
 }
 
 function constructBoxBooleanLiteral(pos, ast) {
@@ -12721,15 +12724,14 @@ function constructBoxV8IntrinsicExpression(pos, ast) {
 
 function constructVecArrayExpressionElement(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(constructArrayExpressionElement(pos, ast));
-    pos += 16;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    16,
+    constructArrayExpressionElement,
+    ast,
+  );
 }
 
 function constructBoxSpreadElement(pos, ast) {
@@ -12738,15 +12740,14 @@ function constructBoxSpreadElement(pos, ast) {
 
 function constructVecObjectPropertyKind(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(constructObjectPropertyKind(pos, ast));
-    pos += 16;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    16,
+    constructObjectPropertyKind,
+    ast,
+  );
 }
 
 function constructBoxObjectProperty(pos, ast) {
@@ -12767,28 +12768,30 @@ function constructBoxPrivateIdentifier(pos, ast) {
 
 function constructVecTemplateElement(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(new TemplateElement(pos, ast));
-    pos += 48;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    48,
+    constructTemplateElement,
+    ast,
+  );
+}
+
+function constructTemplateElement(pos, ast) {
+  return new TemplateElement(pos, ast);
 }
 
 function constructVecExpression(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(constructExpression(pos, ast));
-    pos += 16;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    16,
+    constructExpression,
+    ast,
+  );
 }
 
 function constructBoxTSTypeParameterInstantiation(pos, ast) {
@@ -12819,15 +12822,14 @@ function constructBoxPrivateFieldExpression(pos, ast) {
 
 function constructVecArgument(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(constructArgument(pos, ast));
-    pos += 16;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    16,
+    constructArgument,
+    ast,
+  );
 }
 
 function constructBoxArrayAssignmentTarget(pos, ast) {
@@ -12845,15 +12847,14 @@ function constructOptionAssignmentTargetMaybeDefault(pos, ast) {
 
 function constructVecOptionAssignmentTargetMaybeDefault(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(constructOptionAssignmentTargetMaybeDefault(pos, ast));
-    pos += 16;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    16,
+    constructOptionAssignmentTargetMaybeDefault,
+    ast,
+  );
 }
 
 function constructOptionAssignmentTargetRest(pos, ast) {
@@ -12863,15 +12864,14 @@ function constructOptionAssignmentTargetRest(pos, ast) {
 
 function constructVecAssignmentTargetProperty(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(constructAssignmentTargetProperty(pos, ast));
-    pos += 16;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    16,
+    constructAssignmentTargetProperty,
+    ast,
+  );
 }
 
 function constructBoxAssignmentTargetWithDefault(pos, ast) {
@@ -12989,15 +12989,18 @@ function constructBoxTSImportEqualsDeclaration(pos, ast) {
 
 function constructVecVariableDeclarator(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(new VariableDeclarator(pos, ast));
-    pos += 64;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    64,
+    constructVariableDeclarator,
+    ast,
+  );
+}
+
+function constructVariableDeclarator(pos, ast) {
+  return new VariableDeclarator(pos, ast);
 }
 
 function constructOptionStatement(pos, ast) {
@@ -13017,15 +13020,18 @@ function constructOptionLabelIdentifier(pos, ast) {
 
 function constructVecSwitchCase(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(new SwitchCase(pos, ast));
-    pos += 48;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    48,
+    constructSwitchCase,
+    ast,
+  );
+}
+
+function constructSwitchCase(pos, ast) {
+  return new SwitchCase(pos, ast);
 }
 
 function constructBoxCatchClause(pos, ast) {
@@ -13074,15 +13080,18 @@ function constructBoxAssignmentPattern(pos, ast) {
 
 function constructVecBindingProperty(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(new BindingProperty(pos, ast));
-    pos += 64;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    64,
+    constructBindingProperty,
+    ast,
+  );
+}
+
+function constructBindingProperty(pos, ast) {
+  return new BindingProperty(pos, ast);
 }
 
 function constructBoxBindingRestElement(pos, ast) {
@@ -13101,15 +13110,14 @@ function constructOptionBindingPattern(pos, ast) {
 
 function constructVecOptionBindingPattern(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(constructOptionBindingPattern(pos, ast));
-    pos += 32;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    32,
+    constructOptionBindingPattern,
+    ast,
+  );
 }
 
 function constructOptionBindingIdentifier(pos, ast) {
@@ -13150,28 +13158,34 @@ function constructOptionBoxFunctionBody(pos, ast) {
 
 function constructVecFormalParameter(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(new FormalParameter(pos, ast));
-    pos += 72;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    72,
+    constructFormalParameter,
+    ast,
+  );
+}
+
+function constructFormalParameter(pos, ast) {
+  return new FormalParameter(pos, ast);
 }
 
 function constructVecDecorator(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(new Decorator(pos, ast));
-    pos += 24;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    24,
+    constructDecorator,
+    ast,
+  );
+}
+
+function constructDecorator(pos, ast) {
+  return new Decorator(pos, ast);
 }
 
 function constructOptionTSAccessibility(pos, ast) {
@@ -13181,15 +13195,18 @@ function constructOptionTSAccessibility(pos, ast) {
 
 function constructVecTSClassImplements(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(new TSClassImplements(pos, ast));
-    pos += 32;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    32,
+    constructTSClassImplements,
+    ast,
+  );
+}
+
+function constructTSClassImplements(pos, ast) {
+  return new TSClassImplements(pos, ast);
 }
 
 function constructBoxClassBody(pos, ast) {
@@ -13198,15 +13215,14 @@ function constructBoxClassBody(pos, ast) {
 
 function constructVecClassElement(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(constructClassElement(pos, ast));
-    pos += 16;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    16,
+    constructClassElement,
+    ast,
+  );
 }
 
 function constructBoxStaticBlock(pos, ast) {
@@ -13260,15 +13276,14 @@ function constructOptionImportPhase(pos, ast) {
 
 function constructVecImportDeclarationSpecifier(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(constructImportDeclarationSpecifier(pos, ast));
-    pos += 16;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    16,
+    constructImportDeclarationSpecifier,
+    ast,
+  );
 }
 
 function constructOptionVecImportDeclarationSpecifier(pos, ast) {
@@ -13299,15 +13314,18 @@ function constructBoxImportNamespaceSpecifier(pos, ast) {
 
 function constructVecImportAttribute(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(new ImportAttribute(pos, ast));
-    pos += 112;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    112,
+    constructImportAttribute,
+    ast,
+  );
+}
+
+function constructImportAttribute(pos, ast) {
+  return new ImportAttribute(pos, ast);
 }
 
 function constructOptionDeclaration(pos, ast) {
@@ -13317,15 +13335,18 @@ function constructOptionDeclaration(pos, ast) {
 
 function constructVecExportSpecifier(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(new ExportSpecifier(pos, ast));
-    pos += 128;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    128,
+    constructExportSpecifier,
+    ast,
+  );
+}
+
+function constructExportSpecifier(pos, ast) {
+  return new ExportSpecifier(pos, ast);
 }
 
 function constructOptionStringLiteral(pos, ast) {
@@ -13352,15 +13373,14 @@ function constructBoxJSXOpeningElement(pos, ast) {
 
 function constructVecJSXChild(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(constructJSXChild(pos, ast));
-    pos += 16;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    16,
+    constructJSXChild,
+    ast,
+  );
 }
 
 function constructBoxJSXClosingElement(pos, ast) {
@@ -13374,15 +13394,14 @@ function constructOptionBoxJSXClosingElement(pos, ast) {
 
 function constructVecJSXAttributeItem(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(constructJSXAttributeItem(pos, ast));
-    pos += 16;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    16,
+    constructJSXAttributeItem,
+    ast,
+  );
 }
 
 function constructBoxJSXIdentifier(pos, ast) {
@@ -13424,15 +13443,18 @@ function constructBoxJSXSpreadChild(pos, ast) {
 
 function constructVecTSEnumMember(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(new TSEnumMember(pos, ast));
-    pos += 40;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    40,
+    constructTSEnumMember,
+    ast,
+  );
+}
+
+function constructTSEnumMember(pos, ast) {
+  return new TSEnumMember(pos, ast);
 }
 
 function constructBoxTSAnyKeyword(pos, ast) {
@@ -13585,28 +13607,26 @@ function constructBoxJSDocUnknownType(pos, ast) {
 
 function constructVecTSType(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(constructTSType(pos, ast));
-    pos += 16;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    16,
+    constructTSType,
+    ast,
+  );
 }
 
 function constructVecTSTupleElement(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(constructTSTupleElement(pos, ast));
-    pos += 16;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    16,
+    constructTSTupleElement,
+    ast,
+  );
 }
 
 function constructBoxTSOptionalType(pos, ast) {
@@ -13628,28 +13648,34 @@ function constructOptionTSType(pos, ast) {
 
 function constructVecTSTypeParameter(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(new TSTypeParameter(pos, ast));
-    pos += 80;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    80,
+    constructTSTypeParameter,
+    ast,
+  );
+}
+
+function constructTSTypeParameter(pos, ast) {
+  return new TSTypeParameter(pos, ast);
 }
 
 function constructVecTSInterfaceHeritage(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(new TSInterfaceHeritage(pos, ast));
-    pos += 32;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    32,
+    constructTSInterfaceHeritage,
+    ast,
+  );
+}
+
+function constructTSInterfaceHeritage(pos, ast) {
+  return new TSInterfaceHeritage(pos, ast);
 }
 
 function constructBoxTSInterfaceBody(pos, ast) {
@@ -13658,15 +13684,14 @@ function constructBoxTSInterfaceBody(pos, ast) {
 
 function constructVecTSSignature(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(constructTSSignature(pos, ast));
-    pos += 16;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    16,
+    constructTSSignature,
+    ast,
+  );
 }
 
 function constructBoxTSPropertySignature(pos, ast) {
@@ -13687,15 +13712,18 @@ function constructBoxTSMethodSignature(pos, ast) {
 
 function constructVecTSIndexSignatureName(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(new TSIndexSignatureName(pos, ast));
-    pos += 32;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    32,
+    constructTSIndexSignatureName,
+    ast,
+  );
+}
+
+function constructTSIndexSignatureName(pos, ast) {
+  return new TSIndexSignatureName(pos, ast);
 }
 
 function constructOptionTSModuleDeclarationBody(pos, ast) {
@@ -13752,104 +13780,128 @@ function constructOptionU64(pos, ast) {
 
 function constructVecError(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(new Error(pos, ast));
-    pos += 80;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    80,
+    constructError,
+    ast,
+  );
+}
+
+function constructError(pos, ast) {
+  return new Error(pos, ast);
 }
 
 function constructVecErrorLabel(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(new ErrorLabel(pos, ast));
-    pos += 24;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    24,
+    constructErrorLabel,
+    ast,
+  );
+}
+
+function constructErrorLabel(pos, ast) {
+  return new ErrorLabel(pos, ast);
 }
 
 function constructVecStaticImport(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(new StaticImport(pos, ast));
-    pos += 56;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    56,
+    constructStaticImport,
+    ast,
+  );
+}
+
+function constructStaticImport(pos, ast) {
+  return new StaticImport(pos, ast);
 }
 
 function constructVecStaticExport(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(new StaticExport(pos, ast));
-    pos += 32;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    32,
+    constructStaticExport,
+    ast,
+  );
+}
+
+function constructStaticExport(pos, ast) {
+  return new StaticExport(pos, ast);
 }
 
 function constructVecDynamicImport(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(new DynamicImport(pos, ast));
-    pos += 16;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    16,
+    constructDynamicImport,
+    ast,
+  );
+}
+
+function constructDynamicImport(pos, ast) {
+  return new DynamicImport(pos, ast);
 }
 
 function constructVecSpan(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(new Span(pos, ast));
-    pos += 8;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    8,
+    constructSpan,
+    ast,
+  );
+}
+
+function constructSpan(pos, ast) {
+  return new Span(pos, ast);
 }
 
 function constructVecImportEntry(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(new ImportEntry(pos, ast));
-    pos += 96;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    96,
+    constructImportEntry,
+    ast,
+  );
+}
+
+function constructImportEntry(pos, ast) {
+  return new ImportEntry(pos, ast);
 }
 
 function constructVecExportEntry(pos, ast) {
   const { uint32 } = ast.buffer,
-    arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(new ExportEntry(pos, ast));
-    pos += 144;
-  }
-  return arr;
+    pos32 = pos >> 2;
+  return new NodeArray(
+    uint32[pos32],
+    uint32[pos32 + 2],
+    144,
+    constructExportEntry,
+    ast,
+  );
+}
+
+function constructExportEntry(pos, ast) {
+  return new ExportEntry(pos, ast);
 }

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -48,7 +48,8 @@
     "generated/deserialize/lazy.js",
     "raw-transfer/index.js",
     "raw-transfer/eager.js",
-    "raw-transfer/lazy.js"
+    "raw-transfer/lazy.js",
+    "raw-transfer/node-array.js"
   ],
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/napi/parser/raw-transfer/node-array.js
+++ b/napi/parser/raw-transfer/node-array.js
@@ -1,0 +1,277 @@
+'use strict';
+
+// Unique token which is not exposed publicly.
+// Used to prevent user calling class constructors.
+const TOKEN = {};
+
+module.exports.TOKEN = TOKEN;
+
+// Mapping from a proxy to the `NodeArray` that it wraps.
+// Used by `slice` method.
+const nodeArrays = new WeakMap();
+
+// Function to get `#internal` property of a `NodeArray`.
+// Initialized in static block in `NodeArray` class.
+let getInternal;
+
+// An array of AST nodes where elements are deserialized lazily upon access.
+//
+// Extends `Array` to make `Array.isArray` return `true` for a `NodeArray`.
+//
+// TODO: Other methods could maybe be more optimal, avoiding going via proxy multiple times.
+// e.g. `some`, `indexOf`
+class NodeArray extends Array {
+  #internal;
+
+  /**
+   * Create a `NodeArray`.
+   *
+   * Constructor does not actually return a `NodeArray`, but one wrapped in a `Proxy`.
+   * The proxy intercepts accesses to elements and lazily deserializes them,
+   * and blocks mutation of elements or `length` property.
+   *
+   * @constructor
+   * @param {number} pos - Buffer position of first element
+   * @param {number} length - Number of elements
+   * @param {number} stride - Element size in bytes
+   * @param {Function} construct - Function to deserialize element
+   * @param {Object} ast - AST object
+   * @returns {Proxy<NodeArray>} - `NodeArray` wrapped in a `Proxy`
+   */
+  constructor(pos, length, stride, construct, ast) {
+    if (ast.token !== TOKEN) throw new Error('Constructor is for internal use only');
+
+    super(length);
+    this.#internal = { pos, ast, stride, construct };
+
+    const proxy = new Proxy(this, PROXY_HANDLERS);
+    nodeArrays.set(proxy, this);
+    return proxy;
+  }
+
+  // Allow `arr.filter`, `arr.map` etc.
+  // TODO: Would be better for `slice` method to return a `NodeArray`.
+  static [Symbol.species] = Array;
+
+  // Override `values` method with a more efficient one that avoids going via proxy for every iteration.
+  // TODO: Benchmark to check that this is actually faster.
+  values() {
+    // Get actual `NodeArray`. `this` is a proxy.
+    const arr = nodeArrays.get(this);
+    return new NodeArrayValuesIterator(arr.#internal, arr.length);
+  }
+
+  // Override `keys` method with a more efficient one that avoids going via proxy for every iteration.
+  // TODO: Benchmark to check that this is actually faster.
+  keys() {
+    // Get actual `NodeArray`. `this` is a proxy.
+    const arr = nodeArrays.get(this);
+    return new NodeArrayKeysIterator(arr.length);
+  }
+
+  // Override `entries` method with a more efficient one that avoids going via proxy for every iteration.
+  // TODO: Benchmark to check that this is actually faster.
+  entries() {
+    // Get actual `NodeArray`. `this` is a proxy.
+    const arr = nodeArrays.get(this);
+    return new NodeArrayEntriesIterator(arr.#internal, arr.length);
+  }
+
+  // Make `console.log` deserialize all elements.
+  [Symbol.for('nodejs.util.inspect.custom')]() {
+    const values = [...this.values()];
+    Object.setPrototypeOf(values, DebugNodeArray.prototype);
+    return values;
+  }
+
+  static {
+    getInternal = arr => arr.#internal;
+  }
+}
+
+NodeArray.prototype[Symbol.iterator] = NodeArray.prototype.values;
+
+module.exports.NodeArray = NodeArray;
+
+// Iterator over values of a `NodeArray`.
+// Returned by `values` method, and also used as iterator for `for (const value of nodeArray) {}`.
+class NodeArrayValuesIterator {
+  #internal;
+
+  constructor(arrInternal, length) {
+    const { ast, pos, stride } = arrInternal;
+    if (ast.token !== TOKEN) throw new Error('Constructor is for internal use only');
+
+    this.#internal = {
+      pos,
+      endPos: pos + length * stride,
+      ast,
+      construct: arrInternal.construct,
+      stride,
+    };
+  }
+
+  next() {
+    const internal = this.#internal,
+      { pos } = internal;
+    if (pos === internal.endPos) return { done: true, value: null };
+    internal.pos = pos + internal.stride;
+    return { done: false, value: (0, internal.construct)(pos, internal.ast) };
+  }
+
+  [Symbol.iterator]() {
+    return this;
+  }
+}
+
+// Iterator over keys of a `NodeArray`. Returned by `keys` method.
+class NodeArrayKeysIterator {
+  #internal;
+
+  constructor(length) {
+    // Don't bother gating constructor with `TOKEN` since this iterator doesn't access buffer,
+    // and so is harmless
+    this.#internal = { index: 0, length };
+  }
+
+  next() {
+    const internal = this.#internal,
+      { index } = internal;
+    if (index === internal.length) return { done: true, value: null };
+    internal.index = index + 1;
+    return { done: false, value: index };
+  }
+
+  [Symbol.iterator]() {
+    return this;
+  }
+}
+
+// Iterator over values of a `NodeArray`. Returned by `entries` method.
+class NodeArrayEntriesIterator {
+  #internal;
+
+  constructor(arrInternal, length) {
+    const { ast } = arrInternal;
+    if (ast.token !== TOKEN) throw new Error('Constructor is for internal use only');
+
+    this.#internal = {
+      index: 0,
+      length,
+      pos: arrInternal.pos,
+      ast,
+      construct: arrInternal.construct,
+      stride: arrInternal.stride,
+    };
+  }
+
+  next() {
+    const internal = this.#internal,
+      { index } = internal;
+    if (index === internal.length) return { done: true, value: null };
+    internal.index = index + 1;
+    return {
+      done: false,
+      value: [index, (0, internal.construct)(internal.pos + index * internal.stride, internal.ast)],
+    };
+  }
+
+  [Symbol.iterator]() {
+    return this;
+  }
+}
+
+// Class used for `[Symbol.for('nodejs.util.inspect.custom')]` method (`console.log`).
+const DebugNodeArray = class NodeArray extends Array {};
+
+/**
+ * Get element of `NodeArray` at index `index`.
+ * `index` must be in bounds (i.e. `< arr.length`).
+ *
+ * @param {NodeArray} arr - `NodeArray` object
+ * @param {number} index - Index of element to get
+ * @returns {*} - Element at index `index`
+ */
+function getElement(arr, index) {
+  const internal = getInternal(arr);
+  return (0, internal.construct)(internal.pos + index * internal.stride, internal.ast);
+}
+
+// Proxy handlers.
+//
+// Every `NodeArray` returned to user is wrapped in a `Proxy`, using these handlers.
+// They lazily deserialize array elements upon access, and block mutation of array elements / `length`.
+const PROXY_HANDLERS = {
+  // Return `true` for indexes which are in bounds.
+  // e.g. `'0' in arr`.
+  has(arr, key) {
+    if (isIndex(key)) return key * 1 < arr.length;
+    return Reflect.has(arr, key);
+  },
+
+  // Get entries which are in bounds.
+  get(arr, key) {
+    if (isIndex(key)) {
+      key *= 1;
+      if (key >= arr.length) return void 0;
+      return getElement(arr, key);
+    }
+    return Reflect.get(arr, key);
+  },
+
+  // Get descriptors which are in bounds.
+  getOwnPropertyDescriptor(arr, key) {
+    if (isIndex(key)) {
+      key *= 1;
+      if (key >= arr.length) return void 0;
+      // Cannot return `configurable: false` unfortunately
+      return { value: getElement(arr, key), writable: false, enumerable: true, configurable: true };
+    }
+    return Reflect.getOwnPropertyDescriptor(arr, key);
+  },
+
+  // Prevent setting `length` or entries.
+  // Catches:
+  // * `Object.defineProperty(arr, 0, {value: null})`.
+  // * `arr[1] = null`.
+  // * `arr.length = 0`.
+  // * `Object.defineProperty(arr, 'length', {value: 0})`.
+  // * Other operations which mutate entries e.g. `arr.push(123)`.
+  defineProperty(arr, key, descriptor) {
+    if (key === 'length' || isIndex(key)) return false;
+    return Reflect.defineProperty(arr, key, descriptor);
+  },
+
+  // Prevent deleting entries.
+  deleteProperty(arr, key) {
+    // Note: `Reflect.deleteProperty(arr, 'length')` already returns `false`
+    if (isIndex(key)) return false;
+    return Reflect.deleteProperty(arr, key);
+  },
+
+  // Get keys, including element indexes.
+  ownKeys(arr) {
+    // `NodeArray`s which are slices don't have their own elements. Act as if they do.
+    const keys = [];
+    for (let i = 0; i < arr.length; i++) {
+      keys.push(i + '');
+    }
+    keys.push(...Reflect.ownKeys(arr));
+    return keys;
+  },
+};
+
+/**
+ * Check if a key is a valid array index.
+ * Only strings comprising of plain integers are valid indexes.
+ * e.g. `"-1"`, `"01"`, `"0xFF"`, `"1e1"`, `"1 "` are not valid indexes.
+ *
+ * @param {*} - Key used for property lookup.
+ * @returns {boolean} - `true` if `key` is a valid array index.
+ */
+function isIndex(key) {
+  // TODO: Any way to do this without a regex?
+  return typeof key === 'string' && (key === '0' || INDEX_REGEX.test(key));
+}
+
+const INDEX_REGEX = /^[1-9]\d*$/;

--- a/napi/parser/test/lazy-deserialization.test.ts
+++ b/napi/parser/test/lazy-deserialization.test.ts
@@ -14,21 +14,391 @@ it('parses', () => {
   const { program } = parseSyncLazy('test.js', 'let x = y + z;');
   expect(program.type).toBe('Program');
   expect(Array.isArray(program.body)).toBe(true);
-  expect(program.body).toHaveLength(1);
+  expect(program.body.length).toBe(1);
 
   const declaration = program.body[0];
   expect(declaration.type).toBe('VariableDeclaration');
   expect(declaration.kind).toBe('let');
   expect(Array.isArray(declaration.declarations)).toBe(true);
-  expect(declaration.declarations).toHaveLength(1);
+  expect(declaration.declarations.length).toBe(1);
 
   const declarator = declaration.declarations[0];
   expect(declarator.type).toBe('VariableDeclarator');
 });
 
-it('returns same node object on each access', () => {
-  const { program } = parseSyncLazy('test.js', 'let x = y + z;');
-  const id1 = program.body[0].declarations[0].id;
-  const id2 = program.body[0].declarations[0].id;
-  expect(id2).toBe(id1);
+it('returns same node objects and node arrays on each access', () => {
+  const data = parseSyncLazy('test.js', 'let x = y + z;');
+  const { program } = data;
+  expect(data.program).toBe(program);
+  const { body } = program;
+  expect(program.body).toBe(body);
+  const stmt = body[0];
+  expect(body[0]).toBe(stmt);
+  const { declarations } = stmt;
+  expect(stmt.declarations).toBe(declarations);
+  const declaration = declarations[0];
+  expect(declarations[0]).toBe(declaration);
+  const { id } = declaration;
+  expect(declaration.id).toBe(id);
+
+  expect(program.body[0].declarations[0].id).toBe(id);
+});
+
+describe('NodeArray', () => {
+  describe('methods', () => {
+    it('at', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      expect(body.at(0)).toBe(body[0]);
+      expect(body.at(1)).toBe(body[1]);
+      expect(body.at(2)).toBeUndefined();
+    });
+
+    it('concat', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      const concat = body.concat(body);
+      expect(Array.isArray(concat)).toBe(true);
+      expect(Object.getPrototypeOf(concat)).toBe(Array.prototype);
+      expect(concat).toHaveLength(4);
+      expect(concat[0]).toBe(body[0]);
+      expect(concat[1]).toBe(body[1]);
+      expect(concat[2]).toBe(body[0]);
+      expect(concat[3]).toBe(body[1]);
+    });
+
+    it('copyWithin (throws)', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      expect(() => body.copyWithin(0, 1, 2)).toThrow(new TypeError('Cannot redefine property: 0'));
+    });
+
+    it('entries', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      const entries = [...body.entries()];
+      expect(entries).toStrictEqual([[0, body[0]], [1, body[1]]]);
+      expect(entries[0][1]).toBe(body[0]);
+      expect(entries[1][1]).toBe(body[1]);
+    });
+
+    it('every', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      expect(body.every(stmt => typeof stmt.type === 'string')).toBe(true);
+      expect(body.every(stmt => stmt.type === 'VariableDeclaration')).toBe(false);
+    });
+
+    it('fill (throws)', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      expect(() => body.fill(0)).toThrow(new TypeError('Cannot redefine property: 0'));
+    });
+
+    it('filter', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      const filter = body.filter(stmt => stmt.type === 'VariableDeclaration');
+      expect(Array.isArray(filter)).toBe(true);
+      expect(Object.getPrototypeOf(filter)).toBe(Array.prototype);
+      expect(filter).toHaveLength(1);
+      expect(filter[0]).toBe(body[0]);
+    });
+
+    it('find', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      expect(body.find(stmt => stmt.type === 'VariableDeclaration')).toBe(body[0]);
+      expect(body.find(stmt => stmt.type === 'ExpressionStatement')).toBe(body[1]);
+    });
+
+    it('findIndex', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      expect(body.findIndex(stmt => stmt.type === 'VariableDeclaration')).toBe(0);
+      expect(body.findIndex(stmt => stmt.type === 'ExpressionStatement')).toBe(1);
+    });
+
+    it('findLast', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      expect(body.findLast(() => true)).toBe(body[1]);
+      expect(body.findLast(stmt => stmt.type === 'VariableDeclaration')).toBe(body[0]);
+    });
+
+    it('findLastIndex', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      expect(body.findLastIndex(() => true)).toBe(1);
+      expect(body.findLastIndex(stmt => stmt.type === 'VariableDeclaration')).toBe(0);
+    });
+
+    it('flat', () => {
+      // Can't test flattening of nested arrays, as we don't have `Vec<Vec>` in AST
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      const flat = body.flat();
+      expect(Array.isArray(flat)).toBe(true);
+      expect(Object.getPrototypeOf(flat)).toBe(Array.prototype);
+      expect(flat).toHaveLength(2);
+      expect(flat[0]).toBe(body[0]);
+      expect(flat[1]).toBe(body[1]);
+    });
+
+    it('flatMap', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      const flat = body.flatMap(stmt => [stmt, stmt]);
+      expect(Array.isArray(flat)).toBe(true);
+      expect(Object.getPrototypeOf(flat)).toBe(Array.prototype);
+      expect(flat).toHaveLength(4);
+      expect(flat[0]).toBe(body[0]);
+      expect(flat[1]).toBe(body[0]);
+      expect(flat[2]).toBe(body[1]);
+      expect(flat[3]).toBe(body[1]);
+    });
+
+    it('forEach', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      const stmts = [];
+      body.forEach(stmt => stmts.push(stmt));
+      expect(stmts).toHaveLength(2);
+      expect(stmts[0]).toBe(body[0]);
+      expect(stmts[1]).toBe(body[1]);
+    });
+
+    it('includes', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      expect(body.includes(body[0])).toBe(true);
+      expect(body.includes(body[1])).toBe(true);
+      expect(body.includes(undefined)).toBe(false);
+      expect(body.includes({ ...body[0] })).toBe(false);
+    });
+
+    it('indexOf', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      expect(body.indexOf(body[0])).toBe(0);
+      expect(body.indexOf(body[1])).toBe(1);
+      expect(body.indexOf(undefined)).toBe(-1);
+      expect(body.indexOf({ ...body[0] })).toBe(-1);
+    });
+
+    it('join', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      expect(body.join()).toBe('[object Object],[object Object]');
+      expect(body.join(' x ')).toBe('[object Object] x [object Object]');
+    });
+
+    it('keys', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      const keys = [...body.keys()];
+      expect(keys).toStrictEqual([0, 1]);
+    });
+
+    it('lastIndexOf', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      expect(body.lastIndexOf(body[0])).toBe(0);
+      expect(body.lastIndexOf(body[1])).toBe(1);
+      expect(body.lastIndexOf(undefined)).toBe(-1);
+      expect(body.lastIndexOf({ ...body[0] })).toBe(-1);
+    });
+
+    it('map', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      const map = body.map(stmt => stmt.type === 'VariableDeclaration');
+      expect(Array.isArray(map)).toBe(true);
+      expect(Object.getPrototypeOf(map)).toBe(Array.prototype);
+      expect(map).toStrictEqual([true, false]);
+    });
+
+    it('pop (throws)', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      expect(() => body.pop())
+        .toThrow(new TypeError("'deleteProperty' on proxy: trap returned falsish for property '1'"));
+    });
+
+    it('push (throws)', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      expect(() => body.push())
+        .toThrow(new TypeError("'defineProperty' on proxy: trap returned falsish for property 'length'"));
+      expect(() => body.push({}))
+        .toThrow(new TypeError("'defineProperty' on proxy: trap returned falsish for property '2'"));
+      expect(() => body.push({}, {}))
+        .toThrow(new TypeError("'defineProperty' on proxy: trap returned falsish for property '2'"));
+    });
+
+    it('reduce', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      const stmts = body.reduce(
+        (stmts, stmt) => {
+          stmts.push(stmt);
+          return stmts;
+        },
+        [],
+      );
+      expect(stmts).toHaveLength(2);
+      expect(stmts[0]).toBe(body[0]);
+      expect(stmts[1]).toBe(body[1]);
+    });
+
+    it('reduceRight', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      const stmts = body.reduceRight(
+        (stmts, stmt) => {
+          stmts.push(stmt);
+          return stmts;
+        },
+        [],
+      );
+      expect(stmts).toHaveLength(2);
+      expect(stmts[0]).toBe(body[1]);
+      expect(stmts[1]).toBe(body[0]);
+    });
+
+    it('reverse (throws)', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      expect(() => body.reverse()).toThrow(new TypeError('Cannot redefine property: 0'));
+    });
+
+    it('shift (throws)', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      expect(() => body.shift()).toThrow(new TypeError('Cannot redefine property: 0'));
+    });
+
+    it('slice', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      const slice = body.slice(1);
+      expect(Array.isArray(slice)).toBe(true);
+      expect(Object.getPrototypeOf(slice)).toBe(Array.prototype);
+      expect(slice).toHaveLength(1);
+      expect(slice[0]).toBe(body[1]);
+    });
+
+    it('some', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      expect(body.some(stmt => stmt.type === 'VariableDeclaration')).toBe(true);
+      expect(body.some(stmt => stmt.type === 'ExpressionStatement')).toBe(true);
+      expect(body.some(stmt => stmt.type === 'Donkey')).toBe(false);
+    });
+
+    it('sort (throws)', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      expect(() => body.sort()).toThrow(new TypeError('Cannot redefine property: 0'));
+    });
+
+    it('splice (throws)', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      expect(() => body.splice(0, 0))
+        .toThrow(new TypeError("'defineProperty' on proxy: trap returned falsish for property 'length'"));
+      expect(() => body.splice(0, 1)).toThrow(new TypeError('Cannot redefine property: 0'));
+      expect(() => body.splice(0, 0, {}))
+        .toThrow(new TypeError("'defineProperty' on proxy: trap returned falsish for property '2'"));
+    });
+
+    it('toLocaleString', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      expect(body.toLocaleString()).toBe('[object Object],[object Object]');
+    });
+
+    it('toReversed', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      const reversed = body.toReversed();
+      expect(Array.isArray(reversed)).toBe(true);
+      expect(Object.getPrototypeOf(reversed)).toBe(Array.prototype);
+      expect(reversed).toHaveLength(2);
+      expect(reversed[0]).toBe(body[1]);
+      expect(reversed[1]).toBe(body[0]);
+    });
+
+    it('toSorted', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      const sorted = body.toSorted((a, b) => {
+        if (a.type === b.type) return 0;
+        return a.type > b.type ? 1 : -1;
+      });
+      expect(Array.isArray(sorted)).toBe(true);
+      expect(Object.getPrototypeOf(sorted)).toBe(Array.prototype);
+      expect(sorted).toHaveLength(2);
+      expect(sorted[0]).toBe(body[1]);
+      expect(sorted[1]).toBe(body[0]);
+    });
+
+    it('toSpliced', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      const spliced = body.toSpliced(1, 0, { x: 1 }, { y: 2 });
+      expect(Array.isArray(spliced)).toBe(true);
+      expect(Object.getPrototypeOf(spliced)).toBe(Array.prototype);
+      expect(spliced).toStrictEqual([body[0], { x: 1 }, { y: 2 }, body[1]]);
+      expect(spliced[0]).toBe(body[0]);
+      expect(spliced[3]).toBe(body[1]);
+    });
+
+    it('toString', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      expect(body.toString()).toBe('[object Object],[object Object]');
+    });
+
+    it('unshift (throws)', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      expect(() => body.unshift({}))
+        .toThrow(new TypeError("'defineProperty' on proxy: trap returned falsish for property '2'"));
+    });
+
+    it('values', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      const values = [...body.values()];
+      expect(values).toHaveLength(2);
+      expect(values[0]).toBe(body[0]);
+      expect(values[1]).toBe(body[1]);
+    });
+
+    it('with', () => {
+      const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      const withed = body.with(0, { x: 1 });
+      expect(Array.isArray(withed)).toBe(true);
+      expect(Object.getPrototypeOf(withed)).toBe(Array.prototype);
+      expect(withed).toStrictEqual([{ x: 1 }, body[1]]);
+      expect(withed[1]).toBe(body[1]);
+    });
+  });
+
+  it('iteration', () => {
+    const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+    const stmts = [];
+    for (const stmt of body) {
+      stmts.push(stmt);
+    }
+    expect(stmts).toHaveLength(2);
+    expect(stmts[0]).toBe(body[0]);
+    expect(stmts[1]).toBe(body[1]);
+  });
+
+  it('set length (throws)', () => {
+    const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+    expect(() => body.length = 0)
+      .toThrow(new TypeError("'defineProperty' on proxy: trap returned falsish for property 'length'"));
+    expect(() => body.length = 2)
+      .toThrow(new TypeError("'defineProperty' on proxy: trap returned falsish for property 'length'"));
+    expect(() => body.length = 3)
+      .toThrow(new TypeError("'defineProperty' on proxy: trap returned falsish for property 'length'"));
+  });
+
+  it('set element (throws)', () => {
+    const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+    expect(() => body[0] = {}).toThrow(new TypeError('Cannot redefine property: 0'));
+    expect(() => body[1] = {}).toThrow(new TypeError('Cannot redefine property: 1'));
+    expect(() => body[2] = {})
+      .toThrow(new TypeError("'defineProperty' on proxy: trap returned falsish for property '2'"));
+  });
+
+  it('set properties', () => {
+    const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+
+    const keys = [
+      'foo',
+      'bar',
+      Symbol('yeah'),
+      -1,
+      '01',
+      '0x1',
+      '1 ',
+      ' 1',
+      '1e1',
+    ];
+
+    for (const [i, key] of keys.entries()) {
+      body[key] = i + 100;
+    }
+
+    for (const [i, key] of keys.entries()) {
+      expect(body[key]).toBe(i + 100);
+    }
+  });
 });


### PR DESCRIPTION
Lazy deserialization return `NodeArray`s which deserialize their contents lazily, instead of plain JS arrays.

`program.body.find(stmt => stmt.type === 'ImportDeclaration')` now only deserializes the nodes up until first `ImportDeclaration`, rather than deserializing every statement in the program into an array, and then searching it. Similarly, getting `program.body.length` does not deserialize any nodes, and all other array methods are similarly optimized.

Also provide an optimized iterator for the common case of:

```js
for (const stmt of program.body) {
  doStuff(stmt);
}
```
