### PR TITLE
refactor(napi/oxlint): simplify atomic operations

### DIFF
--- a/crates/oxc_allocator/src/pool_fixed_size.rs
+++ b/crates/oxc_allocator/src/pool_fixed_size.rs
@@ -324,7 +324,7 @@ pub unsafe fn free_fixed_size_allocator(metadata_ptr: NonNull<FixedSizeAllocator
         // so going with `Ordering::SeqCst` to be on safe side.
         // Deallocation only happens at the end of the whole process, so it shouldn't matter much.
         // TODO: Figure out if can use `Ordering::Relaxed`.
-        let is_double_owned = metadata.is_double_owned.fetch_and(false, Ordering::SeqCst);
+        let is_double_owned = metadata.is_double_owned.swap(false, Ordering::SeqCst);
         if is_double_owned {
             return;
         }

--- a/napi/oxlint2/src/lib.rs
+++ b/napi/oxlint2/src/lib.rs
@@ -62,7 +62,7 @@ fn wrap_run(cb: JsRunCb) -> ExternalLinterCb {
             // stored at the pointer returned by `Allocator::fixed_size_metadata_ptr`.
             let metadata = unsafe { metadata_ptr.as_ref() };
             // TODO: Is `Ordering::SeqCst` excessive here?
-            let already_sent_to_js = metadata.is_double_owned.fetch_or(true, Ordering::SeqCst);
+            let already_sent_to_js = metadata.is_double_owned.swap(true, Ordering::SeqCst);
 
             (metadata.id, already_sent_to_js)
         };


### PR DESCRIPTION
`AtomicBool::store` does the same as `fetch_and(false)` / `fetch_or(true)`, is simpler, and possibly a little bit cheaper. Not sure why I didn't use it in the first place in #12381!