### PR TITLE
fix(semantic): allow `arguments`/`eval` as name of `TSTypeAliasDeclaration`, `TSInterfaceDeclaration`

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -146,6 +146,7 @@ pub fn check_binding_identifier(ident: &BindingIdentifier, ctx: &SemanticBuilder
                         )
                 }
             }
+            AstKind::TSTypeAliasDeclaration(_) | AstKind::TSInterfaceDeclaration(_) => true,
             _ => false,
         };
 

--- a/tasks/coverage/misc/pass/arguments-eval.d.ts
+++ b/tasks/coverage/misc/pass/arguments-eval.d.ts
@@ -5,3 +5,13 @@ interface Foo {
   bar(arguments: any[]): void;
   bar2(...arguments: any[]): void;
 }
+
+declare namespace foo {
+  type arguments = {};
+  type eval = {};
+}
+
+declare namespace foo2 {
+  interface arguments {}
+  interface eval {}
+}


### PR DESCRIPTION
this stack should fix #12286