### PR TITLE
feat(codegen)!: introduce `CommentOptions`

### DIFF
--- a/crates/oxc_ast/src/ast/comment.rs
+++ b/crates/oxc_ast/src/ast/comment.rs
@@ -209,7 +209,10 @@ impl Comment {
     /// Is comment with special meaning.
     #[inline]
     pub fn is_annotation(self) -> bool {
-        self.content != CommentContent::None && self.content != CommentContent::Legal
+        self.content != CommentContent::None
+            && self.content != CommentContent::Legal
+            && self.content != CommentContent::Jsdoc
+            && self.content != CommentContent::JsdocLegal
     }
 
     /// Returns `true` if this comment is a JSDoc comment. Implies `is_leading` and `is_block`.

--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -4,16 +4,13 @@ use std::borrow::Cow;
 use oxc_ast::{Comment, CommentKind, ast::Program};
 use oxc_syntax::identifier::is_line_terminator;
 
-use crate::{Codegen, LegalComment};
+use crate::{Codegen, LegalComment, options::CommentOptions};
 
 pub type CommentsMap = FxHashMap</* attached_to */ u32, Vec<Comment>>;
 
 impl Codegen<'_> {
     pub(crate) fn build_comments(&mut self, comments: &[Comment]) {
-        if !self.options.comments
-            && self.options.legal_comments.is_none()
-            && !self.options.annotation_comments
-        {
+        if self.options.comments == CommentOptions::disabled() {
             return;
         }
         for comment in comments {
@@ -24,6 +21,9 @@ impl Codegen<'_> {
             let mut add = false;
             if comment.is_leading() {
                 if comment.is_legal() && self.options.print_legal_comment() {
+                    add = true;
+                }
+                if comment.is_jsdoc() && self.options.print_jsdoc_comment() {
                     add = true;
                 }
                 if comment.is_annotation() && self.options.print_annotation_comment() {
@@ -151,7 +151,7 @@ impl Codegen<'_> {
         &mut self,
         program: &Program<'_>,
     ) -> Vec<Comment> {
-        let legal_comments = &self.options.legal_comments;
+        let legal_comments = &self.options.comments.legal;
         if matches!(legal_comments, LegalComment::None | LegalComment::Inline) {
             return vec![];
         }

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2032,9 +2032,10 @@ impl GenExpr for ImportExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         let wrap = precedence >= Precedence::New || ctx.intersects(Context::FORBID_CALL);
 
-        let has_comment_before_right_paren =
-            p.options.comments && self.span.end > 0 && p.has_comment(self.span.end - 1);
-        let has_comment = p.options.comments
+        let has_comment_before_right_paren = p.options.print_annotation_comment()
+            && self.span.end > 0
+            && p.has_comment(self.span.end - 1);
+        let has_comment = p.options.print_annotation_comment()
             && (has_comment_before_right_paren
                 || p.has_comment(self.source.span().start)
                 || self

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -40,7 +40,7 @@ use crate::{
 pub use crate::{
     context::Context,
     r#gen::{Gen, GenExpr},
-    options::{CodegenOptions, LegalComment},
+    options::{CodegenOptions, CommentOptions, LegalComment},
 };
 
 /// Output from [`Codegen::build`]

--- a/crates/oxc_codegen/tests/integration/comments.rs
+++ b/crates/oxc_codegen/tests/integration/comments.rs
@@ -171,7 +171,7 @@ catch(e) {
 }
 
 pub mod legal {
-    use oxc_codegen::{CodegenOptions, LegalComment};
+    use oxc_codegen::{CodegenOptions, CommentOptions, LegalComment};
 
     use crate::{codegen_options, snapshot, snapshot_options};
 
@@ -217,8 +217,10 @@ pub mod legal {
 
     #[test]
     fn legal_eof_comment() {
-        let options =
-            CodegenOptions { legal_comments: LegalComment::Eof, ..CodegenOptions::default() };
+        let options = CodegenOptions {
+            comments: CommentOptions { legal: LegalComment::Eof, ..CommentOptions::default() },
+            ..CodegenOptions::default()
+        };
         snapshot_options("legal_eof_comments", &cases(), &options);
     }
 
@@ -226,7 +228,7 @@ pub mod legal {
     fn legal_eof_minify_comment() {
         let options = CodegenOptions {
             minify: true,
-            legal_comments: LegalComment::Eof,
+            comments: CommentOptions { legal: LegalComment::Eof, ..CommentOptions::default() },
             ..CodegenOptions::default()
         };
         snapshot_options("legal_eof_minify_comments", &cases(), &options);
@@ -235,7 +237,10 @@ pub mod legal {
     #[test]
     fn legal_linked_comment() {
         let options = CodegenOptions {
-            legal_comments: LegalComment::Linked(String::from("test.js")),
+            comments: CommentOptions {
+                legal: LegalComment::Linked(String::from("test.js")),
+                ..CommentOptions::default()
+            },
             ..CodegenOptions::default()
         };
         snapshot_options("legal_linked_comments", &cases(), &options);
@@ -243,8 +248,10 @@ pub mod legal {
 
     #[test]
     fn legal_external_comment() {
-        let options =
-            CodegenOptions { legal_comments: LegalComment::External, ..CodegenOptions::default() };
+        let options = CodegenOptions {
+            comments: CommentOptions { legal: LegalComment::External, ..CommentOptions::default() },
+            ..CodegenOptions::default()
+        };
         let code = "/* @license */\n/* @preserve */\nfoo;\n";
         let ret = codegen_options(code, &options);
         assert_eq!(ret.code, "foo;\n");
@@ -473,7 +480,7 @@ delete /* @__PURE__ */ (() => {})();",
 }
 
 pub mod options {
-    use oxc_codegen::{CodegenOptions, LegalComment};
+    use oxc_codegen::{CodegenOptions, CommentOptions, LegalComment};
 
     use crate::codegen_options;
 
@@ -490,42 +497,51 @@ function foo() {
         //! Function Legal Comment
     }
     x(/* Normal Comment */);
-    x(/** Call Expression Annotation Comment */ token);
+    x(/** Call Expression Jsdoc Comment */ token);
 }";
 
-        for comments in [true, false] {
-            for annotation in [true, false] {
-                for legal in [LegalComment::Inline, LegalComment::Eof, LegalComment::None] {
-                    let options = CodegenOptions {
-                        comments,
-                        annotation_comments: annotation,
-                        legal_comments: legal.clone(),
-                        ..CodegenOptions::default()
-                    };
-                    let printed = codegen_options(code, &options).code;
+        for normal in [true, false] {
+            for jsdoc in [true, false] {
+                for annotation in [true, false] {
+                    for legal in [LegalComment::Inline, LegalComment::Eof, LegalComment::None] {
+                        let options = CodegenOptions {
+                            comments: CommentOptions {
+                                normal,
+                                jsdoc,
+                                annotation,
+                                legal: legal.clone(),
+                            },
+                            ..CodegenOptions::default()
+                        };
+                        let printed = codegen_options(code, &options).code;
 
-                    if comments {
-                        assert!(printed.contains("Normal Comment"));
-                    } else {
-                        assert!(!printed.contains("Normal Comment"));
-                    }
+                        if normal {
+                            assert!(printed.contains("Normal Comment"));
+                        } else {
+                            assert!(!printed.contains("Normal Comment"));
+                        }
 
-                    if annotation {
-                        assert!(printed.contains("JSDoc Comment"));
-                        assert!(printed.contains("__PURE__"));
-                        assert!(printed.contains("Call Expression Annotation Comment"));
-                    } else {
-                        assert!(!printed.contains("JSDoc Comment"));
-                        assert!(!printed.contains("__PURE__"));
-                        assert!(!printed.contains("Call Expression Annotation Comment"));
-                    }
+                        if jsdoc {
+                            assert!(printed.contains("JSDoc Comment"));
+                            assert!(printed.contains("Call Expression Jsdoc Comment"));
+                        } else {
+                            assert!(!printed.contains("JSDoc Comment"));
+                            assert!(!printed.contains("Call Expression Jsdoc Comment"));
+                        }
 
-                    if legal.is_none() {
-                        assert!(!printed.contains("Top Legal Comment"));
-                        assert!(!printed.contains("Function Legal Comment"));
-                    } else {
-                        assert!(printed.contains("Top Legal Comment"));
-                        assert!(printed.contains("Function Legal Comment"));
+                        if annotation {
+                            assert!(printed.contains("__PURE__"));
+                        } else {
+                            assert!(!printed.contains("__PURE__"));
+                        }
+
+                        if legal.is_none() {
+                            assert!(!printed.contains("Top Legal Comment"));
+                            assert!(!printed.contains("Function Legal Comment"));
+                        } else {
+                            assert!(printed.contains("Top Legal Comment"));
+                            assert!(printed.contains("Function Legal Comment"));
+                        }
                     }
                 }
             }

--- a/crates/oxc_isolated_declarations/examples/isolated_declarations.rs
+++ b/crates/oxc_isolated_declarations/examples/isolated_declarations.rs
@@ -2,7 +2,7 @@
 use std::{env, path::Path};
 
 use oxc_allocator::Allocator;
-use oxc_codegen::Codegen;
+use oxc_codegen::{Codegen, CodegenOptions, CommentOptions};
 use oxc_isolated_declarations::{IsolatedDeclarations, IsolatedDeclarationsOptions};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
@@ -35,7 +35,13 @@ fn main() -> std::io::Result<()> {
     let id_ret =
         IsolatedDeclarations::new(&allocator, IsolatedDeclarationsOptions { strip_internal: true })
             .build(&ret.program);
-    let printed = Codegen::new().build(&id_ret.program).code;
+    let printed = Codegen::new()
+        .with_options(CodegenOptions {
+            comments: CommentOptions { jsdoc: true, ..CommentOptions::disabled() },
+            ..CodegenOptions::default()
+        })
+        .build(&id_ret.program)
+        .code;
 
     println!("Dts Emit:\n");
     println!("{printed}\n");

--- a/crates/oxc_minifier/examples/minifier.rs
+++ b/crates/oxc_minifier/examples/minifier.rs
@@ -2,7 +2,7 @@
 use std::path::Path;
 
 use oxc_allocator::Allocator;
-use oxc_codegen::{Codegen, CodegenOptions};
+use oxc_codegen::{Codegen, CodegenOptions, CommentOptions};
 use oxc_mangler::MangleOptions;
 use oxc_minifier::{CompressOptions, Minifier, MinifierOptions};
 use oxc_parser::Parser;
@@ -56,9 +56,7 @@ fn minify(
     Codegen::new()
         .with_options(CodegenOptions {
             minify: nospace,
-            comments: false,
-            annotation_comments: false,
-            legal_comments: oxc_codegen::LegalComment::Inline,
+            comments: CommentOptions::disabled(),
             ..CodegenOptions::default()
         })
         .with_scoping(ret.scoping)

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -852,7 +852,7 @@ mod test {
     use similar::TextDiff;
 
     use oxc_allocator::Allocator;
-    use oxc_codegen::{Codegen, CodegenOptions};
+    use oxc_codegen::{Codegen, CodegenOptions, CommentOptions};
     use oxc_diagnostics::OxcDiagnostic;
     use oxc_parser::Parser;
     use oxc_semantic::SemanticBuilder;
@@ -889,7 +889,7 @@ mod test {
         }
         let code = Codegen::new()
             .with_options(CodegenOptions {
-                comments: false,
+                comments: CommentOptions::disabled(),
                 single_quote: true,
                 ..CodegenOptions::default()
             })
@@ -906,7 +906,7 @@ mod test {
 
         Codegen::new()
             .with_options(CodegenOptions {
-                comments: false,
+                comments: CommentOptions::disabled(),
                 single_quote: true,
                 ..CodegenOptions::default()
             })

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -14,7 +14,7 @@ use oxc::{
     allocator::Allocator,
     ast::ast::Program,
     ast_visit::Visit,
-    codegen::{Codegen, CodegenOptions, LegalComment},
+    codegen::{Codegen, CodegenOptions, CommentOptions},
     diagnostics::OxcDiagnostic,
     isolated_declarations::{IsolatedDeclarations, IsolatedDeclarationsOptions},
     minifier::{CompressOptions, MangleOptions, Minifier, MinifierOptions},
@@ -174,6 +174,7 @@ impl Oxc {
                 if ret.errors.is_empty() {
                     let codegen_result = Codegen::new()
                         .with_options(CodegenOptions {
+                            comments: CommentOptions { jsdoc: true, ..CommentOptions::disabled() },
                             source_map_path: codegen_options
                                 .enable_sourcemap
                                 .unwrap_or_default()
@@ -235,9 +236,6 @@ impl Oxc {
             .with_scoping(symbol_table)
             .with_options(CodegenOptions {
                 minify: minifier_options.whitespace.unwrap_or_default(),
-                comments: true,
-                annotation_comments: true,
-                legal_comments: LegalComment::Inline,
                 source_map_path: codegen_options
                     .enable_sourcemap
                     .unwrap_or_default()

--- a/napi/transform/src/isolated_declaration.rs
+++ b/napi/transform/src/isolated_declaration.rs
@@ -4,7 +4,7 @@ use napi_derive::napi;
 
 use oxc::{
     allocator::Allocator,
-    codegen::{Codegen, CodegenOptions},
+    codegen::{Codegen, CodegenOptions, CommentOptions},
     isolated_declarations::IsolatedDeclarations,
     parser::Parser,
     span::SourceType,
@@ -67,7 +67,11 @@ pub fn isolated_declaration(
         _ => None,
     };
     let codegen_ret = Codegen::new()
-        .with_options(CodegenOptions { source_map_path, ..CodegenOptions::default() })
+        .with_options(CodegenOptions {
+            comments: CommentOptions { jsdoc: true, ..CommentOptions::disabled() },
+            source_map_path,
+            ..CodegenOptions::default()
+        })
         .build(&transformed_ret.program);
 
     let diagnostics = ret.errors.into_iter().chain(transformed_ret.errors).collect::<Vec<_>>();

--- a/napi/transform/test/id.test.ts
+++ b/napi/transform/test/id.test.ts
@@ -13,6 +13,8 @@ describe('isolated declaration', () => {
      */
     foo = "bar";
   }
+  // Do not keep normal comments
+  export class B {}
   `;
 
   it('matches output', () => {
@@ -26,9 +28,10 @@ describe('isolated declaration', () => {
         '\t* jsdoc 2\n' +
         '\t*/\n' +
         '\tfoo: string;\n' +
-        '}\n',
+        '}\n' +
+        'export declare class B {}\n',
       map: {
-        mappings: ';;;AAIE,OAAO,cAAM,EAAE;;;;CAIb;AACD',
+        mappings: ';;;AAIE,OAAO,cAAM,EAAE;;;;CAIb;AACD;AAED,OAAO,cAAM,EAAE,CAAE',
         names: [],
         sources: ['test.ts'],
         sourcesContent: [code],

--- a/tasks/coverage/src/typescript/transpile_runner.rs
+++ b/tasks/coverage/src/typescript/transpile_runner.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use oxc::{
     allocator::Allocator,
-    codegen::{Codegen, CodegenOptions},
+    codegen::{Codegen, CodegenOptions, CommentOptions},
     diagnostics::OxcDiagnostic,
     isolated_declarations::{IsolatedDeclarations, IsolatedDeclarationsOptions},
     parser::Parser,
@@ -182,7 +182,10 @@ fn transpile(path: &Path, source_text: &str) -> (String, Vec<OxcDiagnostic>) {
         IsolatedDeclarations::new(&allocator, IsolatedDeclarationsOptions { strip_internal: true })
             .build(&ret.program);
     let printed = Codegen::new()
-        .with_options(CodegenOptions { comments: false, ..CodegenOptions::default() })
+        .with_options(CodegenOptions {
+            comments: CommentOptions { jsdoc: true, ..CommentOptions::disabled() },
+            ..CodegenOptions::default()
+        })
         .build(&ret.program)
         .code;
     (printed, ret.errors)

--- a/tasks/transform_conformance/src/driver.rs
+++ b/tasks/transform_conformance/src/driver.rs
@@ -3,7 +3,7 @@ use std::{mem, ops::ControlFlow, path::Path};
 use oxc::{
     CompilerInterface,
     ast::ast::Program,
-    codegen::{CodegenOptions, CodegenReturn},
+    codegen::{CodegenOptions, CodegenReturn, CommentOptions},
     diagnostics::OxcDiagnostic,
     parser::ParseOptions,
     span::SourceType,
@@ -34,8 +34,10 @@ impl CompilerInterface for Driver {
 
     fn codegen_options(&self) -> Option<CodegenOptions> {
         Some(CodegenOptions {
-            comments: false,
-            annotation_comments: self.print_annotation_comments,
+            comments: CommentOptions {
+                annotation: self.print_annotation_comments,
+                ..CommentOptions::default()
+            },
             ..CodegenOptions::default()
         })
     }

--- a/tasks/transform_conformance/src/test_case.rs
+++ b/tasks/transform_conformance/src/test_case.rs
@@ -8,7 +8,7 @@ use similar::TextDiff;
 
 use oxc::{
     allocator::Allocator,
-    codegen::{Codegen, CodegenOptions},
+    codegen::{Codegen, CodegenOptions, CommentOptions},
     diagnostics::{NamedSource, OxcDiagnostic},
     parser::{ParseOptions, Parser},
     span::{SourceType, VALID_EXTENSIONS},
@@ -325,10 +325,12 @@ impl TestCase {
 
                     Codegen::new()
                         .with_options(CodegenOptions {
-                            comments: false,
-                            // Disable pure annotation comments for async_to_generator plugin,
-                            // because it's weird some tests have it and some don't.
-                            annotation_comments: !babel_options.plugins.async_to_generator,
+                            comments: CommentOptions {
+                                // Disable pure annotation comments for async_to_generator plugin,
+                                // because it's weird some tests have it and some don't.
+                                annotation: !babel_options.plugins.async_to_generator,
+                                ..CommentOptions::default()
+                            },
                             ..CodegenOptions::default()
                         })
                         .build(&ret.program)


### PR DESCRIPTION
Control printing of comments more precisely via more options:

The logic change here is that jsdoc is no longer part of annotation
comments.

```rust
pub struct CommentOptions {
    /// Print normal comments that do not have special meanings.
    ///
    /// At present only statement level comments are printed.
    ///
    /// Default is `true`.
    pub normal: bool,

    /// Print jsdoc comments.
    ///
    /// * jsdoc: `/** jsdoc */`
    ///
    /// Default is `true`.
    pub jsdoc: bool,

    /// Print annotation comments.
    ///
    /// * pure: `/* #__PURE__ */` and `/* #__NO_SIDE_EFFECTS__ */`
    /// * webpack: `/* webpackChunkName */`
    /// * vite: `/* @vite-ignore */`
    /// * coverage: `v8 ignore`, `c8 ignore`, `node:coverage`, `istanbul ignore`
    ///
    /// Default is `true`.
    pub annotation: bool,

    /// Print legal comments.
    ///
    /// * starts with `//!` or `/*!`.
    /// * contains `/* @license */` or `/* @preserve */`
    ///
    /// Default is [LegalComment::Inline].
    pub legal: LegalComment,
}
```

closes #12030
related https://github.com/rolldown/tsdown/issues/357