### PR TITLE
refactor(parser): remove unnecessary `unbox`

### DIFF
--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -221,7 +221,6 @@ impl<'a> ParserImpl<'a> {
         let params = {
             let ident = match ident {
                 Expression::Identifier(ident) => {
-                    let ident = ident.unbox();
                     self.ast.alloc_binding_identifier(ident.span, ident.name)
                 }
                 _ => return self.unexpected(),


### PR DESCRIPTION
`unbox` here is unnecessary. There's no need to pull this node onto the stack.