### PR TITLE
perf(napi/parser): lazy-load raw transfer and lazy deser code

### DIFF
--- a/napi/parser/index.js
+++ b/napi/parser/index.js
@@ -2,13 +2,7 @@
 
 const bindings = require('./bindings.js');
 const { wrap } = require('./wrap.cjs');
-const {
-  parseSyncRaw,
-  parseAsyncRaw,
-  parseSyncLazy,
-  parseAsyncLazy,
-  rawTransferSupported,
-} = require('./raw-transfer/index.js');
+const rawTransferSupported = require('./raw-transfer/supported.js');
 
 module.exports.ParseResult = bindings.ParseResult;
 module.exports.ExportExportNameKind = bindings.ExportExportNameKind;
@@ -18,15 +12,45 @@ module.exports.ImportNameKind = bindings.ImportNameKind;
 module.exports.parseWithoutReturn = bindings.parseWithoutReturn;
 module.exports.Severity = bindings.Severity;
 
+// Lazily loaded as needed
+let parseSyncRaw = null,
+  parseAsyncRaw,
+  parseSyncLazy = null,
+  parseAsyncLazy;
+
+function loadRawTransfer() {
+  if (parseSyncRaw === null) {
+    ({ parseSyncRaw, parseAsyncRaw } = require('./raw-transfer/eager.js'));
+  }
+}
+
+function loadRawTransferLazy() {
+  if (parseSyncLazy === null) {
+    ({ parseSyncLazy, parseAsyncLazy } = require('./raw-transfer/lazy.js'));
+  }
+}
+
 module.exports.parseAsync = async function parseAsync(filename, sourceText, options) {
-  if (options?.experimentalRawTransfer) return await parseAsyncRaw(filename, sourceText, options);
-  if (options?.experimentalLazy) return await parseAsyncLazy(filename, sourceText, options);
+  if (options?.experimentalRawTransfer) {
+    loadRawTransfer();
+    return await parseAsyncRaw(filename, sourceText, options);
+  }
+  if (options?.experimentalLazy) {
+    loadRawTransferLazy();
+    return await parseAsyncLazy(filename, sourceText, options);
+  }
   return wrap(await bindings.parseAsync(filename, sourceText, options));
 };
 
 module.exports.parseSync = function parseSync(filename, sourceText, options) {
-  if (options?.experimentalRawTransfer) return parseSyncRaw(filename, sourceText, options);
-  if (options?.experimentalLazy) return parseSyncLazy(filename, sourceText, options);
+  if (options?.experimentalRawTransfer) {
+    loadRawTransfer();
+    return parseSyncRaw(filename, sourceText, options);
+  }
+  if (options?.experimentalLazy) {
+    loadRawTransferLazy();
+    return parseSyncLazy(filename, sourceText, options);
+  }
   return wrap(bindings.parseSync(filename, sourceText, options));
 };
 

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -50,7 +50,8 @@
     "raw-transfer/eager.js",
     "raw-transfer/lazy.js",
     "raw-transfer/lazy-common.js",
-    "raw-transfer/node-array.js"
+    "raw-transfer/node-array.js",
+    "raw-transfer/supported.js"
   ],
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/napi/parser/raw-transfer/index.js
+++ b/napi/parser/raw-transfer/index.js
@@ -1,25 +1,16 @@
 'use strict';
 
 const os = require('node:os');
+const rawTransferSupported = require('./supported.js');
 const bindings = require('../bindings.js');
 
 module.exports = {
-  rawTransferSupported,
   parseSyncRawImpl,
   parseAsyncRawImpl,
   prepareRaw,
   isJsAst,
   returnBufferToCache,
 };
-
-// Import `eager.js` and `lazy.js` after the exports above, because of circular dependencies
-const { parseSyncRaw, parseAsyncRaw } = require('./eager.js');
-module.exports.parseSyncRaw = parseSyncRaw;
-module.exports.parseAsyncRaw = parseAsyncRaw;
-
-const { parseSyncLazy, parseAsyncLazy } = require('./lazy.js');
-module.exports.parseSyncLazy = parseSyncLazy;
-module.exports.parseAsyncLazy = parseAsyncLazy;
 
 function parseSyncRawImpl(filename, sourceText, options, deserialize) {
   const { buffer, sourceByteLen, options: optionsAmended } = prepareRaw(sourceText, options);
@@ -147,8 +138,9 @@ let encoder = null, clearBuffersTimeout = null;
 function prepareRaw(sourceText, options) {
   if (!rawTransferSupported()) {
     throw new Error(
-      '`experimentalRawTransfer` option is not supported on 32-bit or big-endian systems, ' +
-        'versions of NodeJS prior to v22.0.0, versions of Deno prior to v2.0.0, and other runtimes',
+      '`experimentalRawTransfer` and `experimentalLazy` options are not supported ' +
+        'on 32-bit or big-endian systems, versions of NodeJS prior to v22.0.0, ' +
+        'versions of Deno prior to v2.0.0, and other runtimes',
     );
   }
 
@@ -236,48 +228,4 @@ function createBuffer() {
   buffer.uint32 = new Uint32Array(arrayBuffer, offset, TWO_GIB / 4);
   buffer.float64 = new Float64Array(arrayBuffer, offset, TWO_GIB / 8);
   return buffer;
-}
-
-let rawTransferIsSupported = null;
-
-// Returns `true` if `experimentalRawTransfer` is option is supported.
-//
-// Raw transfer is only supported on 64-bit little-endian systems,
-// and NodeJS >= v22.0.0 or Deno >= v2.0.0.
-//
-// Versions of NodeJS prior to v22.0.0 do not support creating an `ArrayBuffer` larger than 4 GiB.
-// Bun (as at v1.2.4) also does not support creating an `ArrayBuffer` larger than 4 GiB.
-// Support on Deno v1 is unknown and it's EOL, so treating Deno before v2.0.0 as unsupported.
-function rawTransferSupported() {
-  if (rawTransferIsSupported === null) {
-    rawTransferIsSupported = rawTransferRuntimeSupported() && bindings.rawTransferSupported();
-  }
-  return rawTransferIsSupported;
-}
-
-// Checks copied from:
-// https://github.com/unjs/std-env/blob/ab15595debec9e9115a9c1d31bc7597a8e71dbfd/src/runtimes.ts
-// MIT license: https://github.com/unjs/std-env/blob/ab15595debec9e9115a9c1d31bc7597a8e71dbfd/LICENCE
-function rawTransferRuntimeSupported() {
-  let global;
-  try {
-    global = globalThis;
-  } catch (e) {
-    return false;
-  }
-
-  const isBun = !!global.Bun || !!global.process?.versions?.bun;
-  if (isBun) return false;
-
-  const isDeno = !!global.Deno;
-  if (isDeno) {
-    const match = Deno.version?.deno?.match(/^(\d+)\./);
-    return !!match && match[1] * 1 >= 2;
-  }
-
-  const isNode = global.process?.release?.name === 'node';
-  if (!isNode) return false;
-
-  const match = process.version?.match(/^v(\d+)\./);
-  return !!match && match[1] * 1 >= 22;
 }

--- a/napi/parser/raw-transfer/lazy.js
+++ b/napi/parser/raw-transfer/lazy.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const { parseSyncRawImpl, parseAsyncRawImpl, returnBufferToCache } = require('./index.js');
+const { parseSyncRawImpl, parseAsyncRawImpl, returnBufferToCache } = require('./index.js'),
+  { construct: constructLazyData, TOKEN } = require('../generated/deserialize/lazy.js');
 
 module.exports = { parseSyncLazy, parseAsyncLazy };
 
@@ -23,15 +24,8 @@ const bufferRecycleRegistry = typeof FinalizationRegistry === 'undefined'
   ? null
   : new FinalizationRegistry(returnBufferToCache);
 
-let constructLazyData = null, TOKEN;
-
 // Get an object with getters which lazy deserialize AST from buffer
 function construct(buffer, sourceText, sourceLen) {
-  // Lazy load deserializer, and get `TOKEN` to store in `ast` objects
-  if (constructLazyData === null) {
-    ({ construct: constructLazyData, TOKEN } = require('../generated/deserialize/lazy.js'));
-  }
-
   // Create AST object
   const sourceIsAscii = sourceText.length === sourceLen;
   const ast = { buffer, sourceText, sourceLen, sourceIsAscii, nodes: new Map(), token: TOKEN };

--- a/napi/parser/raw-transfer/supported.js
+++ b/napi/parser/raw-transfer/supported.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const rawTransferSupportedBinding = require('../bindings.js').rawTransferSupported;
+
+module.exports = rawTransferSupported;
+
+let rawTransferIsSupported = null;
+
+// Returns `true` if `experimentalRawTransfer` is option is supported.
+//
+// Raw transfer is only supported on 64-bit little-endian systems,
+// and NodeJS >= v22.0.0 or Deno >= v2.0.0.
+//
+// Versions of NodeJS prior to v22.0.0 do not support creating an `ArrayBuffer` larger than 4 GiB.
+// Bun (as at v1.2.4) also does not support creating an `ArrayBuffer` larger than 4 GiB.
+// Support on Deno v1 is unknown and it's EOL, so treating Deno before v2.0.0 as unsupported.
+//
+// No easy way to determining pointer width (64 bit or 32 bit) in JS,
+// so call a function on Rust side to find out.
+function rawTransferSupported() {
+  if (rawTransferIsSupported === null) {
+    rawTransferIsSupported = rawTransferRuntimeSupported() && rawTransferSupportedBinding();
+  }
+  return rawTransferIsSupported;
+}
+
+// Checks copied from:
+// https://github.com/unjs/std-env/blob/ab15595debec9e9115a9c1d31bc7597a8e71dbfd/src/runtimes.ts
+// MIT license: https://github.com/unjs/std-env/blob/ab15595debec9e9115a9c1d31bc7597a8e71dbfd/LICENCE
+function rawTransferRuntimeSupported() {
+  let global;
+  try {
+    global = globalThis;
+  } catch (e) {
+    return false;
+  }
+
+  const isBun = !!global.Bun || !!global.process?.versions?.bun;
+  if (isBun) return false;
+
+  const isDeno = !!global.Deno;
+  if (isDeno) {
+    const match = Deno.version?.deno?.match(/^(\d+)\./);
+    return !!match && match[1] * 1 >= 2;
+  }
+
+  const isNode = global.process?.release?.name === 'node';
+  if (!isNode) return false;
+
+  const match = process.version?.match(/^v(\d+)\./);
+  return !!match && match[1] * 1 >= 22;
+}


### PR DESCRIPTION
Raw transfer and raw lazy deserialization are experimental and not publicly advertised. Lazy-load all code for these features only when they're first used.

Lazy deserialization in particular requires a non-trivial amount of code.

`rawTransferSupported` still needs to be eagerly loaded, as user would call it before calling `parseSync` or `parseAsync`. So move it into a separate module.
