### PR TITLE
refactor(formatter): reduce memory allocation for `DynamicText`

### DIFF
--- a/crates/oxc_formatter/src/formatter/context.rs
+++ b/crates/oxc_formatter/src/formatter/context.rs
@@ -22,7 +22,7 @@ pub struct FormatContext<'ast> {
 
     comments: Comments<'ast>,
 
-    cached_function_body: Option<(Span, FormatElement)>,
+    cached_function_body: Option<(Span, FormatElement<'ast>)>,
 
     allocator: &'ast Allocator,
 }
@@ -82,7 +82,7 @@ impl<'ast> FormatContext<'ast> {
     pub(crate) fn get_cached_function_body(
         &self,
         body: &AstNode<'ast, FunctionBody<'ast>>,
-    ) -> Option<FormatElement> {
+    ) -> Option<FormatElement<'ast>> {
         self.cached_function_body.as_ref().and_then(|(expected_body_span, formatted)| {
             if *expected_body_span == body.span() { Some(formatted.clone()) } else { None }
         })
@@ -94,7 +94,7 @@ impl<'ast> FormatContext<'ast> {
     pub(crate) fn set_cached_function_body(
         &mut self,
         body: &AstNode<'ast, FunctionBody<'ast>>,
-        formatted: FormatElement,
+        formatted: FormatElement<'ast>,
     ) {
         self.cached_function_body = Some((body.span(), formatted));
     }

--- a/crates/oxc_formatter/src/formatter/formatter.rs
+++ b/crates/oxc_formatter/src/formatter/formatter.rs
@@ -231,7 +231,10 @@ impl<'buf, 'ast> Formatter<'buf, 'ast> {
     }
 
     /// Formats `content` into an interned element without writing it to the formatter's buffer.
-    pub fn intern(&mut self, content: &dyn Format<'ast>) -> FormatResult<Option<FormatElement>> {
+    pub fn intern(
+        &mut self,
+        content: &dyn Format<'ast>,
+    ) -> FormatResult<Option<FormatElement<'ast>>> {
         let mut buffer = VecBuffer::new(self.state_mut());
         crate::write!(&mut buffer, [content])?;
         let elements = buffer.into_vec();
@@ -239,7 +242,10 @@ impl<'buf, 'ast> Formatter<'buf, 'ast> {
         Ok(self.intern_vec(elements))
     }
 
-    pub fn intern_vec(&mut self, mut elements: Vec<FormatElement>) -> Option<FormatElement> {
+    pub fn intern_vec(
+        &mut self,
+        mut elements: Vec<FormatElement<'ast>>,
+    ) -> Option<FormatElement<'ast>> {
         match elements.len() {
             0 => None,
             // Doesn't get cheaper than calling clone, use the element directly
@@ -267,11 +273,11 @@ impl Formatter<'_, '_> {
 
 impl<'ast> Buffer<'ast> for Formatter<'_, 'ast> {
     #[inline(always)]
-    fn write_element(&mut self, element: FormatElement) -> FormatResult<()> {
+    fn write_element(&mut self, element: FormatElement<'ast>) -> FormatResult<()> {
         self.buffer.write_element(element)
     }
 
-    fn elements(&self) -> &[FormatElement] {
+    fn elements(&self) -> &[FormatElement<'ast>] {
         self.buffer.elements()
     }
 

--- a/crates/oxc_formatter/src/formatter/mod.rs
+++ b/crates/oxc_formatter/src/formatter/mod.rs
@@ -78,12 +78,12 @@ use self::{format_element::document::Document, group_id::UniqueGroupIdBuilder, p
 
 #[derive(Debug, Clone)]
 pub struct Formatted<'a> {
-    document: Document,
+    document: Document<'a>,
     context: FormatContext<'a>,
 }
 
 impl<'a> Formatted<'a> {
-    pub fn new(document: Document, context: FormatContext<'a>) -> Self {
+    pub fn new(document: Document<'a>, context: FormatContext<'a>) -> Self {
         Self { document, context }
     }
 
@@ -93,12 +93,12 @@ impl<'a> Formatted<'a> {
     }
 
     /// Returns the formatted document.
-    pub fn document(&self) -> &Document {
+    pub fn document(&self) -> &Document<'a> {
         &self.document
     }
 
     /// Consumes `self` and returns the formatted document.
-    pub fn into_document(self) -> Document {
+    pub fn into_document(self) -> Document<'a> {
         self.document
     }
 }

--- a/crates/oxc_formatter/src/formatter/printer/line_suffixes.rs
+++ b/crates/oxc_formatter/src/formatter/printer/line_suffixes.rs
@@ -10,7 +10,7 @@ impl<'a> LineSuffixes<'a> {
     /// Extends the line suffixes with `elements`, storing their call stack arguments with them.
     pub(super) fn extend<I>(&mut self, args: PrintElementArgs, elements: I)
     where
-        I: IntoIterator<Item = &'a FormatElement>,
+        I: IntoIterator<Item = &'a FormatElement<'a>>,
     {
         self.suffixes.extend(elements.into_iter().map(LineSuffixEntry::Suffix));
         self.suffixes.push(LineSuffixEntry::Args(args));
@@ -32,7 +32,7 @@ impl<'a> LineSuffixes<'a> {
 #[derive(Debug, Copy, Clone)]
 pub(super) enum LineSuffixEntry<'a> {
     /// A line suffix to print
-    Suffix(&'a FormatElement),
+    Suffix(&'a FormatElement<'a>),
 
     /// Potentially changed call arguments that should be used to format any following items.
     Args(PrintElementArgs),

--- a/crates/oxc_formatter/src/formatter/token/number.rs
+++ b/crates/oxc_formatter/src/formatter/token/number.rs
@@ -68,6 +68,7 @@ struct FormatNumberLiteralExponent {
 }
 
 // Regex-free version of https://github.com/prettier/prettier/blob/ca246afacee8e6d5db508dae01730c9523bbff1d/src/common/util.js#L341-L356
+// TODO: Use arena String to construct the cleaned text.
 fn format_trimmed_number(text: &str, options: NumberFormatOptions) -> Cow<'_, str> {
     use FormatNumberLiteralState::{DecimalPart, Exponent, IntegerPart};
 

--- a/crates/oxc_formatter/src/formatter/trivia.rs
+++ b/crates/oxc_formatter/src/formatter/trivia.rs
@@ -695,7 +695,7 @@ impl<'a> Format<'a> for Comment {
 
             // `is_alignable_comment` only returns `true` for multiline comments
             let first_line = lines.next().unwrap();
-            write!(f, [dynamic_text(first_line.trim_end(), source_offset)])?;
+            write!(f, [dynamic_text(first_line.trim_end())])?;
 
             source_offset += first_line.len() as u32;
 
@@ -704,17 +704,14 @@ impl<'a> Format<'a> for Comment {
                 f,
                 [&format_once(|f| {
                     for line in lines {
-                        write!(
-                            f,
-                            [hard_line_break(), " ", dynamic_text(line.trim(), source_offset)]
-                        )?;
+                        write!(f, [hard_line_break(), " ", dynamic_text(line.trim())])?;
                         source_offset += line.len() as u32;
                     }
                     Ok(())
                 })]
             )
         } else {
-            write!(f, [dynamic_text(source_text, self.span.start)])
+            write!(f, [dynamic_text(source_text)])
         }
     }
 }

--- a/crates/oxc_formatter/src/write/call_arguments.rs
+++ b/crates/oxc_formatter/src/write/call_arguments.rs
@@ -143,7 +143,7 @@ pub enum FormatCallArgument<'a, 'b> {
     /// Allows to re-use the formatted output rather than having to call into the formatting again.
     Inspected {
         /// The formatted element
-        content: FormatResult<Option<FormatElement>>,
+        content: FormatResult<Option<FormatElement<'a>>>,
 
         /// The separated element
         element: &'b AstNode<'a, Argument<'a>>,


### PR DESCRIPTION
Change `DynamicText` to take a `&'a str` rather than `Box<str>`, so that we can avoid changing a `str` to `Box<str>` and gain a performance improvement. The main change is in `DynamicText`, the rest of the changes stem from the main change.