### PR TITLE
refactor(transformer/plugins): short-circuit early when a call expressions is part of `ComputedMemberExpression`

### DIFF
--- a/crates/oxc_transformer/src/plugins/styled_components.rs
+++ b/crates/oxc_transformer/src/plugins/styled_components.rs
@@ -326,7 +326,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for StyledComponents<'a, '_> {
             // or a callee of another call expression.
             && !matches!(
                 ctx.parent(),
-                Ancestor::CallExpressionCallee(_) | Ancestor::StaticMemberExpressionObject(_)
+                Ancestor::CallExpressionCallee(_) | Ancestor::StaticMemberExpressionObject(_) | Ancestor::ComputedMemberExpressionObject(_)
             )
         {
             self.add_display_name_and_component_id(&mut call.callee, ctx);


### PR DESCRIPTION
close: https://github.com/oxc-project/oxc/pull/12066#discussion_r2196097399

We haven't supported transform `ComputedMemberExpression`, because I found that Babel plugin support for `styled['div']` is also incomplete. Anyway, short-circuiting for this is still a good improvement.