### PR TITLE
perf(linter/no-constructor-return): optimize loop

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_constructor_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constructor_return.rs
@@ -67,12 +67,16 @@ fn is_constructor(node: &AstNode<'_>) -> bool {
 }
 
 fn is_definitely_in_constructor(ctx: &LintContext, node_id: NodeId) -> bool {
-    ctx.nodes()
-        .ancestor_ids(node_id)
-        .map(|id| ctx.nodes().get_node(id))
-        .skip_while(|node| !node.kind().is_function_like())
-        .nth(1)
-        .is_some_and(is_constructor)
+    for ancestor_id in ctx.nodes().ancestor_ids(node_id).skip(1) {
+        match ctx.nodes().kind(ancestor_id) {
+            AstKind::Function(_) => {
+                return is_constructor(ctx.nodes().parent_node(ancestor_id));
+            }
+            AstKind::ArrowFunctionExpression(_) => return false,
+            _ => {}
+        }
+    }
+    false
 }
 
 #[test]


### PR DESCRIPTION
Small optimization to `eslint/no-constructor-return` rule:

1. After finding a `Function`, there's no need to check if parent is a `Function` too. That's not relevant.
2. Exit immediately after finding an `ArrowFunctionExpression`. Its parent can't be a `MethodDefinition` which is a constructor.
3. Skip the first result of iterator, since we know it's a `ReturnStatement`.