### PR TITLE
feat(ast): Add AstKind to `TSTypePredicate` node

### DIFF
--- a/crates/oxc_ast/src/ast_kind_impl.rs
+++ b/crates/oxc_ast/src/ast_kind_impl.rs
@@ -359,6 +359,7 @@ impl AstKind<'_> {
             Self::TSTypeParameter(t) => format!("TSTypeParameter({})", t.name).into(),
             Self::TSTypeParameterDeclaration(_) => "TSTypeParameterDeclaration".into(),
             Self::TSTypeParameterInstantiation(_) => "TSTypeParameterInstantiation".into(),
+            Self::TSTypePredicate(_) => "TSTypePredicate".into(),
             Self::TSImportType(_) => "TSImportType".into(),
             Self::TSNamedTupleMember(_) => "TSNamedTupleMember".into(),
 

--- a/crates/oxc_ast/src/generated/ast_kind.rs
+++ b/crates/oxc_ast/src/generated/ast_kind.rs
@@ -165,27 +165,28 @@ pub enum AstType {
     TSConstructSignatureDeclaration = 149,
     TSIndexSignatureName = 150,
     TSInterfaceHeritage = 151,
-    TSModuleDeclaration = 152,
-    TSModuleBlock = 153,
-    TSTypeLiteral = 154,
-    TSInferType = 155,
-    TSTypeQuery = 156,
-    TSImportType = 157,
-    TSMappedType = 158,
-    TSTemplateLiteralType = 159,
-    TSAsExpression = 160,
-    TSSatisfiesExpression = 161,
-    TSTypeAssertion = 162,
-    TSImportEqualsDeclaration = 163,
-    TSModuleReference = 164,
-    TSExternalModuleReference = 165,
-    TSNonNullExpression = 166,
-    Decorator = 167,
-    TSExportAssignment = 168,
-    TSInstantiationExpression = 169,
-    JSDocNullableType = 170,
-    JSDocNonNullableType = 171,
-    JSDocUnknownType = 172,
+    TSTypePredicate = 152,
+    TSModuleDeclaration = 153,
+    TSModuleBlock = 154,
+    TSTypeLiteral = 155,
+    TSInferType = 156,
+    TSTypeQuery = 157,
+    TSImportType = 158,
+    TSMappedType = 159,
+    TSTemplateLiteralType = 160,
+    TSAsExpression = 161,
+    TSSatisfiesExpression = 162,
+    TSTypeAssertion = 163,
+    TSImportEqualsDeclaration = 164,
+    TSModuleReference = 165,
+    TSExternalModuleReference = 166,
+    TSNonNullExpression = 167,
+    Decorator = 168,
+    TSExportAssignment = 169,
+    TSInstantiationExpression = 170,
+    JSDocNullableType = 171,
+    JSDocNonNullableType = 172,
+    JSDocUnknownType = 173,
 }
 
 /// Untyped AST Node Kind
@@ -355,6 +356,7 @@ pub enum AstKind<'a> {
         AstType::TSConstructSignatureDeclaration as u8,
     TSIndexSignatureName(&'a TSIndexSignatureName<'a>) = AstType::TSIndexSignatureName as u8,
     TSInterfaceHeritage(&'a TSInterfaceHeritage<'a>) = AstType::TSInterfaceHeritage as u8,
+    TSTypePredicate(&'a TSTypePredicate<'a>) = AstType::TSTypePredicate as u8,
     TSModuleDeclaration(&'a TSModuleDeclaration<'a>) = AstType::TSModuleDeclaration as u8,
     TSModuleBlock(&'a TSModuleBlock<'a>) = AstType::TSModuleBlock as u8,
     TSTypeLiteral(&'a TSTypeLiteral<'a>) = AstType::TSTypeLiteral as u8,
@@ -548,6 +550,7 @@ impl GetSpan for AstKind<'_> {
             Self::TSConstructSignatureDeclaration(it) => it.span(),
             Self::TSIndexSignatureName(it) => it.span(),
             Self::TSInterfaceHeritage(it) => it.span(),
+            Self::TSTypePredicate(it) => it.span(),
             Self::TSModuleDeclaration(it) => it.span(),
             Self::TSModuleBlock(it) => it.span(),
             Self::TSTypeLiteral(it) => it.span(),
@@ -1336,6 +1339,11 @@ impl<'a> AstKind<'a> {
     #[inline]
     pub fn as_ts_interface_heritage(self) -> Option<&'a TSInterfaceHeritage<'a>> {
         if let Self::TSInterfaceHeritage(v) = self { Some(v) } else { None }
+    }
+
+    #[inline]
+    pub fn as_ts_type_predicate(self) -> Option<&'a TSTypePredicate<'a>> {
+        if let Self::TSTypePredicate(v) = self { Some(v) } else { None }
     }
 
     #[inline]

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -3770,12 +3770,14 @@ pub mod walk {
 
     #[inline]
     pub fn walk_ts_type_predicate<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypePredicate<'a>) {
-        // No `AstKind` for this type
+        let kind = AstKind::TSTypePredicate(visitor.alloc(it));
+        visitor.enter_node(kind);
         visitor.visit_span(&it.span);
         visitor.visit_ts_type_predicate_name(&it.parameter_name);
         if let Some(type_annotation) = &it.type_annotation {
             visitor.visit_ts_type_annotation(type_annotation);
         }
+        visitor.leave_node(kind);
     }
 
     #[inline]

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -3979,12 +3979,14 @@ pub mod walk_mut {
         visitor: &mut V,
         it: &mut TSTypePredicate<'a>,
     ) {
-        // No `AstType` for this type
+        let kind = AstType::TSTypePredicate;
+        visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type_predicate_name(&mut it.parameter_name);
         if let Some(type_annotation) = &mut it.type_annotation {
             visitor.visit_ts_type_annotation(type_annotation);
         }
+        visitor.leave_node(kind);
     }
 
     #[inline]

--- a/crates/oxc_formatter/src/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/generated/ast_nodes.rs
@@ -179,6 +179,7 @@ pub enum AstNodes<'a> {
     TSConstructSignatureDeclaration(&'a AstNode<'a, TSConstructSignatureDeclaration<'a>>),
     TSIndexSignatureName(&'a AstNode<'a, TSIndexSignatureName<'a>>),
     TSInterfaceHeritage(&'a AstNode<'a, TSInterfaceHeritage<'a>>),
+    TSTypePredicate(&'a AstNode<'a, TSTypePredicate<'a>>),
     TSModuleDeclaration(&'a AstNode<'a, TSModuleDeclaration<'a>>),
     TSModuleBlock(&'a AstNode<'a, TSModuleBlock<'a>>),
     TSTypeLiteral(&'a AstNode<'a, TSTypeLiteral<'a>>),
@@ -358,6 +359,7 @@ impl<'a> AstNodes<'a> {
             Self::TSConstructSignatureDeclaration(n) => n.span(),
             Self::TSIndexSignatureName(n) => n.span(),
             Self::TSInterfaceHeritage(n) => n.span(),
+            Self::TSTypePredicate(n) => n.span(),
             Self::TSModuleDeclaration(n) => n.span(),
             Self::TSModuleBlock(n) => n.span(),
             Self::TSTypeLiteral(n) => n.span(),
@@ -537,6 +539,7 @@ impl<'a> AstNodes<'a> {
             Self::TSConstructSignatureDeclaration(n) => n.parent,
             Self::TSIndexSignatureName(n) => n.parent,
             Self::TSInterfaceHeritage(n) => n.parent,
+            Self::TSTypePredicate(n) => n.parent,
             Self::TSModuleDeclaration(n) => n.parent,
             Self::TSModuleBlock(n) => n.parent,
             Self::TSTypeLiteral(n) => n.parent,
@@ -716,6 +719,7 @@ impl<'a> AstNodes<'a> {
             Self::TSConstructSignatureDeclaration(_) => "TSConstructSignatureDeclaration",
             Self::TSIndexSignatureName(_) => "TSIndexSignatureName",
             Self::TSInterfaceHeritage(_) => "TSInterfaceHeritage",
+            Self::TSTypePredicate(_) => "TSTypePredicate",
             Self::TSModuleDeclaration(_) => "TSModuleDeclaration",
             Self::TSModuleBlock(_) => "TSModuleBlock",
             Self::TSTypeLiteral(_) => "TSTypeLiteral",
@@ -5758,9 +5762,11 @@ impl<'a> AstNode<'a, TSType<'a>> {
                 )
             }
             TSType::TSTypePredicate(s) => {
-                panic!(
-                    "No kind for current enum variant yet, please see `tasks/ast_tools/src/generators/ast_kind.rs`"
-                )
+                AstNodes::TSTypePredicate(self.allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                }))
             }
             TSType::TSTypeQuery(s) => AstNodes::TSTypeQuery(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
@@ -6817,7 +6823,7 @@ impl<'a> AstNode<'a, TSTypePredicate<'a>> {
         self.allocator.alloc(AstNode {
             inner: &self.inner.parameter_name,
             allocator: self.allocator,
-            parent: self.parent,
+            parent: self.allocator.alloc(AstNodes::TSTypePredicate(transmute_self(self))),
         })
     }
 
@@ -6832,7 +6838,7 @@ impl<'a> AstNode<'a, TSTypePredicate<'a>> {
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: self.parent,
+                parent: self.allocator.alloc(AstNodes::TSTypePredicate(transmute_self(self))),
             }))
             .as_ref()
     }

--- a/crates/oxc_formatter/src/generated/format.rs
+++ b/crates/oxc_formatter/src/generated/format.rs
@@ -1840,7 +1840,10 @@ impl<'a> Format<'a> for AstNode<'a, TSInterfaceHeritage<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSTypePredicate<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        self.write(f)
+        format_leading_comments(self.span().start).fmt(f)?;
+        let result = self.write(f);
+        format_trailing_comments(self.span().end).fmt(f)?;
+        result
     }
 }
 

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts2.snap
@@ -42,7 +42,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 18
+            "node_id": 19
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate1.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
                 "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "arg",
-                "node_id": 18
+                "node_id": 19
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate2.snap
@@ -28,7 +28,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
                 "flags": "ReferenceFlags(Read)",
                 "id": 1,
                 "name": "arg",
-                "node_id": 23
+                "node_id": 24
               }
             ]
           }
@@ -49,7 +49,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 18
+            "node_id": 19
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate-asserts2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate-asserts2.snap
@@ -42,7 +42,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 16
+            "node_id": 17
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate1.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
                 "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "arg",
-                "node_id": 16
+                "node_id": 17
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate2.snap
@@ -28,7 +28,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
                 "flags": "ReferenceFlags(Read)",
                 "id": 1,
                 "name": "arg",
-                "node_id": 21
+                "node_id": 22
               }
             ]
           }
@@ -49,7 +49,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 16
+            "node_id": 17
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate-asserts2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate-asserts2.snap
@@ -42,7 +42,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 18
+            "node_id": 19
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate1.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
                 "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "arg",
-                "node_id": 18
+                "node_id": 19
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate2.snap
@@ -28,7 +28,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
                 "flags": "ReferenceFlags(Read)",
                 "id": 1,
                 "name": "arg",
-                "node_id": 23
+                "node_id": 24
               }
             ]
           }
@@ -49,7 +49,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 18
+            "node_id": 19
           }
         ]
       },

--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -44,7 +44,6 @@ const STRUCTS_BLACK_LIST: &[&str] = &[
     "TSRestType",
     "TSInterfaceBody",
     "TSIndexSignature",
-    "TSTypePredicate",
     "TSFunctionType",
     "TSConstructorType",
     "TSNamespaceExportDeclaration",


### PR DESCRIPTION
This PR is part of the ongoing work in https://github.com/oxc-project/oxc/issues/11490.

Adds AstKind to `TSTypePredicate` nodes by removing the entry from the list of exceptions in ast_tools.