### PR TITLE
feat(formatter): support `fmt_with_options` method for `Format` trait

### DIFF
--- a/crates/oxc_formatter/src/formatter/mod.rs
+++ b/crates/oxc_formatter/src/formatter/mod.rs
@@ -217,10 +217,16 @@ pub type FormatResult<F> = Result<F, FormatError>;
 /// # Ok(())
 /// # }
 /// ```
-pub trait Format<'ast> {
+pub trait Format<'ast, T = ()> {
     /// Formats the object using the given formatter.
     /// # Errors
     fn fmt(&self, f: &mut Formatter<'_, 'ast>) -> FormatResult<()>;
+
+    /// Formats the object using the given formatter with additional options.
+    /// # Errors
+    fn fmt_with_options(&self, options: T, f: &mut Formatter<'_, 'ast>) -> FormatResult<()> {
+        unreachable!("Please implement it first.")
+    }
 }
 
 impl<'ast, T> Format<'ast> for &T

--- a/crates/oxc_formatter/src/generated/format.rs
+++ b/crates/oxc_formatter/src/generated/format.rs
@@ -4,13 +4,10 @@
 use oxc_ast::ast::*;
 
 use crate::{
-    formatter::{
-        Buffer, Format, FormatResult, Formatter,
-        trivia::{FormatTrailingComments, format_leading_comments, format_trailing_comments},
-    },
+    formatter::{Buffer, Format, FormatResult, Formatter, trivia::FormatTrailingComments},
     generated::ast_nodes::{AstNode, SiblingNode},
     parentheses::NeedsParentheses,
-    write::FormatWrite,
+    write::{FormatJsArrowFunctionExpressionOptions, FormatWrite},
 };
 
 impl<'a> Format<'a> for AstNode<'a, Program<'a>> {
@@ -923,7 +920,9 @@ impl<'a> Format<'a> for AstNode<'a, FunctionBody<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ArrowFunctionExpression<'a>> {
+impl<'a> Format<'a, FormatJsArrowFunctionExpressionOptions>
+    for AstNode<'a, ArrowFunctionExpression<'a>>
+{
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
@@ -931,6 +930,24 @@ impl<'a> Format<'a> for AstNode<'a, ArrowFunctionExpression<'a>> {
             "(".fmt(f)?;
         }
         let result = self.write(f);
+        if needs_parentheses {
+            ")".fmt(f)?;
+        }
+        self.format_trailing_comments(f)?;
+        result
+    }
+
+    fn fmt_with_options(
+        &self,
+        options: FormatJsArrowFunctionExpressionOptions,
+        f: &mut Formatter<'_, 'a>,
+    ) -> FormatResult<()> {
+        self.format_leading_comments(f)?;
+        let needs_parentheses = self.needs_parentheses(f);
+        if needs_parentheses {
+            "(".fmt(f)?;
+        }
+        let result = self.write_with_options(options, f);
         if needs_parentheses {
             ")".fmt(f)?;
         }

--- a/crates/oxc_formatter/src/parentheses/expression.rs
+++ b/crates/oxc_formatter/src/parentheses/expression.rs
@@ -11,7 +11,7 @@ use crate::{
     Format,
     formatter::Formatter,
     generated::ast_nodes::{AstNode, AstNodes},
-    write::{BinaryLikeExpression, arrow_function_expression::ExpressionLeftSide, should_flatten},
+    write::{BinaryLikeExpression, ExpressionLeftSide, should_flatten},
 };
 
 use super::NeedsParentheses;

--- a/crates/oxc_formatter/src/utils/assignment_like.rs
+++ b/crates/oxc_formatter/src/utils/assignment_like.rs
@@ -6,9 +6,7 @@ use oxc_span::GetSpan;
 use crate::formatter::prelude::{FormatElements, format_once, line_suffix_boundary};
 use crate::formatter::{BufferExtensions, VecBuffer};
 use crate::write::BinaryLikeExpression;
-use crate::write::arrow_function_expression::{
-    FormatJsArrowFunctionExpression, FormatJsArrowFunctionExpressionOptions,
-};
+use crate::write::{FormatJsArrowFunctionExpression, FormatJsArrowFunctionExpressionOptions};
 use crate::{
     format_args,
     formatter::{

--- a/crates/oxc_formatter/src/write/call_arguments.rs
+++ b/crates/oxc_formatter/src/write/call_arguments.rs
@@ -227,15 +227,12 @@ impl<'a> FormatCallArgument<'a, '_> {
                             function
                         )?;
                     }
-                    AstNodes::ArrowFunctionExpression(arrow) => write!(
+                    AstNodes::ArrowFunctionExpression(arrow) => arrow.fmt_with_options(
+                        FormatJsArrowFunctionExpressionOptions {
+                            body_cache_mode: cache_mode,
+                            ..FormatJsArrowFunctionExpressionOptions::default()
+                        },
                         f,
-                        FormatJsArrowFunctionExpression::new_with_options(
-                            arrow,
-                            FormatJsArrowFunctionExpressionOptions {
-                                body_cache_mode: cache_mode,
-                                ..FormatJsArrowFunctionExpressionOptions::default()
-                            },
-                        )
                     )?,
                     _ => write!(f, element)?,
                 }
@@ -897,18 +894,14 @@ impl<'a> Format<'a> for FormatGroupedFirstArgument<'a, '_> {
             // Call the arrow function formatting but explicitly passes the call argument layout down
             // so that the arrow function formatting removes any soft line breaks between parameters and the return type.
             AstNodes::ArrowFunctionExpression(arrow) => with_token_tracking_disabled(f, |f| {
-                write!(
+                arrow.fmt_with_options(
+                    FormatJsArrowFunctionExpressionOptions {
+                        body_cache_mode: FunctionBodyCacheMode::Cached,
+                        call_arg_layout: Some(GroupedCallArgumentLayout::GroupedFirstArgument),
+                        ..FormatJsArrowFunctionExpressionOptions::default()
+                    },
                     f,
-                    FormatJsArrowFunctionExpression::new_with_options(
-                        arrow,
-                        FormatJsArrowFunctionExpressionOptions {
-                            body_cache_mode: FunctionBodyCacheMode::Cached,
-                            call_arg_layout: Some(GroupedCallArgumentLayout::GroupedFirstArgument),
-                            ..FormatJsArrowFunctionExpressionOptions::default()
-                        },
-                    )
-                )?;
-
+                );
                 write!(f, ",")
             }),
 
@@ -954,19 +947,14 @@ impl<'a> Format<'a> for FormatGroupedLastArgument<'a, '_> {
             }
 
             AstNodes::ArrowFunctionExpression(arrow) => with_token_tracking_disabled(f, |f| {
-                write!(
+                arrow.fmt_with_options(
+                    FormatJsArrowFunctionExpressionOptions {
+                        body_cache_mode: FunctionBodyCacheMode::Cached,
+                        call_arg_layout: Some(GroupedCallArgumentLayout::GroupedLastArgument),
+                        ..FormatJsArrowFunctionExpressionOptions::default()
+                    },
                     f,
-                    FormatJsArrowFunctionExpression::new_with_options(
-                        arrow,
-                        FormatJsArrowFunctionExpressionOptions {
-                            body_cache_mode: FunctionBodyCacheMode::Cached,
-                            call_arg_layout: Some(GroupedCallArgumentLayout::GroupedLastArgument),
-                            ..FormatJsArrowFunctionExpressionOptions::default()
-                        },
-                    )
-                )?;
-
-                Ok(())
+                )
             }),
             _ => self.argument.fmt(f),
         }

--- a/crates/oxc_formatter/src/write/mod.rs
+++ b/crates/oxc_formatter/src/write/mod.rs
@@ -1,6 +1,6 @@
 mod array_element_list;
 mod array_expression;
-pub mod arrow_function_expression;
+mod arrow_function_expression;
 mod assignment_pattern_property_list;
 mod binary_like_expression;
 mod binding_property_list;
@@ -15,6 +15,9 @@ mod semicolon;
 mod type_parameters;
 mod utils;
 mod variable_declaration;
+pub use arrow_function_expression::{
+    ExpressionLeftSide, FormatJsArrowFunctionExpression, FormatJsArrowFunctionExpressionOptions,
+};
 pub use binary_like_expression::{BinaryLikeExpression, BinaryLikeOperator, should_flatten};
 
 use call_arguments::{FormatAllArgsBrokenOut, FormatCallArgument, is_function_composition_args};
@@ -47,7 +50,6 @@ use crate::{
 
 use self::{
     array_expression::FormatArrayExpression,
-    arrow_function_expression::FormatJsArrowFunctionExpression,
     object_like::ObjectLike,
     object_pattern_like::ObjectPatternLike,
     parameter_list::{ParameterLayout, ParameterList},
@@ -60,8 +62,11 @@ use self::{
     },
 };
 
-pub trait FormatWrite<'ast> {
+pub trait FormatWrite<'ast, T = ()> {
     fn write(&self, f: &mut Formatter<'_, 'ast>) -> FormatResult<()>;
+    fn write_with_options(&self, options: T, f: &mut Formatter<'_, 'ast>) -> FormatResult<()> {
+        unreachable!("Please implement it first.");
+    }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, Program<'a>> {
@@ -1172,9 +1177,19 @@ impl<'a> FormatWrite<'a> for AstNode<'a, FormalParameter<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ArrowFunctionExpression<'a>> {
+impl<'a> FormatWrite<'a, FormatJsArrowFunctionExpressionOptions>
+    for AstNode<'a, ArrowFunctionExpression<'a>>
+{
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         FormatJsArrowFunctionExpression::new(self).fmt(f)
+    }
+
+    fn write_with_options(
+        &self,
+        options: FormatJsArrowFunctionExpressionOptions,
+        f: &mut Formatter<'_, 'a>,
+    ) -> FormatResult<()> {
+        FormatJsArrowFunctionExpression::new_with_options(self, options).fmt(f)
     }
 }
 

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -9,7 +9,7 @@ js compatibility: 387/699 (55.36%)
 | js/arrows/call.js | 💥💥 | 75.68% |
 | js/arrows/comment.js | 💥💥 | 60.87% |
 | js/arrows/curried.js | 💥💥 | 92.55% |
-| js/arrows/currying-4.js | 💥💥 | 86.67% |
+| js/arrows/currying-4.js | 💥💥 | 94.34% |
 | js/arrows/issue-1389-curry.js | 💥💥 | 86.96% |
 | js/arrows/semi/semi.js | 💥✨ | 0.00% |
 | js/assignment/destructuring-array.js | 💥 | 0.00% |

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -58,7 +58,7 @@ ts compatibility: 219/573 (38.22%)
 | typescript/argument-expansion/argument_expansion.ts | 💥 | 93.22% |
 | typescript/argument-expansion/arrow-with-return-type.ts | 💥 | 92.31% |
 | typescript/array/comment.ts | 💥 | 87.50% |
-| typescript/arrow/16067.ts | 💥💥 | 65.31% |
+| typescript/arrow/16067.ts | 💥💥 | 67.35% |
 | typescript/arrow/comments.ts | 💥✨ | 44.44% |
 | typescript/as/array-pattern.ts | 💥 | 0.00% |
 | typescript/as/as.ts | 💥 | 64.57% |


### PR DESCRIPTION
Add `fmt_with_options` method to allow printing some AstNode with special options, and keep the `AstNode` print comments as before.