### PR TITLE
fix(napi/parser): remove non-existent `parseAsyncRaw` and `parseSyncRaw` from type defs

### DIFF
--- a/napi/parser/index.d.ts
+++ b/napi/parser/index.d.ts
@@ -144,38 +144,6 @@ export declare const enum ImportNameKind {
  */
 export declare function parseAsync(filename: string, sourceText: string, options?: ParserOptions | undefined | null): Promise<ParseResult>
 
-/**
- * Parse AST into provided `Uint8Array` buffer, asynchronously.
- *
- * Note: This function can be slower than `parseSyncRaw` due to the overhead of spawning a thread.
- *
- * Source text must be written into the start of the buffer, and its length (in UTF-8 bytes)
- * provided as `source_len`.
- *
- * This function will parse the source, and write the AST into the buffer, starting at the end.
- *
- * It also writes to the very end of the buffer the offset of `Program` within the buffer.
- *
- * Caller can deserialize data from the buffer on JS side.
- *
- * # SAFETY
- *
- * Caller must ensure:
- * * Source text is written into start of the buffer.
- * * Source text's UTF-8 byte length is `source_len`.
- * * The 1st `source_len` bytes of the buffer comprises a valid UTF-8 string.
- * * Contents of buffer must not be mutated by caller until the `AsyncTask` returned by this
- *   function resolves.
- *
- * If source text is originally a JS string on JS side, and converted to a buffer with
- * `Buffer.from(str)` or `new TextEncoder().encode(str)`, this guarantees it's valid UTF-8.
- *
- * # Panics
- *
- * Panics if source text is too long, or AST takes more memory than is available in the buffer.
- */
-export declare function parseAsyncRaw(filename: string, buffer: Uint8Array, sourceLen: number, options?: ParserOptions | undefined | null): Promise<unknown>
-
 export interface ParserOptions {
   /** Treat the source text as `js`, `jsx`, `ts`, or `tsx`. */
   lang?: 'js' | 'jsx' | 'ts' | 'tsx'
@@ -219,34 +187,6 @@ export interface ParserOptions {
 
 /** Parse synchronously. */
 export declare function parseSync(filename: string, sourceText: string, options?: ParserOptions | undefined | null): ParseResult
-
-/**
- * Parse AST into provided `Uint8Array` buffer, synchronously.
- *
- * Source text must be written into the start of the buffer, and its length (in UTF-8 bytes)
- * provided as `source_len`.
- *
- * This function will parse the source, and write the AST into the buffer, starting at the end.
- *
- * It also writes to the very end of the buffer the offset of `Program` within the buffer.
- *
- * Caller can deserialize data from the buffer on JS side.
- *
- * # SAFETY
- *
- * Caller must ensure:
- * * Source text is written into start of the buffer.
- * * Source text's UTF-8 byte length is `source_len`.
- * * The 1st `source_len` bytes of the buffer comprises a valid UTF-8 string.
- *
- * If source text is originally a JS string on JS side, and converted to a buffer with
- * `Buffer.from(str)` or `new TextEncoder().encode(str)`, this guarantees it's valid UTF-8.
- *
- * # Panics
- *
- * Panics if source text is too long, or AST takes more memory than is available in the buffer.
- */
-export declare function parseSyncRaw(filename: string, buffer: Uint8Array, sourceLen: number, options?: ParserOptions | undefined | null): void
 
 /** Returns `true` if raw transfer is supported on this platform. */
 export declare function rawTransferSupported(): boolean


### PR DESCRIPTION
fixes #11950

Neither of these function are exposed by `parser/index.js`, so they shouldn't exist in the `index.d.ts` ts declaration file.