### PR TITLE
feat(allocator): `FixedSizeAllocator` store flag recording if owned by both Rust and JS

### DIFF
--- a/crates/oxc_allocator/src/generated/assert_layouts.rs
+++ b/crates/oxc_allocator/src/generated/assert_layouts.rs
@@ -9,20 +9,22 @@ use crate::*;
 
 #[cfg(target_pointer_width = "64")]
 const _: () = {
-    // Padding: 4 bytes
+    // Padding: 3 bytes
     assert!(size_of::<FixedSizeAllocatorMetadata>() == 16);
     assert!(align_of::<FixedSizeAllocatorMetadata>() == 8);
     assert!(offset_of!(FixedSizeAllocatorMetadata, id) == 8);
     assert!(offset_of!(FixedSizeAllocatorMetadata, alloc_ptr) == 0);
+    assert!(offset_of!(FixedSizeAllocatorMetadata, is_double_owned) == 12);
 };
 
 #[cfg(target_pointer_width = "32")]
 const _: () = {
-    // Padding: 0 bytes
-    assert!(size_of::<FixedSizeAllocatorMetadata>() == 8);
+    // Padding: 3 bytes
+    assert!(size_of::<FixedSizeAllocatorMetadata>() == 12);
     assert!(align_of::<FixedSizeAllocatorMetadata>() == 4);
     assert!(offset_of!(FixedSizeAllocatorMetadata, id) == 4);
     assert!(offset_of!(FixedSizeAllocatorMetadata, alloc_ptr) == 0);
+    assert!(offset_of!(FixedSizeAllocatorMetadata, is_double_owned) == 8);
 };
 
 #[cfg(not(any(target_pointer_width = "64", target_pointer_width = "32")))]

--- a/crates/oxc_ast_macros/src/generated/structs.rs
+++ b/crates/oxc_ast_macros/src/generated/structs.rs
@@ -254,7 +254,7 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
         ),
         ("Pattern", StructDetails { field_order: None }),
         ("EmptyStatement", StructDetails { field_order: None }),
-        ("FixedSizeAllocatorMetadata", StructDetails { field_order: Some(&[1, 0]) }),
+        ("FixedSizeAllocatorMetadata", StructDetails { field_order: Some(&[1, 0, 2]) }),
         ("Hashbang", StructDetails { field_order: None }),
         ("UnaryExpression", StructDetails { field_order: Some(&[0, 2, 1]) }),
         ("ThrowStatement", StructDetails { field_order: None }),


### PR DESCRIPTION
Add a field `is_double_owned` to `FixedSizeAllocatorMetadata`. This field tracks ownership of the allocator/buffer. It's `true` if both Rust and JS currently hold a reference to the memory, or `false` if only one does.

`Drop` impl for `FixedSizeAllocator` checks the value of this field and only frees the memory if JS doesn't also hold a reference.

At present, `is_double_owned` is always `false`, because we're not transferring buffers over to JS yet. But it'll come into play in later PR. At that point the finalizer which runs when JS garbage collector collects the buffer will also update `is_double_owned`, and free the memory if Rust already dropped the `FixedSizeAllocator`, so JS is the only remaining owner.