### PR TITLE
feat(transformer, minifier, syntax)!: remove `ESTarget::ES5`

### DIFF
--- a/crates/oxc_syntax/src/es_target.rs
+++ b/crates/oxc_syntax/src/es_target.rs
@@ -7,7 +7,6 @@ use cow_utils::CowUtils;
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 #[expect(missing_docs)]
 pub enum ESTarget {
-    ES5,
     ES2015,
     ES2016,
     ES2017,
@@ -28,7 +27,7 @@ impl FromStr for ESTarget {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.cow_to_ascii_lowercase().as_ref() {
-            "es5" => Ok(Self::ES5),
+            "es5" => Err(String::from("ES5 is not yet supported.")),
             "es6" | "es2015" => Ok(Self::ES2015),
             "es2016" => Ok(Self::ES2016),
             "es2017" => Ok(Self::ES2017),
@@ -49,7 +48,6 @@ impl FromStr for ESTarget {
 impl fmt::Display for ESTarget {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match self {
-            Self::ES5 => "es5",
             Self::ES2015 => "es2015",
             Self::ES2016 => "es2016",
             Self::ES2017 => "es2017",

--- a/crates/oxc_transformer/src/options/es_target.rs
+++ b/crates/oxc_transformer/src/options/es_target.rs
@@ -9,7 +9,6 @@ pub trait ESVersion {
 impl ESVersion for ESTarget {
     fn version(&self) -> Version {
         match self {
-            Self::ES5 => Version(5, 0, 0),
             Self::ES2015 => Version(2015, 0, 0),
             Self::ES2016 => Version(2016, 0, 0),
             Self::ES2017 => Version(2017, 0, 0),

--- a/crates/oxc_transformer/tests/integrations/es_target.rs
+++ b/crates/oxc_transformer/tests/integrations/es_target.rs
@@ -10,7 +10,6 @@ fn es_target() {
     use std::fmt::Write;
 
     let cases = [
-        ("es5", "() => {}"),
         ("es6", "a ** b"),
         ("es2015", "a ** b"),
         ("es2016", "async function foo() {}"),

--- a/crates/oxc_transformer/tests/integrations/snapshots/es_target.snap
+++ b/crates/oxc_transformer/tests/integrations/snapshots/es_target.snap
@@ -1,22 +1,17 @@
 ---
 source: crates/oxc_transformer/tests/integrations/es_target.rs
 ---
-########## 0 es5
-() => {}
-----------
-(function() {});
-
-########## 1 es6
+########## 0 es6
 a ** b
 ----------
 Math.pow(a, b);
 
-########## 2 es2015
+########## 1 es2015
 a ** b
 ----------
 Math.pow(a, b);
 
-########## 3 es2016
+########## 2 es2016
 async function foo() {}
 ----------
 import _asyncToGenerator from '@oxc-project/runtime/helpers/asyncToGenerator';
@@ -28,35 +23,35 @@ function _foo() {
 	return _foo.apply(this, arguments);
 }
 
-########## 4 es2017
+########## 3 es2017
 ({ ...x })
 ----------
 import _objectSpread from '@oxc-project/runtime/helpers/objectSpread2';
 _objectSpread({}, x);
 
-########## 5 es2018
+########## 4 es2018
 try {} catch {}
 ----------
 try {} catch (_unused) {}
 
-########## 6 es2019
+########## 5 es2019
 a?.b
 ----------
 var _a;
 (_a = a) === null || _a === void 0 ? void 0 : _a.b;
 
-########## 7 es2019
+########## 6 es2019
 a ?? b
 ----------
 var _a;
 (_a = a) !== null && _a !== void 0 ? _a : b;
 
-########## 8 es2020
+########## 7 es2020
 a ||= b
 ----------
 a || (a = b);
 
-########## 9 es2019
+########## 8 es2019
 1n ** 2n
 ----------
 
@@ -75,13 +70,13 @@ a || (a = b);
    :       ^^
    `----
 
-########## 10 es2021
+########## 9 es2021
 class foo { static {} }
 ----------
 class foo {}
 (() => {})();
 
-########## 11 es2021
+########## 10 es2021
 class Foo { #a; }
 ----------
 import _classPrivateFieldInitSpec from '@oxc-project/runtime/helpers/classPrivateFieldInitSpec';

--- a/crates/oxc_transformer/tests/integrations/targets.rs
+++ b/crates/oxc_transformer/tests/integrations/targets.rs
@@ -26,9 +26,9 @@ fn targets() {
     }
 
     // Test transformation for very low targets.
-    let options = TransformOptions::from(ESTarget::ES5);
+    let options = TransformOptions::from(ESTarget::ES2015);
     let options_node = TransformOptions {
-        env: EnvOptions::from_browserslist_query("node 0.10").unwrap(),
+        env: EnvOptions::from_browserslist_query("node 6").unwrap(),
         ..TransformOptions::default()
     };
     for case in cases {

--- a/napi/transform/test/transform.test.ts
+++ b/napi/transform/test/transform.test.ts
@@ -68,7 +68,6 @@ describe('transform', () => {
 
 describe('target', () => {
   const data = [
-    ['es5', '() => {};\n'],
     ['es6', 'a ** b;\n'],
     ['es2015', 'a ** b;\n'],
     ['es2016', 'async function foo() {}\n'],


### PR DESCRIPTION
* close https://github.com/oxc-project/oxc/issues/11296

Both `Transformer` and `Minifier` have a minimum ES version support of `ES2015`. However, we can set the `ESTarget` to `ES5` now, which might mislead users into thinking we already support `ES5`, so for now, let's remove the `ESTarget::ES5` option to eliminate the confusion.

Suggested by @shulaoda 