### PR TITLE
ci(benchmarks): disable mangler benchmarks

### DIFF
--- a/tasks/benchmark/benches/minifier.rs
+++ b/tasks/benchmark/benches/minifier.rs
@@ -50,6 +50,7 @@ fn bench_minifier(criterion: &mut Criterion) {
     group.finish();
 }
 
+#[expect(dead_code)]
 fn bench_mangler(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("mangler");
     for file in TestFiles::minimal().files() {
@@ -75,5 +76,9 @@ fn bench_mangler(criterion: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(minifier, bench_minifier, bench_mangler);
+// Mangler benchmark disabled, as it displays too much variance to be useful.
+// e.g. this PR does not touch the mangler, but shows a 13% regression on mangler benchmark:
+// https://github.com/oxc-project/oxc/pull/12106
+// criterion_group!(minifier, bench_minifier, bench_mangler);
+criterion_group!(minifier, bench_minifier);
 criterion_main!(minifier);


### PR DESCRIPTION
Related to #11347.

Mangler benchmarks display so much variance that they're pretty useless. Valiant attempts to reduce the variance (#11408, #11409) have not worked, and contributors have been getting confused by the bonkers "Performance regressed 13%" alerts on unrelated PRs.

No one is working on mangler at the moment, so just disable the damn things!
