### PR TITLE
refactor(napi/parser): do not compile raw transfer code on WASM

### DIFF
--- a/napi/parser/src/lib.rs
+++ b/napi/parser/src/lib.rs
@@ -22,13 +22,28 @@ use oxc::{
 use oxc_napi::{Comment, OxcError, convert_utf8_to_utf16, get_source_type};
 
 mod convert;
+mod types;
+pub use types::{EcmaScriptModule, ParseResult, ParserOptions};
+
+// Raw transfer is only supported on 64-bit little-endian systems.
+// Don't include raw transfer code on other platforms (notably WASM32).
+// `raw_transfer_types` still needs to be compiled, as `assert_layouts` refers to those types,
+// but it's all dead code on unsupported platforms, and will be excluded from binary.
+#[cfg(all(target_pointer_width = "64", target_endian = "little"))]
 mod raw_transfer;
 mod raw_transfer_types;
-mod types;
+#[cfg(all(target_pointer_width = "64", target_endian = "little"))]
 pub use raw_transfer::{
     get_buffer_offset, parse_async_raw, parse_sync_raw, raw_transfer_supported,
 };
-pub use types::{EcmaScriptModule, ParseResult, ParserOptions};
+
+// Fallback for 32-bit or big-endian platforms.
+/// Returns `true` if raw transfer is supported on this platform.
+#[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
+#[napi]
+pub fn raw_transfer_supported() -> bool {
+    false
+}
 
 mod generated {
     // Note: We intentionally don't import `generated/derive_estree.rs`. It's not needed.

--- a/napi/parser/src/raw_transfer_types.rs
+++ b/napi/parser/src/raw_transfer_types.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(all(target_pointer_width = "64", target_endian = "little")), expect(dead_code))]
+
 use std::sync::Arc;
 
 use rustc_hash::FxHashMap;


### PR DESCRIPTION
Reduce size of `oxc-parser` WASM binary by omitting code for raw transfer. Raw transfer is not supported on WASM.

This also allows removing the workaround to prevent compilation failure on 32-bit systems due to `1 << 32` overflowing `usize`. This code is no longer compiled on 32-bit systems.