### PR TITLE
refactor(formatter): implement `GetSpan` for `AstNode` instead of generating a `span` method

### DIFF
--- a/crates/oxc_formatter/src/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/generated/ast_nodes.rs
@@ -3135,11 +3135,6 @@ impl<'a, T> AstNode<'a, Option<T>> {
 
 impl<'a> AstNode<'a, Program<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn source_type(&self) -> SourceType {
         self.inner.source_type
     }
@@ -3215,6 +3210,13 @@ impl<'a> AstNode<'a, Program<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, Program<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -3556,11 +3558,6 @@ impl<'a> GetSpan for AstNode<'a, Expression<'a>> {
 
 impl<'a> AstNode<'a, IdentifierName<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn name(&self) -> Atom<'a> {
         self.inner.name
     }
@@ -3576,16 +3573,18 @@ impl<'a> AstNode<'a, IdentifierName<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, IdentifierName<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
 impl<'a> AstNode<'a, IdentifierReference<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn name(&self) -> Atom<'a> {
         self.inner.name
     }
@@ -3601,16 +3600,18 @@ impl<'a> AstNode<'a, IdentifierReference<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, IdentifierReference<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
 impl<'a> AstNode<'a, BindingIdentifier<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn name(&self) -> Atom<'a> {
         self.inner.name
     }
@@ -3626,16 +3627,18 @@ impl<'a> AstNode<'a, BindingIdentifier<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, BindingIdentifier<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
 impl<'a> AstNode<'a, LabelIdentifier<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn name(&self) -> Atom<'a> {
         self.inner.name
     }
@@ -3654,12 +3657,14 @@ impl<'a> AstNode<'a, LabelIdentifier<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ThisExpression> {
+impl<'a> GetSpan for AstNode<'a, LabelIdentifier<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, ThisExpression> {
     pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_leading_comments(self.span()).fmt(f)
     }
@@ -3674,12 +3679,14 @@ impl<'a> AstNode<'a, ThisExpression> {
     }
 }
 
-impl<'a> AstNode<'a, ArrayExpression<'a>> {
+impl<'a> GetSpan for AstNode<'a, ThisExpression> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, ArrayExpression<'a>> {
     #[inline]
     pub fn elements(&self) -> &AstNode<'a, Vec<'a, ArrayExpressionElement<'a>>> {
         let following_node = self.following_node;
@@ -3702,6 +3709,13 @@ impl<'a> AstNode<'a, ArrayExpression<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, ArrayExpression<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -3750,11 +3764,6 @@ impl<'a> GetSpan for AstNode<'a, ArrayExpressionElement<'a>> {
 }
 
 impl<'a> AstNode<'a, Elision> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_leading_comments(self.span()).fmt(f)
     }
@@ -3769,12 +3778,14 @@ impl<'a> AstNode<'a, Elision> {
     }
 }
 
-impl<'a> AstNode<'a, ObjectExpression<'a>> {
+impl<'a> GetSpan for AstNode<'a, Elision> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, ObjectExpression<'a>> {
     #[inline]
     pub fn properties(&self) -> &AstNode<'a, Vec<'a, ObjectPropertyKind<'a>>> {
         let following_node = self.following_node;
@@ -3797,6 +3808,13 @@ impl<'a> AstNode<'a, ObjectExpression<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, ObjectExpression<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -3834,11 +3852,6 @@ impl<'a> GetSpan for AstNode<'a, ObjectPropertyKind<'a>> {
 }
 
 impl<'a> AstNode<'a, ObjectProperty<'a>> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     #[inline]
     pub fn kind(&self) -> PropertyKind {
         self.inner.kind
@@ -3895,6 +3908,13 @@ impl<'a> AstNode<'a, ObjectProperty<'a>> {
     }
 }
 
+impl<'a> GetSpan for AstNode<'a, ObjectProperty<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
+    }
+}
+
 impl<'a> AstNode<'a, PropertyKey<'a>> {
     #[inline]
     pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
@@ -3941,11 +3961,6 @@ impl<'a> GetSpan for AstNode<'a, PropertyKey<'a>> {
 
 impl<'a> AstNode<'a, TemplateLiteral<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn quasis(&self) -> &AstNode<'a, Vec<'a, TemplateElement<'a>>> {
         let following_node = self
             .inner
@@ -3988,12 +4003,14 @@ impl<'a> AstNode<'a, TemplateLiteral<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TaggedTemplateExpression<'a>> {
+impl<'a> GetSpan for AstNode<'a, TemplateLiteral<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TaggedTemplateExpression<'a>> {
     #[inline]
     pub fn tag(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = self
@@ -4049,12 +4066,14 @@ impl<'a> AstNode<'a, TaggedTemplateExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TemplateElement<'a>> {
+impl<'a> GetSpan for AstNode<'a, TaggedTemplateExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TemplateElement<'a>> {
     #[inline]
     pub fn value(&self) -> &TemplateElementValue<'a> {
         &self.inner.value
@@ -4081,6 +4100,13 @@ impl<'a> AstNode<'a, TemplateElement<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, TemplateElement<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -4127,11 +4153,6 @@ impl<'a> GetSpan for AstNode<'a, MemberExpression<'a>> {
 
 impl<'a> AstNode<'a, ComputedMemberExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn object(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.expression));
         self.allocator.alloc(AstNode {
@@ -4172,12 +4193,14 @@ impl<'a> AstNode<'a, ComputedMemberExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, StaticMemberExpression<'a>> {
+impl<'a> GetSpan for AstNode<'a, ComputedMemberExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, StaticMemberExpression<'a>> {
     #[inline]
     pub fn object(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.property));
@@ -4219,12 +4242,14 @@ impl<'a> AstNode<'a, StaticMemberExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, PrivateFieldExpression<'a>> {
+impl<'a> GetSpan for AstNode<'a, StaticMemberExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, PrivateFieldExpression<'a>> {
     #[inline]
     pub fn object(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.field));
@@ -4266,12 +4291,14 @@ impl<'a> AstNode<'a, PrivateFieldExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, CallExpression<'a>> {
+impl<'a> GetSpan for AstNode<'a, PrivateFieldExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, CallExpression<'a>> {
     #[inline]
     pub fn callee(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = self
@@ -4344,12 +4371,14 @@ impl<'a> AstNode<'a, CallExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, NewExpression<'a>> {
+impl<'a> GetSpan for AstNode<'a, CallExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, NewExpression<'a>> {
     #[inline]
     pub fn callee(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = self
@@ -4417,12 +4446,14 @@ impl<'a> AstNode<'a, NewExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, MetaProperty<'a>> {
+impl<'a> GetSpan for AstNode<'a, NewExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, MetaProperty<'a>> {
     #[inline]
     pub fn meta(&self) -> &AstNode<'a, IdentifierName<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.property));
@@ -4459,12 +4490,14 @@ impl<'a> AstNode<'a, MetaProperty<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, SpreadElement<'a>> {
+impl<'a> GetSpan for AstNode<'a, MetaProperty<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, SpreadElement<'a>> {
     #[inline]
     pub fn argument(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = self.following_node;
@@ -4487,6 +4520,13 @@ impl<'a> AstNode<'a, SpreadElement<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, SpreadElement<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -4526,11 +4566,6 @@ impl<'a> GetSpan for AstNode<'a, Argument<'a>> {
 
 impl<'a> AstNode<'a, UpdateExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn operator(&self) -> UpdateOperator {
         self.inner.operator
     }
@@ -4565,12 +4600,14 @@ impl<'a> AstNode<'a, UpdateExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, UnaryExpression<'a>> {
+impl<'a> GetSpan for AstNode<'a, UpdateExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, UnaryExpression<'a>> {
     #[inline]
     pub fn operator(&self) -> UnaryOperator {
         self.inner.operator
@@ -4601,12 +4638,14 @@ impl<'a> AstNode<'a, UnaryExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, BinaryExpression<'a>> {
+impl<'a> GetSpan for AstNode<'a, UnaryExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, BinaryExpression<'a>> {
     #[inline]
     pub fn left(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.right));
@@ -4648,12 +4687,14 @@ impl<'a> AstNode<'a, BinaryExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, PrivateInExpression<'a>> {
+impl<'a> GetSpan for AstNode<'a, BinaryExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, PrivateInExpression<'a>> {
     #[inline]
     pub fn left(&self) -> &AstNode<'a, PrivateIdentifier<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.right));
@@ -4690,12 +4731,14 @@ impl<'a> AstNode<'a, PrivateInExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, LogicalExpression<'a>> {
+impl<'a> GetSpan for AstNode<'a, PrivateInExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, LogicalExpression<'a>> {
     #[inline]
     pub fn left(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.right));
@@ -4737,12 +4780,14 @@ impl<'a> AstNode<'a, LogicalExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ConditionalExpression<'a>> {
+impl<'a> GetSpan for AstNode<'a, LogicalExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, ConditionalExpression<'a>> {
     #[inline]
     pub fn test(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.consequent));
@@ -4790,12 +4835,14 @@ impl<'a> AstNode<'a, ConditionalExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, AssignmentExpression<'a>> {
+impl<'a> GetSpan for AstNode<'a, ConditionalExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, AssignmentExpression<'a>> {
     #[inline]
     pub fn operator(&self) -> AssignmentOperator {
         self.inner.operator
@@ -4834,6 +4881,13 @@ impl<'a> AstNode<'a, AssignmentExpression<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, AssignmentExpression<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -4976,11 +5030,6 @@ impl<'a> GetSpan for AstNode<'a, AssignmentTargetPattern<'a>> {
 
 impl<'a> AstNode<'a, ArrayAssignmentTarget<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn elements(&self) -> &AstNode<'a, Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>> {
         let following_node =
             self.inner.rest.as_ref().map(SiblingNode::from).or(self.following_node);
@@ -5019,12 +5068,14 @@ impl<'a> AstNode<'a, ArrayAssignmentTarget<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ObjectAssignmentTarget<'a>> {
+impl<'a> GetSpan for AstNode<'a, ArrayAssignmentTarget<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, ObjectAssignmentTarget<'a>> {
     #[inline]
     pub fn properties(&self) -> &AstNode<'a, Vec<'a, AssignmentTargetProperty<'a>>> {
         let following_node =
@@ -5065,12 +5116,14 @@ impl<'a> AstNode<'a, ObjectAssignmentTarget<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, AssignmentTargetRest<'a>> {
+impl<'a> GetSpan for AstNode<'a, ObjectAssignmentTarget<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, AssignmentTargetRest<'a>> {
     #[inline]
     pub fn target(&self) -> &AstNode<'a, AssignmentTarget<'a>> {
         let following_node = self.following_node;
@@ -5093,6 +5146,13 @@ impl<'a> AstNode<'a, AssignmentTargetRest<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, AssignmentTargetRest<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -5134,11 +5194,6 @@ impl<'a> GetSpan for AstNode<'a, AssignmentTargetMaybeDefault<'a>> {
 
 impl<'a> AstNode<'a, AssignmentTargetWithDefault<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn binding(&self) -> &AstNode<'a, AssignmentTarget<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.init));
         self.allocator.alloc(AstNode {
@@ -5178,6 +5233,13 @@ impl<'a> AstNode<'a, AssignmentTargetWithDefault<'a>> {
     }
 }
 
+impl<'a> GetSpan for AstNode<'a, AssignmentTargetWithDefault<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
+    }
+}
+
 impl<'a> AstNode<'a, AssignmentTargetProperty<'a>> {
     #[inline]
     pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
@@ -5212,11 +5274,6 @@ impl<'a> GetSpan for AstNode<'a, AssignmentTargetProperty<'a>> {
 }
 
 impl<'a> AstNode<'a, AssignmentTargetPropertyIdentifier<'a>> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     #[inline]
     pub fn binding(&self) -> &AstNode<'a, IdentifierReference<'a>> {
         let following_node =
@@ -5262,12 +5319,14 @@ impl<'a> AstNode<'a, AssignmentTargetPropertyIdentifier<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, AssignmentTargetPropertyProperty<'a>> {
+impl<'a> GetSpan for AstNode<'a, AssignmentTargetPropertyIdentifier<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, AssignmentTargetPropertyProperty<'a>> {
     #[inline]
     pub fn name(&self) -> &AstNode<'a, PropertyKey<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.binding));
@@ -5313,12 +5372,14 @@ impl<'a> AstNode<'a, AssignmentTargetPropertyProperty<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, SequenceExpression<'a>> {
+impl<'a> GetSpan for AstNode<'a, AssignmentTargetPropertyProperty<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, SequenceExpression<'a>> {
     #[inline]
     pub fn expressions(&self) -> &AstNode<'a, Vec<'a, Expression<'a>>> {
         let following_node = self.following_node;
@@ -5344,12 +5405,14 @@ impl<'a> AstNode<'a, SequenceExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, Super> {
+impl<'a> GetSpan for AstNode<'a, SequenceExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, Super> {
     pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_leading_comments(self.span()).fmt(f)
     }
@@ -5364,12 +5427,14 @@ impl<'a> AstNode<'a, Super> {
     }
 }
 
-impl<'a> AstNode<'a, AwaitExpression<'a>> {
+impl<'a> GetSpan for AstNode<'a, Super> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, AwaitExpression<'a>> {
     #[inline]
     pub fn argument(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = self.following_node;
@@ -5395,12 +5460,14 @@ impl<'a> AstNode<'a, AwaitExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ChainExpression<'a>> {
+impl<'a> GetSpan for AstNode<'a, AwaitExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, ChainExpression<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, ChainElement<'a>> {
         let following_node = self.following_node;
@@ -5423,6 +5490,13 @@ impl<'a> AstNode<'a, ChainExpression<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, ChainExpression<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -5472,11 +5546,6 @@ impl<'a> GetSpan for AstNode<'a, ChainElement<'a>> {
 
 impl<'a> AstNode<'a, ParenthesizedExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = self.following_node;
         self.allocator.alloc(AstNode {
@@ -5498,6 +5567,13 @@ impl<'a> AstNode<'a, ParenthesizedExpression<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, ParenthesizedExpression<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -5678,11 +5754,6 @@ impl<'a> GetSpan for AstNode<'a, Statement<'a>> {
 
 impl<'a> AstNode<'a, Directive<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn expression(&self) -> &AstNode<'a, StringLiteral<'a>> {
         let following_node = self.following_node;
         self.allocator.alloc(AstNode {
@@ -5712,12 +5783,14 @@ impl<'a> AstNode<'a, Directive<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, Hashbang<'a>> {
+impl<'a> GetSpan for AstNode<'a, Directive<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, Hashbang<'a>> {
     #[inline]
     pub fn value(&self) -> Atom<'a> {
         self.inner.value
@@ -5737,12 +5810,14 @@ impl<'a> AstNode<'a, Hashbang<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, BlockStatement<'a>> {
+impl<'a> GetSpan for AstNode<'a, Hashbang<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, BlockStatement<'a>> {
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
         let following_node = self.following_node;
@@ -5765,6 +5840,13 @@ impl<'a> AstNode<'a, BlockStatement<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, BlockStatement<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -5849,11 +5931,6 @@ impl<'a> GetSpan for AstNode<'a, Declaration<'a>> {
 
 impl<'a> AstNode<'a, VariableDeclaration<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn kind(&self) -> VariableDeclarationKind {
         self.inner.kind
     }
@@ -5888,12 +5965,14 @@ impl<'a> AstNode<'a, VariableDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, VariableDeclarator<'a>> {
+impl<'a> GetSpan for AstNode<'a, VariableDeclaration<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, VariableDeclarator<'a>> {
     #[inline]
     pub fn kind(&self) -> VariableDeclarationKind {
         self.inner.kind
@@ -5943,12 +6022,14 @@ impl<'a> AstNode<'a, VariableDeclarator<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, EmptyStatement> {
+impl<'a> GetSpan for AstNode<'a, VariableDeclarator<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, EmptyStatement> {
     pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_leading_comments(self.span()).fmt(f)
     }
@@ -5963,12 +6044,14 @@ impl<'a> AstNode<'a, EmptyStatement> {
     }
 }
 
-impl<'a> AstNode<'a, ExpressionStatement<'a>> {
+impl<'a> GetSpan for AstNode<'a, EmptyStatement> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, ExpressionStatement<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = None;
@@ -5994,12 +6077,14 @@ impl<'a> AstNode<'a, ExpressionStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, IfStatement<'a>> {
+impl<'a> GetSpan for AstNode<'a, ExpressionStatement<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, IfStatement<'a>> {
     #[inline]
     pub fn test(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.consequent));
@@ -6050,12 +6135,14 @@ impl<'a> AstNode<'a, IfStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, DoWhileStatement<'a>> {
+impl<'a> GetSpan for AstNode<'a, IfStatement<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, DoWhileStatement<'a>> {
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Statement<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.test));
@@ -6092,12 +6179,14 @@ impl<'a> AstNode<'a, DoWhileStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, WhileStatement<'a>> {
+impl<'a> GetSpan for AstNode<'a, DoWhileStatement<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, WhileStatement<'a>> {
     #[inline]
     pub fn test(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.body));
@@ -6134,12 +6223,14 @@ impl<'a> AstNode<'a, WhileStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ForStatement<'a>> {
+impl<'a> GetSpan for AstNode<'a, WhileStatement<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, ForStatement<'a>> {
     #[inline]
     pub fn init(&self) -> Option<&AstNode<'a, ForStatementInit<'a>>> {
         let following_node = self
@@ -6215,6 +6306,13 @@ impl<'a> AstNode<'a, ForStatement<'a>> {
     }
 }
 
+impl<'a> GetSpan for AstNode<'a, ForStatement<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
+    }
+}
+
 impl<'a> AstNode<'a, ForStatementInit<'a>> {
     #[inline]
     pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
@@ -6252,11 +6350,6 @@ impl<'a> GetSpan for AstNode<'a, ForStatementInit<'a>> {
 }
 
 impl<'a> AstNode<'a, ForInStatement<'a>> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     #[inline]
     pub fn left(&self) -> &AstNode<'a, ForStatementLeft<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.right));
@@ -6304,6 +6397,13 @@ impl<'a> AstNode<'a, ForInStatement<'a>> {
     }
 }
 
+impl<'a> GetSpan for AstNode<'a, ForInStatement<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
+    }
+}
+
 impl<'a> AstNode<'a, ForStatementLeft<'a>> {
     #[inline]
     pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
@@ -6341,11 +6441,6 @@ impl<'a> GetSpan for AstNode<'a, ForStatementLeft<'a>> {
 }
 
 impl<'a> AstNode<'a, ForOfStatement<'a>> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     #[inline]
     pub fn r#await(&self) -> bool {
         self.inner.r#await
@@ -6398,12 +6493,14 @@ impl<'a> AstNode<'a, ForOfStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ContinueStatement<'a>> {
+impl<'a> GetSpan for AstNode<'a, ForOfStatement<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, ContinueStatement<'a>> {
     #[inline]
     pub fn label(&self) -> Option<&AstNode<'a, LabelIdentifier<'a>>> {
         let following_node = self.following_node;
@@ -6431,12 +6528,14 @@ impl<'a> AstNode<'a, ContinueStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, BreakStatement<'a>> {
+impl<'a> GetSpan for AstNode<'a, ContinueStatement<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, BreakStatement<'a>> {
     #[inline]
     pub fn label(&self) -> Option<&AstNode<'a, LabelIdentifier<'a>>> {
         let following_node = self.following_node;
@@ -6464,12 +6563,14 @@ impl<'a> AstNode<'a, BreakStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ReturnStatement<'a>> {
+impl<'a> GetSpan for AstNode<'a, BreakStatement<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, ReturnStatement<'a>> {
     #[inline]
     pub fn argument(&self) -> Option<&AstNode<'a, Expression<'a>>> {
         let following_node = self.following_node;
@@ -6497,12 +6598,14 @@ impl<'a> AstNode<'a, ReturnStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, WithStatement<'a>> {
+impl<'a> GetSpan for AstNode<'a, ReturnStatement<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, WithStatement<'a>> {
     #[inline]
     pub fn object(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.body));
@@ -6539,12 +6642,14 @@ impl<'a> AstNode<'a, WithStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, SwitchStatement<'a>> {
+impl<'a> GetSpan for AstNode<'a, WithStatement<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, SwitchStatement<'a>> {
     #[inline]
     pub fn discriminant(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = self
@@ -6588,12 +6693,14 @@ impl<'a> AstNode<'a, SwitchStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, SwitchCase<'a>> {
+impl<'a> GetSpan for AstNode<'a, SwitchStatement<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, SwitchCase<'a>> {
     #[inline]
     pub fn test(&self) -> Option<&AstNode<'a, Expression<'a>>> {
         let following_node = self
@@ -6639,12 +6746,14 @@ impl<'a> AstNode<'a, SwitchCase<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, LabeledStatement<'a>> {
+impl<'a> GetSpan for AstNode<'a, SwitchCase<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, LabeledStatement<'a>> {
     #[inline]
     pub fn label(&self) -> &AstNode<'a, LabelIdentifier<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.body));
@@ -6681,12 +6790,14 @@ impl<'a> AstNode<'a, LabeledStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ThrowStatement<'a>> {
+impl<'a> GetSpan for AstNode<'a, LabeledStatement<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, ThrowStatement<'a>> {
     #[inline]
     pub fn argument(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = self.following_node;
@@ -6712,12 +6823,14 @@ impl<'a> AstNode<'a, ThrowStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TryStatement<'a>> {
+impl<'a> GetSpan for AstNode<'a, ThrowStatement<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TryStatement<'a>> {
     #[inline]
     pub fn block(&self) -> &AstNode<'a, BlockStatement<'a>> {
         let following_node = self
@@ -6776,12 +6889,14 @@ impl<'a> AstNode<'a, TryStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, CatchClause<'a>> {
+impl<'a> GetSpan for AstNode<'a, TryStatement<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, CatchClause<'a>> {
     #[inline]
     pub fn param(&self) -> Option<&AstNode<'a, CatchParameter<'a>>> {
         let following_node = Some(SiblingNode::from(self.inner.body.as_ref()));
@@ -6820,12 +6935,14 @@ impl<'a> AstNode<'a, CatchClause<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, CatchParameter<'a>> {
+impl<'a> GetSpan for AstNode<'a, CatchClause<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, CatchParameter<'a>> {
     #[inline]
     pub fn pattern(&self) -> &AstNode<'a, BindingPattern<'a>> {
         let following_node = self.following_node;
@@ -6851,12 +6968,14 @@ impl<'a> AstNode<'a, CatchParameter<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, DebuggerStatement> {
+impl<'a> GetSpan for AstNode<'a, CatchParameter<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, DebuggerStatement> {
     pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_leading_comments(self.span()).fmt(f)
     }
@@ -6868,6 +6987,13 @@ impl<'a> AstNode<'a, DebuggerStatement> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, DebuggerStatement> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -6913,6 +7039,13 @@ impl<'a> AstNode<'a, BindingPattern<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, BindingPattern<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -6967,11 +7100,6 @@ impl<'a> GetSpan for AstNode<'a, BindingPatternKind<'a>> {
 
 impl<'a> AstNode<'a, AssignmentPattern<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn left(&self) -> &AstNode<'a, BindingPattern<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.right));
         self.allocator.alloc(AstNode {
@@ -7007,12 +7135,14 @@ impl<'a> AstNode<'a, AssignmentPattern<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ObjectPattern<'a>> {
+impl<'a> GetSpan for AstNode<'a, AssignmentPattern<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, ObjectPattern<'a>> {
     #[inline]
     pub fn properties(&self) -> &AstNode<'a, Vec<'a, BindingProperty<'a>>> {
         let following_node =
@@ -7052,12 +7182,14 @@ impl<'a> AstNode<'a, ObjectPattern<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, BindingProperty<'a>> {
+impl<'a> GetSpan for AstNode<'a, ObjectPattern<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, BindingProperty<'a>> {
     #[inline]
     pub fn key(&self) -> &AstNode<'a, PropertyKey<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.value));
@@ -7104,12 +7236,14 @@ impl<'a> AstNode<'a, BindingProperty<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ArrayPattern<'a>> {
+impl<'a> GetSpan for AstNode<'a, BindingProperty<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, ArrayPattern<'a>> {
     #[inline]
     pub fn elements(&self) -> &AstNode<'a, Vec<'a, Option<BindingPattern<'a>>>> {
         let following_node =
@@ -7149,12 +7283,14 @@ impl<'a> AstNode<'a, ArrayPattern<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, BindingRestElement<'a>> {
+impl<'a> GetSpan for AstNode<'a, ArrayPattern<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, BindingRestElement<'a>> {
     #[inline]
     pub fn argument(&self) -> &AstNode<'a, BindingPattern<'a>> {
         let following_node = self.following_node;
@@ -7180,12 +7316,14 @@ impl<'a> AstNode<'a, BindingRestElement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, Function<'a>> {
+impl<'a> GetSpan for AstNode<'a, BindingRestElement<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, Function<'a>> {
     #[inline]
     pub fn r#type(&self) -> FunctionType {
         self.inner.r#type
@@ -7319,12 +7457,14 @@ impl<'a> AstNode<'a, Function<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, FormalParameters<'a>> {
+impl<'a> GetSpan for AstNode<'a, Function<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, FormalParameters<'a>> {
     #[inline]
     pub fn kind(&self) -> FormalParameterKind {
         self.inner.kind
@@ -7369,12 +7509,14 @@ impl<'a> AstNode<'a, FormalParameters<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, FormalParameter<'a>> {
+impl<'a> GetSpan for AstNode<'a, FormalParameters<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, FormalParameter<'a>> {
     #[inline]
     pub fn decorators(&self) -> &AstNode<'a, Vec<'a, Decorator<'a>>> {
         let following_node = Some(SiblingNode::from(&self.inner.pattern));
@@ -7426,12 +7568,14 @@ impl<'a> AstNode<'a, FormalParameter<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, FunctionBody<'a>> {
+impl<'a> GetSpan for AstNode<'a, FormalParameter<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, FunctionBody<'a>> {
     #[inline]
     pub fn directives(&self) -> &AstNode<'a, Vec<'a, Directive<'a>>> {
         let following_node = self
@@ -7475,12 +7619,14 @@ impl<'a> AstNode<'a, FunctionBody<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ArrowFunctionExpression<'a>> {
+impl<'a> GetSpan for AstNode<'a, FunctionBody<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, ArrowFunctionExpression<'a>> {
     #[inline]
     pub fn expression(&self) -> bool {
         self.inner.expression
@@ -7570,12 +7716,14 @@ impl<'a> AstNode<'a, ArrowFunctionExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, YieldExpression<'a>> {
+impl<'a> GetSpan for AstNode<'a, ArrowFunctionExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, YieldExpression<'a>> {
     #[inline]
     pub fn delegate(&self) -> bool {
         self.inner.delegate
@@ -7608,12 +7756,14 @@ impl<'a> AstNode<'a, YieldExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, Class<'a>> {
+impl<'a> GetSpan for AstNode<'a, YieldExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, Class<'a>> {
     #[inline]
     pub fn r#type(&self) -> ClassType {
         self.inner.r#type
@@ -7765,12 +7915,14 @@ impl<'a> AstNode<'a, Class<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ClassBody<'a>> {
+impl<'a> GetSpan for AstNode<'a, Class<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, ClassBody<'a>> {
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Vec<'a, ClassElement<'a>>> {
         let following_node = self.following_node;
@@ -7793,6 +7945,13 @@ impl<'a> AstNode<'a, ClassBody<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, ClassBody<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -7852,11 +8011,6 @@ impl<'a> GetSpan for AstNode<'a, ClassElement<'a>> {
 }
 
 impl<'a> AstNode<'a, MethodDefinition<'a>> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     #[inline]
     pub fn r#type(&self) -> MethodDefinitionType {
         self.inner.r#type
@@ -7939,12 +8093,14 @@ impl<'a> AstNode<'a, MethodDefinition<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, PropertyDefinition<'a>> {
+impl<'a> GetSpan for AstNode<'a, MethodDefinition<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, PropertyDefinition<'a>> {
     #[inline]
     pub fn r#type(&self) -> PropertyDefinitionType {
         self.inner.r#type
@@ -8059,12 +8215,14 @@ impl<'a> AstNode<'a, PropertyDefinition<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, PrivateIdentifier<'a>> {
+impl<'a> GetSpan for AstNode<'a, PropertyDefinition<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, PrivateIdentifier<'a>> {
     #[inline]
     pub fn name(&self) -> Atom<'a> {
         self.inner.name
@@ -8084,12 +8242,14 @@ impl<'a> AstNode<'a, PrivateIdentifier<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, StaticBlock<'a>> {
+impl<'a> GetSpan for AstNode<'a, PrivateIdentifier<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, StaticBlock<'a>> {
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
         let following_node = self.following_node;
@@ -8112,6 +8272,13 @@ impl<'a> AstNode<'a, StaticBlock<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, StaticBlock<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -8181,11 +8348,6 @@ impl<'a> GetSpan for AstNode<'a, ModuleDeclaration<'a>> {
 }
 
 impl<'a> AstNode<'a, AccessorProperty<'a>> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     #[inline]
     pub fn r#type(&self) -> AccessorPropertyType {
         self.inner.r#type
@@ -8285,12 +8447,14 @@ impl<'a> AstNode<'a, AccessorProperty<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ImportExpression<'a>> {
+impl<'a> GetSpan for AstNode<'a, AccessorProperty<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, ImportExpression<'a>> {
     #[inline]
     pub fn source(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node =
@@ -8335,12 +8499,14 @@ impl<'a> AstNode<'a, ImportExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ImportDeclaration<'a>> {
+impl<'a> GetSpan for AstNode<'a, ImportExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, ImportDeclaration<'a>> {
     #[inline]
     pub fn specifiers(&self) -> Option<&AstNode<'a, Vec<'a, ImportDeclarationSpecifier<'a>>>> {
         let following_node = Some(SiblingNode::from(&self.inner.source));
@@ -8403,6 +8569,13 @@ impl<'a> AstNode<'a, ImportDeclaration<'a>> {
     }
 }
 
+impl<'a> GetSpan for AstNode<'a, ImportDeclaration<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
+    }
+}
+
 impl<'a> AstNode<'a, ImportDeclarationSpecifier<'a>> {
     #[inline]
     pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
@@ -8446,11 +8619,6 @@ impl<'a> GetSpan for AstNode<'a, ImportDeclarationSpecifier<'a>> {
 
 impl<'a> AstNode<'a, ImportSpecifier<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn imported(&self) -> &AstNode<'a, ModuleExportName<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.local));
         self.allocator.alloc(AstNode {
@@ -8491,12 +8659,14 @@ impl<'a> AstNode<'a, ImportSpecifier<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ImportDefaultSpecifier<'a>> {
+impl<'a> GetSpan for AstNode<'a, ImportSpecifier<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, ImportDefaultSpecifier<'a>> {
     #[inline]
     pub fn local(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
         let following_node = self.following_node;
@@ -8522,12 +8692,14 @@ impl<'a> AstNode<'a, ImportDefaultSpecifier<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ImportNamespaceSpecifier<'a>> {
+impl<'a> GetSpan for AstNode<'a, ImportDefaultSpecifier<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, ImportNamespaceSpecifier<'a>> {
     #[inline]
     pub fn local(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
         let following_node = self.following_node;
@@ -8553,12 +8725,14 @@ impl<'a> AstNode<'a, ImportNamespaceSpecifier<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, WithClause<'a>> {
+impl<'a> GetSpan for AstNode<'a, ImportNamespaceSpecifier<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, WithClause<'a>> {
     #[inline]
     pub fn attributes_keyword(&self) -> &AstNode<'a, IdentifierName<'a>> {
         let following_node = self
@@ -8602,12 +8776,14 @@ impl<'a> AstNode<'a, WithClause<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ImportAttribute<'a>> {
+impl<'a> GetSpan for AstNode<'a, WithClause<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, ImportAttribute<'a>> {
     #[inline]
     pub fn key(&self) -> &AstNode<'a, ImportAttributeKey<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.value));
@@ -8641,6 +8817,13 @@ impl<'a> AstNode<'a, ImportAttribute<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, ImportAttribute<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -8678,11 +8861,6 @@ impl<'a> GetSpan for AstNode<'a, ImportAttributeKey<'a>> {
 }
 
 impl<'a> AstNode<'a, ExportNamedDeclaration<'a>> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     #[inline]
     pub fn declaration(&self) -> Option<&AstNode<'a, Declaration<'a>>> {
         let following_node = self
@@ -8771,12 +8949,14 @@ impl<'a> AstNode<'a, ExportNamedDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ExportDefaultDeclaration<'a>> {
+impl<'a> GetSpan for AstNode<'a, ExportNamedDeclaration<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, ExportDefaultDeclaration<'a>> {
     #[inline]
     pub fn exported(&self) -> &AstNode<'a, ModuleExportName<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.declaration));
@@ -8813,12 +8993,14 @@ impl<'a> AstNode<'a, ExportDefaultDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ExportAllDeclaration<'a>> {
+impl<'a> GetSpan for AstNode<'a, ExportDefaultDeclaration<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, ExportAllDeclaration<'a>> {
     #[inline]
     pub fn exported(&self) -> Option<&AstNode<'a, ModuleExportName<'a>>> {
         let following_node = Some(SiblingNode::from(&self.inner.source));
@@ -8876,12 +9058,14 @@ impl<'a> AstNode<'a, ExportAllDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ExportSpecifier<'a>> {
+impl<'a> GetSpan for AstNode<'a, ExportAllDeclaration<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, ExportSpecifier<'a>> {
     #[inline]
     pub fn local(&self) -> &AstNode<'a, ModuleExportName<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.exported));
@@ -8920,6 +9104,13 @@ impl<'a> AstNode<'a, ExportSpecifier<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, ExportSpecifier<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -9018,11 +9209,6 @@ impl<'a> GetSpan for AstNode<'a, ModuleExportName<'a>> {
 
 impl<'a> AstNode<'a, V8IntrinsicExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn name(&self) -> &AstNode<'a, IdentifierName<'a>> {
         let following_node = self
             .inner
@@ -9065,12 +9251,14 @@ impl<'a> AstNode<'a, V8IntrinsicExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, BooleanLiteral> {
+impl<'a> GetSpan for AstNode<'a, V8IntrinsicExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, BooleanLiteral> {
     #[inline]
     pub fn value(&self) -> bool {
         self.inner.value
@@ -9090,12 +9278,14 @@ impl<'a> AstNode<'a, BooleanLiteral> {
     }
 }
 
-impl<'a> AstNode<'a, NullLiteral> {
+impl<'a> GetSpan for AstNode<'a, BooleanLiteral> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, NullLiteral> {
     pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_leading_comments(self.span()).fmt(f)
     }
@@ -9110,12 +9300,14 @@ impl<'a> AstNode<'a, NullLiteral> {
     }
 }
 
-impl<'a> AstNode<'a, NumericLiteral<'a>> {
+impl<'a> GetSpan for AstNode<'a, NullLiteral> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, NumericLiteral<'a>> {
     #[inline]
     pub fn value(&self) -> f64 {
         self.inner.value
@@ -9145,12 +9337,14 @@ impl<'a> AstNode<'a, NumericLiteral<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, StringLiteral<'a>> {
+impl<'a> GetSpan for AstNode<'a, NumericLiteral<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, StringLiteral<'a>> {
     #[inline]
     pub fn value(&self) -> Atom<'a> {
         self.inner.value
@@ -9180,12 +9374,14 @@ impl<'a> AstNode<'a, StringLiteral<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, BigIntLiteral<'a>> {
+impl<'a> GetSpan for AstNode<'a, StringLiteral<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, BigIntLiteral<'a>> {
     #[inline]
     pub fn value(&self) -> Atom<'a> {
         self.inner.value
@@ -9215,12 +9411,14 @@ impl<'a> AstNode<'a, BigIntLiteral<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, RegExpLiteral<'a>> {
+impl<'a> GetSpan for AstNode<'a, BigIntLiteral<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, RegExpLiteral<'a>> {
     #[inline]
     pub fn regex(&self) -> &RegExp<'a> {
         &self.inner.regex
@@ -9245,12 +9443,14 @@ impl<'a> AstNode<'a, RegExpLiteral<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSXElement<'a>> {
+impl<'a> GetSpan for AstNode<'a, RegExpLiteral<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, JSXElement<'a>> {
     #[inline]
     pub fn opening_element(&self) -> &AstNode<'a, JSXOpeningElement<'a>> {
         let following_node = self
@@ -9309,12 +9509,14 @@ impl<'a> AstNode<'a, JSXElement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSXOpeningElement<'a>> {
+impl<'a> GetSpan for AstNode<'a, JSXElement<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, JSXOpeningElement<'a>> {
     #[inline]
     pub fn name(&self) -> &AstNode<'a, JSXElementName<'a>> {
         let following_node = self
@@ -9377,12 +9579,14 @@ impl<'a> AstNode<'a, JSXOpeningElement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSXClosingElement<'a>> {
+impl<'a> GetSpan for AstNode<'a, JSXOpeningElement<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, JSXClosingElement<'a>> {
     #[inline]
     pub fn name(&self) -> &AstNode<'a, JSXElementName<'a>> {
         let following_node = self.following_node;
@@ -9408,12 +9612,14 @@ impl<'a> AstNode<'a, JSXClosingElement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSXFragment<'a>> {
+impl<'a> GetSpan for AstNode<'a, JSXClosingElement<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, JSXFragment<'a>> {
     #[inline]
     pub fn opening_fragment(&self) -> &AstNode<'a, JSXOpeningFragment> {
         let following_node = self
@@ -9468,12 +9674,14 @@ impl<'a> AstNode<'a, JSXFragment<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSXOpeningFragment> {
+impl<'a> GetSpan for AstNode<'a, JSXFragment<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, JSXOpeningFragment> {
     pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_leading_comments(self.span()).fmt(f)
     }
@@ -9488,12 +9696,14 @@ impl<'a> AstNode<'a, JSXOpeningFragment> {
     }
 }
 
-impl<'a> AstNode<'a, JSXClosingFragment> {
+impl<'a> GetSpan for AstNode<'a, JSXOpeningFragment> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, JSXClosingFragment> {
     pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_leading_comments(self.span()).fmt(f)
     }
@@ -9505,6 +9715,13 @@ impl<'a> AstNode<'a, JSXClosingFragment> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, JSXClosingFragment> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -9567,11 +9784,6 @@ impl<'a> GetSpan for AstNode<'a, JSXElementName<'a>> {
 
 impl<'a> AstNode<'a, JSXNamespacedName<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn namespace(&self) -> &AstNode<'a, JSXIdentifier<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.name));
         self.allocator.alloc(AstNode {
@@ -9607,12 +9819,14 @@ impl<'a> AstNode<'a, JSXNamespacedName<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSXMemberExpression<'a>> {
+impl<'a> GetSpan for AstNode<'a, JSXNamespacedName<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, JSXMemberExpression<'a>> {
     #[inline]
     pub fn object(&self) -> &AstNode<'a, JSXMemberExpressionObject<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.property));
@@ -9646,6 +9860,13 @@ impl<'a> AstNode<'a, JSXMemberExpression<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, JSXMemberExpression<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -9692,11 +9913,6 @@ impl<'a> GetSpan for AstNode<'a, JSXMemberExpressionObject<'a>> {
 
 impl<'a> AstNode<'a, JSXExpressionContainer<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn expression(&self) -> &AstNode<'a, JSXExpression<'a>> {
         let following_node = self.following_node;
         self.allocator.alloc(AstNode {
@@ -9718,6 +9934,13 @@ impl<'a> AstNode<'a, JSXExpressionContainer<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, JSXExpressionContainer<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -9758,11 +9981,6 @@ impl<'a> GetSpan for AstNode<'a, JSXExpression<'a>> {
 }
 
 impl<'a> AstNode<'a, JSXEmptyExpression> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_leading_comments(self.span()).fmt(f)
     }
@@ -9774,6 +9992,13 @@ impl<'a> AstNode<'a, JSXEmptyExpression> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, JSXEmptyExpression> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -9811,11 +10036,6 @@ impl<'a> GetSpan for AstNode<'a, JSXAttributeItem<'a>> {
 }
 
 impl<'a> AstNode<'a, JSXAttribute<'a>> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     #[inline]
     pub fn name(&self) -> &AstNode<'a, JSXAttributeName<'a>> {
         let following_node =
@@ -9855,12 +10075,14 @@ impl<'a> AstNode<'a, JSXAttribute<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSXSpreadAttribute<'a>> {
+impl<'a> GetSpan for AstNode<'a, JSXAttribute<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, JSXSpreadAttribute<'a>> {
     #[inline]
     pub fn argument(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = self.following_node;
@@ -9883,6 +10105,13 @@ impl<'a> AstNode<'a, JSXSpreadAttribute<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, JSXSpreadAttribute<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -9968,11 +10197,6 @@ impl<'a> GetSpan for AstNode<'a, JSXAttributeValue<'a>> {
 
 impl<'a> AstNode<'a, JSXIdentifier<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn name(&self) -> Atom<'a> {
         self.inner.name
     }
@@ -9988,6 +10212,13 @@ impl<'a> AstNode<'a, JSXIdentifier<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, JSXIdentifier<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -10042,11 +10273,6 @@ impl<'a> GetSpan for AstNode<'a, JSXChild<'a>> {
 
 impl<'a> AstNode<'a, JSXSpreadChild<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = self.following_node;
         self.allocator.alloc(AstNode {
@@ -10071,12 +10297,14 @@ impl<'a> AstNode<'a, JSXSpreadChild<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSXText<'a>> {
+impl<'a> GetSpan for AstNode<'a, JSXSpreadChild<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, JSXText<'a>> {
     #[inline]
     pub fn value(&self) -> Atom<'a> {
         self.inner.value
@@ -10101,12 +10329,14 @@ impl<'a> AstNode<'a, JSXText<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSThisParameter<'a>> {
+impl<'a> GetSpan for AstNode<'a, JSXText<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSThisParameter<'a>> {
     #[inline]
     pub fn this_span(&self) -> Span {
         self.inner.this_span
@@ -10139,12 +10369,14 @@ impl<'a> AstNode<'a, TSThisParameter<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSEnumDeclaration<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSThisParameter<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSEnumDeclaration<'a>> {
     #[inline]
     pub fn id(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.body));
@@ -10191,12 +10423,14 @@ impl<'a> AstNode<'a, TSEnumDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSEnumBody<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSEnumDeclaration<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSEnumBody<'a>> {
     #[inline]
     pub fn members(&self) -> &AstNode<'a, Vec<'a, TSEnumMember<'a>>> {
         let following_node = self.following_node;
@@ -10222,12 +10456,14 @@ impl<'a> AstNode<'a, TSEnumBody<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSEnumMember<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSEnumBody<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSEnumMember<'a>> {
     #[inline]
     pub fn id(&self) -> &AstNode<'a, TSEnumMemberName<'a>> {
         let following_node =
@@ -10264,6 +10500,13 @@ impl<'a> AstNode<'a, TSEnumMember<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, TSEnumMember<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -10316,11 +10559,6 @@ impl<'a> GetSpan for AstNode<'a, TSEnumMemberName<'a>> {
 
 impl<'a> AstNode<'a, TSTypeAnnotation<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
         let following_node = self.following_node;
         self.allocator.alloc(AstNode {
@@ -10345,12 +10583,14 @@ impl<'a> AstNode<'a, TSTypeAnnotation<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSLiteralType<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSTypeAnnotation<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSLiteralType<'a>> {
     #[inline]
     pub fn literal(&self) -> &AstNode<'a, TSLiteral<'a>> {
         let following_node = self.following_node;
@@ -10373,6 +10613,13 @@ impl<'a> AstNode<'a, TSLiteralType<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, TSLiteralType<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -10722,11 +10969,6 @@ impl<'a> GetSpan for AstNode<'a, TSType<'a>> {
 
 impl<'a> AstNode<'a, TSConditionalType<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn check_type(&self) -> &AstNode<'a, TSType<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.extends_type));
         self.allocator.alloc(AstNode {
@@ -10784,12 +11026,14 @@ impl<'a> AstNode<'a, TSConditionalType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSUnionType<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSConditionalType<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSUnionType<'a>> {
     #[inline]
     pub fn types(&self) -> &AstNode<'a, Vec<'a, TSType<'a>>> {
         let following_node = self.following_node;
@@ -10815,12 +11059,14 @@ impl<'a> AstNode<'a, TSUnionType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSIntersectionType<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSUnionType<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSIntersectionType<'a>> {
     #[inline]
     pub fn types(&self) -> &AstNode<'a, Vec<'a, TSType<'a>>> {
         let following_node = self.following_node;
@@ -10846,12 +11092,14 @@ impl<'a> AstNode<'a, TSIntersectionType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSParenthesizedType<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSIntersectionType<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSParenthesizedType<'a>> {
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
         let following_node = self.following_node;
@@ -10877,12 +11125,14 @@ impl<'a> AstNode<'a, TSParenthesizedType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTypeOperator<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSParenthesizedType<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSTypeOperator<'a>> {
     #[inline]
     pub fn operator(&self) -> TSTypeOperatorOperator {
         self.inner.operator
@@ -10913,12 +11163,14 @@ impl<'a> AstNode<'a, TSTypeOperator<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSArrayType<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSTypeOperator<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSArrayType<'a>> {
     #[inline]
     pub fn element_type(&self) -> &AstNode<'a, TSType<'a>> {
         let following_node = self.following_node;
@@ -10944,12 +11196,14 @@ impl<'a> AstNode<'a, TSArrayType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSIndexedAccessType<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSArrayType<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSIndexedAccessType<'a>> {
     #[inline]
     pub fn object_type(&self) -> &AstNode<'a, TSType<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.index_type));
@@ -10986,12 +11240,14 @@ impl<'a> AstNode<'a, TSIndexedAccessType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTupleType<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSIndexedAccessType<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSTupleType<'a>> {
     #[inline]
     pub fn element_types(&self) -> &AstNode<'a, Vec<'a, TSTupleElement<'a>>> {
         let following_node = self.following_node;
@@ -11017,12 +11273,14 @@ impl<'a> AstNode<'a, TSTupleType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSNamedTupleMember<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSTupleType<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSNamedTupleMember<'a>> {
     #[inline]
     pub fn label(&self) -> &AstNode<'a, IdentifierName<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.element_type));
@@ -11064,12 +11322,14 @@ impl<'a> AstNode<'a, TSNamedTupleMember<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSOptionalType<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSNamedTupleMember<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSOptionalType<'a>> {
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
         let following_node = self.following_node;
@@ -11095,12 +11355,14 @@ impl<'a> AstNode<'a, TSOptionalType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSRestType<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSOptionalType<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSRestType<'a>> {
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
         let following_node = self.following_node;
@@ -11123,6 +11385,13 @@ impl<'a> AstNode<'a, TSRestType<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, TSRestType<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -11169,11 +11438,6 @@ impl<'a> GetSpan for AstNode<'a, TSTupleElement<'a>> {
 }
 
 impl<'a> AstNode<'a, TSAnyKeyword> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_leading_comments(self.span()).fmt(f)
     }
@@ -11185,15 +11449,17 @@ impl<'a> AstNode<'a, TSAnyKeyword> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, TSAnyKeyword> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
 impl<'a> AstNode<'a, TSStringKeyword> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_leading_comments(self.span()).fmt(f)
     }
@@ -11205,15 +11471,17 @@ impl<'a> AstNode<'a, TSStringKeyword> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, TSStringKeyword> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
 impl<'a> AstNode<'a, TSBooleanKeyword> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_leading_comments(self.span()).fmt(f)
     }
@@ -11225,15 +11493,17 @@ impl<'a> AstNode<'a, TSBooleanKeyword> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, TSBooleanKeyword> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
 impl<'a> AstNode<'a, TSNumberKeyword> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_leading_comments(self.span()).fmt(f)
     }
@@ -11245,15 +11515,17 @@ impl<'a> AstNode<'a, TSNumberKeyword> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, TSNumberKeyword> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
 impl<'a> AstNode<'a, TSNeverKeyword> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_leading_comments(self.span()).fmt(f)
     }
@@ -11265,15 +11537,17 @@ impl<'a> AstNode<'a, TSNeverKeyword> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, TSNeverKeyword> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
 impl<'a> AstNode<'a, TSIntrinsicKeyword> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_leading_comments(self.span()).fmt(f)
     }
@@ -11285,15 +11559,17 @@ impl<'a> AstNode<'a, TSIntrinsicKeyword> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, TSIntrinsicKeyword> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
 impl<'a> AstNode<'a, TSUnknownKeyword> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_leading_comments(self.span()).fmt(f)
     }
@@ -11305,15 +11581,17 @@ impl<'a> AstNode<'a, TSUnknownKeyword> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, TSUnknownKeyword> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
 impl<'a> AstNode<'a, TSNullKeyword> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_leading_comments(self.span()).fmt(f)
     }
@@ -11325,15 +11603,17 @@ impl<'a> AstNode<'a, TSNullKeyword> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, TSNullKeyword> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
 impl<'a> AstNode<'a, TSUndefinedKeyword> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_leading_comments(self.span()).fmt(f)
     }
@@ -11345,15 +11625,17 @@ impl<'a> AstNode<'a, TSUndefinedKeyword> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, TSUndefinedKeyword> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
 impl<'a> AstNode<'a, TSVoidKeyword> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_leading_comments(self.span()).fmt(f)
     }
@@ -11365,15 +11647,17 @@ impl<'a> AstNode<'a, TSVoidKeyword> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, TSVoidKeyword> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
 impl<'a> AstNode<'a, TSSymbolKeyword> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_leading_comments(self.span()).fmt(f)
     }
@@ -11385,15 +11669,17 @@ impl<'a> AstNode<'a, TSSymbolKeyword> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, TSSymbolKeyword> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
 impl<'a> AstNode<'a, TSThisType> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_leading_comments(self.span()).fmt(f)
     }
@@ -11405,15 +11691,17 @@ impl<'a> AstNode<'a, TSThisType> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, TSThisType> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
 impl<'a> AstNode<'a, TSObjectKeyword> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_leading_comments(self.span()).fmt(f)
     }
@@ -11425,15 +11713,17 @@ impl<'a> AstNode<'a, TSObjectKeyword> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, TSObjectKeyword> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
 impl<'a> AstNode<'a, TSBigIntKeyword> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_leading_comments(self.span()).fmt(f)
     }
@@ -11448,12 +11738,14 @@ impl<'a> AstNode<'a, TSBigIntKeyword> {
     }
 }
 
-impl<'a> AstNode<'a, TSTypeReference<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSBigIntKeyword> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSTypeReference<'a>> {
     #[inline]
     pub fn type_name(&self) -> &AstNode<'a, TSTypeName<'a>> {
         let following_node =
@@ -11490,6 +11782,13 @@ impl<'a> AstNode<'a, TSTypeReference<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, TSTypeReference<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -11536,11 +11835,6 @@ impl<'a> GetSpan for AstNode<'a, TSTypeName<'a>> {
 
 impl<'a> AstNode<'a, TSQualifiedName<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn left(&self) -> &AstNode<'a, TSTypeName<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.right));
         self.allocator.alloc(AstNode {
@@ -11576,12 +11870,14 @@ impl<'a> AstNode<'a, TSQualifiedName<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTypeParameterInstantiation<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSQualifiedName<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSTypeParameterInstantiation<'a>> {
     #[inline]
     pub fn params(&self) -> &AstNode<'a, Vec<'a, TSType<'a>>> {
         let following_node = self.following_node;
@@ -11609,12 +11905,14 @@ impl<'a> AstNode<'a, TSTypeParameterInstantiation<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTypeParameter<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSTypeParameterInstantiation<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSTypeParameter<'a>> {
     #[inline]
     pub fn name(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
         let following_node = self
@@ -11688,12 +11986,14 @@ impl<'a> AstNode<'a, TSTypeParameter<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTypeParameterDeclaration<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSTypeParameter<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSTypeParameterDeclaration<'a>> {
     #[inline]
     pub fn params(&self) -> &AstNode<'a, Vec<'a, TSTypeParameter<'a>>> {
         let following_node = self.following_node;
@@ -11721,12 +12021,14 @@ impl<'a> AstNode<'a, TSTypeParameterDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTypeAliasDeclaration<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSTypeParameterDeclaration<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSTypeAliasDeclaration<'a>> {
     #[inline]
     pub fn id(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
         let following_node = self
@@ -11787,12 +12089,14 @@ impl<'a> AstNode<'a, TSTypeAliasDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSClassImplements<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSTypeAliasDeclaration<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSClassImplements<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, TSTypeName<'a>> {
         let following_node =
@@ -11832,12 +12136,14 @@ impl<'a> AstNode<'a, TSClassImplements<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSInterfaceDeclaration<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSClassImplements<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSInterfaceDeclaration<'a>> {
     #[inline]
     pub fn id(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
         let following_node = self
@@ -11917,12 +12223,14 @@ impl<'a> AstNode<'a, TSInterfaceDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSInterfaceBody<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSInterfaceDeclaration<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSInterfaceBody<'a>> {
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Vec<'a, TSSignature<'a>>> {
         let following_node = self.following_node;
@@ -11948,12 +12256,14 @@ impl<'a> AstNode<'a, TSInterfaceBody<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSPropertySignature<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSInterfaceBody<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSPropertySignature<'a>> {
     #[inline]
     pub fn computed(&self) -> bool {
         self.inner.computed
@@ -12005,6 +12315,13 @@ impl<'a> AstNode<'a, TSPropertySignature<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, TSPropertySignature<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -12067,11 +12384,6 @@ impl<'a> GetSpan for AstNode<'a, TSSignature<'a>> {
 
 impl<'a> AstNode<'a, TSIndexSignature<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn parameters(&self) -> &AstNode<'a, Vec<'a, TSIndexSignatureName<'a>>> {
         let following_node = Some(SiblingNode::from(self.inner.type_annotation.as_ref()));
         self.allocator.alloc(AstNode {
@@ -12117,12 +12429,14 @@ impl<'a> AstNode<'a, TSIndexSignature<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSCallSignatureDeclaration<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSIndexSignature<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSCallSignatureDeclaration<'a>> {
     #[inline]
     pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
         let following_node = self
@@ -12207,12 +12521,14 @@ impl<'a> AstNode<'a, TSCallSignatureDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSMethodSignature<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSCallSignatureDeclaration<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSMethodSignature<'a>> {
     #[inline]
     pub fn key(&self) -> &AstNode<'a, PropertyKey<'a>> {
         let following_node = self
@@ -12315,12 +12631,14 @@ impl<'a> AstNode<'a, TSMethodSignature<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSConstructSignatureDeclaration<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSMethodSignature<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSConstructSignatureDeclaration<'a>> {
     #[inline]
     pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
         let following_node = Some(SiblingNode::from(self.inner.params.as_ref()));
@@ -12383,12 +12701,14 @@ impl<'a> AstNode<'a, TSConstructSignatureDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSIndexSignatureName<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSConstructSignatureDeclaration<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSIndexSignatureName<'a>> {
     #[inline]
     pub fn name(&self) -> Atom<'a> {
         self.inner.name
@@ -12419,12 +12739,14 @@ impl<'a> AstNode<'a, TSIndexSignatureName<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSInterfaceHeritage<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSIndexSignatureName<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSInterfaceHeritage<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node =
@@ -12464,12 +12786,14 @@ impl<'a> AstNode<'a, TSInterfaceHeritage<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTypePredicate<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSInterfaceHeritage<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSTypePredicate<'a>> {
     #[inline]
     pub fn parameter_name(&self) -> &AstNode<'a, TSTypePredicateName<'a>> {
         let following_node =
@@ -12514,6 +12838,13 @@ impl<'a> AstNode<'a, TSTypePredicate<'a>> {
     }
 }
 
+impl<'a> GetSpan for AstNode<'a, TSTypePredicate<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
+    }
+}
+
 impl<'a> AstNode<'a, TSTypePredicateName<'a>> {
     #[inline]
     pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
@@ -12546,11 +12877,6 @@ impl<'a> GetSpan for AstNode<'a, TSTypePredicateName<'a>> {
 }
 
 impl<'a> AstNode<'a, TSModuleDeclaration<'a>> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     #[inline]
     pub fn id(&self) -> &AstNode<'a, TSModuleDeclarationName<'a>> {
         let following_node =
@@ -12597,6 +12923,13 @@ impl<'a> AstNode<'a, TSModuleDeclaration<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, TSModuleDeclaration<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -12668,11 +13001,6 @@ impl<'a> GetSpan for AstNode<'a, TSModuleDeclarationBody<'a>> {
 
 impl<'a> AstNode<'a, TSModuleBlock<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn directives(&self) -> &AstNode<'a, Vec<'a, Directive<'a>>> {
         let following_node = self
             .inner
@@ -12715,12 +13043,14 @@ impl<'a> AstNode<'a, TSModuleBlock<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTypeLiteral<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSModuleBlock<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSTypeLiteral<'a>> {
     #[inline]
     pub fn members(&self) -> &AstNode<'a, Vec<'a, TSSignature<'a>>> {
         let following_node = self.following_node;
@@ -12746,12 +13076,14 @@ impl<'a> AstNode<'a, TSTypeLiteral<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSInferType<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSTypeLiteral<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSInferType<'a>> {
     #[inline]
     pub fn type_parameter(&self) -> &AstNode<'a, TSTypeParameter<'a>> {
         let following_node = self.following_node;
@@ -12777,12 +13109,14 @@ impl<'a> AstNode<'a, TSInferType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTypeQuery<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSInferType<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSTypeQuery<'a>> {
     #[inline]
     pub fn expr_name(&self) -> &AstNode<'a, TSTypeQueryExprName<'a>> {
         let following_node =
@@ -12819,6 +13153,13 @@ impl<'a> AstNode<'a, TSTypeQuery<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, TSTypeQuery<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
@@ -12859,11 +13200,6 @@ impl<'a> GetSpan for AstNode<'a, TSTypeQueryExprName<'a>> {
 }
 
 impl<'a> AstNode<'a, TSImportType<'a>> {
-    #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
     #[inline]
     pub fn argument(&self) -> &AstNode<'a, TSType<'a>> {
         let following_node = self
@@ -12942,12 +13278,14 @@ impl<'a> AstNode<'a, TSImportType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSFunctionType<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSImportType<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSFunctionType<'a>> {
     #[inline]
     pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
         let following_node = self
@@ -13015,12 +13353,14 @@ impl<'a> AstNode<'a, TSFunctionType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSConstructorType<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSFunctionType<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSConstructorType<'a>> {
     #[inline]
     pub fn r#abstract(&self) -> bool {
         self.inner.r#abstract
@@ -13075,12 +13415,14 @@ impl<'a> AstNode<'a, TSConstructorType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSMappedType<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSConstructorType<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSMappedType<'a>> {
     #[inline]
     pub fn type_parameter(&self) -> &AstNode<'a, TSTypeParameter<'a>> {
         let following_node = self
@@ -13149,12 +13491,14 @@ impl<'a> AstNode<'a, TSMappedType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTemplateLiteralType<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSMappedType<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSTemplateLiteralType<'a>> {
     #[inline]
     pub fn quasis(&self) -> &AstNode<'a, Vec<'a, TemplateElement<'a>>> {
         let following_node = self
@@ -13198,12 +13542,14 @@ impl<'a> AstNode<'a, TSTemplateLiteralType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSAsExpression<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSTemplateLiteralType<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSAsExpression<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.type_annotation));
@@ -13237,16 +13583,18 @@ impl<'a> AstNode<'a, TSAsExpression<'a>> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, TSAsExpression<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 
 impl<'a> AstNode<'a, TSSatisfiesExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.type_annotation));
         self.allocator.alloc(AstNode {
@@ -13282,12 +13630,14 @@ impl<'a> AstNode<'a, TSSatisfiesExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTypeAssertion<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSSatisfiesExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSTypeAssertion<'a>> {
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.expression));
@@ -13324,12 +13674,14 @@ impl<'a> AstNode<'a, TSTypeAssertion<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSImportEqualsDeclaration<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSTypeAssertion<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSImportEqualsDeclaration<'a>> {
     #[inline]
     pub fn id(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
         let following_node = Some(SiblingNode::from(&self.inner.module_reference));
@@ -13371,6 +13723,13 @@ impl<'a> AstNode<'a, TSImportEqualsDeclaration<'a>> {
     }
 }
 
+impl<'a> GetSpan for AstNode<'a, TSImportEqualsDeclaration<'a>> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
+    }
+}
+
 impl<'a> AstNode<'a, TSModuleReference<'a>> {
     #[inline]
     pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
@@ -13409,11 +13768,6 @@ impl<'a> GetSpan for AstNode<'a, TSModuleReference<'a>> {
 
 impl<'a> AstNode<'a, TSExternalModuleReference<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
-    }
-
-    #[inline]
     pub fn expression(&self) -> &AstNode<'a, StringLiteral<'a>> {
         let following_node = self.following_node;
         self.allocator.alloc(AstNode {
@@ -13438,12 +13792,14 @@ impl<'a> AstNode<'a, TSExternalModuleReference<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSNonNullExpression<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSExternalModuleReference<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSNonNullExpression<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = self.following_node;
@@ -13469,12 +13825,14 @@ impl<'a> AstNode<'a, TSNonNullExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, Decorator<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSNonNullExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, Decorator<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = self.following_node;
@@ -13500,12 +13858,14 @@ impl<'a> AstNode<'a, Decorator<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSExportAssignment<'a>> {
+impl<'a> GetSpan for AstNode<'a, Decorator<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSExportAssignment<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = self.following_node;
@@ -13531,12 +13891,14 @@ impl<'a> AstNode<'a, TSExportAssignment<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSNamespaceExportDeclaration<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSExportAssignment<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSNamespaceExportDeclaration<'a>> {
     #[inline]
     pub fn id(&self) -> &AstNode<'a, IdentifierName<'a>> {
         let following_node = self.following_node;
@@ -13564,12 +13926,14 @@ impl<'a> AstNode<'a, TSNamespaceExportDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSInstantiationExpression<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSNamespaceExportDeclaration<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, TSInstantiationExpression<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
         let following_node = Some(SiblingNode::from(self.inner.type_arguments.as_ref()));
@@ -13606,12 +13970,14 @@ impl<'a> AstNode<'a, TSInstantiationExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSDocNullableType<'a>> {
+impl<'a> GetSpan for AstNode<'a, TSInstantiationExpression<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, JSDocNullableType<'a>> {
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
         let following_node = self.following_node;
@@ -13642,12 +14008,14 @@ impl<'a> AstNode<'a, JSDocNullableType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSDocNonNullableType<'a>> {
+impl<'a> GetSpan for AstNode<'a, JSDocNullableType<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, JSDocNonNullableType<'a>> {
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
         let following_node = self.following_node;
@@ -13678,12 +14046,14 @@ impl<'a> AstNode<'a, JSDocNonNullableType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSDocUnknownType> {
+impl<'a> GetSpan for AstNode<'a, JSDocNonNullableType<'a>> {
     #[inline]
-    pub fn span(&self) -> Span {
-        self.inner.span
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
+}
 
+impl<'a> AstNode<'a, JSDocUnknownType> {
     pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_leading_comments(self.span()).fmt(f)
     }
@@ -13695,6 +14065,13 @@ impl<'a> AstNode<'a, JSDocUnknownType> {
             self.following_node.as_ref(),
         )
         .fmt(f)
+    }
+}
+
+impl<'a> GetSpan for AstNode<'a, JSDocUnknownType> {
+    #[inline]
+    fn span(&self) -> oxc_span::Span {
+        self.inner.span()
     }
 }
 

--- a/crates/oxc_formatter/src/write/array_expression.rs
+++ b/crates/oxc_formatter/src/write/array_expression.rs
@@ -30,7 +30,7 @@ impl<'a> Format<'a> for FormatArrayExpression<'a, '_> {
         write!(f, "[")?;
 
         if self.array.elements().is_empty() {
-            write!(f, format_dangling_comments(self.array.span()).with_block_indent());
+            write!(f, format_dangling_comments(self.array.span).with_block_indent());
         } else {
             let group_id = f.group_id("array");
             let should_expand = (!self.options.is_force_flat_mode && should_break(self.array))

--- a/crates/oxc_formatter/src/write/binding_property_list.rs
+++ b/crates/oxc_formatter/src/write/binding_property_list.rs
@@ -35,7 +35,7 @@ impl<'a> Format<'a> for BindingPropertyList<'a, '_> {
             .zip(self.properties.iter());
         let mut join = f.join_nodes_with_soft_line();
         for (format_entry, node) in entries {
-            join.entry(node.span(), &format_entry);
+            join.entry(node.span, &format_entry);
         }
         join.finish()
     }

--- a/crates/oxc_formatter/src/write/object_pattern_like.rs
+++ b/crates/oxc_formatter/src/write/object_pattern_like.rs
@@ -23,8 +23,8 @@ pub enum ObjectPatternLike<'a, 'b> {
 impl<'a> ObjectPatternLike<'a, '_> {
     fn span(&self) -> Span {
         match self {
-            Self::ObjectPattern(o) => o.span(),
-            Self::ObjectAssignmentTarget(o) => o.span(),
+            Self::ObjectPattern(o) => o.span,
+            Self::ObjectAssignmentTarget(o) => o.span,
         }
     }
 

--- a/tasks/ast_tools/src/generators/formatter/ast_nodes.rs
+++ b/tasks/ast_tools/src/generators/formatter/ast_nodes.rs
@@ -201,6 +201,11 @@ fn generate_struct_impls(struct_def: &StructDef, schema: &Schema) -> TokenStream
 
     let fields = &struct_def.fields;
     let methods = fields.iter().enumerate().filter_map(|(index, field)| {
+        if field.name == "span" {
+            // Instead of generating a method for `span`, we implement the `GetSpan` trait for it.
+            return None;
+        }
+
         let field_type_def = field.type_def(schema);
         let is_option = field_type_def.is_option();
         let (original_field_type, is_box) = if let TypeDef::Box(box_def) =
@@ -365,6 +370,13 @@ fn generate_struct_impls(struct_def: &StructDef, schema: &Schema) -> TokenStream
             }
         }
 
+        ///@@line_break
+        impl<'a> GetSpan for AstNode<'a, #type_ty>  {
+            #[inline]
+            fn span(&self) -> oxc_span::Span {
+                self.inner.span()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
`GetSpan` can be used in a generic method that can constrain a generic parameter to satisfy `GetSpan` trait. So that would be useful than a pure method.