### PR TITLE
refactor(semantic): remove redundant code handling reference flags

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -2014,9 +2014,6 @@ impl<'a> SemanticBuilder<'a> {
             AstKind::TSTypeParameter(type_parameter) => {
                 type_parameter.bind(self);
             }
-            AstKind::TSInterfaceHeritage(_) => {
-                self.current_reference_flags = ReferenceFlags::Type;
-            }
             AstKind::TSPropertySignature(signature) => {
                 if signature.key.is_expression() {
                     // interface A { [prop]: string }
@@ -2029,33 +2026,18 @@ impl<'a> SemanticBuilder<'a> {
                 //          ^^^^^^^^
                 self.current_reference_flags = ReferenceFlags::ValueAsType;
             }
-            AstKind::TSTypeParameterInstantiation(_) => {
-                // type A<T> = typeof a<T>;
-                //                     ^^^ avoid treat T as a value and TSTypeQuery
-                self.current_reference_flags -= ReferenceFlags::ValueAsType;
-            }
-            AstKind::TSClassImplements(_) | AstKind::TSTypeReference(_) => {
-                // type X = SomeType;
-                //          ^^^^^^^^
+            AstKind::TSInterfaceHeritage(_)
+            | AstKind::TSClassImplements(_)
+            | AstKind::TSTypeReference(_) => {
+                // interface A extends B {}
+                //             ^^^^^^^^^
                 //
                 // class A implements B {}
                 //         ^^^^^^^^^^^^
-                //
-                // let X: import('module').Y;
-                //        ^^^^^^^^^^^^^^^^
-                if !self.current_reference_flags.is_value_as_type() {
-                    self.current_reference_flags = ReferenceFlags::Type;
-                }
+
+                self.current_reference_flags = ReferenceFlags::Type;
             }
             AstKind::IdentifierReference(ident) => {
-                if let Some(AstKind::TSImportType(_)) = self.nodes.parent_kind(self.current_node_id)
-                {
-                    // let X: import('module').X
-                    //                         ^
-                    // We don't want to treat this as a value reference.
-                    self.current_reference_flags = ReferenceFlags::Type;
-                }
-
                 self.reference_identifier(ident);
             }
             AstKind::LabeledStatement(stmt) => {
@@ -2092,12 +2074,6 @@ impl<'a> SemanticBuilder<'a> {
             }
             AstKind::CatchParameter(_) => {
                 self.resolve_references_for_current_scope();
-            }
-            AstKind::IdentifierReference(_) | AstKind::TSQualifiedName(_) => {
-                if matches!(self.nodes.parent_kind(self.current_node_id), Some(AstKind::TSImportType(_) | AstKind::TSTypeReference(_) | AstKind::TSClassImplements(_))) {
-                    // Clear the type reference flags that were set in `enter_kind` for these kinds.
-                    self.current_reference_flags -= ReferenceFlags::Type;
-                }
             }
             AstKind::TSTypeQuery(_)
             // Clear the reference flags that are set in AstKind::PropertySignature

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -176,13 +176,19 @@ after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/import/input.js
+Symbol reference IDs mismatch for "Y":
+after transform: SymbolId(1): [ReferenceId(0)]
+rebuilt        : SymbolId(1): []
 Unresolved references mismatch:
-after transform: ["Y", "foo"]
+after transform: ["foo"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/import-babel-7/input.js
+Symbol reference IDs mismatch for "Y":
+after transform: SymbolId(1): [ReferenceId(0)]
+rebuilt        : SymbolId(1): []
 Unresolved references mismatch:
-after transform: ["Y", "foo"]
+after transform: ["foo"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/import-dot-this/input.js
@@ -196,13 +202,19 @@ after transform: ["this"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/import-with-options/input.js
+Symbol reference IDs mismatch for "Y":
+after transform: SymbolId(1): [ReferenceId(0)]
+rebuilt        : SymbolId(1): []
 Unresolved references mismatch:
-after transform: ["Y", "foo"]
+after transform: ["foo"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/import-with-options-babel-7/input.js
+Symbol reference IDs mismatch for "Y":
+after transform: SymbolId(1): [ReferenceId(0)]
+rebuilt        : SymbolId(1): []
 Unresolved references mismatch:
-after transform: ["Y", "foo"]
+after transform: ["foo"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/instantiation-expression-optional-chain/input.ts
@@ -2677,13 +2689,19 @@ after transform: ScopeId(0): ["A", "B", "T", "Types"]
 rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/import-type-dynamic/input.ts
+Symbol reference IDs mismatch for "Y":
+after transform: SymbolId(1): [ReferenceId(0)]
+rebuilt        : SymbolId(1): []
 Unresolved references mismatch:
-after transform: ["Y", "foo"]
+after transform: ["foo"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/import-type-dynamic-babel-7/input.ts
+Symbol reference IDs mismatch for "Y":
+after transform: SymbolId(1): [ReferenceId(0)]
+rebuilt        : SymbolId(1): []
 Unresolved references mismatch:
-after transform: ["Y", "foo"]
+after transform: ["foo"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/indexed/input.ts

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -47344,6 +47344,9 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/moduleResoluti
 Bindings mismatch:
 after transform: ScopeId(0): ["User", "getUser", "user"]
 rebuilt        : ScopeId(0): ["getUser", "user"]
+Unresolved references mismatch:
+after transform: ["User"]
+rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/bundler/bundlerDirectoryModule.ts
 Bindings mismatch:


### PR DESCRIPTION
This PR is a follow-up to #11990. After `AstKind::TSTypeName` has been removed, a lot of prior handling of the kind can be removed. The semantic snapshot changes are expected, caused by #12042.