### PR TITLE
test(ast/estree): bump `acorn-test262` submodule

### DIFF
--- a/.github/actions/clone-submodules/action.yml
+++ b/.github/actions/clone-submodules/action.yml
@@ -38,4 +38,4 @@ runs:
         show-progress: false
         repository: oxc-project/acorn-test262
         path: tasks/coverage/acorn-test262
-        ref: 9bfb9ab035c3df785284d27004a80824fb8a2dd6 # Latest main at 8/6/25
+        ref: 25df720d20c5299b016dcaa99ce0ca917e2df5b9 # Latest main at 16/6/25

--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ submodules:
   just clone-submodule tasks/coverage/babel https://github.com/babel/babel.git 1d4546bcb80009303aab386b59f4df1fd335c1d5
   just clone-submodule tasks/coverage/typescript https://github.com/microsoft/TypeScript.git 81c951894e93bdc37c6916f18adcd80de76679bc
   just clone-submodule tasks/prettier_conformance/prettier https://github.com/prettier/prettier.git 7584432401a47a26943dd7a9ca9a8e032ead7285
-  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 9bfb9ab035c3df785284d27004a80824fb8a2dd6
+  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 25df720d20c5299b016dcaa99ce0ca917e2df5b9
   just update-transformer-fixtures
 
 # Install git pre-commit to format files

--- a/tasks/coverage/snapshots/estree_acorn_jsx.snap
+++ b/tasks/coverage/snapshots/estree_acorn_jsx.snap
@@ -1,4 +1,4 @@
-commit: 9bfb9ab0
+commit: 25df720d
 
 estree_acorn_jsx Summary:
 AST Parsed     : 39/39 (100.00%)

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -2,7 +2,9 @@ commit: 81c95189
 
 estree_typescript Summary:
 AST Parsed     : 6489/6489 (100.00%)
-Positive Passed: 6486/6489 (99.95%)
+Positive Passed: 6485/6489 (99.94%)
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/quotedConstructors.ts
+
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuite.tsx
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitEntities.tsx


### PR DESCRIPTION
Bump `acorn-test262` submodule, which bumps `@typescript-eslint/parser`. Latest version of TS-ESLint contains fixes for bugs which I reported. Currently this breaks 1 conformance test - will fix in following PR.