### PR TITLE
fix(napi/oxlint): rule interface match ESLint

### DIFF
--- a/napi/oxlint2/src/index.js
+++ b/napi/oxlint2/src/index.js
@@ -87,7 +87,7 @@ class Linter {
 
     const rules = [];
     for (const { rule, ruleId } of this.pluginRegistry.getRules(ruleIds)) {
-      rules.push(rule(createContext(ruleId)));
+      rules.push(rule.create(createContext(ruleId)));
     }
 
     // TODO: walk the AST

--- a/napi/oxlint2/test/fixtures/basic_custom_plugin/test_plugin/index.js
+++ b/napi/oxlint2/test/fixtures/basic_custom_plugin/test_plugin/index.js
@@ -3,15 +3,17 @@ export default {
     name: "basic-custom-plugin",
   },
   rules: {
-    "no-debugger": (context) => {
-      // TODO: move this call into `DebuggerStatement`, once we are walking the ast.
-      context.report({
-        message: "Unexpected Debugger Statement",
-        node: { start: 0, end: 0 },
-      });
-      return {
-        DebuggerStatement(_debuggerStatement) {},
-      };
+    "no-debugger": {
+      create(context) {
+        // TODO: move this call into `DebuggerStatement`, once we are walking the ast.
+        context.report({
+          message: "Unexpected Debugger Statement",
+          node: { start: 0, end: 0 },
+        });
+        return {
+          DebuggerStatement(_debuggerStatement) {},
+        };
+      },
     },
   },
 };


### PR DESCRIPTION
Follow-on after #12160. Alter rule interface to match ESLint.