### PR TITLE
feat(minifier): remove symbol references when code is removed

### DIFF
--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -352,6 +352,7 @@ impl<'a> PeepholeOptimizations {
         }
 
         if self.remove_unused_expression(&mut expr_stmt.expression, state, ctx) {
+            ctx.delete_semantic_from_expression(&expr_stmt.expression);
             *stmt = ctx.ast.statement_empty(expr_stmt.span);
             state.changed = true;
         }


### PR DESCRIPTION
Need to find the best way to call `SyncSemantic` when code gets removed.