### PR TITLE
perf(napi/parser): lazy deser: avoid changing shape of `NodeArray` prototype

### DIFF
--- a/napi/parser/raw-transfer/node-array.js
+++ b/napi/parser/raw-transfer/node-array.js
@@ -72,6 +72,10 @@ class NodeArray extends Array {
     return new NodeArrayEntriesIterator(arr.#internal, arr.length);
   }
 
+  // This method is overwritten with reference to `values` method below.
+  // Defining dummy method here to prevent the later assignment altering the shape of class prototype.
+  [Symbol.iterator]() {}
+
   // Override `slice` method to return a `NodeArray`.
   //
   // The new `NodeArray` references this `NodeArray` so element accesses on the slice will


### PR DESCRIPTION
Simple object shapes are faster. Adding extra property to `NodeArray.prototype` alters its shape. Prevent this by defining a placeholder method in class definition, and then mutating this property later, rather than adding a new property.