### PR TITLE
test-only: setup to analyze language server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1937,7 +1937,6 @@ dependencies = [
  "oxc_diagnostics",
  "oxc_linter",
  "papaya",
- "rustc-demangle",
  "rustc-hash",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,6 +1371,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "memory-stats"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c73f5c649995a115e1a0220b35e4df0a1294500477f97a91d0660fb5abeb574a"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "mimalloc-safe"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1922,10 +1932,12 @@ dependencies = [
  "ignore",
  "insta",
  "log",
+ "memory-stats",
  "oxc_allocator",
  "oxc_diagnostics",
  "oxc_linter",
  "papaya",
+ "rustc-demangle",
  "rustc-hash",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,7 +233,6 @@ tower-lsp-server = "0.22.0"
 tracing-subscriber = "0.3.19"
 ureq = { version = "3.0.11", default-features = false }
 walkdir = "2.5.0"
-rustc-demangle = "0.1.25"
 
 [workspace.metadata.cargo-shear]
 ignored = ["napi", "oxc_transform_napi", "oxc_parser_napi", "prettyplease", "lazy_static"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,6 +233,7 @@ tower-lsp-server = "0.22.0"
 tracing-subscriber = "0.3.19"
 ureq = { version = "3.0.11", default-features = false }
 walkdir = "2.5.0"
+rustc-demangle = "0.1.25"
 
 [workspace.metadata.cargo-shear]
 ignored = ["napi", "oxc_transform_napi", "oxc_parser_napi", "prettyplease", "lazy_static"]
@@ -245,7 +246,8 @@ debug = false
 [profile.test]
 # Disabling debug info speeds up local and CI builds,
 # and we don't rely on it for debugging that much.
-debug = false
+debug = true
+strip = false # Keep debug information in binary
 
 [profile.dev.package]
 # Compile macros with some optimizations to make consuming crates build faster
@@ -262,11 +264,8 @@ opt-level = 'z'
 [profile.release]
 # Configurations explicitly listed here for clarity.
 # Using the best options for performance.
-opt-level = 3
-lto = "fat"
-codegen-units = 1
-strip = "symbols" # Set to `false` for debug information
-debug = false # Set to `true` for debug information
+strip = false # Set to `false` for debug information
+debug = true # Set to `true` for debug information
 panic = "abort" # Let it crash and force ourselves to write safe Rust
 
 # Profile used for release mode, but with debugging information for profiling

--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -18,8 +18,16 @@ workspace = true
 
 [[bin]]
 name = "oxc_language_server"
-test = true
+path = "src/lib.rs"
+test = false
 doctest = false
+debug = true
+strip = false # Keep debug information in binary
+
+# [[bin]]
+# name = "oxc_language_server"
+# test = true
+# doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }
@@ -38,6 +46,9 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "io-std", "macros"] }
 tower-lsp-server = { workspace = true, features = ["proposed"] }
+insta = { workspace = true }
+memory-stats = "1.2.0"
+rustc-demangle = "0.1.25"
 
 [dev-dependencies]
-insta = { workspace = true }
+

--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -39,16 +39,14 @@ env_logger = { workspace = true, features = ["humantime"] }
 futures = { workspace = true }
 globset = { workspace = true }
 ignore = { workspace = true, features = ["simd-accel"] }
+insta = { workspace = true }
 log = { workspace = true }
+memory-stats = "1.2.0"
 papaya = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "io-std", "macros"] }
 tower-lsp-server = { workspace = true, features = ["proposed"] }
-insta = { workspace = true }
-memory-stats = "1.2.0"
-rustc-demangle = "0.1.25"
 
 [dev-dependencies]
-

--- a/crates/oxc_language_server/fixtures/linter/oxc_resolver_memory_leak/.oxlintrc.json
+++ b/crates/oxc_language_server/fixtures/linter/oxc_resolver_memory_leak/.oxlintrc.json
@@ -1,0 +1,12 @@
+{
+  "plugins": ["import"],
+  "categories": {
+    "correctness": "error",
+    "restriction": "error",
+    "pedantic": "error",
+    "perf": "error",
+    "style": "error",
+    "suspicious": "error",
+    "nursery": "error"
+  }
+}

--- a/crates/oxc_language_server/fixtures/linter/oxc_resolver_memory_leak/index.tsx
+++ b/crates/oxc_language_server/fixtures/linter/oxc_resolver_memory_leak/index.tsx
@@ -42,17 +42,6 @@ debugger;
 
 
 
-
-
-
-
-
-
-
-
-
-
-
 export function ThreeDMain() {
   return (
     <Canvas

--- a/crates/oxc_language_server/fixtures/linter/oxc_resolver_memory_leak/package-lock.json
+++ b/crates/oxc_language_server/fixtures/linter/oxc_resolver_memory_leak/package-lock.json
@@ -1,0 +1,279 @@
+{
+  "name": "oxc_resolver_memory_leak",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@react-three/fiber": "^9.1.4",
+        "three": "^0.178.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.2.0.tgz",
+      "integrity": "sha512-esZe+E9T/aYEM4HlBkirr/yRE8qWTp9WUsLISyHHMCHKlJv85uc5N4wwKw+Ay0QeTSITw6T9Q3Svpu383Q+CSQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/react-reconciler": "^0.28.9",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^2.0.0",
+        "react-reconciler": "^0.31.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.25.0",
+        "suspend-react": "^0.1.3",
+        "use-sync-external-store": "^1.4.0",
+        "zustand": "^5.0.3"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "react-native": ">=0.78",
+        "three": ">=0.156"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
+      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.22.tgz",
+      "integrity": "sha512-Vr6Stjv5jPRqH690f5I5GLjVk8GSsoQSYJ2FVd/3jJF7KaqfwPi3ehfBS96mlQ2kPCwZaX6U0rG2+NGHBKkA/A==",
+      "dev": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "dev": true,
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.31.0.tgz",
+      "integrity": "sha512-7Ob7Z+URmesIsIVRjnLoDGwBEG/tVitidU0nMsqX/eeJaLY89RISO/10ERe0MqmzuKUUB1rmY+h1itMbUHg9BQ==",
+      "dev": true,
+      "dependencies": {
+        "scheduler": "^0.25.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "dev": true,
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "dev": true
+    },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "dev": true,
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.178.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.178.0.tgz",
+      "integrity": "sha512-ybFIB0+x8mz0wnZgSGy2MO/WCO6xZhQSZnmfytSPyNpM0sBafGRVhdaj+erYh5U+RhQOAg/eXqw5uVDiM2BjhQ==",
+      "dev": true
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "dev": true,
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.6.tgz",
+      "integrity": "sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/crates/oxc_language_server/src/lib.rs
+++ b/crates/oxc_language_server/src/lib.rs
@@ -16,5 +16,6 @@ const OXC_CONFIG_FILE: &str = ".oxlintrc.json";
 #[tokio::main]
 async fn main() {
     Tester::new("crates/oxc_language_server/fixtures/linter/oxc_resolver_memory_leak", None)
-        .test_memory_leak("index.tsx", 100).await;
+        .test_memory_leak("index.tsx", 100)
+        .await;
 }

--- a/crates/oxc_language_server/src/lib.rs
+++ b/crates/oxc_language_server/src/lib.rs
@@ -1,0 +1,20 @@
+use rustc_hash::FxBuildHasher;
+
+use crate::tester::Tester;
+
+mod capabilities;
+mod code_actions;
+mod commands;
+mod linter;
+mod options;
+mod tester;
+mod worker;
+
+type ConcurrentHashMap<K, V> = papaya::HashMap<K, V, FxBuildHasher>;
+
+const OXC_CONFIG_FILE: &str = ".oxlintrc.json";
+#[tokio::main]
+async fn main() {
+    Tester::new("crates/oxc_language_server/fixtures/linter/oxc_resolver_memory_leak", None)
+        .test_memory_leak("index.tsx", 100).await;
+}

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -15,8 +15,8 @@ use crate::linter::{
     error_with_position::DiagnosticReport,
     isolated_lint_handler::{IsolatedLintHandler, IsolatedLintHandlerOptions},
 };
-use crate::options::UnusedDisableDirectives;
-use crate::{ConcurrentHashMap, Options};
+use crate::options::{UnusedDisableDirectives, Options};
+use crate::{ConcurrentHashMap};
 
 use super::config_walker::ConfigWalker;
 
@@ -245,7 +245,7 @@ mod test {
     use std::path::{Path, PathBuf};
 
     use crate::{
-        Options,
+        options::Options,
         linter::server_linter::{ServerLinter, normalize_path},
         tester::{Tester, get_file_path},
     };

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -11,12 +11,12 @@ use tower_lsp_server::lsp_types::Uri;
 use oxc_linter::{AllowWarnDeny, Config, ConfigStore, ConfigStoreBuilder, LintOptions, Oxlintrc};
 use tower_lsp_server::UriExt;
 
+use crate::ConcurrentHashMap;
 use crate::linter::{
     error_with_position::DiagnosticReport,
     isolated_lint_handler::{IsolatedLintHandler, IsolatedLintHandlerOptions},
 };
-use crate::options::{UnusedDisableDirectives, Options};
-use crate::{ConcurrentHashMap};
+use crate::options::{Options, UnusedDisableDirectives};
 
 use super::config_walker::ConfigWalker;
 
@@ -245,8 +245,8 @@ mod test {
     use std::path::{Path, PathBuf};
 
     use crate::{
-        options::Options,
         linter::server_linter::{ServerLinter, normalize_path},
+        options::Options,
         tester::{Tester, get_file_path},
     };
     use rustc_hash::FxHashMap;

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -13,7 +13,6 @@ use tower_lsp_server::{
 
 use crate::{
     ConcurrentHashMap,
-    options::{Options, Run},
     code_actions::{
         apply_all_fix_code_action, apply_fix_code_actions, ignore_this_line_code_action,
         ignore_this_rule_code_action,
@@ -22,6 +21,7 @@ use crate::{
         error_with_position::{DiagnosticReport, PossibleFixContent},
         server_linter::{ServerLinter, normalize_path},
     },
+    options::{Options, Run},
 };
 
 pub struct WorkspaceWorker {

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -12,7 +12,8 @@ use tower_lsp_server::{
 };
 
 use crate::{
-    ConcurrentHashMap, Options, Run,
+    ConcurrentHashMap,
+    options::{Options, Run},
     code_actions::{
         apply_all_fix_code_action, apply_fix_code_actions, ignore_this_line_code_action,
         ignore_this_rule_code_action,


### PR DESCRIPTION
Setup:

- Install [heaptrack](https://github.com/KDE/heaptrack) and probably the [cargo counterpart part](https://crates.io/crates/cargo-heaptrack) too. (Only way it worked for me).
- `cd crates/oxc_language_server/fixtures/linter/oxc_resolver_memory_leak && npm i`
- Run `cargo heaptrack -p oxc_language_server` on the project root
- Follow the gzip/heaptrack_interpret part outputted
- Run `heaptrack --analyze <outputted-name>`. For the GUI, install `heaptrack-gui` (via `apt get`)

## Result

[heaptrack.oxc_language_server.330583.gz](https://github.com/user-attachments/files/21090524/heaptrack.oxc_language_server.330583.gz)

![Allocation grows and grows](https://github.com/user-attachments/assets/1f5b8b10-04be-4f5a-bed6-aae9ddb1f604)


