### PR TITLE
feat(linter): add fix for unused disable directive

### DIFF
--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_unused_disabled_directives@test.js.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_unused_disabled_directives@test.js.snap
@@ -38,7 +38,7 @@ related_information[0].location.range: Range { start: Position { line: 0, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
-fixed: None
+fixed: Single(FixedContent { message: Some("remove unused disable directive"), code: "", range: Range { start: Position { line: 0, character: 2 }, end: Position { line: 0, character: 56 } } })
 
 
 code: ""
@@ -51,7 +51,7 @@ related_information[0].location.range: Range { start: Position { line: 5, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
-fixed: None
+fixed: Single(FixedContent { message: Some("remove unused disable directive"), code: "", range: Range { start: Position { line: 5, character: 39 }, end: Position { line: 5, character: 52 } } })
 
 
 code: ""
@@ -64,4 +64,4 @@ related_information[0].location.range: Range { start: Position { line: 8, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
-fixed: None
+fixed: Single(FixedContent { message: Some("remove unused disable directive"), code: "", range: Range { start: Position { line: 8, character: 2 }, end: Position { line: 8, character: 52 } } })

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -8,7 +8,7 @@ use crate::{
     AllowWarnDeny, FrameworkFlags,
     config::{LintConfig, LintPlugins},
     disable_directives::{DisableDirectives, DisableDirectivesBuilder, RuleCommentType},
-    fixer::{FixKind, Message, PossibleFixes},
+    fixer::{Fix, FixKind, Message, PossibleFixes},
     frameworks,
     module_record::ModuleRecord,
     options::LintOptions,
@@ -167,34 +167,48 @@ impl<'a> ContextHost<'a> {
 
     /// report unused enable/disable directives, add these as Messages to diagnostics
     pub fn report_unused_directives(&self, rule_severity: Severity) {
-        let unused_enable_comments = self.disable_directives.unused_enable_comments();
-        let unused_disable_comments = self.disable_directives.collect_unused_disable_comments();
-        let mut unused_directive_diagnostics: Vec<(Cow<str>, Span)> =
-            Vec::with_capacity(unused_enable_comments.len() + unused_disable_comments.len());
-
         // report unused disable
         // relate to lint result, check after linter run finish
         let unused_disable_comments = self.disable_directives.collect_unused_disable_comments();
         let message_for_disable = "Unused eslint-disable directive (no problems were reported).";
+        let fix_message = "remove unused disable directive";
+        let source_text = self.semantic.source_text();
+
         for unused_disable_comment in unused_disable_comments {
+            let span = unused_disable_comment.span;
             match &unused_disable_comment.r#type {
                 RuleCommentType::All => {
                     // eslint-disable
-                    let disable_comment_span = unused_disable_comment.span;
-                    unused_directive_diagnostics
-                        .push((Cow::Borrowed(message_for_disable), disable_comment_span));
+                    self.push_diagnostic(Message::new(
+                        OxcDiagnostic::error(message_for_disable)
+                            .with_label(span)
+                            .with_severity(rule_severity),
+                        PossibleFixes::Single(Fix::delete(span).with_message(fix_message)),
+                    ));
                 }
-                RuleCommentType::Single(rules) => {
-                    for rule in rules {
-                        unused_directive_diagnostics.push((
-                            Cow::Owned(format!("Unused eslint-disable directive (no problems were reported from {}).", rule.rule_name)),
-                            rule.name_span,
+                RuleCommentType::Single(rules_vec) => {
+                    for rule in rules_vec {
+                        let rule_message = Cow::<str>::Owned(format!(
+                            "Unused eslint-disable directive (no problems were reported from {}).",
+                            rule.rule_name
+                        ));
+
+                        let fix = rule.create_fix(source_text, span).with_message(fix_message);
+
+                        self.push_diagnostic(Message::new(
+                            OxcDiagnostic::error(rule_message)
+                                .with_label(rule.name_span)
+                                .with_severity(rule_severity),
+                            PossibleFixes::Single(fix),
                         ));
                     }
                 }
             }
         }
 
+        let unused_enable_comments = self.disable_directives.unused_enable_comments();
+        let mut unused_directive_diagnostics: Vec<(Cow<str>, Span)> =
+            Vec::with_capacity(unused_enable_comments.len());
         // report unused enable
         // not relate to lint result, check during comment directives' construction
         let message_for_enable =
@@ -217,7 +231,7 @@ impl<'a> ContextHost<'a> {
                     Message::new(
                         OxcDiagnostic::error(message).with_label(span).with_severity(rule_severity),
                         // TODO: fixer
-                        // if all rules in the same directive are unused, fixer should remove the entire comment
+                        // copy the structure of disable directives
                         PossibleFixes::None,
                     )
                 })

--- a/editors/vscode/fixtures/changing_unused_disable_directives/unused_disable_directives.js
+++ b/editors/vscode/fixtures/changing_unused_disable_directives/unused_disable_directives.js
@@ -1,0 +1,2 @@
+// oxlint-disable-next-line no-console
+(() => { "" })();

--- a/editors/vscode/tests/test-helpers.ts
+++ b/editors/vscode/tests/test-helpers.ts
@@ -67,7 +67,7 @@ export async function activateExtension(full: boolean = true): Promise<void> {
 
   if (full) {
     await loadFixture('debugger');
-    const fileUri = Uri.joinPath(WORKSPACE_DIR, 'fixtures', 'debugger.js');
+    const fileUri = Uri.joinPath(fixturesWorkspaceUri(), 'fixtures', 'debugger.js');
     await window.showTextDocument(fileUri);
     // wait for initialized requests
     await sleep(500);


### PR DESCRIPTION
Added tests for later, see linked issue #11709.


![screenshot of code action in VSCode](https://github.com/user-attachments/assets/fc102ca2-0d57-42b1-87b7-235e19a50b4c)

```
// oxlint-disable-next-line no-debugger -- on wrong line
(() => {
  debugger;
})();
```

will fix to:

```
//
(() => {
  debugger;
})();
```

Not the best, but at least a start.
Don't know what kind of fix it should be. It is currently a `SafeFix`.

ToDo:

- No other code actions ✔️ 
- generate correct spans for directives with multiple rules ✔️ 