### PR TITLE
refactor(transformer/styled_components): make unreachable branch `unreachable!`

### DIFF
--- a/crates/oxc_transformer/src/plugins/styled_components.rs
+++ b/crates/oxc_transformer/src/plugins/styled_components.rs
@@ -340,7 +340,7 @@ impl<'a> StyledComponents<'a, '_> {
         ctx: &TraverseCtx<'a>,
     ) {
         let Expression::TaggedTemplateExpression(tagged) = expr else {
-            return;
+            unreachable!();
         };
 
         let is_styled = if self.options.display_name || self.options.ssr {


### PR DESCRIPTION
This branch is unreachable, so use `unreachable!` for it, rather than `return`.

Despite `unreachable!` producing more code, this may still be more performant, because it tells the compiler which branch is going to be taken. Compiler will generate assembly to make the branch which is taken the fast path. Either way, it's a micro micro optimization.

Mainly I think it's preferable because it's clearer when reading the code.