### PR TITLE
perf(semantic): reduce match arms in `check_binding_identifier`

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -163,14 +163,13 @@ pub fn check_binding_identifier(ident: &BindingIdentifier, ctx: &SemanticBuilder
         if ident.name == "let" {
             for node_kind in ctx.nodes.ancestor_kinds(ctx.current_node_id) {
                 match node_kind {
-                    AstKind::VariableDeclaration(decl) if decl.kind.is_lexical() => {
-                        return ctx.error(invalid_let_declaration(decl.kind.as_str(), ident.span));
-                    }
-                    AstKind::VariableDeclaration(_)
-                    | AstKind::Function(_)
-                    | AstKind::Program(_) => {
+                    AstKind::VariableDeclarator(decl) => {
+                        if decl.kind.is_lexical() {
+                            ctx.error(invalid_let_declaration(decl.kind.as_str(), ident.span));
+                        }
                         break;
                     }
+                    AstKind::Function(_) => break,
                     _ => {}
                 }
             }


### PR DESCRIPTION
Small optimization.

1. First arm match on `VariableDeclarator`, instead of `VariableDeclaration` - requires 1 less iteration to get to.
2. Remove match for `Program`. There's no point as iterator does that check on each turn of the loop anyway.
