### PR TITLE
refactor(linter): make unwrap unconditional

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -232,8 +232,8 @@ impl Linter {
             return;
         }
 
-        // TODO: Error or `unwrap` instead of `return`?
-        let Some(external_linter) = &self.external_linter else { return };
+        // `external_linter` always exists when `oxlint2` feature is enabled
+        let external_linter = self.external_linter.as_ref().unwrap();
 
         let result = (external_linter.run)(
             path.to_str().unwrap().to_string(),


### PR DESCRIPTION
Refactor. When we know something is always `Some`, in my view it's preferable to `unwrap` it rather than exiting early if `None`. This makes the code less ambiguous - otherwise it reads like maybe it's `Some`, maybe it's `None`.