### PR TITLE
feat(linter): init import plugin settings

### DIFF
--- a/apps/oxlint/src/snapshots/_-A all --print-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-A all --print-config@oxlint.snap
@@ -14,6 +14,12 @@ working directory:
   "categories": {},
   "rules": {},
   "settings": {
+    "import": {
+      "external-module-folders": [
+        "node_modules"
+      ],
+      "internal-regex": ""
+    },
     "jsx-a11y": {
       "polymorphicPropName": null,
       "components": {}

--- a/apps/oxlint/src/snapshots/_-c fixtures__print_config__ban_rules__eslintrc.json -A all -D eqeqeq --print-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__print_config__ban_rules__eslintrc.json -A all -D eqeqeq --print-config@oxlint.snap
@@ -21,6 +21,12 @@ working directory:
     ]
   },
   "settings": {
+    "import": {
+      "external-module-folders": [
+        "node_modules"
+      ],
+      "internal-regex": ""
+    },
     "jsx-a11y": {
       "polymorphicPropName": null,
       "components": {}

--- a/crates/oxc_linter/src/config/settings/import.rs
+++ b/crates/oxc_linter/src/config/settings/import.rs
@@ -1,0 +1,70 @@
+use lazy_regex::Regex;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// See: [settings](https://github.com/import-js/eslint-plugin-import/blob/main/README.md#settings)
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct ImportPluginSettings {
+    /// An array of folders. Resolved modules only from those folders will be considered as "external".
+    ///
+    /// See: [import/external-module-folders](https://github.com/import-js/eslint-plugin-import/blob/main/README.md#importexternal-module-folders)
+    #[serde(default = "default_external_module_folders", rename = "external-module-folders")]
+    external_module_folders: Vec<String>,
+
+    /// A regex for packages should be treated as internal.
+    /// Useful when you are utilizing a monorepo setup or developing a set of packages that depend on each other.
+    ///
+    /// See: [import/internal-regex](https://github.com/import-js/eslint-plugin-import/blob/main/README.md#importinternal-regex)
+    ///
+    /// Example:
+    ///
+    /// ```json
+    /// {
+    ///   "settings": {
+    ///     "import": {
+    ///       "internal-regex": "^@scope/"
+    ///     }
+    ///   }
+    /// }
+    /// ```
+    #[serde(default, rename = "internal-regex")]
+    internal_regex: String,
+}
+
+impl Default for ImportPluginSettings {
+    fn default() -> Self {
+        Self {
+            external_module_folders: default_external_module_folders(),
+            internal_regex: Default::default(),
+        }
+    }
+}
+
+impl ImportPluginSettings {
+    pub fn get_external_module_folders(&self) -> Vec<String> {
+        self.external_module_folders.clone()
+    }
+
+    pub fn get_internal_regex(&self) -> Regex {
+        Regex::new(&self.internal_regex).unwrap()
+    }
+}
+
+fn default_external_module_folders() -> Vec<String> {
+    vec!["node_modules".to_string()]
+}
+
+#[cfg(test)]
+mod test {
+    use serde::Deserialize;
+
+    use super::ImportPluginSettings;
+
+    #[test]
+    fn parse_defaults() {
+        let settings = ImportPluginSettings::deserialize(serde_json::json!({})).unwrap();
+        assert!(settings.get_internal_regex().as_str().is_empty());
+        assert_eq!(settings.get_external_module_folders(), ["node_modules"]);
+    }
+}

--- a/crates/oxc_linter/src/config/settings/import.rs
+++ b/crates/oxc_linter/src/config/settings/import.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 /// See: [settings](https://github.com/import-js/eslint-plugin-import/blob/main/README.md#settings)
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct ImportPluginSettings {
     /// An array of folders. Resolved modules only from those folders will be considered as "external".
     ///
@@ -36,7 +36,7 @@ impl Default for ImportPluginSettings {
     fn default() -> Self {
         Self {
             external_module_folders: default_external_module_folders(),
-            internal_regex: Default::default(),
+            internal_regex: String::default(),
         }
     }
 }

--- a/crates/oxc_linter/src/config/settings/mod.rs
+++ b/crates/oxc_linter/src/config/settings/mod.rs
@@ -1,3 +1,4 @@
+mod import;
 pub mod jsdoc;
 mod jsx_a11y;
 mod next;
@@ -7,8 +8,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use self::{
-    jsdoc::JSDocPluginSettings, jsx_a11y::JSXA11yPluginSettings, next::NextPluginSettings,
-    react::ReactPluginSettings,
+    import::ImportPluginSettings, jsdoc::JSDocPluginSettings, jsx_a11y::JSXA11yPluginSettings,
+    next::NextPluginSettings, react::ReactPluginSettings,
 };
 
 /// # Oxlint Plugin Settings
@@ -40,6 +41,9 @@ use self::{
 #[derive(Debug, Clone, Deserialize, Serialize, Default, JsonSchema)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct OxlintSettings {
+    #[serde(default)]
+    pub import: ImportPluginSettings,
+
     #[serde(default)]
     #[serde(rename = "jsx-a11y")]
     pub jsx_a11y: JSXA11yPluginSettings,

--- a/crates/oxc_linter/src/snapshots/schema_json.snap
+++ b/crates/oxc_linter/src/snapshots/schema_json.snap
@@ -81,6 +81,12 @@ expression: json
     },
     "settings": {
       "default": {
+        "import": {
+          "external-module-folders": [
+            "node_modules"
+          ],
+          "internal-regex": ""
+        },
         "jsx-a11y": {
           "polymorphicPropName": null,
           "components": {}
@@ -204,6 +210,27 @@ expression: json
         "writeable",
         "off"
       ]
+    },
+    "ImportPluginSettings": {
+      "description": "See: [settings](https://github.com/import-js/eslint-plugin-import/blob/main/README.md#settings)",
+      "type": "object",
+      "properties": {
+        "external-module-folders": {
+          "description": "An array of folders. Resolved modules only from those folders will be considered as \"external\".\n\nSee: [import/external-module-folders](https://github.com/import-js/eslint-plugin-import/blob/main/README.md#importexternal-module-folders)",
+          "default": [
+            "node_modules"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "internal-regex": {
+          "description": "A regex for packages should be treated as internal.\nUseful when you are utilizing a monorepo setup or developing a set of packages that depend on each other.\n\nSee: [import/internal-regex](https://github.com/import-js/eslint-plugin-import/blob/main/README.md#importinternal-regex)\n\nExample:\n\n```json\n{\n\"settings\": {\n\"import\": {\n\"internal-regex\": \"^@scope/\"\n}\n}\n}\n```",
+          "default": "",
+          "type": "string"
+        }
+      }
     },
     "JSDocPluginSettings": {
       "type": "object",
@@ -445,6 +472,19 @@ expression: json
       "description": "Configure the behavior of linter plugins.\n\nHere's an example if you're using Next.js in a monorepo:\n\n```json\n{\n\"settings\": {\n\"next\": {\n\"rootDir\": \"apps/dashboard/\"\n},\n\"react\": {\n\"linkComponents\": [\n{ \"name\": \"Link\", \"linkAttribute\": \"to\" }\n]\n},\n\"jsx-a11y\": {\n\"components\": {\n\"Link\": \"a\",\n\"Button\": \"button\"\n}\n}\n}\n}\n```",
       "type": "object",
       "properties": {
+        "import": {
+          "default": {
+            "external-module-folders": [
+              "node_modules"
+            ],
+            "internal-regex": ""
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/ImportPluginSettings"
+            }
+          ]
+        },
         "jsdoc": {
           "default": {
             "ignorePrivate": false,

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -77,6 +77,12 @@
     },
     "settings": {
       "default": {
+        "import": {
+          "external-module-folders": [
+            "node_modules"
+          ],
+          "internal-regex": ""
+        },
         "jsx-a11y": {
           "polymorphicPropName": null,
           "components": {}
@@ -200,6 +206,27 @@
         "writeable",
         "off"
       ]
+    },
+    "ImportPluginSettings": {
+      "description": "See: [settings](https://github.com/import-js/eslint-plugin-import/blob/main/README.md#settings)",
+      "type": "object",
+      "properties": {
+        "external-module-folders": {
+          "description": "An array of folders. Resolved modules only from those folders will be considered as \"external\".\n\nSee: [import/external-module-folders](https://github.com/import-js/eslint-plugin-import/blob/main/README.md#importexternal-module-folders)",
+          "default": [
+            "node_modules"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "internal-regex": {
+          "description": "A regex for packages should be treated as internal.\nUseful when you are utilizing a monorepo setup or developing a set of packages that depend on each other.\n\nSee: [import/internal-regex](https://github.com/import-js/eslint-plugin-import/blob/main/README.md#importinternal-regex)\n\nExample:\n\n```json\n{\n\"settings\": {\n\"import\": {\n\"internal-regex\": \"^@scope/\"\n}\n}\n}\n```",
+          "default": "",
+          "type": "string"
+        }
+      }
     },
     "JSDocPluginSettings": {
       "type": "object",
@@ -441,6 +468,19 @@
       "description": "Configure the behavior of linter plugins.\n\nHere's an example if you're using Next.js in a monorepo:\n\n```json\n{\n\"settings\": {\n\"next\": {\n\"rootDir\": \"apps/dashboard/\"\n},\n\"react\": {\n\"linkComponents\": [\n{ \"name\": \"Link\", \"linkAttribute\": \"to\" }\n]\n},\n\"jsx-a11y\": {\n\"components\": {\n\"Link\": \"a\",\n\"Button\": \"button\"\n}\n}\n}\n}\n```",
       "type": "object",
       "properties": {
+        "import": {
+          "default": {
+            "external-module-folders": [
+              "node_modules"
+            ],
+            "internal-regex": ""
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/ImportPluginSettings"
+            }
+          ]
+        },
         "jsdoc": {
           "default": {
             "ignorePrivate": false,

--- a/tasks/website/src/linter/snapshots/schema_markdown.snap
+++ b/tasks/website/src/linter/snapshots/schema_markdown.snap
@@ -267,6 +267,49 @@ Here's an example if you're using Next.js in a monorepo:
 ```
 
 
+### settings.import
+
+type: `object`
+
+
+See: [settings](https://github.com/import-js/eslint-plugin-import/blob/main/README.md#settings)
+
+
+#### settings.import.external-module-folders
+
+type: `string[]`
+
+default: `["node_modules"]`
+
+An array of folders. Resolved modules only from those folders will be considered as "external".
+
+See: [import/external-module-folders](https://github.com/import-js/eslint-plugin-import/blob/main/README.md#importexternal-module-folders)
+
+
+#### settings.import.internal-regex
+
+type: `string`
+
+default: `""`
+
+A regex for packages should be treated as internal.
+Useful when you are utilizing a monorepo setup or developing a set of packages that depend on each other.
+
+See: [import/internal-regex](https://github.com/import-js/eslint-plugin-import/blob/main/README.md#importinternal-regex)
+
+Example:
+
+```json
+{
+"settings": {
+"import": {
+"internal-regex": "^@scope/"
+}
+}
+}
+```
+
+
 ### settings.jsdoc
 
 type: `object`


### PR DESCRIPTION
Added import plugin settings with "external-module-folders" and "internal-regex" options.

Refs: #1117, #7903