### PR TITLE
feat(minifier): remove no-op function call

### DIFF
--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -181,6 +181,11 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
         }
     }
 
+    fn enter_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
+        let ctx = &mut Ctx::new(ctx);
+        Self::keep_track_of_empty_functions(stmt, ctx);
+    }
+
     fn exit_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
         if !self.is_prev_function_changed() {
             return;

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -953,7 +953,7 @@ mod test {
             treeshake: TreeShakeOptions { annotations: false, ..TreeShakeOptions::default() },
             ..default_options()
         };
-        test_same_options("function test() {} /* @__PURE__ */ test()", &options);
+        test_same_options("function test() { bar } /* @__PURE__ */ test()", &options);
         test_same_options("function test() {} /* @__PURE__ */ new test()", &options);
 
         let options = CompressOptions {

--- a/crates/oxc_minifier/src/peephole/remove_unused_variable_declaration.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_variable_declaration.rs
@@ -115,7 +115,7 @@ mod test {
     fn remove_unused_function_declaration() {
         let options = CompressOptions::smallest();
         test_options("function foo() {}", "", &options);
-        test_same_options("function foo() {} foo()", &options);
+        test_same_options("function foo() { bar } foo()", &options);
         test_same_options("export function foo() {} foo()", &options);
     }
 

--- a/crates/oxc_minifier/src/state.rs
+++ b/crates/oxc_minifier/src/state.rs
@@ -1,4 +1,4 @@
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_ecmascript::constant_evaluation::ConstantValue;
 use oxc_semantic::SymbolId;
@@ -16,10 +16,18 @@ pub struct MinifierState<'a> {
     /// Values are saved during constant evaluation phase.
     /// Values are read during [oxc_ecmascript::is_global_reference::IsGlobalReference::get_constant_value_for_reference_id].
     pub constant_values: FxHashMap<SymbolId, ConstantValue<'a>>,
+
+    /// Function declarations that are empty
+    pub empty_functions: FxHashSet<SymbolId>,
 }
 
 impl MinifierState<'_> {
     pub fn new(source_type: SourceType, options: CompressOptions) -> Self {
-        Self { source_type, options, constant_values: FxHashMap::default() }
+        Self {
+            source_type,
+            options,
+            constant_values: FxHashMap::default(),
+            empty_functions: FxHashSet::default(),
+        }
     }
 }


### PR DESCRIPTION
Remove function calls where the function is empty:

* `function foo() {} foo()` -> ``
* `var foo = () => {}; foo() -> ``
* `function foo() {} x = foo(a, b)` -> `x = (a, b, void 0)`

closes #11469