### PR TITLE
refactor(linter): shorten code

### DIFF
--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -156,11 +156,9 @@ impl Oxlintrc {
         let json = serde_json::from_str::<serde_json::Value>(json_string)
             .unwrap_or(serde_json::Value::Null);
 
-        let config = Self::deserialize(&json).map_err(|err| {
+        Self::deserialize(&json).map_err(|err| {
             OxcDiagnostic::error(format!("Failed to parse config with error {err:?}"))
-        })?;
-
-        Ok(config)
+        })
     }
 
     /// Merges two [Oxlintrc] files together


### PR DESCRIPTION
Pure refactor. Return `Result` directly, rather than going via a temp var.