### PR TITLE
refactor(napi/oxlint): remove classes

### DIFF
--- a/napi/oxlint2/src-js/index.js
+++ b/napi/oxlint2/src-js/index.js
@@ -11,131 +11,138 @@ const { TOKEN } = require('../../parser/raw-transfer/lazy-common.js'),
   { Visitor, getVisitorsArr } = require('../../parser/raw-transfer/visitor.js'),
   walkProgram = require('../../parser/generated/lazy/walk.js');
 
-const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true });
+// --------------------
+// Plugin loading
+// --------------------
 
-class PluginRegistry {
-  registeredPluginPaths = new Set();
+// Absolute paths of plugins which have been loaded
+const registeredPluginPaths = new Set();
 
-  registeredRules = [];
+// Rule objects for loaded rules.
+// Indexed by `ruleId`, passed to `lintFile`.
+const registeredRules = [];
 
-  isPluginRegistered(path) {
-    return this.registeredPluginPaths.has(path);
-  }
-
-  registerPlugin(path, plugin) {
-    // TODO: use a validation library to assert the shape of the plugin
-    this.registeredPluginPaths.add(path);
-    const ret = {
-      name: plugin.meta.name,
-      offset: this.registeredRules.length,
-      rules: [],
-    };
-
-    for (const [ruleName, rule] of Object.entries(plugin.rules)) {
-      ret.rules.push(ruleName);
-      this.registeredRules.push(rule);
-    }
-
-    return ret;
-  }
-
-  *getRules(ruleIds) {
-    for (const ruleId of ruleIds) {
-      yield { rule: this.registeredRules[ruleId], ruleId };
-    }
+/**
+ * Load a plugin.
+ *
+ * Main logic is in separate function `loadPluginImpl`, because V8 cannot optimize functions
+ * containing try/catch.
+ *
+ * @param {string} path - Absolute path of plugin file
+ * @returns {string} - JSON result
+ */
+async function loadPlugin(path) {
+  try {
+    return await loadPluginImpl(path);
+  } catch (error) {
+    const errorMessage = 'message' in error && typeof error.message === 'string'
+      ? error.message
+      : 'An unknown error occurred';
+    return JSON.stringify({ Failure: errorMessage });
   }
 }
 
-// Buffers cache
+async function loadPluginImpl(path) {
+  if (registeredPluginPaths.has(path)) {
+    return JSON.stringify({ Failure: 'This plugin has already been registered' });
+  }
+
+  const { default: plugin } = await import(path);
+
+  registeredPluginPaths.add(path);
+
+  // TODO: Use a validation library to assert the shape of the plugin, and of rules
+  const rules = [];
+  const ret = {
+    name: plugin.meta.name,
+    offset: registeredRules.length,
+    rules,
+  };
+
+  for (const [ruleName, rule] of Object.entries(plugin.rules)) {
+    rules.push(ruleName);
+    registeredRules.push(rule);
+  }
+
+  return JSON.stringify({ Success: ret });
+}
+
+// --------------------
+// Running rules
+// --------------------
+
+// Buffers cache.
+//
+// All buffers sent from Rust are stored in this array, indexed by `bufferId` (also sent from Rust).
+// Buffers are only added to this array, never removed, so no buffers will be garbage collected
+// until the process exits.
 const buffers = [];
 
 // Diagnostics array. Reused for every file.
 const diagnostics = [];
 
-class Linter {
-  pluginRegistry = new PluginRegistry();
+// Text decoder, for decoding source text from buffer
+const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true });
 
-  run() {
-    return lint(this.loadPlugin.bind(this), this.lint.bind(this));
+// Run rules on a file.
+//
+// TODO(camc314): why do we have to destructure here?
+// In `./bindings.d.ts`, it doesn't indicate that we have to
+// (typed as `(filePath: string, bufferId: number, buffer: Uint8Array | undefined | null, ruleIds: number[])`).
+function lintFile([filePath, bufferId, buffer, ruleIds]) {
+  // If new buffer, add it to `buffers` array. Otherwise, get existing buffer from array.
+  // Do this before checks below, to make sure buffer doesn't get garbage collected when not expected
+  // if there's an error.
+  // TODO: Is this enough to guarantee soundness?
+  if (buffer !== null) {
+    const { buffer: arrayBuffer, byteOffset } = buffer;
+    buffer.uint32 = new Uint32Array(arrayBuffer, byteOffset);
+    buffer.float64 = new Float64Array(arrayBuffer, byteOffset);
+
+    while (buffers.length <= bufferId) {
+      buffers.push(null);
+    }
+    buffers[bufferId] = buffer;
+  } else {
+    buffer = buffers[bufferId];
   }
 
-  /**
-   * @param {string} path - The absolute path of the plugin we're loading
-   */
-  async loadPlugin(path) {
-    if (this.pluginRegistry.isPluginRegistered(path)) {
-      return JSON.stringify({
-        Failure: 'This plugin has already been registered',
-      });
-    }
-
-    try {
-      const { default: plugin } = await import(path);
-      const ret = this.pluginRegistry.registerPlugin(path, plugin);
-      return JSON.stringify({ Success: ret });
-    } catch (error) {
-      const errorMessage = 'message' in error && typeof error.message === 'string'
-        ? error.message
-        : 'An unknown error occurred';
-      return JSON.stringify({ Failure: errorMessage });
-    }
+  if (typeof filePath !== 'string' || filePath.length === 0) {
+    throw new Error('expected filePath to be a non-zero length string');
+  }
+  if (!Array.isArray(ruleIds) || ruleIds.length === 0) {
+    throw new Error('Expected `ruleIds` to be a non-zero len array');
   }
 
-  // TODO(camc314): why do we have to destructure here?
-  // In `./bindings.d.ts`, it doesn't indicate that we have to
-  // (typed as `(filePath: string, bufferId: number, buffer: Uint8Array | undefined | null, ruleIds: number[])`).
-  lint([filePath, bufferId, buffer, ruleIds]) {
-    // If new buffer, add it to `buffers` array. Otherwise, get existing buffer from array.
-    // Do this before checks below, to make sure buffer doesn't get garbage collected when not expected
-    // if there's an error.
-    // TODO: Is this enough to guarantee soundness?
-    if (buffer !== null) {
-      const { buffer: arrayBuffer, byteOffset } = buffer;
-      buffer.uint32 = new Uint32Array(arrayBuffer, byteOffset);
-      buffer.float64 = new Float64Array(arrayBuffer, byteOffset);
+  // Get visitors for this file from all rules
+  const visitors = ruleIds.map(
+    ruleId => registeredRules[ruleId].create(new Context(ruleId, filePath)),
+  );
+  const visitor = new Visitor(
+    visitors.length === 1 ? visitors[0] : combineVisitors(visitors),
+  );
 
-      while (buffers.length <= bufferId) {
-        buffers.push(null);
-      }
-      buffers[bufferId] = buffer;
-    } else {
-      buffer = buffers[bufferId];
-    }
+  // Visit AST
+  const programPos = buffer.uint32[DATA_POINTER_POS_32],
+    sourceByteLen = buffer.uint32[SOURCE_LEN_POS_32];
 
-    if (typeof filePath !== 'string' || filePath.length === 0) {
-      throw new Error('expected filePath to be a non-zero length string');
-    }
-    if (!Array.isArray(ruleIds) || ruleIds.length === 0) {
-      throw new Error('Expected `ruleIds` to be a non-zero len array');
-    }
+  const sourceText = textDecoder.decode(buffer.subarray(0, sourceByteLen));
+  const sourceIsAscii = sourceText.length === sourceByteLen;
+  const ast = { buffer, sourceText, sourceByteLen, sourceIsAscii, nodes: new Map(), token: TOKEN };
 
-    // Get visitors for this file from all rules
-    const visitors = [];
-    for (const { rule, ruleId } of this.pluginRegistry.getRules(ruleIds)) {
-      visitors.push(rule.create(new Context(ruleId, filePath)));
-    }
+  walkProgram(programPos, ast, getVisitorsArr(visitor));
 
-    const visitor = new Visitor(
-      visitors.length === 1 ? visitors[0] : combineVisitors(visitors),
-    );
-
-    // Visit AST
-    const programPos = buffer.uint32[DATA_POINTER_POS_32],
-      sourceByteLen = buffer.uint32[SOURCE_LEN_POS_32];
-
-    const sourceText = textDecoder.decode(buffer.subarray(0, sourceByteLen));
-    const sourceIsAscii = sourceText.length === sourceByteLen;
-    const ast = { buffer, sourceText, sourceByteLen, sourceIsAscii, nodes: new Map(), token: TOKEN };
-
-    walkProgram(programPos, ast, getVisitorsArr(visitor));
-
-    // Send diagnostics back to Rust
-    const ret = JSON.stringify(diagnostics);
-    diagnostics.length = 0;
-    return ret;
-  }
+  // Send diagnostics back to Rust
+  const ret = JSON.stringify(diagnostics);
+  diagnostics.length = 0;
+  return ret;
 }
 
+/**
+ * Combine multiple visitor objects into a single visitor object.
+ * @param {Array<Object>} visitors - Array of visitor objects
+ * @returns {Object} - Combined visitor object
+ */
 function combineVisitors(visitors) {
   const combinedVisitor = {};
   for (const visitor of visitors) {
@@ -161,7 +168,7 @@ function combineVisitors(visitors) {
  * A `Context` is passed to each rule's `create` function.
  */
 class Context {
-  // Rule ID. Index into `PluginRegistry`'s `registeredRules` array.
+  // Rule ID. Index into `registeredRules` array.
   #ruleId;
 
   /**
@@ -192,15 +199,14 @@ class Context {
   }
 }
 
-async function main() {
-  const linter = new Linter();
+// --------------------
+// Run linter
+// --------------------
 
-  const success = await linter.run();
+// Call Rust, passing `loadPlugin` and `lintFile` as callbacks
+const success = await lint(loadPlugin, lintFile);
 
-  // Note: It's recommended to set `process.exitCode` instead of calling `process.exit()`.
-  // `process.exit()` kills the process immediately and `stdout` may not be flushed before process dies.
-  // https://nodejs.org/api/process.html#processexitcode
-  if (!success) process.exitCode = 1;
-}
-
-main();
+// Note: It's recommended to set `process.exitCode` instead of calling `process.exit()`.
+// `process.exit()` kills the process immediately and `stdout` may not be flushed before process dies.
+// https://nodejs.org/api/process.html#processexitcode
+if (!success) process.exitCode = 1;


### PR DESCRIPTION
Flatten code in `napi/oxlint2`, removing the `PluginRegistry` and `Linter` classes.

Only a single instance of these classes was created, so the classes added nothing in terms of utility, and added a (small) perf cost.

The classes *did* provide a nice encapsulation of concerns, but in my opinion our aim with the JS code here should be performance above all else. I hope we can avoid the code descending into a spaghetti monstrosity by breaking things up into separate files and with good documentation (I assume we'll bundle and minify this code at some point, so splitting code into multiple files and verbose comments won't have a cost at run time).
