### PR TITLE
style(linter): re-order imports

### DIFF
--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -5,13 +5,14 @@ use std::{
 
 use rustc_hash::FxHashMap;
 
-use super::{
-    BuiltinLintPlugins, LintConfig, categories::OxlintCategories, overrides::OxlintOverrides,
-};
 use crate::{
     AllowWarnDeny, LintPlugins,
     external_plugin_store::{ExternalPluginStore, ExternalRuleId},
     rules::{RULES, RuleEnum},
+};
+
+use super::{
+    BuiltinLintPlugins, LintConfig, categories::OxlintCategories, overrides::OxlintOverrides,
 };
 
 // TODO: support `categories` et. al. in overrides.

--- a/crates/oxc_linter/src/fixer/fix.rs
+++ b/crates/oxc_linter/src/fixer/fix.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, ops::Deref};
 
 use bitflags::bitflags;
+
 use oxc_allocator::{Allocator, CloneIn};
 use oxc_span::{GetSpan, SPAN, Span};
 

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -1,6 +1,12 @@
 #![expect(clippy::self_named_module_files)] // for rules.rs
 #![allow(clippy::literal_string_with_formatting_args)]
 
+use std::{path::Path, rc::Rc, sync::Arc};
+
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_semantic::{AstNode, Semantic};
+use oxc_span::Span;
+
 #[cfg(test)]
 mod tester;
 
@@ -23,12 +29,6 @@ mod utils;
 pub mod loader;
 pub mod rules;
 pub mod table;
-
-use std::{path::Path, rc::Rc, sync::Arc};
-
-use oxc_diagnostics::OxcDiagnostic;
-use oxc_semantic::{AstNode, Semantic};
-use oxc_span::Span;
 
 pub use crate::{
     config::{

--- a/crates/oxc_linter/src/loader/partial_loader/astro.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/astro.rs
@@ -1,8 +1,10 @@
 use memchr::memmem::Finder;
+
 use oxc_span::{SourceType, Span};
 
-use super::{SCRIPT_END, SCRIPT_START};
 use crate::loader::JavaScriptSource;
+
+use super::{SCRIPT_END, SCRIPT_START};
 
 const ASTRO_SPLIT: &str = "---";
 

--- a/crates/oxc_linter/src/loader/partial_loader/mod.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/mod.rs
@@ -1,11 +1,13 @@
+use oxc_span::VALID_EXTENSIONS;
+
+use crate::loader::JavaScriptSource;
+
 mod astro;
 mod svelte;
 mod vue;
-
-use oxc_span::VALID_EXTENSIONS;
-
-pub use self::{astro::AstroPartialLoader, svelte::SveltePartialLoader, vue::VuePartialLoader};
-use crate::loader::JavaScriptSource;
+pub use astro::AstroPartialLoader;
+pub use svelte::SveltePartialLoader;
+pub use vue::VuePartialLoader;
 
 const SCRIPT_START: &str = "<script";
 const SCRIPT_END: &str = "</script>";

--- a/crates/oxc_linter/src/loader/partial_loader/svelte.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/svelte.rs
@@ -1,8 +1,10 @@
 use memchr::memmem::Finder;
+
 use oxc_span::SourceType;
 
-use super::{SCRIPT_END, SCRIPT_START, find_script_closing_angle};
 use crate::loader::JavaScriptSource;
+
+use super::{SCRIPT_END, SCRIPT_START, find_script_closing_angle};
 
 pub struct SveltePartialLoader<'a> {
     source_text: &'a str,

--- a/crates/oxc_linter/src/module_graph_visitor.rs
+++ b/crates/oxc_linter/src/module_graph_visitor.rs
@@ -1,7 +1,8 @@
 use std::{marker::PhantomData, path::PathBuf, sync::Arc};
 
-use oxc_span::CompactStr;
 use rustc_hash::FxHashSet;
+
+use oxc_span::CompactStr;
 
 use crate::ModuleRecord;
 

--- a/crates/oxc_linter/src/options/mod.rs
+++ b/crates/oxc_linter/src/options/mod.rs
@@ -1,10 +1,10 @@
+use crate::{FrameworkFlags, fixer::FixKind};
+
 mod allow_warn_deny;
 mod filter;
 
 pub use allow_warn_deny::AllowWarnDeny;
 pub use filter::{InvalidFilterKind, LintFilter, LintFilterKind};
-
-use crate::{FrameworkFlags, fixer::FixKind};
 
 /// Subset of options used directly by the linter.
 #[derive(Debug, Default, Clone, Copy)]

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -2,9 +2,10 @@
 use std::borrow::Cow;
 use std::{fmt, hash::Hash};
 
-use oxc_semantic::SymbolId;
 use schemars::{JsonSchema, SchemaGenerator, schema::Schema};
 use serde::{Deserialize, Serialize};
+
+use oxc_semantic::SymbolId;
 
 use crate::{
     AstNode, FixKind,

--- a/crates/oxc_linter/src/service/mod.rs
+++ b/crates/oxc_linter/src/service/mod.rs
@@ -5,12 +5,12 @@ use std::{
 };
 
 use oxc_diagnostics::DiagnosticSender;
-use runtime::Runtime;
-pub use runtime::RuntimeFileSystem;
 
 use crate::Linter;
 
 mod runtime;
+use runtime::Runtime;
+pub use runtime::RuntimeFileSystem;
 
 #[cfg(feature = "language_server")]
 pub mod offset_to_position;

--- a/crates/oxc_linter/src/service/offset_to_position.rs
+++ b/crates/oxc_linter/src/service/offset_to_position.rs
@@ -1,5 +1,6 @@
-use oxc_data_structures::rope::{Rope, get_line_column};
 use std::borrow::Cow;
+
+use oxc_data_structures::rope::{Rope, get_line_column};
 
 #[derive(Clone, Debug)]
 pub struct SpanPositionMessage<'a> {

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -22,7 +22,6 @@ use oxc_resolver::Resolver;
 use oxc_semantic::{Semantic, SemanticBuilder};
 use oxc_span::{CompactStr, SourceType, VALID_EXTENSIONS};
 
-use super::LintServiceOptions;
 use crate::{
     Fixer, Linter, Message,
     fixer::PossibleFixes,
@@ -33,6 +32,8 @@ use crate::{
 
 #[cfg(feature = "language_server")]
 use crate::fixer::MessageWithPosition;
+
+use super::LintServiceOptions;
 
 pub struct Runtime {
     cwd: Box<Path>,

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -7,11 +7,12 @@ use std::{
 };
 
 use cow_utils::CowUtils;
-use oxc_allocator::{Allocator, AllocatorPool};
-use oxc_diagnostics::{GraphicalReportHandler, GraphicalTheme, NamedSource};
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use serde_json::{Value, json};
+
+use oxc_allocator::{Allocator, AllocatorPool};
+use oxc_diagnostics::{GraphicalReportHandler, GraphicalTheme, NamedSource};
 
 use crate::{
     AllowWarnDeny, BuiltinLintPlugins, ConfigStore, ConfigStoreBuilder, LintPlugins, LintService,

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -12,13 +12,13 @@ use oxc_semantic::{AstNode, ReferenceId, Semantic, SymbolId};
 use oxc_span::CompactStr;
 
 use crate::LintContext;
-
-mod parse_jest_fn;
 pub use crate::utils::jest::parse_jest_fn::{
     ExpectError, KnownMemberExpressionParentKind, KnownMemberExpressionProperty,
     MemberExpressionElement, ParsedExpectFnCall, ParsedGeneralJestFnCall,
     ParsedJestFnCall as ParsedJestFnCallNew, parse_jest_fn_call,
 };
+
+mod parse_jest_fn;
 
 const JEST_METHOD_NAMES: [&str; 18] = [
     "afterAll",

--- a/crates/oxc_linter/src/utils/jsdoc.rs
+++ b/crates/oxc_linter/src/utils/jsdoc.rs
@@ -1,10 +1,11 @@
+use rustc_hash::FxHashSet;
+
 use oxc_ast::{
     AstKind,
     ast::{BindingPattern, BindingPatternKind, Expression, FormalParameters},
 };
 use oxc_semantic::{JSDoc, JSDocTag, Semantic};
 use oxc_span::Span;
-use rustc_hash::FxHashSet;
 
 use crate::{AstNode, config::JSDocPluginSettings};
 

--- a/crates/oxc_linter/src/utils/unicorn.rs
+++ b/crates/oxc_linter/src/utils/unicorn.rs
@@ -1,4 +1,3 @@
-mod boolean;
 use oxc_ast::{
     AstKind,
     ast::{
@@ -10,8 +9,10 @@ use oxc_semantic::AstNode;
 use oxc_span::{ContentEq, Span};
 use oxc_syntax::operator::LogicalOperator;
 
-pub use self::boolean::*;
 use crate::LintContext;
+
+mod boolean;
+pub use boolean::*;
 
 pub fn is_node_value_not_dom_node(expr: &Expression) -> bool {
     matches!(

--- a/crates/oxc_linter/src/utils/vitest.rs
+++ b/crates/oxc_linter/src/utils/vitest.rs
@@ -1,7 +1,8 @@
 use oxc_ast::ast::CallExpression;
 
-use super::{ParsedExpectFnCall, ParsedJestFnCallNew, PossibleJestNode, parse_jest_fn_call};
 use crate::LintContext;
+
+use super::{ParsedExpectFnCall, ParsedJestFnCallNew, PossibleJestNode, parse_jest_fn_call};
 
 pub mod valid_vitest_fn;
 


### PR DESCRIPTION
Pure refactor. Re-order imports in `oxc_linter` crate to be in standard order.