### PR TITLE
fix(ast/estree): remove custom serializer for `MethodDefinition` `key` field

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -2097,7 +2097,6 @@ pub struct MethodDefinition<'a> {
     /// This will always be true when an `abstract` modifier is used on the method.
     pub r#type: MethodDefinitionType,
     pub decorators: Vec<'a, Decorator<'a>>,
-    #[estree(via = MethodDefinitionKey)]
     pub key: PropertyKey<'a>,
     #[visit(args(flags = match self.kind {
         MethodDefinitionKind::Get => ScopeFlags::Function | ScopeFlags::GetAccessor,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1499,7 +1499,7 @@ impl ESTree for MethodDefinition<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("decorators", &self.decorators);
-        state.serialize_field("key", &crate::serialize::js::MethodDefinitionKey(self));
+        state.serialize_field("key", &self.key);
         state.serialize_field("value", &self.value);
         state.serialize_field("kind", &self.kind);
         state.serialize_field("computed", &self.computed);

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -956,27 +956,14 @@ function deserializeClassBody(pos) {
 }
 
 function deserializeMethodDefinition(pos) {
-  const kind = deserializeMethodDefinitionKind(pos + 57);
-  let key = deserializePropertyKey(pos + 32);
-  if (kind === 'constructor') {
-    key = {
-      type: 'Identifier',
-      start: key.start,
-      end: key.end,
-      decorators: [],
-      name: 'constructor',
-      optional: false,
-      typeAnnotation: null,
-    };
-  }
   return {
     type: deserializeMethodDefinitionType(pos + 56),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     decorators: deserializeVecDecorator(pos + 8),
-    key,
+    key: deserializePropertyKey(pos + 32),
     value: deserializeBoxFunction(pos + 48),
-    kind,
+    kind: deserializeMethodDefinitionKind(pos + 57),
     computed: deserializeBool(pos + 58),
     static: deserializeBool(pos + 59),
     override: deserializeBool(pos + 60),

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -2,9 +2,7 @@ commit: 81c95189
 
 estree_typescript Summary:
 AST Parsed     : 6489/6489 (100.00%)
-Positive Passed: 6485/6489 (99.94%)
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/quotedConstructors.ts
-
+Positive Passed: 6486/6489 (99.95%)
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuite.tsx
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitEntities.tsx


### PR DESCRIPTION
Remove the custom ESTree serializer for `MethodDefinition`'s `key` field. This serializer was required to replicate a bug in TS-ESLint, which they've now fixed. This fixes the test case which was broken by #11762.