### PR TITLE
feat(semantic/example): add ability to print symbols and references in example

### DIFF
--- a/crates/oxc_semantic/examples/semantic.rs
+++ b/crates/oxc_semantic/examples/semantic.rs
@@ -14,6 +14,7 @@ use oxc_span::SourceType;
 
 fn main() -> std::io::Result<()> {
     let name = env::args().nth(1).unwrap_or_else(|| "test.js".to_string());
+    let show_symbols = env::args().skip(1).any(|arg| arg == "--symbols");
     let path = Path::new(&name);
     let source_text = Arc::new(std::fs::read_to_string(path)?);
     let source_type = SourceType::from_path(path).unwrap();
@@ -46,6 +47,19 @@ fn main() -> std::io::Result<()> {
             .map(|error| format!("{:?}", error.with_source_code(Arc::clone(&source_text))))
             .join("\n");
         println!("Semantic analysis failed:\n\n{error_message}",);
+    }
+
+    if show_symbols {
+        let scoping = semantic.semantic.scoping();
+        for symbol_id in scoping.symbol_ids() {
+            let name = scoping.symbol_name(symbol_id);
+            let flags = scoping.symbol_flags(symbol_id);
+            println!("Symbol: {name}, ID: {symbol_id:?}, Flags: {flags:?}");
+            for reference_id in scoping.get_resolved_reference_ids(symbol_id) {
+                let reference = scoping.get_reference(*reference_id);
+                println!("  Reference ID: {reference_id:?}, Flags: {:?}", reference.flags());
+            }
+        }
     }
 
     Ok(())


### PR DESCRIPTION
This was helpful for debugging some issues in semantic. It roughly matches what we show in the playground on the website as well.