### PR TITLE
perf(semantic): implement `FusedIterator` for `AstNodeParentIter`

### DIFF
--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -1,3 +1,5 @@
+use std::iter::FusedIterator;
+
 use oxc_allocator::{Address, GetAddress};
 use oxc_ast::AstKind;
 use oxc_cfg::BlockNodeId;
@@ -289,3 +291,5 @@ impl<'s, 'a> Iterator for AstNodeParentIter<'s, 'a> {
         }
     }
 }
+
+impl FusedIterator for AstNodeParentIter<'_, '_> {}


### PR DESCRIPTION
All iterators which never return `Some` after returning `None` should implement `FusedIterator`. It can speed up code using the iterator in some instances. `AstNodeParentIter` follows this pattern, so implement `FusedIterator` on it.