### PR TITLE
fix(semantic): remove needless ts type param empty check

### DIFF
--- a/crates/oxc_semantic/src/checker/mod.rs
+++ b/crates/oxc_semantic/src/checker/mod.rs
@@ -107,9 +107,6 @@ pub fn check<'a>(kind: AstKind<'a>, ctx: &SemanticBuilder<'a>) {
             }
         }
         AstKind::TSTypeAnnotation(annot) => ts::check_ts_type_annotation(annot, ctx),
-        AstKind::TSTypeParameterDeclaration(declaration) => {
-            ts::check_ts_type_parameter_declaration(declaration, ctx);
-        }
         AstKind::TSInterfaceDeclaration(decl) => ts::check_ts_interface_declaration(decl, ctx),
         AstKind::TSTypeParameter(param) => ts::check_ts_type_parameter(param, ctx),
         AstKind::TSModuleDeclaration(decl) => ts::check_ts_module_declaration(decl, ctx),

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -14,18 +14,6 @@ fn ts_error<M: Into<Cow<'static, str>>>(code: &'static str, message: M) -> OxcDi
     OxcDiagnostic::error(message).with_error_code("TS", code)
 }
 
-fn empty_type_parameter_list(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Type parameter list cannot be empty.").with_label(span)
-}
-
-pub fn check_ts_type_parameter_declaration(
-    declaration: &TSTypeParameterDeclaration<'_>,
-    ctx: &SemanticBuilder<'_>,
-) {
-    if declaration.params.is_empty() {
-        ctx.error(empty_type_parameter_list(declaration.span));
-    }
-}
 pub fn check_ts_type_parameter<'a>(param: &TSTypeParameter<'a>, ctx: &SemanticBuilder<'a>) {
     check_type_name_is_reserved(&param.name, ctx, "Type parameter");
 }

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -12127,12 +12127,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·        ──
    ╰────
 
-  × Type parameter list cannot be empty.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/empty-type-parameters/input.ts:1:8]
- 1 │ class C<> {}
-   ·        ──
-   ╰────
-
   × Expected `{` but found `EOF`
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/extends-empty/input.ts:3:1]
  2 │ }
@@ -12472,12 +12466,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
   help: Remove the duplicate modifier.
 
   × TS(1098): Type parameter list cannot be empty.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/empty-type-parameters/input.ts:1:13]
- 1 │ function foo<>() {}
-   ·             ──
-   ╰────
-
-  × Type parameter list cannot be empty.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/empty-type-parameters/input.ts:1:13]
  1 │ function foo<>() {}
    ·             ──

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -10323,13 +10323,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  2 │ }
    ╰────
 
-  × Type parameter list cannot be empty.
-   ╭─[typescript/tests/cases/compiler/classWithEmptyTypeParameter.ts:1:8]
- 1 │ class C<> {
-   ·        ──
- 2 │ }
-   ╰────
-
   × Function implementation is missing or not immediately following the declaration.
    ╭─[typescript/tests/cases/compiler/classWithOverloadImplementationOfWrongName.ts:3:5]
  2 │     foo(): string;
@@ -15729,70 +15722,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
     ╰────
 
   × TS(1092): Type parameters cannot appear on a constructor declaration
-    ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:9:15]
-  8 │   constructor < >() { }
-  9 │   constructor < > () { }
-    ·               ───
- 10 │ }
-    ╰────
-
-  × Type parameter list cannot be empty.
-   ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:2:14]
- 1 │ class C {
- 2 │   constructor<>() { }
-   ·              ──
- 3 │   constructor<> () { }
-   ╰────
-
-  × Type parameter list cannot be empty.
-   ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:3:14]
- 2 │   constructor<>() { }
- 3 │   constructor<> () { }
-   ·              ──
- 4 │   constructor <>() { }
-   ╰────
-
-  × Type parameter list cannot be empty.
-   ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:4:15]
- 3 │   constructor<> () { }
- 4 │   constructor <>() { }
-   ·               ──
- 5 │   constructor <> () { }
-   ╰────
-
-  × Type parameter list cannot be empty.
-   ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:5:15]
- 4 │   constructor <>() { }
- 5 │   constructor <> () { }
-   ·               ──
- 6 │   constructor< >() { }
-   ╰────
-
-  × Type parameter list cannot be empty.
-   ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:6:14]
- 5 │   constructor <> () { }
- 6 │   constructor< >() { }
-   ·              ───
- 7 │   constructor< > () { }
-   ╰────
-
-  × Type parameter list cannot be empty.
-   ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:7:14]
- 6 │   constructor< >() { }
- 7 │   constructor< > () { }
-   ·              ───
- 8 │   constructor < >() { }
-   ╰────
-
-  × Type parameter list cannot be empty.
-   ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:8:15]
- 7 │   constructor< > () { }
- 8 │   constructor < >() { }
-   ·               ───
- 9 │   constructor < > () { }
-   ╰────
-
-  × Type parameter list cannot be empty.
     ╭─[typescript/tests/cases/compiler/parserConstructorDeclaration12.ts:9:15]
   8 │   constructor < >() { }
   9 │   constructor < > () { }
@@ -26674,14 +26603,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╰────
 
   × TS(1092): Type parameters cannot appear on a constructor declaration
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration11.ts:2:14]
- 1 │ class C {
- 2 │   constructor<>() { }
-   ·              ──
- 3 │ }
-   ╰────
-
-  × Type parameter list cannot be empty.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration11.ts:2:14]
  1 │ class C {
  2 │   constructor<>() { }


### PR DESCRIPTION
we already check this in the parser, we don't need to check in semantic as well

https://github.com/oxc-project/oxc/blob/8c341a2699022a7e8c70107604d93a77a8afa529/crates/oxc_parser/src/diagnostics.rs#L410-L413