### PR TITLE
perf(linter/no-extend-native): do not create unnecessary `CompactStr`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
@@ -97,8 +97,7 @@ impl Rule for NoExtendNative {
                     continue;
                 }
                 // If the referenced name is explicitly allowed, skip it.
-                let compact_name = CompactStr::from(name);
-                if self.exceptions.contains(&compact_name) {
+                if self.exceptions.iter().any(|exception| name == exception) {
                     continue;
                 }
                 // If the first letter is capital, like `Object`, we will assume it is a native object


### PR DESCRIPTION
Small optimization. There's no need to create a `CompactStr` just to search a `Vec<CompactStr>` for a match.