### PR TITLE
perf(napi/parser): lazy visit: cheaper for loop

### DIFF
--- a/napi/parser/raw-transfer/visitor.js
+++ b/napi/parser/raw-transfer/visitor.js
@@ -69,7 +69,7 @@ function createVisitorsArr(visitor) {
 
   // Create empty visitors array
   const visitorsArr = [];
-  for (let i = 0; i < NODE_TYPES_COUNT; i++) {
+  for (let i = NODE_TYPES_COUNT; i !== 0; i--) {
     visitorsArr.push(null);
   }
 


### PR DESCRIPTION
Tiny optimization to lazy visitor. It's marginally cheaper in a loop to compare to 0, rather than to a constant. I also assume that `!== 0` is cheaper than `> 0` as it doesn't involve type coercion.