### PR TITLE
feat(linter): add `read_to_arena_str` function

### DIFF
--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -1,3 +1,14 @@
+use std::{
+    alloc::Layout,
+    fs::File,
+    io::{self, Read},
+    mem::ManuallyDrop,
+    path::Path,
+    slice,
+};
+
+use oxc_allocator::Allocator;
+
 mod comment;
 mod config;
 mod express;
@@ -11,8 +22,6 @@ mod regex;
 mod unicorn;
 mod url;
 mod vitest;
-
-use std::{io, path::Path};
 
 pub use self::{
     comment::*, config::*, express::*, jest::*, jsdoc::*, nextjs::*, promise::*, react::*,
@@ -130,4 +139,121 @@ pub fn read_to_string(path: &Path) -> io::Result<String> {
     }
     // SAFETY: `simdutf8` has ensured it's a valid UTF-8 string
     Ok(unsafe { String::from_utf8_unchecked(bytes) })
+}
+
+/// Read the contents of a UTF-8 encoded file directly into arena allocator.
+/// Avoids intermediate allocations if file size is known in advance.
+///
+/// This function opens the file at `path`, reads its entire contents into memory
+/// allocated from the given [`Allocator`], validates that the bytes are valid UTF-8,
+/// and returns a borrowed `&str` pointing to the allocator-backed data.
+///
+/// This is useful for performance-critical workflows where zero-copy string handling is desired,
+/// such as parsing large source files in memory-constrained or throughput-sensitive environments.
+///
+/// # Parameters
+///
+/// - `path`: The path to the file to read.
+/// - `allocator`: The [`Allocator`] into which the file contents will be allocated.
+///
+/// # Errors
+///
+/// Returns [`io::Error`] if any of:
+///
+/// - The file cannot be read.
+/// - The file's contents are not valid UTF-8.
+/// - The file is larger than `isize::MAX` bytes.
+#[expect(unused)]
+pub fn read_to_arena_str<'alloc>(
+    path: &Path,
+    allocator: &'alloc Allocator,
+) -> io::Result<&'alloc str> {
+    let file = File::open(path)?;
+
+    let bytes = if let Ok(metadata) = file.metadata() {
+        read_to_arena_bytes_known_size(file, metadata.len(), allocator)
+    } else {
+        read_to_arena_bytes_unknown_size(file, allocator)
+    }?;
+
+    // Convert to `&str`, checking contents is valid UTF-8
+    simdutf8::basic::from_utf8(bytes).map_err(|_| {
+        io::Error::new(io::ErrorKind::InvalidData, "stream did not contain valid UTF-8")
+    })
+}
+
+/// Read contents of file directly into arena.
+fn read_to_arena_bytes_known_size(
+    file: File,
+    size: u64,
+    allocator: &Allocator,
+) -> io::Result<&[u8]> {
+    // Check file is not larger than `isize::MAX` bytes (the max size of an allocation)
+    let Ok(size) = isize::try_from(size) else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "File is larger than `isize::MAX` bytes",
+        ));
+    };
+    #[expect(clippy::cast_sign_loss)]
+    let mut size = size as usize;
+
+    // Allocate space for string in allocator.
+    // SAFETY: We checked above that `size <= isize::MAX`. `&str` has no alignment requirements.
+    let layout = unsafe { Layout::from_size_align_unchecked(size, 1) };
+    let ptr = allocator.alloc_layout(layout);
+
+    // Read contents of file into allocated space.
+    //
+    // * Create a `Vec` which pretends to own the allocation we just created in arena.
+    // * Wrap the `Vec` in `ManuallyDrop`, so it doesn't free the memory at end of the block,
+    //   or if there's a panic during reading.
+    // * Use `File::take` to obtain a reader which yields no more than `size` bytes.
+    //   This ensures it can't produce more data than we allocated space for - in case file increased
+    //   in size since the call to `file.metadata()`, or `file.metadata()` returned inaccurate size.
+    // * Use `Read::read_to_end` to fill the `Vec` from this reader.
+    //
+    // This is a hack. It's completely bananas that Rust doesn't provide a method to write into
+    // a slice of uninitialized bytes, but this seems to be the only safe way to do it on stable Rust.
+    // https://users.rust-lang.org/t/reading-c-style-structures-from-disk/70529/7
+    //
+    // I (@overlookmotel) have reviewed the code for `Read::read_to_end` and it will never grow the `Vec`,
+    // as long as it has sufficient capacity for the reader's contents to start with.
+    // If it did, that would be UB as it would free the chunk of memory backing the `Vec`,
+    // which it doesn't actually own.
+    //
+    // Unfortunately `Read::read_to_end`'s docs don't guarantee this behavior. But the code is written
+    // specifically to avoid growing the `Vec`, and there was a PR to make sure it doesn't:
+    // https://github.com/rust-lang/rust/pull/89165
+    // So I think in practice we can rely on this behavior.
+    {
+        // SAFETY: We've allocated `size` bytes starting at `ptr`.
+        // This `Vec` doesn't actually own that memory, but we immediately wrap it in `ManuallyDrop`,
+        // so it won't free the memory on drop. As long as the `Vec` doesn't grow, no UB (see above).
+        let vec = unsafe { Vec::from_raw_parts(ptr.as_ptr(), 0, size) };
+        let mut vec = ManuallyDrop::new(vec);
+        let bytes_written = file.take(size as u64).read_to_end(&mut vec)?;
+
+        debug_assert!(vec.capacity() == size);
+        debug_assert!(vec.len() == bytes_written);
+
+        // Update `size`, in case file was altered and got smaller since the call to `file.metadata()`,
+        // or `file.metadata()` reported inaccurate size
+        size = vec.len();
+    }
+
+    // SAFETY: `size` bytes were written starting at `ptr`
+    let bytes = unsafe { slice::from_raw_parts(ptr.as_ptr(), size) };
+    Ok(bytes)
+}
+
+/// Fallback for when file size is unknown.
+/// Read file contents into a `Vec`, and then copy into arena.
+fn read_to_arena_bytes_unknown_size(mut file: File, allocator: &Allocator) -> io::Result<&[u8]> {
+    // Read file into a `Vec`
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)?;
+
+    // Allocate bytes into arena
+    Ok(allocator.alloc_slice_copy(&bytes))
 }


### PR DESCRIPTION
Alternative to #11816. Read a file from disk directly into an `Allocator`.

Unfortunately, involves a pretty egregious hack (see comments in code), but this appears to be the only way that stable Rust provides to read a file into uninitialized memory without UB. Bonkers!