### PR TITLE
refactor(linter/js-plugins): use `u32` for IDs

### DIFF
--- a/crates/oxc_linter/src/external_plugin_store.rs
+++ b/crates/oxc_linter/src/external_plugin_store.rs
@@ -2,46 +2,14 @@ use std::fmt;
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use nonmax::NonMaxU32;
-use oxc_index::{Idx, IndexVec};
+use oxc_index::{IndexVec, define_index_type};
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ExternalPluginId(NonMaxU32);
-
-impl Idx for ExternalPluginId {
-    #[expect(clippy::cast_possible_truncation)]
-    fn from_usize(idx: usize) -> Self {
-        assert!(idx < u32::MAX as usize);
-        // SAFETY: We just checked `idx` is valid for `NonMaxU32`
-        Self(unsafe { NonMaxU32::new_unchecked(idx as u32) })
-    }
-
-    fn index(self) -> usize {
-        self.0.get() as usize
-    }
+define_index_type! {
+    pub struct ExternalPluginId = u32;
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ExternalRuleId(NonMaxU32);
-
-impl Idx for ExternalRuleId {
-    #[expect(clippy::cast_possible_truncation)]
-    fn from_usize(idx: usize) -> Self {
-        assert!(idx < u32::MAX as usize);
-        // SAFETY: We just checked `idx` is valid for `NonMaxU32`
-        Self(unsafe { NonMaxU32::new_unchecked(idx as u32) })
-    }
-
-    fn index(self) -> usize {
-        self.0.get() as usize
-    }
-}
-
-impl ExternalRuleId {
-    #[inline]
-    pub fn as_u32(self) -> u32 {
-        self.0.get()
-    }
+define_index_type! {
+    pub struct ExternalRuleId = u32;
 }
 
 #[derive(Debug, Default)]
@@ -112,8 +80,7 @@ impl ExternalPluginStore {
     }
 
     pub fn resolve_plugin_rule_names(&self, external_rule_id: u32) -> Option<(&str, &str)> {
-        let external_rule =
-            self.rules.get(NonMaxU32::new(external_rule_id).map(ExternalRuleId)?)?;
+        let external_rule = self.rules.get(ExternalRuleId::from_raw(external_rule_id))?;
         let plugin = &self.plugins[external_rule.plugin_id];
 
         Some((&plugin.name, &external_rule.name))

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -203,7 +203,7 @@ impl Linter {
                 let result = (external_linter.run)(
                     #[expect(clippy::missing_panics_doc)]
                     path.to_str().unwrap().to_string(),
-                    external_rules.iter().map(|(rule_id, _)| rule_id.as_u32()).collect(),
+                    external_rules.iter().map(|(rule_id, _)| rule_id.raw()).collect(),
                 );
                 match result {
                     Ok(diagnostics) => {


### PR DESCRIPTION
Follow-on after #12160.

Use `u32` for inner type of `ExternalPluginId` and `ExternalRuleId`. The only advantage of `NonMaxU32` is that `Option<NonMaxU32>` is 4 bytes. That's why we use it for `ScopeId` etc. But `ExternalPluginId` and `ExternalRuleId` aren't stored in `Option`s, so it's simpler to use plain `u32`.
