### PR TITLE
fix(ast): `MemberExpression::static_property_info` use `cooked` not `raw` for `TemplateElement`s

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -615,7 +615,7 @@ impl<'a> MemberExpression<'a> {
                 Expression::StringLiteral(lit) => Some((lit.span, lit.value.as_str())),
                 Expression::TemplateLiteral(lit) => {
                     if lit.expressions.is_empty() && lit.quasis.len() == 1 {
-                        Some((lit.span, lit.quasis[0].value.raw.as_str()))
+                        lit.quasis[0].value.cooked.map(|cooked| (lit.span, cooked.as_str()))
                     } else {
                         None
                     }


### PR DESCRIPTION
Same as #11829. `MemberExpression::static_property_info` use `cooked` not `raw` for `TemplateElement`s.

The value of a template literal is the cooked version. e.g. ``obj[`\x41`]`` -> property name `"A"` not `"\x41"`.
