### PR TITLE
perf(linter): do not create `Resolver` unless required

### DIFF
--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -139,14 +139,16 @@ impl ConfigStoreBuilder {
         let (oxlintrc, extended_paths) = resolve_oxlintrc_config(oxlintrc)?;
 
         if let Some(plugins) = oxlintrc.plugins.as_ref() {
-            let resolver = oxc_resolver::Resolver::new(ResolveOptions::default());
-            for plugin_name in &plugins.external {
-                Self::load_external_plugin(
-                    &oxlintrc.path,
-                    plugin_name,
-                    external_linter,
-                    &resolver,
-                )?;
+            if !plugins.external.is_empty() {
+                let resolver = oxc_resolver::Resolver::new(ResolveOptions::default());
+                for plugin_name in &plugins.external {
+                    Self::load_external_plugin(
+                        &oxlintrc.path,
+                        plugin_name,
+                        external_linter,
+                        &resolver,
+                    )?;
+                }
             }
         }
         let plugins = oxlintrc.plugins.unwrap_or_default();


### PR DESCRIPTION
Follow-on after #11980. Skip creating a `Resolver` unless there are JS plugins which need to be resolved. Creating a `Resolver` is not so expensive, but it's not super-cheap either.