### PR TITLE
feat(allocator): `AllocatorPool` store IDs in `Allocator`s

### DIFF
--- a/crates/oxc_allocator/src/generated/assert_layouts.rs
+++ b/crates/oxc_allocator/src/generated/assert_layouts.rs
@@ -9,17 +9,19 @@ use crate::*;
 
 #[cfg(target_pointer_width = "64")]
 const _: () = {
-    // Padding: 0 bytes
-    assert!(size_of::<FixedSizeAllocatorMetadata>() == 8);
+    // Padding: 4 bytes
+    assert!(size_of::<FixedSizeAllocatorMetadata>() == 16);
     assert!(align_of::<FixedSizeAllocatorMetadata>() == 8);
+    assert!(offset_of!(FixedSizeAllocatorMetadata, id) == 8);
     assert!(offset_of!(FixedSizeAllocatorMetadata, alloc_ptr) == 0);
 };
 
 #[cfg(target_pointer_width = "32")]
 const _: () = {
     // Padding: 0 bytes
-    assert!(size_of::<FixedSizeAllocatorMetadata>() == 4);
+    assert!(size_of::<FixedSizeAllocatorMetadata>() == 8);
     assert!(align_of::<FixedSizeAllocatorMetadata>() == 4);
+    assert!(offset_of!(FixedSizeAllocatorMetadata, id) == 4);
     assert!(offset_of!(FixedSizeAllocatorMetadata, alloc_ptr) == 0);
 };
 

--- a/crates/oxc_ast_macros/src/generated/structs.rs
+++ b/crates/oxc_ast_macros/src/generated/structs.rs
@@ -254,7 +254,7 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
         ),
         ("Pattern", StructDetails { field_order: None }),
         ("EmptyStatement", StructDetails { field_order: None }),
-        ("FixedSizeAllocatorMetadata", StructDetails { field_order: None }),
+        ("FixedSizeAllocatorMetadata", StructDetails { field_order: Some(&[1, 0]) }),
         ("Hashbang", StructDetails { field_order: None }),
         ("UnaryExpression", StructDetails { field_order: Some(&[0, 2, 1]) }),
         ("ThrowStatement", StructDetails { field_order: None }),

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -4020,6 +4020,10 @@ function deserializeErrorSeverity(pos) {
   }
 }
 
+function deserializeU32(pos) {
+  return uint32[pos >> 2];
+}
+
 function deserializeU8(pos) {
   return uint8[pos];
 }
@@ -5232,10 +5236,6 @@ function deserializeOptionTSMappedTypeModifierOperator(pos) {
 
 function deserializeBoxTSExternalModuleReference(pos) {
   return deserializeTSExternalModuleReference(uint32[pos >> 2]);
-}
-
-function deserializeU32(pos) {
-  return uint32[pos >> 2];
 }
 
 function deserializeOptionNameSpan(pos) {

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -4151,6 +4151,10 @@ function deserializeErrorSeverity(pos) {
   }
 }
 
+function deserializeU32(pos) {
+  return uint32[pos >> 2];
+}
+
 function deserializeU8(pos) {
   return uint8[pos];
 }
@@ -5363,10 +5367,6 @@ function deserializeOptionTSMappedTypeModifierOperator(pos) {
 
 function deserializeBoxTSExternalModuleReference(pos) {
   return deserializeTSExternalModuleReference(uint32[pos >> 2]);
-}
-
-function deserializeU32(pos) {
-  return uint32[pos >> 2];
 }
 
 function deserializeOptionNameSpan(pos) {

--- a/napi/parser/generated/lazy/constructors.js
+++ b/napi/parser/generated/lazy/constructors.js
@@ -12472,6 +12472,10 @@ class StaticExport {
 
 const DebugStaticExport = class StaticExport {};
 
+function constructU32(pos, ast) {
+  return ast.buffer.uint32[pos >> 2];
+}
+
 function constructU8(pos, ast) {
   return ast.buffer[pos];
 }
@@ -13746,10 +13750,6 @@ function constructOptionTSMappedTypeModifierOperator(pos, ast) {
 
 function constructBoxTSExternalModuleReference(pos, ast) {
   return new TSExternalModuleReference(ast.buffer.uint32[pos >> 2], ast);
-}
-
-function constructU32(pos, ast) {
-  return ast.buffer.uint32[pos >> 2];
 }
 
 function constructOptionNameSpan(pos, ast) {


### PR DESCRIPTION
Fixed size allocator pool give each `Allocator` a unique ID and store it in `FixedSizeAllocatorMetadata` struct at end of the buffer. This prepares the way for sharing buffers created on Rust side with JS while avoiding use-after-free or double-free.
