### PR TITLE
refactor(allocator): remove unnecessary `Send` impl for `FixedSizeAllocator`

### DIFF
--- a/crates/oxc_allocator/src/pool_fixed_size.rs
+++ b/crates/oxc_allocator/src/pool_fixed_size.rs
@@ -337,10 +337,6 @@ pub unsafe fn free_fixed_size_allocator(metadata_ptr: NonNull<FixedSizeAllocator
     unsafe { System.dealloc(alloc_ptr.as_ptr(), ALLOC_LAYOUT) }
 }
 
-// SAFETY: `Allocator` is `Send`.
-// Moving `alloc_ptr: NonNull<u8>` across threads along with the `Allocator` is safe.
-unsafe impl Send for FixedSizeAllocator {}
-
 impl Allocator {
     /// Get pointer to the `FixedSizeAllocatorMetadata` for this [`Allocator`].
     ///


### PR DESCRIPTION
Pure refactor. #12380 removed the `NonNull<u8>` from `FixedSizeAllocator`, so `FixedSizeAllocator` is now automatically `Send`. Remove redundant manual `Send` impl.