### PR TITLE
perf(ast): call `Expression::without_parentheses` only once

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -373,10 +373,11 @@ impl<'a> Expression<'a> {
 
     /// Is identifier or `a.b` expression where `a` is an identifier.
     pub fn is_entity_name_expression(&self) -> bool {
-        matches!(self.without_parentheses(), Expression::Identifier(_))
-            // Special case: treat `this.B` like `this` was an identifier
-            || matches!(self.without_parentheses(), Expression::ThisExpression(_))
-            || self.is_property_access_entity_name_expression()
+        // Special case: treat `this.B` like `this` was an identifier
+        matches!(
+            self.without_parentheses(),
+            Expression::Identifier(_) | Expression::ThisExpression(_)
+        ) || self.is_property_access_entity_name_expression()
     }
 
     /// `a.b` expression where `a` is an identifier.


### PR DESCRIPTION
Follow-on after #12038. Call `Expression::without_parentheses` once, instead of twice.