### PR TITLE
fix(linter/no-console): false negative when `console.*` methods are used as args to functions

### DIFF
--- a/crates/oxc_linter/src/snapshots/eslint_no_console.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_console.snap
@@ -9,9 +9,9 @@ source: crates/oxc_linter/src/tester.rs
   help: Delete this console statement.
 
   ⚠ eslint(no-console): Unexpected console statement.
-   ╭─[no_console.tsx:1:2]
- 1 │ (console.log())
-   ·  ───────────
+   ╭─[no_console.tsx:1:5]
+ 1 │ foo(console.log)
+   ·     ───────────
    ╰────
   help: Delete this console statement.
 


### PR DESCRIPTION
we can't really fix this case as 
```
function x(log: (...args: any[]) => void) {
    log()
}

// changing this arg to undefined would cause a type error
x(console.log)
```