### PR TITLE
feat(parser): report duplicate `private` / `protected` / `public` modifier

### DIFF
--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -460,7 +460,14 @@ impl<'a> ParserImpl<'a> {
     }
 
     fn check_for_duplicate_modifiers(&mut self, seen_flags: ModifierFlags, modifier: &Modifier) {
-        if seen_flags.contains(modifier.kind.into()) {
+        if seen_flags.contains(modifier.kind.into())
+            || (matches!(
+                modifier.kind,
+                ModifierKind::Public | ModifierKind::Protected | ModifierKind::Private
+            ) && seen_flags.intersects(
+                ModifierFlags::PUBLIC | ModifierFlags::PROTECTED | ModifierFlags::PRIVATE,
+            ))
+        {
             self.error(diagnostics::modifier_already_seen(modifier));
         }
     }

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -12121,6 +12121,51 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Remove the duplicate modifier.
 
+  × TS(1030): 'public' modifier already seen.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/duplicates-accessibility/input.ts:3:11]
+ 2 │   public public a;
+ 3 │   private public b;
+   ·           ──────
+ 4 │   protected private c;
+   ╰────
+  help: Remove the duplicate modifier.
+
+  × TS(1030): 'private' modifier already seen.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/duplicates-accessibility/input.ts:4:13]
+ 3 │   private public b;
+ 4 │   protected private c;
+   ·             ───────
+ 5 │   public protected d;
+   ╰────
+  help: Remove the duplicate modifier.
+
+  × TS(1030): 'protected' modifier already seen.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/duplicates-accessibility/input.ts:5:10]
+ 4 │   protected private c;
+ 5 │   public protected d;
+   ·          ─────────
+ 6 │   public protected private e;
+   ╰────
+  help: Remove the duplicate modifier.
+
+  × TS(1030): 'protected' modifier already seen.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/duplicates-accessibility/input.ts:6:10]
+ 5 │   public protected d;
+ 6 │   public protected private e;
+   ·          ─────────
+ 7 │ }
+   ╰────
+  help: Remove the duplicate modifier.
+
+  × TS(1030): 'private' modifier already seen.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/duplicates-accessibility/input.ts:6:20]
+ 5 │   public protected d;
+ 6 │   public protected private e;
+   ·                    ───────
+ 7 │ }
+   ╰────
+  help: Remove the duplicate modifier.
+
   × TS(1098): Type parameter list cannot be empty.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/empty-type-parameters/input.ts:1:8]
  1 │ class C<> {}

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: 81c95189
 parser_typescript Summary:
 AST Parsed     : 6569/6576 (99.89%)
 Positive Passed: 6558/6576 (99.73%)
-Negative Passed: 1418/5722 (24.78%)
+Negative Passed: 1422/5722 (24.85%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment8.ts
@@ -799,8 +799,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constraintEr
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constraintWithIndexedAccess.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constraints0.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constructorArgsErrors4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constructorAsType.ts
 
@@ -7134,8 +7132,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration4.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration7.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration3.d.ts
@@ -7284,11 +7280,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected4.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected7.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RealWorld/parserindenter.ts
 
@@ -11155,6 +11147,15 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  1 │ class foo {
  2 │     constructor (public public a: number) {
    ·                         ──────
+ 3 │     }
+   ╰────
+  help: Remove the duplicate modifier.
+
+  × TS(1030): 'public' modifier already seen.
+   ╭─[typescript/tests/cases/compiler/constructorArgsErrors4.ts:2:26]
+ 1 │ class foo {
+ 2 │     constructor (private public a: number) {
+   ·                          ──────
  3 │     }
    ╰────
   help: Remove the duplicate modifier.
@@ -20484,6 +20485,42 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╰────
 
   × TS(1030): 'public' modifier already seen.
+    ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessibilityModifiers.ts:39:13]
+ 38 │ class E {
+ 39 │     private public protected property;
+    ·             ──────
+ 40 │     public protected method() { }
+    ╰────
+  help: Remove the duplicate modifier.
+
+  × TS(1030): 'protected' modifier already seen.
+    ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessibilityModifiers.ts:39:20]
+ 38 │ class E {
+ 39 │     private public protected property;
+    ·                    ─────────
+ 40 │     public protected method() { }
+    ╰────
+  help: Remove the duplicate modifier.
+
+  × TS(1030): 'protected' modifier already seen.
+    ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessibilityModifiers.ts:40:12]
+ 39 │     private public protected property;
+ 40 │     public protected method() { }
+    ·            ─────────
+ 41 │     private protected get getter() { return 0; }
+    ╰────
+  help: Remove the duplicate modifier.
+
+  × TS(1030): 'protected' modifier already seen.
+    ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessibilityModifiers.ts:41:13]
+ 40 │     public protected method() { }
+ 41 │     private protected get getter() { return 0; }
+    ·             ─────────
+ 42 │     public public set setter(a: number) { }
+    ╰────
+  help: Remove the duplicate modifier.
+
+  × TS(1030): 'public' modifier already seen.
     ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessibilityModifiers.ts:42:12]
  41 │     private protected get getter() { return 0; }
  42 │     public public set setter(a: number) { }
@@ -26554,6 +26591,15 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╰────
   help: Remove the duplicate modifier.
 
+  × TS(1030): 'private' modifier already seen.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration7.ts:2:10]
+ 1 │ class C {
+ 2 │   public private constructor() { }
+   ·          ───────
+ 3 │ }
+   ╰────
+  help: Remove the duplicate modifier.
+
   × Expected `(` but found `;`
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration8.ts:3:21]
  2 │   // Not a constructor
@@ -27831,6 +27877,24 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    · ─────────
  2 │ }
    ╰────
+
+  × TS(1030): 'public' modifier already seen.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected4.ts:2:13]
+ 1 │ class C {
+ 2 │   protected public m() { }
+   ·             ──────
+ 3 │ }
+   ╰────
+  help: Remove the duplicate modifier.
+
+  × TS(1030): 'private' modifier already seen.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected7.ts:2:13]
+ 1 │ class C {
+ 2 │   protected private m() { }
+   ·             ───────
+ 3 │ }
+   ╰────
+  help: Remove the duplicate modifier.
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
       ╭─[typescript/tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts:1430:16]


### PR DESCRIPTION
closes #11712