### PR TITLE
chore(infra): remove unnecessary `'Check Char and Byte Offset'`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,16 +205,6 @@ jobs:
           components: clippy
       - run: cargo lint -- -D warnings
       - run: cargo lint --profile dev-no-debug-assertions -- -D warnings
-      # Waiting for https://github.com/rust-lang/rust-clippy/pull/13435
-      - name: Check Char and Byte Offset
-        run: |
-          npm i @ast-grep/cli -g
-          output=$(sg -p '$A.chars().enumerate()' -r '$A.char_indices()' -l rs)
-          echo "Output: $output"
-          if [ -n "$output" ]; then
-            echo "Error: Unexpected output detected"
-            exit 1
-          fi
 
   doc:
     name: Doc


### PR DESCRIPTION
Related to https://github.com/oxc-project/oxc/issues/6071

The `char_indices_as_byte_indices` rule is officially supported in Rust 1.88.0 and is enabled by default under the `correctness` lint group. Ref https://rust-lang.github.io/rust-clippy/rust-1.88.0/index.html#char_indices_as_byte_indices