### PR TITLE
refactor(linter/no-unused-vars): simplify check for export nodes

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
@@ -186,8 +186,8 @@ impl<'a> Symbol<'_, 'a> {
     fn in_export_node(&self) -> bool {
         for parent in self.nodes().ancestors(self.declaration_id()).skip(1) {
             match parent.kind() {
-                m if m.is_module_declaration() => {
-                    return m.as_module_declaration_kind().unwrap().is_export();
+                AstKind::ExportNamedDeclaration(_) | AstKind::ExportDefaultDeclaration(_) => {
+                    return true;
                 }
                 AstKind::VariableDeclaration(_)
                 | AstKind::ArrayExpression(_)


### PR DESCRIPTION
This PR is a follow-up to https://github.com/oxc-project/oxc/pull/12022

This method checks whether a symbol has been exported, and only `ExportNamedDeclaration` and `ExportDefaultDeclaration` can produce a Symbol, so the `module.is_export()` is unnecessary. 