### PR TITLE
perf(transformer/styled-components): generate file path hash in `InlineString`

### DIFF
--- a/crates/oxc_transformer/Cargo.toml
+++ b/crates/oxc_transformer/Cargo.toml
@@ -25,7 +25,7 @@ oxc-browserslist = { workspace = true }
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
-oxc_data_structures = { workspace = true, features = ["rope", "stack"] }
+oxc_data_structures = { workspace = true, features = ["inline_string", "rope", "stack"] }
 oxc_diagnostics = { workspace = true }
 oxc_ecmascript = { workspace = true }
 oxc_parser = { workspace = true }


### PR DESCRIPTION
Use an `InlineString` to build the file path hash, instead of a `Vec`. For short strings like this, `InlineString` is cheaper to build and involves no allocations.

Also, don't store this temporary value in arena.
