### PR TITLE
refactor(minifier): remove change detection based on function changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2037,7 +2037,6 @@ dependencies = [
  "oxc_ast",
  "oxc_ast_visit",
  "oxc_codegen",
- "oxc_data_structures",
  "oxc_ecmascript",
  "oxc_mangler",
  "oxc_parser",

--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -25,7 +25,6 @@ oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_codegen = { workspace = true }
-oxc_data_structures = { workspace = true, features = ["stack"] }
 oxc_ecmascript = { workspace = true }
 oxc_mangler = { workspace = true }
 oxc_parser = { workspace = true }

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -11,23 +11,18 @@ use oxc_traverse::Ancestor;
 
 use crate::ctx::Ctx;
 
-use super::{PeepholeOptimizations, State};
+use super::PeepholeOptimizations;
 
 impl<'a> PeepholeOptimizations {
     /// Constant Folding
     ///
     /// <https://github.com/google/closure-compiler/blob/v20240609/src/com/google/javascript/jscomp/PeepholeFoldConstants.java>
-    pub fn fold_constants_exit_expression(
-        &self,
-        expr: &mut Expression<'a>,
-        state: &mut State,
-        ctx: &mut Ctx<'a, '_>,
-    ) {
+    pub fn fold_constants_exit_expression(&self, expr: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) {
         match expr {
             Expression::TemplateLiteral(t) => {
-                self.try_inline_values_in_template_literal(t, state, ctx);
+                self.try_inline_values_in_template_literal(t, ctx);
             }
-            Expression::ObjectExpression(e) => self.fold_object_spread(e, state, ctx),
+            Expression::ObjectExpression(e) => self.fold_object_spread(e, ctx),
             _ => {}
         }
 
@@ -43,7 +38,7 @@ impl<'a> PeepholeOptimizations {
             _ => None,
         } {
             *expr = folded_expr;
-            state.changed = true;
+            ctx.state.changed = true;
         }
 
         // Save `const value = false` into constant values.
@@ -664,12 +659,7 @@ impl<'a> PeepholeOptimizations {
         None
     }
 
-    fn fold_object_spread(
-        &self,
-        e: &mut ObjectExpression<'a>,
-        state: &mut State,
-        ctx: &mut Ctx<'a, '_>,
-    ) {
+    fn fold_object_spread(&self, e: &mut ObjectExpression<'a>, ctx: &mut Ctx<'a, '_>) {
         let (new_size, should_fold) =
             e.properties.iter().fold((0, false), |(new_size, should_fold), p| {
                 let ObjectPropertyKind::SpreadProperty(spread_element) = p else {
@@ -745,7 +735,7 @@ impl<'a> PeepholeOptimizations {
         }
 
         e.properties = new_properties;
-        state.changed = true;
+        ctx.state.changed = true;
     }
 
     fn is_spread_inlineable_object_literal(
@@ -774,7 +764,7 @@ impl<'a> PeepholeOptimizations {
     fn try_inline_values_in_template_literal(
         &self,
         t: &mut TemplateLiteral<'a>,
-        state: &mut State,
+
         ctx: &mut Ctx<'a, '_>,
     ) {
         let has_expr_to_inline = t
@@ -824,7 +814,7 @@ impl<'a> PeepholeOptimizations {
             }
         }
 
-        state.changed = true;
+        ctx.state.changed = true;
     }
 }
 

--- a/crates/oxc_minifier/src/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditions.rs
@@ -6,7 +6,7 @@ use oxc_syntax::es_target::ESTarget;
 
 use crate::ctx::Ctx;
 
-use super::{PeepholeOptimizations, State};
+use super::PeepholeOptimizations;
 
 /// Minimize Conditions
 ///
@@ -15,7 +15,6 @@ impl<'a> PeepholeOptimizations {
     pub fn minimize_conditions_exit_expression(
         &self,
         expr: &mut Expression<'a>,
-        state: &mut State,
         ctx: &mut Ctx<'a, '_>,
     ) {
         let mut changed = false;
@@ -57,7 +56,7 @@ impl<'a> PeepholeOptimizations {
             }
         }
         if changed {
-            state.changed = true;
+            ctx.state.changed = true;
         }
     }
 

--- a/crates/oxc_minifier/src/peephole/minimize_for_statement.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_for_statement.rs
@@ -4,16 +4,11 @@ use oxc_span::GetSpan;
 
 use crate::ctx::Ctx;
 
-use super::{PeepholeOptimizations, State};
+use super::PeepholeOptimizations;
 
 impl<'a> PeepholeOptimizations {
     /// `mangleFor`: <https://github.com/evanw/esbuild/blob/v0.24.2/internal/js_ast/js_parser.go#L9801>
-    pub fn minimize_for_statement(
-        &self,
-        for_stmt: &mut ForStatement<'a>,
-        state: &mut State,
-        ctx: &mut Ctx<'a, '_>,
-    ) {
+    pub fn minimize_for_statement(&self, for_stmt: &mut ForStatement<'a>, ctx: &mut Ctx<'a, '_>) {
         // Get the first statement in the loop
         let mut first = &for_stmt.body;
         if let Statement::BlockStatement(block_stmt) = first {
@@ -66,7 +61,7 @@ impl<'a> PeepholeOptimizations {
 
             let alternate = if_stmt.alternate.take();
             for_stmt.body = Self::drop_first_statement(span, body, alternate, ctx);
-            state.changed = true;
+            ctx.state.changed = true;
             return;
         }
         // "for (;;) if (x) y(); else break;" => "for (; x;) y();"
@@ -103,7 +98,7 @@ impl<'a> PeepholeOptimizations {
 
             let consequent = if_stmt.consequent.take_in(ctx.ast);
             for_stmt.body = Self::drop_first_statement(span, body, Some(consequent), ctx);
-            state.changed = true;
+            ctx.state.changed = true;
         }
     }
 

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -8,7 +8,7 @@ use oxc_traverse::Ancestor;
 
 use crate::{ctx::Ctx, keep_var::KeepVar};
 
-use super::{LatePeepholeOptimizations, PeepholeOptimizations, State};
+use super::{LatePeepholeOptimizations, PeepholeOptimizations};
 
 /// Remove Dead Code from the AST.
 ///
@@ -17,16 +17,11 @@ use super::{LatePeepholeOptimizations, PeepholeOptimizations, State};
 /// See `KeepVar` at the end of this file for `var` hoisting logic.
 /// <https://github.com/google/closure-compiler/blob/v20240609/src/com/google/javascript/jscomp/PeepholeRemoveDeadCode.java>
 impl<'a> PeepholeOptimizations {
-    pub fn remove_dead_code_exit_statement(
-        &self,
-        stmt: &mut Statement<'a>,
-        state: &mut State,
-        ctx: &mut Ctx<'a, '_>,
-    ) {
+    pub fn remove_dead_code_exit_statement(&self, stmt: &mut Statement<'a>, ctx: &mut Ctx<'a, '_>) {
         if let Some(new_stmt) = match stmt {
             Statement::BlockStatement(s) => Self::try_optimize_block(s, ctx),
-            Statement::IfStatement(s) => Self::try_fold_if(s, state, ctx),
-            Statement::ForStatement(s) => self.try_fold_for(s, state, ctx),
+            Statement::IfStatement(s) => Self::try_fold_if(s, ctx),
+            Statement::ForStatement(s) => self.try_fold_for(s, ctx),
             Statement::TryStatement(s) => Self::try_fold_try(s, ctx),
             Statement::LabeledStatement(s) => Self::try_fold_labeled(s, ctx),
             Statement::FunctionDeclaration(f) => Self::remove_unused_function_declaration(f, ctx),
@@ -34,25 +29,23 @@ impl<'a> PeepholeOptimizations {
             _ => None,
         } {
             *stmt = new_stmt;
-            state.changed = true;
+            ctx.state.changed = true;
         }
 
-        self.try_fold_expression_stmt(stmt, state, ctx);
+        self.try_fold_expression_stmt(stmt, ctx);
     }
 
     pub fn remove_dead_code_exit_expression(
         &self,
         expr: &mut Expression<'a>,
-        state: &mut State,
+
         ctx: &mut Ctx<'a, '_>,
     ) {
         if let Some(folded_expr) = match expr {
-            Expression::ConditionalExpression(e) => {
-                self.try_fold_conditional_expression(e, state, ctx)
-            }
-            Expression::SequenceExpression(e) => self.try_fold_sequence_expression(e, state, ctx),
+            Expression::ConditionalExpression(e) => self.try_fold_conditional_expression(e, ctx),
+            Expression::SequenceExpression(e) => self.try_fold_sequence_expression(e, ctx),
             Expression::AssignmentExpression(_) => {
-                self.remove_unused_assignment_expression(expr, state, ctx);
+                self.remove_unused_assignment_expression(expr, ctx);
                 None
             }
             Expression::CallExpression(call_expr) => self.remove_call_expression(call_expr, ctx),
@@ -60,7 +53,7 @@ impl<'a> PeepholeOptimizations {
             _ => None,
         } {
             *expr = folded_expr;
-            state.changed = true;
+            ctx.state.changed = true;
         }
     }
 
@@ -100,30 +93,26 @@ impl<'a> PeepholeOptimizations {
         }
     }
 
-    fn try_fold_if(
-        if_stmt: &mut IfStatement<'a>,
-        state: &mut State,
-        ctx: &mut Ctx<'a, '_>,
-    ) -> Option<Statement<'a>> {
+    fn try_fold_if(if_stmt: &mut IfStatement<'a>, ctx: &mut Ctx<'a, '_>) -> Option<Statement<'a>> {
         // Descend and remove `else` blocks first.
         match &mut if_stmt.alternate {
             Some(Statement::IfStatement(alternate)) => {
-                if let Some(new_stmt) = Self::try_fold_if(alternate, state, ctx) {
+                if let Some(new_stmt) = Self::try_fold_if(alternate, ctx) {
                     if matches!(new_stmt, Statement::EmptyStatement(_)) {
                         if_stmt.alternate = None;
                     } else {
                         if_stmt.alternate = Some(new_stmt);
                     }
-                    state.changed = true;
+                    ctx.state.changed = true;
                 }
             }
             Some(Statement::BlockStatement(s)) if s.body.is_empty() => {
                 if_stmt.alternate = None;
-                state.changed = true;
+                ctx.state.changed = true;
             }
             Some(Statement::EmptyStatement(_)) => {
                 if_stmt.alternate = None;
-                state.changed = true;
+                ctx.state.changed = true;
             }
             _ => {}
         }
@@ -188,21 +177,21 @@ impl<'a> PeepholeOptimizations {
     fn try_fold_for(
         &self,
         for_stmt: &mut ForStatement<'a>,
-        state: &mut State,
+
         ctx: &mut Ctx<'a, '_>,
     ) -> Option<Statement<'a>> {
         if let Some(init) = &mut for_stmt.init {
             if let Some(init) = init.as_expression_mut() {
-                if self.remove_unused_expression(init, state, ctx) {
+                if self.remove_unused_expression(init, ctx) {
                     for_stmt.init = None;
-                    state.changed = true;
+                    ctx.state.changed = true;
                 }
             }
         }
         if let Some(update) = &mut for_stmt.update {
-            if self.remove_unused_expression(update, state, ctx) {
+            if self.remove_unused_expression(update, ctx) {
                 for_stmt.update = None;
-                state.changed = true;
+                ctx.state.changed = true;
             }
         }
 
@@ -244,7 +233,7 @@ impl<'a> PeepholeOptimizations {
             Some(true) => {
                 // Remove the test expression.
                 for_stmt.test = None;
-                state.changed = true;
+                ctx.state.changed = true;
                 None
             }
             None => None,
@@ -278,12 +267,7 @@ impl<'a> PeepholeOptimizations {
         var_decl.unwrap_or_else(|| ctx.ast.statement_empty(s.span)).into()
     }
 
-    fn try_fold_expression_stmt(
-        &self,
-        stmt: &mut Statement<'a>,
-        state: &mut State,
-        ctx: &mut Ctx<'a, '_>,
-    ) {
+    fn try_fold_expression_stmt(&self, stmt: &mut Statement<'a>, ctx: &mut Ctx<'a, '_>) {
         let Statement::ExpressionStatement(expr_stmt) = stmt else { return };
         // We need to check if it is in arrow function with `expression: true`.
         // This is the only scenario where we can't remove it even if `ExpressionStatement`.
@@ -293,9 +277,9 @@ impl<'a> PeepholeOptimizations {
             }
         }
 
-        if self.remove_unused_expression(&mut expr_stmt.expression, state, ctx) {
+        if self.remove_unused_expression(&mut expr_stmt.expression, ctx) {
             *stmt = ctx.ast.statement_empty(expr_stmt.span);
-            state.changed = true;
+            ctx.state.changed = true;
         }
     }
 
@@ -336,7 +320,7 @@ impl<'a> PeepholeOptimizations {
     fn try_fold_conditional_expression(
         &self,
         expr: &mut ConditionalExpression<'a>,
-        state: &mut State,
+
         ctx: &mut Ctx<'a, '_>,
     ) -> Option<Expression<'a>> {
         expr.test.evaluate_value_to_boolean(ctx).map(|v| {
@@ -345,7 +329,7 @@ impl<'a> PeepholeOptimizations {
                 let exprs = ctx.ast.vec_from_array([
                     {
                         let mut test = expr.test.take_in(ctx.ast);
-                        self.remove_unused_expression(&mut test, state, ctx);
+                        self.remove_unused_expression(&mut test, ctx);
                         test
                     },
                     if v {
@@ -388,7 +372,7 @@ impl<'a> PeepholeOptimizations {
     fn try_fold_sequence_expression(
         &self,
         sequence_expr: &mut SequenceExpression<'a>,
-        state: &mut State,
+
         ctx: &mut Ctx<'a, '_>,
     ) -> Option<Expression<'a>> {
         let should_keep_as_sequence_expr = sequence_expr
@@ -407,28 +391,28 @@ impl<'a> PeepholeOptimizations {
         sequence_expr.expressions.retain_mut(|e| {
             i += 1;
             if should_keep_as_sequence_expr && i == old_len - 1 {
-                if self.remove_unused_expression(e, state, ctx) {
+                if self.remove_unused_expression(e, ctx) {
                     *e = ctx.ast.expression_numeric_literal(
                         e.span(),
                         0.0,
                         None,
                         NumberBase::Decimal,
                     );
-                    state.changed = true;
+                    ctx.state.changed = true;
                 }
                 return true;
             }
             if i == old_len {
                 return true;
             }
-            !self.remove_unused_expression(e, state, ctx)
+            !self.remove_unused_expression(e, ctx)
         });
         if sequence_expr.expressions.len() == 1 {
             return Some(sequence_expr.expressions.pop().unwrap());
         }
 
         if sequence_expr.expressions.len() != old_len {
-            state.changed = true;
+            ctx.state.changed = true;
         }
         None
     }

--- a/crates/oxc_minifier/src/peephole/remove_unused_variable_declaration.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_variable_declaration.rs
@@ -2,7 +2,7 @@ use oxc_ast::ast::*;
 
 use crate::{CompressOptionsUnused, ctx::Ctx};
 
-use super::{PeepholeOptimizations, State};
+use super::PeepholeOptimizations;
 
 impl<'a> PeepholeOptimizations {
     pub fn should_remove_unused_declarator(
@@ -89,7 +89,6 @@ impl<'a> PeepholeOptimizations {
     pub fn remove_unused_assignment_expression(
         &self,
         _e: &mut Expression<'a>,
-        _state: &mut State,
         _ctx: &mut Ctx<'a, '_>,
     ) -> bool {
         // let Expression::AssignmentExpression(assign_expr) = e else { return false };

--- a/crates/oxc_minifier/src/state.rs
+++ b/crates/oxc_minifier/src/state.rs
@@ -19,6 +19,8 @@ pub struct MinifierState<'a> {
 
     /// Function declarations that are empty
     pub empty_functions: FxHashSet<SymbolId>,
+
+    pub changed: bool,
 }
 
 impl MinifierState<'_> {
@@ -28,6 +30,7 @@ impl MinifierState<'_> {
             options,
             constant_values: FxHashMap::default(),
             empty_functions: FxHashSet::default(),
+            changed: false,
         }
     }
 }


### PR DESCRIPTION
Previously minification methods were run when functions are changed
during the previous iteration, this is not longer the case after
addition of removing unused vars and inline constant values.