### PR TITLE
feat(minifier): inline and evaluate constant values

### DIFF
--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -1991,6 +1991,15 @@ mod test {
         fold("`foo${'${}'}`", "'foo${}'");
         fold("`foo${'${}'}${i}`", "`foo\\${}${i}`");
         fold_same("foo`foo${1}bar`");
+        fold(
+            r#"
+            const o = 'o';
+            const d = 'd';
+            const b = false;
+            var frag = `<p autocapitalize="${`w${o}r${d}s`}" contenteditable="${boolean}"> </p>`;
+            "#,
+            r#"var frag = "<p autocapitalize=\"words\" contenteditable=\"false\"> </p>";"#,
+        )
     }
 
     mod bigint {


### PR DESCRIPTION
part of #2646

Rules for constant evaluation is much harder than I thought, because the resulting code length can be larger:

```
const a = 'aaaa';
const b = 'bbbb';
const c = a + b'
```

I may reduce this PR to inline template variables, it is safe for length <= 3:

```
const a = 'aaa';
const b = 'bbb';
const c = `${a}${b}`
```