### PR TITLE
refactor(ast/estree): simplify adding `range` field

### DIFF
--- a/crates/oxc_ast/src/serialize/jsx.rs
+++ b/crates/oxc_ast/src/serialize/jsx.rs
@@ -33,10 +33,7 @@ impl ESTree for JSXElementOpeningElement<'_, '_> {
         state.serialize_field("attributes", &opening_element.attributes);
         state.serialize_field("selfClosing", &element.closing_element.is_none());
         if ranges {
-            state.serialize_field(
-                "range",
-                &[&opening_element.span.start, &opening_element.span.end],
-            );
+            state.serialize_field("range", &[opening_element.span.start, opening_element.span.end]);
         }
         state.end();
     }

--- a/crates/oxc_ast/src/serialize/literal.rs
+++ b/crates/oxc_ast/src/serialize/literal.rs
@@ -223,9 +223,11 @@ impl ESTree for TemplateElementConverter<'_, '_> {
 
         state.serialize_field("value", &TemplateElementValue(element));
         state.serialize_field("tail", &element.tail);
+
         if ranges {
-            state.serialize_field("range", &[&span.start, &span.end]);
+            state.serialize_field("range", &[span.start, span.end]);
         }
+
         state.end();
     }
 }

--- a/crates/oxc_ast/src/serialize/ts.rs
+++ b/crates/oxc_ast/src/serialize/ts.rs
@@ -187,9 +187,11 @@ impl ESTree for TSModuleDeclarationIdParts<'_, '_> {
         }
 
         state.serialize_field("right", last);
+
         if ranges {
-            state.serialize_field("range", &[&span_start, &last.span.end]);
+            state.serialize_field("range", &[span_start, last.span.end]);
         }
+
         state.end();
     }
 }
@@ -339,12 +341,13 @@ struct TSTypeNameAsMemberExpression<'a, 'b>(&'b TSTypeName<'a>);
 
 impl ESTree for TSTypeNameAsMemberExpression<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         match self.0 {
             TSTypeName::IdentifierReference(ident) => {
                 TSTypeNameIdentifierReference(ident).serialize(serializer);
             }
             TSTypeName::QualifiedName(name) => {
+                let ranges = serializer.ranges();
+
                 // Convert to `TSQualifiedName` to `MemberExpression`.
                 // Recursively convert `left` to `MemberExpression` too if it's a `TSQualifiedName`.
                 let mut state = serializer.serialize_struct();
@@ -356,7 +359,7 @@ impl ESTree for TSTypeNameAsMemberExpression<'_, '_> {
                 state.serialize_field("optional", &false);
                 state.serialize_field("computed", &false);
                 if ranges {
-                    state.serialize_field("range", &[&name.span.start, &name.span.end]);
+                    state.serialize_field("range", &[name.span.start, name.span.end]);
                 }
                 state.end();
             }


### PR DESCRIPTION
Follow-on after #11890. Simplify adding `range` field to ESTree AST. Most changes are to serialize `range` as `&[u32; 2]` instead of `&[&u32; 2]`.