### PR TITLE
chore(formatter): align parser options of example with prettier conformance

### DIFF
--- a/crates/oxc_formatter/examples/formatter.rs
+++ b/crates/oxc_formatter/examples/formatter.rs
@@ -17,7 +17,11 @@ fn main() -> Result<(), String> {
     let source_type = SourceType::from_path(path).unwrap();
     let allocator = Allocator::new();
     let ret = Parser::new(&allocator, &source_text, source_type)
-        .with_options(ParseOptions { parse_regular_expression: true, ..ParseOptions::default() })
+        .with_options(ParseOptions {
+            preserve_parens: false,
+            allow_v8_intrinsics: true,
+            ..ParseOptions::default()
+        })
         .parse();
 
     for error in ret.errors {


### PR DESCRIPTION
Keep them as the same, so that it wouldn't confuse you.
https://github.com/oxc-project/oxc/blob/36d5a795f053662238eead81021efad4ed0bf332/tasks/prettier_conformance/src/lib.rs#L423-L429