### PR TITLE
fix(linter): `eslint/array-calback-return` respect `throw` as end of CFG path

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
@@ -425,6 +425,18 @@ fn test() {
         ("foo[`${every}`](function() {})", None),
         ("foo.every(() => true)", None),
         ("return function() {}", None),
+        // oxc-project/oxc#12176
+        (
+            r#"
+        [1, 2].map((x) => {
+  if (x % 2) {
+    return x * 2;
+  } else {
+    throw new Error("x is even");
+  }
+});"#,
+            None,
+        ),
     ];
 
     let fail = vec![
@@ -594,6 +606,19 @@ fn test() {
         ("Array?.from([], () => { console.log('hello') })", None),
         ("(Array?.from)([], () => { console.log('hello') })", None),
         ("foo?.filter((function() { return () => { console.log('hello') } })?.())", None),
+        (
+            r#"
+        [1, 2].map((x) => {
+  if (x % 2) {
+    return x * 2;
+  } else {
+   try {
+    throw new Error("x is even");
+   } catch {}
+  }
+});"#,
+            None,
+        ),
     ];
 
     Tester::new(ArrayCallbackReturn::NAME, ArrayCallbackReturn::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/return_checker.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/return_checker.rs
@@ -9,6 +9,9 @@ use oxc_ecmascript::{ToBoolean, is_global_reference::WithoutGlobalReferenceInfor
 /// 1. the test is always true and the consequent is terminated by explicit return
 /// 2. the test is always false and the alternate is terminated by explicit return
 /// 3. both the consequent and the alternate is terminated by explicit return
+///
+/// `throw` Statements will count as a return status,
+/// because the branch will not continue to be executed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum StatementReturnStatus {
     /// Only explicit return on all paths
@@ -127,6 +130,9 @@ pub fn check_statement(statement: &Statement) -> StatementReturnStatus {
                 StatementReturnStatus::AlwaysImplicit
             }
         }
+
+        // throw statements count as return for our CFG
+        Statement::ThrowStatement(_) => StatementReturnStatus::AlwaysExplicit,
 
         Statement::IfStatement(stmt) => {
             let test = &stmt.test;

--- a/crates/oxc_linter/src/snapshots/eslint_array_callback_return.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_array_callback_return.snap
@@ -790,3 +790,18 @@ source: crates/oxc_linter/src/tester.rs
    ·                                        ────────────────────────
    ╰────
   help: Array method "Array.prototype.filter" needs to have valid return on all code paths
+
+  ⚠ eslint(array-callback-return): Missing return on some path for array method "Array.prototype.map"
+    ╭─[array_callback_return.tsx:2:27]
+  1 │     
+  2 │ ╭─▶         [1, 2].map((x) => {
+  3 │ │     if (x % 2) {
+  4 │ │       return x * 2;
+  5 │ │     } else {
+  6 │ │      try {
+  7 │ │       throw new Error("x is even");
+  8 │ │      } catch {}
+  9 │ │     }
+ 10 │ ╰─▶ });
+    ╰────
+  help: Array method "Array.prototype.map" needs to have valid return on all code paths


### PR DESCRIPTION
closes #12176