### PR TITLE
refactor(linter): feature gate `load_external_plugin` by both `oxlint2` and `disable_oxlint2` features

### DIFF
--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -385,7 +385,7 @@ impl ConfigStoreBuilder {
         serde_json::to_string_pretty(&oxlintrc).unwrap()
     }
 
-    #[cfg(not(feature = "oxlint2"))]
+    #[cfg(any(not(feature = "oxlint2"), feature = "disable_oxlint2"))]
     fn load_external_plugin(
         _oxlintrc_path: &Path,
         _plugin_name: &str,
@@ -395,7 +395,7 @@ impl ConfigStoreBuilder {
         Err(ConfigBuilderError::NoExternalLinterConfigured)
     }
 
-    #[cfg(feature = "oxlint2")]
+    #[cfg(all(feature = "oxlint2", not(feature = "disable_oxlint2")))]
     fn load_external_plugin(
         oxlintrc_path: &Path,
         plugin_name: &str,


### PR DESCRIPTION
Follow-on after #11980. Prevent this function being compiled in `oxc_linter` tests. It should be unreachable anyway.