### PR TITLE
fix(codegen): escape `</script`

### DIFF
--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -128,7 +128,7 @@ impl Codegen<'_> {
         let comment_source = comment.span.source_text(source_text);
         match comment.kind {
             CommentKind::Line => {
-                self.print_str(comment_source);
+                self.print_str_escaping_script_close_tag(comment_source);
             }
             CommentKind::Block => {
                 // Print block comments with our own indentation.
@@ -136,7 +136,7 @@ impl Codegen<'_> {
                     if !line.starts_with("/*") {
                         self.print_indent();
                     }
-                    self.print_str(line.trim_start());
+                    self.print_str_escaping_script_close_tag(line.trim_start());
                     if !line.ends_with("*/") {
                         self.print_hard_newline();
                     }

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2083,7 +2083,7 @@ impl Gen for TemplateLiteral<'_> {
 
         for quasi in &self.quasis {
             p.add_source_mapping(quasi.span);
-            p.print_str(quasi.value.raw.as_str());
+            p.print_str_escaping_script_close_tag(quasi.value.raw.as_str());
             p.add_source_mapping_end(quasi.span);
 
             if let Some(expr) = expressions.next() {

--- a/crates/oxc_codegen/src/str.rs
+++ b/crates/oxc_codegen/src/str.rs
@@ -340,9 +340,10 @@ enum Escape {
     DQ = 11, // "     - Double quote
     BQ = 12, // `     - Backtick quote
     DO = 13, // $     - Dollar sign
-    LS = 14, // LS/PS - U+2028 LINE SEPARATOR or U+2029 PARAGRAPH SEPARATOR (first byte)
-    NB = 15, // NBSP  - Non-breaking space (first byte)
-    LO = 16, // �     - U+FFFD lossy replacement character (first byte)
+    LT = 14, // <     - Less-than sign
+    LS = 15, // LS/PS - U+2028 LINE SEPARATOR or U+2029 PARAGRAPH SEPARATOR (first byte)
+    NB = 16, // NBSP  - Non-breaking space (first byte)
+    LO = 17, // �     - U+FFFD lossy replacement character (first byte)
 }
 
 /// Struct which ensures content is aligned on 128.
@@ -362,7 +363,7 @@ static ESCAPES: Aligned128<[Escape; 256]> = {
         NU, __, __, __, __, __, __, BE, BK, __, NL, VT, FF, CR, __, __, // 0
         __, __, __, __, __, __, __, __, __, __, __, ES, __, __, __, __, // 1
         __, __, DQ, __, DO, __, __, SQ, __, __, __, __, __, __, __, __, // 2
-        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 3
+        __, __, __, __, __, __, __, __, __, __, __, __, LT, __, __, __, // 3
         __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 4
         __, __, __, __, __, __, __, __, __, __, __, __, BS, __, __, __, // 5
         BQ, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 6
@@ -385,9 +386,10 @@ type ByteHandler = unsafe fn(&mut Codegen, &mut PrintStringState);
 /// Indexed by `escape as usize - 1` (where `escape` is not `Escape::__`).
 /// Must be in same order as discriminants in `Escape`.
 ///
-/// Function pointers are 8 bytes each, so `BYTE_HANDLERS` is 128 bytes in total.
-/// Aligned on 128, so occupies a pair of L1 cache lines.
-static BYTE_HANDLERS: Aligned128<[ByteHandler; 16]> = Aligned128([
+/// Function pointers are 8 bytes each, so `BYTE_HANDLERS` is 136 bytes in total.
+/// Aligned on 128, so first 16 occupy a pair of L1 cache lines.
+/// The last will be in separate cache line, but it should be vanishingly rare that it's accessed.
+static BYTE_HANDLERS: Aligned128<[ByteHandler; 17]> = Aligned128([
     print_null,
     print_bell,
     print_backspace,
@@ -401,6 +403,7 @@ static BYTE_HANDLERS: Aligned128<[ByteHandler; 16]> = Aligned128([
     print_double_quote,
     print_backtick,
     print_dollar,
+    print_less_than,
     print_ls_or_ps,
     print_non_breaking_space,
     print_lossy_replacement,
@@ -576,6 +579,42 @@ unsafe fn print_dollar(codegen: &mut Codegen, state: &mut PrintStringState) {
         // No need to escape.
         // SAFETY: Next byte is `$`, which is ASCII.
         unsafe { state.consume_byte_unchecked() };
+    }
+}
+
+// <
+unsafe fn print_less_than(codegen: &mut Codegen, state: &mut PrintStringState) {
+    debug_assert_eq!(state.peek(), Some(b'<'));
+
+    // Get slice of remaining bytes, including leading `<`
+    let slice = state.bytes.as_slice();
+
+    // SAFETY: Next byte is `<`, which is ASCII
+    unsafe { state.consume_byte_unchecked() };
+
+    // We have to check 2nd byte separately as `next8_lower_case == *b"</script"`
+    // would also match `<\x0Fscript` (0xF | 32 == b'/').
+    if slice.len() >= 8 && slice[1] == b'/' {
+        // Compiler condenses these operations to an 8-byte read, u64 AND, and u64 compare.
+        // https://godbolt.org/z/9ndYnbj53
+        let next8: [u8; 8] = slice[0..8].try_into().unwrap();
+        let mut next8_lower_case = [0; 8];
+        for i in 0..8 {
+            // `| 32` converts ASCII upper case letters to lower case. `<` and `/` are unaffected.
+            next8_lower_case[i] = next8[i] | 32;
+        }
+
+        if next8_lower_case == *b"</script" {
+            // Flush up to and including `<`. Skip `/`. Write `\/` instead. Then skip over `script`.
+            // Next chunk starts with `script`.
+            // SAFETY: We already consumed `<`. Next byte is `/`, which is ASCII.
+            unsafe { state.flush_and_consume_byte(codegen) };
+            // SAFETY: `slice.len() >= 8` check above ensures there are 6 bytes left, after consuming 2 already.
+            // `script` / `SCRIPT` is all ASCII bytes, so skipping them leaves `bytes` iterator
+            // positioned on UTF-8 char boundary.
+            unsafe { state.consume_bytes_unchecked::<6>() };
+            codegen.print_str("\\/");
+        }
     }
 }
 

--- a/crates/oxc_codegen/tests/integration/esbuild.rs
+++ b/crates/oxc_codegen/tests/integration/esbuild.rs
@@ -1014,7 +1014,6 @@ fn test_jsx_single_line() {
 }
 
 #[test]
-#[ignore]
 fn test_avoid_slash_script() {
     // Positive cases
     test("x = '</script'", "x = \"<\\/script\";\n");
@@ -1027,6 +1026,9 @@ fn test_avoid_slash_script() {
     test("x = `</ScRiPt`", "x = `<\\/ScRiPt`;\n");
     test("x = `</script${y}`", "x = `<\\/script${y}`;\n");
     test("x = `${y}</script`", "x = `${y}<\\/script`;\n");
+    test("x = `<</script`", "x = `<<\\/script`;\n");
+    test("x = `</</script`", "x = `</<\\/script`;\n");
+    test("x = `</script</script`", "x = `<\\/script<\\/script`;\n");
     test_minify("x = 1 < /script/.exec(y).length", "x=1< /script/.exec(y).length;");
     test_minify("x = 1 < /SCRIPT/.exec(y).length", "x=1< /SCRIPT/.exec(y).length;");
     test_minify("x = 1 < /ScRiPt/.exec(y).length", "x=1< /ScRiPt/.exec(y).length;");
@@ -1034,29 +1036,14 @@ fn test_avoid_slash_script() {
     test("//! </script\n//! >/script\n//! /script", "//! <\\/script\n//! >/script\n//! /script\n");
     test("//! </SCRIPT\n//! >/SCRIPT\n//! /SCRIPT", "//! <\\/SCRIPT\n//! >/SCRIPT\n//! /SCRIPT\n");
     test("//! </ScRiPt\n//! >/ScRiPt\n//! /ScRiPt", "//! <\\/ScRiPt\n//! >/ScRiPt\n//! /ScRiPt\n");
-    test("/*! </script \n </script */", "/*! <\\/script \n <\\/script */\n");
-    test("/*! </SCRIPT \n </SCRIPT */", "/*! <\\/SCRIPT \n <\\/SCRIPT */\n");
-    test("/*! </ScRiPt \n </ScRiPt */", "/*! <\\/ScRiPt \n <\\/ScRiPt */\n");
-    test(
-        "String.raw`</script`",
-        "import { __template } from \"<runtime>\";\nvar _a;\nString.raw(_a || (_a = __template([\"<\\/script\"])));\n",
-    );
-    test(
-        "String.raw`</script${a}`",
-        "import { __template } from \"<runtime>\";\nvar _a;\nString.raw(_a || (_a = __template([\"<\\/script\", \"\"])), a);\n",
-    );
-    test(
-        "String.raw`${a}</script`",
-        "import { __template } from \"<runtime>\";\nvar _a;\nString.raw(_a || (_a = __template([\"\", \"<\\/script\"])), a);\n",
-    );
-    test(
-        "String.raw`</SCRIPT`",
-        "import { __template } from \"<runtime>\";\nvar _a;\nString.raw(_a || (_a = __template([\"<\\/SCRIPT\"])));\n",
-    );
-    test(
-        "String.raw`</ScRiPt`",
-        "import { __template } from \"<runtime>\";\nvar _a;\nString.raw(_a || (_a = __template([\"<\\/ScRiPt\"])));\n",
-    );
+    test("/*! </script \n</script */", "/*! <\\/script \n<\\/script */");
+    test("/*! </SCRIPT \n</SCRIPT */", "/*! <\\/SCRIPT \n<\\/SCRIPT */");
+    test("/*! </ScRiPt \n</ScRiPt */", "/*! <\\/ScRiPt \n<\\/ScRiPt */");
+    test("String.raw`</script`", "String.raw`<\\/script`;\n");
+    test("String.raw`</script${a}`", "String.raw`<\\/script${a}`;\n");
+    test("String.raw`${a}</script`", "String.raw`${a}<\\/script`;\n");
+    test("String.raw`</SCRIPT`", "String.raw`<\\/SCRIPT`;\n");
+    test("String.raw`</ScRiPt`", "String.raw`<\\/ScRiPt`;\n");
 
     // Negative cases
     test("x = '</'", "x = \"</\";\n");

--- a/crates/oxc_codegen/tests/integration/esbuild.rs
+++ b/crates/oxc_codegen/tests/integration/esbuild.rs
@@ -1018,6 +1018,10 @@ fn test_jsx_single_line() {
 fn test_avoid_slash_script() {
     // Positive cases
     test("x = '</script'", "x = \"<\\/script\";\n");
+    test("x = '</SCRIPT'", "x = \"<\\/SCRIPT\";\n");
+    test("x = '</ScRiPt'", "x = \"<\\/ScRiPt\";\n");
+    test("x = 'abc </script def'", "x = \"abc <\\/script def\";\n");
+    test("x = 'abc </ScRiPt def'", "x = \"abc <\\/ScRiPt def\";\n");
     test("x = `</script`", "x = `<\\/script`;\n");
     test("x = `</SCRIPT`", "x = `<\\/SCRIPT`;\n");
     test("x = `</ScRiPt`", "x = `<\\/ScRiPt`;\n");


### PR DESCRIPTION
Fixes #10334.

Replace #10340 to cover the escape for both template literals and comments. We don’t need to handle regex, which is already covered by existing codegen. 

Please let me know anything needed to merge this PR. Thanks. 

