### PR TITLE
feat(ast): Add AstKind to TSNamespaceExportDeclaration node

### DIFF
--- a/crates/oxc_ast/src/ast_kind_impl.rs
+++ b/crates/oxc_ast/src/ast_kind_impl.rs
@@ -349,6 +349,7 @@ impl AstKind<'_> {
             Self::TSEnumBody(_) => "TSEnumBody".into(),
             Self::TSEnumMember(_) => "TSEnumMember".into(),
 
+            Self::TSNamespaceExportDeclaration(_) => "TSNamespaceExportDeclaration".into(),
             Self::TSImportEqualsDeclaration(_) => "TSImportEqualsDeclaration".into(),
             Self::TSCallSignatureDeclaration(_) => "TSCallSignatureDeclaration".into(),
             Self::TSTypeName(n) => format!("TSTypeName({n})").into(),

--- a/crates/oxc_ast/src/generated/ast_kind.rs
+++ b/crates/oxc_ast/src/generated/ast_kind.rs
@@ -187,10 +187,11 @@ pub enum AstType {
     TSNonNullExpression = 171,
     Decorator = 172,
     TSExportAssignment = 173,
-    TSInstantiationExpression = 174,
-    JSDocNullableType = 175,
-    JSDocNonNullableType = 176,
-    JSDocUnknownType = 177,
+    TSNamespaceExportDeclaration = 174,
+    TSInstantiationExpression = 175,
+    JSDocNullableType = 176,
+    JSDocNonNullableType = 177,
+    JSDocUnknownType = 178,
 }
 
 /// Untyped AST Node Kind
@@ -384,6 +385,8 @@ pub enum AstKind<'a> {
     TSNonNullExpression(&'a TSNonNullExpression<'a>) = AstType::TSNonNullExpression as u8,
     Decorator(&'a Decorator<'a>) = AstType::Decorator as u8,
     TSExportAssignment(&'a TSExportAssignment<'a>) = AstType::TSExportAssignment as u8,
+    TSNamespaceExportDeclaration(&'a TSNamespaceExportDeclaration<'a>) =
+        AstType::TSNamespaceExportDeclaration as u8,
     TSInstantiationExpression(&'a TSInstantiationExpression<'a>) =
         AstType::TSInstantiationExpression as u8,
     JSDocNullableType(&'a JSDocNullableType<'a>) = AstType::JSDocNullableType as u8,
@@ -580,6 +583,7 @@ impl GetSpan for AstKind<'_> {
             Self::TSNonNullExpression(it) => it.span(),
             Self::Decorator(it) => it.span(),
             Self::TSExportAssignment(it) => it.span(),
+            Self::TSNamespaceExportDeclaration(it) => it.span(),
             Self::TSInstantiationExpression(it) => it.span(),
             Self::JSDocNullableType(it) => it.span(),
             Self::JSDocNonNullableType(it) => it.span(),
@@ -1461,6 +1465,13 @@ impl<'a> AstKind<'a> {
     #[inline]
     pub fn as_ts_export_assignment(self) -> Option<&'a TSExportAssignment<'a>> {
         if let Self::TSExportAssignment(v) = self { Some(v) } else { None }
+    }
+
+    #[inline]
+    pub fn as_ts_namespace_export_declaration(
+        self,
+    ) -> Option<&'a TSNamespaceExportDeclaration<'a>> {
+        if let Self::TSNamespaceExportDeclaration(v) = self { Some(v) } else { None }
     }
 
     #[inline]

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -4092,9 +4092,11 @@ pub mod walk {
         visitor: &mut V,
         it: &TSNamespaceExportDeclaration<'a>,
     ) {
-        // No `AstKind` for this type
+        let kind = AstKind::TSNamespaceExportDeclaration(visitor.alloc(it));
+        visitor.enter_node(kind);
         visitor.visit_span(&it.span);
         visitor.visit_identifier_name(&it.id);
+        visitor.leave_node(kind);
     }
 
     #[inline]

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -4316,9 +4316,11 @@ pub mod walk_mut {
         visitor: &mut V,
         it: &mut TSNamespaceExportDeclaration<'a>,
     ) {
-        // No `AstType` for this type
+        let kind = AstType::TSNamespaceExportDeclaration;
+        visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
         visitor.visit_identifier_name(&mut it.id);
+        visitor.leave_node(kind);
     }
 
     #[inline]

--- a/crates/oxc_formatter/src/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/generated/ast_nodes.rs
@@ -201,6 +201,7 @@ pub enum AstNodes<'a> {
     TSNonNullExpression(&'a AstNode<'a, TSNonNullExpression<'a>>),
     Decorator(&'a AstNode<'a, Decorator<'a>>),
     TSExportAssignment(&'a AstNode<'a, TSExportAssignment<'a>>),
+    TSNamespaceExportDeclaration(&'a AstNode<'a, TSNamespaceExportDeclaration<'a>>),
     TSInstantiationExpression(&'a AstNode<'a, TSInstantiationExpression<'a>>),
     JSDocNullableType(&'a AstNode<'a, JSDocNullableType<'a>>),
     JSDocNonNullableType(&'a AstNode<'a, JSDocNonNullableType<'a>>),
@@ -385,6 +386,7 @@ impl<'a> AstNodes<'a> {
             Self::TSNonNullExpression(n) => n.span(),
             Self::Decorator(n) => n.span(),
             Self::TSExportAssignment(n) => n.span(),
+            Self::TSNamespaceExportDeclaration(n) => n.span(),
             Self::TSInstantiationExpression(n) => n.span(),
             Self::JSDocNullableType(n) => n.span(),
             Self::JSDocNonNullableType(n) => n.span(),
@@ -569,6 +571,7 @@ impl<'a> AstNodes<'a> {
             Self::TSNonNullExpression(n) => n.parent,
             Self::Decorator(n) => n.parent,
             Self::TSExportAssignment(n) => n.parent,
+            Self::TSNamespaceExportDeclaration(n) => n.parent,
             Self::TSInstantiationExpression(n) => n.parent,
             Self::JSDocNullableType(n) => n.parent,
             Self::JSDocNonNullableType(n) => n.parent,
@@ -753,6 +756,7 @@ impl<'a> AstNodes<'a> {
             Self::TSNonNullExpression(_) => "TSNonNullExpression",
             Self::Decorator(_) => "Decorator",
             Self::TSExportAssignment(_) => "TSExportAssignment",
+            Self::TSNamespaceExportDeclaration(_) => "TSNamespaceExportDeclaration",
             Self::TSInstantiationExpression(_) => "TSInstantiationExpression",
             Self::JSDocNullableType(_) => "JSDocNullableType",
             Self::JSDocNonNullableType(_) => "JSDocNonNullableType",
@@ -4124,9 +4128,11 @@ impl<'a> AstNode<'a, ModuleDeclaration<'a>> {
                 }))
             }
             ModuleDeclaration::TSNamespaceExportDeclaration(s) => {
-                panic!(
-                    "No kind for current enum variant yet, please see `tasks/ast_tools/src/generators/ast_kind.rs`"
-                )
+                AstNodes::TSNamespaceExportDeclaration(self.allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                }))
             }
         };
         self.allocator.alloc(node)
@@ -7509,7 +7515,9 @@ impl<'a> AstNode<'a, TSNamespaceExportDeclaration<'a>> {
         self.allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
-            parent: self.parent,
+            parent: self
+                .allocator
+                .alloc(AstNodes::TSNamespaceExportDeclaration(transmute_self(self))),
         })
     }
 }

--- a/crates/oxc_formatter/src/generated/format.rs
+++ b/crates/oxc_formatter/src/generated/format.rs
@@ -2078,7 +2078,10 @@ impl<'a> Format<'a> for AstNode<'a, TSExportAssignment<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSNamespaceExportDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        self.write(f)
+        format_leading_comments(self.span().start).fmt(f)?;
+        let result = self.write(f);
+        format_trailing_comments(self.span().end).fmt(f)?;
+        result
     }
 }
 

--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -41,7 +41,6 @@ const STRUCTS_BLACK_LIST: &[&str] = &[
     "TSIndexSignature",
     "TSFunctionType",
     "TSConstructorType",
-    "TSNamespaceExportDeclaration",
     "Span",
 ];
 


### PR DESCRIPTION
This PR is part of the ongoing work in #11490.

Adds AstKind to `TSNamespaceExportDeclaration` nodes by removing the entry from the list of exceptions in ast_tools.