### PR TITLE
perf(napi/parser): lazy deser: speed up creating `NodeArray`s

### DIFF
--- a/napi/parser/test/lazy-deserialization.test.ts
+++ b/napi/parser/test/lazy-deserialization.test.ts
@@ -495,6 +495,15 @@ describe('NodeArray', () => {
     expect(stmtsTwice[3]).toBe(body[1]);
   });
 
+  it('get length', () => {
+    const body0 = parseSyncLazy('test.js', '').program.body;
+    expect(body0.length).toBe(0);
+    const body2 = parseSyncLazy('test.js', 'let x = 1; x = 2;').program.body;
+    expect(body2.length).toBe(2);
+    const body4 = parseSyncLazy('test.js', 'x; y; z; 123;').program.body;
+    expect(body4.length).toBe(4);
+  });
+
   it('set length (throws)', () => {
     const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
     expect(() => body.length = 0)


### PR DESCRIPTION
`NodeArray` store length as an internal property, rather then creating an underlying `Array` with that length. This is much faster when the array is large.

Produces an 18x speed-up in getting `program.body` for `cal.com.tsx` benchmark fixture, because it has 3942 statements.
