### PR TITLE
refactor(napi/parser): remove options amendment from `prepareRaw`

### DIFF
--- a/napi/parser/bench.bench.mjs
+++ b/napi/parser/bench.bench.mjs
@@ -79,8 +79,8 @@ for (const { filename, code } of fixtures) {
     });
 
     // Prepare buffer but don't deserialize
-    const { buffer, sourceByteLen, options } = prepareRaw(code, { experimentalRawTransfer: true });
-    bindings.parseSyncRaw(filename, buffer, sourceByteLen, options);
+    const { buffer, sourceByteLen } = prepareRaw(code);
+    bindings.parseSyncRaw(filename, buffer, sourceByteLen, {});
     const deserialize = isJsAst(buffer) ? deserializeJS : deserializeTS;
 
     benchRaw('parser_napi_raw_deser_only', () => {

--- a/napi/parser/raw-transfer/eager.js
+++ b/napi/parser/raw-transfer/eager.js
@@ -14,6 +14,8 @@ module.exports = { parseSyncRaw, parseAsyncRaw };
  * @throws {Error} - If raw transfer is not supported on this platform
  */
 function parseSyncRaw(filename, sourceText, options) {
+  let _;
+  ({ experimentalRawTransfer: _, ...options } = options);
   return parseSyncRawImpl(filename, sourceText, options, deserialize);
 }
 
@@ -37,6 +39,8 @@ function parseSyncRaw(filename, sourceText, options) {
  * @throws {Error} - If raw transfer is not supported on this platform
  */
 function parseAsyncRaw(filename, sourceText, options) {
+  let _;
+  ({ experimentalRawTransfer: _, ...options } = options);
   return parseAsyncRawImpl(filename, sourceText, options, deserialize);
 }
 

--- a/napi/parser/raw-transfer/lazy.js
+++ b/napi/parser/raw-transfer/lazy.js
@@ -27,6 +27,8 @@ module.exports = { parseSyncLazy, parseAsyncLazy };
  * @throws {Error} - If raw transfer is not supported on this platform
  */
 function parseSyncLazy(filename, sourceText, options) {
+  let _;
+  ({ experimentalLazy: _, ...options } = options);
   return parseSyncRawImpl(filename, sourceText, options, construct);
 }
 
@@ -56,6 +58,8 @@ function parseSyncLazy(filename, sourceText, options) {
  * @throws {Error} - If raw transfer is not supported on this platform
  */
 function parseAsyncLazy(filename, sourceText, options) {
+  let _;
+  ({ experimentalLazy: _, ...options } = options);
   return parseAsyncRawImpl(filename, sourceText, options, construct);
 }
 


### PR DESCRIPTION
Pure refactor (raw transfer). Remove logic for amending `options` objects from `prepareRaw`. It's an unnatural place for it.