### PR TITLE
perf(allocator): remove `Arc` from `AllocatorPool`

### DIFF
--- a/crates/oxc_allocator/src/pool.rs
+++ b/crates/oxc_allocator/src/pool.rs
@@ -1,7 +1,7 @@
 use std::{
     mem::ManuallyDrop,
     ops::{Deref, DerefMut},
-    sync::{Arc, Mutex},
+    sync::Mutex,
 };
 
 use crate::Allocator;
@@ -11,14 +11,14 @@ use crate::Allocator;
 /// Internally uses a `Vec` protected by a `Mutex` to store available allocators.
 #[derive(Default)]
 pub struct AllocatorPool {
-    allocators: Arc<Mutex<Vec<Allocator>>>,
+    allocators: Mutex<Vec<Allocator>>,
 }
 
 impl AllocatorPool {
     /// Creates a new `AllocatorPool` pre-filled with the given number of default `Allocator` instances.
     pub fn new(size: usize) -> AllocatorPool {
         let allocators = std::iter::repeat_with(Allocator::default).take(size).collect();
-        AllocatorPool { allocators: Arc::new(Mutex::new(allocators)) }
+        AllocatorPool { allocators: Mutex::new(allocators) }
     }
 
     /// Retrieves an `Allocator` from the pool, or creates a new one if the pool is empty.
@@ -34,22 +34,31 @@ impl AllocatorPool {
             allocators.pop().unwrap_or_default()
         };
 
-        AllocatorGuard {
-            allocator: ManuallyDrop::new(allocator),
-            pool: Arc::clone(&self.allocators),
-        }
+        AllocatorGuard { allocator: ManuallyDrop::new(allocator), pool: self }
+    }
+
+    /// Add an `Allocator` to the pool.
+    ///
+    /// The `Allocator` should be empty, ready to be re-used.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the underlying mutex is poisoned.
+    fn add(&self, allocator: Allocator) {
+        let mut allocators = self.allocators.lock().unwrap();
+        allocators.push(allocator);
     }
 }
 
 /// A guard object representing exclusive access to an `Allocator` from the pool.
 ///
 /// On drop, the `Allocator` is reset and returned to the pool.
-pub struct AllocatorGuard {
+pub struct AllocatorGuard<'alloc_pool> {
     allocator: ManuallyDrop<Allocator>,
-    pool: Arc<Mutex<Vec<Allocator>>>,
+    pool: &'alloc_pool AllocatorPool,
 }
 
-impl Deref for AllocatorGuard {
+impl Deref for AllocatorGuard<'_> {
     type Target = Allocator;
 
     fn deref(&self) -> &Self::Target {
@@ -57,18 +66,18 @@ impl Deref for AllocatorGuard {
     }
 }
 
-impl DerefMut for AllocatorGuard {
+impl DerefMut for AllocatorGuard<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.allocator
     }
 }
 
-impl Drop for AllocatorGuard {
+impl Drop for AllocatorGuard<'_> {
+    /// Return `Allocator` back to the pool.
     fn drop(&mut self) {
-        // SAFETY: we're taking ownership and promise not to drop `allocator` again.
+        // SAFETY: After taking ownership of the `Allocator`, we do not touch the `ManuallyDrop` again
         let mut allocator = unsafe { ManuallyDrop::take(&mut self.allocator) };
         allocator.reset();
-        let mut allocators = self.pool.lock().unwrap();
-        allocators.push(allocator);
+        self.pool.add(allocator);
     }
 }


### PR DESCRIPTION
Follow-on after #11736. Remove the overhead of `Arc` from `AllocatorPool`.

This does introduce more lifetimes in linter, which is unwelcome, but as well as removing the synchronization overhead of `Arc`, I think it reflects the semantics of what we're trying to do more correctly.

`AllocatorPool` solely owns the `Vec<Allocator>` pool. It doesn't need to (and shouldn't) share ownership of it with `AllocatorGuard`s, which `Arc` does. So `AllocatorGuard`s can just hold a reference to the `AllocatorPool`.
