### PR TITLE
feat(linter/exhaustive-deps): add auto-fixer

### DIFF
--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -291,6 +291,27 @@ impl<'a> LintContext<'a> {
         self.diagnostic_with_fix_of_kind(diagnostic, FixKind::Suggestion, fix);
     }
 
+    /// Report a lint rule violation and provide a suggestion for fixing it.
+    ///
+    /// The second argument is a [closure] that takes a [`RuleFixer`] and
+    /// returns something that can turn into a `CompositeFix`.
+    ///
+    /// Fixes created this way should not create parse errors, but have the
+    /// potential to change the code's semantics. If your fix is completely safe
+    /// and definitely does not change semantics, use [`LintContext::diagnostic_with_fix`].
+    /// If your fix has the potential to create parse errors, use
+    /// [`LintContext::diagnostic_with_dangerous_fix`].
+    ///
+    /// [closure]: <https://doc.rust-lang.org/book/ch13-01-closures.html>
+    #[inline]
+    pub fn diagnostic_with_dangerous_suggestion<C, F>(&self, diagnostic: OxcDiagnostic, fix: F)
+    where
+        C: Into<RuleFix<'a>>,
+        F: FnOnce(RuleFixer<'_, 'a>) -> C,
+    {
+        self.diagnostic_with_fix_of_kind(diagnostic, FixKind::DangerousSuggestion, fix);
+    }
+
     /// Report a lint rule violation and provide a potentially dangerous
     /// automatic fix for it.
     ///

--- a/crates/oxc_macros/src/declare_oxc_lint.rs
+++ b/crates/oxc_macros/src/declare_oxc_lint.rs
@@ -256,7 +256,11 @@ fn parse_fix(s: &str) -> proc_macro2::TokenStream {
                 is_conditional = true;
                 false
             }
-            "and" | "or" => false, // e.g. fix_or_suggestion
+            // e.g. "safe_fix". safe is implied
+            "safe"
+            // e.g. fix_or_suggestion
+            | "and" | "or" 
+            => false,
             _ => true,
         })
         .unique()
@@ -273,8 +277,8 @@ fn parse_fix(s: &str) -> proc_macro2::TokenStream {
 
 fn parse_fix_kind(s: &str) -> proc_macro2::TokenStream {
     match s {
-        "fix" => quote! { FixKind::Fix },
-        "suggestion" => quote! { FixKind::Suggestion },
+        "fix" | "fixes" => quote! { FixKind::Fix },
+        "suggestion" | "suggestions" => quote! { FixKind::Suggestion },
         "dangerous" => quote! { FixKind::Dangerous },
         _ => panic!("invalid fix kind: {s}. Valid fix kinds are fix, suggestion, or dangerous."),
     }


### PR DESCRIPTION
## What This PR Does
Adds auto-fixing capabilities for some scenarios in `react-hooks/exhaustive-deps`.

This is a poor man's stacked PR. #12337 must be merged first.