### PR TITLE
fix(linter): parse second script block for `svelte` files

### DIFF
--- a/crates/oxc_linter/src/loader/partial_loader/svelte.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/svelte.rs
@@ -16,32 +16,46 @@ impl<'a> SveltePartialLoader<'a> {
     }
 
     pub fn parse(self) -> Vec<JavaScriptSource<'a>> {
-        self.parse_script().map_or_else(Vec::new, |source| vec![source])
+        self.parse_scripts()
     }
 
-    fn parse_script(&self) -> Option<JavaScriptSource<'a>> {
+    /// Each *.svelte file can contain at most
+    ///  * one `<script>` block
+    ///  * one `<script context="module">` or `<script module>` block
+    /// <https://github.com/sveltejs/svelte.dev/blob/ba7ad256f786aa5bc67eac3a58608f3f50b59e91/apps/svelte.dev/content/tutorial/02-advanced-svelte/08-script-module/02-module-exports/index.md>
+    fn parse_scripts(&self) -> Vec<JavaScriptSource<'a>> {
+        let mut pointer = 0;
+        let Some(result1) = self.parse_script(&mut pointer) else {
+            return vec![];
+        };
+        let Some(result2) = self.parse_script(&mut pointer) else {
+            return vec![result1];
+        };
+        vec![result1, result2]
+    }
+
+    fn parse_script(&self, pointer: &mut usize) -> Option<JavaScriptSource<'a>> {
         let script_start_finder = Finder::new(SCRIPT_START);
         let script_end_finder = Finder::new(SCRIPT_END);
 
-        let mut pointer = 0;
-
         // find opening "<script"
-        let offset = script_start_finder.find(&self.source_text.as_bytes()[pointer..])?;
-        pointer += offset + SCRIPT_START.len();
+        let offset = script_start_finder.find(&self.source_text.as_bytes()[*pointer..])?;
+        *pointer += offset + SCRIPT_START.len();
 
         // find closing ">"
-        let offset = find_script_closing_angle(self.source_text, pointer)?;
+        let offset = find_script_closing_angle(self.source_text, *pointer)?;
 
         // get lang="ts" attribute
-        let content = &self.source_text[pointer..pointer + offset];
+        let content = &self.source_text[*pointer..*pointer + offset];
         let is_ts = content.contains("ts");
 
-        pointer += offset + 1;
-        let js_start = pointer;
+        *pointer += offset + 1;
+        let js_start = *pointer;
 
         // find "</script>"
-        let offset = script_end_finder.find(&self.source_text.as_bytes()[pointer..])?;
-        let js_end = pointer + offset;
+        let offset = script_end_finder.find(&self.source_text.as_bytes()[*pointer..])?;
+        let js_end = *pointer + offset;
+        *pointer += offset + SCRIPT_END.len();
 
         let source_text = &self.source_text[js_start..js_end];
         let source_type = SourceType::mjs().with_typescript(is_ts);
@@ -85,5 +99,26 @@ mod test {
 
         let result = parse_svelte(source_text);
         assert_eq!(result.source_text.trim(), r#"console.log("hi");"#);
+    }
+
+    #[test]
+    fn test_parse_svelte_with_module_script() {
+        let source_text = r#"
+        <script module>
+          export async function load() { /* some loading logic */ }
+        </script>
+        <script>
+          console.log("hi");
+        </script>
+        <h1>Hello World</h1>
+        "#;
+
+        let sources = SveltePartialLoader::new(source_text).parse();
+        assert_eq!(sources.len(), 2);
+        assert_eq!(
+            sources[0].source_text.trim(),
+            "export async function load() { /* some loading logic */ }"
+        );
+        assert_eq!(sources[1].source_text.trim(), r#"console.log("hi");"#);
     }
 }


### PR DESCRIPTION
https://svelte.dev/tutorial/svelte/module-exports

I could not find a better doc.
Now the Vue parser and svelte parser are almost similar. Maybe refactor it to share the `script` logic.