### PR TITLE
perf(napi/parser): raw transfer: reduce size of buffer by 16 bytes

### DIFF
--- a/crates/oxc_allocator/src/generated/fixed_size_constants.rs
+++ b/crates/oxc_allocator/src/generated/fixed_size_constants.rs
@@ -3,5 +3,5 @@
 
 #![expect(clippy::unreadable_literal)]
 
-pub const BUFFER_SIZE: usize = 2147483648;
+pub const BUFFER_SIZE: usize = 2147483632;
 pub const BUFFER_ALIGN: usize = 4294967296;

--- a/napi/parser/generated/constants.js
+++ b/napi/parser/generated/constants.js
@@ -1,10 +1,10 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
-const BUFFER_SIZE = 2147483648,
+const BUFFER_SIZE = 2147483632,
   BUFFER_ALIGN = 4294967296,
-  DATA_POINTER_POS_32 = 536870910,
-  IS_TS_FLAG_POS = 2147483644,
+  DATA_POINTER_POS_32 = 536870906,
+  IS_TS_FLAG_POS = 2147483628,
   PROGRAM_OFFSET = 0;
 
 module.exports = {

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -20,7 +20,7 @@ function deserialize(buffer, sourceTextInput, sourceLenInput) {
   sourceLen = sourceLenInput;
   sourceIsAscii = sourceText.length === sourceLen;
 
-  const data = deserializeRawTransferData(uint32[536870910]);
+  const data = deserializeRawTransferData(uint32[536870906]);
 
   uint8 =
     uint32 =

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -20,7 +20,7 @@ function deserialize(buffer, sourceTextInput, sourceLenInput) {
   sourceLen = sourceLenInput;
   sourceIsAscii = sourceText.length === sourceLen;
 
-  const data = deserializeRawTransferData(uint32[536870910]);
+  const data = deserializeRawTransferData(uint32[536870906]);
 
   uint8 =
     uint32 =

--- a/napi/parser/src/generated/raw_transfer_constants.rs
+++ b/napi/parser/src/generated/raw_transfer_constants.rs
@@ -3,5 +3,5 @@
 
 #![expect(clippy::unreadable_literal)]
 
-pub const BUFFER_SIZE: usize = 2147483648;
+pub const BUFFER_SIZE: usize = 2147483632;
 pub const BUFFER_ALIGN: usize = 4294967296;

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -28,7 +28,8 @@ use super::define_generator;
 
 /// Size of raw transfer buffer.
 /// Must be a multiple of 16.
-const BUFFER_SIZE: u32 = 1 << 31; // 2 GiB
+/// 16 bytes less than 2 GiB, to allow 16 bytes for `malloc` metadata (like Bumpalo does).
+const BUFFER_SIZE: u32 = (1 << 31) - 16; // 2 GiB - 16 bytes
 const _: () = assert!(BUFFER_SIZE % 16 == 0);
 /// Alignment of raw transfer buffer.
 const BUFFER_ALIGN: u64 = 1 << 32; // 4 GiB


### PR DESCRIPTION
Reduce the size of the buffer used for raw transfer by 16 bytes so that there's 16 bytes space for `malloc`'s metadata without committing another memory page. I don't know for sure that `malloc` would store metadata in the allocation for allocations this large, but this is what Bumpalo does, so it's probably a good idea.