### PR TITLE
fix(napi/parser): `NodeArray` allow setting large integer properties

### DIFF
--- a/napi/parser/test/lazy-deserialization.test.ts
+++ b/napi/parser/test/lazy-deserialization.test.ts
@@ -530,6 +530,8 @@ describe('NodeArray', () => {
     expect(() => body[1] = {}).toThrow(new TypeError('Cannot redefine property: 1'));
     expect(() => body[2] = {})
       .toThrow(new TypeError("'defineProperty' on proxy: trap returned falsish for property '2'"));
+    expect(() => body[4294967294] = {})
+      .toThrow(new TypeError("'defineProperty' on proxy: trap returned falsish for property '4294967294'"));
   });
 
   it('set element via `defineProperty` (throws)', () => {
@@ -540,28 +542,45 @@ describe('NodeArray', () => {
       .toThrow(new TypeError("'defineProperty' on proxy: trap returned falsish for property '1'"));
     expect(() => Object.defineProperty(body, 2, { value: {} }))
       .toThrow(new TypeError("'defineProperty' on proxy: trap returned falsish for property '2'"));
+    expect(() => Object.defineProperty(body, 4294967294, { value: {} }))
+      .toThrow(new TypeError("'defineProperty' on proxy: trap returned falsish for property '4294967294'"));
   });
+
+  const propertyKeys = [
+    'foo',
+    'bar',
+    Symbol('yeah'),
+    -1,
+    '01',
+    '0x1',
+    '1 ',
+    ' 1',
+    '1e1',
+    '4294967295',
+    '4294967296',
+    '10000000000000',
+  ];
 
   it('set properties', () => {
     const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
 
-    const keys = [
-      'foo',
-      'bar',
-      Symbol('yeah'),
-      -1,
-      '01',
-      '0x1',
-      '1 ',
-      ' 1',
-      '1e1',
-    ];
-
-    for (const [i, key] of keys.entries()) {
+    for (const [i, key] of propertyKeys.entries()) {
       body[key] = i + 100;
     }
 
-    for (const [i, key] of keys.entries()) {
+    for (const [i, key] of propertyKeys.entries()) {
+      expect(body[key]).toBe(i + 100);
+    }
+  });
+
+  it('set properties via `defineProperty`', () => {
+    const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+
+    for (const [i, key] of propertyKeys.entries()) {
+      Object.defineProperty(body, key, { value: i + 100 });
+    }
+
+    for (const [i, key] of propertyKeys.entries()) {
       expect(body[key]).toBe(i + 100);
     }
   });


### PR DESCRIPTION
Integers `>= 4294967295` are treated as string properties, not numerical array indexes. Make `NodeArray` behave the same as `Array` for such properties, and allow user to set them.
