### PR TITLE
fix(linter): fix `jsx-a11y/label-has-associated-control` default values

### DIFF
--- a/apps/oxlint/fixtures/issue_11644/.oxlintrc.json
+++ b/apps/oxlint/fixtures/issue_11644/.oxlintrc.json
@@ -1,0 +1,26 @@
+{
+  "plugins": [
+    "eslint",
+    "import",
+    "jsx-a11y",
+    "nextjs",
+    "node",
+    "oxc",
+    "promise",
+    "react",
+    "react-perf",
+    "typescript",
+    "unicorn"
+  ],
+  "rules": {
+    "import/no-default-export": 0,
+    "no-console": 1,
+    "react/button-has-type": 0,
+    "react/rules-of-hooks": 2,
+    "typescript/explicit-function-return-type": 0,
+    "typescript/no-non-null-assertion": 0,
+    "unicorn/filename-case": [2, { "case": "kebabCase" }],
+    "unicorn/no-nested-ternary": 0,
+    // "jsx-a11y/label-has-associated-control": ["warn", { "depth": 0}]
+  }
+}

--- a/apps/oxlint/fixtures/issue_11644/test.jsx
+++ b/apps/oxlint/fixtures/issue_11644/test.jsx
@@ -1,0 +1,18 @@
+// oxlint-disable-next-line no-unused-vars
+function Foo() {
+  return (
+    <template>
+      <label>
+        <span>name</span>
+        <input
+          defaultValue={
+            actionState.payload?.get("name")?.toString() ?? "Pool party"
+          }
+          name="name"
+          placeholder="name"
+          type="text"
+        />
+      </label>
+    </template>
+  )
+}

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1159,4 +1159,10 @@ mod test {
         let args = &["-c", ".oxlintrc.json"];
         Tester::new().with_cwd("fixtures/issue_10394".into()).test_and_snapshot(args);
     }
+
+    #[test]
+    fn test_jsx_a11y_label_has_associated_control() {
+        let args = &["-c", ".oxlintrc.json"];
+        Tester::new().with_cwd("fixtures/issue_11644".into()).test_and_snapshot(args);
+    }
 }

--- a/apps/oxlint/src/snapshots/fixtures__issue_11644_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__issue_11644_-c .oxlintrc.json@oxlint.snap
@@ -1,0 +1,12 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: -c .oxlintrc.json
+working directory: fixtures/issue_11644
+----------
+Found 0 warnings and 0 errors.
+Finished in <variable>ms on 1 file with 158 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------


### PR DESCRIPTION
`LabelHasAssociatedControl.from_configuration` never got called. 
Only the `LabelHasAssociatedControlConfig::default()`.

closes #11644