### PR TITLE
refactor(napi/parser): raw transfer: store offsets as consts

### DIFF
--- a/.github/generated/ast_changes_watch_list.yml
+++ b/.github/generated/ast_changes_watch_list.yml
@@ -60,6 +60,7 @@ src:
   - 'crates/oxc_syntax/src/serialize.rs'
   - 'crates/oxc_syntax/src/symbol.rs'
   - 'crates/oxc_traverse/src/generated/scopes_collector.rs'
+  - 'napi/parser/generated/constants.js'
   - 'napi/parser/generated/deserialize/js.js'
   - 'napi/parser/generated/deserialize/ts.js'
   - 'napi/parser/generated/lazy/constructors.js'

--- a/napi/parser/bench.bench.mjs
+++ b/napi/parser/bench.bench.mjs
@@ -8,6 +8,7 @@ import { experimentalGetLazyVisitor, parseAsync, parseSync } from './index.js';
 // Use `require` not `import` to load these internal modules, to avoid evaluating the modules
 // twice as ESM and CJS
 const require = createRequire(import.meta.filename);
+const { DATA_POINTER_POS_32, PROGRAM_OFFSET } = require('./generated/constants.js');
 const deserializeJS = require('./generated/deserialize/js.js');
 const deserializeTS = require('./generated/deserialize/ts.js');
 const { isJsAst, prepareRaw, returnBufferToCache } = require('./raw-transfer/common.js');
@@ -180,9 +181,7 @@ for (const { filename, code } of fixtures) {
       token: TOKEN,
     };
 
-    // (2 * 1024 * 1024 * 1024 - 16) >> 2
-    const metadataPos32 = 536870908;
-    const programPos = buffer.uint32[metadataPos32];
+    const programPos = buffer.uint32[DATA_POINTER_POS_32] + PROGRAM_OFFSET;
 
     benchRaw('parser_napi_raw_lazy_visit_only(debugger)', () => {
       ast.nodes = new Map();

--- a/napi/parser/generated/constants.js
+++ b/napi/parser/generated/constants.js
@@ -1,0 +1,8 @@
+// Auto-generated code, DO NOT EDIT DIRECTLY!
+// To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
+
+const DATA_POINTER_POS_32 = 536870908,
+  IS_TS_FLAG_POS = 2147483636,
+  PROGRAM_OFFSET = 0;
+
+module.exports = { DATA_POINTER_POS_32, IS_TS_FLAG_POS, PROGRAM_OFFSET };

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -20,10 +20,7 @@ function deserialize(buffer, sourceTextInput, sourceLenInput) {
   sourceLen = sourceLenInput;
   sourceIsAscii = sourceText.length === sourceLen;
 
-  // (2 * 1024 * 1024 * 1024 - 16) >> 2
-  const metadataPos32 = 536870908;
-
-  const data = deserializeRawTransferData(uint32[metadataPos32]);
+  const data = deserializeRawTransferData(uint32[536870908]);
 
   uint8 =
     uint32 =

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -20,10 +20,7 @@ function deserialize(buffer, sourceTextInput, sourceLenInput) {
   sourceLen = sourceLenInput;
   sourceIsAscii = sourceText.length === sourceLen;
 
-  // (2 * 1024 * 1024 * 1024 - 16) >> 2
-  const metadataPos32 = 536870908;
-
-  const data = deserializeRawTransferData(uint32[metadataPos32]);
+  const data = deserializeRawTransferData(uint32[536870908]);
 
   uint8 =
     uint32 =

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -44,6 +44,7 @@
     "wasm.mjs",
     "bindings.js",
     "webcontainer-fallback.js",
+    "generated/constants.js",
     "generated/deserialize/js.js",
     "generated/deserialize/ts.js",
     "generated/lazy/constructors.js",

--- a/napi/parser/raw-transfer/common.js
+++ b/napi/parser/raw-transfer/common.js
@@ -7,6 +7,7 @@ const {
   parseAsyncRaw: parseAsyncRawBinding,
   getBufferOffset,
 } = require('../bindings.js');
+const { IS_TS_FLAG_POS } = require('../generated/constants.js');
 
 module.exports = {
   parseSyncRawImpl,
@@ -227,9 +228,7 @@ function prepareRaw(sourceText) {
  * @returns {boolean} - `true` if AST is JS, `false` if TS
  */
 function isJsAst(buffer) {
-  // 2147483636 = (2 * 1024 * 1024 * 1024) - 12
-  // i.e. 12 bytes from end of 2 GiB buffer
-  return buffer[2147483636] === 0;
+  return buffer[IS_TS_FLAG_POS] === 0;
 }
 
 /**

--- a/napi/parser/raw-transfer/lazy.js
+++ b/napi/parser/raw-transfer/lazy.js
@@ -2,6 +2,7 @@
 
 const { parseSyncRawImpl, parseAsyncRawImpl, returnBufferToCache } = require('./common.js'),
   { TOKEN } = require('./lazy-common.js'),
+  { DATA_POINTER_POS_32, PROGRAM_OFFSET } = require('../generated/constants.js'),
   { RawTransferData } = require('../generated/lazy/constructors.js'),
   walkProgram = require('../generated/lazy/walk.js'),
   { Visitor, getVisitorsArr } = require('./visitor.js');
@@ -102,9 +103,7 @@ function construct(buffer, sourceText, sourceLen) {
   bufferRecycleRegistry.register(ast, buffer, ast);
 
   // Get root data class instance
-  // (2 * 1024 * 1024 * 1024 - 16) >> 2
-  const metadataPos32 = 536870908;
-  const rawDataPos = buffer.uint32[metadataPos32];
+  const rawDataPos = buffer.uint32[DATA_POINTER_POS_32];
   const data = new RawTransferData(rawDataPos, ast);
 
   return {
@@ -122,7 +121,7 @@ function construct(buffer, sourceText, sourceLen) {
     },
     dispose: dispose.bind(null, ast),
     visit(visitor) {
-      walkProgram(rawDataPos, ast, getVisitorsArr(visitor));
+      walkProgram(rawDataPos + PROGRAM_OFFSET, ast, getVisitorsArr(visitor));
     },
   };
 }


### PR DESCRIPTION
Pure refactor. Instead of hard-coding constants for fixed offsets of data in the buffer, generate these constants in one place and import them from `constants.js` everywhere else.