### PR TITLE
test(coverage/typescript): Update `9xxx`, `17xxx` error codes handling

### DIFF
--- a/tasks/coverage/snapshots/codegen_typescript.snap
+++ b/tasks/coverage/snapshots/codegen_typescript.snap
@@ -1,5 +1,5 @@
 commit: 81c95189
 
 codegen_typescript Summary:
-AST Parsed     : 6561/6561 (100.00%)
-Positive Passed: 6561/6561 (100.00%)
+AST Parsed     : 6576/6576 (100.00%)
+Positive Passed: 6576/6576 (100.00%)

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -1,8 +1,8 @@
 commit: 81c95189
 
 estree_typescript Summary:
-AST Parsed     : 6513/6513 (100.00%)
-Positive Passed: 6510/6513 (99.95%)
+AST Parsed     : 6528/6528 (100.00%)
+Positive Passed: 6525/6528 (99.95%)
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuite.tsx
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitEntities.tsx

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -1,9 +1,9 @@
 commit: 81c95189
 
 parser_typescript Summary:
-AST Parsed     : 6554/6561 (99.89%)
-Positive Passed: 6543/6561 (99.73%)
-Negative Passed: 1418/5737 (24.72%)
+AST Parsed     : 6569/6576 (99.89%)
+Positive Passed: 6558/6576 (99.73%)
+Negative Passed: 1418/5722 (24.78%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment8.ts
@@ -722,8 +722,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/computedProp
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesInDestructuring2_ES6.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesNarrowed.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/concatClassAndString.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conditionalAnyCheckTypePicksBothBranches.ts
@@ -1007,8 +1005,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationE
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInvalidReference2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInvalidReferenceAllowJs.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitIsolatedDeclarationErrorNotEmittedForNonEmittedFile.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitLambdaWithMissingTypeParameterNoCrash.ts
 
@@ -2328,31 +2324,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isLiteral1.t
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorTypes1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrors.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsAugmentation.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsClasses.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsClassesExpressions.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsDefault.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsEnums.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsExpandoFunctions.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsExpressions.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsFunctionDeclarations.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsObjects.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsReturnTypes.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationLazySymbols.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsAddUndefined.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsAddUndefined2.ts
 
@@ -2513,8 +2489,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxEmptyExpr
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxExcessPropsAndAssignability.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryAndReactNamespace.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryButNoJsxFragmentFactory.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryIdentifierWithAbsentParameter.ts
 
@@ -6549,10 +6523,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/dec
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsCrossfileMerge.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsDefaultsErr.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsExportAssignedConstructorFunctionWithSub.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypeReassignmentFromDeclaration2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/enumTag.ts
 

--- a/tasks/coverage/snapshots/transformer_typescript.snap
+++ b/tasks/coverage/snapshots/transformer_typescript.snap
@@ -1,8 +1,8 @@
 commit: 81c95189
 
 transformer_typescript Summary:
-AST Parsed     : 6561/6561 (100.00%)
-Positive Passed: 6557/6561 (99.94%)
+AST Parsed     : 6576/6576 (100.00%)
+Positive Passed: 6572/6576 (99.94%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/esDecoratorsClassFieldsCrash.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor2.ts

--- a/tasks/coverage/src/typescript/mod.rs
+++ b/tasks/coverage/src/typescript/mod.rs
@@ -131,9 +131,34 @@ impl Case for TypeScriptCase {
     }
 }
 
+// spellchecker:off
 // TODO: Filter out more not-supported error codes here
 static NOT_SUPPORTED_ERROR_CODES: phf::Set<&'static str> = phf::phf_set![
     "2315",  // Type 'U' is not generic.
+    "9005", // Declaration emit for this file requires using private name 'Sub'. An explicit type annotation may unblock declaration emit.
+    "9006", // DeclaDeclaration emit for this file requires using private name 'Item' from module '"some-mod"'. An explicit type annotation may unblock declaration emit.
+    "9007", // FunctDeclaion must have an explicit return type annotation with --isolatedDeclarations.
+    "9008", // MethoDeclad must have an explicit return type annotation with --isolatedDeclarations.
+    "9009", // At leDeclaast one accessor must have an explicit type annotation with --isolatedDeclarations.
+    "9010", // VariaDeclable must have an explicit type annotation with --isolatedDeclarations.
+    "9011", // ParamDeclaeter must have an explicit type annotation with --isolatedDeclarations.
+    "9012", // PropeDeclarty must have an explicit type annotation with --isolatedDeclarations.
+    "9013", // ExpreDeclassion type can't be inferred with --isolatedDeclarations.
+    "9015", // ObjecDeclats that contain spread assignments can't be inferred with --isolatedDeclarations.
+    "9016", // ObjecDeclats that contain shorthand properties can't be inferred with --isolatedDeclarations.
+    "9017", // Only Declaconst arrays can be inferred with --isolatedDeclarations.
+    "9018", // ArrayDeclas with spread elements can't inferred with --isolatedDeclarations.
+    "9019", // BindiDeclang elements can't be exported directly with --isolatedDeclarations.
+    "9020", // Enum Declamember initializers must be computable without references to external symbols with --isolatedDeclarations.
+    "9021", // ExtenDeclads clause can't contain an expression with --isolatedDeclarations.
+    "9022", // InferDeclaence from class expressions is not supported with --isolatedDeclarations.
+    "9023", // AssigDeclaning properties to functions without declaring them is not supported with --isolatedDeclarations. Add an explicit declaration for the properties assigned to this function.
+    "9026", // DeclaDeclaration emit for this file requires preserving this import for augmentations. This is not supported with --isolatedDeclarations.
+    "9037", // DefauDeclalt exports can't be inferred with --isolatedDeclarations.
+    "9038", // CompuDeclated property names on class or object literals cannot be inferred with --isolatedDeclarations.
+    "17004", // Cannot use JSX unless the '--jsx' flag is provided.
+    "17016", // The 'jsxFragmentFactory' compiler option must be provided to use JSX fragments with the 'jsxFactory' compiler option.
+    "17017", // An @jsxFrag pragma is required when using an @jsx pragma with JSX fragments.
     "18028", // Private identifiers are only available when targeting ECMAScript 2015 and higher.
     "18033", // Type 'Number' is not assignable to type 'number' as required for computed enum member values.
     "18035", // Invalid value for 'jsxFragmentFactory'. '234' is not a valid identifier or qualified-name.
@@ -147,3 +172,4 @@ static NOT_SUPPORTED_ERROR_CODES: phf::Set<&'static str> = phf::phf_set![
     "18055", // 'A.a' has a string type, but must have syntactically recognizable string syntax when 'isolatedModules' is enabled.
     "18057", // String literal import and export names are not supported when the '--module' flag is set to 'es2015' or 'es2020'.
 ];
+// spellchecker:on


### PR DESCRIPTION
Part of #11582