### PR TITLE
fix(language_server): respect the root `.oxlintrc.json` file for `ignorePatterns`

### DIFF
--- a/crates/oxc_language_server/fixtures/linter/root_ignore_patterns/.oxlintrc.json
+++ b/crates/oxc_language_server/fixtures/linter/root_ignore_patterns/.oxlintrc.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "no-debugger": "error"
+  },
+  "ignorePatterns": [
+    "**/*.ts"
+  ]
+}

--- a/crates/oxc_language_server/fixtures/linter/root_ignore_patterns/ignored-file.ts
+++ b/crates/oxc_language_server/fixtures/linter/root_ignore_patterns/ignored-file.ts
@@ -1,0 +1,2 @@
+debugger;
+

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_root_ignore_patterns@ignored-file.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_root_ignore_patterns@ignored-file.ts.snap
@@ -1,0 +1,5 @@
+---
+source: crates/oxc_language_server/src/tester.rs
+input_file: crates/oxc_language_server/fixtures/linter/root_ignore_patterns/ignored-file.ts
+---
+File is ignored

--- a/crates/oxc_language_server/src/tester.rs
+++ b/crates/oxc_language_server/src/tester.rs
@@ -116,17 +116,17 @@ impl Tester<'_> {
     #[expect(clippy::disallowed_methods)]
     pub fn test_and_snapshot_single_file(&self, relative_file_path: &str) {
         let uri = get_file_uri(&format!("{}/{}", self.relative_root_dir, relative_file_path));
-        let reports = tokio::runtime::Runtime::new().unwrap().block_on(async {
-            self.create_workspace_worker()
-                .await
-                .lint_file(&uri, None)
-                .await
-                .expect("lint file is ignored")
-        });
-        let snapshot = if reports.is_empty() {
-            "No diagnostic reports".to_string()
+        let reports = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(async { self.create_workspace_worker().await.lint_file(&uri, None).await });
+        let snapshot = if let Some(reports) = reports {
+            if reports.is_empty() {
+                "No diagnostic reports".to_string()
+            } else {
+                reports.iter().map(get_snapshot_from_report).collect::<Vec<_>>().join("\n")
+            }
         } else {
-            reports.iter().map(get_snapshot_from_report).collect::<Vec<_>>().join("\n")
+            "File is ignored".to_string()
         };
 
         let snapshot_name = self.relative_root_dir.replace('/', "_");


### PR DESCRIPTION
The server is not searching for the root `.oxlintrc.json` file as a root config.
Fixed the problem to be aligned with the CLI tool `oxlint`.