### PR TITLE
feat(oxlint): add `--type-aware` flag

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -49,6 +49,10 @@ pub struct LintCommand {
     #[bpaf(external)]
     pub inline_config_options: InlineConfigOptions,
 
+    /// Enables type-aware linting. Requires `tsgolint` to be installed.
+    #[bpaf(switch)]
+    pub type_aware: bool,
+
     /// Single file, single path or list of paths
     #[bpaf(positional("PATH"), many, guard(validate_paths, PATHS_ERROR_MESSAGE))]
     pub paths: Vec<PathBuf>,
@@ -363,7 +367,7 @@ pub enum ReportUnusedDirectives {
         /// Same as `--report-unused-disable-directives`, but allows you to specify the severity level of the reported errors.
         /// Only one of these two options can be used at a time.
         #[bpaf(
-            long("report-unused-disable-directives-severity"), 
+            long("report-unused-disable-directives-severity"),
             argument::<String>("SEVERITY"),
             guard(|s| AllowWarnDeny::try_from(s.as_str()).is_ok(), "Invalid severity value"),
             map(|s| AllowWarnDeny::try_from(s.as_str()).unwrap()), // guard ensures try_from will be Ok
@@ -562,6 +566,14 @@ mod lint_options {
         assert!(options.disable_nested_config);
         let options = get_lint_options(".");
         assert!(!options.disable_nested_config);
+    }
+
+    #[test]
+    fn type_aware() {
+        let options = get_lint_options("--type-aware");
+        assert!(options.type_aware);
+        let options = get_lint_options(".");
+        assert!(!options.type_aware);
     }
 }
 

--- a/tasks/website/src/linter/snapshots/cli.snap
+++ b/tasks/website/src/linter/snapshots/cli.snap
@@ -3,7 +3,7 @@ source: tasks/website/src/linter/cli.rs
 expression: snapshot
 ---
 ## Usage
- **`oxlint`** \[**`-c`**=_`<./oxlintrc.json>`_\] \[_`PATH`_\]...
+ **`oxlint`** \[**`-c`**=_`<./oxlintrc.json>`_\] \[**`--type-aware`**\] \[_`PATH`_\]...
 
 ## Basic Configuration
 - **`-c`**, **`--config`**=_`<./oxlintrc.json>`_ &mdash; 
@@ -141,6 +141,8 @@ Arguments:
   list all the rules that are currently registered
 - **`    --disable-nested-config`** &mdash; 
   Disables the automatic loading of nested configuration files.
+- **`    --type-aware`** &mdash; 
+  Enables type-aware linting. Requires `tsgolint` to be installed.
 - **`-h`**, **`--help`** &mdash; 
   Prints help information
 - **`-V`**, **`--version`** &mdash; 

--- a/tasks/website/src/linter/snapshots/cli_terminal.snap
+++ b/tasks/website/src/linter/snapshots/cli_terminal.snap
@@ -2,7 +2,7 @@
 source: tasks/website/src/linter/cli.rs
 expression: snapshot
 ---
-Usage: [-c=<./oxlintrc.json>] [PATH]...
+Usage: [-c=<./oxlintrc.json>] [--type-aware] [PATH]...
 
 Basic Configuration
     -c, --config=<./oxlintrc.json>  Oxlint configuration file (experimental)
@@ -89,5 +89,6 @@ Available positional items:
 Available options:
         --rules               list all the rules that are currently registered
         --disable-nested-config  Disables the automatic loading of nested configuration files.
+        --type-aware          Enables type-aware linting. Requires `tsgolint` to be installed.
     -h, --help                Prints help information
     -V, --version             Prints version information


### PR DESCRIPTION
Adds a `--type-aware` flag that toggles the option to enable type-aware linting.