### PR TITLE
docs(linter): fix prefer-string-replace-all example

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
@@ -35,7 +35,7 @@ declare_oxc_lint!(
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```js
-    /// array.reduceRight(reducer, initialValue);
+    /// foo.replace(/a/g, bar)
     /// ```
     ///
     /// Examples of **correct** code for this rule:


### PR DESCRIPTION
`prefer-string-replace-all` has an incorrect "incorrect" example 😄 
(copy-pasted from `no-array-reduce`)
