### PR TITLE
fix(transformer/decorator): transformed decorators should be injected after class-properties has run

### DIFF
--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -54,6 +54,7 @@ use oxc_semantic::{ScopeFlags, SymbolFlags};
 use oxc_span::SPAN;
 use oxc_syntax::operator::AssignmentOperator;
 use oxc_traverse::{Ancestor, BoundIdentifier, Traverse};
+use rustc_hash::FxHashMap;
 
 use crate::{
     Helper,
@@ -92,6 +93,8 @@ pub struct LegacyDecorator<'a, 'ctx> {
     /// we have to transforms decorators to `exit_class` otherwise after class is being transformed by
     /// `class-properties` plugin, the decorators' nodes might be lost.
     class_decorated_data: Option<ClassDecoratedData<'a>>,
+    /// Transformed decorators, they will be inserted in the statements at [`Self::exit_class_at_end`].
+    decorations: FxHashMap<Address, Vec<Statement<'a>>>,
     ctx: &'ctx TransformCtx<'a>,
 }
 
@@ -102,6 +105,7 @@ impl<'a, 'ctx> LegacyDecorator<'a, 'ctx> {
             metadata: LegacyDecoratorMetadata::new(ctx),
             class_decorated_data: None,
             ctx,
+            decorations: FxHashMap::default(),
         }
     }
 }
@@ -492,8 +496,8 @@ impl<'a> LegacyDecorator<'a, '_> {
         };
 
         if has_private_in_expression_in_decorator {
-            let stmts = mem::replace(&mut decoration_stmts, ctx.ast.vec());
-            Self::insert_decorations_into_class_static_block(class, stmts, ctx);
+            let decorations = mem::take(&mut decoration_stmts);
+            Self::insert_decorations_into_class_static_block(class, decorations, ctx);
         } else {
             let address = match ctx.parent() {
                 Ancestor::ExportDefaultDeclarationDeclaration(_)
@@ -503,7 +507,7 @@ impl<'a> LegacyDecorator<'a, '_> {
             };
 
             decoration_stmts.push(constructor_decoration);
-            self.ctx.statement_injector.insert_many_after(&address, decoration_stmts);
+            self.decorations.entry(address).or_default().append(&mut decoration_stmts);
             self.class_decorated_data = Some(ClassDecoratedData {
                 binding: class_binding,
                 // If the class alias has reassigned to `this` in the static block, then
@@ -561,7 +565,7 @@ impl<'a> LegacyDecorator<'a, '_> {
 
     /// Transforms a non-decorated class declaration.
     fn transform_class_declaration_without_class_decorators(
-        &self,
+        &mut self,
         class: &mut Class<'a>,
         has_private_in_expression_in_decorator: bool,
         ctx: &mut TraverseCtx<'a>,
@@ -575,7 +579,7 @@ impl<'a> LegacyDecorator<'a, '_> {
             class_binding
         };
 
-        let decoration_stmts =
+        let mut decoration_stmts =
             self.transform_decorators_of_class_elements(class, &class_binding, ctx);
 
         if has_private_in_expression_in_decorator {
@@ -587,7 +591,7 @@ impl<'a> LegacyDecorator<'a, '_> {
                 // `Class` is always stored in a `Box`, so has a stable memory location
                 _ => Address::from_ptr(class),
             };
-            self.ctx.statement_injector.insert_many_after(&stmt_address, decoration_stmts);
+            self.decorations.entry(stmt_address).or_default().append(&mut decoration_stmts);
         }
     }
 
@@ -598,8 +602,8 @@ impl<'a> LegacyDecorator<'a, '_> {
         class: &mut Class<'a>,
         class_binding: &BoundIdentifier<'a>,
         ctx: &mut TraverseCtx<'a>,
-    ) -> ArenaVec<'a, Statement<'a>> {
-        let mut decoration_stmts = ctx.ast.vec_with_capacity(class.body.body.len());
+    ) -> Vec<Statement<'a>> {
+        let mut decoration_stmts = Vec::with_capacity(class.body.body.len());
 
         for element in &mut class.body.body {
             let (is_static, key, descriptor, decorations) = match element {
@@ -738,10 +742,11 @@ impl<'a> LegacyDecorator<'a, '_> {
     /// ```
     fn insert_decorations_into_class_static_block(
         class: &mut Class<'a>,
-        decorations: ArenaVec<'a, Statement<'a>>,
+        decorations: Vec<Statement<'a>>,
         ctx: &mut TraverseCtx<'a>,
     ) {
         let scope_id = ctx.create_child_scope(class.scope_id(), ScopeFlags::ClassStaticBlock);
+        let decorations = ctx.ast.vec_from_iter(decorations);
         let element = ctx.ast.class_element_static_block_with_scope_id(SPAN, decorations, scope_id);
         class.body.body.push(element);
     }
@@ -777,6 +782,14 @@ impl<'a> LegacyDecorator<'a, '_> {
                     ctx,
                 ))
             }));
+        }
+    }
+
+    /// Injects the class decorator statements after class-properties plugin has run, ensuring that
+    /// all transformed fields are injected before the class decorator statements.
+    pub fn exit_class_at_end(&mut self, _class: &mut Class<'a>, _ctx: &mut TraverseCtx<'a>) {
+        for (address, stmts) in mem::take(&mut self.decorations) {
+            self.ctx.statement_injector.insert_many_after(&address, stmts);
         }
     }
 

--- a/crates/oxc_transformer/src/decorator/mod.rs
+++ b/crates/oxc_transformer/src/decorator/mod.rs
@@ -82,3 +82,11 @@ impl<'a> Traverse<'a, TransformState<'a>> for Decorator<'a, '_> {
         }
     }
 }
+
+impl<'a> Decorator<'a, '_> {
+    pub fn exit_class_at_end(&mut self, class: &mut Class<'a>, ctx: &mut TraverseCtx<'a>) {
+        if self.options.legacy {
+            self.legacy_decorator.exit_class_at_end(class, ctx);
+        }
+    }
+}

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -300,6 +300,8 @@ impl<'a> Traverse<'a, TransformState<'a>> for TransformerImpl<'a, '_> {
             typescript.exit_class(class, ctx);
         }
         self.x2_es2022.exit_class(class, ctx);
+        // `decorator` has some statements should be inserted after `class-properties` plugin.
+        self.decorator.exit_class_at_end(class, ctx);
     }
 
     fn enter_class_body(&mut self, body: &mut ClassBody<'a>, ctx: &mut TraverseCtx<'a>) {

--- a/napi/transform/test/transform.test.ts
+++ b/napi/transform/test/transform.test.ts
@@ -403,18 +403,18 @@ describe('typescript', () => {
         },
       });
       expect(ret.code).toMatchInlineSnapshot(`
-				"import _decorate from "@oxc-project/runtime/helpers/decorate";
-				class Foo {
-					constructor() {
-						this.b = 1;
-					}
-				}
-				_decorate([dec], Foo.prototype, "c", void 0);
-				class StaticFoo {}
-				_decorate([dec], StaticFoo, "c", void 0);
-				StaticFoo.b = 1;
-				"
-			`);
+        "import _decorate from "@oxc-project/runtime/helpers/decorate";
+        class Foo {
+        	constructor() {
+        		this.b = 1;
+        	}
+        }
+        _decorate([dec], Foo.prototype, "c", void 0);
+        class StaticFoo {}
+        StaticFoo.b = 1;
+        _decorate([dec], StaticFoo, "c", void 0);
+        "
+      `);
     });
   });
 });

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -29199,7 +29199,7 @@ after transform: SymbolId(1): Span { start: 90, end: 92 }
 rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C1":
 after transform: SymbolId(1): [ReferenceId(1), ReferenceId(5), ReferenceId(7), ReferenceId(9)]
-rebuilt        : SymbolId(4): [ReferenceId(3), ReferenceId(7), ReferenceId(9)]
+rebuilt        : SymbolId(4): [ReferenceId(4), ReferenceId(6), ReferenceId(10)]
 Symbol span mismatch for "C1":
 after transform: SymbolId(3): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(5): Span { start: 90, end: 92 }
@@ -29208,7 +29208,7 @@ after transform: SymbolId(2): Span { start: 141, end: 143 }
 rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C2":
 after transform: SymbolId(2): [ReferenceId(3), ReferenceId(13), ReferenceId(15)]
-rebuilt        : SymbolId(6): [ReferenceId(12), ReferenceId(16)]
+rebuilt        : SymbolId(6): [ReferenceId(13), ReferenceId(17)]
 Symbol span mismatch for "C2":
 after transform: SymbolId(7): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(7): Span { start: 141, end: 143 }
@@ -35833,7 +35833,7 @@ after transform: SymbolId(1): Span { start: 106, end: 129 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "BulkEditPreviewProvider":
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14)]
-rebuilt        : SymbolId(5): [ReferenceId(6), ReferenceId(13), ReferenceId(15), ReferenceId(17)]
+rebuilt        : SymbolId(5): [ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(18)]
 Symbol span mismatch for "BulkEditPreviewProvider":
 after transform: SymbolId(4): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(6): Span { start: 106, end: 129 }
@@ -35898,7 +35898,7 @@ after transform: SymbolId(3): Span { start: 119, end: 129 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "Testing123":
 after transform: SymbolId(3): [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(13)]
-rebuilt        : SymbolId(3): [ReferenceId(1), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12)]
+rebuilt        : SymbolId(3): [ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(10), ReferenceId(11), ReferenceId(12)]
 Symbol span mismatch for "Testing123":
 after transform: SymbolId(4): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(4): Span { start: 119, end: 129 }
@@ -35941,7 +35941,7 @@ after transform: SymbolId(3): Span { start: 119, end: 129 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "Testing123":
 after transform: SymbolId(3): [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(13)]
-rebuilt        : SymbolId(3): [ReferenceId(1), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12)]
+rebuilt        : SymbolId(3): [ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(10), ReferenceId(11), ReferenceId(12)]
 Symbol span mismatch for "Testing123":
 after transform: SymbolId(4): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(4): Span { start: 119, end: 129 }
@@ -36100,7 +36100,7 @@ after transform: SymbolId(2): Span { start: 102, end: 103 }
 rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "B":
 after transform: SymbolId(2): [ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12)]
-rebuilt        : SymbolId(4): [ReferenceId(5), ReferenceId(9), ReferenceId(11), ReferenceId(13)]
+rebuilt        : SymbolId(4): [ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(14)]
 Symbol span mismatch for "B":
 after transform: SymbolId(3): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(5): Span { start: 102, end: 103 }
@@ -38350,7 +38350,7 @@ after transform: SymbolId(3): Span { start: 51, end: 52 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(3): [ReferenceId(3), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10)]
-rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(8), ReferenceId(10), ReferenceId(11)]
+rebuilt        : SymbolId(3): [ReferenceId(5), ReferenceId(6), ReferenceId(10), ReferenceId(11)]
 Symbol span mismatch for "C":
 after transform: SymbolId(5): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(4): Span { start: 51, end: 52 }
@@ -38373,7 +38373,7 @@ after transform: SymbolId(3): Span { start: 58, end: 59 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(3): [ReferenceId(3), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(13)]
-rebuilt        : SymbolId(3): [ReferenceId(2), ReferenceId(6), ReferenceId(8), ReferenceId(9), ReferenceId(10)]
+rebuilt        : SymbolId(3): [ReferenceId(3), ReferenceId(4), ReferenceId(8), ReferenceId(9), ReferenceId(10)]
 Symbol span mismatch for "C":
 after transform: SymbolId(5): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(4): Span { start: 58, end: 59 }
@@ -38396,7 +38396,7 @@ after transform: SymbolId(3): Span { start: 66, end: 67 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(3): [ReferenceId(3), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(13)]
-rebuilt        : SymbolId(3): [ReferenceId(2), ReferenceId(6), ReferenceId(8), ReferenceId(9), ReferenceId(10)]
+rebuilt        : SymbolId(3): [ReferenceId(3), ReferenceId(4), ReferenceId(8), ReferenceId(9), ReferenceId(10)]
 Symbol span mismatch for "C":
 after transform: SymbolId(5): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(4): Span { start: 66, end: 67 }
@@ -38426,11 +38426,11 @@ rebuilt        : SymbolId(3): ScopeId(1)
 Symbol reference IDs mismatch for "_Class":
 after transform: SymbolId(3): [ReferenceId(6)]
 rebuilt        : SymbolId(3): []
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
 Reference symbol mismatch for "_Class":
 after transform: SymbolId(3) "_Class"
+rebuilt        : <None>
+Reference symbol mismatch for "dec":
+after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
@@ -39143,7 +39143,7 @@ after transform: SymbolId(3): Span { start: 137, end: 138 }
 rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "D":
 after transform: SymbolId(3): [ReferenceId(23), ReferenceId(25)]
-rebuilt        : SymbolId(9): [ReferenceId(19), ReferenceId(22), ReferenceId(24)]
+rebuilt        : SymbolId(9): [ReferenceId(20), ReferenceId(30), ReferenceId(33)]
 Symbol span mismatch for "D":
 after transform: SymbolId(14): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(10): Span { start: 137, end: 138 }
@@ -39156,12 +39156,12 @@ rebuilt        : <None>
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
 Reference symbol mismatch for "D":
 after transform: SymbolId(14) "D"
 rebuilt        : SymbolId(9) "D"
+Reference symbol mismatch for "dec":
+after transform: SymbolId(0) "dec"
+rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Function", "Object", "require"]
 rebuilt        : ["Function", "Object", "dec", "require"]
@@ -39178,7 +39178,7 @@ after transform: SymbolId(4): Span { start: 125, end: 126 }
 rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(4): [ReferenceId(4), ReferenceId(6)]
-rebuilt        : SymbolId(4): [ReferenceId(3), ReferenceId(6), ReferenceId(8)]
+rebuilt        : SymbolId(4): [ReferenceId(4), ReferenceId(25), ReferenceId(28)]
 Symbol span mismatch for "C":
 after transform: SymbolId(5): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(5): Span { start: 125, end: 126 }
@@ -39188,12 +39188,12 @@ rebuilt        : SymbolId(5): []
 Reference symbol mismatch for "Base":
 after transform: SymbolId(1) "Base"
 rebuilt        : <None>
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
 Reference symbol mismatch for "C":
 after transform: SymbolId(5) "C"
 rebuilt        : SymbolId(4) "C"
+Reference symbol mismatch for "dec":
+after transform: SymbolId(0) "dec"
+rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["require"]
 rebuilt        : ["Base", "dec", "require"]
@@ -39207,7 +39207,7 @@ after transform: SymbolId(1): Span { start: 97, end: 99 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C1":
 after transform: SymbolId(1): [ReferenceId(3), ReferenceId(5)]
-rebuilt        : SymbolId(5): [ReferenceId(2), ReferenceId(5), ReferenceId(7)]
+rebuilt        : SymbolId(5): [ReferenceId(3), ReferenceId(7), ReferenceId(10)]
 Symbol span mismatch for "C1":
 after transform: SymbolId(4): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(6): Span { start: 97, end: 99 }
@@ -39219,7 +39219,7 @@ after transform: SymbolId(2): Span { start: 239, end: 241 }
 rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C2":
 after transform: SymbolId(2): [ReferenceId(11), ReferenceId(13)]
-rebuilt        : SymbolId(7): [ReferenceId(11), ReferenceId(14), ReferenceId(16)]
+rebuilt        : SymbolId(7): [ReferenceId(12), ReferenceId(16), ReferenceId(19)]
 Symbol span mismatch for "C2":
 after transform: SymbolId(8): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(8): Span { start: 239, end: 241 }
@@ -39231,16 +39231,13 @@ after transform: SymbolId(3): Span { start: 389, end: 391 }
 rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C3":
 after transform: SymbolId(3): [ReferenceId(19), ReferenceId(21)]
-rebuilt        : SymbolId(9): [ReferenceId(20), ReferenceId(23), ReferenceId(25)]
+rebuilt        : SymbolId(9): [ReferenceId(21), ReferenceId(25), ReferenceId(28)]
 Symbol span mismatch for "C3":
 after transform: SymbolId(10): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(10): Span { start: 389, end: 391 }
 Symbol reference IDs mismatch for "C3":
 after transform: SymbolId(10): [ReferenceId(25)]
 rebuilt        : SymbolId(10): []
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
 Reference symbol mismatch for "C1":
 after transform: SymbolId(4) "C1"
 rebuilt        : SymbolId(5) "C1"
@@ -39256,6 +39253,9 @@ rebuilt        : <None>
 Reference symbol mismatch for "C3":
 after transform: SymbolId(10) "C3"
 rebuilt        : SymbolId(9) "C3"
+Reference symbol mismatch for "dec":
+after transform: SymbolId(0) "dec"
+rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["require"]
 rebuilt        : ["dec", "require"]
@@ -39272,7 +39272,7 @@ after transform: SymbolId(3): Span { start: 96, end: 97 }
 rebuilt        : SymbolId(23): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(3): [ReferenceId(11), ReferenceId(13)]
-rebuilt        : SymbolId(23): [ReferenceId(4), ReferenceId(7), ReferenceId(9)]
+rebuilt        : SymbolId(23): [ReferenceId(5), ReferenceId(170), ReferenceId(173)]
 Symbol span mismatch for "C":
 after transform: SymbolId(4): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(24): Span { start: 96, end: 97 }
@@ -39282,12 +39282,12 @@ rebuilt        : SymbolId(24): []
 Reference symbol mismatch for "Base":
 after transform: SymbolId(1) "Base"
 rebuilt        : <None>
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
 Reference symbol mismatch for "C":
 after transform: SymbolId(4) "C"
 rebuilt        : SymbolId(23) "C"
+Reference symbol mismatch for "dec":
+after transform: SymbolId(0) "dec"
+rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["require"]
 rebuilt        : ["Base", "dec", "require"]
@@ -39304,7 +39304,7 @@ after transform: SymbolId(4): Span { start: 127, end: 128 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(4): [ReferenceId(4), ReferenceId(6), ReferenceId(10), ReferenceId(15), ReferenceId(20), ReferenceId(25), ReferenceId(30), ReferenceId(35)]
-rebuilt        : SymbolId(5): [ReferenceId(4), ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(16), ReferenceId(21), ReferenceId(27), ReferenceId(32), ReferenceId(37)]
+rebuilt        : SymbolId(5): [ReferenceId(5), ReferenceId(7), ReferenceId(12), ReferenceId(17), ReferenceId(23), ReferenceId(28), ReferenceId(33), ReferenceId(38), ReferenceId(41)]
 Symbol span mismatch for "C":
 after transform: SymbolId(5): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(6): Span { start: 127, end: 128 }
@@ -39314,12 +39314,12 @@ rebuilt        : SymbolId(6): []
 Reference symbol mismatch for "Base":
 after transform: SymbolId(1) "Base"
 rebuilt        : <None>
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
 Reference symbol mismatch for "C":
 after transform: SymbolId(5) "C"
 rebuilt        : SymbolId(5) "C"
+Reference symbol mismatch for "dec":
+after transform: SymbolId(0) "dec"
+rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["require"]
 rebuilt        : ["Base", "dec", "require"]
@@ -39336,7 +39336,7 @@ after transform: SymbolId(3): Span { start: 96, end: 98 }
 rebuilt        : SymbolId(26): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C1":
 after transform: SymbolId(3): [ReferenceId(15), ReferenceId(17), ReferenceId(21), ReferenceId(26), ReferenceId(34), ReferenceId(47), ReferenceId(60), ReferenceId(70), ReferenceId(80), ReferenceId(82), ReferenceId(84)]
-rebuilt        : SymbolId(26): [ReferenceId(5), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(17), ReferenceId(22), ReferenceId(30), ReferenceId(43), ReferenceId(56), ReferenceId(66), ReferenceId(76), ReferenceId(78)]
+rebuilt        : SymbolId(26): [ReferenceId(6), ReferenceId(8), ReferenceId(13), ReferenceId(18), ReferenceId(26), ReferenceId(39), ReferenceId(52), ReferenceId(62), ReferenceId(72), ReferenceId(74), ReferenceId(75), ReferenceId(78)]
 Symbol span mismatch for "C1":
 after transform: SymbolId(6): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(27): Span { start: 96, end: 98 }
@@ -39348,7 +39348,7 @@ after transform: SymbolId(4): Span { start: 389, end: 391 }
 rebuilt        : SymbolId(28): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C2":
 after transform: SymbolId(4): [ReferenceId(88), ReferenceId(90), ReferenceId(94), ReferenceId(99), ReferenceId(107), ReferenceId(120), ReferenceId(133), ReferenceId(143), ReferenceId(153), ReferenceId(155), ReferenceId(157)]
-rebuilt        : SymbolId(28): [ReferenceId(80), ReferenceId(83), ReferenceId(85), ReferenceId(87), ReferenceId(92), ReferenceId(97), ReferenceId(105), ReferenceId(118), ReferenceId(131), ReferenceId(141), ReferenceId(151), ReferenceId(153)]
+rebuilt        : SymbolId(28): [ReferenceId(81), ReferenceId(83), ReferenceId(88), ReferenceId(93), ReferenceId(101), ReferenceId(114), ReferenceId(127), ReferenceId(137), ReferenceId(147), ReferenceId(149), ReferenceId(150), ReferenceId(153)]
 Symbol span mismatch for "C2":
 after transform: SymbolId(18): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(29): Span { start: 389, end: 391 }
@@ -39360,7 +39360,7 @@ after transform: SymbolId(5): Span { start: 709, end: 711 }
 rebuilt        : SymbolId(30): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C3":
 after transform: SymbolId(5): [ReferenceId(161), ReferenceId(163), ReferenceId(167), ReferenceId(172), ReferenceId(181), ReferenceId(195), ReferenceId(209), ReferenceId(220), ReferenceId(231), ReferenceId(233), ReferenceId(235)]
-rebuilt        : SymbolId(30): [ReferenceId(155), ReferenceId(158), ReferenceId(160), ReferenceId(162), ReferenceId(168), ReferenceId(174), ReferenceId(184), ReferenceId(199), ReferenceId(214), ReferenceId(226), ReferenceId(238), ReferenceId(241)]
+rebuilt        : SymbolId(30): [ReferenceId(156), ReferenceId(158), ReferenceId(164), ReferenceId(170), ReferenceId(180), ReferenceId(195), ReferenceId(210), ReferenceId(222), ReferenceId(234), ReferenceId(237), ReferenceId(239), ReferenceId(242)]
 Symbol span mismatch for "C3":
 after transform: SymbolId(26): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(31): Span { start: 709, end: 711 }
@@ -39370,30 +39370,30 @@ rebuilt        : SymbolId(31): []
 Reference symbol mismatch for "Base":
 after transform: SymbolId(1) "Base"
 rebuilt        : <None>
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
 Reference symbol mismatch for "C1":
 after transform: SymbolId(6) "C1"
 rebuilt        : SymbolId(26) "C1"
-Reference symbol mismatch for "Base":
-after transform: SymbolId(1) "Base"
-rebuilt        : <None>
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
+rebuilt        : <None>
+Reference symbol mismatch for "Base":
+after transform: SymbolId(1) "Base"
 rebuilt        : <None>
 Reference symbol mismatch for "C2":
 after transform: SymbolId(18) "C2"
 rebuilt        : SymbolId(28) "C2"
-Reference symbol mismatch for "Base":
-after transform: SymbolId(1) "Base"
-rebuilt        : <None>
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
+rebuilt        : <None>
+Reference symbol mismatch for "Base":
+after transform: SymbolId(1) "Base"
 rebuilt        : <None>
 Reference symbol mismatch for "C3":
 after transform: SymbolId(26) "C3"
 rebuilt        : SymbolId(30) "C3"
+Reference symbol mismatch for "dec":
+after transform: SymbolId(0) "dec"
+rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["require"]
 rebuilt        : ["Base", "dec", "require"]
@@ -39430,19 +39430,19 @@ after transform: SymbolId(1): Span { start: 34, end: 35 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(1): [ReferenceId(1), ReferenceId(3), ReferenceId(6)]
-rebuilt        : SymbolId(3): [ReferenceId(2), ReferenceId(5), ReferenceId(7), ReferenceId(10)]
+rebuilt        : SymbolId(3): [ReferenceId(3), ReferenceId(6), ReferenceId(8), ReferenceId(11)]
 Symbol span mismatch for "C":
 after transform: SymbolId(2): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(4): Span { start: 34, end: 35 }
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(2): [ReferenceId(8)]
 rebuilt        : SymbolId(4): []
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
 Reference symbol mismatch for "C":
 after transform: SymbolId(2) "C"
 rebuilt        : SymbolId(3) "C"
+Reference symbol mismatch for "dec":
+after transform: SymbolId(0) "dec"
+rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["require"]
 rebuilt        : ["dec", "require"]
@@ -39456,19 +39456,19 @@ after transform: SymbolId(1): Span { start: 34, end: 35 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(1): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(8)]
-rebuilt        : SymbolId(3): [ReferenceId(3), ReferenceId(4), ReferenceId(7), ReferenceId(9), ReferenceId(12)]
+rebuilt        : SymbolId(3): [ReferenceId(3), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(13)]
 Symbol span mismatch for "C":
 after transform: SymbolId(2): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(4): Span { start: 34, end: 35 }
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(2): [ReferenceId(10)]
 rebuilt        : SymbolId(4): []
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
 Reference symbol mismatch for "C":
 after transform: SymbolId(2) "C"
 rebuilt        : SymbolId(3) "C"
+Reference symbol mismatch for "dec":
+after transform: SymbolId(0) "dec"
+rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["require"]
 rebuilt        : ["dec", "require"]
@@ -39888,7 +39888,7 @@ after transform: SymbolId(3): Span { start: 199, end: 200 }
 rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "D":
 after transform: SymbolId(3): [ReferenceId(19), ReferenceId(21), ReferenceId(22)]
-rebuilt        : SymbolId(6): [ReferenceId(21), ReferenceId(22), ReferenceId(25), ReferenceId(27)]
+rebuilt        : SymbolId(6): [ReferenceId(21), ReferenceId(25), ReferenceId(26), ReferenceId(29)]
 Symbol span mismatch for "D":
 after transform: SymbolId(7): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(7): Span { start: 199, end: 200 }
@@ -39907,12 +39907,12 @@ rebuilt        : <None>
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
 Reference symbol mismatch for "D":
 after transform: SymbolId(7) "D"
 rebuilt        : SymbolId(6) "D"
+Reference symbol mismatch for "dec":
+after transform: SymbolId(0) "dec"
+rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Object", "require"]
 rebuilt        : ["Object", "dec", "require"]
@@ -39926,7 +39926,7 @@ after transform: SymbolId(2): Span { start: 76, end: 77 }
 rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "D":
 after transform: SymbolId(2): [ReferenceId(12), ReferenceId(14)]
-rebuilt        : SymbolId(6): [ReferenceId(8), ReferenceId(11), ReferenceId(13)]
+rebuilt        : SymbolId(6): [ReferenceId(9), ReferenceId(18), ReferenceId(21)]
 Symbol span mismatch for "D":
 after transform: SymbolId(9): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(7): Span { start: 76, end: 77 }
@@ -39936,12 +39936,12 @@ rebuilt        : SymbolId(7): []
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
 Reference symbol mismatch for "D":
 after transform: SymbolId(9) "D"
 rebuilt        : SymbolId(6) "D"
+Reference symbol mismatch for "dec":
+after transform: SymbolId(0) "dec"
+rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Object", "require"]
 rebuilt        : ["Object", "dec", "require"]
@@ -39955,16 +39955,13 @@ after transform: SymbolId(2): Span { start: 85, end: 86 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "D":
 after transform: SymbolId(2): [ReferenceId(12), ReferenceId(14), ReferenceId(15)]
-rebuilt        : SymbolId(5): [ReferenceId(9), ReferenceId(10), ReferenceId(13), ReferenceId(15)]
+rebuilt        : SymbolId(5): [ReferenceId(9), ReferenceId(19), ReferenceId(20), ReferenceId(23)]
 Symbol span mismatch for "D":
 after transform: SymbolId(7): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(6): Span { start: 85, end: 86 }
 Symbol reference IDs mismatch for "D":
 after transform: SymbolId(7): [ReferenceId(19)]
 rebuilt        : SymbolId(6): []
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -39975,6 +39972,9 @@ Reference symbol mismatch for "":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Reference symbol mismatch for "":
+after transform: SymbolId(0) "dec"
+rebuilt        : <None>
+Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
@@ -40251,7 +40251,7 @@ after transform: ScopeId(0): ["_decorate", "_decorateMetadata", "_defineProperty
 rebuilt        : ScopeId(0): ["_decorate", "_decorateMetadata", "_defineProperty"]
 Symbol reference IDs mismatch for "_decorateMetadata":
 after transform: SymbolId(21): [ReferenceId(40), ReferenceId(45), ReferenceId(50), ReferenceId(55), ReferenceId(60), ReferenceId(69), ReferenceId(74), ReferenceId(78)]
-rebuilt        : SymbolId(1): [ReferenceId(59)]
+rebuilt        : SymbolId(1): [ReferenceId(62)]
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -40296,7 +40296,7 @@ after transform: ["Object", "require"]
 rebuilt        : ["Object", "dec", "f", "require"]
 Unresolved reference IDs mismatch for "Object":
 after transform: [ReferenceId(39), ReferenceId(44), ReferenceId(49), ReferenceId(54), ReferenceId(59), ReferenceId(68), ReferenceId(73), ReferenceId(77)]
-rebuilt        : [ReferenceId(60)]
+rebuilt        : [ReferenceId(63)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.11.ts
 Bindings mismatch:
@@ -40528,124 +40528,124 @@ after transform: ScopeId(2): [ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(7), Sc
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(9): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(3): Some(ScopeId(2))
-rebuilt        : ScopeId(9): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(10): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(5): Some(ScopeId(2))
-rebuilt        : ScopeId(10): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(7): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(11): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(7): Some(ScopeId(2))
-rebuilt        : ScopeId(11): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(9): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(12): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(9): Some(ScopeId(2))
-rebuilt        : ScopeId(12): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(11): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(13): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(11): Some(ScopeId(2))
-rebuilt        : ScopeId(13): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(13): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(14): ScopeFlags(Function | Arrow)
-Scope parent mismatch:
-after transform: ScopeId(13): Some(ScopeId(2))
-rebuilt        : ScopeId(14): Some(ScopeId(0))
-Scope flags mismatch:
-after transform: ScopeId(15): ScopeFlags(StrictMode | Function | Arrow)
 rebuilt        : ScopeId(15): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
-after transform: ScopeId(15): Some(ScopeId(2))
+after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(15): Some(ScopeId(0))
 Scope flags mismatch:
-after transform: ScopeId(16): ScopeFlags(StrictMode | Function | Arrow)
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function | Arrow)
 rebuilt        : ScopeId(16): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
-after transform: ScopeId(16): Some(ScopeId(2))
+after transform: ScopeId(5): Some(ScopeId(2))
 rebuilt        : ScopeId(16): Some(ScopeId(0))
 Scope flags mismatch:
-after transform: ScopeId(17): ScopeFlags(StrictMode | Function | Arrow)
+after transform: ScopeId(7): ScopeFlags(StrictMode | Function | Arrow)
 rebuilt        : ScopeId(17): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
-after transform: ScopeId(17): Some(ScopeId(2))
+after transform: ScopeId(7): Some(ScopeId(2))
 rebuilt        : ScopeId(17): Some(ScopeId(0))
 Scope flags mismatch:
-after transform: ScopeId(18): ScopeFlags(StrictMode | Function | Arrow)
+after transform: ScopeId(9): ScopeFlags(StrictMode | Function | Arrow)
 rebuilt        : ScopeId(18): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
-after transform: ScopeId(18): Some(ScopeId(2))
+after transform: ScopeId(9): Some(ScopeId(2))
 rebuilt        : ScopeId(18): Some(ScopeId(0))
 Scope flags mismatch:
-after transform: ScopeId(19): ScopeFlags(StrictMode | Function | Arrow)
+after transform: ScopeId(11): ScopeFlags(StrictMode | Function | Arrow)
 rebuilt        : ScopeId(19): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
-after transform: ScopeId(19): Some(ScopeId(2))
+after transform: ScopeId(11): Some(ScopeId(2))
 rebuilt        : ScopeId(19): Some(ScopeId(0))
 Scope flags mismatch:
-after transform: ScopeId(21): ScopeFlags(StrictMode | Function | Arrow)
+after transform: ScopeId(13): ScopeFlags(StrictMode | Function | Arrow)
 rebuilt        : ScopeId(20): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
-after transform: ScopeId(21): Some(ScopeId(2))
+after transform: ScopeId(13): Some(ScopeId(2))
 rebuilt        : ScopeId(20): Some(ScopeId(0))
 Scope flags mismatch:
-after transform: ScopeId(23): ScopeFlags(StrictMode | Function | Arrow)
+after transform: ScopeId(15): ScopeFlags(StrictMode | Function | Arrow)
 rebuilt        : ScopeId(21): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
-after transform: ScopeId(23): Some(ScopeId(2))
+after transform: ScopeId(15): Some(ScopeId(2))
 rebuilt        : ScopeId(21): Some(ScopeId(0))
 Scope flags mismatch:
-after transform: ScopeId(25): ScopeFlags(StrictMode | Function | Arrow)
+after transform: ScopeId(16): ScopeFlags(StrictMode | Function | Arrow)
 rebuilt        : ScopeId(22): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
-after transform: ScopeId(25): Some(ScopeId(2))
+after transform: ScopeId(16): Some(ScopeId(2))
 rebuilt        : ScopeId(22): Some(ScopeId(0))
 Scope flags mismatch:
-after transform: ScopeId(27): ScopeFlags(StrictMode | Function | Arrow)
+after transform: ScopeId(17): ScopeFlags(StrictMode | Function | Arrow)
 rebuilt        : ScopeId(23): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
-after transform: ScopeId(27): Some(ScopeId(2))
+after transform: ScopeId(17): Some(ScopeId(2))
 rebuilt        : ScopeId(23): Some(ScopeId(0))
 Scope flags mismatch:
-after transform: ScopeId(29): ScopeFlags(StrictMode | Function | Arrow)
+after transform: ScopeId(18): ScopeFlags(StrictMode | Function | Arrow)
 rebuilt        : ScopeId(24): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
-after transform: ScopeId(29): Some(ScopeId(2))
+after transform: ScopeId(18): Some(ScopeId(2))
 rebuilt        : ScopeId(24): Some(ScopeId(0))
 Scope flags mismatch:
-after transform: ScopeId(31): ScopeFlags(StrictMode | Function | Arrow)
+after transform: ScopeId(19): ScopeFlags(StrictMode | Function | Arrow)
 rebuilt        : ScopeId(25): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
-after transform: ScopeId(31): Some(ScopeId(2))
+after transform: ScopeId(19): Some(ScopeId(2))
 rebuilt        : ScopeId(25): Some(ScopeId(0))
 Scope flags mismatch:
-after transform: ScopeId(32): ScopeFlags(StrictMode | Function | Arrow)
+after transform: ScopeId(21): ScopeFlags(StrictMode | Function | Arrow)
 rebuilt        : ScopeId(26): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
-after transform: ScopeId(32): Some(ScopeId(2))
+after transform: ScopeId(21): Some(ScopeId(2))
 rebuilt        : ScopeId(26): Some(ScopeId(0))
 Scope flags mismatch:
-after transform: ScopeId(33): ScopeFlags(StrictMode | Function | Arrow)
+after transform: ScopeId(23): ScopeFlags(StrictMode | Function | Arrow)
 rebuilt        : ScopeId(27): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
-after transform: ScopeId(33): Some(ScopeId(2))
+after transform: ScopeId(23): Some(ScopeId(2))
 rebuilt        : ScopeId(27): Some(ScopeId(0))
 Scope flags mismatch:
-after transform: ScopeId(34): ScopeFlags(StrictMode | Function | Arrow)
+after transform: ScopeId(25): ScopeFlags(StrictMode | Function | Arrow)
 rebuilt        : ScopeId(28): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
-after transform: ScopeId(34): Some(ScopeId(2))
+after transform: ScopeId(25): Some(ScopeId(2))
 rebuilt        : ScopeId(28): Some(ScopeId(0))
+Scope flags mismatch:
+after transform: ScopeId(27): ScopeFlags(StrictMode | Function | Arrow)
+rebuilt        : ScopeId(29): ScopeFlags(Function | Arrow)
+Scope parent mismatch:
+after transform: ScopeId(27): Some(ScopeId(2))
+rebuilt        : ScopeId(29): Some(ScopeId(0))
+Scope flags mismatch:
+after transform: ScopeId(29): ScopeFlags(StrictMode | Function | Arrow)
+rebuilt        : ScopeId(30): ScopeFlags(Function | Arrow)
+Scope parent mismatch:
+after transform: ScopeId(29): Some(ScopeId(2))
+rebuilt        : ScopeId(30): Some(ScopeId(0))
+Scope flags mismatch:
+after transform: ScopeId(31): ScopeFlags(StrictMode | Function | Arrow)
+rebuilt        : ScopeId(31): ScopeFlags(Function | Arrow)
+Scope parent mismatch:
+after transform: ScopeId(31): Some(ScopeId(2))
+rebuilt        : ScopeId(31): Some(ScopeId(0))
+Scope flags mismatch:
+after transform: ScopeId(32): ScopeFlags(StrictMode | Function | Arrow)
+rebuilt        : ScopeId(32): ScopeFlags(Function | Arrow)
+Scope parent mismatch:
+after transform: ScopeId(32): Some(ScopeId(2))
+rebuilt        : ScopeId(32): Some(ScopeId(0))
+Scope flags mismatch:
+after transform: ScopeId(33): ScopeFlags(StrictMode | Function | Arrow)
+rebuilt        : ScopeId(33): ScopeFlags(Function | Arrow)
+Scope parent mismatch:
+after transform: ScopeId(33): Some(ScopeId(2))
+rebuilt        : ScopeId(33): Some(ScopeId(0))
+Scope flags mismatch:
+after transform: ScopeId(34): ScopeFlags(StrictMode | Function | Arrow)
+rebuilt        : ScopeId(34): ScopeFlags(Function | Arrow)
+Scope parent mismatch:
+after transform: ScopeId(34): Some(ScopeId(2))
+rebuilt        : ScopeId(34): Some(ScopeId(0))
 Symbol span mismatch for "C":
 after transform: SymbolId(0): Span { start: 23, end: 24 }
 rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
@@ -44342,7 +44342,7 @@ after transform: SymbolId(2): Span { start: 69, end: 70 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(2): [ReferenceId(1), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(11)]
-rebuilt        : SymbolId(3): [ReferenceId(3), ReferenceId(7), ReferenceId(9), ReferenceId(10)]
+rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(5), ReferenceId(9), ReferenceId(10)]
 Symbol span mismatch for "C":
 after transform: SymbolId(4): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(4): Span { start: 69, end: 70 }
@@ -44483,7 +44483,7 @@ after transform: SymbolId(2): Span { start: 69, end: 70 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(2): [ReferenceId(1), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(11)]
-rebuilt        : SymbolId(3): [ReferenceId(3), ReferenceId(7), ReferenceId(9), ReferenceId(10)]
+rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(5), ReferenceId(9), ReferenceId(10)]
 Symbol span mismatch for "C":
 after transform: SymbolId(4): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(4): Span { start: 69, end: 70 }

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -617,7 +617,7 @@ after transform: SymbolId(2): Span { start: 103, end: 106 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "Foo":
 after transform: SymbolId(2): [ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10)]
-rebuilt        : SymbolId(3): [ReferenceId(3), ReferenceId(7), ReferenceId(9)]
+rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(6), ReferenceId(10)]
 Symbol span mismatch for "Foo":
 after transform: SymbolId(3): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(4): Span { start: 103, end: 106 }

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/static-field-with-class-properties/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/static-field-with-class-properties/output.js
@@ -5,5 +5,5 @@ function Bar() {
   };
 }
 let Foo = _Foo = class Foo {};
-Foo = _Foo = babelHelpers.decorate([Bar()], Foo);
 babelHelpers.defineProperty(Foo, "foo", `${_Foo.name}`);
+Foo = _Foo = babelHelpers.decorate([Bar()], Foo);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/use-define-for-class-fields/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/use-define-for-class-fields/output.js
@@ -6,5 +6,5 @@ class Cls {
 babelHelpers.decorate([dce], Cls.prototype, "z", void 0);
 
 class StaticCls { }
-babelHelpers.decorate([dce], StaticCls, "z", void 0);
 StaticCls.y = 1;
+babelHelpers.decorate([dce], StaticCls, "z", void 0);


### PR DESCRIPTION
* close https://github.com/rolldown/rolldown/issues/5374

Example:

Input: 
```ts
function myPropertyDecorator() {
  return (target: any, propertyKey: number) => {
    console.log(target.constructor.modelName, propertyKey);
  };
}

class Test {
  public static modelName = 'Test';

  @myPropertyDecorator()
  public myProperty = 1;
}

const instance = new Test();

export default instance;
```

Output diff: 
```diff
function myPropertyDecorator() {
        return (target, propertyKey) => {
                console.log(target.constructor.modelName, propertyKey);
        };
}
class Test {
        constructor() {
                babelHelpers.defineProperty(this, "myProperty", 1);
        }
}
-babelHelpers.decorate([myPropertyDecorator()], Test.prototype, "myProperty", void 0);
-babelHelpers.defineProperty(Test, "modelName", "Test");
+babelHelpers.defineProperty(Test, "modelName", "Test");
+babelHelpers.decorate([myPropertyDecorator()], Test.prototype, "myProperty", void 0);

const instance = new Test();
export default instance;
```

The cause is that we transform class fields and decorators in two different plugins, and the decorator plugin should be transformed first, and then run the class-properties plugin, because class-properties might erase some decorator information. However, this cause transformed decorators injected before transformed class fields.

This PR fixes this problem by collecting all transformed decorators that wait for injection, and injecting them in batch after the `class-properties` plugin has run.