### PR TITLE
refactor(linter): make `tokio` dependency optional

### DIFF
--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -72,7 +72,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 simdutf8 = { workspace = true }
 smallvec = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, optional = true }
 
 [dev-dependencies]
 insta = { workspace = true }


### PR DESCRIPTION
Follow-on after #11980. `tokio` dependency is only required if `oxlint2` feature is enabled.