### PR TITLE
docs(allocator): update comments about `bumpalo` version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,7 @@ allocator-api2 = "=0.2.21"
 base64 = "0.22.1"
 bitflags = "2.9.1"
 bpaf = "0.9.20"
-# `bumpalo` must be pinned to exactly this version.
+# `bumpalo` must be pinned to exactly version 3.19.0.
 # `Allocator::from_raw_parts` (used in raw transfer) depends on internal implementation details
 # of `bumpalo` which may change in a future version.
 # This is a temporary situation - we'll replace `bumpalo` with our own allocator.

--- a/crates/oxc_allocator/src/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/from_raw_parts.rs
@@ -33,7 +33,7 @@ impl Allocator {
     /// This code only remains sound as long as the code in version of `bumpalo` we're using matches
     /// the duplicate of `bumpalo`'s internals contained in this file.
     ///
-    /// `bumpalo` is pinned to version `=3.17.0` in `Cargo.toml`.
+    /// `bumpalo` is pinned to version `=3.19.0` in `Cargo.toml`.
     ///
     /// The [`Allocator`] which is returned takes ownership of the memory allocation,
     /// and the allocation will be freed if the `Allocator` is dropped.


### PR DESCRIPTION
We've bumped `bumpalo` to v3.19.0. Update comments to reflect this.