### PR TITLE
refactor(ast/estree): add `#[inline(always)]` to `ranges` methods

### DIFF
--- a/crates/oxc_estree/src/serialize/mod.rs
+++ b/crates/oxc_estree/src/serialize/mod.rs
@@ -180,6 +180,7 @@ impl<'s, C: Config, F: Formatter> Serializer for &'s mut ESTreeSerializer<C, F> 
     type StructSerializer = ESTreeStructSerializer<'s, C, F>;
     type SequenceSerializer = ESTreeSequenceSerializer<'s, C, F>;
 
+    #[inline(always)]
     fn ranges(&self) -> bool {
         self.config.ranges()
     }

--- a/crates/oxc_estree/src/serialize/structs.rs
+++ b/crates/oxc_estree/src/serialize/structs.rs
@@ -150,6 +150,7 @@ impl<C: Config, F: Formatter> StructSerializer for ESTreeStructSerializer<'_, C,
         buffer.print_ascii_byte(b'}');
     }
 
+    #[inline(always)]
     fn ranges(&self) -> bool {
         self.serializer.ranges()
     }
@@ -223,6 +224,7 @@ impl<'p, P: StructSerializer> Serializer for FlatStructSerializer<'p, P> {
         }
     }
 
+    #[inline(always)]
     fn ranges(&self) -> bool {
         self.0.ranges()
     }
@@ -292,6 +294,7 @@ impl<P: StructSerializer> StructSerializer for FlatStructSerializer<'_, P> {
         // No-op - there may be more fields to be added to the struct in the parent
     }
 
+    #[inline(always)]
     fn ranges(&self) -> bool {
         self.0.ranges()
     }


### PR DESCRIPTION
Add `#[inline(always)]` to these trivial methods.