### PR TITLE
refactor(linter): remove `RulesCache`

### DIFF
--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -510,7 +510,7 @@ impl Tester {
                         ConfigStoreBuilder::from_oxlintrc(true, Oxlintrc::deserialize(v).unwrap())
                             .unwrap()
                     })
-                    .with_plugins(self.plugins)
+                    .with_plugins(self.plugins.union(LintPlugins::from(self.plugin_name)))
                     .with_rule(rule, AllowWarnDeny::Warn)
                     .build(),
                 FxHashMap::default(),


### PR DESCRIPTION
Keeping `RulesCache` makes `ConfigStoreBuilder` wayy too complicated.
For now, we are going to remove it (ther may be a tiny perf hit, but in the majority of repos, this code is ony run once so should be ok.
Once custom JS plugins are complete, we can consider adding back in the cache