### PR TITLE
perf(transformer/styled_components): mark `enter_expression` as `#[inline]`

### DIFF
--- a/crates/oxc_transformer/src/plugins/styled_components.rs
+++ b/crates/oxc_transformer/src/plugins/styled_components.rs
@@ -313,6 +313,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for StyledComponents<'a, '_> {
         self.handle_pure_annotation(variable_declarator, ctx);
     }
 
+    #[inline] // Because it's a hot path, and most `Expression`s are not `TaggedTemplateExpression`s
     fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         if matches!(expr, Expression::TaggedTemplateExpression(_)) {
             self.transform_tagged_template_expression(expr, ctx);


### PR DESCRIPTION
Not sure if this'll make any difference - compiler may inline it anyway - but we have found it's usually beneficial in other transforms.