### PR TITLE
ci(test): run tests on big endian with `--all-features`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           save-cache: ${{ github.ref_name == 'main' }}
           cache-key: s390x-unknown-linux-gnu
           tools: cross
-      - run: cross test --target s390x-unknown-linux-gnu
+      - run: cross test --all-features --target s390x-unknown-linux-gnu
 
   test-wasm32-wasip1-threads:
     name: Test wasm32-wasip1-threads


### PR DESCRIPTION
Big endian tests were failing on CI. This is due to a strange combination of cargo features getting enabled in the tests, causing problems in linter crates, since #12122.

I don't entirely understand how this was happening, but running the tests with `cross test --all-features` fixes it. In any case, we do want to run tests for all features on big endian.