### PR TITLE
docs(consistent-indexed-object-style): clarify docs

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
@@ -33,7 +33,7 @@ enum ConsistentIndexedObjectStyleConfig {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Require or disallow the `Record` type.
+    /// Choose between requiring either `Record` type or indexed signature types.
     ///
     /// ### Why is this bad?
     ///
@@ -41,8 +41,10 @@ declare_oxc_lint!(
     ///
     /// ### Examples
     ///
-    /// Examples of **incorrect** code for this rule:
+    /// Examples of **incorrect** code for this rule with the default "record":
     /// ```ts
+    /// /*eslint consistent-indexed-object-style: ["error", "record"]*/
+    /// 
     /// interface Foo {
     ///  [key: string]: unknown;
     /// }
@@ -53,7 +55,28 @@ declare_oxc_lint!(
     ///
     /// Examples of **correct** code for this rule:
     /// ```ts
+    /// /*eslint consistent-indexed-object-style: ["error", "record"]*/
+    /// 
     /// type Foo = Record<string, unknown>;
+    /// ```
+    /// 
+    /// Examples of **incorrect** code for this rule with "index-signature":
+    /// ```ts
+    /// /*eslint consistent-indexed-object-style: ["error", "index-signature"]*/
+    /// 
+    /// type Foo = Record<string, unknown>;
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// /*eslint consistent-indexed-object-style: ["error", "index-signature"]*/
+    /// 
+    /// interface Foo {
+    ///  [key: string]: unknown;
+    /// }
+    /// type Foo = {
+    ///  [key: string]: unknown;
+    /// };
     /// ```
     ConsistentIndexedObjectStyle,
     typescript,

--- a/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
@@ -44,7 +44,7 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule with the default "record":
     /// ```ts
     /// /*eslint consistent-indexed-object-style: ["error", "record"]*/
-    /// 
+    ///
     /// interface Foo {
     ///  [key: string]: unknown;
     /// }
@@ -56,21 +56,21 @@ declare_oxc_lint!(
     /// Examples of **correct** code for this rule:
     /// ```ts
     /// /*eslint consistent-indexed-object-style: ["error", "record"]*/
-    /// 
+    ///
     /// type Foo = Record<string, unknown>;
     /// ```
-    /// 
+    ///
     /// Examples of **incorrect** code for this rule with "index-signature":
     /// ```ts
     /// /*eslint consistent-indexed-object-style: ["error", "index-signature"]*/
-    /// 
+    ///
     /// type Foo = Record<string, unknown>;
     /// ```
     ///
     /// Examples of **correct** code for this rule:
     /// ```ts
     /// /*eslint consistent-indexed-object-style: ["error", "index-signature"]*/
-    /// 
+    ///
     /// interface Foo {
     ///  [key: string]: unknown;
     /// }


### PR DESCRIPTION
clarify the docs of `consistent-indexed-object-style`