### PR TITLE
refactor(linter): make feature gates for `oxlint2` feature consistent

### DIFF
--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -427,13 +427,14 @@ impl ConfigStoreBuilder {
         serde_json::to_string_pretty(&oxlintrc).unwrap()
     }
 
-    #[cfg(any(not(feature = "oxlint2"), feature = "disable_oxlint2"))]
+    #[cfg(not(all(feature = "oxlint2", not(feature = "disable_oxlint2"))))]
+    #[expect(unused_variables, clippy::needless_pass_by_ref_mut)]
     fn load_external_plugin(
-        _oxlintrc_dir_path: &Path,
-        _plugin_specifier: &str,
-        _external_linter: &ExternalLinter,
-        _resolver: &Resolver,
-        _external_plugin_store: &mut ExternalPluginStore,
+        oxlintrc_dir_path: &Path,
+        plugin_specifier: &str,
+        external_linter: &ExternalLinter,
+        resolver: &Resolver,
+        external_plugin_store: &mut ExternalPluginStore,
     ) -> Result<(), ConfigBuilderError> {
         unreachable!()
     }

--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -43,7 +43,7 @@ pub struct Loc {
 }
 
 #[derive(Clone)]
-#[cfg_attr(any(not(feature = "oxlint2"), feature = "disable_oxlint2"), expect(dead_code))]
+#[cfg_attr(not(all(feature = "oxlint2", not(feature = "disable_oxlint2"))), expect(dead_code))]
 pub struct ExternalLinter {
     pub(crate) load_plugin: ExternalLinterLoadPluginCb,
     pub(crate) run: ExternalLinterCb,


### PR DESCRIPTION
Pure refactor. Make the feature gates for "`oxlint2` feature and not `disable_oxlint2` feature" consistent everywhere. Also make the function signature for the gated/ungated function pairs identical so you can copy and paste them.