### PR TITLE
fix(isolated-declarations): missing parameter properties of `constructor` overload

### DIFF
--- a/crates/oxc_isolated_declarations/tests/fixtures/class.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/class.ts
@@ -69,3 +69,9 @@ export class PublicMethodClass {
     return {[('x')]: 1};
   }
 }
+
+export class ConstructorOverloadsClass {
+  constructor(a: number);
+  constructor(a: string);
+  constructor(readonly a: any) {}
+}

--- a/crates/oxc_isolated_declarations/tests/snapshots/class.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/class.snap
@@ -59,6 +59,11 @@ export declare class PublicMethodClass {
 	bad(a): void;
 	get badGetter(): {};
 }
+export declare class ConstructorOverloadsClass {
+	readonly a: any;
+	constructor(a: number);
+	constructor(a: string);
+}
 
 
 ==================== Errors ====================


### PR DESCRIPTION
close: #11784

The parameter properties of the constructor overload should be retained anyway.