### PR TITLE
fix(minifier): always escape `$` when concatenating template literals

### DIFF
--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -806,7 +806,7 @@ impl<'a> PeepholeOptimizations {
             Cow::Owned(
                 s.cow_replace("\\", "\\\\")
                     .cow_replace("`", "\\`")
-                    .cow_replace("${", "\\${")
+                    .cow_replace("$", "\\$")
                     .cow_replace("\r\n", "\\r\n")
                     .into_owned(),
             )
@@ -1830,6 +1830,14 @@ mod test {
         test("x = []['concat'](1)", "x = [1]");
         test("x = ''['concat'](1)", "x = '1'");
         test_same("x = obj.concat([1,2]).concat(1)");
+    }
+
+    #[test]
+    fn test_add_template_literal() {
+        test("x = '$' + `{${x}}`", "x = `\\${${x}}`");
+        test("x = `{${x}}` + '$'", "x = `{${x}}\\$`");
+        test("x = `$` + `{${x}}`", "x = `\\${${x}}`");
+        test("x = `{${x}}` + `$`", "x = `{${x}}\\$`");
     }
 
     #[test]

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -21,7 +21,7 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 3.20 MB    | 1.01 MB    | 1.01 MB    | 324.12 kB  | 331.56 kB  | echarts.js
 
-6.69 MB    | 2.28 MB    | 2.31 MB    | 466.11 kB  | 488.28 kB  | antd.js   
+6.69 MB    | 2.28 MB    | 2.31 MB    | 466.10 kB  | 488.28 kB  | antd.js   
 
 10.95 MB   | 3.35 MB    | 3.49 MB    | 860.93 kB  | 915.50 kB  | typescript.js
 


### PR DESCRIPTION
fixes #11840