### PR TITLE
fix(linter): count own indirect export entries to the threshold for `oxc/no-barrel-file`

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -96,6 +96,9 @@ impl Rule for NoBarrelFile {
         let mut total: usize = 0;
 
         for module_request in module_requests {
+            // the own module is counted as well
+            total += 1;
+
             if let Some(remote_module) =
                 module_record.loaded_modules.read().unwrap().get(module_request.name())
             {

--- a/crates/oxc_linter/src/snapshots/oxc_no_barrel_file.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_barrel_file.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ oxc(no-barrel-file): Barrel file detected, 6 modules are loaded.
+  ⚠ oxc(no-barrel-file): Barrel file detected, 10 modules are loaded.
    ╭─[index.ts:1:15]
  1 │ export * from "./deep/a.js";
    ·               ──────┬──────
@@ -14,6 +14,6 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ╰── 1 modules
  4 │            export * from "./deep/d.js";
    ╰────
-  help: Loading 6 modules is slow for runtimes and bundlers.
+  help: Loading 10 modules is slow for runtimes and bundlers.
         The configured threshold is 1.
         See also: <https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7>.


### PR DESCRIPTION
closes #11594

I think this is a bug too :). The own export entries should be counted into the threshold