### PR TITLE
test(oxlint2): dont reject if oxlint fails

### DIFF
--- a/napi/oxlint2/test/e2e.test.ts
+++ b/napi/oxlint2/test/e2e.test.ts
@@ -10,6 +10,7 @@ const ENTRY_POINT_PATH = path.join(PACKAGE_ROOT_PATH, 'src/index.js');
 async function runOxlint(cwd: string, args: string[] = []) {
   return await execa('node', [ENTRY_POINT_PATH, ...args], {
     cwd: path.join(PACKAGE_ROOT_PATH, cwd),
+    reject: false,
   });
 }
 


### PR DESCRIPTION
we need to be able to snapshot error cases, and having `execa` throw and then trying to catch ect... isn't ideal.

In our tests, we should always assert the exit code is what we expect