### PR TITLE
refactor(ast_tools): prepare lazy deserializer codegen for visitor

### DIFF
--- a/napi/parser/generated/deserialize/lazy.js
+++ b/napi/parser/generated/deserialize/lazy.js
@@ -11,7 +11,6 @@ module.exports = { construct, TOKEN };
 function construct(ast) {
   // (2 * 1024 * 1024 * 1024 - 16) >> 2
   const metadataPos32 = 536870908;
-
   return new RawTransferData(ast.buffer.uint32[metadataPos32], ast);
 }
 


### PR DESCRIPTION
Pure refactor. Adapt lazy deserialization codegen in preparation for adding lazy visitor. Involves introducing a `State` struct, renaming things, and moving code around. No substantive changes.