### PR TITLE
fix(ast): `ComputedMemberExpression::static_property_name` use `cooked` for `TemplateElement`s

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -662,7 +662,7 @@ impl<'a> ComputedMemberExpression<'a> {
             Expression::TemplateLiteral(lit)
                 if lit.expressions.is_empty() && lit.quasis.len() == 1 =>
             {
-                Some(lit.quasis[0].value.raw)
+                lit.quasis[0].value.cooked
             }
             Expression::RegExpLiteral(lit) => lit.raw,
             _ => None,

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 1d4546bc
 
-Passed: 154/258
+Passed: 155/259
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -467,7 +467,7 @@ after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(4), ReferenceId(9)
 rebuilt        : [ReferenceId(5)]
 
 
-# babel-plugin-transform-react-jsx (42/45)
+# babel-plugin-transform-react-jsx (43/46)
 * refresh/does-not-transform-it-because-it-is-not-used-in-the-AST/input.jsx
 x Output mismatch
 

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/display-name-computed-member-expr/input.jsx
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/display-name-computed-member-expr/input.jsx
@@ -1,0 +1,4 @@
+obj["a"] = React.createClass({});
+obj["\x62"] = React.createClass({}); // b
+obj[`c`] = React.createClass({});
+obj[`\x64`] = React.createClass({}); // d

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/display-name-computed-member-expr/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/display-name-computed-member-expr/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": [["transform-react-jsx"], ["transform-react-display-name"]],
+  "sourceType": "module"
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/display-name-computed-member-expr/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/display-name-computed-member-expr/output.js
@@ -1,0 +1,4 @@
+obj["a"] = React.createClass({ displayName: "a" });
+obj["b"] = React.createClass({ displayName: "b" });
+obj[`c`] = React.createClass({ displayName: "c" });
+obj[`\x64`] = React.createClass({ displayName: "d" });


### PR DESCRIPTION
Fix `ComputedMemberExpression::static_property_name`. The value of a template literal is the cooked version. e.g. ``obj[`\x41`]`` -> property name `"A"` not `"\x41"`.

The only place we use this method is in React transform. Add a test for it there.
