### PR TITLE
fix(linter/no-standalone-expect): false positive in callback fn

### DIFF
--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect/mod.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect/mod.rs
@@ -215,14 +215,25 @@ fn is_var_declarator_or_test_block<'a>(
                 return true;
             }
         }
-        AstKind::Argument(_) => {
-            if let Some(parent) = ctx.nodes().parent_node(node.id()) {
-                return is_var_declarator_or_test_block(
-                    parent,
-                    additional_test_block_functions,
-                    id_nodes_mapping,
-                    ctx,
-                );
+        AstKind::Argument(_) | AstKind::ArrayExpression(_) | AstKind::ObjectExpression(_) => {
+            let mut current = node;
+            while let Some(parent) = ctx.nodes().parent_node(current.id()) {
+                match parent.kind() {
+                    AstKind::CallExpression(_) | AstKind::VariableDeclarator(_) => {
+                        return is_var_declarator_or_test_block(
+                            parent,
+                            additional_test_block_functions,
+                            id_nodes_mapping,
+                            ctx,
+                        );
+                    }
+                    AstKind::Argument(_)
+                    | AstKind::ArrayExpression(_)
+                    | AstKind::ObjectExpression(_) => {
+                        current = parent;
+                    }
+                    _ => break,
+                }
             }
         }
         _ => {}

--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect/tests/jest.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect/tests/jest.rs
@@ -62,6 +62,18 @@ fn test() {
             ",
             Some(serde_json::json!([{ "additionalTestBlockFunctions": ["each.test"] }])),
         ),
+        (
+            r"function funcWithCallback(callback) { callback(5); }
+            describe('testWithCallback', () => {
+              it('should call the callback', (done) => {
+                funcWithCallback((result) => {
+                  expect(result).toBe(5);
+                  done();
+                });
+              });
+            });",
+            None,
+        ),
     ];
 
     let fail = vec![


### PR DESCRIPTION
closes #11934