### PR TITLE
fix(linter): fix default values for `eslint/max-depth`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/max_depth.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_depth.rs
@@ -15,9 +15,17 @@ fn max_depth_diagnostic(num: usize, max: usize, span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone, JsonSchema)]
+const DEFAULT_MAX_DEPTH: usize = 4;
+
+#[derive(Debug, Clone, JsonSchema)]
 pub struct MaxDepth {
     max: usize,
+}
+
+impl Default for MaxDepth {
+    fn default() -> Self {
+        Self { max: DEFAULT_MAX_DEPTH }
+    }
 }
 
 declare_oxc_lint!(
@@ -132,7 +140,7 @@ impl Rule for MaxDepth {
                 .and_then(|config| config.get("max"))
                 .and_then(Value::as_number)
                 .and_then(serde_json::Number::as_u64)
-                .map_or(4, |v| usize::try_from(v).unwrap_or(4))
+                .map_or(DEFAULT_MAX_DEPTH, |v| usize::try_from(v).unwrap_or(DEFAULT_MAX_DEPTH))
         };
         Self { max }
     }
@@ -156,6 +164,9 @@ fn should_stop(node: &AstNode<'_>) -> bool {
 #[test]
 fn test() {
     use crate::tester::Tester;
+
+    let defaults = MaxDepth::default();
+    assert_eq!(defaults.max, 4);
 
     let pass = vec![
         (


### PR DESCRIPTION
related #11906