### PR TITLE
docs(linter): fix doc formatting for perfer-logical-op-over-ternary

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_logical_operator_over_ternary.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_logical_operator_over_ternary.rs
@@ -33,7 +33,7 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Examples of **correct** code for this rule:
-    //  ```javascript
+    /// ```javascript
     /// const foo = bar || baz;
     /// console.log(foo ?? bar);
     /// ```


### PR DESCRIPTION
closes oxc-project/oxc-project.github.io#407