### PR TITLE
feat(ast): Add AstKind to ` TSCallSignatureDeclaration` node

### DIFF
--- a/crates/oxc_ast/src/ast_kind_impl.rs
+++ b/crates/oxc_ast/src/ast_kind_impl.rs
@@ -344,6 +344,7 @@ impl AstKind<'_> {
             Self::TSEnumMember(_) => "TSEnumMember".into(),
 
             Self::TSImportEqualsDeclaration(_) => "TSImportEqualsDeclaration".into(),
+            Self::TSCallSignatureDeclaration(_) => "TSCallSignatureDeclaration".into(),
             Self::TSTypeName(n) => format!("TSTypeName({n})").into(),
             Self::TSExternalModuleReference(_) => "TSExternalModuleReference".into(),
             Self::TSQualifiedName(n) => format!("TSQualifiedName({n})").into(),

--- a/crates/oxc_ast/src/generated/ast_kind.rs
+++ b/crates/oxc_ast/src/generated/ast_kind.rs
@@ -160,31 +160,32 @@ pub enum AstType {
     TSClassImplements = 144,
     TSInterfaceDeclaration = 145,
     TSPropertySignature = 146,
-    TSMethodSignature = 147,
-    TSConstructSignatureDeclaration = 148,
-    TSIndexSignatureName = 149,
-    TSInterfaceHeritage = 150,
-    TSModuleDeclaration = 151,
-    TSModuleBlock = 152,
-    TSTypeLiteral = 153,
-    TSInferType = 154,
-    TSTypeQuery = 155,
-    TSImportType = 156,
-    TSMappedType = 157,
-    TSTemplateLiteralType = 158,
-    TSAsExpression = 159,
-    TSSatisfiesExpression = 160,
-    TSTypeAssertion = 161,
-    TSImportEqualsDeclaration = 162,
-    TSModuleReference = 163,
-    TSExternalModuleReference = 164,
-    TSNonNullExpression = 165,
-    Decorator = 166,
-    TSExportAssignment = 167,
-    TSInstantiationExpression = 168,
-    JSDocNullableType = 169,
-    JSDocNonNullableType = 170,
-    JSDocUnknownType = 171,
+    TSCallSignatureDeclaration = 147,
+    TSMethodSignature = 148,
+    TSConstructSignatureDeclaration = 149,
+    TSIndexSignatureName = 150,
+    TSInterfaceHeritage = 151,
+    TSModuleDeclaration = 152,
+    TSModuleBlock = 153,
+    TSTypeLiteral = 154,
+    TSInferType = 155,
+    TSTypeQuery = 156,
+    TSImportType = 157,
+    TSMappedType = 158,
+    TSTemplateLiteralType = 159,
+    TSAsExpression = 160,
+    TSSatisfiesExpression = 161,
+    TSTypeAssertion = 162,
+    TSImportEqualsDeclaration = 163,
+    TSModuleReference = 164,
+    TSExternalModuleReference = 165,
+    TSNonNullExpression = 166,
+    Decorator = 167,
+    TSExportAssignment = 168,
+    TSInstantiationExpression = 169,
+    JSDocNullableType = 170,
+    JSDocNonNullableType = 171,
+    JSDocUnknownType = 172,
 }
 
 /// Untyped AST Node Kind
@@ -347,6 +348,8 @@ pub enum AstKind<'a> {
     TSClassImplements(&'a TSClassImplements<'a>) = AstType::TSClassImplements as u8,
     TSInterfaceDeclaration(&'a TSInterfaceDeclaration<'a>) = AstType::TSInterfaceDeclaration as u8,
     TSPropertySignature(&'a TSPropertySignature<'a>) = AstType::TSPropertySignature as u8,
+    TSCallSignatureDeclaration(&'a TSCallSignatureDeclaration<'a>) =
+        AstType::TSCallSignatureDeclaration as u8,
     TSMethodSignature(&'a TSMethodSignature<'a>) = AstType::TSMethodSignature as u8,
     TSConstructSignatureDeclaration(&'a TSConstructSignatureDeclaration<'a>) =
         AstType::TSConstructSignatureDeclaration as u8,
@@ -540,6 +543,7 @@ impl GetSpan for AstKind<'_> {
             Self::TSClassImplements(it) => it.span(),
             Self::TSInterfaceDeclaration(it) => it.span(),
             Self::TSPropertySignature(it) => it.span(),
+            Self::TSCallSignatureDeclaration(it) => it.span(),
             Self::TSMethodSignature(it) => it.span(),
             Self::TSConstructSignatureDeclaration(it) => it.span(),
             Self::TSIndexSignatureName(it) => it.span(),
@@ -1305,6 +1309,11 @@ impl<'a> AstKind<'a> {
     #[inline]
     pub fn as_ts_property_signature(self) -> Option<&'a TSPropertySignature<'a>> {
         if let Self::TSPropertySignature(v) = self { Some(v) } else { None }
+    }
+
+    #[inline]
+    pub fn as_ts_call_signature_declaration(self) -> Option<&'a TSCallSignatureDeclaration<'a>> {
+        if let Self::TSCallSignatureDeclaration(v) = self { Some(v) } else { None }
     }
 
     #[inline]

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -3685,7 +3685,8 @@ pub mod walk {
         visitor: &mut V,
         it: &TSCallSignatureDeclaration<'a>,
     ) {
-        // No `AstKind` for this type
+        let kind = AstKind::TSCallSignatureDeclaration(visitor.alloc(it));
+        visitor.enter_node(kind);
         visitor.visit_span(&it.span);
         if let Some(type_parameters) = &it.type_parameters {
             visitor.visit_ts_type_parameter_declaration(type_parameters);
@@ -3697,6 +3698,7 @@ pub mod walk {
         if let Some(return_type) = &it.return_type {
             visitor.visit_ts_type_annotation(return_type);
         }
+        visitor.leave_node(kind);
     }
 
     pub fn walk_ts_method_signature<'a, V: Visit<'a>>(visitor: &mut V, it: &TSMethodSignature<'a>) {

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -3888,7 +3888,8 @@ pub mod walk_mut {
         visitor: &mut V,
         it: &mut TSCallSignatureDeclaration<'a>,
     ) {
-        // No `AstType` for this type
+        let kind = AstType::TSCallSignatureDeclaration;
+        visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
         if let Some(type_parameters) = &mut it.type_parameters {
             visitor.visit_ts_type_parameter_declaration(type_parameters);
@@ -3900,6 +3901,7 @@ pub mod walk_mut {
         if let Some(return_type) = &mut it.return_type {
             visitor.visit_ts_type_annotation(return_type);
         }
+        visitor.leave_node(kind);
     }
 
     pub fn walk_ts_method_signature<'a, V: VisitMut<'a>>(

--- a/crates/oxc_formatter/src/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/generated/ast_nodes.rs
@@ -174,6 +174,7 @@ pub enum AstNodes<'a> {
     TSClassImplements(&'a AstNode<'a, TSClassImplements<'a>>),
     TSInterfaceDeclaration(&'a AstNode<'a, TSInterfaceDeclaration<'a>>),
     TSPropertySignature(&'a AstNode<'a, TSPropertySignature<'a>>),
+    TSCallSignatureDeclaration(&'a AstNode<'a, TSCallSignatureDeclaration<'a>>),
     TSMethodSignature(&'a AstNode<'a, TSMethodSignature<'a>>),
     TSConstructSignatureDeclaration(&'a AstNode<'a, TSConstructSignatureDeclaration<'a>>),
     TSIndexSignatureName(&'a AstNode<'a, TSIndexSignatureName<'a>>),
@@ -352,6 +353,7 @@ impl<'a> AstNodes<'a> {
             Self::TSClassImplements(n) => n.span(),
             Self::TSInterfaceDeclaration(n) => n.span(),
             Self::TSPropertySignature(n) => n.span(),
+            Self::TSCallSignatureDeclaration(n) => n.span(),
             Self::TSMethodSignature(n) => n.span(),
             Self::TSConstructSignatureDeclaration(n) => n.span(),
             Self::TSIndexSignatureName(n) => n.span(),
@@ -530,6 +532,7 @@ impl<'a> AstNodes<'a> {
             Self::TSClassImplements(n) => n.parent,
             Self::TSInterfaceDeclaration(n) => n.parent,
             Self::TSPropertySignature(n) => n.parent,
+            Self::TSCallSignatureDeclaration(n) => n.parent,
             Self::TSMethodSignature(n) => n.parent,
             Self::TSConstructSignatureDeclaration(n) => n.parent,
             Self::TSIndexSignatureName(n) => n.parent,
@@ -708,6 +711,7 @@ impl<'a> AstNodes<'a> {
             Self::TSClassImplements(_) => "TSClassImplements",
             Self::TSInterfaceDeclaration(_) => "TSInterfaceDeclaration",
             Self::TSPropertySignature(_) => "TSPropertySignature",
+            Self::TSCallSignatureDeclaration(_) => "TSCallSignatureDeclaration",
             Self::TSMethodSignature(_) => "TSMethodSignature",
             Self::TSConstructSignatureDeclaration(_) => "TSConstructSignatureDeclaration",
             Self::TSIndexSignatureName(_) => "TSIndexSignatureName",
@@ -6510,9 +6514,11 @@ impl<'a> AstNode<'a, TSSignature<'a>> {
                 }))
             }
             TSSignature::TSCallSignatureDeclaration(s) => {
-                panic!(
-                    "No kind for current enum variant yet, please see `tasks/ast_tools/src/generators/ast_kind.rs`"
-                )
+                AstNodes::TSCallSignatureDeclaration(self.allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                }))
             }
             TSSignature::TSConstructSignatureDeclaration(s) => {
                 AstNodes::TSConstructSignatureDeclaration(self.allocator.alloc(AstNode {
@@ -6582,22 +6588,30 @@ impl<'a> AstNode<'a, TSCallSignatureDeclaration<'a>> {
     #[inline]
     pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
         self.allocator
-            .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
-                inner: inner.as_ref(),
-                allocator: self.allocator,
-                parent: self.parent,
-            }))
+            .alloc(
+                self.inner.type_parameters.as_ref().map(|inner| AstNode {
+                    inner: inner.as_ref(),
+                    allocator: self.allocator,
+                    parent: self
+                        .allocator
+                        .alloc(AstNodes::TSCallSignatureDeclaration(transmute_self(self))),
+                }),
+            )
             .as_ref()
     }
 
     #[inline]
     pub fn this_param(&self) -> Option<&AstNode<'a, TSThisParameter<'a>>> {
         self.allocator
-            .alloc(self.inner.this_param.as_ref().map(|inner| AstNode {
-                inner: inner.as_ref(),
-                allocator: self.allocator,
-                parent: self.parent,
-            }))
+            .alloc(
+                self.inner.this_param.as_ref().map(|inner| AstNode {
+                    inner: inner.as_ref(),
+                    allocator: self.allocator,
+                    parent: self
+                        .allocator
+                        .alloc(AstNodes::TSCallSignatureDeclaration(transmute_self(self))),
+                }),
+            )
             .as_ref()
     }
 
@@ -6606,18 +6620,24 @@ impl<'a> AstNode<'a, TSCallSignatureDeclaration<'a>> {
         self.allocator.alloc(AstNode {
             inner: self.inner.params.as_ref(),
             allocator: self.allocator,
-            parent: self.parent,
+            parent: self
+                .allocator
+                .alloc(AstNodes::TSCallSignatureDeclaration(transmute_self(self))),
         })
     }
 
     #[inline]
     pub fn return_type(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
         self.allocator
-            .alloc(self.inner.return_type.as_ref().map(|inner| AstNode {
-                inner: inner.as_ref(),
-                allocator: self.allocator,
-                parent: self.parent,
-            }))
+            .alloc(
+                self.inner.return_type.as_ref().map(|inner| AstNode {
+                    inner: inner.as_ref(),
+                    allocator: self.allocator,
+                    parent: self
+                        .allocator
+                        .alloc(AstNodes::TSCallSignatureDeclaration(transmute_self(self))),
+                }),
+            )
             .as_ref()
     }
 }

--- a/crates/oxc_formatter/src/generated/format.rs
+++ b/crates/oxc_formatter/src/generated/format.rs
@@ -1795,7 +1795,10 @@ impl<'a> Format<'a> for AstNode<'a, TSIndexSignature<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSCallSignatureDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        self.write(f)
+        format_leading_comments(self.span().start).fmt(f)?;
+        let result = self.write(f);
+        format_trailing_comments(self.span().end).fmt(f)?;
+        result
     }
 }
 

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call-generics.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call-generics.snap
@@ -28,7 +28,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
-                "node_id": 17
+                "node_id": 18
               }
             ]
           }
@@ -49,7 +49,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 21
+            "node_id": 22
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call.snap
@@ -34,13 +34,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 14
+            "node_id": 15
           },
           {
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 18
+            "node_id": 19
           }
         ]
       },

--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -44,7 +44,6 @@ const STRUCTS_BLACK_LIST: &[&str] = &[
     "TSRestType",
     "TSInterfaceBody",
     "TSIndexSignature",
-    "TSCallSignatureDeclaration",
     "TSTypePredicate",
     "TSFunctionType",
     "TSConstructorType",

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -84,7 +84,7 @@ ts compatibility: 186/573 (32.46%)
 | typescript/assignment/issue-6783.ts | 💥 | 0.00% |
 | typescript/assignment/issue-8619.ts | 💥 | 80.00% |
 | typescript/assignment/issue-9172.ts | 💥 | 0.00% |
-| typescript/call-signature/call-signature.ts | 💥 | 66.10% |
+| typescript/call-signature/call-signature.ts | 💥 | 79.66% |
 | typescript/cast/as-const.ts | 💥 | 60.00% |
 | typescript/cast/assert-and-assign.ts | 💥 | 50.00% |
 | typescript/cast/generic-cast.ts | 💥 | 42.51% |
@@ -248,7 +248,7 @@ ts compatibility: 186/573 (32.46%)
 | typescript/export/export.ts | 💥 | 85.71% |
 | typescript/export-default/function_as.ts | 💥 | 0.00% |
 | typescript/function/single_expand.ts | 💥 | 30.00% |
-| typescript/function-type/consistent.ts | 💥 | 85.71% |
+| typescript/function-type/consistent.ts | 💥 | 70.83% |
 | typescript/function-type/single-parameter.ts | 💥 | 0.00% |
 | typescript/function-type/type-annotation.ts | 💥 | 0.00% |
 | typescript/functional-composition/pipe-function-calls-with-comments.ts | 💥 | 77.08% |
@@ -298,7 +298,7 @@ ts compatibility: 186/573 (32.46%)
 | typescript/module/global.ts | 💥 | 75.00% |
 | typescript/module/namespace_function.ts | 💥 | 66.67% |
 | typescript/multiparser-css/issue-6259.ts | 💥 | 15.38% |
-| typescript/new/new-signature.ts | 💥 | 90.91% |
+| typescript/new/new-signature.ts | 💥 | 93.85% |
 | typescript/no-semi/no-semi.ts | 💥✨ | 45.45% |
 | typescript/no-semi/non-null.ts | 💥💥 | 66.67% |
 | typescript/non-null/braces.ts | 💥 | 70.59% |


### PR DESCRIPTION
This PR is part of the ongoing work in #11490 .

Adds AstKind to `TSCallSignatureDeclaration` nodes by removing the entry from the list of exceptions in ast_tools.