### PR TITLE
test(transformer/styled-components): fix memory leak

### DIFF
--- a/crates/oxc_transformer/src/plugins/styled_components.rs
+++ b/crates/oxc_transformer/src/plugins/styled_components.rs
@@ -1256,8 +1256,8 @@ mod tests {
 
         #[test]
         fn returns_indices_of_removed_placeholders() {
-            let allocator = Box::leak(Box::new(Allocator::default()));
-            let ast = AstBuilder::new(allocator);
+            let allocator = Allocator::default();
+            let ast = AstBuilder::new(&allocator);
 
             // Create raw values that will generate placeholders
             let css = "this is some\ninput with __PLACEHOLDER_0__ and // ignored __PLACEHOLDER_1__";


### PR DESCRIPTION
Fix memory leak in tests for `styled-components` transform.

```rs
let allocator = Box::leak(Box::new(Allocator::default()));
let ast = AstBuilder::new(allocator);
```

Miri didn't run on the PR that introduced this code, but it caught the leak in an unrelated PR touching `oxc_allocator` which ran Miri in CI: https://github.com/oxc-project/oxc/actions/runs/16203915572/job/45749445785?pr=12203#step:5:822

I'm unclear why `Box::leak` was used here.
