### PR TITLE
perf(linter/no-console): get static property name only once

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -112,13 +112,13 @@ impl Rule for NoConsole {
         };
 
         if ident.name == "console"
-            && ctx.scoping().root_unresolved_references().contains_key(ident.name.as_str())
-            && !self
-                .allow
-                .iter()
-                .any(|s| member_expr.static_property_name().is_some_and(|f| f == s))
+            && ctx.scoping().root_unresolved_references().contains_key("console")
         {
-            if let Some((mem_span, _)) = member_expr.static_property_info() {
+            if let Some((mem_span, prop_name)) = member_expr.static_property_info() {
+                if self.allow.iter().any(|allowed_name| allowed_name == prop_name) {
+                    return;
+                }
+
                 let diagnostic_span = ident.span().merge(mem_span);
 
                 ctx.diagnostic_with_suggestion(


### PR DESCRIPTION
Instead of iterating over `allow` and recalculating the static property name on each turn of the loop, check if the property name is allowed once it's already calculated with `MemberExpression::static_property_info`.

This PR also ensures that the fix made in #11879 works. If not stacked on top of that PR, one of the tests added in #11878 fails.