### PR TITLE
fix(linter, language_server): correctly identify usage of `import` plugin

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -257,11 +257,8 @@ impl Runner for LintRunner {
 
         // TODO(refactor): pull this into a shared function, so that the language server can use
         // the same functionality.
-        let use_cross_module = if nested_configs.is_empty() {
-            config_builder.plugins().has_import()
-        } else {
-            nested_configs.values().any(|config| config.plugins().has_import())
-        };
+        let use_cross_module = config_builder.plugins().has_import()
+            || nested_configs.values().any(|config| config.plugins().has_import());
         let mut options =
             LintServiceOptions::new(self.cwd, paths).with_cross_module(use_cross_module);
 

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -59,11 +59,9 @@ impl ServerLinter {
         // TODO(refactor): pull this into a shared function, because in oxlint we have the same functionality.
         let use_nested_config = options.use_nested_configs();
 
-        let use_cross_module = if use_nested_config {
-            nested_configs.pin().values().any(|config| config.plugins().has_import())
-        } else {
-            config_builder.plugins().has_import()
-        };
+        let use_cross_module = config_builder.plugins().has_import()
+            || (use_nested_config
+                && nested_configs.pin().values().any(|config| config.plugins().has_import()));
 
         extended_paths.extend(config_builder.extended_paths.clone());
         let base_config = config_builder.build();


### PR DESCRIPTION
Previously `use_cross_module` would be `false` if root config enables import plugin, and there are nested configs, but none of them enable import plugin. Make it `true` in this case.
