### PR TITLE
refactor(napi/parser): clarify pointer maths

### DIFF
--- a/napi/parser/src/raw_transfer.rs
+++ b/napi/parser/src/raw_transfer.rs
@@ -42,11 +42,11 @@ const BUMP_ALIGN: usize = 16;
 /// Get offset within a `Uint8Array` which is aligned on `BUFFER_ALIGN`.
 ///
 /// Does not check that the offset is within bounds of `buffer`.
-/// To ensure it always is, provide a `Uint8Array` of at least `BUFFER_SIZE` bytes.
+/// To ensure it always is, provide a `Uint8Array` of at least `BUFFER_SIZE + BUFFER_ALIGN` bytes.
 #[napi(skip_typescript)]
 pub fn get_buffer_offset(buffer: Uint8Array) -> u32 {
     let buffer = &*buffer;
-    let offset = BUFFER_ALIGN - (buffer.as_ptr() as usize % BUFFER_ALIGN);
+    let offset = (BUFFER_ALIGN - (buffer.as_ptr() as usize % BUFFER_ALIGN)) % BUFFER_ALIGN;
     #[expect(clippy::cast_possible_truncation)]
     return offset as u32;
 }


### PR DESCRIPTION
Correct comment for `get_buffer_offset` (used by raw transfer) about buffer size, and add an additional rounding down. The latter makes no difference because the offset is truncated to `u32` straight after anyway, but better to code defensively in case we change buffer size / alignment later on.