### PR TITLE
refactor(ast): derive `Copy` on small AST types

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -302,7 +302,7 @@ pub struct LabelIdentifier<'a> {
 ///
 /// Represents a `this` expression, which is a reference to the current object.
 #[ast(visit)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ThisExpression {
     pub span: Span,
@@ -345,7 +345,7 @@ pub enum ArrayExpressionElement<'a> {
 ///
 /// Array Expression Elision Element
 #[ast(visit)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(via = Null)]
 pub struct Elision {
@@ -1005,7 +1005,7 @@ pub struct SequenceExpression<'a> {
 ///
 /// Represents a super expression.
 #[ast(visit)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct Super {
     pub span: Span,
@@ -1220,7 +1220,7 @@ pub struct VariableDeclarator<'a> {
 
 /// Empty Statement
 #[ast(visit)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct EmptyStatement {
     pub span: Span,
@@ -1511,7 +1511,7 @@ pub struct CatchParameter<'a> {
 /// debugger; // <--
 /// ```
 #[ast(visit)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct DebuggerStatement {
     pub span: Span,

--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -123,7 +123,7 @@ pub struct JSXFragment<'a> {
 
 /// JSX Opening Fragment (`<>`)
 #[ast(visit)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(add_fields(attributes = JsEmptyArray, selfClosing = JsFalse))]
 pub struct JSXOpeningFragment {
@@ -133,7 +133,7 @@ pub struct JSXOpeningFragment {
 
 /// JSX Closing Fragment (`</>`)
 #[ast(visit)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct JSXClosingFragment {
     /// Node location in source code
@@ -284,7 +284,7 @@ pub enum JSXExpression<'a> {
 
 /// An empty JSX expression (`{}`)
 #[ast(visit)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct JSXEmptyExpression {
     /// Node location in source code

--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -18,7 +18,7 @@ use oxc_syntax::number::{BigintBase, NumberBase};
 ///
 /// <https://tc39.es/ecma262/#prod-BooleanLiteral>
 #[ast(visit)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(rename = "Literal", add_fields(raw = BooleanLiteralRaw))]
 pub struct BooleanLiteral {
@@ -32,7 +32,7 @@ pub struct BooleanLiteral {
 ///
 /// <https://tc39.es/ecma262/#sec-null-literals>
 #[ast(visit)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(rename = "Literal", add_fields(value = Null, raw = NullLiteralRaw))]
 pub struct NullLiteral {

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -570,7 +570,7 @@ pub enum TSTupleElement<'a> {
 /// ## Reference
 /// * [TypeScript Handbook - Any Type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#any)
 #[ast(visit)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSAnyKeyword {
     pub span: Span,
@@ -586,7 +586,7 @@ pub struct TSAnyKeyword {
 /// ## Reference
 /// * [TypeScript Handbook - Everyday Types](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#the-primitives-string-number-and-boolean)
 #[ast(visit)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSStringKeyword {
     pub span: Span,
@@ -602,7 +602,7 @@ pub struct TSStringKeyword {
 /// ## Reference
 /// * [TypeScript Handbook - Everyday Types](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#the-primitives-string-number-and-boolean)
 #[ast(visit)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSBooleanKeyword {
     pub span: Span,
@@ -618,7 +618,7 @@ pub struct TSBooleanKeyword {
 /// ## Reference
 /// * [TypeScript Handbook - Everyday Types](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#the-primitives-string-number-and-boolean)
 #[ast(visit)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSNumberKeyword {
     pub span: Span,
@@ -635,7 +635,7 @@ pub struct TSNumberKeyword {
 /// ## Reference
 /// * [TypeScript Handbook - Advanced Topics](https://www.typescriptlang.org/docs/handbook/type-compatibility.html#advanced-topics)
 #[ast(visit)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSNeverKeyword {
     pub span: Span,
@@ -652,7 +652,7 @@ pub struct TSNeverKeyword {
 /// Types](https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html#intrinsic-string-manipulation-types)
 /// * [microsoft/TypeScript #40580](https://github.com/microsoft/TypeScript/pull/40580)
 #[ast(visit)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSIntrinsicKeyword {
     pub span: Span,
@@ -670,7 +670,7 @@ pub struct TSIntrinsicKeyword {
 /// ## Reference
 /// * [TypeScript Handbook - Advanced Topics](https://www.typescriptlang.org/docs/handbook/type-compatibility.html#advanced-topics)
 #[ast(visit)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSUnknownKeyword {
     pub span: Span,
@@ -687,7 +687,7 @@ pub struct TSUnknownKeyword {
 /// ## Reference
 /// * [TypeScript Handbook - Everyday Types](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#null-and-undefined)
 #[ast(visit)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSNullKeyword {
     pub span: Span,
@@ -706,42 +706,42 @@ pub struct TSNullKeyword {
 /// ## Reference
 /// * [TypeScript Handbook - Everyday Types](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#null-and-undefined)
 #[ast(visit)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSUndefinedKeyword {
     pub span: Span,
 }
 
 #[ast(visit)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSVoidKeyword {
     pub span: Span,
 }
 
 #[ast(visit)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSSymbolKeyword {
     pub span: Span,
 }
 
 #[ast(visit)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSThisType {
     pub span: Span,
 }
 
 #[ast(visit)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSObjectKeyword {
     pub span: Span,
 }
 
 #[ast(visit)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSBigIntKeyword {
     pub span: Span,
@@ -1703,7 +1703,7 @@ pub struct JSDocNonNullableType<'a> {
 }
 
 #[ast(visit)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(rename = "TSJSDocUnknownType")]
 pub struct JSDocUnknownType {

--- a/crates/oxc_formatter/src/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/generated/ast_nodes.rs
@@ -4906,12 +4906,8 @@ impl<'a> AstNode<'a, JSXFragment<'a>> {
     }
 
     #[inline]
-    pub fn opening_fragment(&self) -> &AstNode<'a, JSXOpeningFragment> {
-        self.allocator.alloc(AstNode {
-            inner: &self.inner.opening_fragment,
-            allocator: self.allocator,
-            parent: self.allocator.alloc(AstNodes::JSXFragment(transmute_self(self))),
-        })
+    pub fn opening_fragment(&self) -> JSXOpeningFragment {
+        self.inner.opening_fragment
     }
 
     #[inline]
@@ -4924,12 +4920,8 @@ impl<'a> AstNode<'a, JSXFragment<'a>> {
     }
 
     #[inline]
-    pub fn closing_fragment(&self) -> &AstNode<'a, JSXClosingFragment> {
-        self.allocator.alloc(AstNode {
-            inner: &self.inner.closing_fragment,
-            allocator: self.allocator,
-            parent: self.allocator.alloc(AstNodes::JSXFragment(transmute_self(self))),
-        })
+    pub fn closing_fragment(&self) -> JSXClosingFragment {
+        self.inner.closing_fragment
     }
 }
 impl<'a> AstNode<'a, JSXOpeningFragment> {

--- a/crates/oxc_linter/src/rules/unicorn/no_null.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_null.rs
@@ -73,7 +73,7 @@ impl NoNull {
     fn diagnose_binary_expression(
         &self,
         ctx: &LintContext,
-        null_literal: &NullLiteral,
+        null_literal: NullLiteral,
         binary_expr: &BinaryExpression,
     ) {
         match binary_expr.operator {
@@ -103,7 +103,7 @@ impl NoNull {
 
 fn diagnose_variable_declarator(
     ctx: &LintContext,
-    null_literal: &NullLiteral,
+    null_literal: NullLiteral,
     variable_declarator: &VariableDeclarator,
     parent_kind: Option<AstKind>,
 ) {
@@ -124,7 +124,7 @@ fn diagnose_variable_declarator(
     });
 }
 
-fn match_call_expression_pass_case(null_literal: &NullLiteral, call_expr: &CallExpression) -> bool {
+fn match_call_expression_pass_case(null_literal: NullLiteral, call_expr: &CallExpression) -> bool {
     // `Object.create(null)`, `Object.create(null, foo)`
     if is_method_call(call_expr, Some(&["Object"]), Some(&["create"]), Some(1), Some(2))
         && !call_expr.optional
@@ -176,7 +176,7 @@ impl Rule for NoNull {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let AstKind::NullLiteral(null_literal) = node.kind() else {
+        let AstKind::NullLiteral(&null_literal) = node.kind() else {
             return;
         };
 
@@ -235,13 +235,13 @@ impl Rule for NoNull {
     }
 }
 
-fn fix_null<'a>(fixer: RuleFixer<'_, 'a>, null: &NullLiteral) -> RuleFix<'a> {
+fn fix_null<'a>(fixer: RuleFixer<'_, 'a>, null: NullLiteral) -> RuleFix<'a> {
     fixer.replace(null.span, "undefined")
 }
 
 fn try_fix_case<'a>(
     fixer: RuleFixer<'_, 'a>,
-    null: &NullLiteral,
+    null: NullLiteral,
     switch: &SwitchStatement<'a>,
 ) -> RuleFix<'a> {
     let also_has_undefined = switch

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -796,7 +796,7 @@ fn unexpected_super_reference(span: Span) -> OxcDiagnostic {
 .with_label(span)
 }
 
-pub fn check_super(sup: &Super, ctx: &SemanticBuilder<'_>) {
+pub fn check_super(sup: Super, ctx: &SemanticBuilder<'_>) {
     let super_call_span = match ctx.nodes.parent_kind(ctx.current_node_id) {
         Some(AstKind::CallExpression(expr)) => Some(expr.span),
         Some(AstKind::NewExpression(expr)) => Some(expr.span),

--- a/crates/oxc_semantic/src/checker/mod.rs
+++ b/crates/oxc_semantic/src/checker/mod.rs
@@ -86,7 +86,7 @@ pub fn check<'a>(kind: AstKind<'a>, ctx: &SemanticBuilder<'a>) {
         AstKind::ObjectProperty(prop) => {
             ts::check_object_property(prop, ctx);
         }
-        AstKind::Super(sup) => js::check_super(sup, ctx),
+        AstKind::Super(&sup) => js::check_super(sup, ctx),
 
         AstKind::FormalParameters(params) => {
             ts::check_formal_parameters(params, ctx);


### PR DESCRIPTION
Various AST types (`ThisExpression`) etc only contain a `Span`, so are 8 bytes. There is no point passing these types by reference, as a reference is also 8 bytes. So make these types `Copy`.

Also make `BooleanLiteral` (16 bytes) `Copy` - that's still small enough to be cheaper to pass by value.