### PR TITLE
fix(semantic): allow `let` as arrow function param in sloppy mode

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -169,7 +169,8 @@ pub fn check_binding_identifier(ident: &BindingIdentifier, ctx: &SemanticBuilder
                         }
                         break;
                     }
-                    AstKind::Function(_) => break,
+                    // `let` is permitted as function name or function param (including arrow functions)
+                    AstKind::Function(_) | AstKind::FormalParameter(_) => break,
                     _ => {}
                 }
             }

--- a/tasks/coverage/misc/pass/oxc-12305.cjs
+++ b/tasks/coverage/misc/pass/oxc-12305.cjs
@@ -1,0 +1,14 @@
+// Sloppy mode
+
+const a = let => {};
+let b = let => {};
+var c = let => {};
+
+const d = (let) => {};
+let e = (let) => {};
+var f = (let) => {};
+
+const g = ({let}) => {};
+const h = ([let]) => {};
+const i = ({x: let}) => {};
+const j = ({x: {y: [let]}}) => {};

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 44/44 (100.00%)
-Positive Passed: 44/44 (100.00%)
+AST Parsed     : 45/45 (100.00%)
+Positive Passed: 45/45 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 44/44 (100.00%)
-Positive Passed: 44/44 (100.00%)
+AST Parsed     : 45/45 (100.00%)
+Positive Passed: 45/45 (100.00%)
 Negative Passed: 48/48 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 44/44 (100.00%)
-Positive Passed: 28/44 (63.64%)
+AST Parsed     : 45/45 (100.00%)
+Positive Passed: 29/45 (64.44%)
 semantic Error: tasks/coverage/misc/pass/oxc-11593.ts
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 44/44 (100.00%)
-Positive Passed: 44/44 (100.00%)
+AST Parsed     : 45/45 (100.00%)
+Positive Passed: 45/45 (100.00%)


### PR DESCRIPTION
Previously semantic would produce an error for this in sloppy mode:

```js
const f = (let) => {};
```

`let` is legal in this position, but the loop in `check_binding_identifier` would continue searching past the arrow function, and would hit the `VariableDeclarator` which produces an error.