### PR TITLE
refactor(napi/oxlint): enable `mimalloc-safe` using `allocator` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,7 +1989,6 @@ dependencies = [
 name = "oxc_linter_napi"
 version = "0.1.0"
 dependencies = [
- "mimalloc-safe",
  "napi",
  "napi-build",
  "napi-derive",

--- a/napi/oxlint2/Cargo.toml
+++ b/napi/oxlint2/Cargo.toml
@@ -22,20 +22,11 @@ test = false
 doctest = false
 
 [dependencies]
-oxlint = { workspace = true, features = ["oxlint2"] }
+oxlint = { workspace = true, features = ["oxlint2", "allocator"] }
 
 napi = { workspace = true, features = ["async"] }
 napi-derive = { workspace = true }
 serde_json = { workspace = true }
-
-[target.'cfg(not(any(target_os = "linux", target_os = "freebsd", target_arch = "arm", target_family = "wasm")))'.dependencies]
-mimalloc-safe = { workspace = true, optional = true, features = ["skip_collect_on_exit"] }
-
-[target.'cfg(all(target_os = "linux", not(target_arch = "arm"), not(target_arch = "aarch64")))'.dependencies]
-mimalloc-safe = { workspace = true, optional = true, features = ["skip_collect_on_exit", "local_dynamic_tls"] }
-
-[target.'cfg(all(target_os = "linux", target_arch = "aarch64"))'.dependencies]
-mimalloc-safe = { workspace = true, optional = true, features = ["skip_collect_on_exit", "local_dynamic_tls", "no_opt_arch"] }
 
 [build-dependencies]
 napi-build = { workspace = true }


### PR DESCRIPTION
Enable `mimalloc-safe` in `napi/oxlint2` by enabling `allocator` feature on `apps/oxlint`, instead of including as dependency in `napi/oxlint2` itself.

Primarily, aim is to stop `cargo shear` producing annoying errors.

I think this works, right?
