### PR TITLE
fix(linter): Fix inconsistent behavior in `no-duplicate-imports` rule

### DIFF
--- a/crates/oxc_linter/src/snapshots/eslint_no_duplicate_imports.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_duplicate_imports.snap
@@ -1,6 +1,19 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
+  ⚠ eslint(no-duplicate-imports): 'foo' export is duplicated
+   ╭─[no_duplicate_imports.tsx:2:26]
+ 1 │ 
+ 2 │                 export { a } from 'foo';
+   ·                          ┬
+   ·                          ╰── This export is duplicated
+ 3 │                 import { f } from 'foo';
+   ·                                   ──┬──
+   ·                                     ╰── Can be merged with this
+ 4 │             
+   ╰────
+  help: Merge the duplicated exports into a single export statement
+
   ⚠ eslint(no-duplicate-imports): 'fs' import is duplicated
    ╭─[no_duplicate_imports.tsx:1:8]
  1 │ import "fs";


### PR DESCRIPTION
Currently, the `no-duplicate-imports` rule in Oxlint does not report an error for the following code:

```js
/*eslint no-duplicate-imports: ["error", { "includeExports": true }]*/
export { a } from 'foo';
import { f } from 'foo';
```