### PR TITLE
refactor(transform/styled-components): use `SliceIterExt`

### DIFF
--- a/crates/oxc_transformer/Cargo.toml
+++ b/crates/oxc_transformer/Cargo.toml
@@ -25,7 +25,7 @@ oxc-browserslist = { workspace = true }
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
-oxc_data_structures = { workspace = true, features = ["assert_unchecked", "inline_string", "rope", "stack"] }
+oxc_data_structures = { workspace = true, features = ["assert_unchecked", "inline_string", "rope", "slice_iter_ext", "stack"] }
 oxc_diagnostics = { workspace = true }
 oxc_ecmascript = { workspace = true }
 oxc_parser = { workspace = true }


### PR DESCRIPTION
Use `SliceIterExt` trait in styled-components transform to shorten and clarify code.