### PR TITLE
refactor(linter): remove number of rules in output

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -165,7 +165,6 @@ impl Runner for LintRunner {
             if provided_path_count > 0 {
                 if let Some(end) = output_formatter.lint_command_info(&LintCommandInfo {
                     number_of_files: 0,
-                    number_of_rules: None,
                     threads_count: rayon::current_num_threads(),
                     start_time: now.elapsed(),
                 }) {
@@ -317,8 +316,6 @@ impl Runner for LintRunner {
             Self::get_diagnostic_service(&output_formatter, &warning_options, &misc_options);
         let tx_error = diagnostic_service.sender().clone();
 
-        let number_of_rules = linter.number_of_rules();
-
         let allocator_pool = AllocatorPool::new(rayon::current_num_threads());
 
         // Spawn linting in another thread so diagnostics can be printed immediately from diagnostic_service.run.
@@ -341,7 +338,6 @@ impl Runner for LintRunner {
 
         if let Some(end) = output_formatter.lint_command_info(&LintCommandInfo {
             number_of_files,
-            number_of_rules,
             threads_count: rayon::current_num_threads(),
             start_time: now.elapsed(),
         }) {

--- a/apps/oxlint/src/output_formatter/default.rs
+++ b/apps/oxlint/src/output_formatter/default.rs
@@ -27,17 +27,10 @@ impl InternalFormatter for DefaultOutputFormatter {
         let time = Self::get_execution_time(&lint_command_info.start_time);
         let s = if lint_command_info.number_of_files == 1 { "" } else { "s" };
 
-        if let Some(number_of_rules) = lint_command_info.number_of_rules {
-            Some(format!(
-                "Finished in {time} on {} file{s} with {} rules using {} threads.\n",
-                lint_command_info.number_of_files, number_of_rules, lint_command_info.threads_count
-            ))
-        } else {
-            Some(format!(
-                "Finished in {time} on {} file{s} using {} threads.\n",
-                lint_command_info.number_of_files, lint_command_info.threads_count
-            ))
-        }
+        Some(format!(
+            "Finished in {time} on {} file{s} using {} threads.\n",
+            lint_command_info.number_of_files, lint_command_info.threads_count
+        ))
     }
 
     #[cfg(not(any(test, feature = "force_test_reporter")))]
@@ -174,24 +167,6 @@ mod test {
         let formatter = DefaultOutputFormatter;
         let result = formatter.lint_command_info(&LintCommandInfo {
             number_of_files: 5,
-            number_of_rules: Some(10),
-            threads_count: 12,
-            start_time: Duration::new(1, 0),
-        });
-
-        assert!(result.is_some());
-        assert_eq!(
-            result.unwrap(),
-            "Finished in 1.0s on 5 files with 10 rules using 12 threads.\n"
-        );
-    }
-
-    #[test]
-    fn lint_command_info_unknown_rules() {
-        let formatter = DefaultOutputFormatter;
-        let result = formatter.lint_command_info(&LintCommandInfo {
-            number_of_files: 5,
-            number_of_rules: None,
             threads_count: 12,
             start_time: Duration::new(1, 0),
         });

--- a/apps/oxlint/src/output_formatter/json.rs
+++ b/apps/oxlint/src/output_formatter/json.rs
@@ -39,21 +39,17 @@ impl InternalFormatter for JsonOutputFormatter {
 
     fn lint_command_info(&self, lint_command_info: &super::LintCommandInfo) -> Option<String> {
         let diagnostics = self.reporter.0.borrow_mut().render();
-        let number_of_rules =
-            lint_command_info.number_of_rules.map_or("null".to_string(), |x| x.to_string());
         let start_time = lint_command_info.start_time.as_secs_f64();
 
         Some(format!(
             r#"{{ "diagnostics": {},
               "number_of_files": {},
-              "number_of_rules": {},
               "threads_count": {},
               "start_time": {}
             }}
             "#,
             diagnostics,
             lint_command_info.number_of_files,
-            number_of_rules,
             lint_command_info.threads_count,
             start_time,
         ))
@@ -148,14 +144,13 @@ mod test {
         let output = formatter
             .lint_command_info(&LintCommandInfo {
                 number_of_files: 0,
-                number_of_rules: Some(0),
                 start_time: Duration::new(0, 0),
                 threads_count: 1,
             })
             .unwrap();
         assert_eq!(
             &output,
-            "{ \"diagnostics\": [{\"message\": \"error message\",\"severity\": \"warning\",\"causes\": [],\"filename\": \"file://test.ts\",\"labels\": [{\"span\": {\"offset\": 0,\"length\": 8,\"line\": 1,\"column\": 1}}],\"related\": []}],\n              \"number_of_files\": 0,\n              \"number_of_rules\": 0,\n              \"threads_count\": 1,\n              \"start_time\": 0\n            }\n            "
+            "{ \"diagnostics\": [{\"message\": \"error message\",\"severity\": \"warning\",\"causes\": [],\"filename\": \"file://test.ts\",\"labels\": [{\"span\": {\"offset\": 0,\"length\": 8,\"line\": 1,\"column\": 1}}],\"related\": []}],\n              \"number_of_files\": 0,\n              \"threads_count\": 1,\n              \"start_time\": 0\n            }\n            "
         );
     }
 }

--- a/apps/oxlint/src/output_formatter/mod.rs
+++ b/apps/oxlint/src/output_formatter/mod.rs
@@ -59,9 +59,6 @@ impl FromStr for OutputFormat {
 pub struct LintCommandInfo {
     /// The number of files that were linted.
     pub number_of_files: usize,
-    /// The number of lint rules that were run. If the number varies and can't be clearly
-    /// computed, then this defaults to None.
-    pub number_of_rules: Option<usize>,
     /// The used CPU threads count
     pub threads_count: usize,
     /// Some reporters want to output the duration it took to finished the task

--- a/apps/oxlint/src/snapshots/_--ignore-path fixtures__linter__.customignore --no-ignore fixtures__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-path fixtures__linter__.customignore --no-ignore fixtures__linter__nan.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Use the isNaN function to compare with NaN.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 87 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--ignore-pattern _____.js --ignore-pattern _____.vue fixtures__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-pattern _____.js --ignore-pattern _____.vue fixtures__linter@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --ignore-pattern **/*.js --ignore-pattern **/*.vue fixtures/linter
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 87 rules using 1 threads.
+Finished in <variable>ms on 0 files using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--import-plugin -A all -D no-cycle fixtures__flow__@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--import-plugin -A all -D no-cycle fixtures__flow__@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --import-plugin -A all -D no-cycle fixtures/flow/
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 2 files with 89 rules using 1 threads.
+Finished in <variable>ms on 2 files using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--import-plugin fixtures__flow__index.mjs@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--import-plugin fixtures__flow__index.mjs@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --import-plugin fixtures/flow/index.mjs
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
@@ -23,7 +23,7 @@ working directory:
   help: Remove the appending `.skip`
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-A all fixtures__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-A all fixtures__linter@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -A all fixtures/linter
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 4 files with 0 rules using 1 threads.
+Finished in <variable>ms on 4 files using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-D correctness fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-D correctness fixtures__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 87 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-W correctness -A no-debugger fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W correctness -A no-debugger fixtures__linter__debugger.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -W correctness -A no-debugger fixtures/linter/debugger.js
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 86 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__eslintrc_env__eslintrc_no_env.json fixtures__eslintrc_env__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__eslintrc_env__eslintrc_no_env.json fixtures__eslintrc_env__test.js@oxlint.snap
@@ -13,7 +13,7 @@ working directory:
    `----
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__no_undef__eslintrc.json fixtures__no_undef__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__no_undef__eslintrc.json fixtures__no_undef__test.js@oxlint.snap
@@ -13,7 +13,7 @@ working directory:
    `----
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension@oxlint.snap
@@ -12,7 +12,7 @@ working directory:
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 87 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_env__eslintrc_env_browser.json fixtures__eslintrc_env__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_env__eslintrc_env_browser.json fixtures__eslintrc_env__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/eslintrc_env/eslintrc_env_browser.json fixtures/eslintrc_
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_off__eslintrc.json fixtures__eslintrc_off__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_off__eslintrc.json fixtures__eslintrc_off__test.js@oxlint.snap
@@ -12,7 +12,7 @@ working directory:
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 87 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/eslintrc_vitest_replace/eslintrc.json fixtures/eslintrc_v
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 87 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__linter__eslintrc.json fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__linter__eslintrc.json fixtures__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 87 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_console_off__eslintrc.json fixtures__no_console_off__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_console_off__eslintrc.json fixtures__no_console_off__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/no_console_off/eslintrc.json fixtures/no_console_off/test
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 87 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_empty_allow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_allow_empty_catch__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_empty_allow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_allow_empty_catch__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/no_empty_allow_empty_catch/eslintrc.json -W no-empty fixt
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_empty_disallow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_disallow_empty_catch__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_empty_disallow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_disallow_empty_catch__test.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove this block or add a comment inside it
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.js -c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.ts -c fixtures__overrides__.oxlintrc.json fixtures__overrides__other.jsx@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.js -c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.ts -c fixtures__overrides__.oxlintrc.json fixtures__overrides__other.jsx@oxlint.snap
@@ -15,7 +15,7 @@ working directory:
   help: Replace var with let or const
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------
@@ -42,7 +42,7 @@ working directory:
   help: Delete this console statement.
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------
@@ -61,7 +61,7 @@ working directory:
   help: Replace var with let or const
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__overrides__directories-config.json fixtures__overrides@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__overrides__directories-config.json fixtures__overrides@oxlint.snap
@@ -35,7 +35,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 2 warnings and 2 errors.
-Finished in <variable>ms on 7 files with 86 rules using 1 threads.
+Finished in <variable>ms on 7 files using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json --disable-typescript-plugin fixtures__typescript_eslint__test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json --disable-typescript-plugin fixtures__typescript_eslint__test.ts@oxlint.snap
@@ -23,7 +23,7 @@ working directory:
    `----
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 50 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json fixtures__typescript_eslint__test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json fixtures__typescript_eslint__test.ts@oxlint.snap
@@ -31,7 +31,7 @@ working directory:
    `----
 
 Found 2 warnings and 1 error.
-Finished in <variable>ms on 1 file with 62 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__astro__debugger.astro@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__astro__debugger.astro@oxlint.snap
@@ -43,7 +43,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 4 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 87 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter@oxlint.snap
@@ -36,7 +36,7 @@ working directory:
   help: Use the isNaN function to compare with NaN.
 
 Found 4 warnings and 0 errors.
-Finished in <variable>ms on 4 files with 87 rules using 1 threads.
+Finished in <variable>ms on 4 files using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js fixtures__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js fixtures__linter__nan.js@oxlint.snap
@@ -21,7 +21,7 @@ working directory:
   help: Use the isNaN function to compare with NaN.
 
 Found 2 warnings and 0 errors.
-Finished in <variable>ms on 2 files with 87 rules using 1 threads.
+Finished in <variable>ms on 2 files using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 87 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter__js_as_jsx.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__js_as_jsx.js@oxlint.snap
@@ -15,7 +15,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 87 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__svelte__debugger.svelte@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__svelte__debugger.svelte@oxlint.snap
@@ -16,7 +16,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 87 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__vue__debugger.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__vue__debugger.vue@oxlint.snap
@@ -25,7 +25,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 2 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 87 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__vue__empty.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__vue__empty.vue@oxlint.snap
@@ -6,7 +6,7 @@ arguments: fixtures/vue/empty.vue
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 87 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_foo.asdf@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_foo.asdf@oxlint.snap
@@ -6,7 +6,7 @@ arguments: foo.asdf
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 87 rules using 1 threads.
+Finished in <variable>ms on 0 files using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__ignore_directory_-c eslintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__ignore_directory_-c eslintrc.json@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/config_ignore_patterns/ignore_directory
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 87 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__with_oxlintrc_-c .__test__eslintrc.json --ignore-pattern _.ts .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__with_oxlintrc_-c .__test__eslintrc.json --ignore-pattern _.ts .@oxlint.snap
@@ -12,7 +12,7 @@ working directory: fixtures/config_ignore_patterns/with_oxlintrc
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 87 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__disable_eslint_and_unicorn_alias_rules_-c .oxlintrc-eslint.json test.js -c .oxlintrc-unicorn.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__disable_eslint_and_unicorn_alias_rules_-c .oxlintrc-eslint.json test.js -c .oxlintrc-unicorn.json test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c .oxlintrc-eslint.json test.js
 working directory: fixtures/disable_eslint_and_unicorn_alias_rules
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 50 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------
@@ -16,7 +16,7 @@ arguments: -c .oxlintrc-unicorn.json test.js
 working directory: fixtures/disable_eslint_and_unicorn_alias_rules
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 63 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__eslint_and_typescript_alias_rules_-c oxlint-eslint.json test.js -c oxlint-typescript.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__eslint_and_typescript_alias_rules_-c oxlint-eslint.json test.js -c oxlint-typescript.json test.js@oxlint.snap
@@ -15,7 +15,7 @@ working directory: fixtures/eslint_and_typescript_alias_rules
    `----
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 1 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------
@@ -34,7 +34,7 @@ working directory: fixtures/eslint_and_typescript_alias_rules
    `----
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 1 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--config extends_rules_config.json console.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--config extends_rules_config.json console.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/extends_config
   help: Delete this console statement.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--config relative_paths__extends_extends_config.json console.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--config relative_paths__extends_extends_config.json console.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/extends_config
   help: Delete this console statement.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--disable-nested-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--disable-nested-config@oxlint.snap
@@ -31,7 +31,7 @@ working directory: fixtures/extends_config
   help: Remove the debugger statement
 
 Found 3 warnings and 0 errors.
-Finished in <variable>ms on 4 files with 87 rules using 1 threads.
+Finished in <variable>ms on 4 files using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__ignore_file_current_dir_ .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__ignore_file_current_dir_ .@oxlint.snap
@@ -6,7 +6,7 @@ arguments:
 working directory: fixtures/ignore_file_current_dir
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 87 rules using 1 threads.
+Finished in <variable>ms on 0 files using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------
@@ -16,7 +16,7 @@ arguments: .
 working directory: fixtures/ignore_file_current_dir
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 87 rules using 1 threads.
+Finished in <variable>ms on 0 files using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__import-cycle_--import-plugin -D import__no-cycle@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__import-cycle_--import-plugin -D import__no-cycle@oxlint.snap
@@ -27,7 +27,7 @@ working directory: fixtures/import-cycle
         -> ./b - fixtures/import-cycle/b.ts
 
 Found 0 warnings and 2 errors.
-Finished in <variable>ms on 2 files with 90 rules using 1 threads.
+Finished in <variable>ms on 2 files using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__import_-c .oxlintrc.json test.js -c .oxlintrc-import-x.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__import_-c .oxlintrc.json test.js -c .oxlintrc-import-x.json test.js@oxlint.snap
@@ -15,7 +15,7 @@ working directory: fixtures/import
    `----
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 52 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------
@@ -34,7 +34,7 @@ working directory: fixtures/import
    `----
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 52 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__issue_10394_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__issue_10394_-c .oxlintrc.json@oxlint.snap
@@ -15,7 +15,7 @@ working directory: fixtures/issue_10394
   help: "Write a meaningful title for your test"
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 87 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__issue_11054_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__issue_11054_-c .oxlintrc.json@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c .oxlintrc.json
 working directory: fixtures/issue_11054
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 87 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__issue_11644_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__issue_11644_-c .oxlintrc.json@oxlint.snap
@@ -1,13 +1,12 @@
 ---
 source: apps/oxlint/src/tester.rs
-assertion_line: 96
 ---
 ########## 
 arguments: -c .oxlintrc.json
 working directory: fixtures/issue_11644
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 159 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__jest_and_vitest_alias_rules_-c oxlint-jest.json test.js -c oxlint-vitest.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__jest_and_vitest_alias_rules_-c oxlint-jest.json test.js -c oxlint-vitest.json test.js@oxlint.snap
@@ -16,7 +16,7 @@ working directory: fixtures/jest_and_vitest_alias_rules
   help: Change the title of test.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 1 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------
@@ -36,7 +36,7 @@ working directory: fixtures/jest_and_vitest_alias_rules
   help: Change the title of test.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 1 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__linter_debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__linter_debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/linter
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 87 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_--config oxlint-no-console.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_--config oxlint-no-console.json@oxlint.snap
@@ -37,7 +37,7 @@ working directory: fixtures/nested_config
   help: Delete this console statement.
 
 Found 0 warnings and 4 errors.
-Finished in <variable>ms on 7 files with 1 rules using 1 threads.
+Finished in <variable>ms on 7 files using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_-A no-console --config oxlint-no-console.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_-A no-console --config oxlint-no-console.json@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -A no-console --config oxlint-no-console.json
 working directory: fixtures/nested_config
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 7 files with 0 rules using 1 threads.
+Finished in <variable>ms on 7 files using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=json test.js@oxlint.snap
@@ -9,7 +9,6 @@ working directory: fixtures/output_formatter_diagnostic
 {"message": "Function 'foo' is declared but never used.","code": "eslint(no-unused-vars)","severity": "warning","causes": [],"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html","help": "Consider removing this declaration.","filename": "test.js","labels": [{"label": "'foo' is declared here","span": {"offset": 9,"length": 3,"line": 1,"column": 10}}],"related": []},
 {"message": "Parameter 'b' is declared but never used. Unused parameters should start with a '_'.","code": "eslint(no-unused-vars)","severity": "warning","causes": [],"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html","help": "Consider removing this parameter.","filename": "test.js","labels": [{"label": "'b' is declared here","span": {"offset": 16,"length": 1,"line": 1,"column": 17}}],"related": []}],
               "number_of_files": 1,
-              "number_of_rules": null,
               "threads_count": 1,
               "start_time": <variable>
             }

--- a/apps/oxlint/src/snapshots/fixtures__overrides_env_globals_-c .oxlintrc.json .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__overrides_env_globals_-c .oxlintrc.json .@oxlint.snap
@@ -51,7 +51,7 @@ working directory: fixtures/overrides_env_globals
    `----
 
 Found 5 warnings and 0 errors.
-Finished in <variable>ms on 3 files with 87 rules using 1 threads.
+Finished in <variable>ms on 3 files using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__overrides_with_plugin_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__overrides_with_plugin_-c .oxlintrc.json@oxlint.snap
@@ -42,7 +42,7 @@ working directory: fixtures/overrides_with_plugin
   help: "Write a meaningful title for your test"
 
 Found 2 warnings and 2 errors.
-Finished in <variable>ms on 2 files with 87 rules using 1 threads.
+Finished in <variable>ms on 2 files using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__report_unused_directives_-c .oxlintrc.json --report-unused-disable-directives test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__report_unused_directives_-c .oxlintrc.json --report-unused-disable-directives test.js@oxlint.snap
@@ -64,7 +64,7 @@ working directory: fixtures/report_unused_directives
     `----
 
 Found 7 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__two_rules_with_same_rule_name_-c .oxlintrc.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__two_rules_with_same_rule_name_-c .oxlintrc.json test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c .oxlintrc.json test.js
 working directory: fixtures/two_rules_with_same_rule_name
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 63 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -917,7 +917,7 @@ mod test {
         "#,
         );
         assert!(allow_all.rules().iter().all(|(_, severity)| *severity == AllowWarnDeny::Allow));
-        assert_eq!(allow_all.number_of_rules(), 0);
+        assert_eq!(allow_all.rules().len(), 0);
 
         let allow_and_override_config = config_store_from_str(
             r#"

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -92,10 +92,6 @@ impl Config {
         &self.base.rules
     }
 
-    pub fn number_of_rules(&self) -> usize {
-        self.base.rules.len()
-    }
-
     pub fn apply_overrides(
         &self,
         path: &Path,
@@ -248,10 +244,6 @@ impl ConfigStore {
         }
     }
 
-    pub fn number_of_rules(&self) -> Option<usize> {
-        self.nested_configs.is_empty().then_some(self.base.base.rules.len())
-    }
-
     pub fn rules(&self) -> &Arc<[(RuleEnum, AllowWarnDeny)]> {
         &self.base.base.rules
     }
@@ -393,7 +385,7 @@ mod test {
             FxHashMap::default(),
             ExternalPluginStore::default(),
         );
-        assert_eq!(store.number_of_rules(), Some(1));
+        assert_eq!(store.rules().len(), 1);
 
         let rules_for_source_file = store.resolve("App.tsx".as_ref());
         assert_eq!(rules_for_source_file.rules.len(), 1);
@@ -423,7 +415,7 @@ mod test {
             FxHashMap::default(),
             ExternalPluginStore::default(),
         );
-        assert_eq!(store.number_of_rules(), Some(1));
+        assert_eq!(store.rules().len(), 1);
 
         assert_eq!(store.resolve("App.tsx".as_ref()).rules.len(), 1);
         assert_eq!(store.resolve("src/App.tsx".as_ref()).rules.len(), 2);
@@ -453,7 +445,7 @@ mod test {
             FxHashMap::default(),
             ExternalPluginStore::default(),
         );
-        assert_eq!(store.number_of_rules(), Some(1));
+        assert_eq!(store.rules().len(), 1);
 
         let app = store.resolve("App.tsx".as_ref()).rules;
         assert_eq!(app.len(), 1);

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -114,13 +114,6 @@ impl Linter {
         &self.options
     }
 
-    /// Returns the number of rules that will are being used, unless there
-    /// nested configurations in use, in which case it returns `None` since the
-    /// number of rules depends on which file is being linted.
-    pub fn number_of_rules(&self) -> Option<usize> {
-        self.config.number_of_rules()
-    }
-
     pub fn run<'a>(
         &self,
         path: &Path,


### PR DESCRIPTION
- closes https://github.com/oxc-project/oxc/issues/12433

This removes the number of rules from the linter output when linting is finished.

As the complexity of the linter has grown and included things like nested configs, overrides, external plugins, dynamically disabling rules, and now external linters (like tsgolint), the number of rules metric is somewhat deceptive. At best, it represents the maximum number of rules that may have been run, and at worst it's just sort of wrong and gives a lower or higher number than the actual number of rules that were run. In addition, it also creates problems for our testing infrastructure because each time we add a new default rule it updates every linter snapshot.

So, I propose that we remove this from the output as its usefulness has decreased, and it will PRs that add new default rules easier to review and write.