### PR TITLE
refactor(linter): `RuntimeFileSystem::write_file` take `&str`

### DIFF
--- a/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
+++ b/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
@@ -58,7 +58,7 @@ impl RuntimeFileSystem for IsolatedLintHandlerFileSystem {
         read_to_arena_str(path, allocator)
     }
 
-    fn write_file(&self, _path: &Path, _content: String) -> Result<(), std::io::Error> {
+    fn write_file(&self, _path: &Path, _content: &str) -> Result<(), std::io::Error> {
         panic!("writing file should not be allowed in Language Server");
     }
 }

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -157,7 +157,7 @@ pub trait RuntimeFileSystem {
     ///
     /// # Errors
     /// When the program does not have write permission for the file system
-    fn write_file(&self, path: &Path, content: String) -> Result<(), std::io::Error>;
+    fn write_file(&self, path: &Path, content: &str) -> Result<(), std::io::Error>;
 }
 
 struct OsFileSystem;
@@ -171,7 +171,7 @@ impl RuntimeFileSystem for OsFileSystem {
         read_to_arena_str(path, allocator)
     }
 
-    fn write_file(&self, path: &Path, content: String) -> Result<(), std::io::Error> {
+    fn write_file(&self, path: &Path, content: &str) -> Result<(), std::io::Error> {
         fs::write(path, content)
     }
 }
@@ -562,7 +562,7 @@ impl<'l> Runtime<'l> {
                     }
                     // If the new source text is owned, that means it was modified,
                     // so we write the new source text to the file.
-                    if let Cow::Owned(new_source_text) = new_source_text {
+                    if let Cow::Owned(new_source_text) = &new_source_text {
                         me.file_system.write_file(path, new_source_text).unwrap();
                     }
                 });

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -207,7 +207,7 @@ impl RuntimeFileSystem for TesterFileSystem {
         read_to_arena_str(path, allocator)
     }
 
-    fn write_file(&self, _path: &Path, _content: String) -> Result<(), std::io::Error> {
+    fn write_file(&self, _path: &Path, _content: &str) -> Result<(), std::io::Error> {
         panic!("writing file should not be allowed in Tester");
     }
 }


### PR DESCRIPTION
Pure refactor. It's unnecessary for `RuntimeFileSystem::write_file` to receive an owned `String`. It can just take a `&str` slice.