### PR TITLE
perf(napi/parser): raw transfer: move check for supported platform

### DIFF
--- a/napi/parser/raw-transfer/eager.js
+++ b/napi/parser/raw-transfer/eager.js
@@ -11,7 +11,6 @@ module.exports = { parseSyncRaw, parseAsyncRaw };
  * @param {string} sourceText - Source text of file
  * @param {Object} options - Parsing options
  * @returns {Object} - Object with property getters for `program`, `module`, `comments`, and `errors`
- * @throws {Error} - If raw transfer is not supported on this platform
  */
 function parseSyncRaw(filename, sourceText, options) {
   let _;
@@ -36,7 +35,6 @@ function parseSyncRaw(filename, sourceText, options) {
  * @param {string} sourceText - Source text of file
  * @param {Object} options - Parsing options
  * @returns {Object} - Object with property getters for `program`, `module`, `comments`, and `errors`
- * @throws {Error} - If raw transfer is not supported on this platform
  */
 function parseAsyncRaw(filename, sourceText, options) {
   let _;

--- a/napi/parser/raw-transfer/lazy.js
+++ b/napi/parser/raw-transfer/lazy.js
@@ -30,7 +30,6 @@ module.exports = { parseSyncLazy, parseAsyncLazy, Visitor };
  * @param {Object} options - Parsing options
  * @returns {Object} - Object with property getters for `program`, `module`, `comments`, and `errors`,
  *   and `dispose` and `visit` methods
- * @throws {Error} - If raw transfer is not supported on this platform
  */
 function parseSyncLazy(filename, sourceText, options) {
   let _;
@@ -64,7 +63,6 @@ function parseSyncLazy(filename, sourceText, options) {
  * @param {Object} options - Parsing options
  * @returns {Object} - Object with property getters for `program`, `module`, `comments`, and `errors`,
  *   and `dispose` and `visit` methods
- * @throws {Error} - If raw transfer is not supported on this platform
  */
 function parseAsyncLazy(filename, sourceText, options) {
   let _;


### PR DESCRIPTION
Small optimization to raw transfer. Move check that running on a supported platform out of `prepareRaw` function (which runs on every call to `parseSync`) to top level (so we only do the check once). This module is lazy-loaded if user calls `parseSync` with `experimentalRawTransfer`, so the check won't run if user is not using raw transfer.