### PR TITLE
refactor(formatter): simplify and correct member expression checks

### DIFF
--- a/crates/oxc_formatter/src/parentheses/expression.rs
+++ b/crates/oxc_formatter/src/parentheses/expression.rs
@@ -416,16 +416,14 @@ impl<'a> NeedsParentheses<'a> for AstNode<'a, TSNonNullExpression<'a>> {
 
 impl<'a> NeedsParentheses<'a> for AstNode<'a, TSInstantiationExpression<'a>> {
     fn needs_parentheses(&self, f: &Formatter<'_, 'a>) -> bool {
-        if let AstNodes::StaticMemberExpression(e) = self.parent {
-            return e.object.without_parentheses().span() == self.span();
-        }
-        if let AstNodes::ComputedMemberExpression(e) = self.parent {
-            return e.object.without_parentheses().span() == self.span();
-        }
-        if let AstNodes::PrivateFieldExpression(e) = self.parent {
-            return e.object.without_parentheses().span() == self.span();
-        }
-        false
+        let expr = match self.parent {
+            AstNodes::StaticMemberExpression(expr) => &expr.object,
+            AstNodes::ComputedMemberExpression(expr) => &expr.object,
+            AstNodes::PrivateFieldExpression(expr) => &expr.object,
+            _ => return false,
+        };
+
+        self.span == expr.span()
     }
 }
 
@@ -441,8 +439,6 @@ fn binary_like_needs_parens(binary_like: BinaryLikeExpression<'_, '_>) -> bool {
         | AstNodes::CallExpression(_)
         | AstNodes::NewExpression(_)
         | AstNodes::StaticMemberExpression(_)
-        | AstNodes::ComputedMemberExpression(_)
-        | AstNodes::PrivateFieldExpression(_)
         | AstNodes::TaggedTemplateExpression(_) => return true,
         AstNodes::BinaryExpression(binary) => BinaryLikeExpression::BinaryExpression(binary),
         AstNodes::LogicalExpression(logical) => BinaryLikeExpression::LogicalExpression(logical),
@@ -532,16 +528,18 @@ fn update_or_lower_expression_needs_parens(span: Span, parent: &AstNodes<'_>) ->
         parent,
         // JsSyntaxKind::JS_EXTENDS_CLAUSE
         // | JsSyntaxKind::JS_TEMPLATE_EXPRESSION
-        AstNodes::TSNonNullExpression(_) | AstNodes::CallExpression(_) | AstNodes::NewExpression(_)
+        AstNodes::TSNonNullExpression(_)
+            | AstNodes::CallExpression(_)
+            | AstNodes::NewExpression(_)
+            | AstNodes::StaticMemberExpression(_)
     ) {
         return true;
     }
-    if let AstNodes::StaticMemberExpression(member_expr) = parent {
-        return member_expr.object.get_inner_expression().span() == span;
-    }
+
     if let AstNodes::ComputedMemberExpression(computed_member_expr) = parent {
-        return computed_member_expr.object.get_inner_expression().span() == span;
+        return computed_member_expr.object.span() == span;
     }
+
     false
 }
 

--- a/crates/oxc_formatter/src/write/binary_like_expression.rs
+++ b/crates/oxc_formatter/src/write/binary_like_expression.rs
@@ -204,10 +204,7 @@ impl<'a> Format<'a> for BinaryLikeExpression<'a, '_> {
         // Add a group with a soft block indent in cases where it is necessary to parenthesize the binary expression.
         // For example, `(a+b)(call)`, `!(a + b)`, `(a + b).test`.
         let is_inside_parenthesis = match parent {
-            AstNodes::StaticMemberExpression(_)
-            | AstNodes::PrivateFieldExpression(_)
-            | AstNodes::ComputedMemberExpression(_)
-            | AstNodes::UnaryExpression(_) => true,
+            AstNodes::StaticMemberExpression(_) | AstNodes::UnaryExpression(_) => true,
             AstNodes::CallExpression(call) => {
                 call.callee().without_parentheses().span() == self.span()
             }

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -37,7 +37,7 @@ js compatibility: 323/699 (46.21%)
 | js/assignment/issue-15534.js | 💥 | 30.77% |
 | js/assignment/issue-1966.js | 💥 | 30.77% |
 | js/assignment/issue-2482-1.js | 💥 | 33.33% |
-| js/assignment/issue-2482-2.js | 💥 | 50.00% |
+| js/assignment/issue-2482-2.js | 💥 | 53.33% |
 | js/assignment/issue-3819.js | 💥 | 0.00% |
 | js/assignment/issue-7091.js | 💥 | 0.00% |
 | js/assignment/issue-7572.js | 💥 | 72.73% |
@@ -54,7 +54,7 @@ js compatibility: 323/699 (46.21%)
 | js/async/inline-await.js | 💥 | 22.22% |
 | js/async/nested.js | 💥 | 16.67% |
 | js/binary-expressions/arrow.js | 💥 | 66.67% |
-| js/binary-expressions/comment.js | 💥 | 74.63% |
+| js/binary-expressions/comment.js | 💥 | 76.92% |
 | js/binary-expressions/in_instanceof.js | 💥 | 97.96% |
 | js/binary-expressions/inline-jsx.js | 💥 | 28.57% |
 | js/binary-expressions/inline-object-array.js | 💥 | 67.78% |
@@ -228,7 +228,7 @@ js compatibility: 323/699 (46.21%)
 | js/logical-assignment/logical-assignment.js | 💥 | 81.48% |
 | js/logical_expressions/issue-7024.js | 💥 | 0.00% |
 | js/member/conditional.js | 💥 | 0.00% |
-| js/member/expand.js | 💥 | 49.41% |
+| js/member/expand.js | 💥 | 52.38% |
 | js/method-chain/assignment-lhs.js | 💥 | 16.67% |
 | js/method-chain/bracket_0-1.js | 💥 | 0.00% |
 | js/method-chain/break-last-member.js | 💥 | 80.56% |


### PR DESCRIPTION
Follow-up after https://github.com/oxc-project/oxc/pull/11767.

I've checked them one by one, corresponding to the Biome's implementation. It still has a regression test, but it is not exactly related to the `AstKind::MemberExpression` change. I will fix that in another PR, but not now.
