### PR TITLE
perf(linter): add `should_run` based on node types (batch 3)

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
@@ -145,6 +145,10 @@ impl Rule for NoUnsafeOptionalChaining {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::ChainExpression)
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
@@ -65,7 +65,8 @@ impl Rule for NoUnusedLabels {
     }
 
     fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
-        ctx.file_path().extension().is_some_and(|ext| ext != "svelte")
+        ctx.semantic().nodes().contains(oxc_ast::AstType::LabeledStatement)
+            && ctx.file_path().extension().is_some_and(|ext| ext != "svelte")
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
@@ -110,6 +110,12 @@ impl Rule for NoUnusedPrivateClassMembers {
             }
         });
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic()
+            .nodes()
+            .contains_all(&[oxc_ast::AstType::Class, oxc_ast::AstType::PrivateIdentifier])
+    }
 }
 
 fn is_read(current_node_id: NodeId, nodes: &AstNodes) -> bool {

--- a/crates/oxc_linter/src/rules/eslint/no_useless_backreference.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_backreference.rs
@@ -87,6 +87,14 @@ impl Rule for NoUselessBackreference {
             }
         });
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[
+            oxc_ast::AstType::RegExpLiteral,
+            oxc_ast::AstType::NewExpression,
+            oxc_ast::AstType::CallExpression,
+        ])
+    }
 }
 
 enum Problem {

--- a/crates/oxc_linter/src/rules/eslint/no_useless_catch.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_catch.rs
@@ -83,6 +83,12 @@ impl Rule for NoUselessCatch {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic()
+            .nodes()
+            .contains_all(&[oxc_ast::AstType::TryStatement, oxc_ast::AstType::CatchClause])
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
@@ -150,6 +150,14 @@ impl Rule for NoUselessEscape {
 
         Self(Box::new(NoUselessEscapeConfig { allow_regex_characters }))
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[
+            oxc_ast::AstType::RegExpLiteral,
+            oxc_ast::AstType::StringLiteral,
+            oxc_ast::AstType::TemplateLiteral,
+        ])
+    }
 }
 
 fn is_within_jsx_attribute(id: NodeId, ctx: &LintContext) -> bool {

--- a/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
@@ -164,6 +164,15 @@ impl Rule for NoUselessRename {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[
+            oxc_ast::AstType::ObjectPattern,
+            oxc_ast::AstType::AssignmentTarget,
+            oxc_ast::AstType::ImportSpecifier,
+            oxc_ast::AstType::ExportNamedDeclaration,
+        ])
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/eslint/no_with.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_with.rs
@@ -42,6 +42,10 @@ impl Rule for NoWith {
             ctx.diagnostic(no_with_diagnostic(Span::sized(with_statement.span.start, 4)));
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::WithStatement)
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/eslint/require_yield.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_yield.rs
@@ -46,6 +46,10 @@ impl Rule for RequireYield {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::Function)
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/eslint/use_isnan.rs
+++ b/crates/oxc_linter/src/rules/eslint/use_isnan.rs
@@ -152,6 +152,15 @@ impl Rule for UseIsnan {
 
         Self { enforce_for_switch_case, enforce_for_index_of }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[
+            oxc_ast::AstType::BinaryExpression,
+            oxc_ast::AstType::SwitchCase,
+            oxc_ast::AstType::SwitchStatement,
+            oxc_ast::AstType::CallExpression,
+        ])
+    }
 }
 
 fn is_nan_identifier<'a>(expr: &'a Expression<'a>) -> bool {

--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -171,6 +171,12 @@ impl Rule for ValidTypeof {
 
         Self { require_string_literals }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic()
+            .nodes()
+            .contains_all(&[oxc_ast::AstType::UnaryExpression, oxc_ast::AstType::BinaryExpression])
+    }
 }
 
 const VALID_TYPES: [&str; 8] =

--- a/crates/oxc_linter/src/rules/import/default.rs
+++ b/crates/oxc_linter/src/rules/import/default.rs
@@ -82,6 +82,13 @@ impl Rule for Default {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[
+            oxc_ast::AstType::ImportDefaultSpecifier,
+            oxc_ast::AstType::ExportDefaultDeclaration,
+        ])
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -218,6 +218,10 @@ impl Rule for Namespace {
             });
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::ImportDeclaration)
+    }
 }
 
 /// If the name is a namespace object in imported module, return the module request name.

--- a/crates/oxc_linter/src/rules/jest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/expect_expect.rs
@@ -133,6 +133,10 @@ impl Rule for ExpectExpect {
     ) {
         run(self, jest_node, ctx);
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::CallExpression)
+    }
 }
 
 fn run<'a>(

--- a/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
@@ -126,6 +126,10 @@ impl Rule for NoConditionalExpect {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::CallExpression)
+    }
 }
 
 fn check_parents<'a>(

--- a/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
@@ -99,6 +99,10 @@ impl Rule for NoDisabledTests {
     ) {
         run(jest_node, ctx);
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::CallExpression)
+    }
 }
 
 fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jest/no_export.rs
+++ b/crates/oxc_linter/src/rules/jest/no_export.rs
@@ -53,6 +53,15 @@ impl Rule for NoExport {
             ctx.diagnostic(no_export_diagnostic(span));
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains_any(&[
+            oxc_ast::AstType::ExportNamedDeclaration,
+            oxc_ast::AstType::ExportDefaultDeclaration,
+            oxc_ast::AstType::ExportAllDeclaration,
+            oxc_ast::AstType::ExportSpecifier,
+        ])
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
@@ -76,6 +76,10 @@ impl Rule for NoFocusedTests {
     ) {
         run(jest_node, ctx);
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::CallExpression)
+    }
 }
 
 fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect/mod.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect/mod.rs
@@ -86,6 +86,10 @@ impl Rule for NoStandaloneExpect {
             self.run(possible_jest_node, &id_nodes_mapping, ctx);
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::CallExpression)
+    }
 }
 
 impl NoStandaloneExpect {

--- a/crates/oxc_linter/src/rules/jest/require_to_throw_message.rs
+++ b/crates/oxc_linter/src/rules/jest/require_to_throw_message.rs
@@ -57,6 +57,10 @@ impl Rule for RequireToThrowMessage {
     ) {
         Self::run(jest_node, ctx);
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::CallExpression)
+    }
 }
 
 impl RequireToThrowMessage {

--- a/crates/oxc_linter/src/rules/jest/valid_describe_callback.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_describe_callback.rs
@@ -82,6 +82,10 @@ impl Rule for ValidDescribeCallback {
     ) {
         run(jest_node, ctx);
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::CallExpression)
+    }
 }
 
 fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jest/valid_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_expect.rs
@@ -131,6 +131,10 @@ impl Rule for ValidExpect {
     ) {
         self.run(jest_node, ctx);
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::CallExpression)
+    }
 }
 
 impl ValidExpect {

--- a/crates/oxc_linter/src/rules/jest/valid_title.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_title.rs
@@ -139,6 +139,10 @@ impl Rule for ValidTitle {
     ) {
         self.run(jest_node, ctx);
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(oxc_ast::AstType::CallExpression)
+    }
 }
 
 impl ValidTitle {


### PR DESCRIPTION
- part of https://github.com/oxc-project/oxc/issues/12223

+1-2% performance improvement:

<img width="757" height="355" alt="Screenshot 2025-07-11 at 1 25 13 PM" src="https://github.com/user-attachments/assets/bdc60b6d-ffaf-453e-8fb7-cd2761394469" />
