### PR TITLE
feat(linter): allow namespace re-export in `import/no-cycle`

### DIFF
--- a/crates/oxc_linter/src/module_record.rs
+++ b/crates/oxc_linter/src/module_record.rs
@@ -385,6 +385,11 @@ impl ExportExportName {
         matches!(self, Self::Null)
     }
 
+    /// Returns `true` if this is [`ExportExportName::Name`].
+    pub fn is_name(&self) -> bool {
+        matches!(self, Self::Name(_))
+    }
+
     /// Attempt to get the [`Span`] of this export name.
     pub fn span(&self) -> Option<Span> {
         match self {

--- a/crates/oxc_linter/src/snapshots/import_no_cycle.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_cycle.snap
@@ -279,3 +279,11 @@ source: crates/oxc_linter/src/tester.rs
   help: These paths form a cycle:
         -> ./typescript/ts-types-re-exporting-type - fixtures/import/cycles/typescript/ts-types-re-exporting-type.ts
         -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+
+  ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
+   ╭─[cycles/depth-zero.js:1:41]
+ 1 │ export function Foo() {}; export * from './depth-zero'
+   ·                                         ──────────────
+   ╰────
+  help: These paths form a cycle:
+        -> ./depth-zero - fixtures/import/cycles/depth-zero.js


### PR DESCRIPTION
Re-exporting as a namespace has no workarounds so should be allowed:

In test.js:
```js
export function Foo() {}
export * as Example from './test.js';
```

But, re-exporting it-self should be disallowed:

```js
export function Foo() {}
export * from './test.js';
```

fixes #11646
closes #11671