### PR TITLE
fix(linter/filename-case): fix default config when no config is provided

### DIFF
--- a/crates/oxc_linter/src/snapshots/unicorn_filename_case.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_filename_case.snap
@@ -155,3 +155,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[filename_case.tsx:1:1]
    ╰────
   help: Rename the file to 'foo_bar.test_utils.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab case
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to 'foo-bar.tsx'


### PR DESCRIPTION
fixes #12276