### PR TITLE
refactor(transformer/styled-components): simplify concating strs

### DIFF
--- a/crates/oxc_transformer/src/plugins/styled_components.rs
+++ b/crates/oxc_transformer/src/plugins/styled_components.rs
@@ -693,11 +693,11 @@ impl<'a> StyledComponents<'a, '_> {
                 if block_name == component_name {
                     return Some(ctx.ast.str(component_name.as_str()));
                 }
-                return Some(
-                    ctx.ast
-                        .atom_from_strs_array([block_name, "__", component_name.as_str()])
-                        .as_str(),
-                );
+                return Some(ctx.ast.allocator.alloc_concat_strs_array([
+                    block_name,
+                    "__",
+                    component_name.as_str(),
+                ]));
             }
             return Some(ctx.ast.str(block_name));
         }


### PR DESCRIPTION
`atom_from_strs_array` returns an `Atom`, but we only need a `str` here, so using `alloc_concat_strs_array` is better.