### PR TITLE
fix(semantic): handle var hoisting in catch block with same catch parameter name

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -71,11 +71,15 @@ impl<'a> Binder<'a> for VariableDeclarator<'a> {
                         builder.add_redeclare_variable(symbol_id, includes, span);
                         declared_symbol_id = Some(symbol_id);
 
-                        // remove current scope binding and add to target scope
-                        // avoid same symbols appear in multi-scopes
-                        builder.scoping.remove_binding(scope_id, &name);
-                        builder.scoping.add_binding(target_scope_id, &name, symbol_id);
-                        builder.scoping.symbol_scope_ids[symbol_id] = target_scope_id;
+                        // Hoist current symbol to target scope when it is not already declared
+                        // in the target scope.
+                        if !builder.scoping.scope_has_binding(target_scope_id, &name) {
+                            // remove current scope binding and add to target scope
+                            // avoid same symbols appear in multi-scopes
+                            builder.scoping.remove_binding(scope_id, &name);
+                            builder.scoping.add_binding(target_scope_id, &name, symbol_id);
+                            builder.scoping.symbol_scope_ids[symbol_id] = target_scope_id;
+                        }
                         break;
                     }
                 }

--- a/crates/oxc_semantic/tests/fixtures/oxc/js/try-catch/with-same-name-var.js
+++ b/crates/oxc_semantic/tests/fixtures/oxc/js/try-catch/with-same-name-var.js
@@ -1,0 +1,7 @@
+var a = 1;
+try {
+  throw 2
+} catch (a) {
+  var a = 3;
+}
+console.log(a);

--- a/crates/oxc_semantic/tests/fixtures/oxc/js/try-catch/with-same-name-var.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/js/try-catch/with-same-name-var.snap
@@ -1,0 +1,59 @@
+---
+source: crates/oxc_semantic/tests/main.rs
+input_file: crates/oxc_semantic/tests/fixtures/oxc/js/try-catch/with-same-name-var.js
+---
+[
+  {
+    "children": [
+      {
+        "children": [],
+        "flags": "ScopeFlags(StrictMode)",
+        "id": 1,
+        "node": "BlockStatement",
+        "symbols": []
+      },
+      {
+        "children": [
+          {
+            "children": [],
+            "flags": "ScopeFlags(StrictMode)",
+            "id": 3,
+            "node": "BlockStatement",
+            "symbols": [
+              {
+                "flags": "SymbolFlags(FunctionScopedVariable | CatchVariable)",
+                "id": 1,
+                "name": "a",
+                "node": "CatchParameter",
+                "references": []
+              }
+            ]
+          }
+        ],
+        "flags": "ScopeFlags(StrictMode | CatchClause)",
+        "id": 2,
+        "node": "CatchClause",
+        "symbols": []
+      }
+    ],
+    "flags": "ScopeFlags(StrictMode | Top)",
+    "id": 0,
+    "node": "Program",
+    "symbols": [
+      {
+        "flags": "SymbolFlags(FunctionScopedVariable)",
+        "id": 0,
+        "name": "a",
+        "node": "VariableDeclarator(a)",
+        "references": [
+          {
+            "flags": "ReferenceFlags(Read)",
+            "id": 1,
+            "name": "a",
+            "node_id": 23
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/napi/minify/test/terser.test.ts
+++ b/napi/minify/test/terser.test.ts
@@ -3224,31 +3224,31 @@ test('mangle_catch_var_ie8_toplevel', () => {
   run(code, expected);
 });
 
-test.skip('mangle_catch_redef_1', () => {
+test('mangle_catch_redef_1', () => {
   const code = 'var a="PASS";try{throw"FAIL1"}catch(a){var a="FAIL2"}console.log(a);';
   const expected = ['PASS'];
   run(code, expected);
 });
 
-test.skip('mangle_catch_redef_1_ie8', () => {
+test('mangle_catch_redef_1_ie8', () => {
   const code = 'var a="PASS";try{throw"FAIL1"}catch(a){var a="FAIL2"}console.log(a);';
   const expected = ['PASS'];
   run(code, expected);
 });
 
-test.skip('mangle_catch_redef_1_toplevel', () => {
+test('mangle_catch_redef_1_toplevel', () => {
   const code = 'var a="PASS";try{throw"FAIL1"}catch(a){var a="FAIL2"}console.log(a);';
   const expected = ['PASS'];
   run(code, expected);
 });
 
-test.skip('mangle_catch_redef_1_ie8_toplevel', () => {
+test('mangle_catch_redef_1_ie8_toplevel', () => {
   const code = 'var a="PASS";try{throw"FAIL1"}catch(a){var a="FAIL2"}console.log(a);';
   const expected = ['PASS'];
   run(code, expected);
 });
 
-test.skip('mangle_catch_redef_2', () => {
+test('mangle_catch_redef_2', () => {
   const code = 'try{throw"FAIL1"}catch(a){var a="FAIL2"}console.log(a);';
   const expected = ['undefined'];
   run(code, expected);
@@ -5313,25 +5313,25 @@ test('mangle_catch_var_ie8_toplevel', () => {
   run(code, expected);
 });
 
-test.skip('mangle_catch_redef_1', () => {
+test('mangle_catch_redef_1', () => {
   const code = 'var a="PASS";try{throw"FAIL1"}catch(a){var a="FAIL2"}console.log(a);';
   const expected = ['PASS'];
   run(code, expected);
 });
 
-test.skip('mangle_catch_redef_1_ie8', () => {
+test('mangle_catch_redef_1_ie8', () => {
   const code = 'var a="PASS";try{throw"FAIL1"}catch(a){var a="FAIL2"}console.log(a);';
   const expected = ['PASS'];
   run(code, expected);
 });
 
-test.skip('mangle_catch_redef_1_toplevel', () => {
+test('mangle_catch_redef_1_toplevel', () => {
   const code = 'var a="PASS";try{throw"FAIL1"}catch(a){var a="FAIL2"}console.log(a);';
   const expected = ['PASS'];
   run(code, expected);
 });
 
-test.skip('mangle_catch_redef_1_ie8_toplevel', () => {
+test('mangle_catch_redef_1_ie8_toplevel', () => {
   const code = 'var a="PASS";try{throw"FAIL1"}catch(a){var a="FAIL2"}console.log(a);';
   const expected = ['PASS'];
   run(code, expected);


### PR DESCRIPTION
The root cause is that the variable was hoisted to a scope that has the same name binding

```js
var a = 1;
try {
  throw 2
} catch (a) {
  var a = 3;
//    ^ Shouldn't hoist to the top scope because there is a same name variable.
}
console.log(a);
```

Ref: https://tc39.es/ecma262/#sec-variablestatements-in-catch-blocks


Note

The [Block](https://tc39.es/ecma262/#prod-Block) of a [Catch](https://tc39.es/ecma262/#prod-Catch) clause may contain var declarations that bind a name that is also bound by the [CatchParameter](https://tc39.es/ecma262/#prod-CatchParameter). At runtime, such bindings are instantiated in the VariableDeclarationEnvironment. They do not shadow the same-named bindings introduced by the [CatchParameter](https://tc39.es/ecma262/#prod-CatchParameter) and hence the [Initializer](https://tc39.es/ecma262/#prod-Initializer) for such var declarations will assign to the corresponding catch parameter rather than the var binding.