### PR TITLE
feat(semantic): add `SymbolFlags::Export` to exported bindings

### DIFF
--- a/crates/oxc_ecmascript/src/bound_names.rs
+++ b/crates/oxc_ecmascript/src/bound_names.rs
@@ -1,8 +1,8 @@
 use oxc_ast::ast::{
     ArrayPattern, AssignmentPattern, BindingIdentifier, BindingPattern, BindingPatternKind,
-    BindingRestElement, Class, Declaration, ExportNamedDeclaration, FormalParameter,
-    FormalParameters, Function, ImportDeclaration, ImportDeclarationSpecifier, ModuleDeclaration,
-    ObjectPattern, VariableDeclaration,
+    BindingRestElement, Class, Declaration, ExportDefaultDeclaration, ExportDefaultDeclarationKind,
+    ExportNamedDeclaration, FormalParameter, FormalParameters, Function, ImportDeclaration,
+    ImportDeclarationSpecifier, ModuleDeclaration, ObjectPattern, VariableDeclaration,
 };
 
 /// [`BoundName`](https://tc39.es/ecma262/#sec-static-semantics-boundnames)
@@ -134,6 +134,7 @@ impl<'a> BoundNames<'a> for ModuleDeclaration<'a> {
         match self {
             ModuleDeclaration::ImportDeclaration(decl) => decl.bound_names(f),
             ModuleDeclaration::ExportNamedDeclaration(decl) => decl.bound_names(f),
+            ModuleDeclaration::ExportDefaultDeclaration(decl) => decl.bound_names(f),
             _ => {}
         }
     }
@@ -163,6 +164,22 @@ impl<'a> BoundNames<'a> for ExportNamedDeclaration<'a> {
     fn bound_names<F: FnMut(&BindingIdentifier<'a>)>(&self, f: &mut F) {
         if let Some(decl) = &self.declaration {
             decl.bound_names(f);
+        }
+    }
+}
+
+impl<'a> BoundNames<'a> for ExportDefaultDeclaration<'a> {
+    fn bound_names<F: FnMut(&BindingIdentifier<'a>)>(&self, f: &mut F) {
+        self.declaration.bound_names(f);
+    }
+}
+
+impl<'a> BoundNames<'a> for ExportDefaultDeclarationKind<'a> {
+    fn bound_names<F: FnMut(&BindingIdentifier<'a>)>(&self, f: &mut F) {
+        match self {
+            Self::FunctionDeclaration(d) => d.bound_names(f),
+            Self::ClassDeclaration(d) => d.bound_names(f),
+            _ => {}
         }
     }
 }

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/exports/default/type-alias.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/exports/default/type-alias.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/exports/default/type-alias
     "node": "Program",
     "symbols": [
       {
-        "flags": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(Export | TypeAlias)",
         "id": 0,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/exports/named/interface-heritage.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/exports/named/interface-heritage.snap
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/exports/named/interface-he
         "references": []
       },
       {
-        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
         "id": 2,
         "name": "MenuTrigger",
         "node": "VariableDeclarator(MenuTrigger)",

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/exports/named/type-and-non-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/exports/named/type-and-non-type.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/exports/named/type-and-non
     "node": "Program",
     "symbols": [
       {
-        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
         "id": 0,
         "name": "ToastViewport",
         "node": "VariableDeclarator(ToastViewport)",

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/issue-7879.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/issue-7879.snap
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/issue-7879.ts
         ]
       },
       {
-        "flags": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class | Export)",
         "id": 1,
         "name": "Foo",
         "node": "Class(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/namespaces/value-module.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/namespaces/value-module.snap
@@ -20,7 +20,7 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/namespaces/value-module.ts
         "node": "TSModuleDeclaration(N1)",
         "symbols": [
           {
-            "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+            "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
             "id": 1,
             "name": "A",
             "node": "VariableDeclarator(A)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-type.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-
     "node": "Program",
     "symbols": [
       {
-        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | TypeAlias)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export | TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "VariableDeclarator(T)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default1.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default1
     "node": "Program",
     "symbols": [
       {
-        "flags": "SymbolFlags(Function)",
+        "flags": "SymbolFlags(Function | Export)",
         "id": 0,
         "name": "f",
         "node": "Function(f)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2.snap
@@ -10,7 +10,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2
     "node": "Program",
     "symbols": [
       {
-        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-dual.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-dual.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-du
     "node": "Program",
     "symbols": [
       {
-        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | TypeAlias)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export | TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "VariableDeclarator(T)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named1.snap
@@ -10,7 +10,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named1.t
     "node": "Program",
     "symbols": [
       {
-        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator(x)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2-type.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2-t
     "node": "Program",
     "symbols": [
       {
-        "flags": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(Export | TypeAlias)",
         "id": 0,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2.snap
@@ -10,7 +10,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2.t
     "node": "Program",
     "symbols": [
       {
-        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3-type.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3-t
     "node": "Program",
     "symbols": [
       {
-        "flags": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(Export | TypeAlias)",
         "id": 0,
         "name": "V",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3.snap
@@ -10,7 +10,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3.t
     "node": "Program",
     "symbols": [
       {
-        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
         "id": 0,
         "name": "v",
         "node": "VariableDeclarator(v)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type.ts
     "node": "Program",
     "symbols": [
       {
-        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | TypeAlias)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export | TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "VariableDeclarator(T)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/class-namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/class-namespace.snap
@@ -19,7 +19,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
         "node": "TSModuleDeclaration(Foo)",
         "symbols": [
           {
-            "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+            "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
             "id": 1,
             "name": "x",
             "node": "VariableDeclarator(x)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/function-namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/function-namespace.snap
@@ -19,7 +19,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
         "node": "TSModuleDeclaration(Foo)",
         "symbols": [
           {
-            "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+            "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
             "id": 1,
             "name": "x",
             "node": "VariableDeclarator(x)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/external-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/external-ref.snap
@@ -12,7 +12,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/exter
         "node": "TSModuleDeclaration(Foo)",
         "symbols": [
           {
-            "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+            "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
             "id": 1,
             "name": "x",
             "node": "VariableDeclarator(x)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-shadowed-in-body.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-shadowed-in-body.snap
@@ -12,7 +12,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-
         "node": "TSModuleDeclaration(Foo)",
         "symbols": [
           {
-            "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+            "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
             "id": 1,
             "name": "Foo",
             "node": "VariableDeclarator(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/namespace.snap
@@ -12,7 +12,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/names
         "node": "TSModuleDeclaration(Foo)",
         "symbols": [
           {
-            "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+            "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
             "id": 1,
             "name": "x",
             "node": "VariableDeclarator(x)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/self-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/self-ref.snap
@@ -12,7 +12,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/self-
         "node": "TSModuleDeclaration(Foo)",
         "symbols": [
           {
-            "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+            "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
             "id": 1,
             "name": "x",
             "node": "VariableDeclarator(x)",

--- a/crates/oxc_semantic/tests/integration/modules.rs
+++ b/crates/oxc_semantic/tests/integration/modules.rs
@@ -22,3 +22,28 @@ fn test_import_type() {
         .contains_flags(SymbolFlags::TypeImport)
         .test();
 }
+
+#[test]
+fn test_export_flag() {
+    let code = [
+        "export let foo, bar",
+        "export const foo = 1, bar = 2",
+        "export function foo() { } export function bar() { }",
+        "export class foo { } export class bar { }",
+        "export const { foo, bar } = o;",
+        "export const [ foo, bar ] = array;",
+        "var foo, bar; export { foo, bar };",
+        "var foo, bar; export { foo as name1, bar as name2 };",
+        "var foo, bar; export { foo as default, bar as default2 };",
+        "var foo, bar; export default foo; export { bar }",
+        "export default function foo() { } export function bar() { }",
+        "export default class foo { } export class bar { }",
+        "export default function* foo() { } export function* bar() { }",
+    ];
+
+    for c in code {
+        let test = SemanticTester::js(c);
+        test.has_symbol("foo").contains_flags(SymbolFlags::Export).test();
+        test.has_symbol("bar").contains_flags(SymbolFlags::Export).test();
+    }
+}

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -116,24 +116,26 @@ bitflags! {
         const Import                  = 1 << 6;
         /// Imported ESM type-only binding
         const TypeImport              = 1 << 7;
+        /// Indicates exported symbol. e.g. `var x; export default x`, `export var x`.
+        const Export                  = 1 << 8;
         // Type specific symbol flags
-        const TypeAlias               = 1 << 8;
-        const Interface               = 1 << 9;
-        const RegularEnum             = 1 << 10;
-        const ConstEnum               = 1 << 11;
-        const EnumMember              = 1 << 12;
-        const TypeParameter           = 1 << 13;
+        const TypeAlias               = 1 << 9;
+        const Interface               = 1 << 10;
+        const RegularEnum             = 1 << 11;
+        const ConstEnum               = 1 << 12;
+        const EnumMember              = 1 << 13;
+        const TypeParameter           = 1 << 14;
         /// Uninstantiated module
-        const NamespaceModule         = 1 << 14;
+        const NamespaceModule         = 1 << 15;
         /// Instantiated module
-        const ValueModule             = 1 << 15;
+        const ValueModule             = 1 << 16;
         /// Declared with `declare` modifier, like `declare function x() {}`.
         //
         // This flag is not part of TypeScript's `SymbolFlags`, it comes from TypeScript's `NodeFlags`. We introduced it into
         // here because `NodeFlags` is incomplete and we only can access to `NodeFlags` in the Semantic, but we also need to
         // access it in the Transformer.
         // https://github.com/microsoft/TypeScript/blob/15392346d05045742e653eab5c87538ff2a3c863/src/compiler/types.ts#L819-L820
-        const Ambient                 = 1 << 16;
+        const Ambient                 = 1 << 17;
 
         const Enum = Self::ConstEnum.bits() | Self::RegularEnum.bits();
         const Variable = Self::FunctionScopedVariable.bits() | Self::BlockScopedVariable.bits();

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 1d4546bc
 
-Passed: 711/1200
+Passed: 705/1200
 
 # All Passed:
 * babel-plugin-transform-logical-assignment-operators
@@ -273,7 +273,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-class-properties (212/269)
+# babel-plugin-transform-class-properties (207/269)
 * assumption-constantSuper/complex-super-class/input.js
 x Output mismatch
 
@@ -291,6 +291,11 @@ x Output mismatch
 
 * assumption-setPublicClassFields/computed/input.js
 x Output mismatch
+
+* assumption-setPublicClassFields/regression-T2983/input.mjs
+Symbol flags mismatch for "_Class2":
+after transform: SymbolId(1): SymbolFlags(Class)
+rebuilt        : SymbolId(1): SymbolFlags(Class | Export)
 
 * assumption-setPublicClassFields/static-infer-name/input.js
 x Output mismatch
@@ -355,6 +360,11 @@ x Output mismatch
 
 * private/parenthesized-optional-member-call-with-transform/input.js
 x Output mismatch
+
+* private/regression-T2983/input.mjs
+Symbol flags mismatch for "_Class2":
+after transform: SymbolId(3): SymbolFlags(Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class | Export)
 
 * private/static-infer-name/input.js
 x Output mismatch
@@ -430,6 +440,11 @@ x Output mismatch
 * public/delete-super-property/input.js
 x Output mismatch
 
+* public/regression-T2983/input.mjs
+Symbol flags mismatch for "_Class2":
+after transform: SymbolId(1): SymbolFlags(Class)
+rebuilt        : SymbolId(1): SymbolFlags(Class | Export)
+
 * public/static-infer-name/input.js
 x Output mismatch
 
@@ -439,6 +454,11 @@ x Output mismatch
 * public-loose/computed/input.js
 x Output mismatch
 
+* public-loose/regression-T2983/input.mjs
+Symbol flags mismatch for "_Class2":
+after transform: SymbolId(1): SymbolFlags(Class)
+rebuilt        : SymbolId(1): SymbolFlags(Class | Export)
+
 * public-loose/static-infer-name/input.js
 x Output mismatch
 
@@ -447,6 +467,11 @@ x Output mismatch
 
 * regression/6153/input.js
 x Output mismatch
+
+* regression/T2983/input.mjs
+Symbol flags mismatch for "_Class2":
+after transform: SymbolId(1): SymbolFlags(Class)
+rebuilt        : SymbolId(1): SymbolFlags(Class | Export)
 
 * source-maps/private-get/input.js
 x Output mismatch
@@ -1343,7 +1368,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-typescript (48/158)
+# babel-plugin-transform-typescript (47/158)
 * cast/as-expression/input.ts
 Unresolved references mismatch:
 after transform: ["T", "x"]
@@ -1549,7 +1574,7 @@ after transform: ScopeId(2): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "E":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 Symbol redeclarations mismatch for "E":
 after transform: SymbolId(0): [Span { start: 12, end: 13 }, Span { start: 40, end: 41 }]
 rebuilt        : SymbolId(0): []
@@ -1701,8 +1726,8 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol flags mismatch for "N":
-after transform: SymbolId(0): SymbolFlags(Class | NamespaceModule | Ambient)
-rebuilt        : SymbolId(0): SymbolFlags(Class)
+after transform: SymbolId(0): SymbolFlags(Class | Export | NamespaceModule | Ambient)
+rebuilt        : SymbolId(0): SymbolFlags(Class | Export)
 Symbol reference IDs mismatch for "N":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
 rebuilt        : SymbolId(0): [ReferenceId(1)]
@@ -1715,8 +1740,8 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Symbol flags mismatch for "Signal":
-after transform: SymbolId(0): SymbolFlags(Class | Function | Ambient)
-rebuilt        : SymbolId(0): SymbolFlags(Function)
+after transform: SymbolId(0): SymbolFlags(Class | Function | Export | Ambient)
+rebuilt        : SymbolId(0): SymbolFlags(Function | Export)
 Symbol span mismatch for "Signal":
 after transform: SymbolId(0): Span { start: 14, end: 20 }
 rebuilt        : SymbolId(0): Span { start: 54, end: 60 }
@@ -1727,8 +1752,8 @@ Symbol redeclarations mismatch for "Signal":
 after transform: SymbolId(0): [Span { start: 14, end: 20 }, Span { start: 54, end: 60 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "Signal2":
-after transform: SymbolId(3): SymbolFlags(Class | Function | Ambient)
-rebuilt        : SymbolId(2): SymbolFlags(Function)
+after transform: SymbolId(3): SymbolFlags(Class | Function | Export | Ambient)
+rebuilt        : SymbolId(2): SymbolFlags(Function | Export)
 Symbol reference IDs mismatch for "Signal2":
 after transform: SymbolId(3): [ReferenceId(4), ReferenceId(7)]
 rebuilt        : SymbolId(2): [ReferenceId(3)]
@@ -1759,14 +1784,14 @@ Scope flags mismatch:
 after transform: ScopeId(16): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "BB":
-after transform: SymbolId(11): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
+after transform: SymbolId(11): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable | Export)
 Symbol redeclarations mismatch for "BB":
 after transform: SymbolId(11): [Span { start: 479, end: 481 }, Span { start: 495, end: 497 }]
 rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "BB2":
-after transform: SymbolId(16): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+after transform: SymbolId(16): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable | Export)
 
 * exports/default-function/input.ts
 Scope children mismatch:
@@ -1778,11 +1803,16 @@ Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "None":
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
+after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "None":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
 rebuilt        : SymbolId(0): [ReferenceId(1)]
+
+* exports/export-import=/input.ts
+Symbol flags mismatch for "JGraph":
+after transform: SymbolId(1): SymbolFlags(FunctionScopedVariable)
+rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable | Export)
 
 * exports/export-type/input.ts
 Scope children mismatch:
@@ -2033,6 +2063,9 @@ rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 6, end: 7 }, Span { start: 22, end: 23 }]
 rebuilt        : SymbolId(0): []
+Symbol flags mismatch for "B":
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
 
 * namespace/clobber-enum/input.ts
 Bindings mismatch:
@@ -2047,11 +2080,14 @@ rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 5, end: 6 }, Span { start: 30, end: 31 }]
 rebuilt        : SymbolId(0): []
+Symbol flags mismatch for "B":
+after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable | ConstVariable)
 
 * namespace/clobber-export/input.ts
 Symbol flags mismatch for "N":
-after transform: SymbolId(0): SymbolFlags(Class | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(Class)
+after transform: SymbolId(0): SymbolFlags(Class | Export | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(Class | Export)
 Symbol redeclarations mismatch for "N":
 after transform: SymbolId(0): [Span { start: 13, end: 14 }, Span { start: 35, end: 36 }]
 rebuilt        : SymbolId(0): []
@@ -2277,7 +2313,7 @@ after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(1): []
 Symbol flags mismatch for "N":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 Symbol span mismatch for "N":
 after transform: SymbolId(0): Span { start: 17, end: 18 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
@@ -2385,7 +2421,7 @@ rebuilt        : SymbolId(24): Span { start: 0, end: 0 }
 * namespace/export/input.ts
 Symbol flags mismatch for "N":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 Symbol span mismatch for "N":
 after transform: SymbolId(0): Span { start: 17, end: 18 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
@@ -2411,17 +2447,23 @@ rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "ns1":
 after transform: SymbolId(1): Span { start: 32, end: 35 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "foo":
+after transform: SymbolId(2): SymbolFlags(Class | Export)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
 Symbol flags mismatch for "ns2":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "ns2":
 after transform: SymbolId(3): Span { start: 113, end: 116 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
+Symbol flags mismatch for "foo":
+after transform: SymbolId(4): SymbolFlags(Class | Export)
+rebuilt        : SymbolId(7): SymbolFlags(Class)
 
 * namespace/module-nested-export/input.ts
 Symbol flags mismatch for "src":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 Symbol span mismatch for "src":
 after transform: SymbolId(0): Span { start: 14, end: 17 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
@@ -2431,12 +2473,18 @@ rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "ns1":
 after transform: SymbolId(1): Span { start: 39, end: 42 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "foo":
+after transform: SymbolId(2): SymbolFlags(Class | Export)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
 Symbol flags mismatch for "ns2":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "ns2":
 after transform: SymbolId(3): Span { start: 120, end: 123 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
+Symbol flags mismatch for "foo":
+after transform: SymbolId(4): SymbolFlags(Class | Export)
+rebuilt        : SymbolId(7): SymbolFlags(Class)
 
 * namespace/multiple/input.ts
 Symbol flags mismatch for "N":
@@ -2497,14 +2545,23 @@ rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "C":
 after transform: SymbolId(1): Span { start: 45, end: 46 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "G":
+after transform: SymbolId(2): SymbolFlags(Class | Export)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol flags mismatch for "E":
+after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable | ConstVariable)
 Symbol flags mismatch for "M":
 after transform: SymbolId(4): SymbolFlags(Function | ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(Function)
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(4): [Span { start: 110, end: 111 }, Span { start: 129, end: 130 }]
 rebuilt        : SymbolId(6): []
+Symbol flags mismatch for "N":
+after transform: SymbolId(5): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable | ConstVariable)
 Symbol flags mismatch for "D":
-after transform: SymbolId(6): SymbolFlags(Function | ValueModule)
+after transform: SymbolId(6): SymbolFlags(Function | Export | ValueModule)
 rebuilt        : SymbolId(9): SymbolFlags(Function)
 Symbol redeclarations mismatch for "D":
 after transform: SymbolId(6): [Span { start: 181, end: 182 }, Span { start: 207, end: 208 }]
@@ -2543,7 +2600,7 @@ after transform: ScopeId(4): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 17, end: 18 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
@@ -2564,6 +2621,9 @@ rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Y":
 after transform: SymbolId(1): Span { start: 12, end: 13 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Z":
+after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable | ConstVariable)
 Symbol flags mismatch for "proj":
 after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
@@ -2588,6 +2648,9 @@ rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "api":
 after transform: SymbolId(6): Span { start: 66, end: 69 }
 rebuilt        : SymbolId(11): Span { start: 0, end: 0 }
+Symbol flags mismatch for "X":
+after transform: SymbolId(7): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(13): SymbolFlags(BlockScopedVariable | ConstVariable)
 
 * namespace/same-name/input.ts
 Scope flags mismatch:
@@ -2614,6 +2677,12 @@ rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "N":
 after transform: SymbolId(3): [Span { start: 59, end: 60 }, Span { start: 115, end: 116 }, Span { start: 166, end: 167 }]
 rebuilt        : SymbolId(5): []
+Symbol flags mismatch for "_N3":
+after transform: SymbolId(4): SymbolFlags(Function | Export)
+rebuilt        : SymbolId(7): SymbolFlags(Function)
+Symbol flags mismatch for "_N5":
+after transform: SymbolId(5): SymbolFlags(Class | Export)
+rebuilt        : SymbolId(9): SymbolFlags(Class)
 Symbol flags mismatch for "_N":
 after transform: SymbolId(6): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -180,14 +180,17 @@ Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch for "Name":
-after transform: SymbolId(7): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+after transform: SymbolId(7): SymbolFlags(Export | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable | Export)
 Symbol span mismatch for "Name":
 after transform: SymbolId(7): Span { start: 116, end: 120 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Q":
+after transform: SymbolId(8): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable | ConstVariable)
 Symbol flags mismatch for "T":
-after transform: SymbolId(9): SymbolFlags(Function | TypeAlias)
-rebuilt        : SymbolId(8): SymbolFlags(Function)
+after transform: SymbolId(9): SymbolFlags(Function | Export | TypeAlias)
+rebuilt        : SymbolId(8): SymbolFlags(Function | Export)
 Symbol span mismatch for "T":
 after transform: SymbolId(9): Span { start: 205, end: 206 }
 rebuilt        : SymbolId(8): Span { start: 226, end: 227 }
@@ -304,13 +307,16 @@ after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(Interface | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 Symbol span mismatch for "Foo":
 after transform: SymbolId(0): Span { start: 17, end: 20 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 17, end: 20 }, Span { start: 41, end: 44 }]
 rebuilt        : SymbolId(0): []
+Symbol flags mismatch for "Bar":
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
 
 * namespace/redeclaration-with-type-alias/input.ts
 Bindings mismatch:
@@ -327,13 +333,19 @@ after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(TypeAlias | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 Symbol span mismatch for "Foo":
 after transform: SymbolId(0): Span { start: 12, end: 15 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 12, end: 15 }, Span { start: 39, end: 42 }, Span { start: 87, end: 90 }]
 rebuilt        : SymbolId(0): []
+Symbol flags mismatch for "Bar":
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
+Symbol flags mismatch for "Zoo":
+after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable | ConstVariable)
 
 * namespace/redeclaration-with-type-only-namespace/input.ts
 Scope children mismatch:
@@ -344,13 +356,16 @@ after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(NamespaceModule | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 Symbol span mismatch for "Foo":
 after transform: SymbolId(0): Span { start: 17, end: 20 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 17, end: 20 }, Span { start: 62, end: 65 }]
 rebuilt        : SymbolId(0): []
+Symbol flags mismatch for "Bar":
+after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
 
 * preserve-import-=/input.js
 Symbol reference IDs mismatch for "Foo":
@@ -365,8 +380,8 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Import)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable)
+after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Import | Export)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 57, end: 58 }
 rebuilt        : SymbolId(0): Span { start: 79, end: 83 }
@@ -377,14 +392,14 @@ Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 57, end: 58 }, Span { start: 79, end: 83 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "T":
-after transform: SymbolId(1): SymbolFlags(Import | TypeAlias)
-rebuilt        : SymbolId(1): SymbolFlags(Import)
+after transform: SymbolId(1): SymbolFlags(Import | Export | TypeAlias)
+rebuilt        : SymbolId(1): SymbolFlags(Import | Export)
 Symbol redeclarations mismatch for "T":
 after transform: SymbolId(1): [Span { start: 149, end: 150 }, Span { start: 170, end: 171 }]
 rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "B":
-after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable | Import | TypeAlias)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
+after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable | Import | Export | TypeAlias)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
 Symbol span mismatch for "B":
 after transform: SymbolId(2): Span { start: 267, end: 268 }
 rebuilt        : SymbolId(2): Span { start: 289, end: 293 }
@@ -499,6 +514,9 @@ rebuilt        : SymbolId(5): ScopeId(4)
 Symbol reference IDs mismatch for "Dependency":
 after transform: SymbolId(1): [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
 rebuilt        : SymbolId(1): [ReferenceId(6), ReferenceId(7)]
+Symbol flags mismatch for "AbstractClass":
+after transform: SymbolId(2): SymbolFlags(BlockScopedVariable)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable | Export)
 Symbol span mismatch for "AbstractClass":
 after transform: SymbolId(2): Span { start: 69, end: 82 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
@@ -632,12 +650,18 @@ rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol span mismatch for "C":
 after transform: SymbolId(5): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(1): Span { start: 11, end: 12 }
+Symbol flags mismatch for "D":
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | Export)
 Symbol span mismatch for "D":
 after transform: SymbolId(1): Span { start: 85, end: 86 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol span mismatch for "D":
 after transform: SymbolId(6): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(3): Span { start: 85, end: 86 }
+Symbol flags mismatch for "E":
+after transform: SymbolId(2): SymbolFlags(BlockScopedVariable)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable | Export)
 Symbol span mismatch for "E":
 after transform: SymbolId(2): Span { start: 167, end: 168 }
 rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
@@ -648,7 +672,7 @@ rebuilt        : SymbolId(5): Span { start: 167, end: 168 }
 * oxc/with-class-private-properties-unnamed-default-export/input.ts
 Symbol flags mismatch for "_default":
 after transform: SymbolId(0): SymbolFlags(Class)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 
 * typescript/accessor/decoratorOnClassAccessor1/input.ts
 Bindings mismatch:
@@ -836,6 +860,9 @@ rebuilt        : ScopeId(0): ["Testing123"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Symbol flags mismatch for "Testing123":
+after transform: SymbolId(3): SymbolFlags(BlockScopedVariable)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 Symbol span mismatch for "Testing123":
 after transform: SymbolId(3): Span { start: 241, end: 251 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
@@ -859,6 +886,9 @@ rebuilt        : ScopeId(0): ["Testing123"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Symbol flags mismatch for "Testing123":
+after transform: SymbolId(3): SymbolFlags(BlockScopedVariable)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 Symbol span mismatch for "Testing123":
 after transform: SymbolId(3): Span { start: 239, end: 249 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
@@ -913,6 +943,9 @@ rebuilt        : ScopeId(0): ["C"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
+Symbol flags mismatch for "C":
+after transform: SymbolId(3): SymbolFlags(BlockScopedVariable)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 Symbol span mismatch for "C":
 after transform: SymbolId(3): Span { start: 127, end: 128 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
@@ -933,6 +966,9 @@ rebuilt        : ScopeId(0): ["C"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
+Symbol flags mismatch for "C":
+after transform: SymbolId(3): SymbolFlags(BlockScopedVariable)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 Symbol span mismatch for "C":
 after transform: SymbolId(3): Span { start: 127, end: 128 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }


### PR DESCRIPTION
The minifier needs to know whether a symbol is exported or not.

e.g.

```js
export var x;
x = 1; // cannot remove this write.
```

This PR reverts #7414 and fixes #7338