### PR TITLE
refactor(parser): move empty ts type parameter checks to parser

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -408,6 +408,11 @@ pub fn ts_arrow_function_this_parameter(span: Span) -> OxcDiagnostic {
 }
 
 #[cold]
+pub fn ts_empty_type_parameter_list(span: Span) -> OxcDiagnostic {
+    ts_error("1098", "Type parameter list cannot be empty.").with_label(span)
+}
+
+#[cold]
 pub fn unexpected_super(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("'super' can only be used with function calls or in property accesses")
         .with_help("replace with `super()` or `super.prop` or `super[prop]`")

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -170,7 +170,11 @@ impl<'a> ParserImpl<'a> {
         let (params, _) =
             self.parse_delimited_list(Kind::RAngle, Kind::Comma, Self::parse_ts_type_parameter);
         self.expect(Kind::RAngle);
-        Some(self.ast.alloc_ts_type_parameter_declaration(self.end_span(span), params))
+        let span = self.end_span(span);
+        if params.is_empty() {
+            self.error(diagnostics::ts_empty_type_parameter_list(span));
+        }
+        Some(self.ast.alloc_ts_type_parameter_declaration(span, params))
     }
 
     pub(crate) fn parse_ts_implements_clause(&mut self) -> Vec<'a, TSClassImplements<'a>> {

--- a/crates/oxc_semantic/src/checker/mod.rs
+++ b/crates/oxc_semantic/src/checker/mod.rs
@@ -107,9 +107,6 @@ pub fn check<'a>(kind: AstKind<'a>, ctx: &SemanticBuilder<'a>) {
             }
         }
         AstKind::TSTypeAnnotation(annot) => ts::check_ts_type_annotation(annot, ctx),
-        AstKind::TSTypeParameterDeclaration(declaration) => {
-            ts::check_ts_type_parameter_declaration(declaration, ctx);
-        }
         AstKind::TSModuleDeclaration(decl) => ts::check_ts_module_declaration(decl, ctx),
         AstKind::TSEnumDeclaration(decl) => ts::check_ts_enum_declaration(decl, ctx),
         AstKind::TSImportEqualsDeclaration(decl) => {

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -14,18 +14,6 @@ fn ts_error<M: Into<Cow<'static, str>>>(code: &'static str, message: M) -> OxcDi
     OxcDiagnostic::error(message).with_error_code("TS", code)
 }
 
-fn empty_type_parameter_list(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Type parameter list cannot be empty.").with_label(span)
-}
-
-pub fn check_ts_type_parameter_declaration(
-    declaration: &TSTypeParameterDeclaration<'_>,
-    ctx: &SemanticBuilder<'_>,
-) {
-    if declaration.params.is_empty() {
-        ctx.error(empty_type_parameter_list(declaration.span));
-    }
-}
 /// '?' at the end of a type is not valid TypeScript syntax. Did you mean to write 'number | null | undefined'?(17019)
 fn jsdoc_type_in_annotation(
     modifier: char,

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -12147,7 +12147,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Remove the duplicate modifier.
 
-  × Type parameter list cannot be empty.
+  × TS(1098): Type parameter list cannot be empty.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/empty-type-parameters/input.ts:1:8]
  1 │ class C<> {}
    ·        ──
@@ -12491,7 +12491,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Remove the duplicate modifier.
 
-  × Type parameter list cannot be empty.
+  × TS(1098): Type parameter list cannot be empty.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/empty-type-parameters/input.ts:1:13]
  1 │ function foo<>() {}
    ·             ──

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -10332,7 +10332,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  12 │ }
     ╰────
 
-  × Type parameter list cannot be empty.
+  × TS(1098): Type parameter list cannot be empty.
    ╭─[typescript/tests/cases/compiler/classWithEmptyTypeParameter.ts:1:8]
  1 │ class C<> {
    ·        ──
@@ -15579,12 +15579,28 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·  ─
    ╰────
 
+  × TS(1098): Type parameter list cannot be empty.
+   ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:2:14]
+ 1 │ class C {
+ 2 │   constructor<>() { }
+   ·              ──
+ 3 │   constructor<> () { }
+   ╰────
+
   × TS(1092): Type parameters cannot appear on a constructor declaration
    ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:2:14]
  1 │ class C {
  2 │   constructor<>() { }
    ·              ──
  3 │   constructor<> () { }
+   ╰────
+
+  × TS(1098): Type parameter list cannot be empty.
+   ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:3:14]
+ 2 │   constructor<>() { }
+ 3 │   constructor<> () { }
+   ·              ──
+ 4 │   constructor <>() { }
    ╰────
 
   × TS(1092): Type parameters cannot appear on a constructor declaration
@@ -15595,12 +15611,28 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  4 │   constructor <>() { }
    ╰────
 
+  × TS(1098): Type parameter list cannot be empty.
+   ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:4:15]
+ 3 │   constructor<> () { }
+ 4 │   constructor <>() { }
+   ·               ──
+ 5 │   constructor <> () { }
+   ╰────
+
   × TS(1092): Type parameters cannot appear on a constructor declaration
    ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:4:15]
  3 │   constructor<> () { }
  4 │   constructor <>() { }
    ·               ──
  5 │   constructor <> () { }
+   ╰────
+
+  × TS(1098): Type parameter list cannot be empty.
+   ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:5:15]
+ 4 │   constructor <>() { }
+ 5 │   constructor <> () { }
+   ·               ──
+ 6 │   constructor< >() { }
    ╰────
 
   × TS(1092): Type parameters cannot appear on a constructor declaration
@@ -15611,12 +15643,28 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  6 │   constructor< >() { }
    ╰────
 
+  × TS(1098): Type parameter list cannot be empty.
+   ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:6:14]
+ 5 │   constructor <> () { }
+ 6 │   constructor< >() { }
+   ·              ───
+ 7 │   constructor< > () { }
+   ╰────
+
   × TS(1092): Type parameters cannot appear on a constructor declaration
    ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:6:14]
  5 │   constructor <> () { }
  6 │   constructor< >() { }
    ·              ───
  7 │   constructor< > () { }
+   ╰────
+
+  × TS(1098): Type parameter list cannot be empty.
+   ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:7:14]
+ 6 │   constructor< >() { }
+ 7 │   constructor< > () { }
+   ·              ───
+ 8 │   constructor < >() { }
    ╰────
 
   × TS(1092): Type parameters cannot appear on a constructor declaration
@@ -15627,7 +15675,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  8 │   constructor < >() { }
    ╰────
 
-  × TS(1092): Type parameters cannot appear on a constructor declaration
+  × TS(1098): Type parameter list cannot be empty.
    ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:8:15]
  7 │   constructor< > () { }
  8 │   constructor < >() { }
@@ -15636,6 +15684,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╰────
 
   × TS(1092): Type parameters cannot appear on a constructor declaration
+   ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:8:15]
+ 7 │   constructor< > () { }
+ 8 │   constructor < >() { }
+   ·               ───
+ 9 │   constructor < > () { }
+   ╰────
+
+  × TS(1098): Type parameter list cannot be empty.
     ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:9:15]
   8 │   constructor < >() { }
   9 │   constructor < > () { }
@@ -15643,63 +15699,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  10 │ }
     ╰────
 
-  × Type parameter list cannot be empty.
-   ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:2:14]
- 1 │ class C {
- 2 │   constructor<>() { }
-   ·              ──
- 3 │   constructor<> () { }
-   ╰────
-
-  × Type parameter list cannot be empty.
-   ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:3:14]
- 2 │   constructor<>() { }
- 3 │   constructor<> () { }
-   ·              ──
- 4 │   constructor <>() { }
-   ╰────
-
-  × Type parameter list cannot be empty.
-   ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:4:15]
- 3 │   constructor<> () { }
- 4 │   constructor <>() { }
-   ·               ──
- 5 │   constructor <> () { }
-   ╰────
-
-  × Type parameter list cannot be empty.
-   ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:5:15]
- 4 │   constructor <>() { }
- 5 │   constructor <> () { }
-   ·               ──
- 6 │   constructor< >() { }
-   ╰────
-
-  × Type parameter list cannot be empty.
-   ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:6:14]
- 5 │   constructor <> () { }
- 6 │   constructor< >() { }
-   ·              ───
- 7 │   constructor< > () { }
-   ╰────
-
-  × Type parameter list cannot be empty.
-   ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:7:14]
- 6 │   constructor< >() { }
- 7 │   constructor< > () { }
-   ·              ───
- 8 │   constructor < >() { }
-   ╰────
-
-  × Type parameter list cannot be empty.
-   ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:8:15]
- 7 │   constructor< > () { }
- 8 │   constructor < >() { }
-   ·               ───
- 9 │   constructor < > () { }
-   ╰────
-
-  × Type parameter list cannot be empty.
+  × TS(1092): Type parameters cannot appear on a constructor declaration
     ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:9:15]
   8 │   constructor < >() { }
   9 │   constructor < > () { }
@@ -26448,7 +26448,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │ }
    ╰────
 
-  × TS(1092): Type parameters cannot appear on a constructor declaration
+  × TS(1098): Type parameter list cannot be empty.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration11.ts:2:14]
  1 │ class C {
  2 │   constructor<>() { }
@@ -26456,7 +26456,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │ }
    ╰────
 
-  × Type parameter list cannot be empty.
+  × TS(1092): Type parameters cannot appear on a constructor declaration
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration11.ts:2:14]
  1 │ class C {
  2 │   constructor<>() { }


### PR DESCRIPTION
Part of an effort to move non symbol/scope checks from semantic -> parser.

> I intend to only keep checks associated with symbols and scopes in the checker, and move everything back to the parser.
> We need to stop the formatter from formatting code when a syntax error occurs. The formatter don't run semantic.
