### PR TITLE
refactor(ast): Remove AstKind from `TSModuleReference` node

### DIFF
--- a/crates/oxc_ast/src/ast_kind_impl.rs
+++ b/crates/oxc_ast/src/ast_kind_impl.rs
@@ -368,7 +368,6 @@ impl AstKind<'_> {
             Self::TSConditionalType(_) => "TSConditionalType".into(),
             Self::TSMappedType(_) => "TSMappedType".into(),
             Self::TSConstructSignatureDeclaration(_) => "TSConstructSignatureDeclaration".into(),
-            Self::TSModuleReference(_) => "TSModuleReference".into(),
             Self::TSExportAssignment(_) => "TSExportAssignment".into(),
             Self::V8IntrinsicExpression(_) => "V8IntrinsicExpression".into(),
 

--- a/crates/oxc_ast/src/generated/ast_kind.rs
+++ b/crates/oxc_ast/src/generated/ast_kind.rs
@@ -178,15 +178,14 @@ pub enum AstType {
     TSSatisfiesExpression = 162,
     TSTypeAssertion = 163,
     TSImportEqualsDeclaration = 164,
-    TSModuleReference = 165,
-    TSExternalModuleReference = 166,
-    TSNonNullExpression = 167,
-    Decorator = 168,
-    TSExportAssignment = 169,
-    TSInstantiationExpression = 170,
-    JSDocNullableType = 171,
-    JSDocNonNullableType = 172,
-    JSDocUnknownType = 173,
+    TSExternalModuleReference = 165,
+    TSNonNullExpression = 166,
+    Decorator = 167,
+    TSExportAssignment = 168,
+    TSInstantiationExpression = 169,
+    JSDocNullableType = 170,
+    JSDocNonNullableType = 171,
+    JSDocUnknownType = 172,
 }
 
 /// Untyped AST Node Kind
@@ -370,7 +369,6 @@ pub enum AstKind<'a> {
     TSTypeAssertion(&'a TSTypeAssertion<'a>) = AstType::TSTypeAssertion as u8,
     TSImportEqualsDeclaration(&'a TSImportEqualsDeclaration<'a>) =
         AstType::TSImportEqualsDeclaration as u8,
-    TSModuleReference(&'a TSModuleReference<'a>) = AstType::TSModuleReference as u8,
     TSExternalModuleReference(&'a TSExternalModuleReference<'a>) =
         AstType::TSExternalModuleReference as u8,
     TSNonNullExpression(&'a TSNonNullExpression<'a>) = AstType::TSNonNullExpression as u8,
@@ -563,7 +561,6 @@ impl GetSpan for AstKind<'_> {
             Self::TSSatisfiesExpression(it) => it.span(),
             Self::TSTypeAssertion(it) => it.span(),
             Self::TSImportEqualsDeclaration(it) => it.span(),
-            Self::TSModuleReference(it) => it.span(),
             Self::TSExternalModuleReference(it) => it.span(),
             Self::TSNonNullExpression(it) => it.span(),
             Self::Decorator(it) => it.span(),
@@ -1404,11 +1401,6 @@ impl<'a> AstKind<'a> {
     #[inline]
     pub fn as_ts_import_equals_declaration(self) -> Option<&'a TSImportEqualsDeclaration<'a>> {
         if let Self::TSImportEqualsDeclaration(v) = self { Some(v) } else { None }
-    }
-
-    #[inline]
-    pub fn as_ts_module_reference(self) -> Option<&'a TSModuleReference<'a>> {
-        if let Self::TSModuleReference(v) = self { Some(v) } else { None }
     }
 
     #[inline]

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -4021,8 +4021,7 @@ pub mod walk {
 
     #[inline]
     pub fn walk_ts_module_reference<'a, V: Visit<'a>>(visitor: &mut V, it: &TSModuleReference<'a>) {
-        let kind = AstKind::TSModuleReference(visitor.alloc(it));
-        visitor.enter_node(kind);
+        // No `AstKind` for this type
         match it {
             TSModuleReference::ExternalModuleReference(it) => {
                 visitor.visit_ts_external_module_reference(it)
@@ -4031,7 +4030,6 @@ pub mod walk {
                 visitor.visit_ts_type_name(it.to_ts_type_name())
             }
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -4245,8 +4245,7 @@ pub mod walk_mut {
         visitor: &mut V,
         it: &mut TSModuleReference<'a>,
     ) {
-        let kind = AstType::TSModuleReference;
-        visitor.enter_node(kind);
+        // No `AstType` for this type
         match it {
             TSModuleReference::ExternalModuleReference(it) => {
                 visitor.visit_ts_external_module_reference(it)
@@ -4255,7 +4254,6 @@ pub mod walk_mut {
                 visitor.visit_ts_type_name(it.to_ts_type_name_mut())
             }
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]

--- a/crates/oxc_formatter/src/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/generated/ast_nodes.rs
@@ -192,7 +192,6 @@ pub enum AstNodes<'a> {
     TSSatisfiesExpression(&'a AstNode<'a, TSSatisfiesExpression<'a>>),
     TSTypeAssertion(&'a AstNode<'a, TSTypeAssertion<'a>>),
     TSImportEqualsDeclaration(&'a AstNode<'a, TSImportEqualsDeclaration<'a>>),
-    TSModuleReference(&'a AstNode<'a, TSModuleReference<'a>>),
     TSExternalModuleReference(&'a AstNode<'a, TSExternalModuleReference<'a>>),
     TSNonNullExpression(&'a AstNode<'a, TSNonNullExpression<'a>>),
     Decorator(&'a AstNode<'a, Decorator<'a>>),
@@ -372,7 +371,6 @@ impl<'a> AstNodes<'a> {
             Self::TSSatisfiesExpression(n) => n.span(),
             Self::TSTypeAssertion(n) => n.span(),
             Self::TSImportEqualsDeclaration(n) => n.span(),
-            Self::TSModuleReference(n) => n.span(),
             Self::TSExternalModuleReference(n) => n.span(),
             Self::TSNonNullExpression(n) => n.span(),
             Self::Decorator(n) => n.span(),
@@ -552,7 +550,6 @@ impl<'a> AstNodes<'a> {
             Self::TSSatisfiesExpression(n) => n.parent,
             Self::TSTypeAssertion(n) => n.parent,
             Self::TSImportEqualsDeclaration(n) => n.parent,
-            Self::TSModuleReference(n) => n.parent,
             Self::TSExternalModuleReference(n) => n.parent,
             Self::TSNonNullExpression(n) => n.parent,
             Self::Decorator(n) => n.parent,
@@ -732,7 +729,6 @@ impl<'a> AstNodes<'a> {
             Self::TSSatisfiesExpression(_) => "TSSatisfiesExpression",
             Self::TSTypeAssertion(_) => "TSTypeAssertion",
             Self::TSImportEqualsDeclaration(_) => "TSImportEqualsDeclaration",
-            Self::TSModuleReference(_) => "TSModuleReference",
             Self::TSExternalModuleReference(_) => "TSExternalModuleReference",
             Self::TSNonNullExpression(_) => "TSNonNullExpression",
             Self::Decorator(_) => "Decorator",
@@ -7391,7 +7387,7 @@ impl<'a> AstNode<'a, TSImportEqualsDeclaration<'a>> {
 impl<'a> AstNode<'a, TSModuleReference<'a>> {
     #[inline]
     pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
-        let parent = self.allocator.alloc(AstNodes::TSModuleReference(transmute_self(self)));
+        let parent = self.parent;
         let node = match self.inner {
             TSModuleReference::ExternalModuleReference(s) => {
                 AstNodes::TSExternalModuleReference(self.allocator.alloc(AstNode {

--- a/crates/oxc_formatter/src/generated/format_write.rs
+++ b/crates/oxc_formatter/src/generated/format_write.rs
@@ -1095,7 +1095,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSModuleReference<'a>> {
     #[inline]
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let allocator = self.allocator;
-        let parent = allocator.alloc(AstNodes::TSModuleReference(transmute_self(self)));
+        let parent = self.parent;
         match self.inner {
             TSModuleReference::ExternalModuleReference(inner) => allocator
                 .alloc(AstNode::<TSExternalModuleReference> { inner, parent, allocator })

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -2041,7 +2041,7 @@ impl<'a> SemanticBuilder<'a> {
                     Some(
                         // import A = a;
                         //            ^
-                        AstKind::TSModuleReference(_),
+                        AstKind::TSImportEqualsDeclaration(_),
                     ) => {
                         self.current_reference_flags = ReferenceFlags::Read;
                     }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals1.snap
@@ -19,7 +19,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals1.
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "foo",
-            "node_id": 7
+            "node_id": 6
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals2.snap
@@ -19,7 +19,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals2.
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
-            "node_id": 9
+            "node_id": 8
           }
         ]
       },

--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -62,7 +62,6 @@ const ENUMS_WHITE_LIST: &[&str] = &[
     "AssignmentTargetPattern",
     "ModuleDeclaration",
     "TSTypeName",
-    "TSModuleReference",
 ];
 
 /// Generator for `AstKind`, `AstType`, and related code.


### PR DESCRIPTION
This PR is part of the ongoing work in #11490 

Removes AstKind from `TSModuleReference` nodes by removing the entry from the list of enum exceptions in ast_tools.