### PR TITLE
fix(allocator)!: remove `vec!` macro

### DIFF
--- a/crates/oxc_allocator/src/vec2/mod.rs
+++ b/crates/oxc_allocator/src/vec2/mod.rs
@@ -31,20 +31,6 @@
 //! let v: Vec<i32> = Vec::new_in(&b);
 //! ```
 //!
-//! ... or by using the [`vec!`] macro:
-//!
-//! ```
-//! use bumpalo::{Bump, collections::Vec};
-//!
-//! let b = Bump::new();
-//!
-//! let v: Vec<i32> = bumpalo::vec![in &b];
-//!
-//! let v = bumpalo::vec![in &b; 1, 2, 3, 4, 5];
-//!
-//! let v = bumpalo::vec![in &b; 0; 10]; // ten zeroes
-//! ```
-//!
 //! You can [`push`] values onto the end of a vector (which will grow the vector
 //! as needed):
 //!
@@ -53,9 +39,9 @@
 //!
 //! let b = Bump::new();
 //!
-//! let mut v = bumpalo::vec![in &b; 1, 2];
+//! let mut v = Vec::new_in(&b);
 //!
-//! v.push(3);
+//! v.push(1);
 //! ```
 //!
 //! Popping values works in much the same way:
@@ -65,7 +51,7 @@
 //!
 //! let b = Bump::new();
 //!
-//! let mut v = bumpalo::vec![in &b; 1, 2];
+//! let mut v = Vec::from_iter_in([1, 2], &b);
 //!
 //! assert_eq!(v.pop(), Some(2));
 //! ```
@@ -77,18 +63,17 @@
 //!
 //! let b = Bump::new();
 //!
-//! let mut v = bumpalo::vec![in &b; 1, 2, 3];
+//! let mut v = Vec::from_iter_in([1, 2, 3], &b);
 //! assert_eq!(v[2], 3);
 //! v[1] += 5;
 //! assert_eq!(v, [1, 7, 3]);
 //! ```
 //!
-//! [`Vec<'a, T>`]: struct.Vec.html
-//! [`new_in`]: struct.Vec.html#method.new_in
-//! [`push`]: struct.Vec.html#method.push
+//! [`Vec<'a, T>`]: Vec
+//! [`new_in`]: Vec::new_in
+//! [`push`]: Vec::push
 //! [`Index`]: https://doc.rust-lang.org/std/ops/trait.Index.html
 //! [`IndexMut`]: https://doc.rust-lang.org/std/ops/trait.IndexMut.html
-//! [`vec!`]: ../../macro.vec.html
 
 #![expect(
     clippy::semicolon_if_nothing_returned,
@@ -238,66 +223,6 @@ where
     d / (pointee_size as isize)
 }
 
-/// Creates a [`Vec`] containing the arguments.
-///
-/// `vec!` allows `Vec`s to be defined with the same syntax as array expressions.
-/// There are two forms of this macro:
-///
-/// - Create a [`Vec`] containing a given list of elements:
-///
-/// ```
-/// use bumpalo::Bump;
-///
-/// let b = Bump::new();
-/// let v = bumpalo::vec![in &b; 1, 2, 3];
-/// assert_eq!(v, [1, 2, 3]);
-/// ```
-///
-/// - Create a [`Vec`] from a given element and size:
-///
-/// ```
-/// use bumpalo::Bump;
-///
-/// let b = Bump::new();
-/// let v = bumpalo::vec![in &b; 1; 3];
-/// assert_eq!(v, [1, 1, 1]);
-/// ```
-///
-/// Note that unlike array expressions, this syntax supports all elements
-/// which implement [`Clone`] and the number of elements doesn't have to be
-/// a constant.
-///
-/// This will use `clone` to duplicate an expression, so one should be careful
-/// using this with types having a non-standard `Clone` implementation. For
-/// example, `bumpalo::vec![in &alloc; Rc::new(1); 5]` will create a vector of five references
-/// to the same boxed integer value, not five references pointing to independently
-/// boxed integers.
-///
-/// [`Vec`]: collections/vec/struct.Vec.html
-/// [`Clone`]: https://doc.rust-lang.org/std/clone/trait.Clone.html
-#[macro_export]
-macro_rules! vec {
-    (in $alloc:expr; $elem:expr; $n:expr) => {{
-        let n = $n;
-        let mut v = $crate::collections::Vec::with_capacity_in(n, $alloc);
-        if n > 0 {
-            let elem = $elem;
-            for _ in 0..n - 1 {
-                v.push(elem.clone());
-            }
-            v.push(elem);
-        }
-        v
-    }};
-    (in $alloc:expr) => { $crate::collections::Vec::new_in($alloc) };
-    (in $alloc:expr; $($x:expr),*) => {{
-        let mut v = $crate::collections::Vec::new_in($alloc);
-        $( v.push($x); )*
-        v
-    }};
-    (in $alloc:expr; $($x:expr,)*) => (bumpalo::vec![in $alloc; $($x),*])
-}
-
 /// A contiguous growable array type, written `Vec<'a, T, A>` but pronounced 'vector'.
 ///
 /// # Examples
@@ -326,35 +251,6 @@ macro_rules! vec {
 ///     println!("{}", x);
 /// }
 /// assert_eq!(vec, [7, 1, 2, 3]);
-/// ```
-///
-/// The [`vec!`] macro is provided to make initialization more convenient:
-///
-/// ```
-/// use bumpalo::{Bump, collections::Vec};
-///
-/// let b = Bump::new();
-///
-/// let mut vec = bumpalo::vec![in &b; 1, 2, 3];
-/// vec.push(4);
-/// assert_eq!(vec, [1, 2, 3, 4]);
-/// ```
-///
-/// It can also initialize each element of a `Vec<'a, T>` with a given value.
-/// This may be more efficient than performing allocation and initialization
-/// in separate steps, especially when initializing a vector of zeros:
-///
-/// ```
-/// use bumpalo::{Bump, collections::Vec};
-///
-/// let b = Bump::new();
-///
-/// let vec = bumpalo::vec![in &b; 0; 5];
-/// assert_eq!(vec, [0, 0, 0, 0, 0]);
-///
-/// // The following is equivalent, but potentially slower:
-/// let mut vec1 = Vec::with_capacity_in(5, &b);
-/// vec1.resize(5, 0);
 /// ```
 ///
 /// Use a `Vec<'a, T>` as an efficient stack:
@@ -386,7 +282,7 @@ macro_rules! vec {
 ///
 /// let b = Bump::new();
 ///
-/// let v = bumpalo::vec![in &b; 0, 2, 4, 6];
+/// let v = Vec::from_iter_in([0, 2, 4, 6], &b);
 /// println!("{}", v[1]); // it will display '2'
 /// ```
 ///
@@ -398,7 +294,7 @@ macro_rules! vec {
 ///
 /// let b = Bump::new();
 ///
-/// let v = bumpalo::vec![in &b; 0, 2, 4, 6];
+/// let v = Vec::from_iter_in([0, 2, 4, 6], &b);
 /// println!("{}", v[6]); // it will panic!
 /// ```
 ///
@@ -419,7 +315,7 @@ macro_rules! vec {
 ///
 /// let b = Bump::new();
 ///
-/// let v = bumpalo::vec![in &b; 0, 1];
+/// let v = Vec::from_iter_in([0, 1], &b);
 /// read_slice(&v);
 ///
 /// // ... and that's all!
@@ -462,7 +358,7 @@ macro_rules! vec {
 /// The pointer will never be null, so this type is null-pointer-optimized.
 ///
 /// However, the pointer may not actually point to allocated memory. In particular,
-/// if you construct a `Vec` with capacity 0 via [`Vec::new_in`], [`bumpalo::vec![in alloc]`][`vec!`],
+/// if you construct a `Vec` with capacity 0 via [`Vec::new_in`],
 /// [`Vec::with_capacity_in(0)`][`Vec::with_capacity_in`], or by calling [`shrink_to_fit`]
 /// on an empty Vec, it will not allocate memory. Similarly, if you store zero-sized
 /// types inside a `Vec`, it will not allocate space for them. *Note that in this case
@@ -508,12 +404,10 @@ macro_rules! vec {
 /// and it may prove desirable to use a non-constant growth factor. Whatever
 /// strategy is used will of course guarantee `O(1)` amortized [`push`].
 ///
-/// `bumpalo::vec![in alloc; x; n]`, `bumpalo::vec![in alloc; a, b, c, d]`, and
-/// [`Vec::with_capacity_in(n)`][`Vec::with_capacity_in`], will all produce a
-/// `Vec` with exactly the requested capacity. If <code>[`len`] == [`capacity`]</code>, (as
-/// is the case for the [`vec!`] macro), then a `Vec<'a, T>` can be converted
-/// to and from a [`Box<[T]>`][owned slice] without reallocating or moving the
-/// elements.
+/// [`Vec::with_capacity_in(n)`][`Vec::with_capacity_in`], will produce a
+/// `Vec` with exactly the requested capacity. If <code>[`len`] == [`capacity`]</code>,
+/// then a `Vec<'a, T>` can be converted to and from a [`Box<[T]>`][owned slice]
+/// without reallocating or moving the elements.
 ///
 /// `Vec` will not specifically overwrite any data that is removed from it,
 /// but also won't specifically preserve it. Its uninitialized memory is
@@ -529,7 +423,6 @@ macro_rules! vec {
 /// `Vec` does not currently guarantee the order in which elements are dropped.
 /// The order has changed in the past and may change again.
 ///
-/// [`vec!`]: ../../macro.vec.html
 /// [`Index`]: https://doc.rust-lang.org/std/ops/trait.Index.html
 /// [`String`]: ../string/struct.String.html
 /// [`&str`]: https://doc.rust-lang.org/std/primitive.str.html
@@ -661,7 +554,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut v = bumpalo::vec![in &b; 1, 2, 3];
+    /// let mut v = Vec::from_iter_in([1, 2, 3], &b);
     ///
     /// // Pull out the various important pieces of information about `v`
     /// let p = v.as_mut_ptr();
@@ -701,7 +594,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let a = bumpalo::vec![in &b; 1, 2, 3];
+    /// let a = Vec::from_iter_in([1, 2, 3], &b);
     /// assert_eq!(a.len(), 3);
     /// ```
     #[inline]
@@ -771,7 +664,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut vec = bumpalo::vec![in &b; 'r', 'u', 's', 't'];
+    /// let mut vec = Vec::from_iter_in(['r', 'u', 's', 't'], &b);
     ///
     /// unsafe {
     ///     ptr::drop_in_place(&mut vec[3]);
@@ -788,10 +681,9 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut vec = bumpalo::vec![in &b;
-    ///                             bumpalo::vec![in &b; 1, 0, 0],
-    ///                             bumpalo::vec![in &b; 0, 1, 0],
-    ///                             bumpalo::vec![in &b; 0, 0, 1]];
+    /// let mut vec = Vec::new_in(&b);
+    /// vec.push("foo".to_string());
+    ///
     /// unsafe {
     ///     vec.set_len(0);
     /// }
@@ -864,7 +756,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     /// use bumpalo::{Bump, collections::Vec};
     ///
     /// let b = Bump::new();
-    /// let mut vec = bumpalo::vec![in &b; 1];
+    /// let mut vec = Vec::from_iter_in([1], &b);
     /// vec.reserve(10);
     /// assert!(vec.capacity() >= 11);
     /// ```
@@ -891,7 +783,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     /// use bumpalo::{Bump, collections::Vec};
     ///
     /// let b = Bump::new();
-    /// let mut vec = bumpalo::vec![in &b; 1];
+    /// let mut vec = Vec::from_iter_in([1], &b);
     /// vec.reserve_exact(10);
     /// assert!(vec.capacity() >= 11);
     /// ```
@@ -915,7 +807,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     /// use bumpalo::{Bump, collections::Vec};
     ///
     /// let b = Bump::new();
-    /// let mut vec = bumpalo::vec![in &b; 1];
+    /// let mut vec = Vec::from_iter_in([1], &b);
     /// vec.try_reserve(10).unwrap();
     /// assert!(vec.capacity() >= 11);
     /// ```
@@ -942,7 +834,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     /// use bumpalo::{Bump, collections::Vec};
     ///
     /// let b = Bump::new();
-    /// let mut vec = bumpalo::vec![in &b; 1];
+    /// let mut vec = Vec::from_iter_in([1], &b);
     /// vec.try_reserve_exact(10).unwrap();
     /// assert!(vec.capacity() >= 11);
     /// ```
@@ -982,7 +874,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     /// use bumpalo::{Bump, collections::Vec};
     ///
     /// let b = Bump::new();
-    /// let v = bumpalo::vec![in &b; 1, 2, 3];
+    /// let v = Vec::from_iter_in([1, 2, 3], &b);
     ///
     /// let slice = v.into_bump_slice();
     /// assert_eq!(slice, [1, 2, 3]);
@@ -1004,7 +896,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     /// use bumpalo::{Bump, collections::Vec};
     ///
     /// let b = Bump::new();
-    /// let v = bumpalo::vec![in &b; 1, 2, 3];
+    /// let v = Vec::from_iter_in([1, 2, 3], &b);
     ///
     /// let mut slice = v.into_bump_slice_mut();
     ///
@@ -1042,7 +934,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut vec = bumpalo::vec![in &b; 1, 2, 3, 4, 5];
+    /// let mut vec = Vec::from_iter_in([1, 2, 3, 4, 5], &b);
     /// vec.truncate(2);
     /// assert_eq!(vec, [1, 2]);
     /// ```
@@ -1055,7 +947,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut vec = bumpalo::vec![in &b; 1, 2, 3];
+    /// let mut vec = Vec::from_iter_in([1, 2, 3], &b);
     /// vec.truncate(8);
     /// assert_eq!(vec, [1, 2, 3]);
     /// ```
@@ -1068,7 +960,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut vec = bumpalo::vec![in &b; 1, 2, 3];
+    /// let mut vec = Vec::from_iter_in([1, 2, 3], &b);
     /// vec.truncate(0);
     /// assert_eq!(vec, []);
     /// ```
@@ -1097,7 +989,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let buffer = bumpalo::vec![in &b; 1, 2, 3, 5, 8];
+    /// let buffer = Vec::from_iter_in([1, 2, 3, 5, 8], &b);
     /// io::sink().write(buffer.as_slice()).unwrap();
     /// ```
     #[inline]
@@ -1116,7 +1008,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     /// use std::io::{self, Read};
     ///
     /// let b = Bump::new();
-    /// let mut buffer = bumpalo::vec![in &b; 0; 3];
+    /// let mut buffer = Vec::from_iter_in([0; 3], &b);
     /// io::repeat(0b101).read_exact(buffer.as_mut_slice()).unwrap();
     /// ```
     #[inline]
@@ -1143,7 +1035,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     ///
     /// let arena = Bump::new();
     ///
-    /// let x = bumpalo::vec![in &arena; 1, 2, 4];
+    /// let x = Vec::from_iter_in([1, 2, 4], &arena);
     /// let x_ptr = x.as_ptr();
     ///
     /// unsafe {
@@ -1226,7 +1118,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut v = bumpalo::vec![in &b; "foo", "bar", "baz", "qux"];
+    /// let mut v = Vec::from_iter_in(["foo", "bar", "baz", "qux"], &b);
     ///
     /// assert_eq!(v.swap_remove(1), "bar");
     /// assert_eq!(v, ["foo", "qux", "baz"]);
@@ -1261,7 +1153,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut vec = bumpalo::vec![in &b; 1, 2, 3];
+    /// let mut vec = Vec::from_iter_in([1, 2, 3], &b);
     /// vec.insert(1, 4);
     /// assert_eq!(vec, [1, 4, 2, 3]);
     /// vec.insert(4, 5);
@@ -1306,7 +1198,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut v = bumpalo::vec![in &b; 1, 2, 3];
+    /// let mut v = Vec::from_iter_in([1, 2, 3], &b);
     /// assert_eq!(v.remove(1), 2);
     /// assert_eq!(v, [1, 3]);
     /// ```
@@ -1375,7 +1267,11 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     /// # Examples
     ///
     /// ```
-    /// let mut vec = vec![1, 2, 3, 4];
+    /// use bumpalo::{Bump, collections::Vec};
+    ///
+    /// let b = Bump::new();
+    ///
+    /// let mut vec = Vec::from_iter_in([1, 2, 3, 4], &b);
     /// vec.retain_mut(|x| if *x <= 3 {
     ///     *x += 1;
     ///     true
@@ -1498,7 +1394,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut numbers = bumpalo::vec![in &b; 1, 2, 3, 4, 5];
+    /// let mut numbers = Vec::from_iter_in([1, 2, 3, 4, 5], &b);
     ///
     /// let evens: Vec<_> = numbers.drain_filter(|x| *x % 2 == 0).collect_in(&b);
     ///
@@ -1531,7 +1427,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut vec = bumpalo::vec![in &b; 10, 20, 21, 30, 20];
+    /// let mut vec = Vec::from_iter_in([10, 20, 21, 30, 20], &b);
     ///
     /// vec.dedup_by_key(|i| *i / 10);
     ///
@@ -1562,7 +1458,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut vec = bumpalo::vec![in &b; "foo", "bar", "Bar", "baz", "bar"];
+    /// let mut vec = Vec::from_iter_in(["foo", "bar", "Bar", "baz", "bar"], &b);
     ///
     /// vec.dedup_by(|a, b| a.eq_ignore_ascii_case(b));
     ///
@@ -1592,7 +1488,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut vec = bumpalo::vec![in &b; 1, 2];
+    /// let mut vec = Vec::from_iter_in([1, 2], &b);
     /// vec.push(3);
     /// assert_eq!(vec, [1, 2, 3]);
     /// ```
@@ -1622,7 +1518,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut vec = bumpalo::vec![in &b; 1, 2, 3];
+    /// let mut vec = Vec::from_iter_in([1, 2, 3], &b);
     /// assert_eq!(vec.pop(), Some(3));
     /// assert_eq!(vec, [1, 2]);
     /// ```
@@ -1652,8 +1548,8 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut vec = bumpalo::vec![in &b; 1, 2, 3];
-    /// let mut vec2 = bumpalo::vec![in &b; 4, 5, 6];
+    /// let mut vec = Vec::from_iter_in([1, 2, 3], &b);
+    /// let mut vec2 = Vec::from_iter_in([4, 5, 6], &b);
     /// vec.append(&mut vec2);
     /// assert_eq!(vec, [1, 2, 3, 4, 5, 6]);
     /// assert_eq!(vec2, []);
@@ -1714,7 +1610,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut v = bumpalo::vec![in &b; 1, 2, 3];
+    /// let mut v = Vec::from_iter_in([1, 2, 3], &b);
     ///
     /// let u: Vec<_> = v.drain(1..).collect_in(&b);
     ///
@@ -1780,7 +1676,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut v = bumpalo::vec![in &b; 1, 2, 3];
+    /// let mut v = Vec::from_iter_in([1, 2, 3], &b);
     ///
     /// v.clear();
     ///
@@ -1828,7 +1724,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut vec = bumpalo::vec![in &b; 1, 2, 3];
+    /// let mut vec = Vec::from_iter_in([1, 2, 3], &b);
     /// let vec2 = vec.split_off(1);
     /// assert_eq!(vec, [1]);
     /// assert_eq!(vec2, [2, 3]);
@@ -1868,7 +1764,7 @@ impl<'a, T> Vec<'a, T> {
     ///
     /// let b = Bump::new();
     ///
-    /// let v = vec![in &b; 1, 2, 3];
+    /// let v = Vec::from_iter_in([1, 2, 3], &b);
     ///
     /// let slice = v.into_boxed_slice();
     /// ```
@@ -1904,11 +1800,11 @@ impl<'a, T: 'a + Clone, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut vec = bumpalo::vec![in &b; "hello"];
+    /// let mut vec = Vec::from_iter_in(["hello"], &b);
     /// vec.resize(3, "world");
     /// assert_eq!(vec, ["hello", "world", "world"]);
     ///
-    /// let mut vec = bumpalo::vec![in &b; 1, 2, 3, 4];
+    /// let mut vec = Vec::from_iter_in([1, 2, 3, 4], &b);
     /// vec.resize(2, 0);
     /// assert_eq!(vec, [1, 2]);
     /// ```
@@ -1943,7 +1839,7 @@ impl<'a, T: 'a + Clone, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut vec = bumpalo::vec![in &b; 1];
+    /// let mut vec = Vec::from_iter_in([1], &b);
     /// vec.extend_from_slice(&[2, 3, 4]);
     /// assert_eq!(vec, [1, 2, 3, 4]);
     /// ```
@@ -1998,7 +1894,7 @@ impl<'a, T: 'a + Copy, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut vec = bumpalo::vec![in &b; 1];
+    /// let mut vec = Vec::from_iter_in([1], &b);
     /// vec.extend_from_slice_copy(&[2, 3, 4]);
     /// assert_eq!(vec, [1, 2, 3, 4]);
     /// ```
@@ -2008,7 +1904,7 @@ impl<'a, T: 'a + Copy, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut vec = bumpalo::vec![in &b; 'H' as u8];
+    /// let mut vec = Vec::from_iter_in(['H' as u8], &b);
     /// vec.extend_from_slice_copy("ello, world!".as_bytes());
     /// assert_eq!(vec, "Hello, world!".as_bytes());
     /// ```
@@ -2047,7 +1943,7 @@ impl<'a, T: 'a + Copy, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut vec = bumpalo::vec![in &b; 1];
+    /// let mut vec = Vec::from_iter_in([1], &b);
     /// vec.extend_from_slices_copy(&[&[2, 3], &[], &[4]]);
     /// assert_eq!(vec, [1, 2, 3, 4]);
     /// ```
@@ -2057,7 +1953,7 @@ impl<'a, T: 'a + Copy, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut vec = bumpalo::vec![in &b; 'H' as u8];
+    /// let mut vec = Vec::from_iter_in(['H' as u8], &b);
     /// vec.extend_from_slices_copy(&["ello,".as_bytes(), &[], " world!".as_bytes()]);
     /// assert_eq!(vec, "Hello, world!".as_bytes());
     /// ```
@@ -2155,7 +2051,7 @@ impl<'a, T: 'a + PartialEq, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut vec = bumpalo::vec![in &b; 1, 2, 2, 3, 2];
+    /// let mut vec = Vec::from_iter_in([1, 2, 2, 3, 2], &b);
     ///
     /// vec.dedup();
     ///
@@ -2257,7 +2153,7 @@ impl<'a, T: 'a, A: Alloc> IntoIterator for Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let v = bumpalo::vec![in &b; "a".to_string(), "b".to_string()];
+    /// let v = Vec::from_iter_in(["a".to_string(), "b".to_string()], &b);
     /// for s in v.into_iter() {
     ///     // s has type String, not &String
     ///     println!("{}", s);
@@ -2377,7 +2273,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     ///
     /// let b = Bump::new();
     ///
-    /// let mut v = bumpalo::vec![in &b; 1, 2, 3];
+    /// let mut v = Vec::from_iter_in([1, 2, 3], &b);
     /// let new = [7, 8];
     /// let u: Vec<_> = Vec::from_iter_in(v.splice(..2, new.iter().cloned()), &b);
     /// assert_eq!(v, &[7, 8, 3]);
@@ -2573,7 +2469,7 @@ impl<'a, T: 'a> IntoIter<'a, T> {
     ///
     /// let b = Bump::new();
     ///
-    /// let vec = bumpalo::vec![in &b; 'a', 'b', 'c'];
+    /// let vec = Vec::from_iter_in(['a', 'b', 'c'], &b);
     /// let mut into_iter = vec.into_iter();
     /// assert_eq!(into_iter.as_slice(), &['a', 'b', 'c']);
     /// let _ = into_iter.next().unwrap();
@@ -2592,7 +2488,7 @@ impl<'a, T: 'a> IntoIter<'a, T> {
     ///
     /// let b = Bump::new();
     ///
-    /// let vec = bumpalo::vec![in &b; 'a', 'b', 'c'];
+    /// let vec = Vec::from_iter_in(['a', 'b', 'c'], &b);
     /// let mut into_iter = vec.into_iter();
     /// assert_eq!(into_iter.as_slice(), &['a', 'b', 'c']);
     /// into_iter.as_mut_slice()[2] = 'z';


### PR DESCRIPTION
Remove `vec!` macro from `oxc_allocator`. This is in the `vec2::raw_vec` module, but is accidentally exposed due to the `#[macro_export]` attribute.

This macro creates a `bumpalo::collections::Vec`, instead of our own `Vec` type, which is confusing.

We could add a `vec!` macro which creates our own `Vec` type, but that's not completely trivial (how to handle cloning `item` in `vec![item; 3]`? `Clone` or `CloneIn`?). So for now, just remove this erroneous macro entirely.
