### PR TITLE
feat(allocator): add `Allocator::end_ptr` method

### DIFF
--- a/crates/oxc_allocator/src/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/from_raw_parts.rs
@@ -4,6 +4,7 @@
 //! * [`Allocator::alloc_bytes_start`]
 //! * [`Allocator::data_ptr`]
 //! * [`Allocator::set_data_ptr`]
+//! * [`Allocator::end_ptr`]
 
 use std::{
     alloc::Layout,
@@ -228,6 +229,15 @@ impl Allocator {
         // reference is alive
         let chunk_footer = unsafe { self.chunk_footer() };
         chunk_footer.ptr.get()
+    }
+
+    /// Get pointer to end of this [`Allocator`]'s current chunk (after the `ChunkFooter`).
+    pub fn end_ptr(&self) -> NonNull<u8> {
+        // SAFETY: `chunk_footer_ptr` returns pointer to a valid `ChunkFooter`,
+        // so stepping past it cannot be out of bounds of the chunk's allocation.
+        // If `Allocator` has not allocated, so `chunk_footer_ptr` returns a pointer to the static
+        // empty chunk, it's still valid.
+        unsafe { self.chunk_footer_ptr().add(1).cast::<u8>() }
     }
 
     /// Get reference to current [`ChunkFooter`].


### PR DESCRIPTION
Add a method `Allocator::end_ptr` which returns a pointer to the end of the current chunk of an `Allocator`, after the `ChunkFooter`. For `Allocator`s used for raw transfer, this pointer will point to the `RawTransferMetadata` which is stored after the allocator chunk.