### PR TITLE
refactor(semantic): streamline handling of no side effects for function

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -155,6 +155,11 @@ impl<'a> Binder<'a> for Function<'a> {
 
             let symbol_id = builder.declare_symbol(ident.span, &ident.name, includes, excludes);
             ident.symbol_id.set(Some(symbol_id));
+
+            // Save `@__NO_SIDE_EFFECTS__`
+            if self.pure {
+                builder.scoping.no_side_effects.insert(symbol_id);
+            }
         }
 
         // Bind scope flags: GetAccessor | SetAccessor
@@ -171,13 +176,6 @@ impl<'a> Binder<'a> for Function<'a> {
                 PropertyKind::Get => *flags |= ScopeFlags::GetAccessor,
                 PropertyKind::Set => *flags |= ScopeFlags::SetAccessor,
                 PropertyKind::Init => {}
-            }
-        }
-
-        // Save `@__NO_SIDE_EFFECTS__`
-        if self.pure {
-            if let Some(symbol_id) = self.id.as_ref().and_then(|id| id.symbol_id.get()) {
-                builder.scoping.no_side_effects.insert(symbol_id);
             }
         }
     }


### PR DESCRIPTION
Pure refactor. `symbol_id` is declared earlier, so we don't need to get the symbol_id from the function again.