### PR TITLE
feat(oxlint): spawn tsgolint process when enabled

### DIFF
--- a/apps/oxlint/src/lib.rs
+++ b/apps/oxlint/src/lib.rs
@@ -4,6 +4,7 @@ mod output_formatter;
 mod result;
 mod runner;
 mod tester;
+mod tsgolint;
 mod walk;
 
 pub mod cli {

--- a/apps/oxlint/src/result.rs
+++ b/apps/oxlint/src/result.rs
@@ -16,6 +16,7 @@ pub enum CliRunResult {
     PrintConfigResult,
     ConfigFileInitFailed,
     ConfigFileInitSucceeded,
+    TsGoLintError,
 }
 
 impl Termination for CliRunResult {
@@ -35,7 +36,8 @@ impl Termination for CliRunResult {
             | Self::InvalidOptionTsConfig
             | Self::InvalidOptionSeverityWithoutFilter
             | Self::InvalidOptionSeverityWithoutPluginName
-            | Self::InvalidOptionSeverityWithoutRuleName => ExitCode::FAILURE,
+            | Self::InvalidOptionSeverityWithoutRuleName
+            | Self::TsGoLintError => ExitCode::FAILURE,
         }
     }
 }

--- a/apps/oxlint/src/tsgolint.rs
+++ b/apps/oxlint/src/tsgolint.rs
@@ -1,0 +1,16 @@
+use std::{ffi::OsStr, path::PathBuf, sync::Arc};
+
+use oxc_linter::rules::RuleEnum;
+
+/// State required to initialize the `tsgolint` linter.
+#[derive(Debug, Clone)]
+pub struct TsGoLintState {
+    /// Current working directory to run `tsgolint` in
+    pub cwd: PathBuf,
+    /// The paths of files to lint
+    #[expect(dead_code)]
+    pub paths: Vec<Arc<OsStr>>,
+    /// The rules to run when linting
+    #[expect(dead_code)]
+    pub rules: Vec<RuleEnum>,
+}


### PR DESCRIPTION
- Towards #12292.

This is a basic implementation of spawning `tsgolint` based on whether `--tsconfig` was passed or not. We landed on this for now as it is simple (no extra options needed), and you need to pass `--tsconfig` anyway for the `tsgolint` command to work.

This could be optimized for speed later: like we currently run `tsgolint` twice technically (by checking if it exists first), but it's plenty fast for an initial release.