### PR TITLE
perf(parser): optimize around `parse_return_type`

### DIFF
--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -12,7 +12,6 @@ struct ArrowFunctionHead<'a> {
     return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
     r#async: bool,
     span: u32,
-    has_return_colon: bool,
 }
 
 impl<'a> ParserImpl<'a> {
@@ -248,14 +247,7 @@ impl<'a> ParserImpl<'a> {
         self.expect(Kind::Arrow);
 
         self.parse_arrow_function_expression_body(
-            ArrowFunctionHead {
-                type_parameters: None,
-                params,
-                return_type: None,
-                r#async,
-                span,
-                has_return_colon: false,
-            },
+            ArrowFunctionHead { type_parameters: None, params, return_type: None, r#async, span },
             allow_return_type_in_arrow_function,
         )
     }
@@ -279,8 +271,7 @@ impl<'a> ParserImpl<'a> {
             self.error(diagnostics::ts_arrow_function_this_parameter(this_param.span));
         }
 
-        let has_return_colon = self.is_ts && self.at(Kind::Colon);
-        let return_type = self.parse_ts_return_type_annotation(Kind::Arrow, false);
+        let return_type = if self.is_ts { self.parse_ts_return_type_annotation() } else { None };
 
         self.ctx = self.ctx.and_await(has_await);
 
@@ -290,7 +281,7 @@ impl<'a> ParserImpl<'a> {
 
         self.expect(Kind::Arrow);
 
-        ArrowFunctionHead { type_parameters, params, return_type, r#async, span, has_return_colon }
+        ArrowFunctionHead { type_parameters, params, return_type, r#async, span }
     }
 
     /// [ConciseBody](https://tc39.es/ecma262/#prod-ConciseBody)
@@ -303,7 +294,7 @@ impl<'a> ParserImpl<'a> {
         arrow_function_head: ArrowFunctionHead<'a>,
         allow_return_type_in_arrow_function: bool,
     ) -> Expression<'a> {
-        let ArrowFunctionHead { type_parameters, params, return_type, r#async, span, .. } =
+        let ArrowFunctionHead { type_parameters, params, return_type, r#async, span } =
             arrow_function_head;
         let has_await = self.ctx.has_await();
         let has_yield = self.ctx.has_yield();
@@ -362,7 +353,7 @@ impl<'a> ParserImpl<'a> {
             return None;
         }
 
-        let has_return_colon = head.has_return_colon;
+        let has_return_type = head.return_type.is_some();
 
         let body =
             self.parse_arrow_function_expression_body(head, allow_return_type_in_arrow_function);
@@ -381,7 +372,7 @@ impl<'a> ParserImpl<'a> {
         //     a() ? (b: number, c?: string): void => d() : e
         // is determined by isParenthesizedArrowFunctionExpression to unambiguously
         // be an arrow expression, so we allow a return type.
-        if !allow_return_type_in_arrow_function && has_return_colon {
+        if !allow_return_type_in_arrow_function && has_return_type {
             // However, if the arrow function we were able to parse is followed by another colon
             // as in:
             //     a ? (x): string => x : null

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -117,8 +117,7 @@ impl<'a> ParserImpl<'a> {
         self.ctx = self.ctx.and_in(true).and_await(r#async).and_yield(generator);
         let type_parameters = self.parse_ts_type_parameters();
         let (this_param, params) = self.parse_formal_parameters(func_kind, param_kind);
-        let return_type =
-            self.parse_ts_return_type_annotation(Kind::Colon, /* is_type */ true);
+        let return_type = if self.is_ts { self.parse_ts_return_type_annotation() } else { None };
         let body = if self.at(Kind::LCurly) { Some(self.parse_function_body()) } else { None };
         self.ctx =
             self.ctx.and_in(ctx.has_in()).and_await(ctx.has_await()).and_yield(ctx.has_yield());


### PR DESCRIPTION
- Removed `has_return_colon` because having both `return_type` and `has_return_colon` on `ArrowFunctionHead` was redundant
- Avoid redundant `self.is_ts` checks by moving only required ones to call site of `parse_ts_return_type_annotation`
- Removed unnecessary parameters `return_kind` and `is_type` from `parse_return_type` and their corresponding checks

Benchmark results:
```
parser[react.development.js] : +0.15%
parser[binder.ts]            : +0.05%
parser[cal.com.tsx]          : +0.01%
```

I expected more improvements on the benchmarks, but less code is also worth the change on its own.