### PR TITLE
refactor(ast/estree): move `start` and `end` fields to last

### DIFF
--- a/.github/actions/clone-submodules/action.yml
+++ b/.github/actions/clone-submodules/action.yml
@@ -38,4 +38,4 @@ runs:
         show-progress: false
         repository: oxc-project/acorn-test262
         path: tasks/coverage/acorn-test262
-        ref: 25df720d20c5299b016dcaa99ce0ca917e2df5b9 # Latest main at 16/6/25
+        ref: d9ba02ddea22800a285c7ad24e3fbfbb00ccbb02 # Latest main at 1/7/25

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -34,7 +34,7 @@ use super::{macros::inherit_variants, *};
 )]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(field_order(span, body, source_type, hashbang), via = ProgramConverter)]
+#[estree(field_order(body, source_type, hashbang, span), via = ProgramConverter)]
 pub struct Program<'a> {
     pub span: Span,
     pub source_type: SourceType,
@@ -215,7 +215,7 @@ pub use match_expression;
 #[estree(
     rename = "Identifier",
     add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
-    field_order(span, decorators, name, optional, typeAnnotation),
+    field_order(decorators, name, optional, typeAnnotation, span),
 )]
 pub struct IdentifierName<'a> {
     pub span: Span,
@@ -234,7 +234,7 @@ pub struct IdentifierName<'a> {
 #[estree(
     rename = "Identifier",
     add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
-    field_order(span, decorators, name, optional, typeAnnotation),
+    field_order(decorators, name, optional, typeAnnotation, span),
 )]
 pub struct IdentifierReference<'a> {
     pub span: Span,
@@ -263,7 +263,7 @@ pub struct IdentifierReference<'a> {
 #[estree(
     rename = "Identifier",
     add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
-    field_order(span, decorators, name, optional, typeAnnotation),
+    field_order(decorators, name, optional, typeAnnotation, span),
 )]
 pub struct BindingIdentifier<'a> {
     pub span: Span,
@@ -290,7 +290,7 @@ pub struct BindingIdentifier<'a> {
 #[estree(
     rename = "Identifier",
     add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
-    field_order(span, decorators, name, optional, typeAnnotation),
+    field_order(decorators, name, optional, typeAnnotation, span),
 )]
 pub struct LabelIdentifier<'a> {
     pub span: Span,
@@ -708,7 +708,7 @@ pub struct BinaryExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "BinaryExpression", add_fields(operator = In), field_order(span, left, operator, right))]
+#[estree(rename = "BinaryExpression", add_fields(operator = In), field_order(left, operator, right, span))]
 pub struct PrivateInExpression<'a> {
     pub span: Span,
     pub left: PrivateIdentifier<'a>,
@@ -855,7 +855,7 @@ pub use match_assignment_target_pattern;
 #[estree(
     rename = "ArrayPattern",
     add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
-    field_order(span, decorators, elements, optional, typeAnnotation),
+    field_order(decorators, elements, optional, typeAnnotation, span),
 )]
 pub struct ArrayAssignmentTarget<'a> {
     pub span: Span,
@@ -873,7 +873,7 @@ pub struct ArrayAssignmentTarget<'a> {
 #[estree(
     rename = "ObjectPattern",
     add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
-    field_order(span, decorators, properties, optional, typeAnnotation),
+    field_order(decorators, properties, optional, typeAnnotation, span),
 )]
 pub struct ObjectAssignmentTarget<'a> {
     pub span: Span,
@@ -891,7 +891,7 @@ pub struct ObjectAssignmentTarget<'a> {
 #[estree(
     rename = "RestElement",
     add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull, value = TsNull),
-    field_order(span, decorators, target, optional, typeAnnotation, value),
+    field_order(decorators, target, optional, typeAnnotation, value, span),
 )]
 pub struct AssignmentTargetRest<'a> {
     pub span: Span,
@@ -921,7 +921,7 @@ pub enum AssignmentTargetMaybeDefault<'a> {
 #[estree(
     rename = "AssignmentPattern",
     add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
-    field_order(span, decorators, binding, init, optional, typeAnnotation),
+    field_order(decorators, binding, init, optional, typeAnnotation, span),
 )]
 pub struct AssignmentTargetWithDefault<'a> {
     pub span: Span,
@@ -949,7 +949,7 @@ pub enum AssignmentTargetProperty<'a> {
 #[estree(
     rename = "Property",
     add_fields(kind = Init, method = False, shorthand = True, computed = False, optional = TsFalse),
-    field_order(span, kind, binding, init, method, shorthand, computed, optional),
+    field_order(kind, binding, init, method, shorthand, computed, optional, span),
 )]
 pub struct AssignmentTargetPropertyIdentifier<'a> {
     pub span: Span,
@@ -968,7 +968,7 @@ pub struct AssignmentTargetPropertyIdentifier<'a> {
 #[estree(
     rename = "Property",
     add_fields(kind = Init, method = False, shorthand = False, optional = TsFalse),
-    field_order(span, kind, name, binding, method, shorthand, computed, optional),
+    field_order(kind, name, binding, method, shorthand, computed, optional, span),
 )]
 pub struct AssignmentTargetPropertyProperty<'a> {
     pub span: Span,
@@ -1603,7 +1603,7 @@ pub enum BindingPatternKind<'a> {
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(
     add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
-    field_order(span, decorators, left, right, optional, typeAnnotation),
+    field_order(decorators, left, right, optional, typeAnnotation, span),
 )]
 pub struct AssignmentPattern<'a> {
     pub span: Span,
@@ -1619,7 +1619,7 @@ pub struct AssignmentPattern<'a> {
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(
     add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
-    field_order(span, decorators, properties, optional, typeAnnotation),
+    field_order(decorators, properties, optional, typeAnnotation, span),
 )]
 pub struct ObjectPattern<'a> {
     pub span: Span,
@@ -1634,7 +1634,7 @@ pub struct ObjectPattern<'a> {
 #[estree(
     rename = "Property",
     add_fields(kind = Init, method = False, optional = TsFalse),
-    field_order(span, kind, key, value, method, shorthand, computed, optional),
+    field_order(kind, key, value, method, shorthand, computed, optional, span),
 )]
 pub struct BindingProperty<'a> {
     pub span: Span,
@@ -1652,7 +1652,7 @@ pub struct BindingProperty<'a> {
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(
     add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
-    field_order(span, decorators, elements, optional, typeAnnotation),
+    field_order(decorators, elements, optional, typeAnnotation, span),
 )]
 pub struct ArrayPattern<'a> {
     pub span: Span,
@@ -1676,7 +1676,7 @@ pub struct ArrayPattern<'a> {
 #[estree(
     rename = "RestElement",
     add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull, value = TsNull),
-    field_order(span, decorators, argument, optional, typeAnnotation, value),
+    field_order(decorators, argument, optional, typeAnnotation, value, span),
 )]
 pub struct BindingRestElement<'a> {
     pub span: Span,

--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -103,7 +103,7 @@ pub struct StringLiteral<'a> {
 #[estree(
     rename = "Literal",
     add_fields(bigint = BigIntLiteralBigint),
-    field_order(span, value, raw, bigint),
+    field_order(value, raw, bigint, span),
 )]
 pub struct BigIntLiteral<'a> {
     /// Node location in source code
@@ -130,7 +130,7 @@ pub struct BigIntLiteral<'a> {
 #[estree(
     rename = "Literal",
     add_fields(value = RegExpLiteralValue),
-    field_order(span, value, raw, regex),
+    field_order(value, raw, regex, span),
 )]
 pub struct RegExpLiteral<'a> {
     /// Node location in source code

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -37,7 +37,7 @@ use super::{inherit_variants, js::*, literal::*};
 #[estree(
     rename = "Identifier",
     add_fields(name = This, decorators = EmptyArray, optional = False),
-    field_order(span, decorators, name, optional, type_annotation),
+    field_order(decorators, name, optional, type_annotation, span),
 )]
 pub struct TSThisParameter<'a> {
     pub span: Span,
@@ -1084,7 +1084,7 @@ pub struct TSConstructSignatureDeclaration<'a> {
 #[estree(
     rename = "Identifier",
     add_fields(decorators = EmptyArray, optional = False),
-    field_order(span, decorators, name, optional, type_annotation),
+    field_order(decorators, name, optional, type_annotation, span),
 )]
 pub struct TSIndexSignatureName<'a> {
     pub span: Span,
@@ -1438,7 +1438,7 @@ pub struct TSConstructorType<'a> {
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(
     add_fields(key = TSMappedTypeKey, constraint = TSMappedTypeConstraint),
-    field_order(span, key, constraint, name_type, type_annotation, optional, readonly),
+    field_order(key, constraint, name_type, type_annotation, optional, readonly, span),
 )]
 pub struct TSMappedType<'a> {
     pub span: Span,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -73,12 +73,12 @@ impl ESTree for IdentifierName<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Identifier"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
         state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -90,12 +90,12 @@ impl ESTree for IdentifierReference<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Identifier"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
         state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -107,12 +107,12 @@ impl ESTree for BindingIdentifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Identifier"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
         state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -124,12 +124,12 @@ impl ESTree for LabelIdentifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Identifier"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
         state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -154,9 +154,9 @@ impl ESTree for ArrayExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ArrayExpression"));
+        state.serialize_field("elements", &self.elements);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("elements", &self.elements);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -226,9 +226,9 @@ impl ESTree for ObjectExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ObjectExpression"));
+        state.serialize_field("properties", &self.properties);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("properties", &self.properties);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -249,8 +249,6 @@ impl ESTree for ObjectProperty<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Property"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("kind", &self.kind);
         state.serialize_field("key", &self.key);
         state.serialize_field("value", &self.value);
@@ -258,6 +256,8 @@ impl ESTree for ObjectProperty<'_> {
         state.serialize_field("shorthand", &self.shorthand);
         state.serialize_field("computed", &self.computed);
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -331,10 +331,10 @@ impl ESTree for TemplateLiteral<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TemplateLiteral"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("quasis", &self.quasis);
         state.serialize_field("expressions", &self.expressions);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -346,11 +346,11 @@ impl ESTree for TaggedTemplateExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TaggedTemplateExpression"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("tag", &self.tag);
         state.serialize_ts_field("typeArguments", &self.type_arguments);
         state.serialize_field("quasi", &self.quasi);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -387,12 +387,12 @@ impl ESTree for ComputedMemberExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("MemberExpression"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("object", &self.object);
         state.serialize_field("property", &self.expression);
         state.serialize_field("optional", &self.optional);
         state.serialize_field("computed", &crate::serialize::basic::True(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -404,12 +404,12 @@ impl ESTree for StaticMemberExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("MemberExpression"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("object", &self.object);
         state.serialize_field("property", &self.property);
         state.serialize_field("optional", &self.optional);
         state.serialize_field("computed", &crate::serialize::basic::False(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -421,12 +421,12 @@ impl ESTree for PrivateFieldExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("MemberExpression"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("object", &self.object);
         state.serialize_field("property", &self.field);
         state.serialize_field("optional", &self.optional);
         state.serialize_field("computed", &crate::serialize::basic::False(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -438,12 +438,12 @@ impl ESTree for CallExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("CallExpression"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("callee", &self.callee);
         state.serialize_ts_field("typeArguments", &self.type_arguments);
         state.serialize_field("arguments", &self.arguments);
         state.serialize_field("optional", &self.optional);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -455,11 +455,11 @@ impl ESTree for NewExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("NewExpression"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("callee", &self.callee);
         state.serialize_ts_field("typeArguments", &self.type_arguments);
         state.serialize_field("arguments", &self.arguments);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -471,10 +471,10 @@ impl ESTree for MetaProperty<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("MetaProperty"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("meta", &self.meta);
         state.serialize_field("property", &self.property);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -486,9 +486,9 @@ impl ESTree for SpreadElement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("SpreadElement"));
+        state.serialize_field("argument", &self.argument);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("argument", &self.argument);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -551,11 +551,11 @@ impl ESTree for UpdateExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("UpdateExpression"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("operator", &self.operator);
         state.serialize_field("prefix", &self.prefix);
         state.serialize_field("argument", &self.argument);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -567,11 +567,11 @@ impl ESTree for UnaryExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("UnaryExpression"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("operator", &self.operator);
         state.serialize_field("argument", &self.argument);
         state.serialize_field("prefix", &crate::serialize::basic::True(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -583,11 +583,11 @@ impl ESTree for BinaryExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("BinaryExpression"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("left", &self.left);
         state.serialize_field("operator", &self.operator);
         state.serialize_field("right", &self.right);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -599,11 +599,11 @@ impl ESTree for PrivateInExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("BinaryExpression"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("left", &self.left);
         state.serialize_field("operator", &crate::serialize::basic::In(self));
         state.serialize_field("right", &self.right);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -615,11 +615,11 @@ impl ESTree for LogicalExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("LogicalExpression"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("left", &self.left);
         state.serialize_field("operator", &self.operator);
         state.serialize_field("right", &self.right);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -631,11 +631,11 @@ impl ESTree for ConditionalExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ConditionalExpression"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("test", &self.test);
         state.serialize_field("consequent", &self.consequent);
         state.serialize_field("alternate", &self.alternate);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -647,11 +647,11 @@ impl ESTree for AssignmentExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("AssignmentExpression"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("operator", &self.operator);
         state.serialize_field("left", &self.left);
         state.serialize_field("right", &self.right);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -704,12 +704,12 @@ impl ESTree for ArrayAssignmentTarget<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ArrayPattern"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
         state.serialize_field("elements", &Concat2(&self.elements, &self.rest));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -721,12 +721,12 @@ impl ESTree for ObjectAssignmentTarget<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ObjectPattern"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
         state.serialize_field("properties", &Concat2(&self.properties, &self.rest));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -738,13 +738,13 @@ impl ESTree for AssignmentTargetRest<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("RestElement"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
         state.serialize_field("argument", &self.target);
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
         state.serialize_ts_field("value", &crate::serialize::basic::TsNull(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -774,13 +774,13 @@ impl ESTree for AssignmentTargetWithDefault<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("AssignmentPattern"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
         state.serialize_field("left", &self.binding);
         state.serialize_field("right", &self.init);
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -801,8 +801,6 @@ impl ESTree for AssignmentTargetPropertyIdentifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Property"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("kind", &crate::serialize::basic::Init(self));
         state.serialize_field("key", &self.binding);
         state.serialize_field(
@@ -813,6 +811,8 @@ impl ESTree for AssignmentTargetPropertyIdentifier<'_> {
         state.serialize_field("shorthand", &crate::serialize::basic::True(self));
         state.serialize_field("computed", &crate::serialize::basic::False(self));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -824,8 +824,6 @@ impl ESTree for AssignmentTargetPropertyProperty<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Property"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("kind", &crate::serialize::basic::Init(self));
         state.serialize_field("key", &self.name);
         state.serialize_field("value", &self.binding);
@@ -833,6 +831,8 @@ impl ESTree for AssignmentTargetPropertyProperty<'_> {
         state.serialize_field("shorthand", &crate::serialize::basic::False(self));
         state.serialize_field("computed", &self.computed);
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -844,9 +844,9 @@ impl ESTree for SequenceExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("SequenceExpression"));
+        state.serialize_field("expressions", &self.expressions);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("expressions", &self.expressions);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -871,9 +871,9 @@ impl ESTree for AwaitExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("AwaitExpression"));
+        state.serialize_field("argument", &self.argument);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("argument", &self.argument);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -885,9 +885,9 @@ impl ESTree for ChainExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ChainExpression"));
+        state.serialize_field("expression", &self.expression);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("expression", &self.expression);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -911,9 +911,9 @@ impl ESTree for ParenthesizedExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ParenthesizedExpression"));
+        state.serialize_field("expression", &self.expression);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("expression", &self.expression);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -964,10 +964,10 @@ impl ESTree for Directive<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ExpressionStatement"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
         state.serialize_field("directive", &self.directive);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -979,9 +979,9 @@ impl ESTree for Hashbang<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Hashbang"));
+        state.serialize_field("value", &self.value);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("value", &self.value);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -993,9 +993,9 @@ impl ESTree for BlockStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("BlockStatement"));
+        state.serialize_field("body", &self.body);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("body", &self.body);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1022,11 +1022,11 @@ impl ESTree for VariableDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("VariableDeclaration"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("kind", &self.kind);
         state.serialize_field("declarations", &self.declarations);
         state.serialize_ts_field("declare", &self.declare);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1050,11 +1050,11 @@ impl ESTree for VariableDeclarator<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("VariableDeclarator"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("id", &self.id);
         state.serialize_field("init", &self.init);
         state.serialize_ts_field("definite", &self.definite);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1079,13 +1079,13 @@ impl ESTree for ExpressionStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ExpressionStatement"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
         state.serialize_ts_field(
             "directive",
             &crate::serialize::ts::ExpressionStatementDirective(self),
         );
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1097,11 +1097,11 @@ impl ESTree for IfStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("IfStatement"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("test", &self.test);
         state.serialize_field("consequent", &self.consequent);
         state.serialize_field("alternate", &self.alternate);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1113,10 +1113,10 @@ impl ESTree for DoWhileStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("DoWhileStatement"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("body", &self.body);
         state.serialize_field("test", &self.test);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1128,10 +1128,10 @@ impl ESTree for WhileStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("WhileStatement"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("test", &self.test);
         state.serialize_field("body", &self.body);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1143,12 +1143,12 @@ impl ESTree for ForStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ForStatement"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("init", &self.init);
         state.serialize_field("test", &self.test);
         state.serialize_field("update", &self.update);
         state.serialize_field("body", &self.body);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1211,11 +1211,11 @@ impl ESTree for ForInStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ForInStatement"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("left", &self.left);
         state.serialize_field("right", &self.right);
         state.serialize_field("body", &self.body);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1245,12 +1245,12 @@ impl ESTree for ForOfStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ForOfStatement"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("await", &self.r#await);
         state.serialize_field("left", &self.left);
         state.serialize_field("right", &self.right);
         state.serialize_field("body", &self.body);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1262,9 +1262,9 @@ impl ESTree for ContinueStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ContinueStatement"));
+        state.serialize_field("label", &self.label);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("label", &self.label);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1276,9 +1276,9 @@ impl ESTree for BreakStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("BreakStatement"));
+        state.serialize_field("label", &self.label);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("label", &self.label);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1290,9 +1290,9 @@ impl ESTree for ReturnStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ReturnStatement"));
+        state.serialize_field("argument", &self.argument);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("argument", &self.argument);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1304,10 +1304,10 @@ impl ESTree for WithStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("WithStatement"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("object", &self.object);
         state.serialize_field("body", &self.body);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1319,10 +1319,10 @@ impl ESTree for SwitchStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("SwitchStatement"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("discriminant", &self.discriminant);
         state.serialize_field("cases", &self.cases);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1334,10 +1334,10 @@ impl ESTree for SwitchCase<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("SwitchCase"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("test", &self.test);
         state.serialize_field("consequent", &self.consequent);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1349,10 +1349,10 @@ impl ESTree for LabeledStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("LabeledStatement"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("label", &self.label);
         state.serialize_field("body", &self.body);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1364,9 +1364,9 @@ impl ESTree for ThrowStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ThrowStatement"));
+        state.serialize_field("argument", &self.argument);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("argument", &self.argument);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1378,11 +1378,11 @@ impl ESTree for TryStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TryStatement"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("block", &self.block);
         state.serialize_field("handler", &self.handler);
         state.serialize_field("finalizer", &self.finalizer);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1394,10 +1394,10 @@ impl ESTree for CatchClause<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("CatchClause"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("param", &self.param);
         state.serialize_field("body", &self.body);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1445,13 +1445,13 @@ impl ESTree for AssignmentPattern<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("AssignmentPattern"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
         state.serialize_field("left", &self.left);
         state.serialize_field("right", &self.right);
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1463,12 +1463,12 @@ impl ESTree for ObjectPattern<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ObjectPattern"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
         state.serialize_field("properties", &Concat2(&self.properties, &self.rest));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1480,8 +1480,6 @@ impl ESTree for BindingProperty<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Property"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("kind", &crate::serialize::basic::Init(self));
         state.serialize_field("key", &self.key);
         state.serialize_field("value", &self.value);
@@ -1489,6 +1487,8 @@ impl ESTree for BindingProperty<'_> {
         state.serialize_field("shorthand", &self.shorthand);
         state.serialize_field("computed", &self.computed);
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1500,12 +1500,12 @@ impl ESTree for ArrayPattern<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ArrayPattern"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
         state.serialize_field("elements", &Concat2(&self.elements, &self.rest));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1517,13 +1517,13 @@ impl ESTree for BindingRestElement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("RestElement"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
         state.serialize_field("argument", &self.argument);
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
         state.serialize_ts_field("value", &crate::serialize::basic::TsNull(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1535,8 +1535,6 @@ impl ESTree for Function<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &self.r#type);
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("id", &self.id);
         state.serialize_field("generator", &self.generator);
         state.serialize_field("async", &self.r#async);
@@ -1546,6 +1544,8 @@ impl ESTree for Function<'_> {
         state.serialize_ts_field("returnType", &self.return_type);
         state.serialize_field("body", &self.body);
         state.serialize_field("expression", &crate::serialize::basic::False(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1599,9 +1599,9 @@ impl ESTree for FunctionBody<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("BlockStatement"));
+        state.serialize_field("body", &Concat2(&self.directives, &self.statements));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("body", &Concat2(&self.directives, &self.statements));
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1613,8 +1613,6 @@ impl ESTree for ArrowFunctionExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ArrowFunctionExpression"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
         state.serialize_field("async", &self.r#async);
         state.serialize_ts_field("typeParameters", &self.type_parameters);
@@ -1623,6 +1621,8 @@ impl ESTree for ArrowFunctionExpression<'_> {
         state.serialize_field("body", &crate::serialize::js::ArrowFunctionExpressionBody(self));
         state.serialize_field("id", &crate::serialize::basic::Null(self));
         state.serialize_field("generator", &crate::serialize::basic::False(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1634,10 +1634,10 @@ impl ESTree for YieldExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("YieldExpression"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("delegate", &self.delegate);
         state.serialize_field("argument", &self.argument);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1649,8 +1649,6 @@ impl ESTree for Class<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &self.r#type);
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("decorators", &self.decorators);
         state.serialize_field("id", &self.id);
         state.serialize_ts_field("typeParameters", &self.type_parameters);
@@ -1660,6 +1658,8 @@ impl ESTree for Class<'_> {
         state.serialize_field("body", &self.body);
         state.serialize_ts_field("abstract", &self.r#abstract);
         state.serialize_ts_field("declare", &self.declare);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1680,9 +1680,9 @@ impl ESTree for ClassBody<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ClassBody"));
+        state.serialize_field("body", &self.body);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("body", &self.body);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1706,8 +1706,6 @@ impl ESTree for MethodDefinition<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &self.r#type);
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("decorators", &self.decorators);
         state.serialize_field("key", &self.key);
         state.serialize_field("value", &self.value);
@@ -1717,6 +1715,8 @@ impl ESTree for MethodDefinition<'_> {
         state.serialize_ts_field("override", &self.r#override);
         state.serialize_ts_field("optional", &self.optional);
         state.serialize_ts_field("accessibility", &self.accessibility);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1739,8 +1739,6 @@ impl ESTree for PropertyDefinition<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &self.r#type);
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("decorators", &self.decorators);
         state.serialize_field("key", &self.key);
         state.serialize_ts_field("typeAnnotation", &self.type_annotation);
@@ -1753,6 +1751,8 @@ impl ESTree for PropertyDefinition<'_> {
         state.serialize_ts_field("definite", &self.definite);
         state.serialize_ts_field("readonly", &self.readonly);
         state.serialize_ts_field("accessibility", &self.accessibility);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1786,9 +1786,9 @@ impl ESTree for PrivateIdentifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("PrivateIdentifier"));
+        state.serialize_field("name", &self.name);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("name", &self.name);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1800,9 +1800,9 @@ impl ESTree for StaticBlock<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("StaticBlock"));
+        state.serialize_field("body", &self.body);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("body", &self.body);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1838,8 +1838,6 @@ impl ESTree for AccessorProperty<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &self.r#type);
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("decorators", &self.decorators);
         state.serialize_field("key", &self.key);
         state.serialize_ts_field("typeAnnotation", &self.type_annotation);
@@ -1852,6 +1850,8 @@ impl ESTree for AccessorProperty<'_> {
         state.serialize_ts_field("declare", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("readonly", &crate::serialize::basic::TsFalse(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1863,11 +1863,11 @@ impl ESTree for ImportExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ImportExpression"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("source", &self.source);
         state.serialize_field("options", &self.options);
         state.serialize_field("phase", &self.phase);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1879,8 +1879,6 @@ impl ESTree for ImportDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ImportDeclaration"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field(
             "specifiers",
             &crate::serialize::js::ImportDeclarationSpecifiers(self),
@@ -1892,6 +1890,8 @@ impl ESTree for ImportDeclaration<'_> {
             &crate::serialize::js::ImportDeclarationWithClause(self),
         );
         state.serialize_ts_field("importKind", &self.import_kind);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1922,11 +1922,11 @@ impl ESTree for ImportSpecifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ImportSpecifier"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("imported", &self.imported);
         state.serialize_field("local", &self.local);
         state.serialize_ts_field("importKind", &self.import_kind);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1938,9 +1938,9 @@ impl ESTree for ImportDefaultSpecifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ImportDefaultSpecifier"));
+        state.serialize_field("local", &self.local);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("local", &self.local);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1952,9 +1952,9 @@ impl ESTree for ImportNamespaceSpecifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ImportNamespaceSpecifier"));
+        state.serialize_field("local", &self.local);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("local", &self.local);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -1977,10 +1977,10 @@ impl ESTree for ImportAttribute<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ImportAttribute"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("key", &self.key);
         state.serialize_field("value", &self.value);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2001,8 +2001,6 @@ impl ESTree for ExportNamedDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ExportNamedDeclaration"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("declaration", &self.declaration);
         state.serialize_field("specifiers", &self.specifiers);
         state.serialize_field("source", &self.source);
@@ -2011,6 +2009,8 @@ impl ESTree for ExportNamedDeclaration<'_> {
             "attributes",
             &crate::serialize::js::ExportNamedDeclarationWithClause(self),
         );
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2022,10 +2022,10 @@ impl ESTree for ExportDefaultDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ExportDefaultDeclaration"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("declaration", &self.declaration);
         state.serialize_ts_field("exportKind", &crate::serialize::basic::TsValue(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2037,8 +2037,6 @@ impl ESTree for ExportAllDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ExportAllDeclaration"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("exported", &self.exported);
         state.serialize_field("source", &self.source);
         state.serialize_field(
@@ -2046,6 +2044,8 @@ impl ESTree for ExportAllDeclaration<'_> {
             &crate::serialize::js::ExportAllDeclarationWithClause(self),
         );
         state.serialize_ts_field("exportKind", &self.export_kind);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2057,11 +2057,11 @@ impl ESTree for ExportSpecifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("ExportSpecifier"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("local", &self.local);
         state.serialize_field("exported", &self.exported);
         state.serialize_ts_field("exportKind", &self.export_kind);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2136,10 +2136,10 @@ impl ESTree for V8IntrinsicExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("V8IntrinsicExpression"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &self.name);
         state.serialize_field("arguments", &self.arguments);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2151,10 +2151,10 @@ impl ESTree for BooleanLiteral {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Literal"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &self.value);
         state.serialize_field("raw", &crate::serialize::literal::BooleanLiteralRaw(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2166,10 +2166,10 @@ impl ESTree for NullLiteral {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Literal"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &crate::serialize::basic::Null(self));
         state.serialize_field("raw", &crate::serialize::literal::NullLiteralRaw(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2181,10 +2181,10 @@ impl ESTree for NumericLiteral<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Literal"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &self.value);
         state.serialize_field("raw", &self.raw.map(|s| JsonSafeString(s.as_str())));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2196,10 +2196,10 @@ impl ESTree for StringLiteral<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Literal"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &crate::serialize::literal::StringLiteralValue(self));
         state.serialize_field("raw", &self.raw);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2211,11 +2211,11 @@ impl ESTree for BigIntLiteral<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Literal"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &crate::serialize::literal::BigIntLiteralValue(self));
         state.serialize_field("raw", &self.raw.map(|s| JsonSafeString(s.as_str())));
         state.serialize_field("bigint", &crate::serialize::literal::BigIntLiteralBigint(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2227,11 +2227,11 @@ impl ESTree for RegExpLiteral<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Literal"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &crate::serialize::literal::RegExpLiteralValue(self));
         state.serialize_field("raw", &self.raw);
         state.serialize_field("regex", &self.regex);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2266,14 +2266,14 @@ impl ESTree for JSXElement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXElement"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field(
             "openingElement",
             &crate::serialize::jsx::JSXElementOpeningElement(self),
         );
         state.serialize_field("children", &self.children);
         state.serialize_field("closingElement", &self.closing_element);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2285,8 +2285,6 @@ impl ESTree for JSXOpeningElement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXOpeningElement"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &self.name);
         state.serialize_ts_field("typeArguments", &self.type_arguments);
         state.serialize_field("attributes", &self.attributes);
@@ -2294,6 +2292,8 @@ impl ESTree for JSXOpeningElement<'_> {
             "selfClosing",
             &crate::serialize::jsx::JSXOpeningElementSelfClosing(self),
         );
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2305,9 +2305,9 @@ impl ESTree for JSXClosingElement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXClosingElement"));
+        state.serialize_field("name", &self.name);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("name", &self.name);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2319,11 +2319,11 @@ impl ESTree for JSXFragment<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXFragment"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("openingFragment", &self.opening_fragment);
         state.serialize_field("children", &self.children);
         state.serialize_field("closingFragment", &self.closing_fragment);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2335,10 +2335,10 @@ impl ESTree for JSXOpeningFragment {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXOpeningFragment"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_js_field("attributes", &crate::serialize::basic::JsEmptyArray(self));
         state.serialize_js_field("selfClosing", &crate::serialize::basic::JsFalse(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2379,10 +2379,10 @@ impl ESTree for JSXNamespacedName<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXNamespacedName"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("namespace", &self.namespace);
         state.serialize_field("name", &self.name);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2394,10 +2394,10 @@ impl ESTree for JSXMemberExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXMemberExpression"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("object", &self.object);
         state.serialize_field("property", &self.property);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2423,9 +2423,9 @@ impl ESTree for JSXExpressionContainer<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXExpressionContainer"));
+        state.serialize_field("expression", &self.expression);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("expression", &self.expression);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2510,10 +2510,10 @@ impl ESTree for JSXAttribute<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXAttribute"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &self.name);
         state.serialize_field("value", &self.value);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2525,9 +2525,9 @@ impl ESTree for JSXSpreadAttribute<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXSpreadAttribute"));
+        state.serialize_field("argument", &self.argument);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("argument", &self.argument);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2559,9 +2559,9 @@ impl ESTree for JSXIdentifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXIdentifier"));
+        state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2585,9 +2585,9 @@ impl ESTree for JSXSpreadChild<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXSpreadChild"));
+        state.serialize_field("expression", &self.expression);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("expression", &self.expression);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2599,10 +2599,10 @@ impl ESTree for JSXText<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXText"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &self.value);
         state.serialize_field("raw", &self.raw);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2614,12 +2614,12 @@ impl ESTree for TSThisParameter<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Identifier"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("decorators", &crate::serialize::basic::EmptyArray(self));
         state.serialize_field("name", &crate::serialize::basic::This(self));
         state.serialize_field("optional", &crate::serialize::basic::False(self));
         state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2631,12 +2631,12 @@ impl ESTree for TSEnumDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSEnumDeclaration"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("id", &self.id);
         state.serialize_field("body", &self.body);
         state.serialize_field("const", &self.r#const);
         state.serialize_field("declare", &self.declare);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2648,9 +2648,9 @@ impl ESTree for TSEnumBody<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSEnumBody"));
+        state.serialize_field("members", &self.members);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("members", &self.members);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2662,11 +2662,11 @@ impl ESTree for TSEnumMember<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSEnumMember"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("id", &self.id);
         state.serialize_field("initializer", &self.initializer);
         state.serialize_field("computed", &crate::serialize::ts::TSEnumMemberComputed(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2689,9 +2689,9 @@ impl ESTree for TSTypeAnnotation<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTypeAnnotation"));
+        state.serialize_field("typeAnnotation", &self.type_annotation);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("typeAnnotation", &self.type_annotation);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2703,9 +2703,9 @@ impl ESTree for TSLiteralType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSLiteralType"));
+        state.serialize_field("literal", &self.literal);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("literal", &self.literal);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2774,12 +2774,12 @@ impl ESTree for TSConditionalType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSConditionalType"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("checkType", &self.check_type);
         state.serialize_field("extendsType", &self.extends_type);
         state.serialize_field("trueType", &self.true_type);
         state.serialize_field("falseType", &self.false_type);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2791,9 +2791,9 @@ impl ESTree for TSUnionType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSUnionType"));
+        state.serialize_field("types", &self.types);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("types", &self.types);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2805,9 +2805,9 @@ impl ESTree for TSIntersectionType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSIntersectionType"));
+        state.serialize_field("types", &self.types);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("types", &self.types);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2819,9 +2819,9 @@ impl ESTree for TSParenthesizedType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSParenthesizedType"));
+        state.serialize_field("typeAnnotation", &self.type_annotation);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("typeAnnotation", &self.type_annotation);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2833,10 +2833,10 @@ impl ESTree for TSTypeOperator<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTypeOperator"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("operator", &self.operator);
         state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2858,9 +2858,9 @@ impl ESTree for TSArrayType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSArrayType"));
+        state.serialize_field("elementType", &self.element_type);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("elementType", &self.element_type);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2872,10 +2872,10 @@ impl ESTree for TSIndexedAccessType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSIndexedAccessType"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("objectType", &self.object_type);
         state.serialize_field("indexType", &self.index_type);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2887,9 +2887,9 @@ impl ESTree for TSTupleType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTupleType"));
+        state.serialize_field("elementTypes", &self.element_types);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("elementTypes", &self.element_types);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2901,11 +2901,11 @@ impl ESTree for TSNamedTupleMember<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSNamedTupleMember"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("label", &self.label);
         state.serialize_field("elementType", &self.element_type);
         state.serialize_field("optional", &self.optional);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2917,9 +2917,9 @@ impl ESTree for TSOptionalType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSOptionalType"));
+        state.serialize_field("typeAnnotation", &self.type_annotation);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("typeAnnotation", &self.type_annotation);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -2931,9 +2931,9 @@ impl ESTree for TSRestType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSRestType"));
+        state.serialize_field("typeAnnotation", &self.type_annotation);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("typeAnnotation", &self.type_annotation);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3173,10 +3173,10 @@ impl ESTree for TSTypeReference<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTypeReference"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("typeName", &self.type_name);
         state.serialize_field("typeArguments", &self.type_arguments);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3199,10 +3199,10 @@ impl ESTree for TSQualifiedName<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSQualifiedName"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("left", &self.left);
         state.serialize_field("right", &self.right);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3214,9 +3214,9 @@ impl ESTree for TSTypeParameterInstantiation<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTypeParameterInstantiation"));
+        state.serialize_field("params", &self.params);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("params", &self.params);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3228,14 +3228,14 @@ impl ESTree for TSTypeParameter<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTypeParameter"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &self.name);
         state.serialize_field("constraint", &self.constraint);
         state.serialize_field("default", &self.default);
         state.serialize_field("in", &self.r#in);
         state.serialize_field("out", &self.out);
         state.serialize_field("const", &self.r#const);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3247,9 +3247,9 @@ impl ESTree for TSTypeParameterDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTypeParameterDeclaration"));
+        state.serialize_field("params", &self.params);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("params", &self.params);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3261,12 +3261,12 @@ impl ESTree for TSTypeAliasDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTypeAliasDeclaration"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("id", &self.id);
         state.serialize_field("typeParameters", &self.type_parameters);
         state.serialize_field("typeAnnotation", &self.type_annotation);
         state.serialize_field("declare", &self.declare);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3288,13 +3288,13 @@ impl ESTree for TSClassImplements<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSClassImplements"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field(
             "expression",
             &crate::serialize::ts::TSClassImplementsExpression(self),
         );
         state.serialize_field("typeArguments", &self.type_arguments);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3306,13 +3306,13 @@ impl ESTree for TSInterfaceDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSInterfaceDeclaration"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("id", &self.id);
         state.serialize_field("typeParameters", &self.type_parameters);
         state.serialize_field("extends", &self.extends);
         state.serialize_field("body", &self.body);
         state.serialize_field("declare", &self.declare);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3324,9 +3324,9 @@ impl ESTree for TSInterfaceBody<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSInterfaceBody"));
+        state.serialize_field("body", &self.body);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("body", &self.body);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3338,8 +3338,6 @@ impl ESTree for TSPropertySignature<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSPropertySignature"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("computed", &self.computed);
         state.serialize_field("optional", &self.optional);
         state.serialize_field("readonly", &self.readonly);
@@ -3347,6 +3345,8 @@ impl ESTree for TSPropertySignature<'_> {
         state.serialize_field("typeAnnotation", &self.type_annotation);
         state.serialize_field("accessibility", &crate::serialize::basic::Null(self));
         state.serialize_field("static", &crate::serialize::basic::False(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3370,13 +3370,13 @@ impl ESTree for TSIndexSignature<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSIndexSignature"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("parameters", &self.parameters);
         state.serialize_field("typeAnnotation", &self.type_annotation);
         state.serialize_field("readonly", &self.readonly);
         state.serialize_field("static", &self.r#static);
         state.serialize_field("accessibility", &crate::serialize::basic::Null(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3388,14 +3388,14 @@ impl ESTree for TSCallSignatureDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSCallSignatureDeclaration"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("typeParameters", &self.type_parameters);
         state.serialize_field(
             "params",
             &crate::serialize::ts::TSCallSignatureDeclarationParams(self),
         );
         state.serialize_field("returnType", &self.return_type);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3417,8 +3417,6 @@ impl ESTree for TSMethodSignature<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSMethodSignature"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("key", &self.key);
         state.serialize_field("computed", &self.computed);
         state.serialize_field("optional", &self.optional);
@@ -3429,6 +3427,8 @@ impl ESTree for TSMethodSignature<'_> {
         state.serialize_field("accessibility", &crate::serialize::basic::Null(self));
         state.serialize_field("readonly", &crate::serialize::basic::False(self));
         state.serialize_field("static", &crate::serialize::basic::False(self));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3440,11 +3440,11 @@ impl ESTree for TSConstructSignatureDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSConstructSignatureDeclaration"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("typeParameters", &self.type_parameters);
         state.serialize_field("params", &self.params);
         state.serialize_field("returnType", &self.return_type);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3456,12 +3456,12 @@ impl ESTree for TSIndexSignatureName<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Identifier"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("decorators", &crate::serialize::basic::EmptyArray(self));
         state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.serialize_field("optional", &crate::serialize::basic::False(self));
         state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3473,10 +3473,10 @@ impl ESTree for TSInterfaceHeritage<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSInterfaceHeritage"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
         state.serialize_field("typeArguments", &self.type_arguments);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3488,11 +3488,11 @@ impl ESTree for TSTypePredicate<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTypePredicate"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("parameterName", &self.parameter_name);
         state.serialize_field("asserts", &self.asserts);
         state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3547,9 +3547,9 @@ impl ESTree for TSModuleBlock<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSModuleBlock"));
+        state.serialize_field("body", &Concat2(&self.directives, &self.body));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("body", &Concat2(&self.directives, &self.body));
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3561,9 +3561,9 @@ impl ESTree for TSTypeLiteral<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTypeLiteral"));
+        state.serialize_field("members", &self.members);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("members", &self.members);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3575,9 +3575,9 @@ impl ESTree for TSInferType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSInferType"));
+        state.serialize_field("typeParameter", &self.type_parameter);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("typeParameter", &self.type_parameter);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3589,10 +3589,10 @@ impl ESTree for TSTypeQuery<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTypeQuery"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("exprName", &self.expr_name);
         state.serialize_field("typeArguments", &self.type_arguments);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3616,12 +3616,12 @@ impl ESTree for TSImportType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSImportType"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("argument", &self.argument);
         state.serialize_field("options", &self.options);
         state.serialize_field("qualifier", &self.qualifier);
         state.serialize_field("typeArguments", &self.type_arguments);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3633,11 +3633,11 @@ impl ESTree for TSFunctionType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSFunctionType"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("typeParameters", &self.type_parameters);
         state.serialize_field("params", &crate::serialize::ts::TSFunctionTypeParams(self));
         state.serialize_field("returnType", &self.return_type);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3649,12 +3649,12 @@ impl ESTree for TSConstructorType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSConstructorType"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("abstract", &self.r#abstract);
         state.serialize_field("typeParameters", &self.type_parameters);
         state.serialize_field("params", &self.params);
         state.serialize_field("returnType", &self.return_type);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3666,14 +3666,14 @@ impl ESTree for TSMappedType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSMappedType"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("key", &crate::serialize::ts::TSMappedTypeKey(self));
         state.serialize_field("constraint", &crate::serialize::ts::TSMappedTypeConstraint(self));
         state.serialize_field("nameType", &self.name_type);
         state.serialize_field("typeAnnotation", &self.type_annotation);
         state.serialize_field("optional", &crate::serialize::ts::TSMappedTypeOptional(self));
         state.serialize_field("readonly", &self.readonly);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3695,10 +3695,10 @@ impl ESTree for TSTemplateLiteralType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTemplateLiteralType"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("quasis", &self.quasis);
         state.serialize_field("types", &self.types);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3710,10 +3710,10 @@ impl ESTree for TSAsExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSAsExpression"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
         state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3725,10 +3725,10 @@ impl ESTree for TSSatisfiesExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSSatisfiesExpression"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
         state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3740,10 +3740,10 @@ impl ESTree for TSTypeAssertion<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSTypeAssertion"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("typeAnnotation", &self.type_annotation);
         state.serialize_field("expression", &self.expression);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3755,11 +3755,11 @@ impl ESTree for TSImportEqualsDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSImportEqualsDeclaration"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("id", &self.id);
         state.serialize_field("moduleReference", &self.module_reference);
         state.serialize_field("importKind", &self.import_kind);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3783,9 +3783,9 @@ impl ESTree for TSExternalModuleReference<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSExternalModuleReference"));
+        state.serialize_field("expression", &self.expression);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("expression", &self.expression);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3797,9 +3797,9 @@ impl ESTree for TSNonNullExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSNonNullExpression"));
+        state.serialize_field("expression", &self.expression);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("expression", &self.expression);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3811,9 +3811,9 @@ impl ESTree for Decorator<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Decorator"));
+        state.serialize_field("expression", &self.expression);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("expression", &self.expression);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3825,9 +3825,9 @@ impl ESTree for TSExportAssignment<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSExportAssignment"));
+        state.serialize_field("expression", &self.expression);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("expression", &self.expression);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3839,9 +3839,9 @@ impl ESTree for TSNamespaceExportDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSNamespaceExportDeclaration"));
+        state.serialize_field("id", &self.id);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("id", &self.id);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3853,10 +3853,10 @@ impl ESTree for TSInstantiationExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSInstantiationExpression"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
         state.serialize_field("typeArguments", &self.type_arguments);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3877,10 +3877,10 @@ impl ESTree for JSDocNullableType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSJSDocNullableType"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("typeAnnotation", &self.type_annotation);
         state.serialize_field("postfix", &self.postfix);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -3892,10 +3892,10 @@ impl ESTree for JSDocNonNullableType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSJSDocNonNullableType"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("typeAnnotation", &self.type_annotation);
         state.serialize_field("postfix", &self.postfix);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }

--- a/crates/oxc_ast/src/serialize/js.rs
+++ b/crates/oxc_ast/src/serialize/js.rs
@@ -59,32 +59,24 @@ impl ESTree for BindingPatternKindAndTsFields<'_, '_> {
         let span = match &self.kind {
             BindingPatternKind::BindingIdentifier(ident) => {
                 state.serialize_field("type", &JsonSafeString("Identifier"));
-                state.serialize_field("start", &ident.span.start);
-                state.serialize_field("end", &ident.span.end);
                 state.serialize_field("decorators", &self.decorators);
                 state.serialize_field("name", &JsonSafeString(ident.name.as_str()));
                 ident.span
             }
             BindingPatternKind::ObjectPattern(object) => {
                 state.serialize_field("type", &JsonSafeString("ObjectPattern"));
-                state.serialize_field("start", &object.span.start);
-                state.serialize_field("end", &object.span.end);
                 state.serialize_field("decorators", &self.decorators);
                 state.serialize_field("properties", &Concat2(&object.properties, &object.rest));
                 object.span
             }
             BindingPatternKind::ArrayPattern(array) => {
                 state.serialize_field("type", &JsonSafeString("ArrayPattern"));
-                state.serialize_field("start", &array.span.start);
-                state.serialize_field("end", &array.span.end);
                 state.serialize_field("decorators", &self.decorators);
                 state.serialize_field("elements", &Concat2(&array.elements, &array.rest));
                 array.span
             }
             BindingPatternKind::AssignmentPattern(assignment) => {
                 state.serialize_field("type", &JsonSafeString("AssignmentPattern"));
-                state.serialize_field("start", &assignment.span.start);
-                state.serialize_field("end", &assignment.span.end);
                 state.serialize_field("decorators", &self.decorators);
                 state.serialize_field("left", &assignment.left);
                 state.serialize_field("right", &assignment.right);
@@ -95,6 +87,8 @@ impl ESTree for BindingPatternKindAndTsFields<'_, '_> {
         state.serialize_field("optional", &self.optional);
         state.serialize_field("typeAnnotation", &self.type_annotation);
 
+        state.serialize_field("start", &span.start);
+        state.serialize_field("end", &span.end);
         if state.ranges() {
             state.serialize_field("range", &[span.start, span.end]);
         }
@@ -131,8 +125,6 @@ impl ESTree for CatchParameterConverter<'_, '_> {
             pos = uint32[(POS_OFFSET.rest) >> 2];
             params.push({
                 type: 'RestElement',
-                start: DESER[u32]( POS_OFFSET<BindingRestElement>.span.start ),
-                end: DESER[u32]( POS_OFFSET<BindingRestElement>.span.end ),
                 /* IF_TS */
                 decorators: [],
                 /* END_IF_TS */
@@ -144,6 +136,8 @@ impl ESTree for CatchParameterConverter<'_, '_> {
                 ),
                 value: null,
                 /* END_IF_TS */
+                start: DESER[u32]( POS_OFFSET<BindingRestElement>.span.start ),
+                end: DESER[u32]( POS_OFFSET<BindingRestElement>.span.end ),
             });
         }
         params
@@ -175,13 +169,13 @@ impl ESTree for FormalParametersRest<'_, '_> {
         let rest = self.0;
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("RestElement"));
-        state.serialize_field("start", &rest.span.start);
-        state.serialize_field("end", &rest.span.end);
         state.serialize_ts_field("decorators", &EmptyArray(()));
         state.serialize_field("argument", &rest.argument.kind);
         state.serialize_ts_field("optional", &rest.argument.optional);
         state.serialize_ts_field("typeAnnotation", &rest.argument.type_annotation);
         state.serialize_ts_field("value", &Null(()));
+        state.serialize_field("start", &rest.span.start);
+        state.serialize_field("end", &rest.span.end);
         if state.ranges() {
             state.serialize_field("range", &[rest.span.start, rest.span.end]);
         }
@@ -214,14 +208,14 @@ impl ESTree for FormalParametersRest<'_, '_> {
         } else {
             param = {
                 type: 'TSParameterProperty',
-                start: DESER[u32](POS_OFFSET.span.start),
-                end: DESER[u32](POS_OFFSET.span.end),
                 accessibility,
                 decorators: DESER[Vec<Decorator>](POS_OFFSET.decorators),
                 override,
                 parameter: DESER[BindingPattern](POS_OFFSET.pattern),
                 readonly,
                 static: false,
+                start: DESER[u32]( POS_OFFSET<BindingRestElement>.span.start ),
+                end: DESER[u32]( POS_OFFSET<BindingRestElement>.span.end ),
             };
         }
         param
@@ -238,14 +232,14 @@ impl ESTree for FormalParameterConverter<'_, '_> {
             if param.has_modifier() {
                 let mut state = serializer.serialize_struct();
                 state.serialize_field("type", &JsonSafeString("TSParameterProperty"));
-                state.serialize_field("start", &param.span.start);
-                state.serialize_field("end", &param.span.end);
                 state.serialize_field("accessibility", &param.accessibility);
                 state.serialize_field("decorators", &param.decorators);
                 state.serialize_field("override", &param.r#override);
                 state.serialize_field("parameter", &param.pattern);
                 state.serialize_field("readonly", &param.readonly);
                 state.serialize_field("static", &false);
+                state.serialize_field("start", &param.span.start);
+                state.serialize_field("end", &param.span.end);
                 if state.ranges() {
                     state.serialize_field("range", &[param.span.start, param.span.end]);
                 }
@@ -429,8 +423,6 @@ impl ESTree for ArrowFunctionExpressionBody<'_> {
                 ? keyCopy
                 : {
                     type: 'AssignmentPattern',
-                    start: THIS.start,
-                    end: THIS.end,
                     /* IF_TS */
                     decorators: [],
                     /* END_IF_TS */
@@ -440,6 +432,8 @@ impl ESTree for ArrowFunctionExpressionBody<'_> {
                     optional: false,
                     typeAnnotation: null,
                     /* END_IF_TS */
+                    start: THIS.start,
+                    end: THIS.end,
                 };
         value
     "
@@ -453,13 +447,13 @@ impl ESTree for AssignmentTargetPropertyIdentifierInit<'_> {
         if let Some(init) = &self.0.init {
             let mut state = serializer.serialize_struct();
             state.serialize_field("type", &JsonSafeString("AssignmentPattern"));
-            state.serialize_field("start", &self.0.span.start);
-            state.serialize_field("end", &self.0.span.end);
             state.serialize_ts_field("decorators", &EmptyArray(()));
             state.serialize_field("left", &self.0.binding);
             state.serialize_field("right", init);
             state.serialize_ts_field("optional", &false);
             state.serialize_ts_field("typeAnnotation", &Null(()));
+            state.serialize_field("start", &self.0.span.start);
+            state.serialize_field("end", &self.0.span.end);
             if state.ranges() {
                 state.serialize_field("range", &[self.0.span.start, self.0.span.end]);
             }

--- a/crates/oxc_ast/src/serialize/jsx.rs
+++ b/crates/oxc_ast/src/serialize/jsx.rs
@@ -24,12 +24,12 @@ impl ESTree for JSXElementOpeningElement<'_, '_> {
 
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("JSXOpeningElement"));
-        state.serialize_field("start", &opening_element.span.start);
-        state.serialize_field("end", &opening_element.span.end);
         state.serialize_field("name", &opening_element.name);
         state.serialize_ts_field("typeArguments", &opening_element.type_arguments);
         state.serialize_field("attributes", &opening_element.attributes);
         state.serialize_field("selfClosing", &element.closing_element.is_none());
+        state.serialize_field("start", &opening_element.span.start);
+        state.serialize_field("end", &opening_element.span.end);
         if state.ranges() {
             state.serialize_field("range", &[opening_element.span.start, opening_element.span.end]);
         }
@@ -60,7 +60,7 @@ impl ESTree for JSXOpeningElementSelfClosing<'_, '_> {
     ts_type = "JSXIdentifier",
     raw_deser = "
         const ident = DESER[Box<IdentifierReference>](POS);
-        { type: 'JSXIdentifier', start: ident.start, end: ident.end, name: ident.name }
+        { type: 'JSXIdentifier', name: ident.name, start: ident.start, end: ident.end }
     "
 )]
 pub struct JSXElementIdentifierReference<'a, 'b>(pub &'b IdentifierReference<'a>);
@@ -79,7 +79,7 @@ impl ESTree for JSXElementIdentifierReference<'_, '_> {
     ts_type = "JSXIdentifier",
     raw_deser = "
         const thisExpr = DESER[Box<ThisExpression>](POS);
-        { type: 'JSXIdentifier', start: thisExpr.start, end: thisExpr.end, name: 'this' }
+        { type: 'JSXIdentifier', name: 'this', start: thisExpr.start, end: thisExpr.end }
     "
 )]
 pub struct JSXElementThisExpression<'b>(pub &'b ThisExpression);

--- a/crates/oxc_ast/src/serialize/literal.rs
+++ b/crates/oxc_ast/src/serialize/literal.rs
@@ -202,7 +202,7 @@ impl ESTree for RegExpFlagsConverter<'_> {
         value.cooked = value.cooked
             .replace(/\uFFFD(.{4})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)));
     }
-    { type: 'TemplateElement', start, end, value, tail }
+    { type: 'TemplateElement', value, tail, start, end }
 "#)]
 pub struct TemplateElementConverter<'a, 'b>(pub &'b TemplateElement<'a>);
 
@@ -213,17 +213,17 @@ impl ESTree for TemplateElementConverter<'_, '_> {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TemplateElement"));
 
+        state.serialize_field("value", &TemplateElementValue(element));
+        state.serialize_field("tail", &element.tail);
+
         let mut span = element.span;
         if S::INCLUDE_TS_FIELDS {
             span.start -= 1;
             span.end += if element.tail { 1 } else { 2 };
         }
+
         state.serialize_field("start", &span.start);
         state.serialize_field("end", &span.end);
-
-        state.serialize_field("value", &TemplateElementValue(element));
-        state.serialize_field("tail", &element.tail);
-
         if state.ranges() {
             state.serialize_field("range", &[span.start, span.end]);
         }

--- a/crates/oxc_ast/src/serialize/mod.rs
+++ b/crates/oxc_ast/src/serialize/mod.rs
@@ -152,11 +152,11 @@ impl Program<'_> {
 
     const program = {
         type: 'Program',
-        start,
-        end,
         body,
         sourceType: DESER[ModuleKind](POS_OFFSET.source_type.module_kind),
         hashbang: DESER[Option<Hashbang>](POS_OFFSET.hashbang),
+        start,
+        end,
     };
     program
 ")]
@@ -165,19 +165,21 @@ pub struct ProgramConverter<'a, 'b>(pub &'b Program<'a>);
 impl ESTree for ProgramConverter<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let program = self.0;
-        let span_start =
-            if S::INCLUDE_TS_FIELDS { get_ts_start_span(program) } else { program.span.start };
 
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Program"));
-        state.serialize_field("start", &span_start);
-        state.serialize_field("end", &program.span.end);
         state.serialize_field("body", &Concat2(&program.directives, &program.body));
         state.serialize_field("sourceType", &program.source_type.module_kind());
         state.serialize_field("hashbang", &program.hashbang);
+
+        let span_start =
+            if S::INCLUDE_TS_FIELDS { get_ts_start_span(program) } else { program.span.start };
+        state.serialize_field("start", &span_start);
+        state.serialize_field("end", &program.span.end);
         if state.ranges() {
             state.serialize_field("range", &[span_start, program.span.end]);
         }
+
         state.end();
     }
 }

--- a/crates/oxc_ast/src/serialize/ts.rs
+++ b/crates/oxc_ast/src/serialize/ts.rs
@@ -62,10 +62,10 @@ impl ESTree for ExpressionStatementDirective<'_, '_> {
         if (innerId.type === 'Identifier') {
             id = {
                 type: 'TSQualifiedName',
-                start: id.start,
-                end: innerId.end,
                 left: id,
                 right: innerId,
+                start: id.start,
+                end: innerId.end,
             };
         } else {
             // Replace `left` of innermost `TSQualifiedName` with a nested `TSQualifiedName` with `id` of
@@ -77,10 +77,10 @@ impl ESTree for ExpressionStatementDirective<'_, '_> {
             }
             innerId.left = {
                 type: 'TSQualifiedName',
-                start: id.start,
-                end: innerId.left.end,
                 left: id,
                 right: innerId.left,
+                start: id.start,
+                end: innerId.left.end,
             };
             id = body.id;
         }
@@ -89,8 +89,8 @@ impl ESTree for ExpressionStatementDirective<'_, '_> {
 
     // Skip `body` field if `null`
     const node = body === null
-        ? { type: 'TSModuleDeclaration', start, end, id, kind, declare, global }
-        : { type: 'TSModuleDeclaration', start, end, id, body, kind, declare, global };
+        ? { type: 'TSModuleDeclaration', id, kind, declare, global, start, end }
+        : { type: 'TSModuleDeclaration', id, body, kind, declare, global, start, end };
     node
 ")]
 pub struct TSModuleDeclarationConverter<'a, 'b>(pub &'b TSModuleDeclaration<'a>);
@@ -101,8 +101,6 @@ impl ESTree for TSModuleDeclarationConverter<'_, '_> {
 
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSModuleDeclaration"));
-        state.serialize_field("start", &module.span.start);
-        state.serialize_field("end", &module.span.end);
 
         match &module.body {
             Some(TSModuleDeclarationBody::TSModuleDeclaration(inner_module)) => {
@@ -158,6 +156,8 @@ impl ESTree for TSModuleDeclarationConverter<'_, '_> {
         state.serialize_field("declare", &module.declare);
         state.serialize_field("global", &TSModuleDeclarationGlobal(module));
 
+        state.serialize_field("start", &module.span.start);
+        state.serialize_field("end", &module.span.end);
         if state.ranges() {
             state.serialize_field("range", &[module.span.start, module.span.end]);
         }
@@ -173,13 +173,10 @@ impl ESTree for TSModuleDeclarationIdParts<'_, '_> {
         let parts = self.0;
         assert!(!parts.is_empty());
 
-        let span_start = parts[0].span.start;
         let (&last, rest) = parts.split_last().unwrap();
 
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSQualifiedName"));
-        state.serialize_field("start", &span_start);
-        state.serialize_field("end", &last.span.end);
 
         if rest.len() == 1 {
             // Only one part remaining (e.g. `X`). Serialize as `Identifier`.
@@ -191,6 +188,9 @@ impl ESTree for TSModuleDeclarationIdParts<'_, '_> {
 
         state.serialize_field("right", last);
 
+        let span_start = parts[0].span.start;
+        state.serialize_field("start", &span_start);
+        state.serialize_field("end", &last.span.end);
         if state.ranges() {
             state.serialize_field("range", &[span_start, last.span.end]);
         }
@@ -307,24 +307,24 @@ impl ESTree for TSTypeNameIdentifierReference<'_, '_> {
         if (expression.type === 'TSQualifiedName') {
             let parent = expression = {
                 type: 'MemberExpression',
-                start: expression.start,
-                end: expression.end,
                 object: expression.left,
                 property: expression.right,
                 optional: false,
                 computed: false,
+                start: expression.start,
+                end: expression.end,
             };
 
             while (parent.object.type === 'TSQualifiedName') {
                 const object = parent.object;
                 parent = parent.object = {
                     type: 'MemberExpression',
-                    start: object.start,
-                    end: object.end,
                     object: object.left,
                     property: object.right,
                     optional: false,
                     computed: false,
+                    start: object.start,
+                    end: object.end,
                 };
             }
         }
@@ -353,12 +353,12 @@ impl ESTree for TSTypeNameAsMemberExpression<'_, '_> {
                 // Recursively convert `left` to `MemberExpression` too if it's a `TSQualifiedName`.
                 let mut state = serializer.serialize_struct();
                 state.serialize_field("type", &JsonSafeString("MemberExpression"));
-                state.serialize_field("start", &name.span.start);
-                state.serialize_field("end", &name.span.end);
                 state.serialize_field("object", &TSTypeNameAsMemberExpression(&name.left));
                 state.serialize_field("property", &name.right);
                 state.serialize_field("optional", &false);
                 state.serialize_field("computed", &false);
+                state.serialize_field("start", &name.span.start);
+                state.serialize_field("end", &name.span.end);
                 if state.ranges() {
                     state.serialize_field("range", &[name.span.start, name.span.end]);
                 }

--- a/crates/oxc_syntax/src/generated/derive_estree.rs
+++ b/crates/oxc_syntax/src/generated/derive_estree.rs
@@ -50,13 +50,13 @@ impl ESTree for ImportImportName<'_> {
 impl ESTree for ExportEntry<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("moduleRequest", &self.module_request);
         state.serialize_field("importName", &self.import_name);
         state.serialize_field("exportName", &self.export_name);
         state.serialize_field("localName", &self.local_name);
         state.serialize_field("isType", &self.is_type);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -102,9 +102,9 @@ impl ESTree for ExportLocalName<'_> {
 impl ESTree for DynamicImport {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
+        state.serialize_field("moduleRequest", &self.module_request);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("moduleRequest", &self.module_request);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }

--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ submodules:
   just clone-submodule tasks/coverage/babel https://github.com/babel/babel.git 1d4546bcb80009303aab386b59f4df1fd335c1d5
   just clone-submodule tasks/coverage/typescript https://github.com/microsoft/TypeScript.git 81c951894e93bdc37c6916f18adcd80de76679bc
   just clone-submodule tasks/prettier_conformance/prettier https://github.com/prettier/prettier.git 7584432401a47a26943dd7a9ca9a8e032ead7285
-  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 25df720d20c5299b016dcaa99ce0ca917e2df5b9
+  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 d9ba02ddea22800a285c7ad24e3fbfbb00ccbb02
   just update-transformer-fixtures
 
 # Install git pre-commit to format files

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -43,11 +43,11 @@ function deserializeProgram(pos) {
 
   const program = {
     type: 'Program',
-    start,
-    end,
     body,
     sourceType: deserializeModuleKind(pos + 125),
     hashbang: deserializeOptionHashbang(pos + 48),
+    start,
+    end,
   };
   return program;
 }
@@ -55,36 +55,36 @@ function deserializeProgram(pos) {
 function deserializeIdentifierName(pos) {
   return {
     type: 'Identifier',
+    name: deserializeStr(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    name: deserializeStr(pos + 8),
   };
 }
 
 function deserializeIdentifierReference(pos) {
   return {
     type: 'Identifier',
+    name: deserializeStr(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    name: deserializeStr(pos + 8),
   };
 }
 
 function deserializeBindingIdentifier(pos) {
   return {
     type: 'Identifier',
+    name: deserializeStr(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    name: deserializeStr(pos + 8),
   };
 }
 
 function deserializeLabelIdentifier(pos) {
   return {
     type: 'Identifier',
+    name: deserializeStr(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    name: deserializeStr(pos + 8),
   };
 }
 
@@ -99,9 +99,9 @@ function deserializeThisExpression(pos) {
 function deserializeArrayExpression(pos) {
   return {
     type: 'ArrayExpression',
+    elements: deserializeVecArrayExpressionElement(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    elements: deserializeVecArrayExpressionElement(pos + 8),
   };
 }
 
@@ -112,43 +112,43 @@ function deserializeElision(pos) {
 function deserializeObjectExpression(pos) {
   return {
     type: 'ObjectExpression',
+    properties: deserializeVecObjectPropertyKind(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    properties: deserializeVecObjectPropertyKind(pos + 8),
   };
 }
 
 function deserializeObjectProperty(pos) {
   return {
     type: 'Property',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     kind: deserializePropertyKind(pos + 40),
     key: deserializePropertyKey(pos + 8),
     value: deserializeExpression(pos + 24),
     method: deserializeBool(pos + 41),
     shorthand: deserializeBool(pos + 42),
     computed: deserializeBool(pos + 43),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTemplateLiteral(pos) {
   return {
     type: 'TemplateLiteral',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     quasis: deserializeVecTemplateElement(pos + 8),
     expressions: deserializeVecExpression(pos + 32),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTaggedTemplateExpression(pos) {
   return {
     type: 'TaggedTemplateExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     tag: deserializeExpression(pos + 8),
     quasi: deserializeTemplateLiteral(pos + 32),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -161,7 +161,7 @@ function deserializeTemplateElement(pos) {
     value.cooked = value.cooked
       .replace(/\uFFFD(.{4})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)));
   }
-  return { type: 'TemplateElement', start, end, value, tail };
+  return { type: 'TemplateElement', value, tail, start, end };
 }
 
 function deserializeTemplateElementValue(pos) {
@@ -174,153 +174,153 @@ function deserializeTemplateElementValue(pos) {
 function deserializeComputedMemberExpression(pos) {
   return {
     type: 'MemberExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     object: deserializeExpression(pos + 8),
     property: deserializeExpression(pos + 24),
     optional: deserializeBool(pos + 40),
     computed: true,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeStaticMemberExpression(pos) {
   return {
     type: 'MemberExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     object: deserializeExpression(pos + 8),
     property: deserializeIdentifierName(pos + 24),
     optional: deserializeBool(pos + 48),
     computed: false,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializePrivateFieldExpression(pos) {
   return {
     type: 'MemberExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     object: deserializeExpression(pos + 8),
     property: deserializePrivateIdentifier(pos + 24),
     optional: deserializeBool(pos + 48),
     computed: false,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeCallExpression(pos) {
   return {
     type: 'CallExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     callee: deserializeExpression(pos + 8),
     arguments: deserializeVecArgument(pos + 32),
     optional: deserializeBool(pos + 56),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeNewExpression(pos) {
   return {
     type: 'NewExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     callee: deserializeExpression(pos + 8),
     arguments: deserializeVecArgument(pos + 32),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeMetaProperty(pos) {
   return {
     type: 'MetaProperty',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     meta: deserializeIdentifierName(pos + 8),
     property: deserializeIdentifierName(pos + 32),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeSpreadElement(pos) {
   return {
     type: 'SpreadElement',
+    argument: deserializeExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    argument: deserializeExpression(pos + 8),
   };
 }
 
 function deserializeUpdateExpression(pos) {
   return {
     type: 'UpdateExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     operator: deserializeUpdateOperator(pos + 24),
     prefix: deserializeBool(pos + 25),
     argument: deserializeSimpleAssignmentTarget(pos + 8),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeUnaryExpression(pos) {
   return {
     type: 'UnaryExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     operator: deserializeUnaryOperator(pos + 24),
     argument: deserializeExpression(pos + 8),
     prefix: true,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeBinaryExpression(pos) {
   return {
     type: 'BinaryExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     left: deserializeExpression(pos + 8),
     operator: deserializeBinaryOperator(pos + 40),
     right: deserializeExpression(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializePrivateInExpression(pos) {
   return {
     type: 'BinaryExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     left: deserializePrivateIdentifier(pos + 8),
     operator: 'in',
     right: deserializeExpression(pos + 32),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeLogicalExpression(pos) {
   return {
     type: 'LogicalExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     left: deserializeExpression(pos + 8),
     operator: deserializeLogicalOperator(pos + 40),
     right: deserializeExpression(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeConditionalExpression(pos) {
   return {
     type: 'ConditionalExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     test: deserializeExpression(pos + 8),
     consequent: deserializeExpression(pos + 24),
     alternate: deserializeExpression(pos + 40),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeAssignmentExpression(pos) {
   return {
     type: 'AssignmentExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     operator: deserializeAssignmentOperator(pos + 40),
     left: deserializeAssignmentTarget(pos + 8),
     right: deserializeExpression(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -330,9 +330,9 @@ function deserializeArrayAssignmentTarget(pos) {
   if (rest !== null) elements.push(rest);
   return {
     type: 'ArrayPattern',
+    elements,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    elements,
   };
 }
 
@@ -342,79 +342,79 @@ function deserializeObjectAssignmentTarget(pos) {
   if (rest !== null) properties.push(rest);
   return {
     type: 'ObjectPattern',
+    properties,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    properties,
   };
 }
 
 function deserializeAssignmentTargetRest(pos) {
   return {
     type: 'RestElement',
+    argument: deserializeAssignmentTarget(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    argument: deserializeAssignmentTarget(pos + 8),
   };
 }
 
 function deserializeAssignmentTargetWithDefault(pos) {
   return {
     type: 'AssignmentPattern',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     left: deserializeAssignmentTarget(pos + 8),
     right: deserializeExpression(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeAssignmentTargetPropertyIdentifier(pos) {
-  const start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    key = deserializeIdentifierReference(pos + 8);
+  const key = deserializeIdentifierReference(pos + 8),
+    start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   const init = deserializeOptionExpression(pos + 40),
     keyCopy = { ...key },
     value = init === null
       ? keyCopy
       : {
         type: 'AssignmentPattern',
-        start: start,
-        end: end,
         left: keyCopy,
         right: init,
+        start: start,
+        end: end,
       };
   return {
     type: 'Property',
-    start,
-    end,
     kind: 'init',
     key,
     value,
     method: false,
     shorthand: true,
     computed: false,
+    start,
+    end,
   };
 }
 
 function deserializeAssignmentTargetPropertyProperty(pos) {
   return {
     type: 'Property',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     kind: 'init',
     key: deserializePropertyKey(pos + 8),
     value: deserializeAssignmentTargetMaybeDefault(pos + 24),
     method: false,
     shorthand: false,
     computed: deserializeBool(pos + 40),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeSequenceExpression(pos) {
   return {
     type: 'SequenceExpression',
+    expressions: deserializeVecExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expressions: deserializeVecExpression(pos + 8),
   };
 }
 
@@ -429,75 +429,75 @@ function deserializeSuper(pos) {
 function deserializeAwaitExpression(pos) {
   return {
     type: 'AwaitExpression',
+    argument: deserializeExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    argument: deserializeExpression(pos + 8),
   };
 }
 
 function deserializeChainExpression(pos) {
   return {
     type: 'ChainExpression',
+    expression: deserializeChainElement(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expression: deserializeChainElement(pos + 8),
   };
 }
 
 function deserializeParenthesizedExpression(pos) {
   return {
     type: 'ParenthesizedExpression',
+    expression: deserializeExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expression: deserializeExpression(pos + 8),
   };
 }
 
 function deserializeDirective(pos) {
   return {
     type: 'ExpressionStatement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     expression: deserializeStringLiteral(pos + 8),
     directive: deserializeStr(pos + 56),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeHashbang(pos) {
   return {
     type: 'Hashbang',
+    value: deserializeStr(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    value: deserializeStr(pos + 8),
   };
 }
 
 function deserializeBlockStatement(pos) {
   return {
     type: 'BlockStatement',
+    body: deserializeVecStatement(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    body: deserializeVecStatement(pos + 8),
   };
 }
 
 function deserializeVariableDeclaration(pos) {
   return {
     type: 'VariableDeclaration',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     kind: deserializeVariableDeclarationKind(pos + 32),
     declarations: deserializeVecVariableDeclarator(pos + 8),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeVariableDeclarator(pos) {
   return {
     type: 'VariableDeclarator',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     id: deserializeBindingPattern(pos + 8),
     init: deserializeOptionExpression(pos + 40),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -512,172 +512,172 @@ function deserializeEmptyStatement(pos) {
 function deserializeExpressionStatement(pos) {
   return {
     type: 'ExpressionStatement',
+    expression: deserializeExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expression: deserializeExpression(pos + 8),
   };
 }
 
 function deserializeIfStatement(pos) {
   return {
     type: 'IfStatement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     test: deserializeExpression(pos + 8),
     consequent: deserializeStatement(pos + 24),
     alternate: deserializeOptionStatement(pos + 40),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeDoWhileStatement(pos) {
   return {
     type: 'DoWhileStatement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     body: deserializeStatement(pos + 8),
     test: deserializeExpression(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeWhileStatement(pos) {
   return {
     type: 'WhileStatement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     test: deserializeExpression(pos + 8),
     body: deserializeStatement(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeForStatement(pos) {
   return {
     type: 'ForStatement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     init: deserializeOptionForStatementInit(pos + 8),
     test: deserializeOptionExpression(pos + 24),
     update: deserializeOptionExpression(pos + 40),
     body: deserializeStatement(pos + 56),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeForInStatement(pos) {
   return {
     type: 'ForInStatement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     left: deserializeForStatementLeft(pos + 8),
     right: deserializeExpression(pos + 24),
     body: deserializeStatement(pos + 40),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeForOfStatement(pos) {
   return {
     type: 'ForOfStatement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     await: deserializeBool(pos + 60),
     left: deserializeForStatementLeft(pos + 8),
     right: deserializeExpression(pos + 24),
     body: deserializeStatement(pos + 40),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeContinueStatement(pos) {
   return {
     type: 'ContinueStatement',
+    label: deserializeOptionLabelIdentifier(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    label: deserializeOptionLabelIdentifier(pos + 8),
   };
 }
 
 function deserializeBreakStatement(pos) {
   return {
     type: 'BreakStatement',
+    label: deserializeOptionLabelIdentifier(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    label: deserializeOptionLabelIdentifier(pos + 8),
   };
 }
 
 function deserializeReturnStatement(pos) {
   return {
     type: 'ReturnStatement',
+    argument: deserializeOptionExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    argument: deserializeOptionExpression(pos + 8),
   };
 }
 
 function deserializeWithStatement(pos) {
   return {
     type: 'WithStatement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     object: deserializeExpression(pos + 8),
     body: deserializeStatement(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeSwitchStatement(pos) {
   return {
     type: 'SwitchStatement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     discriminant: deserializeExpression(pos + 8),
     cases: deserializeVecSwitchCase(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeSwitchCase(pos) {
   return {
     type: 'SwitchCase',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     test: deserializeOptionExpression(pos + 8),
     consequent: deserializeVecStatement(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeLabeledStatement(pos) {
   return {
     type: 'LabeledStatement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     label: deserializeLabelIdentifier(pos + 8),
     body: deserializeStatement(pos + 32),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeThrowStatement(pos) {
   return {
     type: 'ThrowStatement',
+    argument: deserializeExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    argument: deserializeExpression(pos + 8),
   };
 }
 
 function deserializeTryStatement(pos) {
   return {
     type: 'TryStatement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     block: deserializeBoxBlockStatement(pos + 8),
     handler: deserializeOptionBoxCatchClause(pos + 16),
     finalizer: deserializeOptionBoxBlockStatement(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeCatchClause(pos) {
   return {
     type: 'CatchClause',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     param: deserializeOptionCatchParameter(pos + 8),
     body: deserializeBoxBlockStatement(pos + 48),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -701,10 +701,10 @@ function deserializeBindingPattern(pos) {
 function deserializeAssignmentPattern(pos) {
   return {
     type: 'AssignmentPattern',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     left: deserializeBindingPattern(pos + 8),
     right: deserializeExpression(pos + 40),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -714,23 +714,23 @@ function deserializeObjectPattern(pos) {
   if (rest !== null) properties.push(rest);
   return {
     type: 'ObjectPattern',
+    properties,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    properties,
   };
 }
 
 function deserializeBindingProperty(pos) {
   return {
     type: 'Property',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     kind: 'init',
     key: deserializePropertyKey(pos + 8),
     value: deserializeBindingPattern(pos + 24),
     method: false,
     shorthand: deserializeBool(pos + 56),
     computed: deserializeBool(pos + 57),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -740,18 +740,18 @@ function deserializeArrayPattern(pos) {
   if (rest !== null) elements.push(rest);
   return {
     type: 'ArrayPattern',
+    elements,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    elements,
   };
 }
 
 function deserializeBindingRestElement(pos) {
   return {
     type: 'RestElement',
+    argument: deserializeBindingPattern(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    argument: deserializeBindingPattern(pos + 8),
   };
 }
 
@@ -759,14 +759,14 @@ function deserializeFunction(pos) {
   const params = deserializeBoxFormalParameters(pos + 56);
   return {
     type: deserializeFunctionType(pos + 84),
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     id: deserializeOptionBindingIdentifier(pos + 8),
     generator: deserializeBool(pos + 85),
     async: deserializeBool(pos + 86),
     params,
     body: deserializeOptionBoxFunctionBody(pos + 72),
     expression: false,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -776,9 +776,9 @@ function deserializeFormalParameters(pos) {
     pos = uint32[(pos + 32) >> 2];
     params.push({
       type: 'RestElement',
+      argument: deserializeBindingPatternKind(pos + 8),
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
-      argument: deserializeBindingPatternKind(pos + 8),
     });
   }
   return params;
@@ -793,9 +793,9 @@ function deserializeFunctionBody(pos) {
   body.push(...deserializeVecStatement(pos + 32));
   return {
     type: 'BlockStatement',
+    body,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    body,
   };
 }
 
@@ -804,114 +804,114 @@ function deserializeArrowFunctionExpression(pos) {
   let body = deserializeBoxFunctionBody(pos + 32);
   return {
     type: 'ArrowFunctionExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     expression,
     async: deserializeBool(pos + 45),
     params: deserializeBoxFormalParameters(pos + 16),
     body: expression ? body.body[0].expression : body,
     id: null,
     generator: false,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeYieldExpression(pos) {
   return {
     type: 'YieldExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     delegate: deserializeBool(pos + 24),
     argument: deserializeOptionExpression(pos + 8),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeClass(pos) {
   return {
     type: deserializeClassType(pos + 132),
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     decorators: deserializeVecDecorator(pos + 8),
     id: deserializeOptionBindingIdentifier(pos + 32),
     superClass: deserializeOptionExpression(pos + 72),
     body: deserializeBoxClassBody(pos + 120),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeClassBody(pos) {
   return {
     type: 'ClassBody',
+    body: deserializeVecClassElement(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    body: deserializeVecClassElement(pos + 8),
   };
 }
 
 function deserializeMethodDefinition(pos) {
   return {
     type: deserializeMethodDefinitionType(pos + 56),
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     decorators: deserializeVecDecorator(pos + 8),
     key: deserializePropertyKey(pos + 32),
     value: deserializeBoxFunction(pos + 48),
     kind: deserializeMethodDefinitionKind(pos + 57),
     computed: deserializeBool(pos + 58),
     static: deserializeBool(pos + 59),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializePropertyDefinition(pos) {
   return {
     type: deserializePropertyDefinitionType(pos + 72),
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     decorators: deserializeVecDecorator(pos + 8),
     key: deserializePropertyKey(pos + 32),
     value: deserializeOptionExpression(pos + 56),
     computed: deserializeBool(pos + 73),
     static: deserializeBool(pos + 74),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializePrivateIdentifier(pos) {
   return {
     type: 'PrivateIdentifier',
+    name: deserializeStr(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    name: deserializeStr(pos + 8),
   };
 }
 
 function deserializeStaticBlock(pos) {
   return {
     type: 'StaticBlock',
+    body: deserializeVecStatement(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    body: deserializeVecStatement(pos + 8),
   };
 }
 
 function deserializeAccessorProperty(pos) {
   return {
     type: deserializeAccessorPropertyType(pos + 72),
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     decorators: deserializeVecDecorator(pos + 8),
     key: deserializePropertyKey(pos + 32),
     value: deserializeOptionExpression(pos + 56),
     computed: deserializeBool(pos + 73),
     static: deserializeBool(pos + 74),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeImportExpression(pos) {
   return {
     type: 'ImportExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     source: deserializeExpression(pos + 8),
     options: deserializeOptionExpression(pos + 24),
     phase: deserializeOptionImportPhase(pos + 40),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -921,40 +921,40 @@ function deserializeImportDeclaration(pos) {
   const withClause = deserializeOptionBoxWithClause(pos + 80);
   return {
     type: 'ImportDeclaration',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     specifiers,
     source: deserializeStringLiteral(pos + 32),
     phase: deserializeOptionImportPhase(pos + 88),
     attributes: withClause === null ? [] : withClause.attributes,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeImportSpecifier(pos) {
   return {
     type: 'ImportSpecifier',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     imported: deserializeModuleExportName(pos + 8),
     local: deserializeBindingIdentifier(pos + 64),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeImportDefaultSpecifier(pos) {
   return {
     type: 'ImportDefaultSpecifier',
+    local: deserializeBindingIdentifier(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    local: deserializeBindingIdentifier(pos + 8),
   };
 }
 
 function deserializeImportNamespaceSpecifier(pos) {
   return {
     type: 'ImportNamespaceSpecifier',
+    local: deserializeBindingIdentifier(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    local: deserializeBindingIdentifier(pos + 8),
   };
 }
 
@@ -967,10 +967,10 @@ function deserializeWithClause(pos) {
 function deserializeImportAttribute(pos) {
   return {
     type: 'ImportAttribute',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     key: deserializeImportAttributeKey(pos + 8),
     value: deserializeStringLiteral(pos + 64),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -978,21 +978,21 @@ function deserializeExportNamedDeclaration(pos) {
   const withClause = deserializeOptionBoxWithClause(pos + 96);
   return {
     type: 'ExportNamedDeclaration',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     declaration: deserializeOptionDeclaration(pos + 8),
     specifiers: deserializeVecExportSpecifier(pos + 24),
     source: deserializeOptionStringLiteral(pos + 48),
     attributes: withClause === null ? [] : withClause.attributes,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeExportDefaultDeclaration(pos) {
   return {
     type: 'ExportDefaultDeclaration',
+    declaration: deserializeExportDefaultDeclarationKind(pos + 64),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    declaration: deserializeExportDefaultDeclarationKind(pos + 64),
   };
 }
 
@@ -1000,44 +1000,44 @@ function deserializeExportAllDeclaration(pos) {
   const withClause = deserializeOptionBoxWithClause(pos + 112);
   return {
     type: 'ExportAllDeclaration',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     exported: deserializeOptionModuleExportName(pos + 8),
     source: deserializeStringLiteral(pos + 64),
     attributes: withClause === null ? [] : withClause.attributes,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeExportSpecifier(pos) {
   return {
     type: 'ExportSpecifier',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     local: deserializeModuleExportName(pos + 8),
     exported: deserializeModuleExportName(pos + 64),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeV8IntrinsicExpression(pos) {
   return {
     type: 'V8IntrinsicExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     name: deserializeIdentifierName(pos + 8),
     arguments: deserializeVecArgument(pos + 32),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeBooleanLiteral(pos) {
-  const start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    value = deserializeBool(pos + 8);
+  const value = deserializeBool(pos + 8),
+    start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Literal',
-    start,
-    end,
     value,
     raw: (start === 0 && end === 0) ? null : value + '',
+    start,
+    end,
   };
 }
 
@@ -1046,20 +1046,20 @@ function deserializeNullLiteral(pos) {
     end = deserializeU32(pos + 4);
   return {
     type: 'Literal',
-    start,
-    end,
     value: null,
     raw: (start === 0 && end === 0) ? null : 'null',
+    start,
+    end,
   };
 }
 
 function deserializeNumericLiteral(pos) {
   return {
     type: 'Literal',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     value: deserializeF64(pos + 8),
     raw: deserializeOptionStr(pos + 16),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1070,10 +1070,10 @@ function deserializeStringLiteral(pos) {
   }
   return {
     type: 'Literal',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     value,
     raw: deserializeOptionStr(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1081,11 +1081,11 @@ function deserializeBigIntLiteral(pos) {
   const bigint = deserializeStr(pos + 8);
   return {
     type: 'Literal',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     value: BigInt(bigint),
     raw: deserializeOptionStr(pos + 24),
     bigint,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1097,11 +1097,11 @@ function deserializeRegExpLiteral(pos) {
   } catch (e) {}
   return {
     type: 'Literal',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     value,
     raw: deserializeOptionStr(pos + 40),
     regex,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1139,52 +1139,52 @@ function deserializeJSXElement(pos) {
   if (closingElement === null) openingElement.selfClosing = true;
   return {
     type: 'JSXElement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     openingElement,
     children: deserializeVecJSXChild(pos + 16),
     closingElement,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeJSXOpeningElement(pos) {
   return {
     type: 'JSXOpeningElement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     name: deserializeJSXElementName(pos + 8),
     attributes: deserializeVecJSXAttributeItem(pos + 32),
     selfClosing: false,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeJSXClosingElement(pos) {
   return {
     type: 'JSXClosingElement',
+    name: deserializeJSXElementName(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    name: deserializeJSXElementName(pos + 8),
   };
 }
 
 function deserializeJSXFragment(pos) {
   return {
     type: 'JSXFragment',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     openingFragment: deserializeJSXOpeningFragment(pos + 8),
     children: deserializeVecJSXChild(pos + 16),
     closingFragment: deserializeJSXClosingFragment(pos + 40),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeJSXOpeningFragment(pos) {
   return {
     type: 'JSXOpeningFragment',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     attributes: [],
     selfClosing: false,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1199,29 +1199,29 @@ function deserializeJSXClosingFragment(pos) {
 function deserializeJSXNamespacedName(pos) {
   return {
     type: 'JSXNamespacedName',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     namespace: deserializeJSXIdentifier(pos + 8),
     name: deserializeJSXIdentifier(pos + 32),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeJSXMemberExpression(pos) {
   return {
     type: 'JSXMemberExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     object: deserializeJSXMemberExpressionObject(pos + 8),
     property: deserializeJSXIdentifier(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeJSXExpressionContainer(pos) {
   return {
     type: 'JSXExpressionContainer',
+    expression: deserializeJSXExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expression: deserializeJSXExpression(pos + 8),
   };
 }
 
@@ -1236,215 +1236,215 @@ function deserializeJSXEmptyExpression(pos) {
 function deserializeJSXAttribute(pos) {
   return {
     type: 'JSXAttribute',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     name: deserializeJSXAttributeName(pos + 8),
     value: deserializeOptionJSXAttributeValue(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeJSXSpreadAttribute(pos) {
   return {
     type: 'JSXSpreadAttribute',
+    argument: deserializeExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    argument: deserializeExpression(pos + 8),
   };
 }
 
 function deserializeJSXIdentifier(pos) {
   return {
     type: 'JSXIdentifier',
+    name: deserializeStr(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    name: deserializeStr(pos + 8),
   };
 }
 
 function deserializeJSXSpreadChild(pos) {
   return {
     type: 'JSXSpreadChild',
+    expression: deserializeExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expression: deserializeExpression(pos + 8),
   };
 }
 
 function deserializeJSXText(pos) {
   return {
     type: 'JSXText',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     value: deserializeStr(pos + 8),
     raw: deserializeOptionStr(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSThisParameter(pos) {
   return {
     type: 'Identifier',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     decorators: [],
     name: 'this',
     optional: false,
     typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 16),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSEnumDeclaration(pos) {
   return {
     type: 'TSEnumDeclaration',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     id: deserializeBindingIdentifier(pos + 8),
     body: deserializeTSEnumBody(pos + 40),
     const: deserializeBool(pos + 76),
     declare: deserializeBool(pos + 77),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSEnumBody(pos) {
   return {
     type: 'TSEnumBody',
+    members: deserializeVecTSEnumMember(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    members: deserializeVecTSEnumMember(pos + 8),
   };
 }
 
 function deserializeTSEnumMember(pos) {
   return {
     type: 'TSEnumMember',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     id: deserializeTSEnumMemberName(pos + 8),
     initializer: deserializeOptionExpression(pos + 24),
     computed: deserializeU8(pos + 8) > 1,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSTypeAnnotation(pos) {
   return {
     type: 'TSTypeAnnotation',
+    typeAnnotation: deserializeTSType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    typeAnnotation: deserializeTSType(pos + 8),
   };
 }
 
 function deserializeTSLiteralType(pos) {
   return {
     type: 'TSLiteralType',
+    literal: deserializeTSLiteral(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    literal: deserializeTSLiteral(pos + 8),
   };
 }
 
 function deserializeTSConditionalType(pos) {
   return {
     type: 'TSConditionalType',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     checkType: deserializeTSType(pos + 8),
     extendsType: deserializeTSType(pos + 24),
     trueType: deserializeTSType(pos + 40),
     falseType: deserializeTSType(pos + 56),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSUnionType(pos) {
   return {
     type: 'TSUnionType',
+    types: deserializeVecTSType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    types: deserializeVecTSType(pos + 8),
   };
 }
 
 function deserializeTSIntersectionType(pos) {
   return {
     type: 'TSIntersectionType',
+    types: deserializeVecTSType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    types: deserializeVecTSType(pos + 8),
   };
 }
 
 function deserializeTSParenthesizedType(pos) {
   return {
     type: 'TSParenthesizedType',
+    typeAnnotation: deserializeTSType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    typeAnnotation: deserializeTSType(pos + 8),
   };
 }
 
 function deserializeTSTypeOperator(pos) {
   return {
     type: 'TSTypeOperator',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     operator: deserializeTSTypeOperatorOperator(pos + 24),
     typeAnnotation: deserializeTSType(pos + 8),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSArrayType(pos) {
   return {
     type: 'TSArrayType',
+    elementType: deserializeTSType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    elementType: deserializeTSType(pos + 8),
   };
 }
 
 function deserializeTSIndexedAccessType(pos) {
   return {
     type: 'TSIndexedAccessType',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     objectType: deserializeTSType(pos + 8),
     indexType: deserializeTSType(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSTupleType(pos) {
   return {
     type: 'TSTupleType',
+    elementTypes: deserializeVecTSTupleElement(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    elementTypes: deserializeVecTSTupleElement(pos + 8),
   };
 }
 
 function deserializeTSNamedTupleMember(pos) {
   return {
     type: 'TSNamedTupleMember',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     label: deserializeIdentifierName(pos + 8),
     elementType: deserializeTSTupleElement(pos + 32),
     optional: deserializeBool(pos + 48),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSOptionalType(pos) {
   return {
     type: 'TSOptionalType',
+    typeAnnotation: deserializeTSType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    typeAnnotation: deserializeTSType(pos + 8),
   };
 }
 
 function deserializeTSRestType(pos) {
   return {
     type: 'TSRestType',
+    typeAnnotation: deserializeTSType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    typeAnnotation: deserializeTSType(pos + 8),
   };
 }
 
@@ -1563,64 +1563,64 @@ function deserializeTSBigIntKeyword(pos) {
 function deserializeTSTypeReference(pos) {
   return {
     type: 'TSTypeReference',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     typeName: deserializeTSTypeName(pos + 8),
     typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSQualifiedName(pos) {
   return {
     type: 'TSQualifiedName',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     left: deserializeTSTypeName(pos + 8),
     right: deserializeIdentifierName(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSTypeParameterInstantiation(pos) {
   return {
     type: 'TSTypeParameterInstantiation',
+    params: deserializeVecTSType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    params: deserializeVecTSType(pos + 8),
   };
 }
 
 function deserializeTSTypeParameter(pos) {
   return {
     type: 'TSTypeParameter',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     name: deserializeBindingIdentifier(pos + 8),
     constraint: deserializeOptionTSType(pos + 40),
     default: deserializeOptionTSType(pos + 56),
     in: deserializeBool(pos + 72),
     out: deserializeBool(pos + 73),
     const: deserializeBool(pos + 74),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSTypeParameterDeclaration(pos) {
   return {
     type: 'TSTypeParameterDeclaration',
+    params: deserializeVecTSTypeParameter(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    params: deserializeVecTSTypeParameter(pos + 8),
   };
 }
 
 function deserializeTSTypeAliasDeclaration(pos) {
   return {
     type: 'TSTypeAliasDeclaration',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     id: deserializeBindingIdentifier(pos + 8),
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 40),
     typeAnnotation: deserializeTSType(pos + 48),
     declare: deserializeBool(pos + 68),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1629,63 +1629,61 @@ function deserializeTSClassImplements(pos) {
   if (expression.type === 'TSQualifiedName') {
     let parent = expression = {
       type: 'MemberExpression',
-      start: expression.start,
-      end: expression.end,
       object: expression.left,
       property: expression.right,
       optional: false,
       computed: false,
+      start: expression.start,
+      end: expression.end,
     };
 
     while (parent.object.type === 'TSQualifiedName') {
       const object = parent.object;
       parent = parent.object = {
         type: 'MemberExpression',
-        start: object.start,
-        end: object.end,
         object: object.left,
         property: object.right,
         optional: false,
         computed: false,
+        start: object.start,
+        end: object.end,
       };
     }
   }
   return {
     type: 'TSClassImplements',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     expression,
     typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSInterfaceDeclaration(pos) {
   return {
     type: 'TSInterfaceDeclaration',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     id: deserializeBindingIdentifier(pos + 8),
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 40),
     extends: deserializeVecTSInterfaceHeritage(pos + 48),
     body: deserializeBoxTSInterfaceBody(pos + 72),
     declare: deserializeBool(pos + 84),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSInterfaceBody(pos) {
   return {
     type: 'TSInterfaceBody',
+    body: deserializeVecTSSignature(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    body: deserializeVecTSSignature(pos + 8),
   };
 }
 
 function deserializeTSPropertySignature(pos) {
   return {
     type: 'TSPropertySignature',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     computed: deserializeBool(pos + 32),
     optional: deserializeBool(pos + 33),
     readonly: deserializeBool(pos + 34),
@@ -1693,19 +1691,21 @@ function deserializeTSPropertySignature(pos) {
     typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 24),
     accessibility: null,
     static: false,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSIndexSignature(pos) {
   return {
     type: 'TSIndexSignature',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     parameters: deserializeVecTSIndexSignatureName(pos + 8),
     typeAnnotation: deserializeBoxTSTypeAnnotation(pos + 32),
     readonly: deserializeBool(pos + 40),
     static: deserializeBool(pos + 41),
     accessibility: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1715,11 +1715,11 @@ function deserializeTSCallSignatureDeclaration(pos) {
   if (thisParam !== null) params.unshift(thisParam);
   return {
     type: 'TSCallSignatureDeclaration',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 8),
     params,
     returnType: deserializeOptionBoxTSTypeAnnotation(pos + 32),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1729,8 +1729,6 @@ function deserializeTSMethodSignature(pos) {
   if (thisParam !== null) params.unshift(thisParam);
   return {
     type: 'TSMethodSignature',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     key: deserializePropertyKey(pos + 8),
     computed: deserializeBool(pos + 60),
     optional: deserializeBool(pos + 61),
@@ -1741,50 +1739,52 @@ function deserializeTSMethodSignature(pos) {
     accessibility: null,
     readonly: false,
     static: false,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSConstructSignatureDeclaration(pos) {
   return {
     type: 'TSConstructSignatureDeclaration',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 8),
     params: deserializeBoxFormalParameters(pos + 16),
     returnType: deserializeOptionBoxTSTypeAnnotation(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSIndexSignatureName(pos) {
   return {
     type: 'Identifier',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     decorators: [],
     name: deserializeStr(pos + 8),
     optional: false,
     typeAnnotation: deserializeBoxTSTypeAnnotation(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSInterfaceHeritage(pos) {
   return {
     type: 'TSInterfaceHeritage',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     expression: deserializeExpression(pos + 8),
     typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSTypePredicate(pos) {
   return {
     type: 'TSTypePredicate',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     parameterName: deserializeTSTypePredicateName(pos + 8),
     asserts: deserializeBool(pos + 32),
     typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1803,10 +1803,10 @@ function deserializeTSModuleDeclaration(pos) {
     if (innerId.type === 'Identifier') {
       id = {
         type: 'TSQualifiedName',
-        start: id.start,
-        end: innerId.end,
         left: id,
         right: innerId,
+        start: id.start,
+        end: innerId.end,
       };
     } else {
       // Replace `left` of innermost `TSQualifiedName` with a nested `TSQualifiedName` with `id` of
@@ -1818,10 +1818,10 @@ function deserializeTSModuleDeclaration(pos) {
       }
       innerId.left = {
         type: 'TSQualifiedName',
-        start: id.start,
-        end: innerId.left.end,
         left: id,
         right: innerId.left,
+        start: id.start,
+        end: innerId.left.end,
       };
       id = body.id;
     }
@@ -1830,8 +1830,8 @@ function deserializeTSModuleDeclaration(pos) {
 
   // Skip `body` field if `null`
   const node = body === null
-    ? { type: 'TSModuleDeclaration', start, end, id, kind, declare, global }
-    : { type: 'TSModuleDeclaration', start, end, id, body, kind, declare, global };
+    ? { type: 'TSModuleDeclaration', id, kind, declare, global, start, end }
+    : { type: 'TSModuleDeclaration', id, body, kind, declare, global, start, end };
   return node;
 }
 
@@ -1840,49 +1840,49 @@ function deserializeTSModuleBlock(pos) {
   body.push(...deserializeVecStatement(pos + 32));
   return {
     type: 'TSModuleBlock',
+    body,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    body,
   };
 }
 
 function deserializeTSTypeLiteral(pos) {
   return {
     type: 'TSTypeLiteral',
+    members: deserializeVecTSSignature(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    members: deserializeVecTSSignature(pos + 8),
   };
 }
 
 function deserializeTSInferType(pos) {
   return {
     type: 'TSInferType',
+    typeParameter: deserializeBoxTSTypeParameter(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    typeParameter: deserializeBoxTSTypeParameter(pos + 8),
   };
 }
 
 function deserializeTSTypeQuery(pos) {
   return {
     type: 'TSTypeQuery',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     exprName: deserializeTSTypeQueryExprName(pos + 8),
     typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSImportType(pos) {
   return {
     type: 'TSImportType',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     argument: deserializeTSType(pos + 8),
     options: deserializeOptionBoxObjectExpression(pos + 24),
     qualifier: deserializeOptionTSTypeName(pos + 32),
     typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 48),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1892,23 +1892,23 @@ function deserializeTSFunctionType(pos) {
   if (thisParam !== null) params.unshift(thisParam);
   return {
     type: 'TSFunctionType',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 8),
     params,
     returnType: deserializeBoxTSTypeAnnotation(pos + 32),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSConstructorType(pos) {
   return {
     type: 'TSConstructorType',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     abstract: deserializeBool(pos + 32),
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 8),
     params: deserializeBoxFormalParameters(pos + 16),
     returnType: deserializeBoxTSTypeAnnotation(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1918,140 +1918,140 @@ function deserializeTSMappedType(pos) {
   if (optional === null) optional = false;
   return {
     type: 'TSMappedType',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     key: typeParameter.name,
     constraint: typeParameter.constraint,
     nameType: deserializeOptionTSType(pos + 16),
     typeAnnotation: deserializeOptionTSType(pos + 32),
     optional,
     readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 53),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSTemplateLiteralType(pos) {
   return {
     type: 'TSTemplateLiteralType',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     quasis: deserializeVecTemplateElement(pos + 8),
     types: deserializeVecTSType(pos + 32),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSAsExpression(pos) {
   return {
     type: 'TSAsExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     expression: deserializeExpression(pos + 8),
     typeAnnotation: deserializeTSType(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSSatisfiesExpression(pos) {
   return {
     type: 'TSSatisfiesExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     expression: deserializeExpression(pos + 8),
     typeAnnotation: deserializeTSType(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSTypeAssertion(pos) {
   return {
     type: 'TSTypeAssertion',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     typeAnnotation: deserializeTSType(pos + 8),
     expression: deserializeExpression(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSImportEqualsDeclaration(pos) {
   return {
     type: 'TSImportEqualsDeclaration',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     id: deserializeBindingIdentifier(pos + 8),
     moduleReference: deserializeTSModuleReference(pos + 40),
     importKind: deserializeImportOrExportKind(pos + 56),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSExternalModuleReference(pos) {
   return {
     type: 'TSExternalModuleReference',
+    expression: deserializeStringLiteral(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expression: deserializeStringLiteral(pos + 8),
   };
 }
 
 function deserializeTSNonNullExpression(pos) {
   return {
     type: 'TSNonNullExpression',
+    expression: deserializeExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expression: deserializeExpression(pos + 8),
   };
 }
 
 function deserializeDecorator(pos) {
   return {
     type: 'Decorator',
+    expression: deserializeExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expression: deserializeExpression(pos + 8),
   };
 }
 
 function deserializeTSExportAssignment(pos) {
   return {
     type: 'TSExportAssignment',
+    expression: deserializeExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expression: deserializeExpression(pos + 8),
   };
 }
 
 function deserializeTSNamespaceExportDeclaration(pos) {
   return {
     type: 'TSNamespaceExportDeclaration',
+    id: deserializeIdentifierName(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    id: deserializeIdentifierName(pos + 8),
   };
 }
 
 function deserializeTSInstantiationExpression(pos) {
   return {
     type: 'TSInstantiationExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     expression: deserializeExpression(pos + 8),
     typeArguments: deserializeBoxTSTypeParameterInstantiation(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeJSDocNullableType(pos) {
   return {
     type: 'TSJSDocNullableType',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     typeAnnotation: deserializeTSType(pos + 8),
     postfix: deserializeBool(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeJSDocNonNullableType(pos) {
   return {
     type: 'TSJSDocNonNullableType',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     typeAnnotation: deserializeTSType(pos + 8),
     postfix: deserializeBool(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -2094,21 +2094,21 @@ function deserializeImportEntry(pos) {
 
 function deserializeExportEntry(pos) {
   return {
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
     exportName: deserializeExportExportName(pos + 72),
     localName: deserializeExportLocalName(pos + 104),
     isType: deserializeBool(pos + 136),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeDynamicImport(pos) {
   return {
+    moduleRequest: deserializeSpan(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    moduleRequest: deserializeSpan(pos + 8),
   };
 }
 
@@ -2164,18 +2164,18 @@ function deserializeEcmaScriptModule(pos) {
 
 function deserializeStaticImport(pos) {
   return {
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     moduleRequest: deserializeNameSpan(pos + 8),
     entries: deserializeVecImportEntry(pos + 32),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeStaticExport(pos) {
   return {
+    entries: deserializeVecExportEntry(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    entries: deserializeVecExportEntry(pos + 8),
   };
 }
 
@@ -3244,14 +3244,14 @@ function deserializeJSXElementName(pos) {
       return deserializeBoxJSXIdentifier(pos + 8);
     case 1:
       const ident = deserializeBoxIdentifierReference(pos + 8);
-      return { type: 'JSXIdentifier', start: ident.start, end: ident.end, name: ident.name };
+      return { type: 'JSXIdentifier', name: ident.name, start: ident.start, end: ident.end };
     case 2:
       return deserializeBoxJSXNamespacedName(pos + 8);
     case 3:
       return deserializeBoxJSXMemberExpression(pos + 8);
     case 4:
       const thisExpr = deserializeBoxThisExpression(pos + 8);
-      return { type: 'JSXIdentifier', start: thisExpr.start, end: thisExpr.end, name: 'this' };
+      return { type: 'JSXIdentifier', name: 'this', start: thisExpr.start, end: thisExpr.end };
     default:
       throw new Error(`Unexpected discriminant ${uint8[pos]} for JSXElementName`);
   }
@@ -3261,12 +3261,12 @@ function deserializeJSXMemberExpressionObject(pos) {
   switch (uint8[pos]) {
     case 0:
       const ident = deserializeBoxIdentifierReference(pos + 8);
-      return { type: 'JSXIdentifier', start: ident.start, end: ident.end, name: ident.name };
+      return { type: 'JSXIdentifier', name: ident.name, start: ident.start, end: ident.end };
     case 1:
       return deserializeBoxJSXMemberExpression(pos + 8);
     case 2:
       const thisExpr = deserializeBoxThisExpression(pos + 8);
-      return { type: 'JSXIdentifier', start: thisExpr.start, end: thisExpr.end, name: 'this' };
+      return { type: 'JSXIdentifier', name: 'this', start: thisExpr.start, end: thisExpr.end };
     default:
       throw new Error(`Unexpected discriminant ${uint8[pos]} for JSXMemberExpressionObject`);
   }

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -59,11 +59,11 @@ function deserializeProgram(pos) {
   }
   const program = {
     type: 'Program',
-    start,
-    end,
     body,
     sourceType: deserializeModuleKind(pos + 125),
     hashbang: deserializeOptionHashbang(pos + 48),
+    start,
+    end,
   };
   return program;
 }
@@ -71,48 +71,48 @@ function deserializeProgram(pos) {
 function deserializeIdentifierName(pos) {
   return {
     type: 'Identifier',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     decorators: [],
     name: deserializeStr(pos + 8),
     optional: false,
     typeAnnotation: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeIdentifierReference(pos) {
   return {
     type: 'Identifier',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     decorators: [],
     name: deserializeStr(pos + 8),
     optional: false,
     typeAnnotation: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeBindingIdentifier(pos) {
   return {
     type: 'Identifier',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     decorators: [],
     name: deserializeStr(pos + 8),
     optional: false,
     typeAnnotation: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeLabelIdentifier(pos) {
   return {
     type: 'Identifier',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     decorators: [],
     name: deserializeStr(pos + 8),
     optional: false,
     typeAnnotation: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -127,9 +127,9 @@ function deserializeThisExpression(pos) {
 function deserializeArrayExpression(pos) {
   return {
     type: 'ArrayExpression',
+    elements: deserializeVecArrayExpressionElement(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    elements: deserializeVecArrayExpressionElement(pos + 8),
   };
 }
 
@@ -140,17 +140,15 @@ function deserializeElision(pos) {
 function deserializeObjectExpression(pos) {
   return {
     type: 'ObjectExpression',
+    properties: deserializeVecObjectPropertyKind(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    properties: deserializeVecObjectPropertyKind(pos + 8),
   };
 }
 
 function deserializeObjectProperty(pos) {
   return {
     type: 'Property',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     kind: deserializePropertyKind(pos + 40),
     key: deserializePropertyKey(pos + 8),
     value: deserializeExpression(pos + 24),
@@ -158,27 +156,29 @@ function deserializeObjectProperty(pos) {
     shorthand: deserializeBool(pos + 42),
     computed: deserializeBool(pos + 43),
     optional: false,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTemplateLiteral(pos) {
   return {
     type: 'TemplateLiteral',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     quasis: deserializeVecTemplateElement(pos + 8),
     expressions: deserializeVecExpression(pos + 32),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTaggedTemplateExpression(pos) {
   return {
     type: 'TaggedTemplateExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     tag: deserializeExpression(pos + 8),
     typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
     quasi: deserializeTemplateLiteral(pos + 32),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -191,7 +191,7 @@ function deserializeTemplateElement(pos) {
     value.cooked = value.cooked
       .replace(/\uFFFD(.{4})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)));
   }
-  return { type: 'TemplateElement', start, end, value, tail };
+  return { type: 'TemplateElement', value, tail, start, end };
 }
 
 function deserializeTemplateElementValue(pos) {
@@ -204,155 +204,155 @@ function deserializeTemplateElementValue(pos) {
 function deserializeComputedMemberExpression(pos) {
   return {
     type: 'MemberExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     object: deserializeExpression(pos + 8),
     property: deserializeExpression(pos + 24),
     optional: deserializeBool(pos + 40),
     computed: true,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeStaticMemberExpression(pos) {
   return {
     type: 'MemberExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     object: deserializeExpression(pos + 8),
     property: deserializeIdentifierName(pos + 24),
     optional: deserializeBool(pos + 48),
     computed: false,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializePrivateFieldExpression(pos) {
   return {
     type: 'MemberExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     object: deserializeExpression(pos + 8),
     property: deserializePrivateIdentifier(pos + 24),
     optional: deserializeBool(pos + 48),
     computed: false,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeCallExpression(pos) {
   return {
     type: 'CallExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     callee: deserializeExpression(pos + 8),
     typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
     arguments: deserializeVecArgument(pos + 32),
     optional: deserializeBool(pos + 56),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeNewExpression(pos) {
   return {
     type: 'NewExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     callee: deserializeExpression(pos + 8),
     typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
     arguments: deserializeVecArgument(pos + 32),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeMetaProperty(pos) {
   return {
     type: 'MetaProperty',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     meta: deserializeIdentifierName(pos + 8),
     property: deserializeIdentifierName(pos + 32),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeSpreadElement(pos) {
   return {
     type: 'SpreadElement',
+    argument: deserializeExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    argument: deserializeExpression(pos + 8),
   };
 }
 
 function deserializeUpdateExpression(pos) {
   return {
     type: 'UpdateExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     operator: deserializeUpdateOperator(pos + 24),
     prefix: deserializeBool(pos + 25),
     argument: deserializeSimpleAssignmentTarget(pos + 8),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeUnaryExpression(pos) {
   return {
     type: 'UnaryExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     operator: deserializeUnaryOperator(pos + 24),
     argument: deserializeExpression(pos + 8),
     prefix: true,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeBinaryExpression(pos) {
   return {
     type: 'BinaryExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     left: deserializeExpression(pos + 8),
     operator: deserializeBinaryOperator(pos + 40),
     right: deserializeExpression(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializePrivateInExpression(pos) {
   return {
     type: 'BinaryExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     left: deserializePrivateIdentifier(pos + 8),
     operator: 'in',
     right: deserializeExpression(pos + 32),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeLogicalExpression(pos) {
   return {
     type: 'LogicalExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     left: deserializeExpression(pos + 8),
     operator: deserializeLogicalOperator(pos + 40),
     right: deserializeExpression(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeConditionalExpression(pos) {
   return {
     type: 'ConditionalExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     test: deserializeExpression(pos + 8),
     consequent: deserializeExpression(pos + 24),
     alternate: deserializeExpression(pos + 40),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeAssignmentExpression(pos) {
   return {
     type: 'AssignmentExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     operator: deserializeAssignmentOperator(pos + 40),
     left: deserializeAssignmentTarget(pos + 8),
     right: deserializeExpression(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -362,12 +362,12 @@ function deserializeArrayAssignmentTarget(pos) {
   if (rest !== null) elements.push(rest);
   return {
     type: 'ArrayPattern',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     decorators: [],
     elements,
     optional: false,
     typeAnnotation: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -377,63 +377,61 @@ function deserializeObjectAssignmentTarget(pos) {
   if (rest !== null) properties.push(rest);
   return {
     type: 'ObjectPattern',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     decorators: [],
     properties,
     optional: false,
     typeAnnotation: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeAssignmentTargetRest(pos) {
   return {
     type: 'RestElement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     decorators: [],
     argument: deserializeAssignmentTarget(pos + 8),
     optional: false,
     typeAnnotation: null,
     value: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeAssignmentTargetWithDefault(pos) {
   return {
     type: 'AssignmentPattern',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     decorators: [],
     left: deserializeAssignmentTarget(pos + 8),
     right: deserializeExpression(pos + 24),
     optional: false,
     typeAnnotation: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeAssignmentTargetPropertyIdentifier(pos) {
-  const start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    key = deserializeIdentifierReference(pos + 8);
+  const key = deserializeIdentifierReference(pos + 8),
+    start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   const init = deserializeOptionExpression(pos + 40),
     keyCopy = { ...key },
     value = init === null
       ? keyCopy
       : {
         type: 'AssignmentPattern',
-        start: start,
-        end: end,
         decorators: [],
         left: keyCopy,
         right: init,
         optional: false,
         typeAnnotation: null,
+        start: start,
+        end: end,
       };
   return {
     type: 'Property',
-    start,
-    end,
     kind: 'init',
     key,
     value,
@@ -441,14 +439,14 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     shorthand: true,
     computed: false,
     optional: false,
+    start,
+    end,
   };
 }
 
 function deserializeAssignmentTargetPropertyProperty(pos) {
   return {
     type: 'Property',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     kind: 'init',
     key: deserializePropertyKey(pos + 8),
     value: deserializeAssignmentTargetMaybeDefault(pos + 24),
@@ -456,15 +454,17 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
     shorthand: false,
     computed: deserializeBool(pos + 40),
     optional: false,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeSequenceExpression(pos) {
   return {
     type: 'SequenceExpression',
+    expressions: deserializeVecExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expressions: deserializeVecExpression(pos + 8),
   };
 }
 
@@ -479,77 +479,77 @@ function deserializeSuper(pos) {
 function deserializeAwaitExpression(pos) {
   return {
     type: 'AwaitExpression',
+    argument: deserializeExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    argument: deserializeExpression(pos + 8),
   };
 }
 
 function deserializeChainExpression(pos) {
   return {
     type: 'ChainExpression',
+    expression: deserializeChainElement(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expression: deserializeChainElement(pos + 8),
   };
 }
 
 function deserializeParenthesizedExpression(pos) {
   return {
     type: 'ParenthesizedExpression',
+    expression: deserializeExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expression: deserializeExpression(pos + 8),
   };
 }
 
 function deserializeDirective(pos) {
   return {
     type: 'ExpressionStatement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     expression: deserializeStringLiteral(pos + 8),
     directive: deserializeStr(pos + 56),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeHashbang(pos) {
   return {
     type: 'Hashbang',
+    value: deserializeStr(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    value: deserializeStr(pos + 8),
   };
 }
 
 function deserializeBlockStatement(pos) {
   return {
     type: 'BlockStatement',
+    body: deserializeVecStatement(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    body: deserializeVecStatement(pos + 8),
   };
 }
 
 function deserializeVariableDeclaration(pos) {
   return {
     type: 'VariableDeclaration',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     kind: deserializeVariableDeclarationKind(pos + 32),
     declarations: deserializeVecVariableDeclarator(pos + 8),
     declare: deserializeBool(pos + 33),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeVariableDeclarator(pos) {
   return {
     type: 'VariableDeclarator',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     id: deserializeBindingPattern(pos + 8),
     init: deserializeOptionExpression(pos + 40),
     definite: deserializeBool(pos + 57),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -564,173 +564,173 @@ function deserializeEmptyStatement(pos) {
 function deserializeExpressionStatement(pos) {
   return {
     type: 'ExpressionStatement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     expression: deserializeExpression(pos + 8),
     directive: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeIfStatement(pos) {
   return {
     type: 'IfStatement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     test: deserializeExpression(pos + 8),
     consequent: deserializeStatement(pos + 24),
     alternate: deserializeOptionStatement(pos + 40),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeDoWhileStatement(pos) {
   return {
     type: 'DoWhileStatement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     body: deserializeStatement(pos + 8),
     test: deserializeExpression(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeWhileStatement(pos) {
   return {
     type: 'WhileStatement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     test: deserializeExpression(pos + 8),
     body: deserializeStatement(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeForStatement(pos) {
   return {
     type: 'ForStatement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     init: deserializeOptionForStatementInit(pos + 8),
     test: deserializeOptionExpression(pos + 24),
     update: deserializeOptionExpression(pos + 40),
     body: deserializeStatement(pos + 56),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeForInStatement(pos) {
   return {
     type: 'ForInStatement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     left: deserializeForStatementLeft(pos + 8),
     right: deserializeExpression(pos + 24),
     body: deserializeStatement(pos + 40),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeForOfStatement(pos) {
   return {
     type: 'ForOfStatement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     await: deserializeBool(pos + 60),
     left: deserializeForStatementLeft(pos + 8),
     right: deserializeExpression(pos + 24),
     body: deserializeStatement(pos + 40),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeContinueStatement(pos) {
   return {
     type: 'ContinueStatement',
+    label: deserializeOptionLabelIdentifier(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    label: deserializeOptionLabelIdentifier(pos + 8),
   };
 }
 
 function deserializeBreakStatement(pos) {
   return {
     type: 'BreakStatement',
+    label: deserializeOptionLabelIdentifier(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    label: deserializeOptionLabelIdentifier(pos + 8),
   };
 }
 
 function deserializeReturnStatement(pos) {
   return {
     type: 'ReturnStatement',
+    argument: deserializeOptionExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    argument: deserializeOptionExpression(pos + 8),
   };
 }
 
 function deserializeWithStatement(pos) {
   return {
     type: 'WithStatement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     object: deserializeExpression(pos + 8),
     body: deserializeStatement(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeSwitchStatement(pos) {
   return {
     type: 'SwitchStatement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     discriminant: deserializeExpression(pos + 8),
     cases: deserializeVecSwitchCase(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeSwitchCase(pos) {
   return {
     type: 'SwitchCase',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     test: deserializeOptionExpression(pos + 8),
     consequent: deserializeVecStatement(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeLabeledStatement(pos) {
   return {
     type: 'LabeledStatement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     label: deserializeLabelIdentifier(pos + 8),
     body: deserializeStatement(pos + 32),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeThrowStatement(pos) {
   return {
     type: 'ThrowStatement',
+    argument: deserializeExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    argument: deserializeExpression(pos + 8),
   };
 }
 
 function deserializeTryStatement(pos) {
   return {
     type: 'TryStatement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     block: deserializeBoxBlockStatement(pos + 8),
     handler: deserializeOptionBoxCatchClause(pos + 16),
     finalizer: deserializeOptionBoxBlockStatement(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeCatchClause(pos) {
   return {
     type: 'CatchClause',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     param: deserializeOptionCatchParameter(pos + 8),
     body: deserializeBoxBlockStatement(pos + 48),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -756,13 +756,13 @@ function deserializeBindingPattern(pos) {
 function deserializeAssignmentPattern(pos) {
   return {
     type: 'AssignmentPattern',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     decorators: [],
     left: deserializeBindingPattern(pos + 8),
     right: deserializeExpression(pos + 40),
     optional: false,
     typeAnnotation: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -772,20 +772,18 @@ function deserializeObjectPattern(pos) {
   if (rest !== null) properties.push(rest);
   return {
     type: 'ObjectPattern',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     decorators: [],
     properties,
     optional: false,
     typeAnnotation: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeBindingProperty(pos) {
   return {
     type: 'Property',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     kind: 'init',
     key: deserializePropertyKey(pos + 8),
     value: deserializeBindingPattern(pos + 24),
@@ -793,6 +791,8 @@ function deserializeBindingProperty(pos) {
     shorthand: deserializeBool(pos + 56),
     computed: deserializeBool(pos + 57),
     optional: false,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -802,25 +802,25 @@ function deserializeArrayPattern(pos) {
   if (rest !== null) elements.push(rest);
   return {
     type: 'ArrayPattern',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     decorators: [],
     elements,
     optional: false,
     typeAnnotation: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeBindingRestElement(pos) {
   return {
     type: 'RestElement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     decorators: [],
     argument: deserializeBindingPattern(pos + 8),
     optional: false,
     typeAnnotation: null,
     value: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -830,8 +830,6 @@ function deserializeFunction(pos) {
   if (thisParam !== null) params.unshift(thisParam);
   return {
     type: deserializeFunctionType(pos + 84),
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     id: deserializeOptionBindingIdentifier(pos + 8),
     generator: deserializeBool(pos + 85),
     async: deserializeBool(pos + 86),
@@ -841,6 +839,8 @@ function deserializeFunction(pos) {
     returnType: deserializeOptionBoxTSTypeAnnotation(pos + 64),
     body: deserializeOptionBoxFunctionBody(pos + 72),
     expression: false,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -850,8 +850,6 @@ function deserializeFormalParameters(pos) {
     pos = uint32[(pos + 32) >> 2];
     params.push({
       type: 'RestElement',
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
       decorators: [],
       argument: deserializeBindingPatternKind(pos + 8),
       optional: deserializeBool(pos + 32),
@@ -859,6 +857,8 @@ function deserializeFormalParameters(pos) {
         pos + 24,
       ),
       value: null,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
     });
   }
   return params;
@@ -877,14 +877,14 @@ function deserializeFormalParameter(pos) {
   } else {
     param = {
       type: 'TSParameterProperty',
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
       accessibility,
       decorators: deserializeVecDecorator(pos + 8),
       override,
       parameter: deserializeBindingPattern(pos + 32),
       readonly,
       static: false,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
     };
   }
   return param;
@@ -895,9 +895,9 @@ function deserializeFunctionBody(pos) {
   body.push(...deserializeVecStatement(pos + 32));
   return {
     type: 'BlockStatement',
+    body,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    body,
   };
 }
 
@@ -906,8 +906,6 @@ function deserializeArrowFunctionExpression(pos) {
   let body = deserializeBoxFunctionBody(pos + 32);
   return {
     type: 'ArrowFunctionExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     expression,
     async: deserializeBool(pos + 45),
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 8),
@@ -916,24 +914,24 @@ function deserializeArrowFunctionExpression(pos) {
     body: expression ? body.body[0].expression : body,
     id: null,
     generator: false,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeYieldExpression(pos) {
   return {
     type: 'YieldExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     delegate: deserializeBool(pos + 24),
     argument: deserializeOptionExpression(pos + 8),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeClass(pos) {
   return {
     type: deserializeClassType(pos + 132),
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     decorators: deserializeVecDecorator(pos + 8),
     id: deserializeOptionBindingIdentifier(pos + 32),
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 64),
@@ -943,23 +941,23 @@ function deserializeClass(pos) {
     body: deserializeBoxClassBody(pos + 120),
     abstract: deserializeBool(pos + 133),
     declare: deserializeBool(pos + 134),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeClassBody(pos) {
   return {
     type: 'ClassBody',
+    body: deserializeVecClassElement(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    body: deserializeVecClassElement(pos + 8),
   };
 }
 
 function deserializeMethodDefinition(pos) {
   return {
     type: deserializeMethodDefinitionType(pos + 56),
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     decorators: deserializeVecDecorator(pos + 8),
     key: deserializePropertyKey(pos + 32),
     value: deserializeBoxFunction(pos + 48),
@@ -969,14 +967,14 @@ function deserializeMethodDefinition(pos) {
     override: deserializeBool(pos + 60),
     optional: deserializeBool(pos + 61),
     accessibility: deserializeOptionTSAccessibility(pos + 62),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializePropertyDefinition(pos) {
   return {
     type: deserializePropertyDefinitionType(pos + 72),
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     decorators: deserializeVecDecorator(pos + 8),
     key: deserializePropertyKey(pos + 32),
     typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 48),
@@ -989,32 +987,32 @@ function deserializePropertyDefinition(pos) {
     definite: deserializeBool(pos + 78),
     readonly: deserializeBool(pos + 79),
     accessibility: deserializeOptionTSAccessibility(pos + 80),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializePrivateIdentifier(pos) {
   return {
     type: 'PrivateIdentifier',
+    name: deserializeStr(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    name: deserializeStr(pos + 8),
   };
 }
 
 function deserializeStaticBlock(pos) {
   return {
     type: 'StaticBlock',
+    body: deserializeVecStatement(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    body: deserializeVecStatement(pos + 8),
   };
 }
 
 function deserializeAccessorProperty(pos) {
   return {
     type: deserializeAccessorPropertyType(pos + 72),
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     decorators: deserializeVecDecorator(pos + 8),
     key: deserializePropertyKey(pos + 32),
     typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 48),
@@ -1027,17 +1025,19 @@ function deserializeAccessorProperty(pos) {
     declare: false,
     optional: false,
     readonly: false,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeImportExpression(pos) {
   return {
     type: 'ImportExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     source: deserializeExpression(pos + 8),
     options: deserializeOptionExpression(pos + 24),
     phase: deserializeOptionImportPhase(pos + 40),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1047,42 +1047,42 @@ function deserializeImportDeclaration(pos) {
   const withClause = deserializeOptionBoxWithClause(pos + 80);
   return {
     type: 'ImportDeclaration',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     specifiers,
     source: deserializeStringLiteral(pos + 32),
     phase: deserializeOptionImportPhase(pos + 88),
     attributes: withClause === null ? [] : withClause.attributes,
     importKind: deserializeImportOrExportKind(pos + 89),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeImportSpecifier(pos) {
   return {
     type: 'ImportSpecifier',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     imported: deserializeModuleExportName(pos + 8),
     local: deserializeBindingIdentifier(pos + 64),
     importKind: deserializeImportOrExportKind(pos + 96),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeImportDefaultSpecifier(pos) {
   return {
     type: 'ImportDefaultSpecifier',
+    local: deserializeBindingIdentifier(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    local: deserializeBindingIdentifier(pos + 8),
   };
 }
 
 function deserializeImportNamespaceSpecifier(pos) {
   return {
     type: 'ImportNamespaceSpecifier',
+    local: deserializeBindingIdentifier(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    local: deserializeBindingIdentifier(pos + 8),
   };
 }
 
@@ -1095,10 +1095,10 @@ function deserializeWithClause(pos) {
 function deserializeImportAttribute(pos) {
   return {
     type: 'ImportAttribute',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     key: deserializeImportAttributeKey(pos + 8),
     value: deserializeStringLiteral(pos + 64),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1106,23 +1106,23 @@ function deserializeExportNamedDeclaration(pos) {
   const withClause = deserializeOptionBoxWithClause(pos + 96);
   return {
     type: 'ExportNamedDeclaration',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     declaration: deserializeOptionDeclaration(pos + 8),
     specifiers: deserializeVecExportSpecifier(pos + 24),
     source: deserializeOptionStringLiteral(pos + 48),
     exportKind: deserializeImportOrExportKind(pos + 104),
     attributes: withClause === null ? [] : withClause.attributes,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeExportDefaultDeclaration(pos) {
   return {
     type: 'ExportDefaultDeclaration',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     declaration: deserializeExportDefaultDeclarationKind(pos + 64),
     exportKind: 'value',
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1130,46 +1130,46 @@ function deserializeExportAllDeclaration(pos) {
   const withClause = deserializeOptionBoxWithClause(pos + 112);
   return {
     type: 'ExportAllDeclaration',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     exported: deserializeOptionModuleExportName(pos + 8),
     source: deserializeStringLiteral(pos + 64),
     attributes: withClause === null ? [] : withClause.attributes,
     exportKind: deserializeImportOrExportKind(pos + 120),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeExportSpecifier(pos) {
   return {
     type: 'ExportSpecifier',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     local: deserializeModuleExportName(pos + 8),
     exported: deserializeModuleExportName(pos + 64),
     exportKind: deserializeImportOrExportKind(pos + 120),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeV8IntrinsicExpression(pos) {
   return {
     type: 'V8IntrinsicExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     name: deserializeIdentifierName(pos + 8),
     arguments: deserializeVecArgument(pos + 32),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeBooleanLiteral(pos) {
-  const start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    value = deserializeBool(pos + 8);
+  const value = deserializeBool(pos + 8),
+    start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Literal',
-    start,
-    end,
     value,
     raw: (start === 0 && end === 0) ? null : value + '',
+    start,
+    end,
   };
 }
 
@@ -1178,20 +1178,20 @@ function deserializeNullLiteral(pos) {
     end = deserializeU32(pos + 4);
   return {
     type: 'Literal',
-    start,
-    end,
     value: null,
     raw: (start === 0 && end === 0) ? null : 'null',
+    start,
+    end,
   };
 }
 
 function deserializeNumericLiteral(pos) {
   return {
     type: 'Literal',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     value: deserializeF64(pos + 8),
     raw: deserializeOptionStr(pos + 16),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1202,10 +1202,10 @@ function deserializeStringLiteral(pos) {
   }
   return {
     type: 'Literal',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     value,
     raw: deserializeOptionStr(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1213,11 +1213,11 @@ function deserializeBigIntLiteral(pos) {
   const bigint = deserializeStr(pos + 8);
   return {
     type: 'Literal',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     value: BigInt(bigint),
     raw: deserializeOptionStr(pos + 24),
     bigint,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1229,11 +1229,11 @@ function deserializeRegExpLiteral(pos) {
   } catch (e) {}
   return {
     type: 'Literal',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     value,
     raw: deserializeOptionStr(pos + 40),
     regex,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1271,43 +1271,43 @@ function deserializeJSXElement(pos) {
   if (closingElement === null) openingElement.selfClosing = true;
   return {
     type: 'JSXElement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     openingElement,
     children: deserializeVecJSXChild(pos + 16),
     closingElement,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeJSXOpeningElement(pos) {
   return {
     type: 'JSXOpeningElement',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     name: deserializeJSXElementName(pos + 8),
     typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
     attributes: deserializeVecJSXAttributeItem(pos + 32),
     selfClosing: false,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeJSXClosingElement(pos) {
   return {
     type: 'JSXClosingElement',
+    name: deserializeJSXElementName(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    name: deserializeJSXElementName(pos + 8),
   };
 }
 
 function deserializeJSXFragment(pos) {
   return {
     type: 'JSXFragment',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     openingFragment: deserializeJSXOpeningFragment(pos + 8),
     children: deserializeVecJSXChild(pos + 16),
     closingFragment: deserializeJSXClosingFragment(pos + 40),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1330,29 +1330,29 @@ function deserializeJSXClosingFragment(pos) {
 function deserializeJSXNamespacedName(pos) {
   return {
     type: 'JSXNamespacedName',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     namespace: deserializeJSXIdentifier(pos + 8),
     name: deserializeJSXIdentifier(pos + 32),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeJSXMemberExpression(pos) {
   return {
     type: 'JSXMemberExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     object: deserializeJSXMemberExpressionObject(pos + 8),
     property: deserializeJSXIdentifier(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeJSXExpressionContainer(pos) {
   return {
     type: 'JSXExpressionContainer',
+    expression: deserializeJSXExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expression: deserializeJSXExpression(pos + 8),
   };
 }
 
@@ -1367,215 +1367,215 @@ function deserializeJSXEmptyExpression(pos) {
 function deserializeJSXAttribute(pos) {
   return {
     type: 'JSXAttribute',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     name: deserializeJSXAttributeName(pos + 8),
     value: deserializeOptionJSXAttributeValue(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeJSXSpreadAttribute(pos) {
   return {
     type: 'JSXSpreadAttribute',
+    argument: deserializeExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    argument: deserializeExpression(pos + 8),
   };
 }
 
 function deserializeJSXIdentifier(pos) {
   return {
     type: 'JSXIdentifier',
+    name: deserializeStr(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    name: deserializeStr(pos + 8),
   };
 }
 
 function deserializeJSXSpreadChild(pos) {
   return {
     type: 'JSXSpreadChild',
+    expression: deserializeExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expression: deserializeExpression(pos + 8),
   };
 }
 
 function deserializeJSXText(pos) {
   return {
     type: 'JSXText',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     value: deserializeStr(pos + 8),
     raw: deserializeOptionStr(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSThisParameter(pos) {
   return {
     type: 'Identifier',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     decorators: [],
     name: 'this',
     optional: false,
     typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 16),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSEnumDeclaration(pos) {
   return {
     type: 'TSEnumDeclaration',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     id: deserializeBindingIdentifier(pos + 8),
     body: deserializeTSEnumBody(pos + 40),
     const: deserializeBool(pos + 76),
     declare: deserializeBool(pos + 77),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSEnumBody(pos) {
   return {
     type: 'TSEnumBody',
+    members: deserializeVecTSEnumMember(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    members: deserializeVecTSEnumMember(pos + 8),
   };
 }
 
 function deserializeTSEnumMember(pos) {
   return {
     type: 'TSEnumMember',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     id: deserializeTSEnumMemberName(pos + 8),
     initializer: deserializeOptionExpression(pos + 24),
     computed: deserializeU8(pos + 8) > 1,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSTypeAnnotation(pos) {
   return {
     type: 'TSTypeAnnotation',
+    typeAnnotation: deserializeTSType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    typeAnnotation: deserializeTSType(pos + 8),
   };
 }
 
 function deserializeTSLiteralType(pos) {
   return {
     type: 'TSLiteralType',
+    literal: deserializeTSLiteral(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    literal: deserializeTSLiteral(pos + 8),
   };
 }
 
 function deserializeTSConditionalType(pos) {
   return {
     type: 'TSConditionalType',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     checkType: deserializeTSType(pos + 8),
     extendsType: deserializeTSType(pos + 24),
     trueType: deserializeTSType(pos + 40),
     falseType: deserializeTSType(pos + 56),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSUnionType(pos) {
   return {
     type: 'TSUnionType',
+    types: deserializeVecTSType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    types: deserializeVecTSType(pos + 8),
   };
 }
 
 function deserializeTSIntersectionType(pos) {
   return {
     type: 'TSIntersectionType',
+    types: deserializeVecTSType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    types: deserializeVecTSType(pos + 8),
   };
 }
 
 function deserializeTSParenthesizedType(pos) {
   return {
     type: 'TSParenthesizedType',
+    typeAnnotation: deserializeTSType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    typeAnnotation: deserializeTSType(pos + 8),
   };
 }
 
 function deserializeTSTypeOperator(pos) {
   return {
     type: 'TSTypeOperator',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     operator: deserializeTSTypeOperatorOperator(pos + 24),
     typeAnnotation: deserializeTSType(pos + 8),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSArrayType(pos) {
   return {
     type: 'TSArrayType',
+    elementType: deserializeTSType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    elementType: deserializeTSType(pos + 8),
   };
 }
 
 function deserializeTSIndexedAccessType(pos) {
   return {
     type: 'TSIndexedAccessType',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     objectType: deserializeTSType(pos + 8),
     indexType: deserializeTSType(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSTupleType(pos) {
   return {
     type: 'TSTupleType',
+    elementTypes: deserializeVecTSTupleElement(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    elementTypes: deserializeVecTSTupleElement(pos + 8),
   };
 }
 
 function deserializeTSNamedTupleMember(pos) {
   return {
     type: 'TSNamedTupleMember',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     label: deserializeIdentifierName(pos + 8),
     elementType: deserializeTSTupleElement(pos + 32),
     optional: deserializeBool(pos + 48),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSOptionalType(pos) {
   return {
     type: 'TSOptionalType',
+    typeAnnotation: deserializeTSType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    typeAnnotation: deserializeTSType(pos + 8),
   };
 }
 
 function deserializeTSRestType(pos) {
   return {
     type: 'TSRestType',
+    typeAnnotation: deserializeTSType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    typeAnnotation: deserializeTSType(pos + 8),
   };
 }
 
@@ -1694,64 +1694,64 @@ function deserializeTSBigIntKeyword(pos) {
 function deserializeTSTypeReference(pos) {
   return {
     type: 'TSTypeReference',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     typeName: deserializeTSTypeName(pos + 8),
     typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSQualifiedName(pos) {
   return {
     type: 'TSQualifiedName',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     left: deserializeTSTypeName(pos + 8),
     right: deserializeIdentifierName(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSTypeParameterInstantiation(pos) {
   return {
     type: 'TSTypeParameterInstantiation',
+    params: deserializeVecTSType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    params: deserializeVecTSType(pos + 8),
   };
 }
 
 function deserializeTSTypeParameter(pos) {
   return {
     type: 'TSTypeParameter',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     name: deserializeBindingIdentifier(pos + 8),
     constraint: deserializeOptionTSType(pos + 40),
     default: deserializeOptionTSType(pos + 56),
     in: deserializeBool(pos + 72),
     out: deserializeBool(pos + 73),
     const: deserializeBool(pos + 74),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSTypeParameterDeclaration(pos) {
   return {
     type: 'TSTypeParameterDeclaration',
+    params: deserializeVecTSTypeParameter(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    params: deserializeVecTSTypeParameter(pos + 8),
   };
 }
 
 function deserializeTSTypeAliasDeclaration(pos) {
   return {
     type: 'TSTypeAliasDeclaration',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     id: deserializeBindingIdentifier(pos + 8),
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 40),
     typeAnnotation: deserializeTSType(pos + 48),
     declare: deserializeBool(pos + 68),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1760,63 +1760,61 @@ function deserializeTSClassImplements(pos) {
   if (expression.type === 'TSQualifiedName') {
     let parent = expression = {
       type: 'MemberExpression',
-      start: expression.start,
-      end: expression.end,
       object: expression.left,
       property: expression.right,
       optional: false,
       computed: false,
+      start: expression.start,
+      end: expression.end,
     };
 
     while (parent.object.type === 'TSQualifiedName') {
       const object = parent.object;
       parent = parent.object = {
         type: 'MemberExpression',
-        start: object.start,
-        end: object.end,
         object: object.left,
         property: object.right,
         optional: false,
         computed: false,
+        start: object.start,
+        end: object.end,
       };
     }
   }
   return {
     type: 'TSClassImplements',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     expression,
     typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSInterfaceDeclaration(pos) {
   return {
     type: 'TSInterfaceDeclaration',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     id: deserializeBindingIdentifier(pos + 8),
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 40),
     extends: deserializeVecTSInterfaceHeritage(pos + 48),
     body: deserializeBoxTSInterfaceBody(pos + 72),
     declare: deserializeBool(pos + 84),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSInterfaceBody(pos) {
   return {
     type: 'TSInterfaceBody',
+    body: deserializeVecTSSignature(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    body: deserializeVecTSSignature(pos + 8),
   };
 }
 
 function deserializeTSPropertySignature(pos) {
   return {
     type: 'TSPropertySignature',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     computed: deserializeBool(pos + 32),
     optional: deserializeBool(pos + 33),
     readonly: deserializeBool(pos + 34),
@@ -1824,19 +1822,21 @@ function deserializeTSPropertySignature(pos) {
     typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 24),
     accessibility: null,
     static: false,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSIndexSignature(pos) {
   return {
     type: 'TSIndexSignature',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     parameters: deserializeVecTSIndexSignatureName(pos + 8),
     typeAnnotation: deserializeBoxTSTypeAnnotation(pos + 32),
     readonly: deserializeBool(pos + 40),
     static: deserializeBool(pos + 41),
     accessibility: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1846,11 +1846,11 @@ function deserializeTSCallSignatureDeclaration(pos) {
   if (thisParam !== null) params.unshift(thisParam);
   return {
     type: 'TSCallSignatureDeclaration',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 8),
     params,
     returnType: deserializeOptionBoxTSTypeAnnotation(pos + 32),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1860,8 +1860,6 @@ function deserializeTSMethodSignature(pos) {
   if (thisParam !== null) params.unshift(thisParam);
   return {
     type: 'TSMethodSignature',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     key: deserializePropertyKey(pos + 8),
     computed: deserializeBool(pos + 60),
     optional: deserializeBool(pos + 61),
@@ -1872,50 +1870,52 @@ function deserializeTSMethodSignature(pos) {
     accessibility: null,
     readonly: false,
     static: false,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSConstructSignatureDeclaration(pos) {
   return {
     type: 'TSConstructSignatureDeclaration',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 8),
     params: deserializeBoxFormalParameters(pos + 16),
     returnType: deserializeOptionBoxTSTypeAnnotation(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSIndexSignatureName(pos) {
   return {
     type: 'Identifier',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     decorators: [],
     name: deserializeStr(pos + 8),
     optional: false,
     typeAnnotation: deserializeBoxTSTypeAnnotation(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSInterfaceHeritage(pos) {
   return {
     type: 'TSInterfaceHeritage',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     expression: deserializeExpression(pos + 8),
     typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSTypePredicate(pos) {
   return {
     type: 'TSTypePredicate',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     parameterName: deserializeTSTypePredicateName(pos + 8),
     asserts: deserializeBool(pos + 32),
     typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1934,10 +1934,10 @@ function deserializeTSModuleDeclaration(pos) {
     if (innerId.type === 'Identifier') {
       id = {
         type: 'TSQualifiedName',
-        start: id.start,
-        end: innerId.end,
         left: id,
         right: innerId,
+        start: id.start,
+        end: innerId.end,
       };
     } else {
       // Replace `left` of innermost `TSQualifiedName` with a nested `TSQualifiedName` with `id` of
@@ -1949,10 +1949,10 @@ function deserializeTSModuleDeclaration(pos) {
       }
       innerId.left = {
         type: 'TSQualifiedName',
-        start: id.start,
-        end: innerId.left.end,
         left: id,
         right: innerId.left,
+        start: id.start,
+        end: innerId.left.end,
       };
       id = body.id;
     }
@@ -1961,8 +1961,8 @@ function deserializeTSModuleDeclaration(pos) {
 
   // Skip `body` field if `null`
   const node = body === null
-    ? { type: 'TSModuleDeclaration', start, end, id, kind, declare, global }
-    : { type: 'TSModuleDeclaration', start, end, id, body, kind, declare, global };
+    ? { type: 'TSModuleDeclaration', id, kind, declare, global, start, end }
+    : { type: 'TSModuleDeclaration', id, body, kind, declare, global, start, end };
   return node;
 }
 
@@ -1971,49 +1971,49 @@ function deserializeTSModuleBlock(pos) {
   body.push(...deserializeVecStatement(pos + 32));
   return {
     type: 'TSModuleBlock',
+    body,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    body,
   };
 }
 
 function deserializeTSTypeLiteral(pos) {
   return {
     type: 'TSTypeLiteral',
+    members: deserializeVecTSSignature(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    members: deserializeVecTSSignature(pos + 8),
   };
 }
 
 function deserializeTSInferType(pos) {
   return {
     type: 'TSInferType',
+    typeParameter: deserializeBoxTSTypeParameter(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    typeParameter: deserializeBoxTSTypeParameter(pos + 8),
   };
 }
 
 function deserializeTSTypeQuery(pos) {
   return {
     type: 'TSTypeQuery',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     exprName: deserializeTSTypeQueryExprName(pos + 8),
     typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSImportType(pos) {
   return {
     type: 'TSImportType',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     argument: deserializeTSType(pos + 8),
     options: deserializeOptionBoxObjectExpression(pos + 24),
     qualifier: deserializeOptionTSTypeName(pos + 32),
     typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 48),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -2023,23 +2023,23 @@ function deserializeTSFunctionType(pos) {
   if (thisParam !== null) params.unshift(thisParam);
   return {
     type: 'TSFunctionType',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 8),
     params,
     returnType: deserializeBoxTSTypeAnnotation(pos + 32),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSConstructorType(pos) {
   return {
     type: 'TSConstructorType',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     abstract: deserializeBool(pos + 32),
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 8),
     params: deserializeBoxFormalParameters(pos + 16),
     returnType: deserializeBoxTSTypeAnnotation(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -2049,140 +2049,140 @@ function deserializeTSMappedType(pos) {
   if (optional === null) optional = false;
   return {
     type: 'TSMappedType',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     key: typeParameter.name,
     constraint: typeParameter.constraint,
     nameType: deserializeOptionTSType(pos + 16),
     typeAnnotation: deserializeOptionTSType(pos + 32),
     optional,
     readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 53),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSTemplateLiteralType(pos) {
   return {
     type: 'TSTemplateLiteralType',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     quasis: deserializeVecTemplateElement(pos + 8),
     types: deserializeVecTSType(pos + 32),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSAsExpression(pos) {
   return {
     type: 'TSAsExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     expression: deserializeExpression(pos + 8),
     typeAnnotation: deserializeTSType(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSSatisfiesExpression(pos) {
   return {
     type: 'TSSatisfiesExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     expression: deserializeExpression(pos + 8),
     typeAnnotation: deserializeTSType(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSTypeAssertion(pos) {
   return {
     type: 'TSTypeAssertion',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     typeAnnotation: deserializeTSType(pos + 8),
     expression: deserializeExpression(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSImportEqualsDeclaration(pos) {
   return {
     type: 'TSImportEqualsDeclaration',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     id: deserializeBindingIdentifier(pos + 8),
     moduleReference: deserializeTSModuleReference(pos + 40),
     importKind: deserializeImportOrExportKind(pos + 56),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeTSExternalModuleReference(pos) {
   return {
     type: 'TSExternalModuleReference',
+    expression: deserializeStringLiteral(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expression: deserializeStringLiteral(pos + 8),
   };
 }
 
 function deserializeTSNonNullExpression(pos) {
   return {
     type: 'TSNonNullExpression',
+    expression: deserializeExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expression: deserializeExpression(pos + 8),
   };
 }
 
 function deserializeDecorator(pos) {
   return {
     type: 'Decorator',
+    expression: deserializeExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expression: deserializeExpression(pos + 8),
   };
 }
 
 function deserializeTSExportAssignment(pos) {
   return {
     type: 'TSExportAssignment',
+    expression: deserializeExpression(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    expression: deserializeExpression(pos + 8),
   };
 }
 
 function deserializeTSNamespaceExportDeclaration(pos) {
   return {
     type: 'TSNamespaceExportDeclaration',
+    id: deserializeIdentifierName(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    id: deserializeIdentifierName(pos + 8),
   };
 }
 
 function deserializeTSInstantiationExpression(pos) {
   return {
     type: 'TSInstantiationExpression',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     expression: deserializeExpression(pos + 8),
     typeArguments: deserializeBoxTSTypeParameterInstantiation(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeJSDocNullableType(pos) {
   return {
     type: 'TSJSDocNullableType',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     typeAnnotation: deserializeTSType(pos + 8),
     postfix: deserializeBool(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeJSDocNonNullableType(pos) {
   return {
     type: 'TSJSDocNonNullableType',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     typeAnnotation: deserializeTSType(pos + 8),
     postfix: deserializeBool(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -2225,21 +2225,21 @@ function deserializeImportEntry(pos) {
 
 function deserializeExportEntry(pos) {
   return {
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
     exportName: deserializeExportExportName(pos + 72),
     localName: deserializeExportLocalName(pos + 104),
     isType: deserializeBool(pos + 136),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeDynamicImport(pos) {
   return {
+    moduleRequest: deserializeSpan(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    moduleRequest: deserializeSpan(pos + 8),
   };
 }
 
@@ -2295,18 +2295,18 @@ function deserializeEcmaScriptModule(pos) {
 
 function deserializeStaticImport(pos) {
   return {
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
     moduleRequest: deserializeNameSpan(pos + 8),
     entries: deserializeVecImportEntry(pos + 32),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeStaticExport(pos) {
   return {
+    entries: deserializeVecExportEntry(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    entries: deserializeVecExportEntry(pos + 8),
   };
 }
 
@@ -3375,14 +3375,14 @@ function deserializeJSXElementName(pos) {
       return deserializeBoxJSXIdentifier(pos + 8);
     case 1:
       const ident = deserializeBoxIdentifierReference(pos + 8);
-      return { type: 'JSXIdentifier', start: ident.start, end: ident.end, name: ident.name };
+      return { type: 'JSXIdentifier', name: ident.name, start: ident.start, end: ident.end };
     case 2:
       return deserializeBoxJSXNamespacedName(pos + 8);
     case 3:
       return deserializeBoxJSXMemberExpression(pos + 8);
     case 4:
       const thisExpr = deserializeBoxThisExpression(pos + 8);
-      return { type: 'JSXIdentifier', start: thisExpr.start, end: thisExpr.end, name: 'this' };
+      return { type: 'JSXIdentifier', name: 'this', start: thisExpr.start, end: thisExpr.end };
     default:
       throw new Error(`Unexpected discriminant ${uint8[pos]} for JSXElementName`);
   }
@@ -3392,12 +3392,12 @@ function deserializeJSXMemberExpressionObject(pos) {
   switch (uint8[pos]) {
     case 0:
       const ident = deserializeBoxIdentifierReference(pos + 8);
-      return { type: 'JSXIdentifier', start: ident.start, end: ident.end, name: ident.name };
+      return { type: 'JSXIdentifier', name: ident.name, start: ident.start, end: ident.end };
     case 1:
       return deserializeBoxJSXMemberExpression(pos + 8);
     case 2:
       const thisExpr = deserializeBoxThisExpression(pos + 8);
-      return { type: 'JSXIdentifier', start: thisExpr.start, end: thisExpr.end, name: 'this' };
+      return { type: 'JSXIdentifier', name: 'this', start: thisExpr.start, end: thisExpr.end };
     default:
       throw new Error(`Unexpected discriminant ${uint8[pos]} for JSXMemberExpressionObject`);
   }

--- a/napi/parser/src/generated/derive_estree.rs
+++ b/napi/parser/src/generated/derive_estree.rs
@@ -70,10 +70,10 @@ impl ESTree for EcmaScriptModule<'_> {
 impl ESTree for StaticImport<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
         state.serialize_field("moduleRequest", &self.module_request);
         state.serialize_field("entries", &self.entries);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }
@@ -84,9 +84,9 @@ impl ESTree for StaticImport<'_> {
 impl ESTree for StaticExport<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
+        state.serialize_field("entries", &self.entries);
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("entries", &self.entries);
         if state.ranges() {
             state.serialize_field("range", &[self.span.start, self.span.end]);
         }

--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -263,9 +263,9 @@ fn prepare_field_orders(schema: &mut Schema, estree_derive_id: DeriveId) {
             // No field order specified with `#[estree(field_order(...))]`.
             // Default field order is:
             // 1. `type` field (if present)
-            // 2. `span` field (if present)
-            // 3. Struct fields, in definition order.
-            // 4. Extra fields (`#[estree(add_fields(...)]`), in order.
+            // 2. Struct fields, in definition order.
+            // 3. Extra fields (`#[estree(add_fields(...)]`), in order.
+            // 4. `span` field (if present)
             let mut field_indices = vec![];
             let mut type_field_index = None;
             let mut span_field_index = None;
@@ -280,9 +280,6 @@ fn prepare_field_orders(schema: &mut Schema, estree_derive_id: DeriveId) {
                 }
             }
 
-            if let Some(span_field_index) = span_field_index {
-                field_indices.insert(0, span_field_index);
-            }
             if let Some(type_field_index) = type_field_index {
                 field_indices.insert(0, type_field_index);
             }
@@ -293,6 +290,10 @@ fn prepare_field_orders(schema: &mut Schema, estree_derive_id: DeriveId) {
                     u8::try_from(struct_def.fields.len() + struct_def.estree.add_fields.len() - 1)
                         .unwrap();
                 field_indices.extend(first_index..=last_index);
+            }
+
+            if let Some(span_field_index) = span_field_index {
+                field_indices.push(span_field_index);
             }
 
             let struct_def = schema.struct_def_mut(type_id);

--- a/tasks/coverage/snapshots/estree_acorn_jsx.snap
+++ b/tasks/coverage/snapshots/estree_acorn_jsx.snap
@@ -1,4 +1,4 @@
-commit: 25df720d
+commit: d9ba02dd
 
 estree_acorn_jsx Summary:
 AST Parsed     : 39/39 (100.00%)


### PR DESCRIPTION
Related to #10307.

Re-arrange fields in ESTree AST, so `start` and `end` are last, instead of first.

Also bump `acorn-test262` submodule to include https://github.com/oxc-project/acorn-test262/pull/54, which rearranges the fields in test snapshots.
