### PR TITLE
perf(parser): optimize code around parsing delimited list and object

### DIFF
--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -26,7 +26,6 @@ impl<'a> ParserImpl<'a> {
                 Self::parse_object_expression_property,
             )
         });
-        self.bump(Kind::Comma); // Trailing Comma
         self.expect(Kind::RCurly);
         self.ast.alloc_object_expression(self.end_span(span), object_expression_properties)
     }

--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -46,13 +46,12 @@ impl<'a> ParserImpl<'a> {
             /* stop_on_start_of_class_static_block */ false,
         );
 
-        let kind = self.cur_kind();
-        if self.parse_contextual_modifier(Kind::Get) || self.parse_contextual_modifier(Kind::Set) {
-            return match kind {
-                Kind::Get => self.parse_method_getter_setter(span, PropertyKind::Get, &modifiers),
-                Kind::Set => self.parse_method_getter_setter(span, PropertyKind::Set, &modifiers),
-                _ => unreachable!(),
-            };
+        if self.parse_contextual_modifier(Kind::Get) {
+            return self.parse_method_getter_setter(span, PropertyKind::Get, &modifiers);
+        }
+
+        if self.parse_contextual_modifier(Kind::Set) {
+            return self.parse_method_getter_setter(span, PropertyKind::Set, &modifiers);
         }
 
         let asterisk_token = self.eat(Kind::Star);


### PR DESCRIPTION
parse_object_expression:
- remove unnecessary `bump(Kind::Comma)`

parse_delimited_list:
- avoid `first` variable and related check by unrolling first iteration of loop
- avoid `trailing_separator` variable by restructuring code
- avoid mostly wasted call to `start_span()` (only possible if `separator` is always one character)

parse_object_literal_element
- avoid redundant kind check when parsing getter and setter