### PR TITLE
fix(linter): remove false positives for `no-extend-native`

### DIFF
--- a/crates/oxc_linter/src/snapshots/eslint_no_extend_native.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_extend_native.snap
@@ -156,3 +156,9 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Array.prototype.p ??= 0
    · ───────────────────────
    ╰────
+
+  ⚠ eslint(no-extend-native): Array prototype is read-only, properties should not be added.
+   ╭─[no_extend_native.tsx:1:1]
+ 1 │ [Array.prototype.p] = [() => {}]
+   · ───────────────────
+   ╰────


### PR DESCRIPTION
Follow-up to some comments in https://github.com/oxc-project/oxc/pull/11766. This addresses an issue where we were not properly checking which side of assignment the prototype access occurred on.