### PR TITLE
perf(napi/parser): destructure `bindings` on import

### DIFF
--- a/napi/parser/index.js
+++ b/napi/parser/index.js
@@ -4,6 +4,8 @@ const bindings = require('./bindings.js');
 const { wrap } = require('./wrap.cjs');
 const rawTransferSupported = require('./raw-transfer/supported.js');
 
+const { parseSync: parseSyncBinding, parseAsync: parseAsyncBinding } = bindings;
+
 module.exports.ParseResult = bindings.ParseResult;
 module.exports.ExportExportNameKind = bindings.ExportExportNameKind;
 module.exports.ExportImportNameKind = bindings.ExportImportNameKind;
@@ -39,7 +41,7 @@ module.exports.parseAsync = async function parseAsync(filename, sourceText, opti
     loadRawTransferLazy();
     return await parseAsyncLazy(filename, sourceText, options);
   }
-  return wrap(await bindings.parseAsync(filename, sourceText, options));
+  return wrap(await parseAsyncBinding(filename, sourceText, options));
 };
 
 module.exports.parseSync = function parseSync(filename, sourceText, options) {
@@ -51,7 +53,7 @@ module.exports.parseSync = function parseSync(filename, sourceText, options) {
     loadRawTransferLazy();
     return parseSyncLazy(filename, sourceText, options);
   }
-  return wrap(bindings.parseSync(filename, sourceText, options));
+  return wrap(parseSyncBinding(filename, sourceText, options));
 };
 
 module.exports.rawTransferSupported = rawTransferSupported;

--- a/napi/parser/raw-transfer/common.js
+++ b/napi/parser/raw-transfer/common.js
@@ -2,7 +2,11 @@
 
 const os = require('node:os');
 const rawTransferSupported = require('./supported.js');
-const bindings = require('../bindings.js');
+const {
+  parseSyncRaw: parseSyncRawBinding,
+  parseAsyncRaw: parseAsyncRawBinding,
+  getBufferOffset,
+} = require('../bindings.js');
 
 module.exports = {
   parseSyncRawImpl,
@@ -14,7 +18,7 @@ module.exports = {
 
 function parseSyncRawImpl(filename, sourceText, options, deserialize) {
   const { buffer, sourceByteLen, options: optionsAmended } = prepareRaw(sourceText, options);
-  bindings.parseSyncRaw(filename, buffer, sourceByteLen, optionsAmended);
+  parseSyncRawBinding(filename, buffer, sourceByteLen, optionsAmended);
   return deserialize(buffer, sourceText, sourceByteLen);
 }
 
@@ -79,7 +83,7 @@ async function parseAsyncRawImpl(filename, sourceText, options, deserialize) {
 
   // Parse
   const { buffer, sourceByteLen, options: optionsAmended } = prepareRaw(sourceText, options);
-  await bindings.parseAsyncRaw(filename, buffer, sourceByteLen, optionsAmended);
+  await parseAsyncRawBinding(filename, buffer, sourceByteLen, optionsAmended);
   const ret = deserialize(buffer, sourceText, sourceByteLen);
 
   // Free the CPU core
@@ -223,7 +227,7 @@ function clearBuffersCache() {
 // Physical memory consumed corresponds to the quantity of data actually written.
 function createBuffer() {
   const arrayBuffer = new ArrayBuffer(SIX_GIB);
-  const offset = bindings.getBufferOffset(new Uint8Array(arrayBuffer));
+  const offset = getBufferOffset(new Uint8Array(arrayBuffer));
   const buffer = new Uint8Array(arrayBuffer, offset, TWO_GIB);
   buffer.uint32 = new Uint32Array(arrayBuffer, offset, TWO_GIB / 4);
   buffer.float64 = new Float64Array(arrayBuffer, offset, TWO_GIB / 8);


### PR DESCRIPTION
Small perf optimization to `oxc-parser`. Destructure `bindings` object when importing it. Calling those methods repeatedly later on avoids overhead of an object property lookup each time.

The effect is infinitesimal, except when using lazy deserialization, which is so fast for small files that it makes sense to optimize every step of its call path.