### PR TITLE
refactor(napi/parser, allocator): raw transfer: store buffer size and align as consts

### DIFF
--- a/.github/generated/ast_changes_watch_list.yml
+++ b/.github/generated/ast_changes_watch_list.yml
@@ -3,6 +3,7 @@
 
 src:
   - '.github/generated/ast_changes_watch_list.yml'
+  - 'crates/oxc_allocator/src/generated/fixed_size_constants.rs'
   - 'crates/oxc_ast/src/ast/comment.rs'
   - 'crates/oxc_ast/src/ast/js.rs'
   - 'crates/oxc_ast/src/ast/jsx.rs'
@@ -68,6 +69,7 @@ src:
   - 'napi/parser/generated/lazy/walk.js'
   - 'napi/parser/src/generated/assert_layouts.rs'
   - 'napi/parser/src/generated/derive_estree.rs'
+  - 'napi/parser/src/generated/raw_transfer_constants.rs'
   - 'napi/parser/src/raw_transfer_types.rs'
   - 'npm/oxc-types/types.d.ts'
   - 'tasks/ast_tools/src/**'

--- a/crates/oxc_allocator/src/generated/fixed_size_constants.rs
+++ b/crates/oxc_allocator/src/generated/fixed_size_constants.rs
@@ -1,0 +1,7 @@
+// Auto-generated code, DO NOT EDIT DIRECTLY!
+// To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
+
+#![expect(clippy::unreadable_literal)]
+
+pub const BUFFER_SIZE: usize = 2147483648;
+pub const BUFFER_ALIGN: usize = 4294967296;

--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -65,3 +65,20 @@ pub use pool::{AllocatorGuard, AllocatorPool};
 pub use string_builder::StringBuilder;
 pub use take_in::{Dummy, TakeIn};
 pub use vec::Vec;
+
+mod generated {
+    #[cfg(all(
+        feature = "fixed_size",
+        not(feature = "disable_fixed_size"),
+        target_pointer_width = "64",
+        target_endian = "little"
+    ))]
+    pub mod fixed_size_constants;
+}
+#[cfg(all(
+    feature = "fixed_size",
+    not(feature = "disable_fixed_size"),
+    target_pointer_width = "64",
+    target_endian = "little"
+))]
+use generated::fixed_size_constants;

--- a/crates/oxc_allocator/src/pool.rs
+++ b/crates/oxc_allocator/src/pool.rs
@@ -117,10 +117,7 @@ mod wrapper {
     target_endian = "little"
 ))]
 mod wrapper {
-    use crate::{
-        Allocator,
-        fixed_size::{CHUNK_ALIGN, FixedSizeAllocator},
-    };
+    use crate::{Allocator, fixed_size::FixedSizeAllocator, fixed_size_constants::BUFFER_ALIGN};
 
     /// Structure which wraps an [`Allocator`] with fixed size of 2 GiB, and aligned on 4 GiB.
     ///
@@ -144,12 +141,12 @@ mod wrapper {
             self.0.reset();
 
             // Set data pointer back to start.
-            // SAFETY: Fixed-size allocators have data pointer originally aligned on `CHUNK_ALIGN`,
-            // and size less than `CHUNK_ALIGN`. So we can restore original data pointer by rounding down
-            // to next multiple of `CHUNK_ALIGN`.
+            // SAFETY: Fixed-size allocators have data pointer originally aligned on `BUFFER_ALIGN`,
+            // and size less than `BUFFER_ALIGN`. So we can restore original data pointer by rounding down
+            // to next multiple of `BUFFER_ALIGN`.
             unsafe {
                 let data_ptr = self.0.data_ptr();
-                let offset = data_ptr.as_ptr() as usize % CHUNK_ALIGN;
+                let offset = data_ptr.as_ptr() as usize % BUFFER_ALIGN;
                 let data_ptr = data_ptr.sub(offset);
                 self.0.set_data_ptr(data_ptr);
             }

--- a/napi/parser/generated/constants.js
+++ b/napi/parser/generated/constants.js
@@ -1,8 +1,16 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
-const DATA_POINTER_POS_32 = 536870908,
+const BUFFER_SIZE = 2147483648,
+  BUFFER_ALIGN = 4294967296,
+  DATA_POINTER_POS_32 = 536870908,
   IS_TS_FLAG_POS = 2147483636,
   PROGRAM_OFFSET = 0;
 
-module.exports = { DATA_POINTER_POS_32, IS_TS_FLAG_POS, PROGRAM_OFFSET };
+module.exports = {
+  BUFFER_SIZE,
+  BUFFER_ALIGN,
+  DATA_POINTER_POS_32,
+  IS_TS_FLAG_POS,
+  PROGRAM_OFFSET,
+};

--- a/napi/parser/raw-transfer/common.js
+++ b/napi/parser/raw-transfer/common.js
@@ -7,7 +7,7 @@ const {
   parseAsyncRaw: parseAsyncRawBinding,
   getBufferOffset,
 } = require('../bindings.js');
-const { IS_TS_FLAG_POS } = require('../generated/constants.js');
+const { BUFFER_SIZE, BUFFER_ALIGN, IS_TS_FLAG_POS } = require('../generated/constants.js');
 
 module.exports = {
   parseSyncRawImpl,
@@ -141,9 +141,8 @@ async function parseAsyncRawImpl(filename, sourceText, options, convert) {
   return data;
 }
 
-const ONE_GIB = 1 << 30,
-  TWO_GIB = ONE_GIB * 2,
-  SIX_GIB = ONE_GIB * 6;
+const ARRAY_BUFFER_SIZE = BUFFER_SIZE + BUFFER_ALIGN;
+const ONE_GIB = 1 << 30;
 
 // We keep a cache of buffers for raw transfer, so we can reuse them as much as possible.
 //
@@ -277,10 +276,10 @@ function clearBuffersCache() {
  * @returns {Uint8Array} - Buffer
  */
 function createBuffer() {
-  const arrayBuffer = new ArrayBuffer(SIX_GIB);
+  const arrayBuffer = new ArrayBuffer(ARRAY_BUFFER_SIZE);
   const offset = getBufferOffset(new Uint8Array(arrayBuffer));
-  const buffer = new Uint8Array(arrayBuffer, offset, TWO_GIB);
-  buffer.uint32 = new Uint32Array(arrayBuffer, offset, TWO_GIB / 4);
-  buffer.float64 = new Float64Array(arrayBuffer, offset, TWO_GIB / 8);
+  const buffer = new Uint8Array(arrayBuffer, offset, BUFFER_SIZE);
+  buffer.uint32 = new Uint32Array(arrayBuffer, offset, BUFFER_SIZE / 4);
+  buffer.float64 = new Float64Array(arrayBuffer, offset, BUFFER_SIZE / 8);
   return buffer;
 }

--- a/napi/parser/src/generated/raw_transfer_constants.rs
+++ b/napi/parser/src/generated/raw_transfer_constants.rs
@@ -1,0 +1,7 @@
+// Auto-generated code, DO NOT EDIT DIRECTLY!
+// To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
+
+#![expect(clippy::unreadable_literal)]
+
+pub const BUFFER_SIZE: usize = 2147483648;
+pub const BUFFER_ALIGN: usize = 4294967296;

--- a/napi/parser/src/lib.rs
+++ b/napi/parser/src/lib.rs
@@ -49,7 +49,11 @@ mod generated {
     // Note: We intentionally don't import `generated/derive_estree.rs`. It's not needed.
     #[cfg(debug_assertions)]
     pub mod assert_layouts;
+    #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
+    pub mod raw_transfer_constants;
 }
+#[cfg(all(target_pointer_width = "64", target_endian = "little"))]
+use generated::raw_transfer_constants;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum AstType {

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -233,6 +233,9 @@ static SOURCE_PATHS: &[&str] = &[
     "napi/parser/src/raw_transfer_types.rs",
 ];
 
+/// Path to `oxc_allocator` crate
+const ALLOCATOR_CRATE_PATH: &str = "crates/oxc_allocator";
+
 /// Path to `oxc_ast` crate
 const AST_CRATE_PATH: &str = "crates/oxc_ast";
 


### PR DESCRIPTION
Similar to #12268. Instead of hard-coding the size and alignment of raw transfer buffers in multiple places, codegen add these to generated files, and everywhere else import the values from those files. This is more robust.