### PR TITLE
refactor(ast/estree): add `#[estree]` attrs to `RegExpFlagsAlias`

### DIFF
--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -227,6 +227,6 @@ bitflags! {
 /// Dummy type to communicate the content of `RegExpFlags` to `oxc_ast_tools`.
 #[ast(foreign = RegExpFlags)]
 #[generate_derive(ESTree)]
-#[estree(via = RegExpFlagsConverter)]
+#[estree(no_type, via = RegExpFlagsConverter)]
 #[expect(dead_code)]
-struct RegExpFlagsAlias(u8);
+struct RegExpFlagsAlias(#[estree(skip)] u8);

--- a/napi/parser/generated/deserialize/lazy.js
+++ b/napi/parser/generated/deserialize/lazy.js
@@ -6661,7 +6661,6 @@ class RegExpPattern {
 const DebugRegExpPattern = class RegExpPattern {};
 
 class RegExpFlags {
-  type = 'RegExpFlags';
   #internal;
 
   constructor(pos, ast) {
@@ -6675,15 +6674,8 @@ class RegExpFlags {
     nodes.set(pos, this);
   }
 
-  get 0() {
-    const internal = this.#internal;
-    return constructU8(internal.pos, internal.ast);
-  }
-
   toJSON() {
-    return {
-      type: 'RegExpFlags',
-    };
+    return {};
   }
 
   [inspectSymbol]() {

--- a/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
@@ -475,10 +475,7 @@ fn generate_struct(
             ");
         }
 
-        // TODO: Remove this special case for `RegExpFlags`
-        if struct_name != "RegExpFlags" {
-            write_it!(to_json, "{field_name}: this.{field_name},\n");
-        }
+        write_it!(to_json, "{field_name}: this.{field_name},\n");
     }
 
     let type_prop_init = if add_type_field {


### PR DESCRIPTION
Pure refactor. Add more `#[estree]` attributes to `RegExpFlagsAlias` type. These have no effect on generated code for JSON serialization or raw transfer deserialization, as `RegExpFlagsAlias` already has a custom converter. But it simplifies the codegen for lazy deserialization.