### PR TITLE
fix(linter/prefer-dom-node-remove): panic when callee is ts non null expression

### DIFF
--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -399,7 +399,7 @@ pub fn is_new_expression<'a>(
 pub fn call_expr_method_callee_info<'a>(
     call_expr: &'a CallExpression<'a>,
 ) -> Option<(Span, &'a str)> {
-    let member_expr = call_expr.callee.without_parentheses().as_member_expression()?;
+    let member_expr = call_expr.callee.get_inner_expression().as_member_expression()?;
     member_expr.static_property_info()
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_remove.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_remove.rs
@@ -187,6 +187,7 @@ fn test() {
         r"a.b?.c.parentNode.removeChild(foo)",
         r"a[b?.c].parentNode.removeChild(foo)",
         r"a?.b.parentNode.removeChild(a.b)",
+        r"a.removeChild!(k)",
     ];
 
     Tester::new(PreferDomNodeRemove::NAME, PreferDomNodeRemove::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_dom_node_remove.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_dom_node_remove.snap
@@ -294,3 +294,10 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ───────────
    ╰────
   help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+
+  ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
+   ╭─[prefer_dom_node_remove.tsx:1:3]
+ 1 │ a.removeChild!(k)
+   ·   ───────────
+   ╰────
+  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.


### PR DESCRIPTION
fixes #11948