### PR TITLE
refactor(allocator): disable fixed size allocators on unsupported platforms

### DIFF
--- a/crates/oxc_allocator/src/fixed_size.rs
+++ b/crates/oxc_allocator/src/fixed_size.rs
@@ -7,14 +7,8 @@ use std::{
 
 use crate::Allocator;
 
-// Only 64-bit little-endian platforms are supported at present
-const IS_SUPPORTED_PLATFORM: bool =
-    cfg!(all(target_pointer_width = "64", target_endian = "little"));
-
 const TWO_GIB: usize = 1 << 31;
-// `1 << 32`.
-// We use `IS_SUPPORTED_PLATFORM as usize * 32` to avoid compilation failure on 32-bit platforms.
-const FOUR_GIB: usize = 1 << (IS_SUPPORTED_PLATFORM as usize * 32);
+const FOUR_GIB: usize = 1 << 32;
 
 // What we ideally want is an allocation 2 GiB in size, aligned on 4 GiB.
 // But system allocator on Mac OS refuses allocations with 4 GiB alignment.
@@ -61,15 +55,7 @@ pub struct FixedSizeAllocator {
 
 impl FixedSizeAllocator {
     /// Create a new [`FixedSizeAllocator`].
-    ///
-    /// # Panics
-    /// Panics if not a 64-bit little-endian platform.
     pub fn new() -> Self {
-        assert!(
-            IS_SUPPORTED_PLATFORM,
-            "Fixed size allocators are only supported on 64-bit little-endian platforms"
-        );
-
         // Allocate block of memory.
         // SAFETY: Layout does not have zero size.
         let alloc_ptr = unsafe { System.alloc(ALLOC_LAYOUT) };

--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -21,6 +21,7 @@
 //!
 //! * `fixed_size` - Makes [`AllocatorPool`] create large fixed-size allocators, instead of
 //!   flexibly-sized ones.
+//!   Only supported on 64-bit little-endian platforms at present.
 //!   Usage of this feature is not advisable, and it will be removed as soon as we're able to.
 //!
 //! * `disable_fixed_size` - Disables `fixed_size` feature.
@@ -36,7 +37,13 @@ mod allocator_api2;
 mod boxed;
 mod clone_in;
 mod convert;
-#[cfg(all(feature = "fixed_size", not(feature = "disable_fixed_size")))]
+// Fixed size allocators are only supported on 64-bit little-endian platforms at present
+#[cfg(all(
+    feature = "fixed_size",
+    not(feature = "disable_fixed_size"),
+    target_pointer_width = "64",
+    target_endian = "little"
+))]
 mod fixed_size;
 #[cfg(feature = "from_raw_parts")]
 mod from_raw_parts;

--- a/crates/oxc_allocator/src/pool.rs
+++ b/crates/oxc_allocator/src/pool.rs
@@ -73,7 +73,12 @@ impl Drop for AllocatorGuard<'_> {
     }
 }
 
-#[cfg(any(not(feature = "fixed_size"), feature = "disable_fixed_size"))]
+#[cfg(not(all(
+    feature = "fixed_size",
+    not(feature = "disable_fixed_size"),
+    target_pointer_width = "64",
+    target_endian = "little"
+)))]
 mod wrapper {
     use crate::Allocator;
 
@@ -105,7 +110,12 @@ mod wrapper {
     }
 }
 
-#[cfg(all(feature = "fixed_size", not(feature = "disable_fixed_size")))]
+#[cfg(all(
+    feature = "fixed_size",
+    not(feature = "disable_fixed_size"),
+    target_pointer_width = "64",
+    target_endian = "little"
+))]
 mod wrapper {
     use crate::{
         Allocator,


### PR DESCRIPTION
Do not compile code for fixed-sized allocators (for raw transfer) on unsupported systems (32 bit, or big-endian).

This allows removing the workaround to prevent compilation failure on 32-bit systems due to `1 << 32` overflowing `usize`. This code is no longer compiled on 32-bit systems.
