### PR TITLE
refactor(semantic): rename function params

### DIFF
--- a/crates/oxc_semantic/src/is_global_reference.rs
+++ b/crates/oxc_semantic/src/is_global_reference.rs
@@ -4,43 +4,43 @@ use crate::{ReferenceId, Scoping};
 
 /// Checks whether the a identifier reference is a global value or not.
 pub trait IsGlobalReference {
-    fn is_global_reference(&self, _symbols: &Scoping) -> bool;
-    fn is_global_reference_name(&self, name: &str, _symbols: &Scoping) -> bool;
+    fn is_global_reference(&self, scoping: &Scoping) -> bool;
+    fn is_global_reference_name(&self, name: &str, scoping: &Scoping) -> bool;
 }
 
 impl IsGlobalReference for ReferenceId {
-    fn is_global_reference(&self, symbols: &Scoping) -> bool {
-        symbols.references[*self].symbol_id().is_none()
+    fn is_global_reference(&self, scoping: &Scoping) -> bool {
+        scoping.references[*self].symbol_id().is_none()
     }
 
-    fn is_global_reference_name(&self, _name: &str, _symbols: &Scoping) -> bool {
+    fn is_global_reference_name(&self, _name: &str, _scoping: &Scoping) -> bool {
         panic!("This function is pointless to be called.");
     }
 }
 
 impl IsGlobalReference for IdentifierReference<'_> {
-    fn is_global_reference(&self, symbols: &Scoping) -> bool {
+    fn is_global_reference(&self, scoping: &Scoping) -> bool {
         self.reference_id
             .get()
-            .is_some_and(|reference_id| reference_id.is_global_reference(symbols))
+            .is_some_and(|reference_id| reference_id.is_global_reference(scoping))
     }
 
-    fn is_global_reference_name(&self, name: &str, symbols: &Scoping) -> bool {
-        self.name == name && self.is_global_reference(symbols)
+    fn is_global_reference_name(&self, name: &str, scoping: &Scoping) -> bool {
+        self.name == name && self.is_global_reference(scoping)
     }
 }
 
 impl IsGlobalReference for Expression<'_> {
-    fn is_global_reference(&self, symbols: &Scoping) -> bool {
+    fn is_global_reference(&self, scoping: &Scoping) -> bool {
         if let Expression::Identifier(ident) = self {
-            return ident.is_global_reference(symbols);
+            return ident.is_global_reference(scoping);
         }
         false
     }
 
-    fn is_global_reference_name(&self, name: &str, symbols: &Scoping) -> bool {
+    fn is_global_reference_name(&self, name: &str, scoping: &Scoping) -> bool {
         if let Expression::Identifier(ident) = self {
-            return ident.is_global_reference_name(name, symbols);
+            return ident.is_global_reference_name(name, scoping);
         }
         false
     }


### PR DESCRIPTION
Pure refactor. These methods all took `symbols: &Scoping`. Rename `symbols` to `scoping` to better reflect what the function param is.