### PR TITLE
refactor(oxlint): adjust ignore patterns by counting bytes instead of chars

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -532,7 +532,7 @@ impl LintRunner {
             ignore_patterns
                 .into_iter()
                 .map(|pattern| {
-                    let prefix_len = pattern.chars().take_while(|&c| c == '!').count();
+                    let prefix_len = pattern.bytes().take_while(|&c| c == b'!').count();
                     let (prefix, pattern) = pattern.split_at(prefix_len);
 
                     let adjusted_path = relative_ignore_path.join(pattern);


### PR DESCRIPTION
`split_at` accepts the offset by bytes. 

Could not create a test where the chars vs bytes could matter:
https://github.com/oxc-project/oxc/blob/29516454d52d2197f9332b39162d27c913f31af6/apps/oxlint/src/lint.rs#L1026-L1039