### PR TITLE
fix(parser): allow `extends this.B` syntax

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -374,6 +374,8 @@ impl<'a> Expression<'a> {
     /// Is identifier or `a.b` expression where `a` is an identifier.
     pub fn is_entity_name_expression(&self) -> bool {
         matches!(self.without_parentheses(), Expression::Identifier(_))
+            // Special case: treat `this.B` like `this` was an identifier
+            || matches!(self.without_parentheses(), Expression::ThisExpression(_))
             || self.is_property_access_entity_name_expression()
     }
 

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -2,8 +2,8 @@ commit: 1d4546bc
 
 parser_babel Summary:
 AST Parsed     : 2351/2362 (99.53%)
-Positive Passed: 2329/2362 (98.60%)
-Negative Passed: 1601/1698 (94.29%)
+Positive Passed: 2330/2362 (98.65%)
+Negative Passed: 1600/1698 (94.23%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/invalid-startindex-and-startline-specified-without-startcolumn/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/startline-and-startcolumn-specified/input.js
@@ -133,6 +133,8 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/ty
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/invalid-modifiers-method-babel-7/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/invalid-modifiers-property/input.ts
+
+Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type-2/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type-disallowed/input.ts
 
@@ -642,16 +644,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/declare-pattern-parameters/input.ts:1:25]
  1 │ declare function f([]?, {})
    ·                         ──
-   ╰────
-
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type-2-babel-7/input.ts
-
-  × TS(2499): An interface can only extend an identifier/qualified-name with optional type arguments.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type-2-babel-7/input.ts:3:21]
- 2 │ // but they are always type-checking errors.
- 3 │ interface A extends this.B {}
-   ·                     ──────
- 4 │ type T = typeof var.bar;
    ╰────
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/nested-extends-in-arrow-type-param/input.ts
@@ -12823,14 +12815,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  2 │     const x = await 42;
    ·               ─────
  3 │ }
-   ╰────
-
-  × TS(2499): An interface can only extend an identifier/qualified-name with optional type arguments.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type-2/input.ts:3:21]
- 2 │ // but they are always type-checking errors.
- 3 │ interface A extends this.B {}
-   ·                     ──────
- 4 │ type T = typeof var.bar;
    ╰────
 
   × Identifier `A` has already been declared

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -1428,7 +1428,6 @@ after transform: ["this"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type-2-babel-7/input.ts
-An interface can only extend an identifier/qualified-name with optional type arguments.
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []


### PR DESCRIPTION
Syntactically, this is valid. It is only an error when you get to type checking. The error code itself can be handled as part of https://github.com/oxc-project/oxc/issues/11582, but this fixes an issue where we emitted an error for a case that should definitely be valid, as pointed out in the file itself.