### PR TITLE
refactor(napi/parser): lazy deser: remove `construct` function

### DIFF
--- a/napi/parser/generated/lazy/constructors.js
+++ b/napi/parser/generated/lazy/constructors.js
@@ -8,13 +8,7 @@ const { TOKEN, constructorError } = require('../../raw-transfer/lazy-common.js')
 
 const constructors = {};
 
-module.exports = { construct, constructors };
-
-function construct(ast) {
-  // (2 * 1024 * 1024 * 1024 - 16) >> 2
-  const metadataPos32 = 536870908;
-  return new RawTransferData(ast.buffer.uint32[metadataPos32], ast);
-}
+module.exports = constructors;
 
 const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),

--- a/napi/parser/generated/lazy/walk.js
+++ b/napi/parser/generated/lazy/walk.js
@@ -182,7 +182,7 @@ const {
   JSDocNullableType,
   JSDocNonNullableType,
   JSDocUnknownType,
-} = require('./constructors.js').constructors;
+} = require('./constructors.js');
 
 module.exports = walkProgram;
 

--- a/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
@@ -62,13 +62,7 @@ static CONSTRUCT_PRELUDE: &str = "
 
     const constructors = {};
 
-    module.exports = { construct, constructors };
-
-    function construct(ast) {
-        // (2 * 1024 * 1024 * 1024 - 16) >> 2
-        const metadataPos32 = 536870908;
-        return new RawTransferData(ast.buffer.uint32[metadataPos32], ast);
-    }
+    module.exports = constructors;
 
     const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
         decodeStr = textDecoder.decode.bind(textDecoder),
@@ -182,7 +176,7 @@ fn generate(
 
         const {{
             {constructor_names}
-        }} = require('./constructors.js').constructors;
+        }} = require('./constructors.js');
 
         module.exports = walkProgram;
 


### PR DESCRIPTION
Pure refactor. Remove `construct` function, and instead construct `RawTransferData` class in the call site. `constructors.js` can now only export an object containing the constructor classes.