### PR TITLE
chore(deps): `oxc-sourcemap` v4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2242,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_sourcemap"
-version = "3.0.2"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24015d93ed1d8f0c2a0d9f534ca85690888990658a8fc4a87ff0c92640e73300"
+checksum = "91e03c9f8967eb444d211b7f00bb4ac414c7cb6107f59bfc387bdbb75ca58f9a"
 dependencies = [
  "base64-simd",
  "cfg-if",
@@ -2252,7 +2252,6 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
- "rayon",
  "rustc-hash",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,7 +160,7 @@ javascript-globals = "1"
 oxc-browserslist = "2"
 oxc_index = "3"
 oxc_resolver = "11"
-oxc_sourcemap = "3"
+oxc_sourcemap = "4"
 
 #
 allocator-api2 = "=0.2.21"

--- a/napi/minify/Cargo.toml
+++ b/napi/minify/Cargo.toml
@@ -28,7 +28,7 @@ oxc_diagnostics = { workspace = true }
 oxc_minifier = { workspace = true }
 oxc_napi = { workspace = true }
 oxc_parser = { workspace = true }
-oxc_sourcemap = { workspace = true, features = ["napi", "rayon"] }
+oxc_sourcemap = { workspace = true, features = ["napi"] }
 oxc_span = { workspace = true }
 oxc_syntax = { workspace = true }
 

--- a/napi/transform/Cargo.toml
+++ b/napi/transform/Cargo.toml
@@ -24,7 +24,7 @@ doctest = false
 [dependencies]
 oxc = { workspace = true, features = ["full"] }
 oxc_napi = { workspace = true }
-oxc_sourcemap = { workspace = true, features = ["napi", "rayon"] }
+oxc_sourcemap = { workspace = true, features = ["napi"] }
 
 rustc-hash = { workspace = true }
 


### PR DESCRIPTION
This release removes rayon support from oxc-sourcemap.

Parallelizing functions calls locally inside sourcemap generation is not optimal,
they interfere with thread scheduling with the rest of the system