### PR TITLE
refactor(formatter): improve printing call arguments with arrow function and function expression

### DIFF
--- a/crates/oxc_formatter/src/utils/assignment_like.rs
+++ b/crates/oxc_formatter/src/utils/assignment_like.rs
@@ -626,16 +626,13 @@ pub fn with_assignment_layout<'a, 'b>(
 impl<'a> Format<'a> for WithAssignmentLayout<'a, '_> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         match self.expression.as_ast_nodes() {
-            AstNodes::ArrowFunctionExpression(arrow) => {
-                FormatJsArrowFunctionExpression::new_with_options(
-                    arrow,
-                    FormatJsArrowFunctionExpressionOptions {
-                        assignment_layout: self.layout,
-                        ..FormatJsArrowFunctionExpressionOptions::default()
-                    },
-                )
-                .fmt(f)
-            }
+            AstNodes::ArrowFunctionExpression(arrow) => arrow.fmt_with_options(
+                FormatJsArrowFunctionExpressionOptions {
+                    assignment_layout: self.layout,
+                    ..FormatJsArrowFunctionExpressionOptions::default()
+                },
+                f,
+            ),
             _ => self.expression.fmt(f),
         }
     }

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 408/699 (58.37%)
+js compatibility: 413/699 (59.08%)
 
 # Failed
 
@@ -17,7 +17,7 @@ js compatibility: 408/699 (58.37%)
 | js/assignment/issue-2482-2.js | 💥 | 62.50% |
 | js/assignment/issue-7572.js | 💥 | 72.73% |
 | js/assignment/sequence.js | 💥 | 71.43% |
-| js/assignment-comments/function.js | 💥 | 78.18% |
+| js/assignment-comments/function.js | 💥 | 92.73% |
 | js/async/inline-await.js | 💥 | 25.00% |
 | js/async/nested.js | 💥 | 16.67% |
 | js/binary-expressions/inline-jsx.js | 💥 | 40.00% |
@@ -25,7 +25,6 @@ js compatibility: 408/699 (58.37%)
 | js/binary-expressions/return.js | 💥 | 77.78% |
 | js/binary-expressions/test.js | 💥 | 95.65% |
 | js/break-calls/reduce.js | 💥 | 77.78% |
-| js/call/first-argument-expansion/issue-13237.js | 💥 | 63.16% |
 | js/call/first-argument-expansion/jsx.js | 💥 | 0.00% |
 | js/call/first-argument-expansion/test.js | 💥 | 96.57% |
 | js/chain-expression/call-expression.js | 💥 | 42.86% |
@@ -52,13 +51,13 @@ js compatibility: 408/699 (58.37%)
 | js/comments/blank.js | 💥💥 | 95.24% |
 | js/comments/call_comment.js | 💥💥 | 90.91% |
 | js/comments/dangling.js | 💥💥 | 93.33% |
-| js/comments/dangling_array.js | 💥💥 | 25.00% |
+| js/comments/dangling_array.js | 💥✨ | 40.00% |
 | js/comments/dangling_for.js | 💥💥 | 22.22% |
 | js/comments/dynamic_imports.js | 💥💥 | 71.43% |
 | js/comments/empty-statements.js | 💥💥 | 90.91% |
 | js/comments/export-and-import.js | 💥💥 | 78.05% |
 | js/comments/export.js | 💥💥 | 84.93% |
-| js/comments/function-declaration.js | 💥💥 | 66.67% |
+| js/comments/function-declaration.js | 💥💥 | 68.29% |
 | js/comments/if.js | 💥💥 | 38.16% |
 | js/comments/issue-3532.js | 💥💥 | 80.82% |
 | js/comments/issues.js | 💥💥 | 74.63% |
@@ -150,14 +149,11 @@ js compatibility: 408/699 (58.37%)
 | js/label/comment.js | 💥 | 53.33% |
 | js/last-argument-expansion/arrow.js | 💥 | 11.43% |
 | js/last-argument-expansion/break-parent.js | 💥 | 57.14% |
-| js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 0.00% |
+| js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 22.22% |
 | js/last-argument-expansion/edge_case.js | 💥 | 83.97% |
-| js/last-argument-expansion/empty-object.js | 💥 | 86.67% |
-| js/last-argument-expansion/issue-10708.js | 💥 | 0.00% |
 | js/last-argument-expansion/issue-7518.js | 💥 | 85.71% |
 | js/last-argument-expansion/jsx.js | 💥 | 25.00% |
 | js/last-argument-expansion/object.js | 💥 | 94.74% |
-| js/last-argument-expansion/overflow.js | 💥 | 71.22% |
 | js/line-suffix-boundary/boundary.js | 💥 | 30.43% |
 | js/logical_expressions/issue-7024.js | 💥 | 66.67% |
 | js/member/conditional.js | 💥 | 0.00% |
@@ -199,7 +195,6 @@ js compatibility: 408/699 (58.37%)
 | js/objects/assignment-expression/object-value.js | 💥 | 85.71% |
 | js/optional-chaining/chaining.js | 💥 | 59.77% |
 | js/optional-chaining/comments.js | 💥 | 16.90% |
-| js/preserve-line/argument-list.js | 💥 | 99.44% |
 | js/preserve-line/member-chain.js | 💥 | 23.30% |
 | js/quote-props/classes.js | 💥💥✨✨ | 47.06% |
 | js/quote-props/objects.js | 💥💥✨✨ | 45.10% |

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -56,9 +56,9 @@ ts compatibility: 234/573 (40.84%)
 | typescript/angular-component-examples/15969-computed.component.ts | 💥💥 | 93.33% |
 | typescript/angular-component-examples/test.component.ts | 💥💥 | 41.18% |
 | typescript/argument-expansion/argument_expansion.ts | 💥 | 93.22% |
-| typescript/argument-expansion/arrow-with-return-type.ts | 💥 | 92.31% |
+| typescript/argument-expansion/arrow-with-return-type.ts | 💥 | 89.47% |
 | typescript/array/comment.ts | 💥 | 87.50% |
-| typescript/arrow/16067.ts | 💥💥 | 67.35% |
+| typescript/arrow/16067.ts | 💥💥 | 79.17% |
 | typescript/arrow/comments.ts | 💥✨ | 44.44% |
 | typescript/as/array-pattern.ts | 💥 | 0.00% |
 | typescript/as/as.ts | 💥 | 64.57% |


### PR DESCRIPTION
Refactor printing call arguments, which will diverge from the Biome implementation. The main reason I want to do this is that the Biome's implementation is not fit with our printing comments architecture.  

The reason is that our architecture has to ensure that everything is linearly printed, that is, you can't print the second argument and then print the first argument, because printing the second argument might cause the comments of the first argument to attach to the second argument.

Why? Let's take a look at the logic of leading comments.
 
https://github.com/oxc-project/oxc/blob/91bb0f6b8a28afef9b5b7e2352c5face1f0edbab/crates/oxc_formatter/src/formatter/trivia.rs#L100-L106

The implementation regards all comments before this node span as leading comments. I think you may know what will happen when you print the second argument; the comments before the second argument will be fully printed out. then the first argument would miss its comments.

So this refactor aims to solve the above problem. 

Additionally, in this refactor, I am trying to remove unneeded allocations and abstractions as much as possible. Now we have less code and 1% performance improvement. 

<img width="694" height="268" alt="image" src="https://github.com/user-attachments/assets/f533f3e9-8258-4dfd-a4a6-a76b9c425c08" />
