### PR TITLE
feat(minifier): remove dead code that evaluates to a constant value

### DIFF
--- a/crates/oxc_ecmascript/src/constant_evaluation/value.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/value.rs
@@ -6,7 +6,7 @@ use num_traits::Zero;
 
 use crate::{ToBoolean, ToJsString, ToNumber, is_global_reference::IsGlobalReference};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum ConstantValue<'a> {
     Number(f64),
     BigInt(BigInt),

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -7,6 +7,7 @@ use oxc_ecmascript::{
 };
 use oxc_span::GetSpan;
 use oxc_syntax::operator::{BinaryOperator, LogicalOperator};
+use oxc_traverse::Ancestor;
 
 use crate::ctx::Ctx;
 
@@ -43,6 +44,20 @@ impl<'a> PeepholeOptimizations {
         } {
             *expr = folded_expr;
             state.changed = true;
+        }
+
+        // Save `const value = false` into constant values.
+        if let Ancestor::VariableDeclaratorInit(decl) = ctx.parent() {
+            // TODO: Check for no write references.
+            if decl.kind().is_const() {
+                if let BindingPatternKind::BindingIdentifier(ident) = &decl.id().kind {
+                    // TODO: refactor all the above code to return value instead of expression, to avoid calling `evaluate_value` again.
+                    if let Some(value) = expr.evaluate_value(ctx) {
+                        let symbol_id = ident.symbol_id();
+                        ctx.state.constant_values.insert(symbol_id, value);
+                    }
+                }
+            }
         }
     }
 

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -762,4 +762,9 @@ mod test {
             "var i; for (i = 0; i < 10; i++) foo(i);",
         );
     }
+
+    #[test]
+    fn remove_constant_value() {
+        test("const foo = false; if (foo) { console.log('foo') }", "const foo = !1;");
+    }
 }


### PR DESCRIPTION
part of #10843

Approach: build a constant table after constant evaluation on variable declarations, use these constant values during dead code removal.