### PR TITLE
refactor(napi/parser): use `sourceByteLen` for UTF8 source length

### DIFF
--- a/napi/parser/bench.bench.mjs
+++ b/napi/parser/bench.bench.mjs
@@ -175,7 +175,7 @@ for (const { filename, code } of fixtures) {
     const ast = {
       buffer,
       sourceText: code,
-      sourceLen: sourceByteLen,
+      sourceByteLen,
       sourceIsAscii: code.length === sourceByteLen,
       nodes: null, // Initialized in bench functions
       token: TOKEN,

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -5,20 +5,20 @@
 
 module.exports = deserialize;
 
-let uint8, uint32, float64, sourceText, sourceIsAscii, sourceLen;
+let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen;
 
 const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
   { fromCodePoint } = String;
 
-function deserialize(buffer, sourceTextInput, sourceLenInput) {
+function deserialize(buffer, sourceTextInput, sourceByteLenInput) {
   uint8 = buffer;
   uint32 = buffer.uint32;
   float64 = buffer.float64;
 
   sourceText = sourceTextInput;
-  sourceLen = sourceLenInput;
-  sourceIsAscii = sourceText.length === sourceLen;
+  sourceByteLen = sourceByteLenInput;
+  sourceIsAscii = sourceText.length === sourceByteLen;
 
   const data = deserializeRawTransferData(uint32[536870906]);
 
@@ -4026,7 +4026,7 @@ function deserializeStr(pos) {
   if (len === 0) return '';
 
   pos = uint32[pos32];
-  if (sourceIsAscii && pos < sourceLen) return sourceText.substr(pos, len);
+  if (sourceIsAscii && pos < sourceByteLen) return sourceText.substr(pos, len);
 
   // Longer strings use `TextDecoder`
   // TODO: Find best switch-over point

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -5,20 +5,20 @@
 
 module.exports = deserialize;
 
-let uint8, uint32, float64, sourceText, sourceIsAscii, sourceLen;
+let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen;
 
 const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
   { fromCodePoint } = String;
 
-function deserialize(buffer, sourceTextInput, sourceLenInput) {
+function deserialize(buffer, sourceTextInput, sourceByteLenInput) {
   uint8 = buffer;
   uint32 = buffer.uint32;
   float64 = buffer.float64;
 
   sourceText = sourceTextInput;
-  sourceLen = sourceLenInput;
-  sourceIsAscii = sourceText.length === sourceLen;
+  sourceByteLen = sourceByteLenInput;
+  sourceIsAscii = sourceText.length === sourceByteLen;
 
   const data = deserializeRawTransferData(uint32[536870906]);
 
@@ -4157,7 +4157,7 @@ function deserializeStr(pos) {
   if (len === 0) return '';
 
   pos = uint32[pos32];
-  if (sourceIsAscii && pos < sourceLen) return sourceText.substr(pos, len);
+  if (sourceIsAscii && pos < sourceByteLen) return sourceText.substr(pos, len);
 
   // Longer strings use `TextDecoder`
   // TODO: Find best switch-over point

--- a/napi/parser/generated/lazy/constructors.js
+++ b/napi/parser/generated/lazy/constructors.js
@@ -12480,7 +12480,7 @@ function constructStr(pos, ast) {
   if (len === 0) return '';
 
   pos = uint32[pos32];
-  if (ast.sourceIsAscii && pos < ast.sourceLen) return ast.sourceText.substr(pos, len);
+  if (ast.sourceIsAscii && pos < ast.sourceByteLen) return ast.sourceText.substr(pos, len);
 
   // Longer strings use `TextDecoder`
   // TODO: Find best switch-over point

--- a/napi/parser/raw-transfer/lazy.js
+++ b/napi/parser/raw-transfer/lazy.js
@@ -93,10 +93,10 @@ const bufferRecycleRegistry = typeof FinalizationRegistry === 'undefined'
  * @returns {Object} - Object with property getters for `program`, `module`, `comments`, and `errors`,
  *   and `dispose` and `visit` methods
  */
-function construct(buffer, sourceText, sourceLen) {
+function construct(buffer, sourceText, sourceByteLen) {
   // Create AST object
-  const sourceIsAscii = sourceText.length === sourceLen;
-  const ast = { buffer, sourceText, sourceLen, sourceIsAscii, nodes: new Map(), token: TOKEN };
+  const sourceIsAscii = sourceText.length === sourceByteLen;
+  const ast = { buffer, sourceText, sourceByteLen, sourceIsAscii, nodes: new Map(), token: TOKEN };
 
   // Register `ast` with the recycle registry so buffer is returned to cache
   // when `ast` is garbage collected

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -100,20 +100,20 @@ fn generate_deserializers(consts: Constants, schema: &Schema, codegen: &Codegen)
 
         module.exports = deserialize;
 
-        let uint8, uint32, float64, sourceText, sourceIsAscii, sourceLen;
+        let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen;
 
         const textDecoder = new TextDecoder('utf-8', {{ ignoreBOM: true }}),
             decodeStr = textDecoder.decode.bind(textDecoder),
             {{ fromCodePoint }} = String;
 
-        function deserialize(buffer, sourceTextInput, sourceLenInput) {{
+        function deserialize(buffer, sourceTextInput, sourceByteLenInput) {{
             uint8 = buffer;
             uint32 = buffer.uint32;
             float64 = buffer.float64;
 
             sourceText = sourceTextInput;
-            sourceLen = sourceLenInput;
-            sourceIsAscii = sourceText.length === sourceLen;
+            sourceByteLen = sourceByteLenInput;
+            sourceIsAscii = sourceText.length === sourceByteLen;
 
             const data = deserializeRawTransferData(uint32[{data_pointer_pos_32}]);
 
@@ -540,7 +540,7 @@ static STR_DESERIALIZER_BODY: &str = "
     if (len === 0) return '';
 
     pos = uint32[pos32];
-    if (sourceIsAscii && pos < sourceLen) return sourceText.substr(pos, len);
+    if (sourceIsAscii && pos < sourceByteLen) return sourceText.substr(pos, len);
 
     // Longer strings use `TextDecoder`
     // TODO: Find best switch-over point

--- a/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
@@ -958,7 +958,7 @@ static STR_DESERIALIZER_BODY: &str = "
     if (len === 0) return '';
 
     pos = uint32[pos32];
-    if (ast.sourceIsAscii && pos < ast.sourceLen) return ast.sourceText.substr(pos, len);
+    if (ast.sourceIsAscii && pos < ast.sourceByteLen) return ast.sourceText.substr(pos, len);
 
     // Longer strings use `TextDecoder`
     // TODO: Find best switch-over point


### PR DESCRIPTION
Pure refactor. Use var name `sourceByteLen` for UTF-8 byte length of source, to disambiguate from UTF-16 length (`sourceText.length`).