### PR TITLE
test(coverage/typescript): Update `7xxx` error codes handling

### DIFF
--- a/tasks/coverage/snapshots/codegen_typescript.snap
+++ b/tasks/coverage/snapshots/codegen_typescript.snap
@@ -1,5 +1,5 @@
 commit: 81c95189
 
 codegen_typescript Summary:
-AST Parsed     : 6592/6592 (100.00%)
-Positive Passed: 6592/6592 (100.00%)
+AST Parsed     : 6700/6700 (100.00%)
+Positive Passed: 6700/6700 (100.00%)

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -1,8 +1,8 @@
 commit: 81c95189
 
 estree_typescript Summary:
-AST Parsed     : 6544/6544 (100.00%)
-Positive Passed: 6541/6544 (99.95%)
+AST Parsed     : 6649/6649 (100.00%)
+Positive Passed: 6646/6649 (99.95%)
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuite.tsx
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitEntities.tsx

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -1,9 +1,9 @@
 commit: 81c95189
 
 parser_typescript Summary:
-AST Parsed     : 6585/6592 (99.89%)
-Positive Passed: 6574/6592 (99.73%)
-Negative Passed: 1422/5706 (24.92%)
+AST Parsed     : 6693/6700 (99.90%)
+Positive Passed: 6682/6700 (99.73%)
+Negative Passed: 1418/5598 (25.33%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment8.ts
@@ -107,8 +107,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/anonymousCla
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/anyIdenticalToItself.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/anyIndexedAccessArrayNoException.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/anyMappedTypesError.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/arguments.ts
 
@@ -542,10 +540,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/circularModu
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/circularOptionalityRemoval.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/circularReferenceInReturnType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/circularReferenceInReturnType2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/circularResolvedSignature.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/circularTypeArgumentsLocalAndOuterNoCrash1.ts
@@ -820,13 +814,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constructorR
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constructorsWithSpecializedSignatures.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualOverloadListFromUnionWithPrimitiveNoImplicitAny.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualPropertyOfGenericFilteringMappedType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInArrayElementLibEs2015.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInArrayElementLibEs5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstatiationContravariance.ts
 
@@ -888,8 +876,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTy
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParametersOptionalInJSDoc.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParametersWithInitializers1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParametersWithQuestionToken.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingOrOperator.ts
@@ -906,8 +892,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowA
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowArrayErrors.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowAutoAccessor1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowDestructuringVariablesInTryCatch.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowForIndexSignatures.ts
@@ -916,11 +900,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowF
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowLoopAnalysis.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowNoImplicitAny.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowNullTypeAndLiteral.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowSelfReferentialLoop.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/copyrightWithNewLine1.ts
 
@@ -1013,8 +993,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationE
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMixinPrivateProtected.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitObjectAssignedDefaultExport.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrivatePromiseLikeInterface.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrivateSymbolCausesVarDeclarationEmit2.ts
 
@@ -1472,8 +1450,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/esmNoSynthes
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/evalAfter0.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/evolvingArrayResolvedAssert.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exactSpellingSuggestion.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/excessPropertiesInOverloads.ts
@@ -1920,8 +1896,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/grammarAmbig
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/heterogeneousArrayAndOverloads.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/hugeDeclarationOutputGetsTruncatedWithError.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/i3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/identityForSignaturesWithTypeParametersAndAny.ts
@@ -1940,41 +1914,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/implementPub
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/implementsIncorrectlyNoAssertion.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/implicitAnyAmbients.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/implicitAnyCastedValue.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareFunctionExprWithoutFormalType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareFunctionWithoutFormalType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareMemberWithoutType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareMemberWithoutType2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareTypePropertyWithoutType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareVariablesWithoutTypeAndInit.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/implicitAnyFromCircularInference.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/implicitAnyFunctionInvocationWithAnyArguements.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/implicitAnyFunctionOverloadWithImplicitAnyReturnType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/implicitAnyFunctionReturnNullOrUndefined.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/implicitAnyGenericTypeInference.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/implicitAnyGetAndSetAccessorWithAnyReturnType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/implicitAnyInAmbientDeclaration.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/implicitAnyInAmbientDeclaration2.d.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/implicitAnyNewExprLackConstructorSignature.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/implicitAnyWidenToAny.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/impliedNodeFormatEmit1.ts
 
@@ -2294,8 +2234,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/intersection
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/intraBindingPatternReferences.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/intrinsics.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/invalidConstraint1.ts
@@ -2323,8 +2261,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isLiteral1.t
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorTypes1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsClasses.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsObjects.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationLazySymbols.ts
 
@@ -2418,8 +2354,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsFileCompil
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsFileFunctionParametersAsOptional2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsFileMethodOverloads3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsFunctionWithPrototypeNoErrorTruncationNoCrash.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsPropertyAssignedAfterMethodDeclaration.ts
@@ -2505,8 +2439,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsic
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxIssuesErrorWhenTagExpectsTooManyArguments.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceElementChildrenAttributeIgnoredWhenReactJsx.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceGlobalReexportMissingAliasTarget.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxNamespacePrefixIntrinsics.tsx
 
@@ -2756,8 +2688,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolu
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSymlinks_preserveSymlinks.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_relativeImportJsFile_noImplicitAny.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleVariableArrayIndexer.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleVisibilityTest2.ts
@@ -2814,15 +2744,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/narrowByClau
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/narrowByEquality.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/narrowSwitchOptionalChainContainmentEvolvingArrayNoCrash1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/narrowingMutualSubtypes.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/narrowingOfDottedNames.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/narrowingOfQualifiedNames.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/narrowingPastLastAssignment.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/narrowingUnionToNeverAssigment.ts
 
@@ -2841,8 +2765,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/nestedRecurs
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/newAbstractInstance.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/newAbstractInstance2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/newFunctionImplicitAny.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/newMap.ts
 
@@ -2874,17 +2796,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noErrorsInCa
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noExcessiveStackDepthError.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyDestructuringParameterDeclaration.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyForIn.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyForMethodParameters.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyForwardReferencedInterface.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyFunctions.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyInBareInterface.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyInCastExpression.ts
 
@@ -2894,35 +2806,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAn
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyLoopCrash.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyMissingGetAccessor.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyMissingSetAccessor.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyModule.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyNamelessParameter.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyParametersInAmbientClass.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyParametersInAmbientFunctions.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyParametersInAmbientModule.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyParametersInBareFunctions.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyParametersInClass.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyParametersInInterface.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyParametersInModule.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyReferencingDeclaredInterface.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyUnionNormalizedObjectLiteral1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyWithOverloads.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsExclusions.ts
 
@@ -3059,8 +2945,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectLitera
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectLiteralMemberWithoutBlock1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectLiteralParameterResolution.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectLiteralPropertyImplicitlyAny.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectLiteralReferencingInternalProperties.ts
 
@@ -3566,10 +3450,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/selfReferenc
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/selfReferencingFile3.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/selfReferencingSpreadInLoop.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/selfReferentialDefaultNoStackOverflow.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/semicolonsInModuleDeclarations.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/separate1-1.ts
@@ -3816,8 +3696,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/trailingComm
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/tripleSlashTypesReferenceWithMissingExports.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/trivialSubtypeReductionNoStructuralCheck.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion1.ts
@@ -3871,10 +3749,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeAssertio
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeAssignabilityErrorMessage.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeCheckExportsVariable.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeCheckObjectLiteralMethodBody.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeCheckReturnExpression.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeCheckTypeArgument.ts
 
@@ -4099,6 +3973,8 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unresolvedTy
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unspecializedConstraints.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts
+
+Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/untypedModuleImport_withAugmentation2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unusedClassesinModule1.ts
 
@@ -4387,8 +4263,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/widenedTypes
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/wrappedRecursiveGenericType.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/yieldExpression1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/yieldExpressionInFlowLoop.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/Symbols/ES5SymbolProperty2.ts
 
@@ -4700,8 +4574,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/m
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAccessors.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAmbientNoImplicitAny.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndObjectRestSpread.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameBadSuper.ts
@@ -4938,10 +4810,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/directive
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/directives/ts-ignore.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpression5ES2020.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpression6ES2020.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionCheckReturntype1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionErrorInES2015.ts
@@ -4951,8 +4819,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/dynamicIm
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionNestedES20152.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionNoModuleKindSpecified.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionSpecifierNotStringTypeError.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/enums/enumConstantMemberWithString.ts
 
@@ -5354,8 +5220,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destr
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVoidStrictNullChecks.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringWithLiteralInitializers2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern10.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern13.ts
@@ -5431,14 +5295,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-o
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of29.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of30.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of32.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of33.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of34.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of35.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of39.ts
 
@@ -5644,10 +5500,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yield
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck31.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck48.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck50.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck6.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck62.ts
@@ -5659,8 +5511,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yield
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck8.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck9.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/yieldExpressionInControlFlow.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCanBeAssigned1.ts
 
@@ -5934,8 +5784,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressio
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/literals/literals.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/newOperator/newOperatorErrorCases_noImplicitAny.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperatorInParameterBindingPattern.2.ts
@@ -6011,8 +5859,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressio
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfactionWithDefaultExport.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_contextualTyping2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_errorLocations1.ts
 
@@ -6308,15 +6154,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/generator
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/generators/generatorExplicitReturnType.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/generators/generatorImplicitAny.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnContextualType.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeFallback.2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeInference.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeInferenceNonStrict.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/importAssertion/importAssertion2.ts
 
@@ -6474,8 +6314,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/che
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag15.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag6.ts
@@ -6485,8 +6323,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/che
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag8.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag9.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypeTag1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypeTag2.ts
 
@@ -6581,8 +6417,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsd
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocParamTag2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocParseBackquotedParamName.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocParseDotDotDotInJSDocFunction.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocPostfixEqualsAddsOptionality.ts
 
@@ -6752,10 +6586,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEl
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution15.tsx
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution16.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution18.tsx
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution3.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution4.tsx
@@ -6842,8 +6672,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleRes
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/bundler/bundlerSyntaxRestrictions.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/declarationNotFoundPackageBundlesTypes.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/importFromDot.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/node10AlternateResult_noResolution.ts
@@ -6867,8 +6695,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleRes
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolutionModeTripleSlash4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolutionModeTripleSlash5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/untypedModuleImport_noImplicitAny_typesForPackageExist.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/allowJs/nodeAllowJsPackageSelfName.ts
 
@@ -7580,18 +7406,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/jsC
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/jsContainerMergeTsDeclaration3.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport6.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAliasUnknown.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAssignment7.ts
@@ -7610,8 +7424,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/mod
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportsAliasLoop2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/namespaceAssignmentToRequireAlias.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/nestedDestructuringOfRequire.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/plainJSTypeErrors.ts
@@ -7627,8 +7439,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/pro
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/requireOfESWithPropertyAccess.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/thisPropertyAssignment.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/thisPropertyAssignmentComputed.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromJSConstructor.ts
 
@@ -7657,8 +7467,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/typ
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPrototypeAssignment.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPrototypeAssignment2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPrototypeAssignment3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/typeLookupInIIFE.ts
 
@@ -7820,8 +7628,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/con
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/commaOperator/contextuallyTypeCommaOperator02.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/commaOperator/contextuallyTypeCommaOperator03.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes01.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes02.tsx
@@ -7831,10 +7637,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/con
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/logicalAnd/contextuallyTypeLogicalAnd03.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedBindingInitializerNegative.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedClassExpressionMethodDeclaration01.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedClassExpressionMethodDeclaration02.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceError.ts
 
@@ -8012,8 +7814,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/non
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveIndexingWithForInNoImplicitAny.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveIndexingWithForInSupressError.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveNarrow.ts
@@ -8132,8 +7932,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/spe
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeReferences/genericTypeReferenceWithoutTypeArgument3.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadIndexSignature.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadNegative.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadSetonlyAccessor.ts
@@ -8188,8 +7986,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/thi
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/thisType/typeRelationships.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/thisType/unionThisTypeInFunctions.ts
@@ -8227,10 +8023,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tup
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples7.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/directDependenceBetweenTypeAliases.ts
 
@@ -18137,13 +17929,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    · ──
    ╰────
 
-  × Expected a semicolon or an implicit semicolon after a statement, but found none
-   ╭─[typescript/tests/cases/compiler/untypedModuleImport_withAugmentation2.ts:1:5]
- 1 │ This file is not processed.
-   ·     ▲
-   ╰────
-  help: Try insert a semicolon here
-
   × Expected `;` but found `)`
     ╭─[typescript/tests/cases/compiler/unusedLocalsAndParameters.ts:83:14]
  82 │ 
@@ -25975,27 +25760,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
     ·    ──           ───
  23 │ ; <Comp\u{0061} x={12} />
     ╰────
-
-  × Expected a semicolon or an implicit semicolon after a statement, but found none
-   ╭─[typescript/tests/cases/conformance/moduleResolution/untypedModuleImport_noImplicitAny.ts:1:5]
- 1 │ This file is not processed.
-   ·     ▲
-   ╰────
-  help: Try insert a semicolon here
-
-  × Expected a semicolon or an implicit semicolon after a statement, but found none
-   ╭─[typescript/tests/cases/conformance/moduleResolution/untypedModuleImport_noImplicitAny_relativePath.ts:1:5]
- 1 │ This file is not processed.
-   ·     ▲
-   ╰────
-  help: Try insert a semicolon here
-
-  × Expected a semicolon or an implicit semicolon after a statement, but found none
-   ╭─[typescript/tests/cases/conformance/moduleResolution/untypedModuleImport_noImplicitAny_scoped.ts:1:5]
- 1 │ This file is not processed.
-   ·     ▲
-   ╰────
-  help: Try insert a semicolon here
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[typescript/tests/cases/conformance/moduleResolution/untypedModuleImport_withAugmentation.ts:3:5]

--- a/tasks/coverage/snapshots/transformer_typescript.snap
+++ b/tasks/coverage/snapshots/transformer_typescript.snap
@@ -1,8 +1,8 @@
 commit: 81c95189
 
 transformer_typescript Summary:
-AST Parsed     : 6592/6592 (100.00%)
-Positive Passed: 6588/6592 (99.94%)
+AST Parsed     : 6700/6700 (100.00%)
+Positive Passed: 6696/6700 (99.94%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/esDecoratorsClassFieldsCrash.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor2.ts

--- a/tasks/coverage/src/typescript/meta.rs
+++ b/tasks/coverage/src/typescript/meta.rs
@@ -151,6 +151,14 @@ impl TestCaseContent {
         let is_module = test_unit_data.len() > 1;
         let test_unit_data = test_unit_data
             .into_iter()
+            // Some snapshot units contain an invalid file with just a message, not even a comment!
+            // e.g. typescript/tests/cases/compiler/extendsUntypedModule.ts
+            // e.g. typescript/tests/cases/conformance/moduleResolution/untypedModuleImport.ts
+            // Based on some config, it's not expected to be read in the first place.
+            .filter(|unit| {
+                !(unit.content.starts_with("This file is not ")
+                    || unit.content.starts_with("Nor is this one."))
+            })
             .filter_map(|mut unit| {
                 let mut source_type = Self::get_source_type(Path::new(&unit.name), &settings)?;
                 if is_module {

--- a/tasks/coverage/src/typescript/mod.rs
+++ b/tasks/coverage/src/typescript/mod.rs
@@ -135,6 +135,37 @@ impl Case for TypeScriptCase {
 // TODO: Filter out more not-supported error codes here
 static NOT_SUPPORTED_ERROR_CODES: phf::Set<&'static str> = phf::phf_set![
     "2315",  // Type 'U' is not generic.
+    "7005",  // Variable 'x' implicitly has an 'any' type.
+    "7006",  // Parameter 'x' implicitly has an 'any' type.
+    "7008",  // Member 'v' implicitly has an 'any' type.
+    "7009", // 'new' expression, whose target lacks a construct signature, implicitly has an 'any' type.
+    "7010", // 'temp', which lacks return-type annotation, implicitly has an 'any' return type.
+    "7011", // Function expression, which lacks return-type annotation, implicitly has an 'any' return type.
+    "7012", // This overload implicitly returns the type 'any' because it lacks a return type annotation.
+    "7013", // Construct signature, which lacks return-type annotation, implicitly has an 'any' return type.
+    "7014", // Function type, which lacks return-type annotation, implicitly has an 'any' return type.
+    "7015", // Element implicitly has an 'any' type because index expression is not of type 'number'.
+    "7016", // Could not find a declaration file for module './b'. '/src/b.js' implicitly has an 'any' type.
+    "7017", // Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.
+    "7018", // Object literal's property 's' implicitly has an 'any' type.
+    "7019", // Rest parameter 'r' implicitly has an 'any[]' type.
+    "7020", // Call signature, which lacks return-type annotation, implicitly has an 'any' return type.
+    "7022", // 'value1' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+    "7023", // 'next' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
+    "7024", // Function implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
+    "7025", // Generator implicitly has yield type 'any'. Consider supplying a return type annotation.
+    "7026", // JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+    "7031", // Binding element 'a5' implicitly has an 'any' type.
+    "7032", // Property 'message' implicitly has type 'any', because its set accessor lacks a parameter type annotation.
+    "7033", // Property 'message' implicitly has type 'any', because its get accessor lacks a return type annotation.
+    "7034", // Variable 'x' implicitly has type 'any[]' in some locations where its type cannot be determined.
+    "7036", // Dynamic import's specifier must be of type 'string', but here has type 'null'.
+    "7039", // Mapped object type implicitly has an 'any' template type.
+    "7052", // Element implicitly has an 'any' type because type '{ get: (key: string) => string; }' has no index signature. Did you mean to call 'c.get'?
+    "7053", // Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
+    "7055", // 'h', which lacks return-type annotation, implicitly has an 'any' yield type.
+    "7056", // The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed.
+    "7057", // 'yield' expression implicitly results in an 'any' type because its containing generator lacks a return-type annotation.
     "8021", // JSDoc '@typedef' tag should either have a type annotation or be followed by '@property' or '@member' tags.
     "8022", // JSDoc '@extends' is not attached to a class.
     "8023", // JSDoc '@extends Mismatch' does not match the 'extends B' clause.


### PR DESCRIPTION
Part of #11582

- Expand error codes as usual
- Excluded invalid test unit like this
  - https://github.com/microsoft/TypeScript/blob/833a8d492c728d606454865e8c0fee84842f9f10/tests/cases/compiler/extendsUntypedModule.ts