### PR TITLE
refactor(napi/parser): lazy visitor: pre-calculate count of node types

### DIFF
--- a/napi/parser/generated/deserialize/lazy-types.js
+++ b/napi/parser/generated/deserialize/lazy-types.js
@@ -187,7 +187,8 @@ const NODE_TYPE_IDS_MAP = new Map([
   ['JSDocNonNullableType', 177],
 ]);
 
-// Number of AST node types which are leaf nodes
-const LEAF_NODES_COUNT = 38;
-
-module.exports = { NODE_TYPE_IDS_MAP, LEAF_NODES_COUNT };
+module.exports = {
+  NODE_TYPE_IDS_MAP,
+  NODE_TYPES_COUNT: 178,
+  LEAF_NODE_TYPES_COUNT: 38,
+};

--- a/napi/parser/raw-transfer/visitor.js
+++ b/napi/parser/raw-transfer/visitor.js
@@ -1,8 +1,10 @@
 'use strict';
 
-const { NODE_TYPE_IDS_MAP, LEAF_NODES_COUNT } = require('../generated/deserialize/lazy-types.js');
-
-const NODE_TYPES_COUNT = NODE_TYPE_IDS_MAP.size;
+const {
+  NODE_TYPE_IDS_MAP,
+  NODE_TYPES_COUNT,
+  LEAF_NODE_TYPES_COUNT,
+} = require('../generated/deserialize/lazy-types.js');
 
 // Getter for private `#visitorsArr` property of `Visitor` class. Initialized in class body below.
 let getVisitorsArr;
@@ -84,7 +86,7 @@ function createVisitorsArr(visitor) {
     const typeId = NODE_TYPE_IDS_MAP.get(name);
     if (typeId === void 0) throw new Error(`Unknown node type '${name}' in \`visitors\` object`);
 
-    if (typeId < LEAF_NODES_COUNT) {
+    if (typeId < LEAF_NODE_TYPES_COUNT) {
       // Leaf node. Store just 1 function.
       const existingVisitFn = visitorsArr[typeId];
       if (existingVisitFn === null) {

--- a/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
@@ -192,6 +192,7 @@ fn generate(
     // Generate file containing mapping from type names to node type IDs
     assert_eq!(state.next_leaf_node_type_id, leaf_nodes_count);
 
+    let nodes_count = state.next_non_leaf_node_type_id;
     let leaf_node_type_ids_map = &state.leaf_node_type_ids_map;
     let non_leaf_node_type_ids_map = &state.non_leaf_node_type_ids_map;
     #[rustfmt::skip]
@@ -205,10 +206,11 @@ fn generate(
             {non_leaf_node_type_ids_map}
         ]);
 
-        // Number of AST node types which are leaf nodes
-        const LEAF_NODES_COUNT = {leaf_nodes_count};
-
-        module.exports = {{ NODE_TYPE_IDS_MAP, LEAF_NODES_COUNT }};
+        module.exports = {{
+            NODE_TYPE_IDS_MAP,
+            NODE_TYPES_COUNT: {nodes_count},
+            LEAF_NODE_TYPES_COUNT: {leaf_nodes_count},
+        }};
     ");
 
     (state.constructors, walkers, node_type_ids_map)


### PR DESCRIPTION
Pure refactor. Pre-calculate number of node types in codegen. This prepares the way for replacing the `Map` with a plain JS object.