### PR TITLE
docs(linter): fix typo in import/no-namespace

### DIFF
--- a/crates/oxc_linter/src/rules/import/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/import/no_namespace.rs
@@ -55,7 +55,7 @@ declare_oxc_lint!(
     ///
     /// ```json
     /// {
-    ///     "ignores": ["*.json"]
+    ///     "ignore": ["*.json"]
     /// }
     /// ```
     ///


### PR DESCRIPTION
closes https://github.com/oxc-project/oxc-project.github.io/pull/397