### PR TITLE
perf(linter): reduce iterations when collecting directories for nested configs

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -445,7 +445,10 @@ impl LintRunner {
             while let Some(dir) = current {
                 // NOTE: Initial benchmarking showed that it was faster to iterate over the directories twice
                 // rather than constructing the configs in one iteration. It's worth re-benchmarking that though.
-                directories.insert(dir);
+                let inserted = directories.insert(dir);
+                if !inserted {
+                    break;
+                }
                 current = dir.parent();
             }
         }


### PR DESCRIPTION
Small perf optimization.

Presumably all paths will usually have the same prefix e.g.:

* `/Users/bozo/projects/best-project-ever`
* `/Users/bozo/projects/best-project-ever/src/components`
* `/Users/bozo/projects/best-project-ever/src/server`

When finding directories to search for nested configs, stop walking up to parent directories when find a directory that's already in the `HashSet`. We know that dir's parent, grandparent, etc will already be in the set too, so no need to check them again.
