### PR TITLE
refactor(linter): rename `LintPlugins` to `BuiltinLintPlugins`

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use bpaf::Bpaf;
-use oxc_linter::{AllowWarnDeny, FixKind, LintPlugins};
+use oxc_linter::{AllowWarnDeny, BuiltinLintPlugins, FixKind};
 
 use crate::output_formatter::OutputFormat;
 
@@ -327,24 +327,24 @@ impl OverrideToggle {
 }
 
 impl EnablePlugins {
-    pub fn apply_overrides(&self, plugins: &mut LintPlugins) {
-        self.react_plugin.inspect(|yes| plugins.set(LintPlugins::REACT, yes));
-        self.unicorn_plugin.inspect(|yes| plugins.set(LintPlugins::UNICORN, yes));
-        self.oxc_plugin.inspect(|yes| plugins.set(LintPlugins::OXC, yes));
-        self.typescript_plugin.inspect(|yes| plugins.set(LintPlugins::TYPESCRIPT, yes));
-        self.import_plugin.inspect(|yes| plugins.set(LintPlugins::IMPORT, yes));
-        self.jsdoc_plugin.inspect(|yes| plugins.set(LintPlugins::JSDOC, yes));
-        self.jest_plugin.inspect(|yes| plugins.set(LintPlugins::JEST, yes));
-        self.vitest_plugin.inspect(|yes| plugins.set(LintPlugins::VITEST, yes));
-        self.jsx_a11y_plugin.inspect(|yes| plugins.set(LintPlugins::JSX_A11Y, yes));
-        self.nextjs_plugin.inspect(|yes| plugins.set(LintPlugins::NEXTJS, yes));
-        self.react_perf_plugin.inspect(|yes| plugins.set(LintPlugins::REACT_PERF, yes));
-        self.promise_plugin.inspect(|yes| plugins.set(LintPlugins::PROMISE, yes));
-        self.node_plugin.inspect(|yes| plugins.set(LintPlugins::NODE, yes));
+    pub fn apply_overrides(&self, plugins: &mut BuiltinLintPlugins) {
+        self.react_plugin.inspect(|yes| plugins.set(BuiltinLintPlugins::REACT, yes));
+        self.unicorn_plugin.inspect(|yes| plugins.set(BuiltinLintPlugins::UNICORN, yes));
+        self.oxc_plugin.inspect(|yes| plugins.set(BuiltinLintPlugins::OXC, yes));
+        self.typescript_plugin.inspect(|yes| plugins.set(BuiltinLintPlugins::TYPESCRIPT, yes));
+        self.import_plugin.inspect(|yes| plugins.set(BuiltinLintPlugins::IMPORT, yes));
+        self.jsdoc_plugin.inspect(|yes| plugins.set(BuiltinLintPlugins::JSDOC, yes));
+        self.jest_plugin.inspect(|yes| plugins.set(BuiltinLintPlugins::JEST, yes));
+        self.vitest_plugin.inspect(|yes| plugins.set(BuiltinLintPlugins::VITEST, yes));
+        self.jsx_a11y_plugin.inspect(|yes| plugins.set(BuiltinLintPlugins::JSX_A11Y, yes));
+        self.nextjs_plugin.inspect(|yes| plugins.set(BuiltinLintPlugins::NEXTJS, yes));
+        self.react_perf_plugin.inspect(|yes| plugins.set(BuiltinLintPlugins::REACT_PERF, yes));
+        self.promise_plugin.inspect(|yes| plugins.set(BuiltinLintPlugins::PROMISE, yes));
+        self.node_plugin.inspect(|yes| plugins.set(BuiltinLintPlugins::NODE, yes));
 
         // Without this, jest plugins adapted to vitest will not be enabled.
         if self.vitest_plugin.is_enabled() && self.jest_plugin.is_not_set() {
-            plugins.set(LintPlugins::JEST, true);
+            plugins.set(BuiltinLintPlugins::JEST, true);
         }
     }
 }
@@ -381,29 +381,30 @@ pub struct InlineConfigOptions {
 
 #[cfg(test)]
 mod plugins {
-    use oxc_linter::LintPlugins;
+    use oxc_linter::BuiltinLintPlugins;
 
     use super::{EnablePlugins, OverrideToggle};
 
     #[test]
     fn test_override_default() {
-        let mut plugins = LintPlugins::default();
+        let mut plugins = BuiltinLintPlugins::default();
         let enable = EnablePlugins::default();
 
         enable.apply_overrides(&mut plugins);
-        assert_eq!(plugins, LintPlugins::default());
+        assert_eq!(plugins, BuiltinLintPlugins::default());
     }
 
     #[test]
     fn test_overrides() {
-        let mut plugins = LintPlugins::default();
+        let mut plugins = BuiltinLintPlugins::default();
         let enable = EnablePlugins {
             react_plugin: OverrideToggle::Enable,
             unicorn_plugin: OverrideToggle::Disable,
             ..EnablePlugins::default()
         };
-        let expected =
-            LintPlugins::default().union(LintPlugins::REACT).difference(LintPlugins::UNICORN);
+        let expected = BuiltinLintPlugins::default()
+            .union(BuiltinLintPlugins::REACT)
+            .difference(BuiltinLintPlugins::UNICORN);
 
         enable.apply_overrides(&mut plugins);
         assert_eq!(plugins, expected);
@@ -411,10 +412,11 @@ mod plugins {
 
     #[test]
     fn test_override_vitest() {
-        let mut plugins = LintPlugins::default();
+        let mut plugins = BuiltinLintPlugins::default();
         let enable =
             EnablePlugins { vitest_plugin: OverrideToggle::Enable, ..EnablePlugins::default() };
-        let expected = LintPlugins::default() | LintPlugins::VITEST | LintPlugins::JEST;
+        let expected =
+            BuiltinLintPlugins::default() | BuiltinLintPlugins::VITEST | BuiltinLintPlugins::JEST;
 
         enable.apply_overrides(&mut plugins);
         assert_eq!(plugins, expected);

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -5,7 +5,9 @@ use std::{
 
 use rustc_hash::FxHashMap;
 
-use super::{LintConfig, LintPlugins, categories::OxlintCategories, overrides::OxlintOverrides};
+use super::{
+    BuiltinLintPlugins, LintConfig, categories::OxlintCategories, overrides::OxlintOverrides,
+};
 use crate::{
     AllowWarnDeny,
     rules::{RULES, RuleEnum},
@@ -69,7 +71,7 @@ impl Config {
         }
     }
 
-    pub fn plugins(&self) -> LintPlugins {
+    pub fn plugins(&self) -> BuiltinLintPlugins {
         self.base.config.plugins
     }
 
@@ -118,13 +120,13 @@ impl Config {
         let mut rules = self
             .base_rules
             .iter()
-            .filter(|(rule, _)| plugins.contains(LintPlugins::from(rule.plugin_name())))
+            .filter(|(rule, _)| plugins.contains(BuiltinLintPlugins::from(rule.plugin_name())))
             .cloned()
             .collect::<FxHashMap<_, _>>();
 
         let all_rules = RULES
             .iter()
-            .filter(|rule| plugins.contains(LintPlugins::from(rule.plugin_name())))
+            .filter(|rule| plugins.contains(BuiltinLintPlugins::from(rule.plugin_name())))
             .cloned()
             .collect::<Vec<_>>();
 
@@ -198,7 +200,7 @@ impl ConfigStore {
         &self.base.base.rules
     }
 
-    pub fn plugins(&self) -> LintPlugins {
+    pub fn plugins(&self) -> BuiltinLintPlugins {
         self.base.base.config.plugins
     }
 
@@ -234,7 +236,7 @@ mod test {
 
     use super::{ConfigStore, OxlintOverrides};
     use crate::{
-        AllowWarnDeny, LintPlugins, RuleEnum,
+        AllowWarnDeny, BuiltinLintPlugins, RuleEnum,
         config::{
             LintConfig, OxlintEnv, OxlintGlobals, OxlintSettings, categories::OxlintCategories,
             config_store::Config,
@@ -369,7 +371,7 @@ mod test {
     #[test]
     fn test_add_plugins() {
         let base_config = LintConfig {
-            plugins: LintPlugins::IMPORT,
+            plugins: BuiltinLintPlugins::IMPORT,
             env: OxlintEnv::default(),
             settings: OxlintSettings::default(),
             globals: OxlintGlobals::default(),
@@ -387,26 +389,29 @@ mod test {
             Config::new(vec![], OxlintCategories::default(), base_config, overrides),
             FxHashMap::default(),
         );
-        assert_eq!(store.base.base.config.plugins, LintPlugins::IMPORT);
+        assert_eq!(store.base.base.config.plugins, BuiltinLintPlugins::IMPORT);
 
         let app = store.resolve("other.mjs".as_ref()).config;
-        assert_eq!(app.plugins, LintPlugins::IMPORT);
+        assert_eq!(app.plugins, BuiltinLintPlugins::IMPORT);
 
         let app = store.resolve("App.jsx".as_ref()).config;
-        assert_eq!(app.plugins, LintPlugins::IMPORT | LintPlugins::REACT);
+        assert_eq!(app.plugins, BuiltinLintPlugins::IMPORT | BuiltinLintPlugins::REACT);
 
         let app = store.resolve("App.ts".as_ref()).config;
-        assert_eq!(app.plugins, LintPlugins::IMPORT | LintPlugins::TYPESCRIPT);
+        assert_eq!(app.plugins, BuiltinLintPlugins::IMPORT | BuiltinLintPlugins::TYPESCRIPT);
 
         let app = store.resolve("App.tsx".as_ref()).config;
-        assert_eq!(app.plugins, LintPlugins::IMPORT | LintPlugins::REACT | LintPlugins::TYPESCRIPT);
+        assert_eq!(
+            app.plugins,
+            BuiltinLintPlugins::IMPORT | BuiltinLintPlugins::REACT | BuiltinLintPlugins::TYPESCRIPT
+        );
     }
 
     #[test]
     fn test_add_env() {
         let base_config = LintConfig {
             env: OxlintEnv::default(),
-            plugins: LintPlugins::ESLINT,
+            plugins: BuiltinLintPlugins::ESLINT,
             settings: OxlintSettings::default(),
             globals: OxlintGlobals::default(),
             path: None,
@@ -433,7 +438,7 @@ mod test {
     fn test_replace_env() {
         let base_config = LintConfig {
             env: OxlintEnv::from_iter(["es2024".into()]),
-            plugins: LintPlugins::ESLINT,
+            plugins: BuiltinLintPlugins::ESLINT,
             settings: OxlintSettings::default(),
             globals: OxlintGlobals::default(),
             path: None,
@@ -460,7 +465,7 @@ mod test {
     fn test_add_globals() {
         let base_config = LintConfig {
             env: OxlintEnv::default(),
-            plugins: LintPlugins::ESLINT,
+            plugins: BuiltinLintPlugins::ESLINT,
             settings: OxlintSettings::default(),
             globals: OxlintGlobals::default(),
             path: None,
@@ -490,7 +495,7 @@ mod test {
     fn test_replace_globals() {
         let base_config = LintConfig {
             env: OxlintEnv::default(),
-            plugins: LintPlugins::ESLINT,
+            plugins: BuiltinLintPlugins::ESLINT,
             settings: OxlintSettings::default(),
             globals: from_json!({
                 "React": "readonly",

--- a/crates/oxc_linter/src/config/mod.rs
+++ b/crates/oxc_linter/src/config/mod.rs
@@ -17,13 +17,13 @@ pub use env::OxlintEnv;
 pub use globals::{GlobalValue, OxlintGlobals};
 pub use overrides::OxlintOverrides;
 pub use oxlintrc::Oxlintrc;
-pub use plugins::LintPlugins;
+pub use plugins::BuiltinLintPlugins;
 pub use rules::{ESLintRule, OxlintRules};
 pub use settings::{OxlintSettings, jsdoc::JSDocPluginSettings};
 
 #[derive(Debug, Default, Clone)]
 pub struct LintConfig {
-    pub(crate) plugins: LintPlugins,
+    pub(crate) plugins: BuiltinLintPlugins,
     pub(crate) settings: OxlintSettings,
     /// Environments enable and disable collections of global variables.
     pub(crate) env: OxlintEnv,

--- a/crates/oxc_linter/src/config/overrides.rs
+++ b/crates/oxc_linter/src/config/overrides.rs
@@ -7,7 +7,7 @@ use std::{
 use schemars::{JsonSchema, r#gen, schema::Schema};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
-use crate::{LintPlugins, OxlintEnv, OxlintGlobals, config::OxlintRules};
+use crate::{BuiltinLintPlugins, OxlintEnv, OxlintGlobals, config::OxlintRules};
 
 // nominal wrapper required to add JsonSchema impl
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
@@ -82,7 +82,7 @@ pub struct OxlintOverride {
     /// Optionally change what plugins are enabled for this override. When
     /// omitted, the base config's plugins are used.
     #[serde(default)]
-    pub plugins: Option<LintPlugins>,
+    pub plugins: Option<BuiltinLintPlugins>,
 
     #[serde(default)]
     pub rules: OxlintRules,
@@ -196,14 +196,17 @@ mod test {
             "plugins": [],
         }))
         .unwrap();
-        assert_eq!(config.plugins, Some(LintPlugins::empty()));
+        assert_eq!(config.plugins, Some(BuiltinLintPlugins::empty()));
 
         let config: OxlintOverride = from_value(json!({
             "files": ["*.tsx"],
             "plugins": ["typescript", "react"],
         }))
         .unwrap();
-        assert_eq!(config.plugins, Some(LintPlugins::REACT | LintPlugins::TYPESCRIPT));
+        assert_eq!(
+            config.plugins,
+            Some(BuiltinLintPlugins::REACT | BuiltinLintPlugins::TYPESCRIPT)
+        );
     }
 
     #[test]

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -13,7 +13,8 @@ use crate::utils::read_to_string;
 
 use super::{
     categories::OxlintCategories, env::OxlintEnv, globals::OxlintGlobals,
-    overrides::OxlintOverrides, plugins::LintPlugins, rules::OxlintRules, settings::OxlintSettings,
+    overrides::OxlintOverrides, plugins::BuiltinLintPlugins, rules::OxlintRules,
+    settings::OxlintSettings,
 };
 
 /// Oxlint Configuration File
@@ -63,7 +64,7 @@ use super::{
 #[serde(default)]
 #[non_exhaustive]
 pub struct Oxlintrc {
-    pub plugins: Option<LintPlugins>,
+    pub plugins: Option<BuiltinLintPlugins>,
     pub categories: OxlintCategories,
     /// Example
     ///
@@ -234,7 +235,7 @@ mod test {
     #[test]
     fn test_oxlintrc_de_plugins_empty_array() {
         let config: Oxlintrc = serde_json::from_value(json!({ "plugins": [] })).unwrap();
-        assert_eq!(config.plugins, Some(LintPlugins::empty()));
+        assert_eq!(config.plugins, Some(BuiltinLintPlugins::empty()));
     }
 
     #[test]
@@ -246,17 +247,20 @@ mod test {
     #[test]
     fn test_oxlintrc_specifying_plugins_will_override() {
         let config: Oxlintrc = serde_json::from_str(r#"{ "plugins": ["react", "oxc"] }"#).unwrap();
-        assert_eq!(config.plugins, Some(LintPlugins::REACT.union(LintPlugins::OXC)));
+        assert_eq!(config.plugins, Some(BuiltinLintPlugins::REACT.union(BuiltinLintPlugins::OXC)));
         let config: Oxlintrc =
             serde_json::from_str(r#"{ "plugins": ["typescript", "unicorn"] }"#).unwrap();
-        assert_eq!(config.plugins, Some(LintPlugins::TYPESCRIPT.union(LintPlugins::UNICORN)));
+        assert_eq!(
+            config.plugins,
+            Some(BuiltinLintPlugins::TYPESCRIPT.union(BuiltinLintPlugins::UNICORN))
+        );
         let config: Oxlintrc =
             serde_json::from_str(r#"{ "plugins": ["typescript", "unicorn", "react", "oxc", "import", "jsdoc", "jest", "vitest", "jsx-a11y", "nextjs", "react-perf", "promise", "node"] }"#).unwrap();
-        assert_eq!(config.plugins, Some(LintPlugins::all()));
+        assert_eq!(config.plugins, Some(BuiltinLintPlugins::all()));
 
         let config: Oxlintrc =
             serde_json::from_str(r#"{ "plugins": ["typescript", "@typescript-eslint"] }"#).unwrap();
-        assert_eq!(config.plugins, Some(LintPlugins::TYPESCRIPT));
+        assert_eq!(config.plugins, Some(BuiltinLintPlugins::TYPESCRIPT));
     }
 
     #[test]

--- a/crates/oxc_linter/src/config/plugins.rs
+++ b/crates/oxc_linter/src/config/plugins.rs
@@ -9,7 +9,7 @@ use serde::{
 bitflags! {
     // NOTE: may be increased to a u32 if needed
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct LintPlugins: u16 {
+    pub struct BuiltinLintPlugins: u16 {
         /// Not really a plugin. Included for completeness.
         const ESLINT = 0;
         /// `eslint-plugin-react`, plus `eslint-plugin-react-hooks`
@@ -40,121 +40,122 @@ bitflags! {
         const NODE = 1 << 12;
     }
 }
-impl Default for LintPlugins {
+
+impl Default for BuiltinLintPlugins {
     #[inline]
     fn default() -> Self {
-        LintPlugins::UNICORN | LintPlugins::TYPESCRIPT | LintPlugins::OXC
+        BuiltinLintPlugins::UNICORN | BuiltinLintPlugins::TYPESCRIPT | BuiltinLintPlugins::OXC
     }
 }
 
-impl LintPlugins {
+impl BuiltinLintPlugins {
     /// Returns `true` if the Vitest plugin is enabled.
     #[inline]
     pub fn has_vitest(self) -> bool {
-        self.contains(LintPlugins::VITEST)
+        self.contains(BuiltinLintPlugins::VITEST)
     }
 
     /// Returns `true` if the Jest plugin is enabled.
     #[inline]
     pub fn has_jest(self) -> bool {
-        self.contains(LintPlugins::JEST)
+        self.contains(BuiltinLintPlugins::JEST)
     }
 
     /// Returns `true` if Jest or Vitest plugins are enabled.
     #[inline]
     pub fn has_test(self) -> bool {
-        self.intersects(LintPlugins::JEST.union(LintPlugins::VITEST))
+        self.intersects(BuiltinLintPlugins::JEST.union(BuiltinLintPlugins::VITEST))
     }
 
     /// Returns `true` if the import plugin is enabled.
     #[inline]
     pub fn has_import(self) -> bool {
-        self.contains(LintPlugins::IMPORT)
+        self.contains(BuiltinLintPlugins::IMPORT)
     }
 }
 
-impl From<&str> for LintPlugins {
+impl From<&str> for BuiltinLintPlugins {
     fn from(value: &str) -> Self {
         match value {
-            "react" | "react-hooks" | "react_hooks" => LintPlugins::REACT,
-            "unicorn" => LintPlugins::UNICORN,
+            "react" | "react-hooks" | "react_hooks" => BuiltinLintPlugins::REACT,
+            "unicorn" => BuiltinLintPlugins::UNICORN,
             "typescript" | "typescript-eslint" | "typescript_eslint" | "@typescript-eslint" => {
-                LintPlugins::TYPESCRIPT
+                BuiltinLintPlugins::TYPESCRIPT
             }
             // deepscan for backwards compatibility. Those rules have been moved into oxc
-            "oxc" | "deepscan" => LintPlugins::OXC,
+            "oxc" | "deepscan" => BuiltinLintPlugins::OXC,
             // import-x has the same rules but better performance
-            "import" | "import-x" => LintPlugins::IMPORT,
-            "jsdoc" => LintPlugins::JSDOC,
-            "jest" => LintPlugins::JEST,
-            "vitest" => LintPlugins::VITEST,
-            "jsx-a11y" | "jsx_a11y" => LintPlugins::JSX_A11Y,
-            "nextjs" => LintPlugins::NEXTJS,
-            "react-perf" | "react_perf" => LintPlugins::REACT_PERF,
-            "promise" => LintPlugins::PROMISE,
-            "node" => LintPlugins::NODE,
+            "import" | "import-x" => BuiltinLintPlugins::IMPORT,
+            "jsdoc" => BuiltinLintPlugins::JSDOC,
+            "jest" => BuiltinLintPlugins::JEST,
+            "vitest" => BuiltinLintPlugins::VITEST,
+            "jsx-a11y" | "jsx_a11y" => BuiltinLintPlugins::JSX_A11Y,
+            "nextjs" => BuiltinLintPlugins::NEXTJS,
+            "react-perf" | "react_perf" => BuiltinLintPlugins::REACT_PERF,
+            "promise" => BuiltinLintPlugins::PROMISE,
+            "node" => BuiltinLintPlugins::NODE,
             // "eslint" is not really a plugin, so it's 'empty'. This has the added benefit of
             // making it the default value.
-            _ => LintPlugins::empty(),
+            _ => BuiltinLintPlugins::empty(),
         }
     }
 }
 
-impl From<LintPlugins> for &'static str {
-    fn from(value: LintPlugins) -> Self {
+impl From<BuiltinLintPlugins> for &'static str {
+    fn from(value: BuiltinLintPlugins) -> Self {
         match value {
-            LintPlugins::REACT => "react",
-            LintPlugins::UNICORN => "unicorn",
-            LintPlugins::TYPESCRIPT => "typescript",
-            LintPlugins::OXC => "oxc",
-            LintPlugins::IMPORT => "import",
-            LintPlugins::JSDOC => "jsdoc",
-            LintPlugins::JEST => "jest",
-            LintPlugins::VITEST => "vitest",
-            LintPlugins::JSX_A11Y => "jsx-a11y",
-            LintPlugins::NEXTJS => "nextjs",
-            LintPlugins::REACT_PERF => "react-perf",
-            LintPlugins::PROMISE => "promise",
-            LintPlugins::NODE => "node",
+            BuiltinLintPlugins::REACT => "react",
+            BuiltinLintPlugins::UNICORN => "unicorn",
+            BuiltinLintPlugins::TYPESCRIPT => "typescript",
+            BuiltinLintPlugins::OXC => "oxc",
+            BuiltinLintPlugins::IMPORT => "import",
+            BuiltinLintPlugins::JSDOC => "jsdoc",
+            BuiltinLintPlugins::JEST => "jest",
+            BuiltinLintPlugins::VITEST => "vitest",
+            BuiltinLintPlugins::JSX_A11Y => "jsx-a11y",
+            BuiltinLintPlugins::NEXTJS => "nextjs",
+            BuiltinLintPlugins::REACT_PERF => "react-perf",
+            BuiltinLintPlugins::PROMISE => "promise",
+            BuiltinLintPlugins::NODE => "node",
             _ => "",
         }
     }
 }
 
-impl<S: AsRef<str>> FromIterator<S> for LintPlugins {
+impl<S: AsRef<str>> FromIterator<S> for BuiltinLintPlugins {
     fn from_iter<T: IntoIterator<Item = S>>(iter: T) -> Self {
         iter.into_iter()
             .map(|plugin| plugin.as_ref().into())
-            .fold(LintPlugins::empty(), LintPlugins::union)
+            .fold(BuiltinLintPlugins::empty(), BuiltinLintPlugins::union)
     }
 }
 
-impl<'de> Deserialize<'de> for LintPlugins {
+impl<'de> Deserialize<'de> for BuiltinLintPlugins {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         struct LintPluginsVisitor;
         impl<'de> de::Visitor<'de> for LintPluginsVisitor {
-            type Value = LintPlugins;
+            type Value = BuiltinLintPlugins;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                 formatter.write_str("a list of plugin names")
             }
 
             fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
-                Ok(LintPlugins::from(value))
+                Ok(BuiltinLintPlugins::from(value))
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
             where
                 E: de::Error,
             {
-                Ok(LintPlugins::from(v.as_str()))
+                Ok(BuiltinLintPlugins::from(v.as_str()))
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
             where
                 A: de::SeqAccess<'de>,
             {
-                let mut plugins = LintPlugins::empty();
+                let mut plugins = BuiltinLintPlugins::empty();
                 loop {
                     // serde_json::from_str will provide an &str, while
                     // serde_json::from_value provides a String. The former is
@@ -182,14 +183,14 @@ impl<'de> Deserialize<'de> for LintPlugins {
     }
 }
 
-impl Serialize for LintPlugins {
+impl Serialize for BuiltinLintPlugins {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let vec: Vec<&str> = self.iter().map(Into::into).collect();
         vec.serialize(serializer)
     }
 }
 
-impl JsonSchema for LintPlugins {
+impl JsonSchema for BuiltinLintPlugins {
     fn schema_name() -> String {
         "LintPlugins".to_string()
     }

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -6,7 +6,7 @@ use oxc_span::{SourceType, Span};
 
 use crate::{
     AllowWarnDeny, FrameworkFlags,
-    config::{LintConfig, LintPlugins},
+    config::{BuiltinLintPlugins, LintConfig},
     disable_directives::{DisableDirectives, DisableDirectivesBuilder, RuleCommentType},
     fixer::{Fix, FixKind, Message, PossibleFixes},
     frameworks,
@@ -131,7 +131,7 @@ impl<'a> ContextHost<'a> {
     }
 
     #[inline]
-    pub fn plugins(&self) -> &LintPlugins {
+    pub fn plugins(&self) -> &BuiltinLintPlugins {
         &self.config.plugins
     }
 

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -29,8 +29,8 @@ use oxc_semantic::{AstNode, Semantic};
 
 pub use crate::{
     config::{
-        Config, ConfigBuilderError, ConfigStore, ConfigStoreBuilder, ESLintRule, LintPlugins,
-        Oxlintrc,
+        BuiltinLintPlugins, Config, ConfigBuilderError, ConfigStore, ConfigStoreBuilder,
+        ESLintRule, Oxlintrc,
     },
     context::LintContext,
     external_linter::{

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -14,8 +14,8 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 
 use crate::{
-    AllowWarnDeny, ConfigStore, ConfigStoreBuilder, LintPlugins, LintService, LintServiceOptions,
-    Linter, Oxlintrc, RuleEnum,
+    AllowWarnDeny, BuiltinLintPlugins, ConfigStore, ConfigStoreBuilder, LintService,
+    LintServiceOptions, Linter, Oxlintrc, RuleEnum,
     fixer::{FixKind, Fixer},
     options::LintOptions,
     rules::RULES,
@@ -232,7 +232,7 @@ pub struct Tester {
     /// See: [insta::Settings::set_snapshot_suffix]
     snapshot_suffix: Option<&'static str>,
     current_working_directory: Box<Path>,
-    plugins: LintPlugins,
+    plugins: BuiltinLintPlugins,
 }
 
 impl Tester {
@@ -259,7 +259,7 @@ impl Tester {
             snapshot: String::new(),
             snapshot_suffix: None,
             current_working_directory,
-            plugins: LintPlugins::default(),
+            plugins: BuiltinLintPlugins::default(),
         }
     }
 
@@ -304,37 +304,37 @@ impl Tester {
     }
 
     pub fn with_import_plugin(mut self, yes: bool) -> Self {
-        self.plugins.set(LintPlugins::IMPORT, yes);
+        self.plugins.set(BuiltinLintPlugins::IMPORT, yes);
         self
     }
 
     pub fn with_jest_plugin(mut self, yes: bool) -> Self {
-        self.plugins.set(LintPlugins::JEST, yes);
+        self.plugins.set(BuiltinLintPlugins::JEST, yes);
         self
     }
 
     pub fn with_vitest_plugin(mut self, yes: bool) -> Self {
-        self.plugins.set(LintPlugins::VITEST, yes);
+        self.plugins.set(BuiltinLintPlugins::VITEST, yes);
         self
     }
 
     pub fn with_jsx_a11y_plugin(mut self, yes: bool) -> Self {
-        self.plugins.set(LintPlugins::JSX_A11Y, yes);
+        self.plugins.set(BuiltinLintPlugins::JSX_A11Y, yes);
         self
     }
 
     pub fn with_nextjs_plugin(mut self, yes: bool) -> Self {
-        self.plugins.set(LintPlugins::NEXTJS, yes);
+        self.plugins.set(BuiltinLintPlugins::NEXTJS, yes);
         self
     }
 
     pub fn with_react_perf_plugin(mut self, yes: bool) -> Self {
-        self.plugins.set(LintPlugins::REACT_PERF, yes);
+        self.plugins.set(BuiltinLintPlugins::REACT_PERF, yes);
         self
     }
 
     pub fn with_node_plugin(mut self, yes: bool) -> Self {
-        self.plugins.set(LintPlugins::NODE, yes);
+        self.plugins.set(BuiltinLintPlugins::NODE, yes);
         self
     }
 
@@ -514,7 +514,7 @@ impl Tester {
                         )
                         .unwrap()
                     })
-                    .with_plugins(self.plugins.union(LintPlugins::from(self.plugin_name)))
+                    .with_plugins(self.plugins.union(BuiltinLintPlugins::from(self.plugin_name)))
                     .with_rule(rule, AllowWarnDeny::Warn)
                     .build(),
                 FxHashMap::default(),

--- a/tasks/website/src/linter/rules/doc_page.rs
+++ b/tasks/website/src/linter/rules/doc_page.rs
@@ -6,7 +6,7 @@ use std::{
     path::PathBuf,
 };
 
-use oxc_linter::{LintPlugins, table::RuleTableRow};
+use oxc_linter::{BuiltinLintPlugins, table::RuleTableRow};
 use schemars::{
     JsonSchema, SchemaGenerator,
     schema::{InstanceType, Schema, SchemaObject, SingleOrVec},
@@ -164,8 +164,8 @@ fn rule_source(rule: &RuleTableRow) -> String {
 /// - Example: `eslint` => true
 /// - Example: `jest` => false
 fn is_default_plugin(plugin: &str) -> bool {
-    let plugin = LintPlugins::from(plugin);
-    LintPlugins::default().contains(plugin)
+    let plugin = BuiltinLintPlugins::from(plugin);
+    BuiltinLintPlugins::default().contains(plugin)
 }
 
 /// Returns the normalized plugin name.
@@ -173,7 +173,7 @@ fn is_default_plugin(plugin: &str) -> bool {
 /// - Example: `eslint` -> `eslint`
 /// - Example: `jsx_a11y` -> `jsx-a11y`
 fn get_normalized_plugin_name(plugin: &str) -> &str {
-    LintPlugins::from(plugin).into()
+    BuiltinLintPlugins::from(plugin).into()
 }
 
 fn how_to_use(rule: &RuleTableRow) -> String {


### PR DESCRIPTION
this is a simple LSP rename from `LintPlugins` to `BuiltinLintPlugins` to reduce the diff on #12117 