### PR TITLE
refactor(linter): move `LintServiceOptions.paths` to `LintService.with_paths`

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -259,8 +259,7 @@ impl Runner for LintRunner {
         // the same functionality.
         let use_cross_module = config_builder.plugins().has_import()
             || nested_configs.values().any(|config| config.plugins().has_import());
-        let mut options =
-            LintServiceOptions::new(self.cwd, paths).with_cross_module(use_cross_module);
+        let mut options = LintServiceOptions::new(self.cwd).with_cross_module(use_cross_module);
 
         let lint_config = config_builder.build();
 
@@ -304,7 +303,8 @@ impl Runner for LintRunner {
 
         // Spawn linting in another thread so diagnostics can be printed immediately from diagnostic_service.run.
         rayon::spawn(move || {
-            let mut lint_service = LintService::new(&linter, allocator_pool, options);
+            let mut lint_service =
+                LintService::new(&linter, allocator_pool, options).with_paths(paths);
 
             // Use `RawTransferFileSystem` if `oxlint2` feature is enabled.
             // This reads the source text into start of allocator, instead of the end.

--- a/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
+++ b/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
@@ -138,18 +138,16 @@ impl IsolatedLintHandler {
 
         debug!("lint {}", path.display());
 
-        let lint_service_options = LintServiceOptions::new(
-            self.options.root_path.clone(),
-            vec![Arc::from(path.as_os_str())],
-        )
-        .with_cross_module(self.options.use_cross_module);
+        let lint_service_options = LintServiceOptions::new(self.options.root_path.clone())
+            .with_cross_module(self.options.use_cross_module);
 
         let mut lint_service =
             LintService::new(&self.linter, AllocatorPool::default(), lint_service_options)
                 .with_file_system(Box::new(IsolatedLintHandlerFileSystem::new(
                     path.to_path_buf(),
                     source_text,
-                )));
+                )))
+                .with_paths(vec![Arc::from(path.as_os_str())]);
         let result = lint_service.run_source(allocator);
 
         Some(result)

--- a/crates/oxc_linter/src/service/mod.rs
+++ b/crates/oxc_linter/src/service/mod.rs
@@ -18,10 +18,6 @@ pub mod offset_to_position;
 pub struct LintServiceOptions {
     /// Current working directory
     cwd: Box<Path>,
-
-    /// All paths to lint
-    paths: Vec<Arc<OsStr>>,
-
     /// TypeScript `tsconfig.json` path for reading path alias and project references
     tsconfig: Option<PathBuf>,
 
@@ -30,11 +26,11 @@ pub struct LintServiceOptions {
 
 impl LintServiceOptions {
     #[must_use]
-    pub fn new<T>(cwd: T, paths: Vec<Arc<OsStr>>) -> Self
+    pub fn new<T>(cwd: T) -> Self
     where
         T: Into<Box<Path>>,
     {
-        Self { cwd: cwd.into(), paths, tsconfig: None, cross_module: false }
+        Self { cwd: cwd.into(), tsconfig: None, cross_module: false }
     }
 
     #[inline]
@@ -85,6 +81,12 @@ impl<'l> LintService<'l> {
         file_system: Box<dyn RuntimeFileSystem + Sync + Send>,
     ) -> Self {
         self.runtime = self.runtime.with_file_system(file_system);
+        self
+    }
+
+    #[must_use]
+    pub fn with_paths(mut self, paths: Vec<Arc<OsStr>>) -> Self {
+        self.runtime = self.runtime.with_paths(paths);
         self
     }
 

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -188,7 +188,7 @@ impl<'l> Runtime<'l> {
         Self {
             allocator_pool,
             cwd: options.cwd,
-            paths: options.paths.iter().cloned().collect(),
+            paths: IndexSet::with_capacity_and_hasher(0, FxBuildHasher),
             linter,
             resolver,
             file_system: Box::new(OsFileSystem),
@@ -200,6 +200,11 @@ impl<'l> Runtime<'l> {
         file_system: Box<dyn RuntimeFileSystem + Sync + Send>,
     ) -> Self {
         self.file_system = file_system;
+        self
+    }
+
+    pub fn with_paths(mut self, paths: Vec<Arc<OsStr>>) -> Self {
+        self.paths = paths.into_iter().collect();
         self
     }
 

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -537,12 +537,13 @@ impl Tester {
 
         let cwd = self.current_working_directory.clone();
         let paths = vec![Arc::<OsStr>::from(path_to_lint.as_os_str())];
-        let options =
-            LintServiceOptions::new(cwd, paths).with_cross_module(self.plugins.has_import());
-        let mut lint_service =
-            LintService::new(&linter, AllocatorPool::default(), options).with_file_system(
-                Box::new(TesterFileSystem::new(path_to_lint, source_text.to_string())),
-            );
+        let options = LintServiceOptions::new(cwd).with_cross_module(self.plugins.has_import());
+        let mut lint_service = LintService::new(&linter, AllocatorPool::default(), options)
+            .with_file_system(Box::new(TesterFileSystem::new(
+                path_to_lint,
+                source_text.to_string(),
+            )))
+            .with_paths(paths);
 
         let (sender, _receiver) = mpsc::channel();
         let result = lint_service.run_test_source(&allocator, false, &sender);


### PR DESCRIPTION
A bit of refactoring.
The language server can use the same `LintService` with different paths now (see downstream PR)