### PR TITLE
perf(linter): skip running `consistent-function-scoping` on `.d.ts` files

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
@@ -299,6 +299,11 @@ impl Rule for ConsistentFunctionScoping {
             function_name,
         ));
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        // .d.ts files are never run, so there are no perf considerations for them.
+        !ctx.source_type().is_typescript_definition()
+    }
 }
 
 #[derive(Default)]


### PR DESCRIPTION
taken from #11682 