### PR TITLE
fix(transformer/legacy-decorator): decorated fields with the `declare` modifier are not transformed

### DIFF
--- a/crates/oxc_transformer/src/decorator/legacy/metadata.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/metadata.rs
@@ -174,7 +174,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for LegacyDecoratorMetadata<'a, '_> {
         prop: &mut PropertyDefinition<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        if prop.declare || prop.decorators.is_empty() {
+        if prop.decorators.is_empty() {
             return;
         }
         prop.decorators.push(self.create_design_type_metadata(prop.type_annotation.as_ref(), ctx));

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -885,8 +885,8 @@ impl<'a> LegacyDecorator<'a, '_> {
                             PrivateInExpressionDetector::has_private_in_expression_in_method_decorator(method);
                     }
                 }
-                ClassElement::PropertyDefinition(prop) if !prop.declare => {
-                    class_element_is_decorated |= !prop.decorators.is_empty();
+                ClassElement::PropertyDefinition(prop) if !prop.decorators.is_empty() => {
+                    class_element_is_decorated = true;
 
                     if class_element_is_decorated && !has_private_in_expression_in_decorator {
                         has_private_in_expression_in_decorator =
@@ -895,8 +895,8 @@ impl<'a> LegacyDecorator<'a, '_> {
                             );
                     }
                 }
-                ClassElement::AccessorProperty(accessor) => {
-                    class_element_is_decorated |= !accessor.decorators.is_empty();
+                ClassElement::AccessorProperty(accessor) if !accessor.decorators.is_empty() => {
+                    class_element_is_decorated = true;
 
                     if class_element_is_decorated && !has_private_in_expression_in_decorator {
                         has_private_in_expression_in_decorator =

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -303,9 +303,6 @@ impl<'a> Traverse<'a, TransformState<'a>> for TransformerImpl<'a, '_> {
     }
 
     fn enter_class_body(&mut self, body: &mut ClassBody<'a>, ctx: &mut TraverseCtx<'a>) {
-        if let Some(typescript) = self.x0_typescript.as_mut() {
-            typescript.enter_class_body(body, ctx);
-        }
         self.x2_es2022.enter_class_body(body, ctx);
     }
 

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -223,9 +223,9 @@ impl<'a> Traverse<'a, TransformState<'a>> for TypeScriptAnnotations<'a, '_> {
         class.r#abstract = false;
     }
 
-    fn enter_class_body(&mut self, body: &mut ClassBody<'a>, _ctx: &mut TraverseCtx<'a>) {
+    fn exit_class(&mut self, class: &mut Class<'a>, _: &mut TraverseCtx<'a>) {
         // Remove type only members
-        body.body.retain(|elem| match elem {
+        class.body.body.retain(|elem| match elem {
             ClassElement::MethodDefinition(method) => {
                 matches!(method.r#type, MethodDefinitionType::MethodDefinition)
                     && !method.value.is_typescript_syntax()
@@ -346,7 +346,6 @@ impl<'a> Traverse<'a, TransformState<'a>> for TypeScriptAnnotations<'a, '_> {
         );
 
         def.accessibility = None;
-        def.declare = false;
         def.definite = false;
         def.r#override = false;
         def.optional = false;

--- a/crates/oxc_transformer/src/typescript/class.rs
+++ b/crates/oxc_transformer/src/typescript/class.rs
@@ -246,14 +246,13 @@ impl<'a> TypeScript<'a, '_> {
         constructor: &mut MethodDefinition<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        if !constructor.kind.is_constructor() {
+        if !constructor.kind.is_constructor() || constructor.value.body.is_none() {
             return;
         }
 
         let params = &constructor.value.params.items;
         let assignments = Self::convert_constructor_params(params, ctx).collect::<Vec<_>>();
 
-        // `constructor {}` is guaranteed that it is `Some`.
         let constructor_body_statements = &mut constructor.value.body.as_mut().unwrap().statements;
         let super_call_position = Self::get_super_call_position(constructor_body_statements);
 

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -131,11 +131,8 @@ impl<'a> Traverse<'a, TransformState<'a>> for TypeScript<'a, '_> {
     }
 
     fn exit_class(&mut self, class: &mut Class<'a>, ctx: &mut TraverseCtx<'a>) {
+        self.annotations.exit_class(class, ctx);
         self.transform_class_on_exit(class, ctx);
-    }
-
-    fn enter_class_body(&mut self, body: &mut ClassBody<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.annotations.enter_class_body(body, ctx);
     }
 
     fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -2,7 +2,7 @@ commit: 1d4546bc
 
 semantic_babel Summary:
 AST Parsed     : 2362/2362 (100.00%)
-Positive Passed: 1948/2362 (82.47%)
+Positive Passed: 1949/2362 (82.51%)
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/decorators/decorators-after-export/input.js
 Symbol span mismatch for "C":
 after transform: SymbolId(0): Span { start: 65, end: 66 }
@@ -116,14 +116,20 @@ after transform: ScopeId(1): [ScopeId(2)]
 rebuilt        : ScopeId(1): []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-private-method/typescript-invalid-abstract/input.ts
+Bindings mismatch:
+after transform: ScopeId(0): ["TSAbstractClass", "_TSAbstractClass_brand", "_classPrivateMethodInitSpec", "_foo"]
+rebuilt        : ScopeId(0): ["TSAbstractClass", "_TSAbstractClass_brand", "_classPrivateMethodInitSpec"]
 Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): []
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(1): [ScopeId(2)]
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-private-method/typescript-invalid-abstract-babel-7/input.ts
+Bindings mismatch:
+after transform: ScopeId(0): ["TSAbstractClass", "_TSAbstractClass_brand", "_classPrivateMethodInitSpec", "_foo"]
+rebuilt        : ScopeId(0): ["TSAbstractClass", "_TSAbstractClass_brand", "_classPrivateMethodInitSpec"]
 Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): []
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(1): [ScopeId(2)]
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-private-property/typescript/input.js
 Unresolved references mismatch:
@@ -401,11 +407,6 @@ Multiple constructor implementations are not allowed.
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/declare/input.ts
 Identifier `x` has already been declared
 
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/declare-readonly-field-initializer/input.ts
-Unresolved references mismatch:
-after transform: ["a"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/expression-extends/input.ts
 Unresolved references mismatch:
 after transform: ["T", "f"]
@@ -528,6 +529,9 @@ semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescr
 A required parameter cannot follow an optional parameter.
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/private-method-overload/input.ts
+Bindings mismatch:
+after transform: ScopeId(0): ["Test", "_Test_brand", "_classPrivateMethodInitSpec", "_f", "_f2", "_f3"]
+rebuilt        : ScopeId(0): ["Test", "_Test_brand", "_classPrivateMethodInitSpec", "_f"]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(5)]
 rebuilt        : ScopeId(1): [ScopeId(2)]

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -216,10 +216,10 @@ rebuilt        : ScopeId(0): []
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/abstractPropertyBasics.ts
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(1): []
+after transform: ScopeId(3): [ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(11)]
+rebuilt        : ScopeId(1): [ScopeId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/acceptableAlias1.ts
 Bindings mismatch:
@@ -8625,12 +8625,9 @@ after transform: SymbolId(0): [ReferenceId(2), ReferenceId(8), ReferenceId(9)]
 rebuilt        : SymbolId(0): [ReferenceId(8), ReferenceId(9)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataElidedImportOnDeclare.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Observable", "Test", "whatever"]
-rebuilt        : ScopeId(0): ["Test", "whatever"]
-Symbol reference IDs mismatch for "whatever":
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
+Symbol reference IDs mismatch for "Observable":
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3), ReferenceId(4)]
+rebuilt        : SymbolId(0): [ReferenceId(5), ReferenceId(6)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataForMethodWithNoReturnTypeAnnotation01.ts
 Bindings mismatch:
@@ -12966,21 +12963,27 @@ after transform: ["DecoratorContext", "require"]
 rebuilt        : ["require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/esNextWeakRefs_IterableWeakMap.ts
+Symbol reference IDs mismatch for "_Symbol$toStringTag":
+after transform: SymbolId(26): [ReferenceId(73), ReferenceId(74)]
+rebuilt        : SymbolId(3): [ReferenceId(6)]
+Symbol reference IDs mismatch for "_Symbol$iterator":
+after transform: SymbolId(29): [ReferenceId(82), ReferenceId(83)]
+rebuilt        : SymbolId(4): [ReferenceId(18)]
 Unresolved references mismatch:
 after transform: ["FinalizationRegistry", "Generator", "Iterable", "Object", "Set", "Symbol", "WeakMap", "WeakRef", "undefined"]
 rebuilt        : ["FinalizationRegistry", "Object", "Set", "Symbol", "WeakMap", "WeakRef", "undefined"]
 Unresolved reference IDs mismatch for "WeakRef":
 after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(11), ReferenceId(15), ReferenceId(33)]
-rebuilt        : [ReferenceId(26)]
+rebuilt        : [ReferenceId(30)]
 Unresolved reference IDs mismatch for "Set":
 after transform: [ReferenceId(1), ReferenceId(14)]
-rebuilt        : [ReferenceId(10)]
+rebuilt        : [ReferenceId(12)]
 Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(8), ReferenceId(55), ReferenceId(69), ReferenceId(72)]
-rebuilt        : [ReferenceId(81), ReferenceId(84)]
+rebuilt        : [ReferenceId(85), ReferenceId(88)]
 Unresolved reference IDs mismatch for "WeakMap":
-after transform: [ReferenceId(5), ReferenceId(9), ReferenceId(108), ReferenceId(109), ReferenceId(110)]
-rebuilt        : [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(7)]
+after transform: [ReferenceId(5), ReferenceId(9), ReferenceId(114), ReferenceId(115), ReferenceId(116)]
+rebuilt        : [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(9)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/escapedIdentifiers.ts
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -18816,14 +18819,17 @@ rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/iterableTReturnTNext.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["MyMap", "_source", "_wrapAsyncGenerator", "doubles", "map", "r1", "r2", "r3", "set", "source"]
-rebuilt        : ScopeId(0): ["MyMap", "_source", "_wrapAsyncGenerator", "doubles", "r1", "r2", "r3", "source"]
+after transform: ScopeId(0): ["MyMap", "_Symbol$iterator", "_Symbol$toStringTag", "_defineProperty", "_source", "_wrapAsyncGenerator", "doubles", "map", "r1", "r2", "r3", "set", "source"]
+rebuilt        : ScopeId(0): ["MyMap", "_Symbol$iterator", "_Symbol$toStringTag", "_defineProperty", "_source", "_wrapAsyncGenerator", "doubles", "r1", "r2", "r3", "source"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(15), ScopeId(16)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
 Scope children mismatch:
 after transform: ScopeId(6): [ScopeId(7)]
-rebuilt        : ScopeId(7): []
+rebuilt        : ScopeId(8): []
+Symbol reference IDs mismatch for "_Symbol$toStringTag":
+after transform: SymbolId(20): [ReferenceId(29), ReferenceId(30)]
+rebuilt        : SymbolId(2): [ReferenceId(19)]
 Reference symbol mismatch for "map":
 after transform: SymbolId(0) "map"
 rebuilt        : <None>
@@ -18838,7 +18844,7 @@ after transform: ["Error", "Map", "MapIterator", "Set", "Symbol", "arguments", "
 rebuilt        : ["Error", "Symbol", "arguments", "map", "require", "set", "undefined"]
 Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(10), ReferenceId(17)]
-rebuilt        : [ReferenceId(15)]
+rebuilt        : [ReferenceId(14)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jqueryInference.ts
 Bindings mismatch:
@@ -19837,13 +19843,13 @@ rebuilt        : []
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mergedInstantiationAssignment.ts
 Symbol reference IDs mismatch for "GenericObject":
 after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
+rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch for "GenericObjectWithoutSetter":
 after transform: SymbolId(4): [ReferenceId(5), ReferenceId(6)]
-rebuilt        : SymbolId(3): [ReferenceId(2)]
+rebuilt        : SymbolId(4): [ReferenceId(4)]
 Symbol reference IDs mismatch for "NormalObject":
 after transform: SymbolId(7): [ReferenceId(8), ReferenceId(9)]
-rebuilt        : SymbolId(5): [ReferenceId(4)]
+rebuilt        : SymbolId(6): [ReferenceId(6)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mergedInterfaceFromMultipleFiles1.ts
 Scope children mismatch:
@@ -36363,14 +36369,20 @@ rebuilt        : ["Object", "dec", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorInAmbientContext.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "b", "decorator"]
-rebuilt        : ScopeId(0): ["Foo", "b"]
+after transform: ScopeId(0): ["Foo", "_decorate", "_decorateMetadata", "_defineProperty", "b", "decorator"]
+rebuilt        : ScopeId(0): ["Foo", "_decorate", "_decorateMetadata", "_defineProperty", "b"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(3): [ReferenceId(3)]
-rebuilt        : SymbolId(0): []
+Reference symbol mismatch for "decorator":
+after transform: SymbolId(0) "decorator"
+rebuilt        : <None>
+Reference symbol mismatch for "decorator":
+after transform: SymbolId(0) "decorator"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: ["Number", "Symbol", "require"]
+rebuilt        : ["Number", "Symbol", "decorator", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorMetadata.ts
 Bindings mismatch:

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 1d4546bc
 
-Passed: 176/293
+Passed: 178/295
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -494,7 +494,7 @@ after transform: SymbolId(4): ScopeId(1)
 rebuilt        : SymbolId(5): ScopeId(4)
 
 
-# legacy-decorators (4/76)
+# legacy-decorators (6/78)
 * oxc/metadata/abstract-class/input.ts
 Symbol reference IDs mismatch for "Dependency":
 after transform: SymbolId(1): [ReferenceId(1), ReferenceId(2), ReferenceId(3)]

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/fields-with-declare-modifier/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/fields-with-declare-modifier/input.ts
@@ -1,0 +1,4 @@
+class DeclareFields {
+	@dec declare name: number;
+	@dec declare output: string;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/fields-with-declare-modifier/output.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/fields-with-declare-modifier/output.ts
@@ -1,0 +1,4 @@
+class DeclareFields {}
+
+babelHelpers.decorate([dec], DeclareFields.prototype, "name", void 0);
+babelHelpers.decorate([dec], DeclareFields.prototype, "output", void 0);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/fields-with-declare-modifier/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/fields-with-declare-modifier/input.ts
@@ -1,0 +1,4 @@
+class DeclareFields {
+	@dec declare name: number;
+	@dec declare output: string;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/fields-with-declare-modifier/output.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/fields-with-declare-modifier/output.ts
@@ -1,0 +1,15 @@
+class DeclareFields {}
+
+babelHelpers.decorate(
+	[dec, babelHelpers.decorateMetadata("design:type", Number)],
+	DeclareFields.prototype,
+	"name",
+	void 0,
+);
+
+babelHelpers.decorate(
+	[dec, babelHelpers.decorateMetadata("design:type", String)],
+	DeclareFields.prototype,
+	"output",
+	void 0,
+);


### PR DESCRIPTION
Input: 
```ts
class DeclareFields {
  @dec declare name: string;
  @dec declare output: number;
}
```

Before output:
```ts
class DeclareFields {}
```

After output:
```ts
class DeclareFields {}

babelHelpers.decorate([dec], DeclareFields.prototype, "name", void 0);
babelHelpers.decorate([dec], DeclareFields.prototype, "output", void 0);
```


The `declare` fields with decorators should be transformed, but they would be removed in the typescript plugin before legacy decorators transform them, so this PR is to adjust the transform order and allow `declare` fields can be transformed 


