### PR TITLE
docs(allocator): improve doc comments for `AllocatorPool`

### DIFF
--- a/crates/oxc_allocator/src/pool.rs
+++ b/crates/oxc_allocator/src/pool.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::Allocator;
 
-/// A thread-safe pool for reusing `Allocator` instances to reduce allocation overhead.
+/// A thread-safe pool for reusing [`Allocator`] instances to reduce allocation overhead.
 ///
 /// Internally uses a `Vec` protected by a `Mutex` to store available allocators.
 #[derive(Default)]
@@ -15,15 +15,15 @@ pub struct AllocatorPool {
 }
 
 impl AllocatorPool {
-    /// Creates a new `AllocatorPool` pre-filled with the given number of default `Allocator` instances.
+    /// Creates a new [`AllocatorPool`] pre-filled with the given number of default [`Allocator`] instances.
     pub fn new(size: usize) -> AllocatorPool {
         let allocators = std::iter::repeat_with(Allocator::default).take(size).collect();
         AllocatorPool { allocators: Mutex::new(allocators) }
     }
 
-    /// Retrieves an `Allocator` from the pool, or creates a new one if the pool is empty.
+    /// Retrieves an [`Allocator`] from the pool, or creates a new one if the pool is empty.
     ///
-    /// Returns an `AllocatorPoolGuard` that gives mutable access to the allocator.
+    /// Returns an [`AllocatorGuard`] that gives mutable access to the allocator.
     ///
     /// # Panics
     ///
@@ -38,7 +38,7 @@ impl AllocatorPool {
         AllocatorGuard { allocator: ManuallyDrop::new(allocator), pool: self }
     }
 
-    /// Add an `Allocator` to the pool.
+    /// Add an [`Allocator`] to the pool.
     ///
     /// The `Allocator` should be empty, ready to be re-used.
     ///
@@ -51,7 +51,7 @@ impl AllocatorPool {
     }
 }
 
-/// A guard object representing exclusive access to an `Allocator` from the pool.
+/// A guard object representing exclusive access to an [`Allocator`] from the pool.
 ///
 /// On drop, the `Allocator` is reset and returned to the pool.
 pub struct AllocatorGuard<'alloc_pool> {
@@ -74,7 +74,7 @@ impl DerefMut for AllocatorGuard<'_> {
 }
 
 impl Drop for AllocatorGuard<'_> {
-    /// Return `Allocator` back to the pool.
+    /// Return [`Allocator`] back to the pool.
     fn drop(&mut self) {
         // SAFETY: After taking ownership of the `Allocator`, we do not touch the `ManuallyDrop` again
         let mut allocator = unsafe { ManuallyDrop::take(&mut self.allocator) };


### PR DESCRIPTION
Correct one typo in docs - `AllocatorPoolGuard` is now called `AllocatorGuard` - and turn type references into links.