### PR TITLE
fix(oxlint): always follow symlinks; remove cli flag `--symlinks`

### DIFF
--- a/apps/oxlint/src/command/ignore.rs
+++ b/apps/oxlint/src/command/ignore.rs
@@ -26,10 +26,6 @@ pub struct IgnoreOptions {
 
     #[bpaf(switch, hide_usage, help(NO_IGNORE_HELP))]
     pub no_ignore: bool,
-
-    /// Follow symbolic links. Oxlint ignores symbolic links by default.
-    #[bpaf(switch, hide_usage)]
-    pub symlinks: bool,
 }
 
 #[cfg(test)]

--- a/apps/oxlint/src/walk.rs
+++ b/apps/oxlint/src/walk.rs
@@ -92,11 +92,7 @@ impl Walk {
             }
         }
 
-        // Turning off `follow_links` because:
-        // * following symlinks is a really slow syscall
-        // * it is super rare to have symlinked source code
-        let inner =
-            inner.ignore(false).git_global(false).follow_links(options.symlinks).build_parallel();
+        let inner = inner.ignore(false).git_global(false).follow_links(true).build_parallel();
         Self { inner, extensions: Extensions::default() }
     }
 
@@ -146,7 +142,6 @@ mod test {
             no_ignore: false,
             ignore_path: OsString::from(".gitignore"),
             ignore_pattern: vec![],
-            symlinks: false,
         };
 
         let override_builder = OverrideBuilder::new("/").build().unwrap();

--- a/crates/oxc_language_server/src/linter/config_walker.rs
+++ b/crates/oxc_language_server/src/linter/config_walker.rs
@@ -64,9 +64,6 @@ impl ConfigWalker {
     /// Will not canonicalize paths.
     /// # Panics
     pub fn new(path: &Path) -> Self {
-        // Turning off `follow_links` because:
-        // * following symlinks is a really slow syscall
-        // * it is super rare to have symlinked source code
         let inner: ignore::WalkParallel = ignore::WalkBuilder::new(path)
             // disable skip hidden, which will not not search for files starting with a dot
             .hidden(false)
@@ -74,7 +71,7 @@ impl ConfigWalker {
             .parents(false)
             .ignore(false)
             .git_global(false)
-            .follow_links(false)
+            .follow_links(true)
             .build_parallel();
 
         Self { inner }

--- a/tasks/website/src/linter/snapshots/cli.snap
+++ b/tasks/website/src/linter/snapshots/cli.snap
@@ -93,8 +93,6 @@ Arguments:
   The supported syntax is the same as for .eslintignore and .gitignore files You should quote your patterns in order to avoid shell interpretation of glob patterns
 - **`    --no-ignore`** &mdash; 
   Disables excluding of files from .eslintignore files, **`--ignore-path`** flags and **`--ignore-pattern`** flags
-- **`    --symlinks`** &mdash; 
-  Follow symbolic links. Oxlint ignores symbolic links by default.
 
 
 

--- a/tasks/website/src/linter/snapshots/cli_terminal.snap
+++ b/tasks/website/src/linter/snapshots/cli_terminal.snap
@@ -57,7 +57,6 @@ Ignore Files
                               .eslintignore)
         --no-ignore           Disables excluding of files from .eslintignore files, --ignore-path
                               flags and --ignore-pattern flags
-        --symlinks            Follow symbolic links. Oxlint ignores symbolic links by default.
 
 Handle Warnings
         --quiet               Disable reporting on warnings, only errors are reported


### PR DESCRIPTION
I didn't know following symlinks had no perf impact if the file is not
symlinked, my assumptions were all wrong many years.

https://github.com/BurntSushi/ripgrep/blob/cbc598f245f3c157a872b69102653e2e349b6d92/crates/ignore/src/walk.rs#L1609-L1610

fixes #11930
closes #11939