### PR TITLE
fix(isolated-declarations): incorrect error when exported type is locally shadowed by an unexported variable

### DIFF
--- a/crates/oxc_isolated_declarations/src/declaration.rs
+++ b/crates/oxc_isolated_declarations/src/declaration.rs
@@ -48,7 +48,7 @@ impl<'a> IsolatedDeclarations<'a> {
     ) -> Option<VariableDeclarator<'a>> {
         if decl.id.kind.is_destructuring_pattern() {
             decl.id.bound_names(&mut |id| {
-                if !check_binding || self.scope.has_reference(&id.name) {
+                if !check_binding || self.scope.has_value_reference(&id.name) {
                     self.error(binding_element_export(id.span));
                 }
             });
@@ -57,7 +57,7 @@ impl<'a> IsolatedDeclarations<'a> {
 
         if check_binding {
             if let Some(name) = decl.id.get_identifier_name() {
-                if !self.scope.has_reference(&name) {
+                if !self.scope.has_value_reference(&name) {
                     return None;
                 }
             }
@@ -159,7 +159,7 @@ impl<'a> IsolatedDeclarations<'a> {
         match decl {
             Declaration::FunctionDeclaration(func) => {
                 let needs_transform = !check_binding
-                    || func.id.as_ref().is_some_and(|id| self.scope.has_reference(&id.name));
+                    || func.id.as_ref().is_some_and(|id| self.scope.has_value_reference(&id.name));
                 needs_transform
                     .then(|| Declaration::FunctionDeclaration(self.transform_function(func, None)))
             }
@@ -202,7 +202,7 @@ impl<'a> IsolatedDeclarations<'a> {
                     || matches!(
                         &decl.id,
                         TSModuleDeclarationName::Identifier(ident)
-                            if self.scope.has_reference(&ident.name)
+                            if self.scope.has_value_reference(&ident.name)
                     )
                 {
                     Some(Declaration::TSModuleDeclaration(

--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -607,7 +607,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 Statement::FunctionDeclaration(func) => {
                     if func.body.is_some() {
                         if let Some(name) = func.name() {
-                            if self.scope.has_reference(&name) {
+                            if self.scope.has_value_reference(&name) {
                                 can_expando_function_names.insert(name);
                             }
                         }
@@ -619,7 +619,7 @@ impl<'a> IsolatedDeclarations<'a> {
                             && declarator.init.as_ref().is_some_and(Expression::is_function)
                         {
                             if let Some(name) = declarator.id.get_identifier_name() {
-                                if self.scope.has_reference(&name) {
+                                if self.scope.has_value_reference(&name) {
                                     can_expando_function_names.insert(name);
                                 }
                             }

--- a/crates/oxc_isolated_declarations/src/scope.rs
+++ b/crates/oxc_isolated_declarations/src/scope.rs
@@ -53,6 +53,12 @@ impl<'a> ScopeTree<'a> {
         scope.references.contains_key(name)
     }
 
+    /// Check if the current scope has a value reference for the given name.
+    pub fn has_value_reference(&self, name: &str) -> bool {
+        let scope = self.levels.last().unwrap();
+        scope.references.get(name).iter().any(|flags| flags.contains(KindFlags::Value))
+    }
+
     fn add_binding(&mut self, name: Atom<'a>, flags: KindFlags) {
         let scope = self.levels.last_mut().unwrap();
         scope.bindings.insert(name, flags);

--- a/crates/oxc_isolated_declarations/tests/fixtures/shadowed.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/shadowed.ts
@@ -1,0 +1,16 @@
+// Shadowed
+export type Foo = {};
+export type Bar = {
+	foo: Foo;
+};
+const Foo = new Map();
+
+type Func = () => void;
+function Func() {}
+export type FuncType = Func;
+
+type Module = () => void;
+namespace Module {
+	export const x = 1;
+}
+export type ModuleType = Module;

--- a/crates/oxc_isolated_declarations/tests/snapshots/shadowed.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/shadowed.snap
@@ -1,0 +1,17 @@
+---
+source: crates/oxc_isolated_declarations/tests/mod.rs
+input_file: crates/oxc_isolated_declarations/tests/fixtures/shadowed.ts
+---
+```
+==================== .D.TS ====================
+
+// Shadowed
+export type Foo = {};
+export type Bar = {
+	foo: Foo;
+};
+type Func = () => void;
+export type FuncType = Func;
+type Module = () => void;
+export type ModuleType = Module;
+export {};


### PR DESCRIPTION
* close #12465

`Variable`, `Function`, and `TSModuleDeclaration` can be shadowed by type declaration, so we should check if there is a value reference to decide whether it should be retained.

Others like `Enum` and `Class` don't allow redeclaration, so don't need to check.