### PR TITLE
fix(parser): Handle `%` token as a v8_intrinsic only if option is enabled

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -181,7 +181,9 @@ impl<'a> ParserImpl<'a> {
             Kind::NoSubstitutionTemplate | Kind::TemplateHead => {
                 self.parse_template_literal_expression(false)
             }
-            Kind::Percent => self.parse_v8_intrinsic_expression(),
+            Kind::Percent if self.options.allow_v8_intrinsics => {
+                self.parse_v8_intrinsic_expression()
+            }
             Kind::New => self.parse_new_expression(),
             Kind::Super => self.parse_super(),
             Kind::Import => self.parse_import_meta_or_call(),
@@ -612,10 +614,6 @@ impl<'a> ParserImpl<'a> {
     /// V8 Runtime calls.
     /// See: [runtime.h](https://github.com/v8/v8/blob/5fe0aa3bc79c0a9d3ad546b79211f07105f09585/src/runtime/runtime.h#L43)
     pub(crate) fn parse_v8_intrinsic_expression(&mut self) -> Expression<'a> {
-        if !self.options.allow_v8_intrinsics {
-            return self.unexpected();
-        }
-
         let span = self.start_span();
         self.expect(Kind::Percent);
         let name = self.parse_identifier_name();

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -690,12 +690,22 @@ mod test {
                 "V8 runtime calls cannot have spread elements as arguments"
             );
         }
-
         {
             let source = "%DebugPrint('~~')";
             let ret = Parser::new(&allocator, source, source_type).parse();
             assert_eq!(ret.errors.len(), 1);
             assert_eq!(ret.errors[0].to_string(), "Unexpected token");
+        }
+        {
+            // https://github.com/oxc-project/oxc/issues/12121
+            let source = "interface Props extends %enuProps {}";
+            let source_type = SourceType::default().with_typescript(true);
+            // Should not panic whether `allow_v8_intrinsics` is set or not.
+            let opts = ParseOptions { allow_v8_intrinsics: true, ..ParseOptions::default() };
+            let ret = Parser::new(&allocator, source, source_type).with_options(opts).parse();
+            assert_eq!(ret.errors.len(), 1);
+            let ret = Parser::new(&allocator, source, source_type).parse();
+            assert_eq!(ret.errors.len(), 1);
         }
     }
 


### PR DESCRIPTION
Fixes #12121 