### PR TITLE
fix(linter/consistent-index-object-style): fix default impl for rule config

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
@@ -18,9 +18,15 @@ fn consistent_indexed_object_style_diagnostic(a: &str, b: &str, span: Span) -> O
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct ConsistentIndexedObjectStyle {
     is_record_mode: bool,
+}
+
+impl Default for ConsistentIndexedObjectStyle {
+    fn default() -> Self {
+        Self { is_record_mode: true }
+    }
 }
 
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]


### PR DESCRIPTION
default for rust bool is false, however this value's default should be true

fixes #12020 