### PR TITLE
refactor(coverage/typescript): Check error codes only for parser suites

### DIFF
--- a/tasks/coverage/snapshots/codegen_typescript.snap
+++ b/tasks/coverage/snapshots/codegen_typescript.snap
@@ -1,5 +1,5 @@
 commit: 81c95189
 
 codegen_typescript Summary:
-AST Parsed     : 6540/6540 (100.00%)
-Positive Passed: 6540/6540 (100.00%)
+AST Parsed     : 6537/6537 (100.00%)
+Positive Passed: 6537/6537 (100.00%)

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -1,8 +1,8 @@
 commit: 81c95189
 
 semantic_typescript Summary:
-AST Parsed     : 6540/6540 (100.00%)
-Positive Passed: 2848/6540 (43.55%)
+AST Parsed     : 6537/6537 (100.00%)
+Positive Passed: 2848/6537 (43.57%)
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
 Symbol reference IDs mismatch for "Cell":
 after transform: SymbolId(0): [ReferenceId(1)]
@@ -20478,14 +20478,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceSharingName2.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["X", "z", "z2"]
-rebuilt        : ScopeId(0): ["z", "z2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceSharingName3.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["X", "z", "z2"]
@@ -29590,11 +29582,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["B"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesNonGenericTypeButWithTypeArguments1.ts
-Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3)]
-rebuilt        : ScopeId(2): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/superElementAccess.ts
 Scope children mismatch:
@@ -51109,38 +51096,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/specifyi
 Unresolved references mismatch:
 after transform: ["this"]
 rebuilt        : []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeReferences/nonGenericTypeReferenceWithTypeArguments.ts
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Scope children mismatch:
-after transform: ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(3): [ScopeId(4), ScopeId(5)]
-Scope flags mismatch:
-after transform: ScopeId(8): ScopeFlags(0x0)
-rebuilt        : ScopeId(5): ScopeFlags(Function)
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
-Symbol flags mismatch for "E":
-after transform: SymbolId(2): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(2): [ReferenceId(2), ReferenceId(10)]
-rebuilt        : SymbolId(1): [ReferenceId(1)]
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(10): [ReferenceId(4)]
-rebuilt        : SymbolId(8): []
-Symbol flags mismatch for "E":
-after transform: SymbolId(12): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(12): [ReferenceId(6)]
-rebuilt        : SymbolId(9): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpread.ts
 Scope children mismatch:

--- a/tasks/coverage/snapshots/transformer_typescript.snap
+++ b/tasks/coverage/snapshots/transformer_typescript.snap
@@ -1,8 +1,8 @@
 commit: 81c95189
 
 transformer_typescript Summary:
-AST Parsed     : 6540/6540 (100.00%)
-Positive Passed: 6536/6540 (99.94%)
+AST Parsed     : 6537/6537 (100.00%)
+Positive Passed: 6533/6537 (99.94%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/esDecoratorsClassFieldsCrash.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor2.ts

--- a/tasks/coverage/src/lib.rs
+++ b/tasks/coverage/src/lib.rs
@@ -39,7 +39,9 @@ use crate::{
             TransformerTypeScriptCase,
         },
     },
-    typescript::{TranspileRunner, TypeScriptCase, TypeScriptSuite, TypeScriptTranspileCase},
+    typescript::{
+        ParserUsage, TranspileRunner, TypeScriptCase, TypeScriptSuite, TypeScriptTranspileCase,
+    },
 };
 
 pub fn workspace_root() -> PathBuf {
@@ -78,7 +80,7 @@ impl AppArgs {
     pub fn run_parser(&self) {
         Test262Suite::<Test262Case>::new().run("parser_test262", self);
         BabelSuite::<BabelCase>::new().run("parser_babel", self);
-        TypeScriptSuite::<TypeScriptCase>::new().run("parser_typescript", self);
+        TypeScriptSuite::<TypeScriptCase<ParserUsage>>::new().run("parser_typescript", self);
         MiscSuite::<MiscCase>::new().run("parser_misc", self);
     }
 

--- a/tasks/coverage/src/tools/estree.rs
+++ b/tasks/coverage/src/tools/estree.rs
@@ -18,7 +18,7 @@ use oxc::{
 use crate::{
     suite::{Case, Suite, TestResult},
     test262::Test262Case,
-    typescript::TypeScriptCase,
+    typescript::{ParserUsage, TypeScriptCase},
     workspace_root,
 };
 
@@ -244,7 +244,7 @@ impl Case for EstreeJsxCase {
 }
 
 pub struct EstreeTypescriptCase {
-    base: TypeScriptCase,
+    base: TypeScriptCase<ParserUsage>,
     estree_file_path: PathBuf,
 }
 

--- a/tasks/coverage/src/typescript/mod.rs
+++ b/tasks/coverage/src/typescript/mod.rs
@@ -1,7 +1,6 @@
 mod meta;
 mod transpile_runner;
 
-use std::any::TypeId;
 use std::path::{Path, PathBuf};
 
 use self::meta::{CompilerSettings, TestCaseContent, TestUnitData};
@@ -71,13 +70,19 @@ impl<T: Case> Suite<T> for TypeScriptSuite<T> {
     }
 }
 
-pub trait TypeScriptUsage: Sync + Send + std::panic::UnwindSafe + 'static {}
+pub trait TypeScriptUsage: Sync + Send + std::panic::UnwindSafe + 'static {
+    const CHECK_NOT_SUPPORTED_ERROR_CODES: bool;
+}
 
 pub struct ParserUsage;
-impl TypeScriptUsage for ParserUsage {}
+impl TypeScriptUsage for ParserUsage {
+    const CHECK_NOT_SUPPORTED_ERROR_CODES: bool = true;
+}
 
 pub struct ToolUsage;
-impl TypeScriptUsage for ToolUsage {}
+impl TypeScriptUsage for ToolUsage {
+    const CHECK_NOT_SUPPORTED_ERROR_CODES: bool = false;
+}
 
 pub struct TypeScriptCase<Usage: TypeScriptUsage = ToolUsage> {
     path: PathBuf,
@@ -117,7 +122,7 @@ impl<Usage: TypeScriptUsage> Case for TypeScriptCase<Usage> {
     }
 
     fn should_fail(&self) -> bool {
-        if TypeId::of::<Usage>() == TypeId::of::<ParserUsage>() {
+        if Usage::CHECK_NOT_SUPPORTED_ERROR_CODES {
             // If there are still error codes to be supported, it should fail
             return self
                 .error_codes

--- a/tasks/coverage/src/typescript/mod.rs
+++ b/tasks/coverage/src/typescript/mod.rs
@@ -1,7 +1,10 @@
 mod meta;
 mod transpile_runner;
 
-use std::path::{Path, PathBuf};
+use std::{
+    panic::UnwindSafe,
+    path::{Path, PathBuf},
+};
 
 use self::meta::{CompilerSettings, TestCaseContent, TestUnitData};
 pub use self::transpile_runner::{TranspileRunner, TypeScriptTranspileCase};
@@ -70,7 +73,7 @@ impl<T: Case> Suite<T> for TypeScriptSuite<T> {
     }
 }
 
-pub trait TypeScriptUsage: Sync + Send + std::panic::UnwindSafe + 'static {
+pub trait TypeScriptUsage: Sized + Sync + Send + UnwindSafe {
     const CHECK_NOT_SUPPORTED_ERROR_CODES: bool;
 }
 


### PR DESCRIPTION
Follow up #11858 

Only parser-related tests 

- `parser_typescript.snap`
- `estree_typescript.snap`

will check for error codes.

Or..., should I just skip it only for `semantic_typescript.snap`?