### PR TITLE
chore(napi/parser): remove undefined `module.exports`

### DIFF
--- a/napi/parser/index.js
+++ b/napi/parser/index.js
@@ -11,7 +11,6 @@ module.exports.ExportExportNameKind = bindings.ExportExportNameKind;
 module.exports.ExportImportNameKind = bindings.ExportImportNameKind;
 module.exports.ExportLocalNameKind = bindings.ExportLocalNameKind;
 module.exports.ImportNameKind = bindings.ImportNameKind;
-module.exports.parseWithoutReturn = bindings.parseWithoutReturn;
 module.exports.Severity = bindings.Severity;
 
 module.exports.parseSync = parseSync;


### PR DESCRIPTION
`parseWithoutReturn` doesn't exist anywhere, so attempting to assign it to modules.exports does nothing:

Logging the value of `import * as k from 'oxc-parser'`

```
node example.mjs test.ts
[Module: null prototype] {
  ExportExportNameKind: { Name: 'Name', Default: 'Default', None: 'None' },
  ExportImportNameKind: {
    Name: 'Name',
    All: 'All',
    AllButDefault: 'AllButDefault',
    None: 'None'
  },
  ExportLocalNameKind: { Name: 'Name', Default: 'Default', None: 'None' },
  ImportNameKind: {
    Name: 'Name',
    NamespaceObject: 'NamespaceObject',
    Default: 'Default'
  },
  ParseResult: [Function: ParseResult],
  Severity: { Error: 'Error', Warning: 'Warning', Advice: 'Advice' },
  default: {
    ParseResult: [Function: ParseResult],
    ExportExportNameKind: { Name: 'Name', Default: 'Default', None: 'None' },
    ExportImportNameKind: {
      Name: 'Name',
      All: 'All',
      AllButDefault: 'AllButDefault',
      None: 'None'
    },
    ExportLocalNameKind: { Name: 'Name', Default: 'Default', None: 'None' },
    ImportNameKind: {
      Name: 'Name',
      NamespaceObject: 'NamespaceObject',
      Default: 'Default'
    },
    parseWithoutReturn: undefined,
    Severity: { Error: 'Error', Warning: 'Warning', Advice: 'Advice' },
    parseSync: [Function: parseSync],
    parseAsync: [AsyncFunction: parseAsync],
    experimentalGetLazyVisitor: [Function: experimentalGetLazyVisitor],
    rawTransferSupported: [Function: rawTransferSupported]
  },
  experimentalGetLazyVisitor: [Function: experimentalGetLazyVisitor],
  parseAsync: [AsyncFunction: parseAsync],
  parseSync: [Function: parseSync],
  parseWithoutReturn: undefined,
  rawTransferSupported: [Function: rawTransferSupported]
}
```