### PR TITLE
perf(linter): enable `union` feature of `smallvec` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,7 @@ sha1 = "0.10.6"
 simdutf8 = { version = "0.1.5", features = ["aarch64_neon"] }
 similar = "2.7.0"
 similar-asserts = "1.7.0"
-smallvec = "1.15.1"
+smallvec = { version = "1.15.1", features = ["union"] }
 tempfile = "3.20.0"
 tokio = { version = "1.45.1", default-features = false }
 tower-lsp-server = "0.22.0"


### PR DESCRIPTION
`union` feature makes `SmallVec`s smaller! (by 8 bytes). In turn this makes `ProcessedModule` in linter 8 bytes smaller.

https://docs.rs/smallvec/latest/smallvec/#union

I believe the only reason this isn't enabled by default in `smallvec` crate is that it requires >= Rust 1.49.