### PR TITLE
feat(playground): Allow specifying a JSON string as the linter config

### DIFF
--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -149,6 +149,17 @@ impl Oxlintrc {
         Ok(config)
     }
 
+    pub fn from_string(json_string: &str) -> Result<Self, OxcDiagnostic> {
+        let json = serde_json::from_str::<serde_json::Value>(json_string)
+            .unwrap_or(serde_json::Value::Null);
+
+        let config = Self::deserialize(&json).map_err(|err| {
+            OxcDiagnostic::error(format!("Failed to parse config with error {err:?}"))
+        })?;
+
+        Ok(config)
+    }
+
     /// Merges two [Oxlintrc] files together
     /// [Self] takes priority over `other`
     #[must_use]

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -149,6 +149,9 @@ impl Oxlintrc {
         Ok(config)
     }
 
+    /// # Errors
+    ///
+    /// * Parse Failure
     pub fn from_string(json_string: &str) -> Result<Self, OxcDiagnostic> {
         let json = serde_json::from_str::<serde_json::Value>(json_string)
             .unwrap_or(serde_json::Value::Null);

--- a/napi/playground/index.d.ts
+++ b/napi/playground/index.d.ts
@@ -69,7 +69,7 @@ export interface OxcControlFlowOptions {
 }
 
 export interface OxcLinterOptions {
-
+  config?: string
 }
 
 export interface OxcMinifierOptions {

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -288,10 +288,10 @@ impl Oxc {
             let semantic = Rc::new(semantic_ret.semantic);
             let lint_config = if linter_options.config.is_some() {
                 let oxlintrc =
-                    Oxlintrc::from_string(&linter_options.config.clone().unwrap().to_string())
+                    Oxlintrc::from_string(&linter_options.config.as_ref().unwrap().to_string())
                         .unwrap_or_default();
                 let config_builder =
-                    ConfigStoreBuilder::from_oxlintrc(false, oxlintrc.clone()).unwrap_or_default();
+                    ConfigStoreBuilder::from_oxlintrc(false, oxlintrc).unwrap_or_default();
                 config_builder.build()
             } else {
                 ConfigStoreBuilder::default().build()

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -29,10 +29,10 @@ use oxc::{
 };
 use oxc_formatter::{FormatOptions, Formatter};
 use oxc_index::Idx;
-use oxc_linter::{ConfigStore, ConfigStoreBuilder, LintOptions, Linter, ModuleRecord};
+use oxc_linter::{ConfigStore, ConfigStoreBuilder, LintOptions, Linter, ModuleRecord, Oxlintrc};
 use oxc_napi::{Comment, OxcError, convert_utf8_to_utf16};
 
-use crate::options::{OxcOptions, OxcRunOptions};
+use crate::options::{OxcLinterOptions, OxcOptions, OxcRunOptions};
 
 mod options;
 
@@ -94,7 +94,7 @@ impl Oxc {
         } = options;
         let run_options = run_options.unwrap_or_default();
         let parser_options = parser_options.unwrap_or_default();
-        let _linter_options = linter_options.unwrap_or_default();
+        let linter_options = linter_options.unwrap_or_default();
         let minifier_options = minifier_options.unwrap_or_default();
         let codegen_options = codegen_options.unwrap_or_default();
         let transform_options = transform_options.unwrap_or_default();
@@ -151,7 +151,7 @@ impl Oxc {
         }
 
         let linter_module_record = Arc::new(ModuleRecord::new(&path, &module_record, &semantic));
-        self.run_linter(&run_options, &path, &program, &linter_module_record);
+        self.run_linter(&run_options, &linter_options, &path, &program, &linter_module_record);
 
         self.run_formatter(&run_options, &source_text, source_type);
 
@@ -277,6 +277,7 @@ impl Oxc {
     fn run_linter(
         &mut self,
         run_options: &OxcRunOptions,
+        linter_options: &OxcLinterOptions,
         path: &Path,
         program: &Program,
         module_record: &Arc<ModuleRecord>,
@@ -285,7 +286,16 @@ impl Oxc {
         if run_options.lint.unwrap_or_default() && self.diagnostics.is_empty() {
             let semantic_ret = SemanticBuilder::new().with_cfg(true).build(program);
             let semantic = Rc::new(semantic_ret.semantic);
-            let lint_config = ConfigStoreBuilder::default().build();
+            let lint_config = if linter_options.config.is_some() {
+                let oxlintrc =
+                    Oxlintrc::from_string(&linter_options.config.clone().unwrap().to_string())
+                        .unwrap_or_default();
+                let config_builder =
+                    ConfigStoreBuilder::from_oxlintrc(false, oxlintrc.clone()).unwrap_or_default();
+                config_builder.build()
+            } else {
+                ConfigStoreBuilder::default().build()
+            };
             let linter_ret = Linter::new(
                 LintOptions::default(),
                 ConfigStore::new(lint_config, FxHashMap::default()),

--- a/napi/playground/src/options.rs
+++ b/napi/playground/src/options.rs
@@ -38,8 +38,9 @@ pub struct OxcParserOptions {
 
 #[napi(object)]
 #[derive(Default)]
-#[expect(clippy::empty_structs_with_brackets)]
-pub struct OxcLinterOptions {}
+pub struct OxcLinterOptions {
+    pub config: Option<String>,
+}
 
 #[napi(object)]
 #[derive(Default)]


### PR DESCRIPTION
When creating bug reports it would be helpful to have a link to a reproduction that just worked in the browser. By adding the ability to config Oxlint here, simple reproductions can be done within the Playground and URLs shared from it.

This would be a lot better if the `config` was a JSON object instead of a string, but I don't know how to do that only on the Rust side.

An option would be to keep the Rust side a string, but on the browser side allow it to be an object. Whenever the object changes, we serialize that to a string before sending it to the Rust side. If there's interest in this, then I think I can make this change in the playground repo.

Example config and screenshots below.

```json
"linter": {},
```
![image](https://github.com/user-attachments/assets/177cdb75-4a45-4c21-bf8b-2e7f46af56df)

```json
"linter": {
  "config": "{\"plugins\":[\"typescript\"],\"categories\":{\"correctness\":\"error\"},\"rules\":{\"no-debugger\":\"warn\"}}"
},
```
![image](https://github.com/user-attachments/assets/7a0843c3-d5e3-4002-bb93-964ddcd0629a)
