### PR TITLE
fix(formatter): incorrect comments checking

### DIFF
--- a/crates/oxc_formatter/src/write/array_element_list.rs
+++ b/crates/oxc_formatter/src/write/array_element_list.rs
@@ -53,7 +53,7 @@ impl<'a> Format<'a> for ArrayElementList<'a, '_> {
                 ) {
                     filler.entry(
                         &format_once(|f| {
-                            if get_lines_before(element.span().start, f) > 1 {
+                            if get_lines_before(element.span(), f) > 1 {
                                 write!(f, empty_line())
                             } else if f
                                 .comments()

--- a/crates/oxc_formatter/src/write/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/write/arrow_function_expression.rs
@@ -111,10 +111,8 @@ impl<'a> Format<'a> for FormatJsArrowFunctionExpression<'a, '_> {
                 // going to get broken anyways.
                 let arrow_expression = arrow.get_expression();
 
-                if matches!(arrow_expression, Some(Expression::SequenceExpression(_))) {
-                    // let has_comment = f.context().comments().has_comments(sequence.syntax());
-                    let has_comment = false;
-                    return if has_comment {
+                if let Some(Expression::SequenceExpression(sequence)) = arrow_expression {
+                    return if f.context().comments().has_comments_before(sequence.span().start) {
                         write!(
                             f,
                             [group(&format_args!(
@@ -552,14 +550,6 @@ impl<'a> Format<'a> for ArrowChain<'a, '_> {
             write!(f, [group(&join_signatures).should_expand(*expand_signatures)])
         });
 
-        // TODO
-        let has_comment = false; //
-        // matches!(
-        // &tail_body,
-        // AnyJsFunctionBody::Expression(Expression::JsSequenceExpression(sequence))
-        // if f.context().comments().has_comments(sequence.syntax())
-        // );
-
         let format_tail_body_inner = format_with(|f| {
             let format_tail_body = FormatMaybeCachedFunctionBody {
                 body: tail_body,
@@ -569,8 +559,8 @@ impl<'a> Format<'a> for ArrowChain<'a, '_> {
 
             // Ensure that the parens of sequence expressions end up on their own line if the
             // body breaks
-            if matches!(tail.get_expression(), Some(Expression::SequenceExpression(_))) {
-                if has_comment {
+            if let Some(Expression::SequenceExpression(sequence)) = tail.get_expression() {
+                if f.context().comments().has_comments_before(sequence.span().start) {
                     write!(
                         f,
                         [group(&format_args!(indent(&format_args!(

--- a/crates/oxc_formatter/src/write/call_arguments.rs
+++ b/crates/oxc_formatter/src/write/call_arguments.rs
@@ -99,7 +99,7 @@ impl<'a> Format<'a> for AstNode<'a, ArenaVec<'a, Argument<'a>>> {
             .iter()
             .enumerate()
             .map(|(index, element)| {
-                let leading_lines = get_lines_before(element.span().start, f);
+                let leading_lines = get_lines_before(element.span(), f);
                 has_empty_line = has_empty_line || leading_lines > 1;
 
                 FormatCallArgument::Default { element, is_last: index == last_index, leading_lines }

--- a/crates/oxc_formatter/src/write/mod.rs
+++ b/crates/oxc_formatter/src/write/mod.rs
@@ -381,7 +381,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, UnaryExpression<'a>> {
         if self.operator().is_keyword() {
             write!(f, space());
         }
-        if f.comments().has_comments_in_span(self.span) {
+        let Span { start, end, .. } = self.argument.span();
+        if f.comments().has_comments_before(start)
+            || f.comments().has_comments_between(end, self.span().end)
+        {
             write!(
                 f,
                 [group(&format_args!(text("("), soft_block_indent(self.argument()), text(")")))]

--- a/crates/oxc_formatter/src/write/parameter_list.rs
+++ b/crates/oxc_formatter/src/write/parameter_list.rs
@@ -160,12 +160,12 @@ pub fn can_avoid_parentheses(
         && !f.comments().has_comments_in_span(arrow.params.span)
 }
 
-pub fn should_hug_function_parameters(
-    parameters: &FormalParameters<'_>,
+pub fn should_hug_function_parameters<'a>(
+    parameters: &AstNode<'a, FormalParameters<'a>>,
     parentheses_not_needed: bool,
-    f: &Formatter<'_, '_>,
+    f: &Formatter<'_, 'a>,
 ) -> bool {
-    let list = &parameters.items;
+    let list = &parameters.items();
     if list.len() != 1 || parameters.rest.is_some() {
         return false;
     }
@@ -177,7 +177,11 @@ pub fn should_hug_function_parameters(
         return false;
     }
 
-    if f.comments().has_comments_in_span(parameters.span) {
+    // `(/* comment before */ only_parameter /* comment after */)`
+    // Checker whether there are comments around the only parameter.
+    if f.comments().has_comments_between(parameters.span.start, only_parameter.span.start)
+        || f.comments().has_comments_between(only_parameter.span.end, parameters.span.end)
+    {
         return false;
     }
 

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 389/699 (55.65%)
+js compatibility: 394/699 (56.37%)
 
 # Failed
 
@@ -7,7 +7,7 @@ js compatibility: 389/699 (55.65%)
 | js/arrays/preserve_empty_lines.js | 💥 | 97.30% |
 | js/arrow-call/arrow_call.js | 💥💥💥 | 94.85% |
 | js/arrows/call.js | 💥💥 | 75.68% |
-| js/arrows/comment.js | 💥💥 | 60.87% |
+| js/arrows/comment.js | 💥💥 | 63.75% |
 | js/arrows/curried.js | 💥💥 | 92.55% |
 | js/arrows/currying-4.js | 💥💥 | 94.34% |
 | js/arrows/issue-1389-curry.js | 💥💥 | 86.96% |
@@ -20,11 +20,11 @@ js compatibility: 389/699 (55.65%)
 | js/assignment/issue-2482-2.js | 💥 | 62.50% |
 | js/assignment/issue-7572.js | 💥 | 72.73% |
 | js/assignment/sequence.js | 💥 | 71.43% |
-| js/assignment-comments/function.js | 💥 | 74.47% |
+| js/assignment-comments/function.js | 💥 | 92.73% |
 | js/async/inline-await.js | 💥 | 25.00% |
 | js/async/nested.js | 💥 | 16.67% |
 | js/binary-expressions/arrow.js | 💥 | 66.67% |
-| js/binary-expressions/comment.js | 💥 | 76.47% |
+| js/binary-expressions/comment.js | 💥 | 86.36% |
 | js/binary-expressions/in_instanceof.js | 💥 | 97.96% |
 | js/binary-expressions/inline-jsx.js | 💥 | 40.00% |
 | js/binary-expressions/inline-object-array.js | 💥 | 85.71% |
@@ -33,7 +33,7 @@ js compatibility: 389/699 (55.65%)
 | js/binary-expressions/test.js | 💥 | 95.65% |
 | js/break-calls/react.js | 💥 | 97.50% |
 | js/break-calls/reduce.js | 💥 | 77.78% |
-| js/call/first-argument-expansion/issue-13237.js | 💥 | 58.54% |
+| js/call/first-argument-expansion/issue-13237.js | 💥 | 63.16% |
 | js/call/first-argument-expansion/jsx.js | 💥 | 0.00% |
 | js/call/first-argument-expansion/test.js | 💥 | 96.57% |
 | js/chain-expression/call-expression.js | 💥 | 42.86% |
@@ -48,16 +48,14 @@ js compatibility: 389/699 (55.65%)
 | js/class-comment/superclass.js | 💥 | 57.83% |
 | js/class-extends/complex.js | 💥 | 89.47% |
 | js/class-extends/extends.js | 💥 | 94.74% |
-| js/class-static-block/class-static-block.js | 💥 | 47.83% |
+| js/class-static-block/class-static-block.js | 💥 | 57.14% |
 | js/class-static-block/with-line-breaks.js | 💥 | 50.00% |
 | js/classes/assignment.js | 💥 | 81.25% |
 | js/classes/method.js | 💥 | 71.43% |
-| js/classes/property.js | 💥 | 54.55% |
+| js/classes/property.js | 💥 | 62.86% |
 | js/classes-private-fields/with_comments.js | 💥💥 | 30.77% |
 | js/comments/15661.js | 💥💥 | 46.15% |
 | js/comments/16398.js | 💥💥 | 80.00% |
-| js/comments/binary-expressions-block-comments.js | 💥💥 | 88.00% |
-| js/comments/binary-expressions-single-comments.js | 💥💥 | 93.33% |
 | js/comments/blank.js | 💥💥 | 95.24% |
 | js/comments/call_comment.js | 💥💥 | 90.91% |
 | js/comments/dangling.js | 💥💥 | 93.33% |
@@ -67,16 +65,15 @@ js compatibility: 389/699 (55.65%)
 | js/comments/empty-statements.js | 💥💥 | 87.88% |
 | js/comments/export-and-import.js | 💥💥 | 78.05% |
 | js/comments/export.js | 💥💥 | 84.93% |
-| js/comments/function-declaration.js | 💥💥 | 72.00% |
+| js/comments/function-declaration.js | 💥💥 | 67.77% |
 | js/comments/if.js | 💥💥 | 38.16% |
 | js/comments/issue-3532.js | 💥💥 | 80.82% |
-| js/comments/issues.js | 💥💥 | 66.67% |
+| js/comments/issues.js | 💥💥 | 73.68% |
 | js/comments/jsdoc-nestled-dangling.js | 💥💥 | 93.02% |
 | js/comments/jsdoc-nestled.js | 💥💥 | 89.29% |
 | js/comments/jsdoc.js | 💥💥 | 47.83% |
 | js/comments/jsx.js | 💥💥 | 41.63% |
 | js/comments/last-arg.js | 💥💥 | 80.65% |
-| js/comments/multi-comments-2.js | 💥💥 | 90.91% |
 | js/comments/multi-comments-on-same-line.js | 💥✨ | 42.78% |
 | js/comments/multi-comments.js | 💥✨ | 36.84% |
 | js/comments/return-statement.js | 💥💥 | 52.32% |
@@ -107,7 +104,7 @@ js compatibility: 389/699 (55.65%)
 | js/conditional/comments.js | 💥💥 | 42.55% |
 | js/conditional/new-ternary-examples.js | 💥💥 | 23.60% |
 | js/conditional/new-ternary-spec.js | 💥💥 | 44.29% |
-| js/conditional/postfix-ternary-regressions.js | 💥💥 | 38.54% |
+| js/conditional/postfix-ternary-regressions.js | 💥💥 | 39.92% |
 | js/decorators/classes.js | 💥 | 66.67% |
 | js/decorators/comments.js | 💥 | 71.19% |
 | js/decorators/member-expression.js | 💥 | 80.60% |
@@ -145,7 +142,6 @@ js compatibility: 389/699 (55.65%)
 | js/functional-composition/pipe-function-calls-with-comments.js | 💥 | 77.08% |
 | js/functional-composition/pipe-function-calls.js | 💥 | 61.11% |
 | js/functional-composition/rxjs_pipe.js | 💥 | 45.45% |
-| js/generator/anonymous.js | 💥 | 91.43% |
 | js/identifier/for-of/await.js | 💥 | 33.33% |
 | js/identifier/for-of/let.js | 💥 | 61.54% |
 | js/identifier/parentheses/const.js | 💥💥 | 0.00% |
@@ -162,7 +158,7 @@ js compatibility: 389/699 (55.65%)
 | js/import-attributes/keyword-detect.js | 💥 | 28.57% |
 | js/import-attributes/long-sources.js | 💥 | 48.48% |
 | js/label/comment.js | 💥 | 53.33% |
-| js/last-argument-expansion/arrow.js | 💥 | 16.67% |
+| js/last-argument-expansion/arrow.js | 💥 | 11.43% |
 | js/last-argument-expansion/break-parent.js | 💥 | 57.14% |
 | js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 0.00% |
 | js/last-argument-expansion/edge_case.js | 💥 | 83.97% |
@@ -188,7 +184,7 @@ js compatibility: 389/699 (55.65%)
 | js/method-chain/inline_merge.js | 💥 | 80.00% |
 | js/method-chain/issue-11298.js | 💥 | 20.00% |
 | js/method-chain/issue-3594.js | 💥 | 50.00% |
-| js/method-chain/issue-4125.js | 💥 | 60.84% |
+| js/method-chain/issue-4125.js | 💥 | 60.39% |
 | js/method-chain/logical.js | 💥 | 76.00% |
 | js/method-chain/multiple-members.js | 💥 | 45.65% |
 | js/method-chain/object-literal.js | 💥 | 7.69% |
@@ -218,7 +214,7 @@ js compatibility: 389/699 (55.65%)
 | js/preserve-line/argument-list.js | 💥 | 99.44% |
 | js/preserve-line/member-chain.js | 💥 | 23.30% |
 | js/quote-props/classes.js | 💥💥✨✨ | 47.06% |
-| js/quote-props/objects.js | 💥💥💥💥 | 71.36% |
+| js/quote-props/objects.js | 💥💥✨✨ | 45.10% |
 | js/quote-props/with_numbers.js | 💥💥✨✨ | 46.43% |
 | js/quotes/objects.js | 💥💥 | 80.00% |
 | js/require/require.js | 💥 | 90.67% |
@@ -257,13 +253,12 @@ js compatibility: 389/699 (55.65%)
 | js/test-declarations/optional.js | 💥💥 | 0.00% |
 | js/test-declarations/test_declarations.js | 💥💥 | 75.81% |
 | js/throw_statement/binaryish.js | 💥 | 25.00% |
-| js/throw_statement/comment.js | 💥 | 34.29% |
+| js/throw_statement/comment.js | 💥 | 43.24% |
 | js/trailing-comma/dynamic-import.js | 💥💥💥 | 0.00% |
 | js/trailing-comma/jsx.js | 💥💥💥 | 0.00% |
-| js/trailing-comma/trailing_whitespace.js | 💥💥💥 | 90.91% |
 | js/try/catch.js | 💥 | 52.63% |
 | js/try/try.js | 💥 | 50.00% |
-| js/unary-expression/comments.js | 💥 | 75.93% |
+| js/unary-expression/comments.js | 💥 | 76.58% |
 | js/unicode/nbsp-jsx.js | 💥 | 22.22% |
 | js/variable_declarator/multiple.js | 💥 | 87.27% |
 | js/yield/jsx-without-parenthesis.js | 💥 | 50.00% |
@@ -313,4 +308,4 @@ js compatibility: 389/699 (55.65%)
 | jsx/spread/child.js | 💥 | 33.33% |
 | jsx/stateless-arrow-fn/test.js | 💥 | 21.58% |
 | jsx/text-wrap/issue-16897.js | 💥 | 56.00% |
-| jsx/text-wrap/test.js | 💥 | 32.99% |
+| jsx/text-wrap/test.js | 💥 | 33.85% |

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 228/573 (39.79%)
+ts compatibility: 233/573 (40.66%)
 
 # Failed
 
@@ -49,7 +49,7 @@ ts compatibility: 228/573 (39.79%)
 | jsx/spread/child.js | 💥 | 33.33% |
 | jsx/stateless-arrow-fn/test.js | 💥 | 21.58% |
 | jsx/text-wrap/issue-16897.js | 💥 | 56.00% |
-| jsx/text-wrap/test.js | 💥 | 32.99% |
+| jsx/text-wrap/test.js | 💥 | 33.85% |
 | typescript/ambient/ambient.ts | 💥 | 88.24% |
 | typescript/angular-component-examples/15934-computed.component.ts | 💥💥 | 72.00% |
 | typescript/angular-component-examples/15934.component.ts | 💥💥 | 48.00% |
@@ -71,13 +71,13 @@ ts compatibility: 228/573 (39.79%)
 | typescript/assert/comment.ts | 💥 | 0.00% |
 | typescript/assert/index.ts | 💥 | 75.00% |
 | typescript/assignment/issue-10846.ts | 💥 | 23.73% |
-| typescript/assignment/issue-10848.tsx | 💥 | 28.57% |
+| typescript/assignment/issue-10848.tsx | 💥 | 41.38% |
 | typescript/assignment/issue-10850.ts | 💥 | 50.00% |
 | typescript/assignment/issue-12413.ts | 💥 | 3.03% |
 | typescript/assignment/issue-2485.ts | 💥 | 44.44% |
 | typescript/call-signature/call-signature.ts | 💥 | 79.66% |
 | typescript/cast/as-const.ts | 💥 | 54.55% |
-| typescript/cast/generic-cast.ts | 💥 | 39.60% |
+| typescript/cast/generic-cast.ts | 💥 | 39.46% |
 | typescript/cast/tuple-and-record.ts | 💥 | 0.00% |
 | typescript/chain-expression/call-expression.ts | 💥 | 32.81% |
 | typescript/chain-expression/member-expression.ts | 💥 | 31.34% |
@@ -95,7 +95,7 @@ ts compatibility: 228/573 (39.79%)
 | typescript/class-comment/misc.ts | 💥 | 71.43% |
 | typescript/classes/break-heritage.ts | 💥 | 51.06% |
 | typescript/classes/break.ts | 💥 | 39.39% |
-| typescript/comments/15707.ts | 💥 | 51.85% |
+| typescript/comments/15707.ts | 💥 | 74.51% |
 | typescript/comments/16065-2.ts | 💥 | 55.56% |
 | typescript/comments/16889.ts | 💥 | 90.60% |
 | typescript/comments/after_jsx_generic.tsx | 💥 | 5.00% |
@@ -103,7 +103,7 @@ ts compatibility: 228/573 (39.79%)
 | typescript/comments/interface.ts | 💥 | 92.86% |
 | typescript/comments/issues.ts | 💥 | 21.21% |
 | typescript/comments/jsx.tsx | 💥 | 20.00% |
-| typescript/comments/location.ts | 💥 | 58.54% |
+| typescript/comments/location.ts | 💥 | 75.00% |
 | typescript/comments/mapped_types.ts | 💥 | 58.82% |
 | typescript/comments/method_types.ts | 💥 | 69.23% |
 | typescript/comments/methods.ts | 💥 | 97.96% |
@@ -119,7 +119,6 @@ ts compatibility: 228/573 (39.79%)
 | typescript/compiler/checkInfiniteExpansionTermination.ts | 💥 | 80.00% |
 | typescript/compiler/commentsInterface.ts | 💥 | 66.67% |
 | typescript/compiler/contextualSignatureInstantiation2.ts | 💥 | 88.89% |
-| typescript/compiler/functionOverloadsOnGenericArity1.ts | 💥 | 90.00% |
 | typescript/compiler/indexSignatureWithInitializer.ts | 💥 | 75.00% |
 | typescript/compiler/mappedTypeWithCombinedTypeMappers.ts | 💥 | 59.46% |
 | typescript/compiler/privacyGloImport.ts | 💥 | 95.92% |
@@ -133,9 +132,7 @@ ts compatibility: 228/573 (39.79%)
 | typescript/conformance/classes/mixinAccessModifiers.ts | 💥 | 99.07% |
 | typescript/conformance/classes/mixinClassesAnnotated.ts | 💥 | 98.57% |
 | typescript/conformance/classes/mixinClassesMembers.ts | 💥 | 92.08% |
-| typescript/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMixedWithModifiers.ts | 💥 | 69.23% |
-| typescript/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractOverloads.ts | 💥 | 93.33% |
-| typescript/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractProperties.ts | 💥 | 91.67% |
+| typescript/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMixedWithModifiers.ts | 💥 | 86.67% |
 | typescript/conformance/classes/classDeclarations/classHeritageSpecification/classExtendingClass.ts | 💥 | 93.55% |
 | typescript/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsItselfIndirectly.ts | 💥 | 86.96% |
 | typescript/conformance/classes/classDeclarations/classHeritageSpecification/classIsSubtypeOfBaseType.ts | 💥 | 85.71% |
@@ -230,7 +227,6 @@ ts compatibility: 228/573 (39.79%)
 | typescript/index-signature/index-signature.ts | 💥 | 75.00% |
 | typescript/index-signature/static.ts | 💥 | 66.67% |
 | typescript/infer-extends/basic.ts | 💥 | 11.76% |
-| typescript/instantiation-expression/inferface-asi.ts | 💥 | 88.89% |
 | typescript/instantiation-expression/property-access.ts | 💥 | 78.57% |
 | typescript/interface/comments-generic.ts | 💥💥 | 30.00% |
 | typescript/interface/generic.ts | 💥💥 | 75.00% |
@@ -246,7 +242,7 @@ ts compatibility: 228/573 (39.79%)
 | typescript/intersection/type-arguments.ts | 💥💥 | 46.67% |
 | typescript/intersection/consistent-with-flow/comment.ts | 💥 | 0.00% |
 | typescript/intersection/consistent-with-flow/intersection-parens.ts | 💥 | 60.47% |
-| typescript/key-remapping-in-mapped-types/key-remapping.ts | 💥 | 0.00% |
+| typescript/key-remapping-in-mapped-types/key-remapping.ts | 💥 | 23.53% |
 | typescript/keyof/keyof.ts | 💥 | 20.00% |
 | typescript/keyword-types/conditional-types.ts | 💥 | 16.67% |
 | typescript/keywords/keywords-2.ts | 💥 | 79.41% |
@@ -280,14 +276,14 @@ ts compatibility: 228/573 (39.79%)
 | typescript/prettier-ignore/mapped-types.ts | 💥 | 58.49% |
 | typescript/prettier-ignore/prettier-ignore-nested-unions.ts | 💥 | 5.56% |
 | typescript/prettier-ignore/prettier-ignore-parenthesized-type.ts | 💥 | 0.00% |
-| typescript/private-fields-in-in/basic.ts | 💥 | 59.26% |
+| typescript/private-fields-in-in/basic.ts | 💥 | 64.29% |
 | typescript/quote-props/types.ts | 💥💥💥 | 55.56% |
 | typescript/readonly/array.ts | 💥 | 0.00% |
 | typescript/rest/rest.ts | 💥 | 0.00% |
 | typescript/rest-type/complex.ts | 💥 | 0.00% |
 | typescript/rest-type/infer-type.ts | 💥 | 60.87% |
 | typescript/satisfies-operators/argument-expansion.ts | 💥✨ | 46.77% |
-| typescript/satisfies-operators/assignment.ts | 💥💥 | 83.72% |
+| typescript/satisfies-operators/assignment.ts | 💥💥 | 86.36% |
 | typescript/satisfies-operators/basic.ts | 💥💥 | 93.33% |
 | typescript/satisfies-operators/export-default-as.ts | 💥💥 | 0.00% |
 | typescript/satisfies-operators/expression-statement.ts | 💥💥 | 78.38% |
@@ -337,7 +333,6 @@ ts compatibility: 228/573 (39.79%)
 | typescript/typeparams/long-function-arg.ts | 💥 | 66.67% |
 | typescript/typeparams/tagged-template-expression.ts | 💥 | 75.00% |
 | typescript/typeparams/empty-parameters-with-arrow-function/issue-13817.ts | 💥 | 66.67% |
-| typescript/typeparams/print-width-120/issue-7542.tsx | 💥 | 80.00% |
 | typescript/typeparams/trailing-comma/type-paramters.ts | 💥💥💥 | 28.57% |
 | typescript/union/comments.ts | 💥 | 15.38% |
 | typescript/union/inlining.ts | 💥 | 29.92% |


### PR DESCRIPTION
Due to our printing comments architecture is different from `Biome`, so it may incorrectly implement the comments checking parts. But fortunately, those will be caught as the port work gradually nears done.