### PR TITLE
refactor(semantic)!: rename `symbol_is_used` to `symbol_is_unused`

### DIFF
--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1027,7 +1027,7 @@ impl<'a> PeepholeOptimizations {
             return;
         }
 
-        if func.id.as_ref().is_some_and(|id| !ctx.scoping().symbol_is_used(id.symbol_id())) {
+        if func.id.as_ref().is_some_and(|id| ctx.scoping().symbol_is_unused(id.symbol_id())) {
             func.id = None;
             state.changed = true;
         }
@@ -1048,7 +1048,7 @@ impl<'a> PeepholeOptimizations {
             return;
         }
 
-        if class.id.as_ref().is_some_and(|id| !ctx.scoping().symbol_is_used(id.symbol_id())) {
+        if class.id.as_ref().is_some_and(|id| ctx.scoping().symbol_is_unused(id.symbol_id())) {
             class.id = None;
             state.changed = true;
         }
@@ -1175,7 +1175,7 @@ impl<'a> LatePeepholeOptimizations {
             if let Some(param) = &catch.param {
                 if let BindingPatternKind::BindingIdentifier(ident) = &param.pattern.kind {
                     if catch.body.body.is_empty()
-                        || !ctx.scoping().symbol_is_used(ident.symbol_id())
+                        || ctx.scoping().symbol_is_unused(ident.symbol_id())
                     {
                         catch.param = None;
                     }

--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -358,9 +358,9 @@ impl Scoping {
         }
     }
 
-    /// Get whether a symbol is used (i.e. read or written after declaration).
-    pub fn symbol_is_used(&self, symbol_id: SymbolId) -> bool {
-        self.get_resolved_references(symbol_id).count() > 0
+    /// Get whether a symbol is unused (i.e. not read or written after declaration).
+    pub fn symbol_is_unused(&self, symbol_id: SymbolId) -> bool {
+        self.get_resolved_reference_ids(symbol_id).is_empty()
     }
 
     /// Add a reference to a symbol.


### PR DESCRIPTION
Also improve performance by not iterating through the resolved
references list.