### PR TITLE
perf(allocator): reduce operations while `Mutex` lock is held in `AllocatorPool`

### DIFF
--- a/crates/oxc_allocator/src/pool.rs
+++ b/crates/oxc_allocator/src/pool.rs
@@ -31,8 +31,9 @@ impl AllocatorPool {
     pub fn get(&self) -> AllocatorGuard {
         let allocator = {
             let mut allocators = self.allocators.lock().unwrap();
-            allocators.pop().unwrap_or_default()
+            allocators.pop()
         };
+        let allocator = allocator.unwrap_or_default();
 
         AllocatorGuard { allocator: ManuallyDrop::new(allocator), pool: self }
     }


### PR DESCRIPTION
Tiny optimization to `AllocatorPool`. `unwrap_or_else` doesn't require the mutex lock, so drop the lock before calling it.
