### PR TITLE
refactor(ast_tools): implement `Eq` for `Layout`

### DIFF
--- a/tasks/ast_tools/src/schema/extensions/layout.rs
+++ b/tasks/ast_tools/src/schema/extensions/layout.rs
@@ -8,7 +8,7 @@ use crate::schema::{
 };
 
 /// The layout of a type.
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default, PartialEq, Eq, Debug)]
 pub struct Layout {
     /// Layout on 64-bit platforms
     pub layout_64: PlatformLayout,
@@ -57,7 +57,7 @@ impl Layout {
 }
 
 /// The layout of a type on a specific platform type (64 bit or 32 bit).
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default, PartialEq, Eq, Debug)]
 pub struct PlatformLayout {
     pub size: u32,
     pub align: u32,
@@ -77,7 +77,7 @@ impl PlatformLayout {
 }
 
 /// Niche that a type has.
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Niche {
     /// Byte offset of the niche from start of type
     pub offset: u32,


### PR DESCRIPTION
Pure refactor. Implement `PartialEq` and `Eq` on `Layout` and its constituent types, to enable easy comparison in a later PR.