### PR TITLE
fix(parser): allocate all strings in arena

### DIFF
--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -758,11 +758,10 @@ impl<'a> ParserImpl<'a> {
                         can_parse_as_keyword = false;
                     } else {
                         // { type as as }
-                        property_name =
-                            Some(self.ast.module_export_name_identifier_name(
-                                type_or_name_token.span(),
-                                "type",
-                            ));
+                        property_name = Some(self.ast.module_export_name_identifier_name(
+                            type_or_name_token.span(),
+                            self.token_source(&type_or_name_token),
+                        ));
                         name = self
                             .ast
                             .module_export_name_identifier_name(second_as.span, second_as.name);

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -140,9 +140,10 @@ impl<'a> ParserImpl<'a> {
             self.bump_any();
             if self.at(Kind::Dot) {
                 // `type something = intrinsic. ...`
-                let intrinsic_ident = self
-                    .ast
-                    .alloc_identifier_reference(intrinsic_token.span(), Kind::Intrinsic.to_str());
+                let intrinsic_ident = self.ast.alloc_identifier_reference(
+                    intrinsic_token.span(),
+                    self.token_source(&intrinsic_token),
+                );
                 let type_name = self.parse_ts_qualified_type_name(
                     intrinsic_token.start(),
                     TSTypeName::IdentifierReference(intrinsic_ident),


### PR DESCRIPTION
Fix #11723.

Fix 2 cases where parser was using static strings for AST nodes.

This is fine on Rust side, but it breaks raw transfer, because raw transfer requires all data (including strings) to be in the arena. All it knows is what's in the arena, and a `&'static str` is stored outside that, so it can't read the string data.

Unfortunately, we have no way to statically prevent putting an `Atom` created from a `&'static str` in AST, because type system allows a `'static` lifetime to be "squeezed" down to `'a`. So we have to play "whack-a-mole" with any such bugs at present (unfortunately conformance tests don't cover the cases in #11723).