### PR TITLE
fix(semantic): disallow `let` as destructured catch param in sloppy mode

### DIFF
--- a/tasks/coverage/misc/fail/oxc-12306.cjs
+++ b/tasks/coverage/misc/fail/oxc-12306.cjs
@@ -1,0 +1,8 @@
+// Sloppy mode
+
+try {} catch ({let}) {}
+try {} catch ([let]) {}
+try {} catch ({x: let}) {}
+try {} catch ({...let}) {}
+try {} catch ([...let]) {}
+try {} catch ({x: {y: [{...let}]}}) {}

--- a/tasks/coverage/misc/pass/oxc-12306.cjs
+++ b/tasks/coverage/misc/pass/oxc-12306.cjs
@@ -1,0 +1,3 @@
+// Sloppy mode
+
+try {} catch (let) {}

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 45/45 (100.00%)
-Positive Passed: 45/45 (100.00%)
+AST Parsed     : 46/46 (100.00%)
+Positive Passed: 46/46 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
-AST Parsed     : 45/45 (100.00%)
-Positive Passed: 45/45 (100.00%)
-Negative Passed: 48/48 (100.00%)
+AST Parsed     : 46/46 (100.00%)
+Positive Passed: 46/46 (100.00%)
+Negative Passed: 49/49 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -186,6 +186,53 @@ Negative Passed: 48/48 (100.00%)
    ╭─[misc/fail/oxc-11789-2.ts:1:14]
  1 │ interface i<>implements K {}
    ·              ──────────
+   ╰────
+
+  × `let` cannot be declared as a variable name inside of a destructured catch parameter
+   ╭─[misc/fail/oxc-12306.cjs:3:16]
+ 2 │ 
+ 3 │ try {} catch ({let}) {}
+   ·                ───
+ 4 │ try {} catch ([let]) {}
+   ╰────
+
+  × `let` cannot be declared as a variable name inside of a destructured catch parameter
+   ╭─[misc/fail/oxc-12306.cjs:4:16]
+ 3 │ try {} catch ({let}) {}
+ 4 │ try {} catch ([let]) {}
+   ·                ───
+ 5 │ try {} catch ({x: let}) {}
+   ╰────
+
+  × `let` cannot be declared as a variable name inside of a destructured catch parameter
+   ╭─[misc/fail/oxc-12306.cjs:5:19]
+ 4 │ try {} catch ([let]) {}
+ 5 │ try {} catch ({x: let}) {}
+   ·                   ───
+ 6 │ try {} catch ({...let}) {}
+   ╰────
+
+  × `let` cannot be declared as a variable name inside of a destructured catch parameter
+   ╭─[misc/fail/oxc-12306.cjs:6:19]
+ 5 │ try {} catch ({x: let}) {}
+ 6 │ try {} catch ({...let}) {}
+   ·                   ───
+ 7 │ try {} catch ([...let]) {}
+   ╰────
+
+  × `let` cannot be declared as a variable name inside of a destructured catch parameter
+   ╭─[misc/fail/oxc-12306.cjs:7:19]
+ 6 │ try {} catch ({...let}) {}
+ 7 │ try {} catch ([...let]) {}
+   ·                   ───
+ 8 │ try {} catch ({x: {y: [{...let}]}}) {}
+   ╰────
+
+  × `let` cannot be declared as a variable name inside of a destructured catch parameter
+   ╭─[misc/fail/oxc-12306.cjs:8:28]
+ 7 │ try {} catch ([...let]) {}
+ 8 │ try {} catch ({x: {y: [{...let}]}}) {}
+   ·                            ───
    ╰────
 
   × Unexpected token

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 45/45 (100.00%)
-Positive Passed: 29/45 (64.44%)
+AST Parsed     : 46/46 (100.00%)
+Positive Passed: 30/46 (65.22%)
 semantic Error: tasks/coverage/misc/pass/oxc-11593.ts
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 45/45 (100.00%)
-Positive Passed: 45/45 (100.00%)
+AST Parsed     : 46/46 (100.00%)
+Positive Passed: 46/46 (100.00%)


### PR DESCRIPTION
Fix `check_binding_identifier` to handle oddities around `let` bindings in catch params.

This is legal:

```js
// Sloppy mode
try {} catch (let) {}
```

But these are syntax errors!

```js
// Sloppy mode
try {} catch ( { let } ) {}
try {} catch ( [ let ] ) {}
```