### PR TITLE
refactor(codegen): use `SliceIterExt` in string printer

### DIFF
--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -22,7 +22,7 @@ doctest = true
 [dependencies]
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
-oxc_data_structures = { workspace = true, features = ["code_buffer", "pointer_ext", "stack"] }
+oxc_data_structures = { workspace = true, features = ["code_buffer", "pointer_ext", "slice_iter_ext", "stack"] }
 oxc_index = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_sourcemap = { workspace = true }


### PR DESCRIPTION
Use `SliceIterExt` trait in the string printer. This allows removing a bunch of const generics. The dynamic implementations in `SliceIterExt` are just as efficient (or maybe more).