### PR TITLE
fix(linter): Report implicit config parse errors (#12258)

### DIFF
--- a/apps/oxlint/fixtures/auto_config_parse_error/.oxlintrc.json
+++ b/apps/oxlint/fixtures/auto_config_parse_error/.oxlintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules" {
+    "no-debugger": "error"
+  }
+}

--- a/apps/oxlint/fixtures/auto_config_parse_error/debugger.js
+++ b/apps/oxlint/fixtures/auto_config_parse_error/debugger.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -491,19 +491,12 @@ impl LintRunner {
     // when no file is found, the default configuration is returned
     fn find_oxlint_config(cwd: &Path, config: Option<&PathBuf>) -> Result<Oxlintrc, OxcDiagnostic> {
         let path: &Path = config.map_or(Self::DEFAULT_OXLINTRC.as_ref(), PathBuf::as_ref);
-        match (absolute(cwd.join(path)), config) {
-            // Config file exists, either explicitly provided or the default file name
-            // Parse the config file and return it, or report an error if parsing fails
-            (Ok(full_path), _) => Oxlintrc::from_file(&full_path),
-            // Failed to resolve config, and it was explicitly provided
-            // Return that the config file could not be found
-            (Err(e), Some(config_path)) => Err(OxcDiagnostic::error(format!(
-                "Failed to resolve config path {}: {e}",
-                config_path.display()
-            ))),
-            // Failed to resolve implicit path, return default config
-            _ => Ok(Oxlintrc::default()),
+        let full_path = cwd.join(path);
+
+        if config.is_some() || full_path.exists() {
+            return Oxlintrc::from_file(&full_path);
         }
+        Ok(Oxlintrc::default())
     }
 
     /// Looks in a directory for an oxlint config file, returns the oxlint config if it exists

--- a/apps/oxlint/src/snapshots/fixtures__auto_config_parse_error_debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__auto_config_parse_error_debugger.js@oxlint.snap
@@ -1,0 +1,15 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: debugger.js
+working directory: fixtures/auto_config_parse_error
+----------
+Failed to parse configuration file.
+
+  x Failed to parse eslint config <cwd>/fixtures/auto_config_parse_error/.oxlintrc.json.
+  | expected `:` at line 2 column 11
+
+----------
+CLI result: InvalidOptionConfig
+----------


### PR DESCRIPTION
Fixes #12258 

Not super sure about the config path normalization, but it Works On My Machine™️! Only other example of `<cwd>` in linter snapshots is the `tsconfig` error, which explicitly formats the error at that location.

Might be nicer to regex the snapshot for any paths to handle Windows, the current cwd detection in there seems a bit hacky anyway.