### PR TITLE
test(coverage/typescript): Update more `7xxx` error codes handling

### DIFF
--- a/tasks/coverage/snapshots/codegen_typescript.snap
+++ b/tasks/coverage/snapshots/codegen_typescript.snap
@@ -1,5 +1,5 @@
 commit: 81c95189
 
 codegen_typescript Summary:
-AST Parsed     : 6700/6700 (100.00%)
-Positive Passed: 6700/6700 (100.00%)
+AST Parsed     : 6720/6720 (100.00%)
+Positive Passed: 6720/6720 (100.00%)

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -1,8 +1,8 @@
 commit: 81c95189
 
 estree_typescript Summary:
-AST Parsed     : 6649/6649 (100.00%)
-Positive Passed: 6646/6649 (99.95%)
+AST Parsed     : 6669/6669 (100.00%)
+Positive Passed: 6666/6669 (99.96%)
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuite.tsx
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitEntities.tsx

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -1,9 +1,9 @@
 commit: 81c95189
 
 parser_typescript Summary:
-AST Parsed     : 6698/6700 (99.97%)
-Positive Passed: 6687/6700 (99.81%)
-Negative Passed: 1415/5597 (25.28%)
+AST Parsed     : 6718/6720 (99.97%)
+Positive Passed: 6707/6720 (99.81%)
+Negative Passed: 1415/5577 (25.37%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment8.ts
@@ -461,8 +461,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/capturedLetC
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/capturedParametersInInitializers1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/capturedParametersInInitializers2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/cf.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/chainedAssignment1.ts
 
@@ -1478,8 +1476,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/excessivelyL
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exhaustiveSwitchCheckCircularity.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exhaustiveSwitchImplicitReturn.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionContextualTypesNoValue.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionNestedAssigments.ts
@@ -1593,8 +1589,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/externalModu
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/extractInferenceImprovement.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/fakeInfinity1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/fallFromLastCase2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors4.ts
 
@@ -2314,8 +2308,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsFileClassP
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationBindDeepExportsAssignment.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationBindReachabilityErrors.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationDuplicateFunctionImplementation.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationDuplicateFunctionImplementationFileOrderReversed.ts
@@ -2812,16 +2804,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAn
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsExclusions.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsInAsync2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsWithProtectedBlocks2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsWithProtectedBlocks3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsWithoutReturnExpression.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitSymbolToString.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitThisFunctions.ts
@@ -3240,21 +3222,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reExportGlob
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reExportUndefined1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks4.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks5.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks6.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks7.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks8.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx
 
@@ -3961,12 +3931,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unmetTypeCon
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unmetTypeConstraintInJSDocImportCall.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unqualifiedCallToClassStatic1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unreachableJavascriptChecked.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unreachableSwitchTypeofAny.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unreachableSwitchTypeofUnknown.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unresolvableSelfReferencingAwaitedUnion.ts
 
@@ -4765,8 +4729,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/controlFl
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/dependentDestructuredVariables.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/exhaustiveSwitchStatements1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/neverReturningFunctions1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/typeGuardsAsAssertions.ts
 
@@ -6283,8 +6245,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/internalM
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/InvalidNonInstantiatedModule.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/invalidNestedModules.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/assertionsAndNonReturningFunctions.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/callOfPropertylessConstructorFunction.ts
 

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: 81c95189
 
 semantic_typescript Summary:
 AST Parsed     : 6537/6537 (100.00%)
-Positive Passed: 2851/6537 (43.61%)
+Positive Passed: 2854/6537 (43.66%)
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
 Symbol reference IDs mismatch for "Cell":
 after transform: SymbolId(0): [ReferenceId(1)]

--- a/tasks/coverage/snapshots/transformer_typescript.snap
+++ b/tasks/coverage/snapshots/transformer_typescript.snap
@@ -1,8 +1,8 @@
 commit: 81c95189
 
 transformer_typescript Summary:
-AST Parsed     : 6700/6700 (100.00%)
-Positive Passed: 6696/6700 (99.94%)
+AST Parsed     : 6720/6720 (100.00%)
+Positive Passed: 6716/6720 (99.94%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/esDecoratorsClassFieldsCrash.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor2.ts

--- a/tasks/coverage/src/typescript/mod.rs
+++ b/tasks/coverage/src/typescript/mod.rs
@@ -157,12 +157,17 @@ static NOT_SUPPORTED_ERROR_CODES: phf::Set<&'static str> = phf::phf_set![
     "7024", // Function implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
     "7025", // Generator implicitly has yield type 'any'. Consider supplying a return type annotation.
     "7026", // JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+    "7027", // Unreachable code detected.
+    "7028", // Unused label.
+    "7029", // Fallthrough case in switch.
+    "7030", // Not all code paths return a value.
     "7031", // Binding element 'a5' implicitly has an 'any' type.
     "7032", // Property 'message' implicitly has type 'any', because its set accessor lacks a parameter type annotation.
     "7033", // Property 'message' implicitly has type 'any', because its get accessor lacks a return type annotation.
     "7034", // Variable 'x' implicitly has type 'any[]' in some locations where its type cannot be determined.
     "7036", // Dynamic import's specifier must be of type 'string', but here has type 'null'.
     "7039", // Mapped object type implicitly has an 'any' template type.
+    "7041", // The containing arrow function captures the global value of 'this'.
     "7052", // Element implicitly has an 'any' type because type '{ get: (key: string) => string; }' has no index signature. Did you mean to call 'c.get'?
     "7053", // Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
     "7055", // 'h', which lacks return-type annotation, implicitly has an 'any' yield type.


### PR DESCRIPTION
Follow up #12067 