### PR TITLE
refactor(estree): use `SliceIterExt` in string serializer

### DIFF
--- a/crates/oxc_estree/Cargo.toml
+++ b/crates/oxc_estree/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 doctest = false
 
 [dependencies]
-oxc_data_structures = { workspace = true, features = ["code_buffer", "pointer_ext", "stack"], optional = true }
+oxc_data_structures = { workspace = true, features = ["code_buffer", "pointer_ext", "slice_iter_ext", "stack"], optional = true }
 
 itoa = { workspace = true, optional = true }
 ryu-js = { workspace = true, optional = true }


### PR DESCRIPTION
Use `SliceIterExt` trait in the string serializer, to reduce repeated code.