### PR TITLE
fix(linter): panic in `consistent-type-imports` when the source contains a `{`

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -793,7 +793,8 @@ fn fix_insert_type_specifier_for_import_declaration<'a>(
 ) -> FixerResult<RuleFix<'a>> {
     let FixOptions { fixer, import_decl, ctx, .. } = options;
     let fixer = fixer.for_multifix();
-    let import_source = ctx.source_range(import_decl.span);
+    let import_specifiers_span = Span::new(import_decl.span.start, import_decl.source.span.start);
+    let import_source = ctx.source_range(import_specifiers_span);
     let mut rule_fixes = fixer.new_fix_with_capacity(1);
 
     // "import { Foo, Bar } from 'foo'" => "import type { Foo, Bar } from 'foo'"
@@ -3390,6 +3391,11 @@ export class Foo extends Bar {}
             const c = defineParallelPlugin()
             ",
             None,
+        ),
+        (
+            "\nimport Foo from'{'; type k = Foo",
+            "\nimport type Foo from'{'; type k = Foo",
+            Some(serde_json::json!([{ "prefer": "type-imports" }])),
         ),
     ];
 


### PR DESCRIPTION
fixes  #11993