### PR TITLE
perf(linter): add `should_run` based on node types (batch 2)

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_case.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_case.rs
@@ -92,6 +92,10 @@ impl Rule for NoDuplicateCase {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::SwitchStatement)
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
@@ -66,6 +66,10 @@ impl Rule for NoEmptyCharacterClass {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::RegExpLiteral)
+    }
 }
 
 struct EmptyClassFinder {

--- a/crates/oxc_linter/src/rules/eslint/no_empty_pattern.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_pattern.rs
@@ -83,6 +83,12 @@ impl Rule for NoEmptyPattern {
         };
         ctx.diagnostic(no_empty_pattern_diagnostic(pattern_type, span));
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic()
+            .nodes()
+            .contains_any(&[oxc_ast::AstType::ObjectPattern, oxc_ast::AstType::ArrayPattern])
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
@@ -68,6 +68,10 @@ impl Rule for NoEmptyStaticBlock {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::StaticBlock)
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
@@ -62,6 +62,12 @@ impl Rule for NoExAssign {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic()
+            .nodes()
+            .contains_any(&[oxc_ast::AstType::TryStatement, oxc_ast::AstType::CatchClause])
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
@@ -128,6 +128,12 @@ impl Rule for NoExtraBooleanCast {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic()
+            .nodes()
+            .contains_any(&[oxc_ast::AstType::CallExpression, oxc_ast::AstType::UnaryExpression])
+    }
 }
 
 // Checks whether the node is a context that should report an error

--- a/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
@@ -81,6 +81,10 @@ impl Rule for NoFuncAssign {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::Function)
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
@@ -81,6 +81,13 @@ impl Rule for NoGlobalAssign {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[
+            oxc_ast::AstType::AssignmentExpression,
+            oxc_ast::AstType::UpdateExpression,
+        ])
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
@@ -99,6 +99,10 @@ impl Rule for NoImportAssign {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::ImportDeclaration)
+    }
 }
 
 /// Check if a given node is at the first argument of a well-known mutation function.

--- a/crates/oxc_linter/src/rules/eslint/no_invalid_regexp.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_invalid_regexp.rs
@@ -160,6 +160,12 @@ impl Rule for NoInvalidRegexp {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic()
+            .nodes()
+            .contains_any(&[oxc_ast::AstType::NewExpression, oxc_ast::AstType::CallExpression])
+    }
 }
 
 fn parse_arguments_to_check<'a>(

--- a/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
@@ -88,6 +88,10 @@ impl Rule for NoLossOfPrecision {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::NumericLiteral)
+    }
 }
 
 pub struct RawNum<'a> {

--- a/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
@@ -64,6 +64,10 @@ impl Rule for NoNewNativeNonconstructor {
             ));
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::NewExpression)
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
@@ -55,6 +55,10 @@ impl Rule for NoNonoctalDecimalEscape {
             check_string(ctx, literal.span.source_text(ctx.source_text()));
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::StringLiteral)
+    }
 }
 trait StickyRegex {
     fn sticky_captures<'h>(&self, haystack: &'h str, start: usize)

--- a/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
@@ -157,6 +157,12 @@ impl Rule for NoObjCalls {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic()
+            .nodes()
+            .contains_any(&[oxc_ast::AstType::NewExpression, oxc_ast::AstType::CallExpression])
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
@@ -127,6 +127,10 @@ impl Rule for NoSelfAssign {
             self.each_self_assignment(&assignment.left, &assignment.right, ctx);
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::AssignmentExpression)
+    }
 }
 
 impl NoSelfAssign {

--- a/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
@@ -56,6 +56,14 @@ impl Rule for NoSetterReturn {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::ReturnStatement)
+            && ctx.semantic().nodes().contains_any(&[
+                oxc_ast::AstType::ObjectProperty,
+                oxc_ast::AstType::MethodDefinition,
+            ])
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/eslint/no_sparse_arrays.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_sparse_arrays.rs
@@ -102,6 +102,10 @@ impl Rule for NoSparseArrays {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::ArrayExpression)
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
@@ -132,6 +132,14 @@ impl Rule for NoThisBeforeSuper {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::Class)
+            && ctx
+                .semantic()
+                .nodes()
+                .contains_any(&[oxc_ast::AstType::Super, oxc_ast::AstType::ThisExpression])
+    }
 }
 
 impl NoThisBeforeSuper {

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
@@ -104,6 +104,10 @@ impl Rule for NoUnsafeFinally {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::TryStatement)
+    }
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
@@ -108,6 +108,12 @@ impl Rule for NoUnsafeNegation {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic()
+            .nodes()
+            .contains_all(&[oxc_ast::AstType::BinaryExpression, oxc_ast::AstType::UnaryExpression])
+    }
 }
 
 #[test]


### PR DESCRIPTION
- part of https://github.com/oxc-project/oxc/issues/12223

+1-3% performance improvement on lint benchmarks:

<img width="740" height="360" alt="Screenshot 2025-07-11 at 1 13 23 PM" src="https://github.com/user-attachments/assets/8ccfabd4-78f0-402b-9bc7-fec3c483e1e6" />
