### PR TITLE
feat(ast): Add AstKind to `TSIndexSignature` node

### DIFF
--- a/crates/oxc_ast/src/ast_kind_impl.rs
+++ b/crates/oxc_ast/src/ast_kind_impl.rs
@@ -362,6 +362,7 @@ impl AstKind<'_> {
             Self::TSNamedTupleMember(_) => "TSNamedTupleMember".into(),
 
             Self::TSPropertySignature(_) => "TSPropertySignature".into(),
+            Self::TSIndexSignatureName(_) => "TSIndexSignatureName".into(),
             Self::TSConditionalType(_) => "TSConditionalType".into(),
             Self::TSMappedType(_) => "TSMappedType".into(),
             Self::TSConstructSignatureDeclaration(_) => "TSConstructSignatureDeclaration".into(),

--- a/crates/oxc_ast/src/generated/ast_kind.rs
+++ b/crates/oxc_ast/src/generated/ast_kind.rs
@@ -162,28 +162,29 @@ pub enum AstType {
     TSPropertySignature = 146,
     TSMethodSignature = 147,
     TSConstructSignatureDeclaration = 148,
-    TSInterfaceHeritage = 149,
-    TSModuleDeclaration = 150,
-    TSModuleBlock = 151,
-    TSTypeLiteral = 152,
-    TSInferType = 153,
-    TSTypeQuery = 154,
-    TSImportType = 155,
-    TSMappedType = 156,
-    TSTemplateLiteralType = 157,
-    TSAsExpression = 158,
-    TSSatisfiesExpression = 159,
-    TSTypeAssertion = 160,
-    TSImportEqualsDeclaration = 161,
-    TSModuleReference = 162,
-    TSExternalModuleReference = 163,
-    TSNonNullExpression = 164,
-    Decorator = 165,
-    TSExportAssignment = 166,
-    TSInstantiationExpression = 167,
-    JSDocNullableType = 168,
-    JSDocNonNullableType = 169,
-    JSDocUnknownType = 170,
+    TSIndexSignatureName = 149,
+    TSInterfaceHeritage = 150,
+    TSModuleDeclaration = 151,
+    TSModuleBlock = 152,
+    TSTypeLiteral = 153,
+    TSInferType = 154,
+    TSTypeQuery = 155,
+    TSImportType = 156,
+    TSMappedType = 157,
+    TSTemplateLiteralType = 158,
+    TSAsExpression = 159,
+    TSSatisfiesExpression = 160,
+    TSTypeAssertion = 161,
+    TSImportEqualsDeclaration = 162,
+    TSModuleReference = 163,
+    TSExternalModuleReference = 164,
+    TSNonNullExpression = 165,
+    Decorator = 166,
+    TSExportAssignment = 167,
+    TSInstantiationExpression = 168,
+    JSDocNullableType = 169,
+    JSDocNonNullableType = 170,
+    JSDocUnknownType = 171,
 }
 
 /// Untyped AST Node Kind
@@ -349,6 +350,7 @@ pub enum AstKind<'a> {
     TSMethodSignature(&'a TSMethodSignature<'a>) = AstType::TSMethodSignature as u8,
     TSConstructSignatureDeclaration(&'a TSConstructSignatureDeclaration<'a>) =
         AstType::TSConstructSignatureDeclaration as u8,
+    TSIndexSignatureName(&'a TSIndexSignatureName<'a>) = AstType::TSIndexSignatureName as u8,
     TSInterfaceHeritage(&'a TSInterfaceHeritage<'a>) = AstType::TSInterfaceHeritage as u8,
     TSModuleDeclaration(&'a TSModuleDeclaration<'a>) = AstType::TSModuleDeclaration as u8,
     TSModuleBlock(&'a TSModuleBlock<'a>) = AstType::TSModuleBlock as u8,
@@ -540,6 +542,7 @@ impl GetSpan for AstKind<'_> {
             Self::TSPropertySignature(it) => it.span(),
             Self::TSMethodSignature(it) => it.span(),
             Self::TSConstructSignatureDeclaration(it) => it.span(),
+            Self::TSIndexSignatureName(it) => it.span(),
             Self::TSInterfaceHeritage(it) => it.span(),
             Self::TSModuleDeclaration(it) => it.span(),
             Self::TSModuleBlock(it) => it.span(),
@@ -1314,6 +1317,11 @@ impl<'a> AstKind<'a> {
         self,
     ) -> Option<&'a TSConstructSignatureDeclaration<'a>> {
         if let Self::TSConstructSignatureDeclaration(v) = self { Some(v) } else { None }
+    }
+
+    #[inline]
+    pub fn as_ts_index_signature_name(self) -> Option<&'a TSIndexSignatureName<'a>> {
+        if let Self::TSIndexSignatureName(v) = self { Some(v) } else { None }
     }
 
     #[inline]

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -3744,9 +3744,11 @@ pub mod walk {
         visitor: &mut V,
         it: &TSIndexSignatureName<'a>,
     ) {
-        // No `AstKind` for this type
+        let kind = AstKind::TSIndexSignatureName(visitor.alloc(it));
+        visitor.enter_node(kind);
         visitor.visit_span(&it.span);
         visitor.visit_ts_type_annotation(&it.type_annotation);
+        visitor.leave_node(kind);
     }
 
     #[inline]

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -3950,9 +3950,11 @@ pub mod walk_mut {
         visitor: &mut V,
         it: &mut TSIndexSignatureName<'a>,
     ) {
-        // No `AstType` for this type
+        let kind = AstType::TSIndexSignatureName;
+        visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type_annotation(&mut it.type_annotation);
+        visitor.leave_node(kind);
     }
 
     #[inline]

--- a/crates/oxc_formatter/src/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/generated/ast_nodes.rs
@@ -176,6 +176,7 @@ pub enum AstNodes<'a> {
     TSPropertySignature(&'a AstNode<'a, TSPropertySignature<'a>>),
     TSMethodSignature(&'a AstNode<'a, TSMethodSignature<'a>>),
     TSConstructSignatureDeclaration(&'a AstNode<'a, TSConstructSignatureDeclaration<'a>>),
+    TSIndexSignatureName(&'a AstNode<'a, TSIndexSignatureName<'a>>),
     TSInterfaceHeritage(&'a AstNode<'a, TSInterfaceHeritage<'a>>),
     TSModuleDeclaration(&'a AstNode<'a, TSModuleDeclaration<'a>>),
     TSModuleBlock(&'a AstNode<'a, TSModuleBlock<'a>>),
@@ -353,6 +354,7 @@ impl<'a> AstNodes<'a> {
             Self::TSPropertySignature(n) => n.span(),
             Self::TSMethodSignature(n) => n.span(),
             Self::TSConstructSignatureDeclaration(n) => n.span(),
+            Self::TSIndexSignatureName(n) => n.span(),
             Self::TSInterfaceHeritage(n) => n.span(),
             Self::TSModuleDeclaration(n) => n.span(),
             Self::TSModuleBlock(n) => n.span(),
@@ -530,6 +532,7 @@ impl<'a> AstNodes<'a> {
             Self::TSPropertySignature(n) => n.parent,
             Self::TSMethodSignature(n) => n.parent,
             Self::TSConstructSignatureDeclaration(n) => n.parent,
+            Self::TSIndexSignatureName(n) => n.parent,
             Self::TSInterfaceHeritage(n) => n.parent,
             Self::TSModuleDeclaration(n) => n.parent,
             Self::TSModuleBlock(n) => n.parent,
@@ -707,6 +710,7 @@ impl<'a> AstNodes<'a> {
             Self::TSPropertySignature(_) => "TSPropertySignature",
             Self::TSMethodSignature(_) => "TSMethodSignature",
             Self::TSConstructSignatureDeclaration(_) => "TSConstructSignatureDeclaration",
+            Self::TSIndexSignatureName(_) => "TSIndexSignatureName",
             Self::TSInterfaceHeritage(_) => "TSInterfaceHeritage",
             Self::TSModuleDeclaration(_) => "TSModuleDeclaration",
             Self::TSModuleBlock(_) => "TSModuleBlock",
@@ -6752,7 +6756,7 @@ impl<'a> AstNode<'a, TSIndexSignatureName<'a>> {
         self.allocator.alloc(AstNode {
             inner: self.inner.type_annotation.as_ref(),
             allocator: self.allocator,
-            parent: self.parent,
+            parent: self.allocator.alloc(AstNodes::TSIndexSignatureName(transmute_self(self))),
         })
     }
 }

--- a/crates/oxc_formatter/src/generated/format.rs
+++ b/crates/oxc_formatter/src/generated/format.rs
@@ -1819,7 +1819,10 @@ impl<'a> Format<'a> for AstNode<'a, TSConstructSignatureDeclaration<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSIndexSignatureName<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        self.write(f)
+        format_leading_comments(self.span().start).fmt(f)?;
+        let result = self.write(f);
+        format_trailing_comments(self.span().end).fmt(f)?;
+        result
     }
 }
 

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/index-signature.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/index-signature.snap
@@ -34,7 +34,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "Bar",
-            "node_id": 14
+            "node_id": 16
           }
         ]
       },
@@ -48,7 +48,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "Foo",
-            "node_id": 22
+            "node_id": 25
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional4.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional4.snap
@@ -23,7 +23,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                     "flags": "ReferenceFlags(Type)",
                     "id": 1,
                     "name": "I",
-                    "node_id": 19
+                    "node_id": 20
                   }
                 ]
               }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional5.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional5.snap
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                     "flags": "ReferenceFlags(Type)",
                     "id": 1,
                     "name": "I",
-                    "node_id": 31
+                    "node_id": 32
                   }
                 ]
               }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/index-sig.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/index-sig.snap
@@ -34,7 +34,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 13
+            "node_id": 14
           }
         ]
       },

--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -45,7 +45,6 @@ const STRUCTS_BLACK_LIST: &[&str] = &[
     "TSInterfaceBody",
     "TSIndexSignature",
     "TSCallSignatureDeclaration",
-    "TSIndexSignatureName",
     "TSTypePredicate",
     "TSFunctionType",
     "TSConstructorType",


### PR DESCRIPTION
This PR is part of the ongoing work in #11490.

Adds AstKind to `TSIndexSignature` nodes by removing the entry from the list of exceptions in ast_tools.