### PR TITLE
refactor(ast_tools): update comments in `AstKind` generator about structs blacklist

### DIFF
--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -27,14 +27,19 @@ use super::define_generator;
 ///
 /// Apart from this list, every struct with `#[ast(visit)]` attr gets an `AstKind`.
 ///
-/// Ideally we want all visited structs to have `AstKind`s.
-/// We are working towards removing all the items from this list (except `Span`).
-/// <https://github.com/oxc-project/oxc/issues/11490>
-const STRUCTS_BLACK_LIST: &[&str] = &[
-    "BindingPattern",
-    // This one should not be removed
-    "Span",
-];
+/// `BindingPattern` and `Span` are special cases:
+///
+/// * `Span` we don't want to have an `AstKind` because it's not an AST node.
+///   Once we have `NodeId` stored in AST types, it won't need to be visited.
+///   So then it won't get an `AstKind` automatically, and can be removed from this blacklist.
+///
+/// * `BindingPattern` we intend to change into an enum.
+///   <https://github.com/oxc-project/oxc/issues/11489#issuecomment-2946791520>
+///
+/// These 2 should continue to be blacklisted for now.
+///
+/// See also: <https://github.com/oxc-project/oxc/issues/11490>
+const STRUCTS_BLACK_LIST: &[&str] = &["BindingPattern", "Span"];
 
 /// Enums to create an `AstKind` for.
 ///


### PR DESCRIPTION
Update comment in `oxc_ast_tools` about the `AstKind` structs blacklist, to reflect discussion in #11490.