### PR TITLE
refactor(ast/estree): remove temp vars for `ranges` from serializer

### DIFF
--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -71,7 +71,6 @@ impl ESTree for Expression<'_> {
 
 impl ESTree for IdentifierName<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("start", &self.span.start);
@@ -80,7 +79,7 @@ impl ESTree for IdentifierName<'_> {
         state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -89,7 +88,6 @@ impl ESTree for IdentifierName<'_> {
 
 impl ESTree for IdentifierReference<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("start", &self.span.start);
@@ -98,7 +96,7 @@ impl ESTree for IdentifierReference<'_> {
         state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -107,7 +105,6 @@ impl ESTree for IdentifierReference<'_> {
 
 impl ESTree for BindingIdentifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("start", &self.span.start);
@@ -116,7 +113,7 @@ impl ESTree for BindingIdentifier<'_> {
         state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -125,7 +122,6 @@ impl ESTree for BindingIdentifier<'_> {
 
 impl ESTree for LabelIdentifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("start", &self.span.start);
@@ -134,7 +130,7 @@ impl ESTree for LabelIdentifier<'_> {
         state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -143,12 +139,11 @@ impl ESTree for LabelIdentifier<'_> {
 
 impl ESTree for ThisExpression {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ThisExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -157,13 +152,12 @@ impl ESTree for ThisExpression {
 
 impl ESTree for ArrayExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ArrayExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("elements", &self.elements);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -230,13 +224,12 @@ impl ESTree for Elision {
 
 impl ESTree for ObjectExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ObjectExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("properties", &self.properties);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -254,7 +247,6 @@ impl ESTree for ObjectPropertyKind<'_> {
 
 impl ESTree for ObjectProperty<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Property"));
         state.serialize_field("start", &self.span.start);
@@ -266,7 +258,7 @@ impl ESTree for ObjectProperty<'_> {
         state.serialize_field("shorthand", &self.shorthand);
         state.serialize_field("computed", &self.computed);
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -337,14 +329,13 @@ impl ESTree for PropertyKind {
 
 impl ESTree for TemplateLiteral<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TemplateLiteral"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("quasis", &self.quasis);
         state.serialize_field("expressions", &self.expressions);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -353,7 +344,6 @@ impl ESTree for TemplateLiteral<'_> {
 
 impl ESTree for TaggedTemplateExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TaggedTemplateExpression"));
         state.serialize_field("start", &self.span.start);
@@ -361,7 +351,7 @@ impl ESTree for TaggedTemplateExpression<'_> {
         state.serialize_field("tag", &self.tag);
         state.serialize_ts_field("typeArguments", &self.type_arguments);
         state.serialize_field("quasi", &self.quasi);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -395,7 +385,6 @@ impl ESTree for MemberExpression<'_> {
 
 impl ESTree for ComputedMemberExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("MemberExpression"));
         state.serialize_field("start", &self.span.start);
@@ -404,7 +393,7 @@ impl ESTree for ComputedMemberExpression<'_> {
         state.serialize_field("property", &self.expression);
         state.serialize_field("optional", &self.optional);
         state.serialize_field("computed", &crate::serialize::basic::True(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -413,7 +402,6 @@ impl ESTree for ComputedMemberExpression<'_> {
 
 impl ESTree for StaticMemberExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("MemberExpression"));
         state.serialize_field("start", &self.span.start);
@@ -422,7 +410,7 @@ impl ESTree for StaticMemberExpression<'_> {
         state.serialize_field("property", &self.property);
         state.serialize_field("optional", &self.optional);
         state.serialize_field("computed", &crate::serialize::basic::False(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -431,7 +419,6 @@ impl ESTree for StaticMemberExpression<'_> {
 
 impl ESTree for PrivateFieldExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("MemberExpression"));
         state.serialize_field("start", &self.span.start);
@@ -440,7 +427,7 @@ impl ESTree for PrivateFieldExpression<'_> {
         state.serialize_field("property", &self.field);
         state.serialize_field("optional", &self.optional);
         state.serialize_field("computed", &crate::serialize::basic::False(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -449,7 +436,6 @@ impl ESTree for PrivateFieldExpression<'_> {
 
 impl ESTree for CallExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("CallExpression"));
         state.serialize_field("start", &self.span.start);
@@ -458,7 +444,7 @@ impl ESTree for CallExpression<'_> {
         state.serialize_ts_field("typeArguments", &self.type_arguments);
         state.serialize_field("arguments", &self.arguments);
         state.serialize_field("optional", &self.optional);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -467,7 +453,6 @@ impl ESTree for CallExpression<'_> {
 
 impl ESTree for NewExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("NewExpression"));
         state.serialize_field("start", &self.span.start);
@@ -475,7 +460,7 @@ impl ESTree for NewExpression<'_> {
         state.serialize_field("callee", &self.callee);
         state.serialize_ts_field("typeArguments", &self.type_arguments);
         state.serialize_field("arguments", &self.arguments);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -484,14 +469,13 @@ impl ESTree for NewExpression<'_> {
 
 impl ESTree for MetaProperty<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("MetaProperty"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("meta", &self.meta);
         state.serialize_field("property", &self.property);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -500,13 +484,12 @@ impl ESTree for MetaProperty<'_> {
 
 impl ESTree for SpreadElement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("SpreadElement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("argument", &self.argument);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -566,7 +549,6 @@ impl ESTree for Argument<'_> {
 
 impl ESTree for UpdateExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("UpdateExpression"));
         state.serialize_field("start", &self.span.start);
@@ -574,7 +556,7 @@ impl ESTree for UpdateExpression<'_> {
         state.serialize_field("operator", &self.operator);
         state.serialize_field("prefix", &self.prefix);
         state.serialize_field("argument", &self.argument);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -583,7 +565,6 @@ impl ESTree for UpdateExpression<'_> {
 
 impl ESTree for UnaryExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("UnaryExpression"));
         state.serialize_field("start", &self.span.start);
@@ -591,7 +572,7 @@ impl ESTree for UnaryExpression<'_> {
         state.serialize_field("operator", &self.operator);
         state.serialize_field("argument", &self.argument);
         state.serialize_field("prefix", &crate::serialize::basic::True(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -600,7 +581,6 @@ impl ESTree for UnaryExpression<'_> {
 
 impl ESTree for BinaryExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("BinaryExpression"));
         state.serialize_field("start", &self.span.start);
@@ -608,7 +588,7 @@ impl ESTree for BinaryExpression<'_> {
         state.serialize_field("left", &self.left);
         state.serialize_field("operator", &self.operator);
         state.serialize_field("right", &self.right);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -617,7 +597,6 @@ impl ESTree for BinaryExpression<'_> {
 
 impl ESTree for PrivateInExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("BinaryExpression"));
         state.serialize_field("start", &self.span.start);
@@ -625,7 +604,7 @@ impl ESTree for PrivateInExpression<'_> {
         state.serialize_field("left", &self.left);
         state.serialize_field("operator", &crate::serialize::basic::In(self));
         state.serialize_field("right", &self.right);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -634,7 +613,6 @@ impl ESTree for PrivateInExpression<'_> {
 
 impl ESTree for LogicalExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("LogicalExpression"));
         state.serialize_field("start", &self.span.start);
@@ -642,7 +620,7 @@ impl ESTree for LogicalExpression<'_> {
         state.serialize_field("left", &self.left);
         state.serialize_field("operator", &self.operator);
         state.serialize_field("right", &self.right);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -651,7 +629,6 @@ impl ESTree for LogicalExpression<'_> {
 
 impl ESTree for ConditionalExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ConditionalExpression"));
         state.serialize_field("start", &self.span.start);
@@ -659,7 +636,7 @@ impl ESTree for ConditionalExpression<'_> {
         state.serialize_field("test", &self.test);
         state.serialize_field("consequent", &self.consequent);
         state.serialize_field("alternate", &self.alternate);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -668,7 +645,6 @@ impl ESTree for ConditionalExpression<'_> {
 
 impl ESTree for AssignmentExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("AssignmentExpression"));
         state.serialize_field("start", &self.span.start);
@@ -676,7 +652,7 @@ impl ESTree for AssignmentExpression<'_> {
         state.serialize_field("operator", &self.operator);
         state.serialize_field("left", &self.left);
         state.serialize_field("right", &self.right);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -726,7 +702,6 @@ impl ESTree for AssignmentTargetPattern<'_> {
 
 impl ESTree for ArrayAssignmentTarget<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ArrayPattern"));
         state.serialize_field("start", &self.span.start);
@@ -735,7 +710,7 @@ impl ESTree for ArrayAssignmentTarget<'_> {
         state.serialize_field("elements", &Concat2(&self.elements, &self.rest));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -744,7 +719,6 @@ impl ESTree for ArrayAssignmentTarget<'_> {
 
 impl ESTree for ObjectAssignmentTarget<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ObjectPattern"));
         state.serialize_field("start", &self.span.start);
@@ -753,7 +727,7 @@ impl ESTree for ObjectAssignmentTarget<'_> {
         state.serialize_field("properties", &Concat2(&self.properties, &self.rest));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -762,7 +736,6 @@ impl ESTree for ObjectAssignmentTarget<'_> {
 
 impl ESTree for AssignmentTargetRest<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("RestElement"));
         state.serialize_field("start", &self.span.start);
@@ -772,7 +745,7 @@ impl ESTree for AssignmentTargetRest<'_> {
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
         state.serialize_ts_field("value", &crate::serialize::basic::TsNull(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -799,7 +772,6 @@ impl ESTree for AssignmentTargetMaybeDefault<'_> {
 
 impl ESTree for AssignmentTargetWithDefault<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("AssignmentPattern"));
         state.serialize_field("start", &self.span.start);
@@ -809,7 +781,7 @@ impl ESTree for AssignmentTargetWithDefault<'_> {
         state.serialize_field("right", &self.init);
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -827,7 +799,6 @@ impl ESTree for AssignmentTargetProperty<'_> {
 
 impl ESTree for AssignmentTargetPropertyIdentifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Property"));
         state.serialize_field("start", &self.span.start);
@@ -842,7 +813,7 @@ impl ESTree for AssignmentTargetPropertyIdentifier<'_> {
         state.serialize_field("shorthand", &crate::serialize::basic::True(self));
         state.serialize_field("computed", &crate::serialize::basic::False(self));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -851,7 +822,6 @@ impl ESTree for AssignmentTargetPropertyIdentifier<'_> {
 
 impl ESTree for AssignmentTargetPropertyProperty<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Property"));
         state.serialize_field("start", &self.span.start);
@@ -863,7 +833,7 @@ impl ESTree for AssignmentTargetPropertyProperty<'_> {
         state.serialize_field("shorthand", &crate::serialize::basic::False(self));
         state.serialize_field("computed", &self.computed);
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -872,13 +842,12 @@ impl ESTree for AssignmentTargetPropertyProperty<'_> {
 
 impl ESTree for SequenceExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("SequenceExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expressions", &self.expressions);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -887,12 +856,11 @@ impl ESTree for SequenceExpression<'_> {
 
 impl ESTree for Super {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Super"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -901,13 +869,12 @@ impl ESTree for Super {
 
 impl ESTree for AwaitExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("AwaitExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("argument", &self.argument);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -916,13 +883,12 @@ impl ESTree for AwaitExpression<'_> {
 
 impl ESTree for ChainExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ChainExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -943,13 +909,12 @@ impl ESTree for ChainElement<'_> {
 
 impl ESTree for ParenthesizedExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ParenthesizedExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -997,14 +962,13 @@ impl ESTree for Statement<'_> {
 
 impl ESTree for Directive<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ExpressionStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
         state.serialize_field("directive", &self.directive);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1013,13 +977,12 @@ impl ESTree for Directive<'_> {
 
 impl ESTree for Hashbang<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Hashbang"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &self.value);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1028,13 +991,12 @@ impl ESTree for Hashbang<'_> {
 
 impl ESTree for BlockStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("BlockStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("body", &self.body);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1058,7 +1020,6 @@ impl ESTree for Declaration<'_> {
 
 impl ESTree for VariableDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("VariableDeclaration"));
         state.serialize_field("start", &self.span.start);
@@ -1066,7 +1027,7 @@ impl ESTree for VariableDeclaration<'_> {
         state.serialize_field("kind", &self.kind);
         state.serialize_field("declarations", &self.declarations);
         state.serialize_ts_field("declare", &self.declare);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1087,7 +1048,6 @@ impl ESTree for VariableDeclarationKind {
 
 impl ESTree for VariableDeclarator<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("VariableDeclarator"));
         state.serialize_field("start", &self.span.start);
@@ -1095,7 +1055,7 @@ impl ESTree for VariableDeclarator<'_> {
         state.serialize_field("id", &self.id);
         state.serialize_field("init", &self.init);
         state.serialize_ts_field("definite", &self.definite);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1104,12 +1064,11 @@ impl ESTree for VariableDeclarator<'_> {
 
 impl ESTree for EmptyStatement {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("EmptyStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1118,7 +1077,6 @@ impl ESTree for EmptyStatement {
 
 impl ESTree for ExpressionStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ExpressionStatement"));
         state.serialize_field("start", &self.span.start);
@@ -1128,7 +1086,7 @@ impl ESTree for ExpressionStatement<'_> {
             "directive",
             &crate::serialize::ts::ExpressionStatementDirective(self),
         );
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1137,7 +1095,6 @@ impl ESTree for ExpressionStatement<'_> {
 
 impl ESTree for IfStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("IfStatement"));
         state.serialize_field("start", &self.span.start);
@@ -1145,7 +1102,7 @@ impl ESTree for IfStatement<'_> {
         state.serialize_field("test", &self.test);
         state.serialize_field("consequent", &self.consequent);
         state.serialize_field("alternate", &self.alternate);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1154,14 +1111,13 @@ impl ESTree for IfStatement<'_> {
 
 impl ESTree for DoWhileStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("DoWhileStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("body", &self.body);
         state.serialize_field("test", &self.test);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1170,14 +1126,13 @@ impl ESTree for DoWhileStatement<'_> {
 
 impl ESTree for WhileStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("WhileStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("test", &self.test);
         state.serialize_field("body", &self.body);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1186,7 +1141,6 @@ impl ESTree for WhileStatement<'_> {
 
 impl ESTree for ForStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ForStatement"));
         state.serialize_field("start", &self.span.start);
@@ -1195,7 +1149,7 @@ impl ESTree for ForStatement<'_> {
         state.serialize_field("test", &self.test);
         state.serialize_field("update", &self.update);
         state.serialize_field("body", &self.body);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1255,7 +1209,6 @@ impl ESTree for ForStatementInit<'_> {
 
 impl ESTree for ForInStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ForInStatement"));
         state.serialize_field("start", &self.span.start);
@@ -1263,7 +1216,7 @@ impl ESTree for ForInStatement<'_> {
         state.serialize_field("left", &self.left);
         state.serialize_field("right", &self.right);
         state.serialize_field("body", &self.body);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1290,7 +1243,6 @@ impl ESTree for ForStatementLeft<'_> {
 
 impl ESTree for ForOfStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ForOfStatement"));
         state.serialize_field("start", &self.span.start);
@@ -1299,7 +1251,7 @@ impl ESTree for ForOfStatement<'_> {
         state.serialize_field("left", &self.left);
         state.serialize_field("right", &self.right);
         state.serialize_field("body", &self.body);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1308,13 +1260,12 @@ impl ESTree for ForOfStatement<'_> {
 
 impl ESTree for ContinueStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ContinueStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("label", &self.label);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1323,13 +1274,12 @@ impl ESTree for ContinueStatement<'_> {
 
 impl ESTree for BreakStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("BreakStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("label", &self.label);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1338,13 +1288,12 @@ impl ESTree for BreakStatement<'_> {
 
 impl ESTree for ReturnStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ReturnStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("argument", &self.argument);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1353,14 +1302,13 @@ impl ESTree for ReturnStatement<'_> {
 
 impl ESTree for WithStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("WithStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("object", &self.object);
         state.serialize_field("body", &self.body);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1369,14 +1317,13 @@ impl ESTree for WithStatement<'_> {
 
 impl ESTree for SwitchStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("SwitchStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("discriminant", &self.discriminant);
         state.serialize_field("cases", &self.cases);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1385,14 +1332,13 @@ impl ESTree for SwitchStatement<'_> {
 
 impl ESTree for SwitchCase<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("SwitchCase"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("test", &self.test);
         state.serialize_field("consequent", &self.consequent);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1401,14 +1347,13 @@ impl ESTree for SwitchCase<'_> {
 
 impl ESTree for LabeledStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("LabeledStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("label", &self.label);
         state.serialize_field("body", &self.body);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1417,13 +1362,12 @@ impl ESTree for LabeledStatement<'_> {
 
 impl ESTree for ThrowStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ThrowStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("argument", &self.argument);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1432,7 +1376,6 @@ impl ESTree for ThrowStatement<'_> {
 
 impl ESTree for TryStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TryStatement"));
         state.serialize_field("start", &self.span.start);
@@ -1440,7 +1383,7 @@ impl ESTree for TryStatement<'_> {
         state.serialize_field("block", &self.block);
         state.serialize_field("handler", &self.handler);
         state.serialize_field("finalizer", &self.finalizer);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1449,14 +1392,13 @@ impl ESTree for TryStatement<'_> {
 
 impl ESTree for CatchClause<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("CatchClause"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("param", &self.param);
         state.serialize_field("body", &self.body);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1471,12 +1413,11 @@ impl ESTree for CatchParameter<'_> {
 
 impl ESTree for DebuggerStatement {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("DebuggerStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1502,7 +1443,6 @@ impl ESTree for BindingPatternKind<'_> {
 
 impl ESTree for AssignmentPattern<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("AssignmentPattern"));
         state.serialize_field("start", &self.span.start);
@@ -1512,7 +1452,7 @@ impl ESTree for AssignmentPattern<'_> {
         state.serialize_field("right", &self.right);
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1521,7 +1461,6 @@ impl ESTree for AssignmentPattern<'_> {
 
 impl ESTree for ObjectPattern<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ObjectPattern"));
         state.serialize_field("start", &self.span.start);
@@ -1530,7 +1469,7 @@ impl ESTree for ObjectPattern<'_> {
         state.serialize_field("properties", &Concat2(&self.properties, &self.rest));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1539,7 +1478,6 @@ impl ESTree for ObjectPattern<'_> {
 
 impl ESTree for BindingProperty<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Property"));
         state.serialize_field("start", &self.span.start);
@@ -1551,7 +1489,7 @@ impl ESTree for BindingProperty<'_> {
         state.serialize_field("shorthand", &self.shorthand);
         state.serialize_field("computed", &self.computed);
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1560,7 +1498,6 @@ impl ESTree for BindingProperty<'_> {
 
 impl ESTree for ArrayPattern<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ArrayPattern"));
         state.serialize_field("start", &self.span.start);
@@ -1569,7 +1506,7 @@ impl ESTree for ArrayPattern<'_> {
         state.serialize_field("elements", &Concat2(&self.elements, &self.rest));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1578,7 +1515,6 @@ impl ESTree for ArrayPattern<'_> {
 
 impl ESTree for BindingRestElement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("RestElement"));
         state.serialize_field("start", &self.span.start);
@@ -1588,7 +1524,7 @@ impl ESTree for BindingRestElement<'_> {
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
         state.serialize_ts_field("value", &crate::serialize::basic::TsNull(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1597,7 +1533,6 @@ impl ESTree for BindingRestElement<'_> {
 
 impl ESTree for Function<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &self.r#type);
         state.serialize_field("start", &self.span.start);
@@ -1611,7 +1546,7 @@ impl ESTree for Function<'_> {
         state.serialize_ts_field("returnType", &self.return_type);
         state.serialize_field("body", &self.body);
         state.serialize_field("expression", &crate::serialize::basic::False(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1662,13 +1597,12 @@ impl ESTree for FormalParameterKind {
 
 impl ESTree for FunctionBody<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("BlockStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("body", &Concat2(&self.directives, &self.statements));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1677,7 +1611,6 @@ impl ESTree for FunctionBody<'_> {
 
 impl ESTree for ArrowFunctionExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ArrowFunctionExpression"));
         state.serialize_field("start", &self.span.start);
@@ -1690,7 +1623,7 @@ impl ESTree for ArrowFunctionExpression<'_> {
         state.serialize_field("body", &crate::serialize::js::ArrowFunctionExpressionBody(self));
         state.serialize_field("id", &crate::serialize::basic::Null(self));
         state.serialize_field("generator", &crate::serialize::basic::False(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1699,14 +1632,13 @@ impl ESTree for ArrowFunctionExpression<'_> {
 
 impl ESTree for YieldExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("YieldExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("delegate", &self.delegate);
         state.serialize_field("argument", &self.argument);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1715,7 +1647,6 @@ impl ESTree for YieldExpression<'_> {
 
 impl ESTree for Class<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &self.r#type);
         state.serialize_field("start", &self.span.start);
@@ -1729,7 +1660,7 @@ impl ESTree for Class<'_> {
         state.serialize_field("body", &self.body);
         state.serialize_ts_field("abstract", &self.r#abstract);
         state.serialize_ts_field("declare", &self.declare);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1747,13 +1678,12 @@ impl ESTree for ClassType {
 
 impl ESTree for ClassBody<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ClassBody"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("body", &self.body);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1774,7 +1704,6 @@ impl ESTree for ClassElement<'_> {
 
 impl ESTree for MethodDefinition<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &self.r#type);
         state.serialize_field("start", &self.span.start);
@@ -1788,7 +1717,7 @@ impl ESTree for MethodDefinition<'_> {
         state.serialize_ts_field("override", &self.r#override);
         state.serialize_ts_field("optional", &self.optional);
         state.serialize_ts_field("accessibility", &self.accessibility);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1808,7 +1737,6 @@ impl ESTree for MethodDefinitionType {
 
 impl ESTree for PropertyDefinition<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &self.r#type);
         state.serialize_field("start", &self.span.start);
@@ -1825,7 +1753,7 @@ impl ESTree for PropertyDefinition<'_> {
         state.serialize_ts_field("definite", &self.definite);
         state.serialize_ts_field("readonly", &self.readonly);
         state.serialize_ts_field("accessibility", &self.accessibility);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1856,13 +1784,12 @@ impl ESTree for MethodDefinitionKind {
 
 impl ESTree for PrivateIdentifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("PrivateIdentifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &self.name);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1871,13 +1798,12 @@ impl ESTree for PrivateIdentifier<'_> {
 
 impl ESTree for StaticBlock<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("StaticBlock"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("body", &self.body);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1910,7 +1836,6 @@ impl ESTree for AccessorPropertyType {
 
 impl ESTree for AccessorProperty<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &self.r#type);
         state.serialize_field("start", &self.span.start);
@@ -1927,7 +1852,7 @@ impl ESTree for AccessorProperty<'_> {
         state.serialize_ts_field("declare", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("readonly", &crate::serialize::basic::TsFalse(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1936,7 +1861,6 @@ impl ESTree for AccessorProperty<'_> {
 
 impl ESTree for ImportExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ImportExpression"));
         state.serialize_field("start", &self.span.start);
@@ -1944,7 +1868,7 @@ impl ESTree for ImportExpression<'_> {
         state.serialize_field("source", &self.source);
         state.serialize_field("options", &self.options);
         state.serialize_field("phase", &self.phase);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1953,7 +1877,6 @@ impl ESTree for ImportExpression<'_> {
 
 impl ESTree for ImportDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ImportDeclaration"));
         state.serialize_field("start", &self.span.start);
@@ -1969,7 +1892,7 @@ impl ESTree for ImportDeclaration<'_> {
             &crate::serialize::js::ImportDeclarationWithClause(self),
         );
         state.serialize_ts_field("importKind", &self.import_kind);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -1997,7 +1920,6 @@ impl ESTree for ImportDeclarationSpecifier<'_> {
 
 impl ESTree for ImportSpecifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ImportSpecifier"));
         state.serialize_field("start", &self.span.start);
@@ -2005,7 +1927,7 @@ impl ESTree for ImportSpecifier<'_> {
         state.serialize_field("imported", &self.imported);
         state.serialize_field("local", &self.local);
         state.serialize_ts_field("importKind", &self.import_kind);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2014,13 +1936,12 @@ impl ESTree for ImportSpecifier<'_> {
 
 impl ESTree for ImportDefaultSpecifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ImportDefaultSpecifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("local", &self.local);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2029,13 +1950,12 @@ impl ESTree for ImportDefaultSpecifier<'_> {
 
 impl ESTree for ImportNamespaceSpecifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ImportNamespaceSpecifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("local", &self.local);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2044,10 +1964,9 @@ impl ESTree for ImportNamespaceSpecifier<'_> {
 
 impl ESTree for WithClause<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("attributes", &self.with_entries);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2056,14 +1975,13 @@ impl ESTree for WithClause<'_> {
 
 impl ESTree for ImportAttribute<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ImportAttribute"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("key", &self.key);
         state.serialize_field("value", &self.value);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2081,7 +1999,6 @@ impl ESTree for ImportAttributeKey<'_> {
 
 impl ESTree for ExportNamedDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ExportNamedDeclaration"));
         state.serialize_field("start", &self.span.start);
@@ -2094,7 +2011,7 @@ impl ESTree for ExportNamedDeclaration<'_> {
             "attributes",
             &crate::serialize::js::ExportNamedDeclarationWithClause(self),
         );
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2103,14 +2020,13 @@ impl ESTree for ExportNamedDeclaration<'_> {
 
 impl ESTree for ExportDefaultDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ExportDefaultDeclaration"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("declaration", &self.declaration);
         state.serialize_ts_field("exportKind", &crate::serialize::basic::TsValue(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2119,7 +2035,6 @@ impl ESTree for ExportDefaultDeclaration<'_> {
 
 impl ESTree for ExportAllDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ExportAllDeclaration"));
         state.serialize_field("start", &self.span.start);
@@ -2131,7 +2046,7 @@ impl ESTree for ExportAllDeclaration<'_> {
             &crate::serialize::js::ExportAllDeclarationWithClause(self),
         );
         state.serialize_ts_field("exportKind", &self.export_kind);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2140,7 +2055,6 @@ impl ESTree for ExportAllDeclaration<'_> {
 
 impl ESTree for ExportSpecifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ExportSpecifier"));
         state.serialize_field("start", &self.span.start);
@@ -2148,7 +2062,7 @@ impl ESTree for ExportSpecifier<'_> {
         state.serialize_field("local", &self.local);
         state.serialize_field("exported", &self.exported);
         state.serialize_ts_field("exportKind", &self.export_kind);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2220,14 +2134,13 @@ impl ESTree for ModuleExportName<'_> {
 
 impl ESTree for V8IntrinsicExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("V8IntrinsicExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &self.name);
         state.serialize_field("arguments", &self.arguments);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2236,14 +2149,13 @@ impl ESTree for V8IntrinsicExpression<'_> {
 
 impl ESTree for BooleanLiteral {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Literal"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &self.value);
         state.serialize_field("raw", &crate::serialize::literal::BooleanLiteralRaw(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2252,14 +2164,13 @@ impl ESTree for BooleanLiteral {
 
 impl ESTree for NullLiteral {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Literal"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &crate::serialize::basic::Null(self));
         state.serialize_field("raw", &crate::serialize::literal::NullLiteralRaw(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2268,14 +2179,13 @@ impl ESTree for NullLiteral {
 
 impl ESTree for NumericLiteral<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Literal"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &self.value);
         state.serialize_field("raw", &self.raw.map(|s| JsonSafeString(s.as_str())));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2284,14 +2194,13 @@ impl ESTree for NumericLiteral<'_> {
 
 impl ESTree for StringLiteral<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Literal"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &crate::serialize::literal::StringLiteralValue(self));
         state.serialize_field("raw", &self.raw);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2300,7 +2209,6 @@ impl ESTree for StringLiteral<'_> {
 
 impl ESTree for BigIntLiteral<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Literal"));
         state.serialize_field("start", &self.span.start);
@@ -2308,7 +2216,7 @@ impl ESTree for BigIntLiteral<'_> {
         state.serialize_field("value", &crate::serialize::literal::BigIntLiteralValue(self));
         state.serialize_field("raw", &self.raw.map(|s| JsonSafeString(s.as_str())));
         state.serialize_field("bigint", &crate::serialize::literal::BigIntLiteralBigint(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2317,7 +2225,6 @@ impl ESTree for BigIntLiteral<'_> {
 
 impl ESTree for RegExpLiteral<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Literal"));
         state.serialize_field("start", &self.span.start);
@@ -2325,7 +2232,7 @@ impl ESTree for RegExpLiteral<'_> {
         state.serialize_field("value", &crate::serialize::literal::RegExpLiteralValue(self));
         state.serialize_field("raw", &self.raw);
         state.serialize_field("regex", &self.regex);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2357,7 +2264,6 @@ impl ESTree for RegExpFlags {
 
 impl ESTree for JSXElement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXElement"));
         state.serialize_field("start", &self.span.start);
@@ -2368,7 +2274,7 @@ impl ESTree for JSXElement<'_> {
         );
         state.serialize_field("children", &self.children);
         state.serialize_field("closingElement", &self.closing_element);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2377,7 +2283,6 @@ impl ESTree for JSXElement<'_> {
 
 impl ESTree for JSXOpeningElement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXOpeningElement"));
         state.serialize_field("start", &self.span.start);
@@ -2389,7 +2294,7 @@ impl ESTree for JSXOpeningElement<'_> {
             "selfClosing",
             &crate::serialize::jsx::JSXOpeningElementSelfClosing(self),
         );
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2398,13 +2303,12 @@ impl ESTree for JSXOpeningElement<'_> {
 
 impl ESTree for JSXClosingElement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXClosingElement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &self.name);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2413,7 +2317,6 @@ impl ESTree for JSXClosingElement<'_> {
 
 impl ESTree for JSXFragment<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXFragment"));
         state.serialize_field("start", &self.span.start);
@@ -2421,7 +2324,7 @@ impl ESTree for JSXFragment<'_> {
         state.serialize_field("openingFragment", &self.opening_fragment);
         state.serialize_field("children", &self.children);
         state.serialize_field("closingFragment", &self.closing_fragment);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2430,14 +2333,13 @@ impl ESTree for JSXFragment<'_> {
 
 impl ESTree for JSXOpeningFragment {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXOpeningFragment"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_js_field("attributes", &crate::serialize::basic::JsEmptyArray(self));
         state.serialize_js_field("selfClosing", &crate::serialize::basic::JsFalse(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2446,12 +2348,11 @@ impl ESTree for JSXOpeningFragment {
 
 impl ESTree for JSXClosingFragment {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXClosingFragment"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2476,14 +2377,13 @@ impl ESTree for JSXElementName<'_> {
 
 impl ESTree for JSXNamespacedName<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXNamespacedName"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("namespace", &self.namespace);
         state.serialize_field("name", &self.name);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2492,14 +2392,13 @@ impl ESTree for JSXNamespacedName<'_> {
 
 impl ESTree for JSXMemberExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXMemberExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("object", &self.object);
         state.serialize_field("property", &self.property);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2522,13 +2421,12 @@ impl ESTree for JSXMemberExpressionObject<'_> {
 
 impl ESTree for JSXExpressionContainer<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXExpressionContainer"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2588,12 +2486,11 @@ impl ESTree for JSXExpression<'_> {
 
 impl ESTree for JSXEmptyExpression {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXEmptyExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2611,14 +2508,13 @@ impl ESTree for JSXAttributeItem<'_> {
 
 impl ESTree for JSXAttribute<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXAttribute"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &self.name);
         state.serialize_field("value", &self.value);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2627,13 +2523,12 @@ impl ESTree for JSXAttribute<'_> {
 
 impl ESTree for JSXSpreadAttribute<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXSpreadAttribute"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("argument", &self.argument);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2662,13 +2557,12 @@ impl ESTree for JSXAttributeValue<'_> {
 
 impl ESTree for JSXIdentifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXIdentifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &JsonSafeString(self.name.as_str()));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2689,13 +2583,12 @@ impl ESTree for JSXChild<'_> {
 
 impl ESTree for JSXSpreadChild<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXSpreadChild"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2704,14 +2597,13 @@ impl ESTree for JSXSpreadChild<'_> {
 
 impl ESTree for JSXText<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXText"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &self.value);
         state.serialize_field("raw", &self.raw);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2720,7 +2612,6 @@ impl ESTree for JSXText<'_> {
 
 impl ESTree for TSThisParameter<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("start", &self.span.start);
@@ -2729,7 +2620,7 @@ impl ESTree for TSThisParameter<'_> {
         state.serialize_field("name", &crate::serialize::basic::This(self));
         state.serialize_field("optional", &crate::serialize::basic::False(self));
         state.serialize_field("typeAnnotation", &self.type_annotation);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2738,7 +2629,6 @@ impl ESTree for TSThisParameter<'_> {
 
 impl ESTree for TSEnumDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSEnumDeclaration"));
         state.serialize_field("start", &self.span.start);
@@ -2747,7 +2637,7 @@ impl ESTree for TSEnumDeclaration<'_> {
         state.serialize_field("body", &self.body);
         state.serialize_field("const", &self.r#const);
         state.serialize_field("declare", &self.declare);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2756,13 +2646,12 @@ impl ESTree for TSEnumDeclaration<'_> {
 
 impl ESTree for TSEnumBody<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSEnumBody"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("members", &self.members);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2771,7 +2660,6 @@ impl ESTree for TSEnumBody<'_> {
 
 impl ESTree for TSEnumMember<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSEnumMember"));
         state.serialize_field("start", &self.span.start);
@@ -2779,7 +2667,7 @@ impl ESTree for TSEnumMember<'_> {
         state.serialize_field("id", &self.id);
         state.serialize_field("initializer", &self.initializer);
         state.serialize_field("computed", &crate::serialize::ts::TSEnumMemberComputed(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2799,13 +2687,12 @@ impl ESTree for TSEnumMemberName<'_> {
 
 impl ESTree for TSTypeAnnotation<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTypeAnnotation"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeAnnotation", &self.type_annotation);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2814,13 +2701,12 @@ impl ESTree for TSTypeAnnotation<'_> {
 
 impl ESTree for TSLiteralType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSLiteralType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("literal", &self.literal);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2886,7 +2772,6 @@ impl ESTree for TSType<'_> {
 
 impl ESTree for TSConditionalType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSConditionalType"));
         state.serialize_field("start", &self.span.start);
@@ -2895,7 +2780,7 @@ impl ESTree for TSConditionalType<'_> {
         state.serialize_field("extendsType", &self.extends_type);
         state.serialize_field("trueType", &self.true_type);
         state.serialize_field("falseType", &self.false_type);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2904,13 +2789,12 @@ impl ESTree for TSConditionalType<'_> {
 
 impl ESTree for TSUnionType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSUnionType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("types", &self.types);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2919,13 +2803,12 @@ impl ESTree for TSUnionType<'_> {
 
 impl ESTree for TSIntersectionType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSIntersectionType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("types", &self.types);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2934,13 +2817,12 @@ impl ESTree for TSIntersectionType<'_> {
 
 impl ESTree for TSParenthesizedType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSParenthesizedType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeAnnotation", &self.type_annotation);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2949,14 +2831,13 @@ impl ESTree for TSParenthesizedType<'_> {
 
 impl ESTree for TSTypeOperator<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTypeOperator"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("operator", &self.operator);
         state.serialize_field("typeAnnotation", &self.type_annotation);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2975,13 +2856,12 @@ impl ESTree for TSTypeOperatorOperator {
 
 impl ESTree for TSArrayType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSArrayType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("elementType", &self.element_type);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -2990,14 +2870,13 @@ impl ESTree for TSArrayType<'_> {
 
 impl ESTree for TSIndexedAccessType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSIndexedAccessType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("objectType", &self.object_type);
         state.serialize_field("indexType", &self.index_type);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3006,13 +2885,12 @@ impl ESTree for TSIndexedAccessType<'_> {
 
 impl ESTree for TSTupleType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTupleType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("elementTypes", &self.element_types);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3021,7 +2899,6 @@ impl ESTree for TSTupleType<'_> {
 
 impl ESTree for TSNamedTupleMember<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSNamedTupleMember"));
         state.serialize_field("start", &self.span.start);
@@ -3029,7 +2906,7 @@ impl ESTree for TSNamedTupleMember<'_> {
         state.serialize_field("label", &self.label);
         state.serialize_field("elementType", &self.element_type);
         state.serialize_field("optional", &self.optional);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3038,13 +2915,12 @@ impl ESTree for TSNamedTupleMember<'_> {
 
 impl ESTree for TSOptionalType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSOptionalType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeAnnotation", &self.type_annotation);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3053,13 +2929,12 @@ impl ESTree for TSOptionalType<'_> {
 
 impl ESTree for TSRestType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSRestType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeAnnotation", &self.type_annotation);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3114,12 +2989,11 @@ impl ESTree for TSTupleElement<'_> {
 
 impl ESTree for TSAnyKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSAnyKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3128,12 +3002,11 @@ impl ESTree for TSAnyKeyword {
 
 impl ESTree for TSStringKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSStringKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3142,12 +3015,11 @@ impl ESTree for TSStringKeyword {
 
 impl ESTree for TSBooleanKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSBooleanKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3156,12 +3028,11 @@ impl ESTree for TSBooleanKeyword {
 
 impl ESTree for TSNumberKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSNumberKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3170,12 +3041,11 @@ impl ESTree for TSNumberKeyword {
 
 impl ESTree for TSNeverKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSNeverKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3184,12 +3054,11 @@ impl ESTree for TSNeverKeyword {
 
 impl ESTree for TSIntrinsicKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSIntrinsicKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3198,12 +3067,11 @@ impl ESTree for TSIntrinsicKeyword {
 
 impl ESTree for TSUnknownKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSUnknownKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3212,12 +3080,11 @@ impl ESTree for TSUnknownKeyword {
 
 impl ESTree for TSNullKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSNullKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3226,12 +3093,11 @@ impl ESTree for TSNullKeyword {
 
 impl ESTree for TSUndefinedKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSUndefinedKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3240,12 +3106,11 @@ impl ESTree for TSUndefinedKeyword {
 
 impl ESTree for TSVoidKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSVoidKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3254,12 +3119,11 @@ impl ESTree for TSVoidKeyword {
 
 impl ESTree for TSSymbolKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSSymbolKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3268,12 +3132,11 @@ impl ESTree for TSSymbolKeyword {
 
 impl ESTree for TSThisType {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSThisType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3282,12 +3145,11 @@ impl ESTree for TSThisType {
 
 impl ESTree for TSObjectKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSObjectKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3296,12 +3158,11 @@ impl ESTree for TSObjectKeyword {
 
 impl ESTree for TSBigIntKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSBigIntKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3310,14 +3171,13 @@ impl ESTree for TSBigIntKeyword {
 
 impl ESTree for TSTypeReference<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTypeReference"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeName", &self.type_name);
         state.serialize_field("typeArguments", &self.type_arguments);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3337,14 +3197,13 @@ impl ESTree for TSTypeName<'_> {
 
 impl ESTree for TSQualifiedName<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSQualifiedName"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("left", &self.left);
         state.serialize_field("right", &self.right);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3353,13 +3212,12 @@ impl ESTree for TSQualifiedName<'_> {
 
 impl ESTree for TSTypeParameterInstantiation<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTypeParameterInstantiation"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("params", &self.params);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3368,7 +3226,6 @@ impl ESTree for TSTypeParameterInstantiation<'_> {
 
 impl ESTree for TSTypeParameter<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTypeParameter"));
         state.serialize_field("start", &self.span.start);
@@ -3379,7 +3236,7 @@ impl ESTree for TSTypeParameter<'_> {
         state.serialize_field("in", &self.r#in);
         state.serialize_field("out", &self.out);
         state.serialize_field("const", &self.r#const);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3388,13 +3245,12 @@ impl ESTree for TSTypeParameter<'_> {
 
 impl ESTree for TSTypeParameterDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTypeParameterDeclaration"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("params", &self.params);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3403,7 +3259,6 @@ impl ESTree for TSTypeParameterDeclaration<'_> {
 
 impl ESTree for TSTypeAliasDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTypeAliasDeclaration"));
         state.serialize_field("start", &self.span.start);
@@ -3412,7 +3267,7 @@ impl ESTree for TSTypeAliasDeclaration<'_> {
         state.serialize_field("typeParameters", &self.type_parameters);
         state.serialize_field("typeAnnotation", &self.type_annotation);
         state.serialize_field("declare", &self.declare);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3431,7 +3286,6 @@ impl ESTree for TSAccessibility {
 
 impl ESTree for TSClassImplements<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSClassImplements"));
         state.serialize_field("start", &self.span.start);
@@ -3441,7 +3295,7 @@ impl ESTree for TSClassImplements<'_> {
             &crate::serialize::ts::TSClassImplementsExpression(self),
         );
         state.serialize_field("typeArguments", &self.type_arguments);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3450,7 +3304,6 @@ impl ESTree for TSClassImplements<'_> {
 
 impl ESTree for TSInterfaceDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSInterfaceDeclaration"));
         state.serialize_field("start", &self.span.start);
@@ -3460,7 +3313,7 @@ impl ESTree for TSInterfaceDeclaration<'_> {
         state.serialize_field("extends", &self.extends);
         state.serialize_field("body", &self.body);
         state.serialize_field("declare", &self.declare);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3469,13 +3322,12 @@ impl ESTree for TSInterfaceDeclaration<'_> {
 
 impl ESTree for TSInterfaceBody<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSInterfaceBody"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("body", &self.body);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3484,7 +3336,6 @@ impl ESTree for TSInterfaceBody<'_> {
 
 impl ESTree for TSPropertySignature<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSPropertySignature"));
         state.serialize_field("start", &self.span.start);
@@ -3496,7 +3347,7 @@ impl ESTree for TSPropertySignature<'_> {
         state.serialize_field("typeAnnotation", &self.type_annotation);
         state.serialize_field("accessibility", &crate::serialize::basic::Null(self));
         state.serialize_field("static", &crate::serialize::basic::False(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3517,7 +3368,6 @@ impl ESTree for TSSignature<'_> {
 
 impl ESTree for TSIndexSignature<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSIndexSignature"));
         state.serialize_field("start", &self.span.start);
@@ -3527,7 +3377,7 @@ impl ESTree for TSIndexSignature<'_> {
         state.serialize_field("readonly", &self.readonly);
         state.serialize_field("static", &self.r#static);
         state.serialize_field("accessibility", &crate::serialize::basic::Null(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3536,7 +3386,6 @@ impl ESTree for TSIndexSignature<'_> {
 
 impl ESTree for TSCallSignatureDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSCallSignatureDeclaration"));
         state.serialize_field("start", &self.span.start);
@@ -3547,7 +3396,7 @@ impl ESTree for TSCallSignatureDeclaration<'_> {
             &crate::serialize::ts::TSCallSignatureDeclarationParams(self),
         );
         state.serialize_field("returnType", &self.return_type);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3566,7 +3415,6 @@ impl ESTree for TSMethodSignatureKind {
 
 impl ESTree for TSMethodSignature<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSMethodSignature"));
         state.serialize_field("start", &self.span.start);
@@ -3581,7 +3429,7 @@ impl ESTree for TSMethodSignature<'_> {
         state.serialize_field("accessibility", &crate::serialize::basic::Null(self));
         state.serialize_field("readonly", &crate::serialize::basic::False(self));
         state.serialize_field("static", &crate::serialize::basic::False(self));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3590,7 +3438,6 @@ impl ESTree for TSMethodSignature<'_> {
 
 impl ESTree for TSConstructSignatureDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSConstructSignatureDeclaration"));
         state.serialize_field("start", &self.span.start);
@@ -3598,7 +3445,7 @@ impl ESTree for TSConstructSignatureDeclaration<'_> {
         state.serialize_field("typeParameters", &self.type_parameters);
         state.serialize_field("params", &self.params);
         state.serialize_field("returnType", &self.return_type);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3607,7 +3454,6 @@ impl ESTree for TSConstructSignatureDeclaration<'_> {
 
 impl ESTree for TSIndexSignatureName<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("start", &self.span.start);
@@ -3616,7 +3462,7 @@ impl ESTree for TSIndexSignatureName<'_> {
         state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.serialize_field("optional", &crate::serialize::basic::False(self));
         state.serialize_field("typeAnnotation", &self.type_annotation);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3625,14 +3471,13 @@ impl ESTree for TSIndexSignatureName<'_> {
 
 impl ESTree for TSInterfaceHeritage<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSInterfaceHeritage"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
         state.serialize_field("typeArguments", &self.type_arguments);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3641,7 +3486,6 @@ impl ESTree for TSInterfaceHeritage<'_> {
 
 impl ESTree for TSTypePredicate<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTypePredicate"));
         state.serialize_field("start", &self.span.start);
@@ -3649,7 +3493,7 @@ impl ESTree for TSTypePredicate<'_> {
         state.serialize_field("parameterName", &self.parameter_name);
         state.serialize_field("asserts", &self.asserts);
         state.serialize_field("typeAnnotation", &self.type_annotation);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3701,13 +3545,12 @@ impl ESTree for TSModuleDeclarationBody<'_> {
 
 impl ESTree for TSModuleBlock<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSModuleBlock"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("body", &Concat2(&self.directives, &self.body));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3716,13 +3559,12 @@ impl ESTree for TSModuleBlock<'_> {
 
 impl ESTree for TSTypeLiteral<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTypeLiteral"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("members", &self.members);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3731,13 +3573,12 @@ impl ESTree for TSTypeLiteral<'_> {
 
 impl ESTree for TSInferType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSInferType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeParameter", &self.type_parameter);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3746,14 +3587,13 @@ impl ESTree for TSInferType<'_> {
 
 impl ESTree for TSTypeQuery<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTypeQuery"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("exprName", &self.expr_name);
         state.serialize_field("typeArguments", &self.type_arguments);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3774,7 +3614,6 @@ impl ESTree for TSTypeQueryExprName<'_> {
 
 impl ESTree for TSImportType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSImportType"));
         state.serialize_field("start", &self.span.start);
@@ -3783,7 +3622,7 @@ impl ESTree for TSImportType<'_> {
         state.serialize_field("options", &self.options);
         state.serialize_field("qualifier", &self.qualifier);
         state.serialize_field("typeArguments", &self.type_arguments);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3792,7 +3631,6 @@ impl ESTree for TSImportType<'_> {
 
 impl ESTree for TSFunctionType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSFunctionType"));
         state.serialize_field("start", &self.span.start);
@@ -3800,7 +3638,7 @@ impl ESTree for TSFunctionType<'_> {
         state.serialize_field("typeParameters", &self.type_parameters);
         state.serialize_field("params", &crate::serialize::ts::TSFunctionTypeParams(self));
         state.serialize_field("returnType", &self.return_type);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3809,7 +3647,6 @@ impl ESTree for TSFunctionType<'_> {
 
 impl ESTree for TSConstructorType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSConstructorType"));
         state.serialize_field("start", &self.span.start);
@@ -3818,7 +3655,7 @@ impl ESTree for TSConstructorType<'_> {
         state.serialize_field("typeParameters", &self.type_parameters);
         state.serialize_field("params", &self.params);
         state.serialize_field("returnType", &self.return_type);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3827,7 +3664,6 @@ impl ESTree for TSConstructorType<'_> {
 
 impl ESTree for TSMappedType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSMappedType"));
         state.serialize_field("start", &self.span.start);
@@ -3838,7 +3674,7 @@ impl ESTree for TSMappedType<'_> {
         state.serialize_field("typeAnnotation", &self.type_annotation);
         state.serialize_field("optional", &crate::serialize::ts::TSMappedTypeOptional(self));
         state.serialize_field("readonly", &self.readonly);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3857,14 +3693,13 @@ impl ESTree for TSMappedTypeModifierOperator {
 
 impl ESTree for TSTemplateLiteralType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTemplateLiteralType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("quasis", &self.quasis);
         state.serialize_field("types", &self.types);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3873,14 +3708,13 @@ impl ESTree for TSTemplateLiteralType<'_> {
 
 impl ESTree for TSAsExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSAsExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
         state.serialize_field("typeAnnotation", &self.type_annotation);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3889,14 +3723,13 @@ impl ESTree for TSAsExpression<'_> {
 
 impl ESTree for TSSatisfiesExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSSatisfiesExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
         state.serialize_field("typeAnnotation", &self.type_annotation);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3905,14 +3738,13 @@ impl ESTree for TSSatisfiesExpression<'_> {
 
 impl ESTree for TSTypeAssertion<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTypeAssertion"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeAnnotation", &self.type_annotation);
         state.serialize_field("expression", &self.expression);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3921,7 +3753,6 @@ impl ESTree for TSTypeAssertion<'_> {
 
 impl ESTree for TSImportEqualsDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSImportEqualsDeclaration"));
         state.serialize_field("start", &self.span.start);
@@ -3929,7 +3760,7 @@ impl ESTree for TSImportEqualsDeclaration<'_> {
         state.serialize_field("id", &self.id);
         state.serialize_field("moduleReference", &self.module_reference);
         state.serialize_field("importKind", &self.import_kind);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3950,13 +3781,12 @@ impl ESTree for TSModuleReference<'_> {
 
 impl ESTree for TSExternalModuleReference<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSExternalModuleReference"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3965,13 +3795,12 @@ impl ESTree for TSExternalModuleReference<'_> {
 
 impl ESTree for TSNonNullExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSNonNullExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3980,13 +3809,12 @@ impl ESTree for TSNonNullExpression<'_> {
 
 impl ESTree for Decorator<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Decorator"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -3995,13 +3823,12 @@ impl ESTree for Decorator<'_> {
 
 impl ESTree for TSExportAssignment<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSExportAssignment"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -4010,13 +3837,12 @@ impl ESTree for TSExportAssignment<'_> {
 
 impl ESTree for TSNamespaceExportDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSNamespaceExportDeclaration"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("id", &self.id);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -4025,14 +3851,13 @@ impl ESTree for TSNamespaceExportDeclaration<'_> {
 
 impl ESTree for TSInstantiationExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSInstantiationExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
         state.serialize_field("typeArguments", &self.type_arguments);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -4050,14 +3875,13 @@ impl ESTree for ImportOrExportKind {
 
 impl ESTree for JSDocNullableType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSJSDocNullableType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeAnnotation", &self.type_annotation);
         state.serialize_field("postfix", &self.postfix);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -4066,14 +3890,13 @@ impl ESTree for JSDocNullableType<'_> {
 
 impl ESTree for JSDocNonNullableType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSJSDocNonNullableType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeAnnotation", &self.type_annotation);
         state.serialize_field("postfix", &self.postfix);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -4082,12 +3905,11 @@ impl ESTree for JSDocNonNullableType<'_> {
 
 impl ESTree for JSDocUnknownType {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSJSDocUnknownType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -4105,13 +3927,12 @@ impl ESTree for CommentKind {
 
 impl ESTree for Comment {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &self.kind);
         state.serialize_field("value", &crate::serialize::CommentValue(self));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();

--- a/crates/oxc_ast/src/serialize/js.rs
+++ b/crates/oxc_ast/src/serialize/js.rs
@@ -54,8 +54,6 @@ struct BindingPatternKindAndTsFields<'a, 'b> {
 
 impl ESTree for BindingPatternKindAndTsFields<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
-
         let mut state = serializer.serialize_struct();
 
         let span = match &self.kind {
@@ -97,7 +95,7 @@ impl ESTree for BindingPatternKindAndTsFields<'_, '_> {
         state.serialize_field("optional", &self.optional);
         state.serialize_field("typeAnnotation", &self.type_annotation);
 
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[span.start, span.end]);
         }
 
@@ -175,7 +173,6 @@ struct FormalParametersRest<'a, 'b>(&'b BindingRestElement<'a>);
 impl ESTree for FormalParametersRest<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let rest = self.0;
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("RestElement"));
         state.serialize_field("start", &rest.span.start);
@@ -185,7 +182,7 @@ impl ESTree for FormalParametersRest<'_, '_> {
         state.serialize_ts_field("optional", &rest.argument.optional);
         state.serialize_ts_field("typeAnnotation", &rest.argument.type_annotation);
         state.serialize_ts_field("value", &Null(()));
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[rest.span.start, rest.span.end]);
         }
         state.end();
@@ -237,8 +234,6 @@ impl ESTree for FormalParameterConverter<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let param = self.0;
 
-        let ranges = serializer.ranges();
-
         if S::INCLUDE_TS_FIELDS {
             if param.has_modifier() {
                 let mut state = serializer.serialize_struct();
@@ -251,7 +246,7 @@ impl ESTree for FormalParameterConverter<'_, '_> {
                 state.serialize_field("parameter", &param.pattern);
                 state.serialize_field("readonly", &param.readonly);
                 state.serialize_field("static", &false);
-                if ranges {
+                if state.ranges() {
                     state.serialize_field("range", &[param.span.start, param.span.end]);
                 }
                 state.end();
@@ -456,8 +451,6 @@ pub struct AssignmentTargetPropertyIdentifierInit<'a>(
 impl ESTree for AssignmentTargetPropertyIdentifierInit<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         if let Some(init) = &self.0.init {
-            let ranges = serializer.ranges();
-
             let mut state = serializer.serialize_struct();
             state.serialize_field("type", &JsonSafeString("AssignmentPattern"));
             state.serialize_field("start", &self.0.span.start);
@@ -467,7 +460,7 @@ impl ESTree for AssignmentTargetPropertyIdentifierInit<'_> {
             state.serialize_field("right", init);
             state.serialize_ts_field("optional", &false);
             state.serialize_ts_field("typeAnnotation", &Null(()));
-            if ranges {
+            if state.ranges() {
                 state.serialize_field("range", &[self.0.span.start, self.0.span.end]);
             }
             state.end();

--- a/crates/oxc_ast/src/serialize/jsx.rs
+++ b/crates/oxc_ast/src/serialize/jsx.rs
@@ -22,8 +22,6 @@ impl ESTree for JSXElementOpeningElement<'_, '_> {
         let element = self.0;
         let opening_element = element.opening_element.as_ref();
 
-        let ranges = serializer.ranges();
-
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXOpeningElement"));
         state.serialize_field("start", &opening_element.span.start);
@@ -32,7 +30,7 @@ impl ESTree for JSXElementOpeningElement<'_, '_> {
         state.serialize_ts_field("typeArguments", &opening_element.type_arguments);
         state.serialize_field("attributes", &opening_element.attributes);
         state.serialize_field("selfClosing", &element.closing_element.is_none());
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[opening_element.span.start, opening_element.span.end]);
         }
         state.end();

--- a/crates/oxc_ast/src/serialize/literal.rs
+++ b/crates/oxc_ast/src/serialize/literal.rs
@@ -209,7 +209,7 @@ pub struct TemplateElementConverter<'a, 'b>(pub &'b TemplateElement<'a>);
 impl ESTree for TemplateElementConverter<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let element = self.0;
-        let ranges = serializer.ranges();
+
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TemplateElement"));
 
@@ -224,7 +224,7 @@ impl ESTree for TemplateElementConverter<'_, '_> {
         state.serialize_field("value", &TemplateElementValue(element));
         state.serialize_field("tail", &element.tail);
 
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[span.start, span.end]);
         }
 

--- a/crates/oxc_ast/src/serialize/mod.rs
+++ b/crates/oxc_ast/src/serialize/mod.rs
@@ -168,7 +168,6 @@ impl ESTree for ProgramConverter<'_, '_> {
         let span_start =
             if S::INCLUDE_TS_FIELDS { get_ts_start_span(program) } else { program.span.start };
 
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Program"));
         state.serialize_field("start", &span_start);
@@ -176,7 +175,7 @@ impl ESTree for ProgramConverter<'_, '_> {
         state.serialize_field("body", &Concat2(&program.directives, &program.body));
         state.serialize_field("sourceType", &program.source_type.module_kind());
         state.serialize_field("hashbang", &program.hashbang);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[span_start, program.span.end]);
         }
         state.end();

--- a/crates/oxc_ast/src/serialize/ts.rs
+++ b/crates/oxc_ast/src/serialize/ts.rs
@@ -99,8 +99,6 @@ impl ESTree for TSModuleDeclarationConverter<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let module = self.0;
 
-        let ranges = serializer.ranges();
-
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSModuleDeclaration"));
         state.serialize_field("start", &module.span.start);
@@ -160,7 +158,7 @@ impl ESTree for TSModuleDeclarationConverter<'_, '_> {
         state.serialize_field("declare", &module.declare);
         state.serialize_field("global", &TSModuleDeclarationGlobal(module));
 
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[module.span.start, module.span.end]);
         }
 
@@ -172,8 +170,6 @@ struct TSModuleDeclarationIdParts<'a, 'b>(&'b [&'b BindingIdentifier<'a>]);
 
 impl ESTree for TSModuleDeclarationIdParts<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
-
         let parts = self.0;
         assert!(!parts.is_empty());
 
@@ -195,7 +191,7 @@ impl ESTree for TSModuleDeclarationIdParts<'_, '_> {
 
         state.serialize_field("right", last);
 
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[span_start, last.span.end]);
         }
 
@@ -353,8 +349,6 @@ impl ESTree for TSTypeNameAsMemberExpression<'_, '_> {
                 TSTypeNameIdentifierReference(ident).serialize(serializer);
             }
             TSTypeName::QualifiedName(name) => {
-                let ranges = serializer.ranges();
-
                 // Convert to `TSQualifiedName` to `MemberExpression`.
                 // Recursively convert `left` to `MemberExpression` too if it's a `TSQualifiedName`.
                 let mut state = serializer.serialize_struct();
@@ -365,7 +359,7 @@ impl ESTree for TSTypeNameAsMemberExpression<'_, '_> {
                 state.serialize_field("property", &name.right);
                 state.serialize_field("optional", &false);
                 state.serialize_field("computed", &false);
-                if ranges {
+                if state.ranges() {
                     state.serialize_field("range", &[name.span.start, name.span.end]);
                 }
                 state.end();

--- a/crates/oxc_syntax/src/generated/derive_estree.rs
+++ b/crates/oxc_syntax/src/generated/derive_estree.rs
@@ -12,12 +12,11 @@ use crate::operator::*;
 
 impl ESTree for NameSpan<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("value", &self.name);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -50,7 +49,6 @@ impl ESTree for ImportImportName<'_> {
 
 impl ESTree for ExportEntry<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
@@ -59,7 +57,7 @@ impl ESTree for ExportEntry<'_> {
         state.serialize_field("exportName", &self.export_name);
         state.serialize_field("localName", &self.local_name);
         state.serialize_field("isType", &self.is_type);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -103,12 +101,11 @@ impl ESTree for ExportLocalName<'_> {
 
 impl ESTree for DynamicImport {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("moduleRequest", &self.module_request);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();

--- a/napi/parser/src/generated/derive_estree.rs
+++ b/napi/parser/src/generated/derive_estree.rs
@@ -44,12 +44,11 @@ impl ESTree for ErrorSeverity {
 
 impl ESTree for ErrorLabel<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("message", &self.message);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -70,13 +69,12 @@ impl ESTree for EcmaScriptModule<'_> {
 
 impl ESTree for StaticImport<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("moduleRequest", &self.module_request);
         state.serialize_field("entries", &self.entries);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();
@@ -85,12 +83,11 @@ impl ESTree for StaticImport<'_> {
 
 impl ESTree for StaticExport<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ranges = serializer.ranges();
         let mut state = serializer.serialize_struct();
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("entries", &self.entries);
-        if ranges {
+        if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
         state.end();

--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -377,22 +377,18 @@ fn generate_body_for_struct(struct_def: &StructDef, schema: &Schema) -> TokenStr
 
     // Check if struct has a span field for range support
     let has_span_field = struct_def.fields.iter().any(|field| field.name() == "span");
-    let (range_declaration, range_field) = if has_span_field {
-        (
-            quote!( let ranges = serializer.ranges(); ),
-            quote! {
-                if ranges {
-                    state.serialize_field("range", &[self.span.start, self.span.end]);
-                }
-            },
-        )
+    let range_field = if has_span_field {
+        quote! {
+            if state.ranges() {
+                state.serialize_field("range", &[self.span.start, self.span.end]);
+            }
+        }
     } else {
-        (quote!(), quote!())
+        quote!()
     };
 
     let stmts = g.stmts;
     quote! {
-        #range_declaration
         let mut state = serializer.serialize_struct();
         #type_field
         #stmts


### PR DESCRIPTION
Pure refactor. Simplify serializers by removing `ranges` temp vars.