### PR TITLE
fix(linter): panic in import/extensions with empty file names

### DIFF
--- a/crates/oxc_linter/src/rules/import/extensions.rs
+++ b/crates/oxc_linter/src/rules/import/extensions.rs
@@ -275,7 +275,8 @@ impl Extensions {
             || ctx.globals().is_enabled(module_name.as_str());
 
         let is_package = module_name.as_str().starts_with('@')
-            || (!module_name.as_str().starts_with('.') && !module_name.as_str()[1..].contains('/'));
+            || (!module_name.as_str().starts_with('.')
+                && !module_name.as_str().get(1..).is_some_and(|v| v.contains('/')));
 
         if is_builtin_node_module || (is_package && ignore_packages) {
             return;
@@ -486,6 +487,8 @@ fn test() {
             "#,
             Some(json!(["always", {"checkTypeImports": true}])),
         ),
+        (r"import''", None),
+        (r"export *from 'íìc'", None),
     ];
 
     let fail = vec![


### PR DESCRIPTION
fixes #11719
fixes #11718
