### PR TITLE
ci(napi/oxlint): run tests with `coverage` profile

### DIFF
--- a/napi/oxlint2/package.json
+++ b/napi/oxlint2/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build-dev": "napi build --platform --js ./bindings.js --dts ./bindings.d.ts --output-dir src --no-dts-cache --esm",
-    "build-test": "pnpm run build-dev --release --features force_test_reporter",
+    "build-test": "pnpm run build-dev --profile coverage --features force_test_reporter",
     "build": "pnpm run build-dev --release",
     "test": "vitest"
   },


### PR DESCRIPTION
The bug fixed in #12299 went unnoticed originally because we build the `napi/oxlint2` crate for tests in release mode, with debug assertions disabled.

Instead, build with `--profile coverage` which enables debug assertions. It's also faster to compile.
