### PR TITLE
test(napi/parser): lazy deser: tests for introspection of `NodeArray`s

### DIFF
--- a/napi/parser/raw-transfer/node-array.js
+++ b/napi/parser/raw-transfer/node-array.js
@@ -260,6 +260,7 @@ const PROXY_HANDLERS = {
       // Cannot return `configurable: false` unfortunately
       return { value: getElement(arr, key), writable: false, enumerable: true, configurable: true };
     }
+    // Cannot return `writable: false` for `length` property unfortunately
     return Reflect.getOwnPropertyDescriptor(arr, key);
   },
 


### PR DESCRIPTION
Add tests for results of `Object.keys`, `Object.getOwnPropertyDescriptors`, and other introspection methods on `NodeArray`s.