### PR TITLE
fix(mangler): handle var redecl scopes

### DIFF
--- a/crates/oxc_minifier/tests/mangler/mod.rs
+++ b/crates/oxc_minifier/tests/mangler/mod.rs
@@ -53,6 +53,13 @@ fn mangler() {
         "function _() { { var x; let y; } }", // x and y should have different names
         "function _() { let a; { let b; { let c; { let d; var x; } } } }",
         "function _() { let a; { let b; { let c; { console.log(a); let d; var x; } } } }",
+        "function _() {
+          if (bar) var a = 0;
+          else {
+            let b = 0;
+            var a = 1;
+          }
+        }", // a and b should have different names
     ];
     let top_level_cases = [
         "function foo(a) {a}",

--- a/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
+++ b/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
@@ -212,6 +212,21 @@ function _() {
 	}
 }
 
+function _() {
+          if (bar) var a = 0;
+          else {
+            let b = 0;
+            var a = 1;
+          }
+        }
+function _() {
+	if (bar) var e = 0;
+	else {
+		let t = 0;
+		var e = 1;
+	}
+}
+
 function foo(a) {a}
 function e(e) {
 	e;


### PR DESCRIPTION
var redeclarations were not handled properly in the mangler.

fixes https://github.com/vitejs/rolldown-vite/issues/316
