### PR TITLE
refactor(parser): shorten code

### DIFF
--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -377,14 +377,14 @@ impl<'a> ParserImpl<'a> {
                 let modifiers = self.parse_modifiers(false, false);
                 let class_decl = self.parse_class_declaration(class_span, &modifiers, decorators);
                 let decl = Declaration::ClassDeclaration(class_decl);
-                ModuleDeclaration::ExportNamedDeclaration(self.ast.alloc_export_named_declaration(
+                self.ast.module_declaration_export_named_declaration(
                     self.end_span(span),
                     Some(decl),
                     self.ast.vec(),
                     None,
                     ImportOrExportKind::Value,
                     NONE,
-                ))
+                )
             }
             Kind::Eq if self.is_ts => ModuleDeclaration::TSExportAssignment(
                 self.parse_ts_export_assignment_declaration(span),

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -140,14 +140,12 @@ impl<'a> ParserImpl<'a> {
             self.bump_any();
             if self.at(Kind::Dot) {
                 // `type something = intrinsic. ...`
-                let intrinsic_ident = self.ast.alloc_identifier_reference(
+                let left_name = self.ast.ts_type_name_identifier_reference(
                     intrinsic_token.span(),
                     self.token_source(&intrinsic_token),
                 );
-                let type_name = self.parse_ts_qualified_type_name(
-                    intrinsic_token.start(),
-                    TSTypeName::IdentifierReference(intrinsic_ident),
-                );
+                let type_name =
+                    self.parse_ts_qualified_type_name(intrinsic_token.start(), left_name);
                 let type_parameters = self.parse_type_arguments_of_type_reference();
                 self.ast.ts_type_type_reference(
                     self.end_span(intrinsic_token.start()),

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -788,12 +788,10 @@ impl<'a> ParserImpl<'a> {
         let span = self.start_span();
         let left = if self.at(Kind::This) {
             self.bump_any();
-            let this_expr = self.ast.alloc_this_expression(self.end_span(span));
-            TSTypeName::ThisExpression(this_expr)
+            self.ast.ts_type_name_this_expression(self.end_span(span))
         } else {
             let ident = self.parse_identifier_name();
-            let ident = self.ast.alloc_identifier_reference(ident.span, ident.name);
-            TSTypeName::IdentifierReference(ident)
+            self.ast.ts_type_name_identifier_reference(ident.span, ident.name)
         };
         if self.at(Kind::Dot) { self.parse_ts_qualified_type_name(span, left) } else { left }
     }


### PR DESCRIPTION
Pure refactor. Shorten code by using more specific `AstBuilder` methods to construct enums.