### PR TITLE
fix(linter/consistent-function-scoping): allow functions in TS modules/namespaces

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
@@ -873,6 +873,10 @@ fn test() {
         ("function foo() { const bar = async () => {} }", None),
         ("function doFoo() { const doBar = function(bar) { return bar; }; }", None),
         ("function outer() { const inner = function inner() {}; }", None),
+        (
+            "export namespace Foo { export function outer() { const inner = function inner() {}; } }",
+            None,
+        ),
     ];
 
     Tester::new(ConsistentFunctionScoping::NAME, ConsistentFunctionScoping::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/unicorn_consistent_function_scoping.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_consistent_function_scoping.snap
@@ -410,3 +410,10 @@ source: crates/oxc_linter/src/tester.rs
    ·                                           ─────
    ╰────
   help: Move this function to the outer scope.
+
+  ⚠ eslint-plugin-unicorn(consistent-function-scoping): Function does not capture any variables from the outer scope.
+   ╭─[consistent_function_scoping.tsx:1:73]
+ 1 │ export namespace Foo { export function outer() { const inner = function inner() {}; } }
+   ·                                                                         ─────
+   ╰────
+  help: Move this function to the outer scope.


### PR DESCRIPTION
## What This PR Does
Fixes a false positive in `unicorn/consistent-function-scoping` on non-exported functions in TypeScript `module` and `namespace` nodes.

TypeScript modules and namespaces are valid ways to encapsulate code.
```ts
export namespace Foo {
  // public-facing API
  export function doThing() {
     let x = privateUtility();
     return x + 2;
  }

  // private function only available to functions within this namespace.
  // this used to be reported.
  function privateUtility() {
     return 1;
  }
}
```