### PR TITLE
perf(linter): experiment: skip rules when no nodes match

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1942,7 +1942,6 @@ dependencies = [
  "convert_case",
  "cow-utils",
  "fast-glob",
- "fixedbitset",
  "globset",
  "icu_segmenter",
  "indexmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1942,6 +1942,7 @@ dependencies = [
  "convert_case",
  "cow-utils",
  "fast-glob",
+ "fixedbitset",
  "globset",
  "icu_segmenter",
  "indexmap",
@@ -2219,6 +2220,7 @@ dependencies = [
 name = "oxc_semantic"
 version = "0.76.0"
 dependencies = [
+ "fixedbitset",
  "insta",
  "itertools",
  "oxc_allocator",

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -51,6 +51,7 @@ constcat = { workspace = true }
 convert_case = { workspace = true }
 cow-utils = { workspace = true }
 fast-glob = { workspace = true }
+fixedbitset = { workspace = true }
 globset = { workspace = true }
 icu_segmenter = { workspace = true }
 indexmap = { workspace = true, features = ["rayon"] }

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -51,7 +51,6 @@ constcat = { workspace = true }
 convert_case = { workspace = true }
 cow-utils = { workspace = true }
 fast-glob = { workspace = true }
-fixedbitset = { workspace = true }
 globset = { workspace = true }
 icu_segmenter = { workspace = true }
 indexmap = { workspace = true, features = ["rayon"] }

--- a/crates/oxc_linter/src/rules/eslint/for_direction.rs
+++ b/crates/oxc_linter/src/rules/eslint/for_direction.rs
@@ -156,6 +156,10 @@ impl Rule for ForDirection {
             );
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::ForStatement])
+    }
 }
 
 type UpdateDirection = i32;

--- a/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
@@ -125,6 +125,10 @@ impl Rule for NoCondAssign {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::AssignmentExpression])
+    }
 }
 
 impl NoCondAssign {

--- a/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
@@ -64,6 +64,10 @@ impl Rule for NoConstAssign {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::VariableDeclaration])
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
@@ -149,6 +149,13 @@ impl Rule for NoConstantBinaryExpression {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[
+            oxc_ast::AstType::LogicalExpression,
+            oxc_ast::AstType::BinaryExpression,
+        ])
+    }
 }
 
 impl NoConstantBinaryExpression {

--- a/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
@@ -132,6 +132,14 @@ impl Rule for NoControlRegex {
             check_pattern(ctx, pattern, span);
         });
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[
+            oxc_ast::AstType::CallExpression,
+            oxc_ast::AstType::RegExpLiteral,
+            oxc_ast::AstType::NewExpression,
+        ])
+    }
 }
 
 fn check_pattern(context: &LintContext, pattern: &Pattern, span: Span) {

--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_case.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_case.rs
@@ -92,6 +92,10 @@ impl Rule for NoDuplicateCase {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::SwitchStatement])
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/eslint/no_empty_pattern.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_pattern.rs
@@ -1,4 +1,4 @@
-use oxc_ast::AstKind;
+use oxc_ast::{AstKind, AstType};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -82,6 +82,10 @@ impl Rule for NoEmptyPattern {
             _ => return,
         };
         ctx.diagnostic(no_empty_pattern_diagnostic(pattern_type, span));
+    }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[AstType::ArrayPattern, AstType::ObjectPattern])
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
@@ -81,6 +81,10 @@ impl Rule for NoFuncAssign {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::Function])
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
@@ -88,6 +88,10 @@ impl Rule for NoLossOfPrecision {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::NumericLiteral])
+    }
 }
 
 pub struct RawNum<'a> {

--- a/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
@@ -64,6 +64,10 @@ impl Rule for NoNewNativeNonconstructor {
             ));
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::NewExpression])
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
@@ -1,5 +1,5 @@
 use oxc_ast::{
-    AstKind,
+    AstKind, AstType,
     ast::{Expression, IdentifierReference, MemberExpression, match_member_expression},
 };
 use oxc_diagnostics::OxcDiagnostic;
@@ -156,6 +156,10 @@ impl Rule for NoObjCalls {
                 // noop
             }
         }
+    }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[AstType::CallExpression, AstType::NewExpression])
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
@@ -1,5 +1,5 @@
 use oxc_ast::{
-    AstKind,
+    AstKind, AstType,
     ast::{Argument, Expression, MethodDefinitionKind},
 };
 use oxc_cfg::{
@@ -131,6 +131,10 @@ impl Rule for NoThisBeforeSuper {
                 ctx.diagnostic(no_this_before_super_diagnostic(parent_span));
             }
         }
+    }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[AstType::Super, AstType::ThisExpression])
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
@@ -104,6 +104,10 @@ impl Rule for NoUnsafeFinally {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::TryStatement])
+    }
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
@@ -145,6 +145,10 @@ impl Rule for NoUnsafeOptionalChaining {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::ChainExpression])
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/crates/oxc_linter/src/rules/eslint/no_useless_backreference.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_backreference.rs
@@ -87,6 +87,14 @@ impl Rule for NoUselessBackreference {
             }
         });
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[
+            oxc_ast::AstType::CallExpression,
+            oxc_ast::AstType::RegExpLiteral,
+            oxc_ast::AstType::NewExpression,
+        ])
+    }
 }
 
 enum Problem {

--- a/crates/oxc_linter/src/rules/eslint/require_yield.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_yield.rs
@@ -46,6 +46,10 @@ impl Rule for RequireYield {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::Function])
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/oxc/bad_comparison_sequence.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_comparison_sequence.rs
@@ -54,6 +54,10 @@ impl Rule for BadComparisonSequence {
             ctx.diagnostic(bad_comparison_sequence_diagnostic(expr.span));
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::BinaryExpression])
+    }
 }
 
 fn has_no_bad_comparison_in_parents<'a, 'b>(

--- a/crates/oxc_linter/src/rules/oxc/bad_min_max_func.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_min_max_func.rs
@@ -84,6 +84,10 @@ impl Rule for BadMinMaxFunc {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::CallExpression])
+    }
 }
 
 enum MinMax {

--- a/crates/oxc_linter/src/rules/oxc/bad_object_literal_comparison.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_object_literal_comparison.rs
@@ -92,6 +92,10 @@ impl Rule for BadObjectLiteralComparison {
             ));
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::BinaryExpression])
+    }
 }
 
 fn is_empty_object_expression(maybe_empty_obj_expr: &Expression) -> bool {

--- a/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
+++ b/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
@@ -105,6 +105,10 @@ impl Rule for DoubleComparisons {
             },
         );
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::LogicalExpression])
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/oxc/number_arg_out_of_range.rs
+++ b/crates/oxc_linter/src/rules/oxc/number_arg_out_of_range.rs
@@ -84,6 +84,10 @@ impl Rule for NumberArgOutOfRange {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::CallExpression])
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/array_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/array_type.rs
@@ -221,6 +221,13 @@ impl Rule for ArrayType {
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
         ctx.source_type().is_typescript()
+            && ctx.semantic().nodes().contains_any(&[
+                oxc_ast::AstType::TSArrayType,
+                oxc_ast::AstType::TSTypeAnnotation,
+                oxc_ast::AstType::TSTypeAliasDeclaration,
+                oxc_ast::AstType::TSTypeReference,
+                oxc_ast::AstType::TSAsExpression,
+            ])
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/ban_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_types.rs
@@ -104,6 +104,10 @@ impl Rule for BanTypes {
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
         ctx.source_type().is_typescript()
+            && ctx
+                .semantic()
+                .nodes()
+                .contains_any(&[oxc_ast::AstType::TSTypeReference, oxc_ast::AstType::TSTypeLiteral])
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
@@ -118,6 +118,11 @@ impl Rule for ConsistentGenericConstructors {
 
     fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
         ctx.source_type().is_typescript()
+            && ctx.semantic().nodes().contains_any(&[
+                oxc_ast::AstType::VariableDeclarator,
+                oxc_ast::AstType::AssignmentPattern,
+                oxc_ast::AstType::PropertyDefinition,
+            ])
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
@@ -276,6 +276,11 @@ impl Rule for ConsistentIndexedObjectStyle {
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
         ctx.source_type().is_typescript()
+            && ctx.semantic().nodes().contains_any(&[
+                oxc_ast::AstType::TSInterfaceDeclaration,
+                oxc_ast::AstType::TSTypeLiteral,
+                oxc_ast::AstType::TSTypeReference,
+            ])
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
@@ -245,6 +245,11 @@ impl Rule for ConsistentTypeDefinitions {
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
         ctx.source_type().is_typescript()
+            && ctx.semantic().nodes().contains_any(&[
+                oxc_ast::AstType::TSTypeAliasDeclaration,
+                oxc_ast::AstType::ExportDefaultDeclaration,
+                oxc_ast::AstType::TSInterfaceDeclaration,
+            ])
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -301,6 +301,11 @@ impl Rule for ConsistentTypeImports {
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
         ctx.source_type().is_typescript()
+            && ctx.semantic().nodes().contains_any(&[
+                oxc_ast::AstType::ImportDeclaration,
+                oxc_ast::AstType::ImportSpecifier,
+                oxc_ast::AstType::TSImportType,
+            ])
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -300,6 +300,10 @@ impl Rule for ExplicitFunctionReturnType {
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
         ctx.source_type().is_typescript()
+            && ctx.semantic().nodes().contains_any(&[
+                oxc_ast::AstType::Function,
+                oxc_ast::AstType::ArrowFunctionExpression,
+            ])
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
@@ -129,6 +129,11 @@ impl Rule for NoConfusingNonNullAssertion {
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
         ctx.source_type().is_typescript()
+            && ctx.semantic().nodes().contains_any(&[
+                oxc_ast::AstType::BinaryExpression,
+                oxc_ast::AstType::AssignmentExpression,
+                oxc_ast::AstType::TSNonNullExpression,
+            ])
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
@@ -133,6 +133,7 @@ impl Rule for NoDuplicateEnumValues {
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
         ctx.source_type().is_typescript()
+            && ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::TSEnumBody])
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
@@ -64,6 +64,10 @@ impl Rule for NoDynamicDelete {
         }
         ctx.diagnostic(no_dynamic_delete_diagnostic(expr.span));
     }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::UnaryExpression])
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
@@ -81,6 +81,7 @@ impl Rule for NoEmptyInterface {
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
         ctx.source_type().is_typescript()
+            && ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::TSInterfaceDeclaration])
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
@@ -146,6 +146,10 @@ impl Rule for NoEmptyObjectType {
 
     fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
         ctx.source_type().is_typescript()
+            && ctx.semantic().nodes().contains_any(&[
+                oxc_ast::AstType::TSInterfaceDeclaration,
+                oxc_ast::AstType::TSTypeLiteral,
+            ])
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
@@ -118,6 +118,7 @@ impl Rule for NoExplicitAny {
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
         ctx.source_type().is_typescript()
+            && ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::TSAnyKeyword])
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
@@ -112,6 +112,7 @@ impl Rule for NoExtraNonNullAssertion {
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
         ctx.source_type().is_typescript()
+            && ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::TSNonNullExpression])
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
@@ -187,6 +187,10 @@ impl Rule for NoExtraneousClass {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::Class])
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/no_import_type_side_effects.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_import_type_side_effects.rs
@@ -132,6 +132,7 @@ impl Rule for NoImportTypeSideEffects {
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
         ctx.source_type().is_typescript()
+            && ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::ImportDeclaration])
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_misused_new.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_misused_new.rs
@@ -136,6 +136,11 @@ impl Rule for NoMisusedNew {
 
     fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
         ctx.source_type().is_typescript()
+            && ctx.semantic().nodes().contains_any(&[
+                oxc_ast::AstType::TSInterfaceDeclaration,
+                oxc_ast::AstType::TSMethodSignature,
+                oxc_ast::AstType::Class,
+            ])
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_namespace.rs
@@ -182,6 +182,7 @@ impl Rule for NoNamespace {
             return false;
         }
         ctx.source_type().is_typescript()
+            && ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::TSModuleDeclaration])
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
@@ -84,6 +84,7 @@ impl Rule for NoNonNullAssertedNullishCoalescing {
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
         ctx.source_type().is_typescript()
+            && ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::TSNonNullExpression])
     }
 }
 fn has_assignment_before_node(

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
@@ -120,6 +120,7 @@ impl Rule for NoNonNullAssertedOptionalChain {
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
         ctx.source_type().is_typescript()
+            && ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::ChainExpression])
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
@@ -55,6 +55,7 @@ impl Rule for NoNonNullAssertion {
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
         ctx.source_type().is_typescript()
+            && ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::TSNonNullExpression])
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
@@ -214,6 +214,13 @@ impl Rule for NoRequireImports {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[
+            oxc_ast::AstType::CallExpression,
+            oxc_ast::AstType::TSImportEqualsDeclaration,
+        ])
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_parameter_property_assignment.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_parameter_property_assignment.rs
@@ -105,6 +105,10 @@ impl Rule for NoUnnecessaryParameterPropertyAssignment {
         };
         visitor.visit_function_body(function_body);
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::MethodDefinition])
+    }
 }
 
 struct AssignmentVisitor<'a, 'b> {

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
@@ -76,6 +76,10 @@ impl Rule for NoUnsafeDeclarationMerging {
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
         ctx.source_type().is_typescript()
+            && ctx
+                .semantic()
+                .nodes()
+                .contains_any(&[oxc_ast::AstType::Class, oxc_ast::AstType::TSInterfaceDeclaration])
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_wrapper_object_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_wrapper_object_types.rs
@@ -1,6 +1,6 @@
 use cow_utils::CowUtils;
 use oxc_ast::{
-    AstKind,
+    AstKind, AstType,
     ast::{Expression, TSTypeName},
 };
 use oxc_diagnostics::OxcDiagnostic;
@@ -101,6 +101,11 @@ impl Rule for NoWrapperObjectTypes {
 
     fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
         ctx.source_type().is_typescript()
+            && ctx.semantic().nodes().contains_any(&[
+                AstType::TSTypeReference,
+                AstType::TSClassImplements,
+                AstType::TSInterfaceHeritage,
+            ])
     }
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
@@ -94,6 +94,10 @@ impl Rule for NoAwaitInPromiseMethods {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::CallExpression])
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
@@ -150,6 +150,17 @@ impl Rule for NoThenable {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[
+            oxc_ast::AstType::ObjectExpression,
+            oxc_ast::AstType::PropertyDefinition,
+            oxc_ast::AstType::MethodDefinition,
+            oxc_ast::AstType::ExportNamedDeclaration,
+            oxc_ast::AstType::CallExpression,
+            oxc_ast::AstType::AssignmentExpression,
+        ])
+    }
 }
 
 fn check_call_expression(expr: &CallExpression, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
@@ -170,6 +170,10 @@ impl Rule for NoUselessLengthCheck {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[oxc_ast::AstType::LogicalExpression])
+    }
 }
 
 fn make_flat_logical_expression<'a>(

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -30,6 +30,7 @@ oxc_index = { workspace = true }
 oxc_span = { workspace = true }
 oxc_syntax = { workspace = true }
 
+fixedbitset = { workspace = true }
 itertools = { workspace = true }
 phf = { workspace = true, features = ["macros"] }
 rustc-hash = { workspace = true }


### PR DESCRIPTION
This is an experimental branch, I do not intend to merge these changes as-is. This is a test to see if skipping more rules by just looking at AST node kinds can have a meaningful impact on performance.