### PR TITLE
refactor(linter): move running external rules into feature-gated function

### DIFF
--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -285,6 +285,7 @@ impl ConfigStore {
         None
     }
 
+    #[cfg_attr(not(all(feature = "oxlint2", not(feature = "disable_oxlint2"))), expect(dead_code))]
     pub(crate) fn resolve_plugin_rule_names(&self, external_rule_id: u32) -> Option<(&str, &str)> {
         self.external_plugin_store.resolve_plugin_rule_names(external_rule_id)
     }


### PR DESCRIPTION
Move running external rules into a separate function and feature gate it. The gate is needed so it can use methods which only exist when the feature is enabled in later PRs.