### PR TITLE
fix(ast/estree): add optional `range` field to `Span` in TS type defs

### DIFF
--- a/crates/oxc_span/src/span.rs
+++ b/crates/oxc_span/src/span.rs
@@ -81,7 +81,12 @@ pub const SPAN: Span = Span::new(0, 0);
 #[generate_derive(ESTree)]
 #[builder(skip)]
 #[content_eq(skip)]
-#[estree(no_type, flatten)]
+#[estree(
+    no_type,
+    flatten,
+    no_ts_def,
+    add_ts_def = "interface Span { start: number; end: number; range?: [number, number]; }"
+)]
 pub struct Span {
     /// The zero-based start offset of the span
     pub start: u32,

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1515,6 +1515,7 @@ export type UpdateOperator = '++' | '--';
 export interface Span {
   start: number;
   end: number;
+  range?: [number, number];
 }
 
 export type ModuleKind = 'script' | 'module';


### PR DESCRIPTION
Part of #10307.

Add optional `range` field to `Span` in TS type defs. All other types which have a span extend `Span`, so this adds `range` field to all AST types.