### PR TITLE
feat(ast): compute max value that can be mapped to `AstType`

### DIFF
--- a/crates/oxc_ast/src/generated/ast_kind.rs
+++ b/crates/oxc_ast/src/generated/ast_kind.rs
@@ -203,6 +203,9 @@ pub enum AstType {
     JSDocUnknownType = 186,
 }
 
+/// The largest integer value that can be mapped to an `AstType`/`AstKind` enum variant.
+pub const AST_TYPE_MAX: u16 = 187;
+
 /// Untyped AST Node Kind
 #[derive(Debug, Clone, Copy)]
 #[repr(C, u8)]

--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -132,6 +132,8 @@ impl Generator for AstKindGenerator {
             next_index += 1;
         }
 
+        let ast_type_max = number_lit(next_index);
+
         let output = quote! {
             #![expect(missing_docs)] ///@ FIXME (in ast_tools/src/generators/ast_kind.rs)
 
@@ -151,6 +153,10 @@ impl Generator for AstKindGenerator {
             pub enum AstType {
                 #type_variants
             }
+
+            ///@@line_break
+            /// The largest integer value that can be mapped to an `AstType`/`AstKind` enum variant.
+            pub const AST_TYPE_MAX: u16 = #ast_type_max;
 
             ///@@line_break
             /// Untyped AST Node Kind


### PR DESCRIPTION
- part of https://github.com/oxc-project/oxc/issues/12223

This adds an automatically generated `usize` which represents the largest variant that is contained in `AstKind`/`AstType`. In following PRs, this is used to create a set of bits that is exactly sized to the number of different AST node types there are.