### PR TITLE
refactor(napi/playground): rename `dev` script to `build-dev`

### DIFF
--- a/napi/playground/package.json
+++ b/napi/playground/package.json
@@ -13,8 +13,8 @@
     "./*": "./*"
   },
   "scripts": {
-    "build": "napi build --platform --release --target wasm32-wasip1-threads && node patch.mjs",
-    "dev": "napi build --platform --target wasm32-wasip1-threads && node patch.mjs"
+    "build-dev": "napi build --platform --target wasm32-wasip1-threads && node patch.mjs",
+    "build": "napi build --platform --release --target wasm32-wasip1-threads && node patch.mjs"
   },
   "dependencies": {
     "@napi-rs/wasm-runtime": "^0.2.7"


### PR DESCRIPTION
just updates the `napi/playground` dev script to be consistent with the other napi packages