### PR TITLE
test(transform/typescript): improve test case

### DIFF
--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/enum-template-literal/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/enum-template-literal/input.ts
@@ -1,11 +1,11 @@
 enum Size {
-  SMALL = "SMALL",
-  LARGE = "LARGE",
+  SMALL = "tiny",
+  LARGE = "big",
 }
 
 enum Animal {
-  CAT = "CAT",
-  DOG = "DOG",
+  CAT = "meow",
+  DOG = "woof",
 }
 
 enum AnimalSize {

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/enum-template-literal/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/enum-template-literal/output.js
@@ -1,17 +1,17 @@
 var Size = /* @__PURE__ */ function(Size) {
-        Size["SMALL"] = "SMALL";
-        Size["LARGE"] = "LARGE";
-        return Size;
+  Size["SMALL"] = "tiny";
+  Size["LARGE"] = "big";
+  return Size;
 }(Size || {});
 
 var Animal = /* @__PURE__ */ function(Animal) {
-        Animal["CAT"] = "CAT";
-        Animal["DOG"] = "DOG";
-        return Animal;
+  Animal["CAT"] = "meow";
+  Animal["DOG"] = "woof";
+  return Animal;
 }(Animal || {});
 
 var AnimalSize = /* @__PURE__ */ function(AnimalSize) {
-        AnimalSize["SMALL_CAT"] = "SMALL_CAT";
-        AnimalSize["LARGE_DOG"] = "LARGE_DOG";
-        return AnimalSize;
+  AnimalSize["SMALL_CAT"] = "tiny_meow";
+  AnimalSize["LARGE_DOG"] = "big_woof";
+  return AnimalSize;
 }(AnimalSize || {});


### PR DESCRIPTION
Follow-on after #12456. Improve the test case added in that PR to make sure values are indeed based on const evaluation of the `TemplateLiteral`s, not the enum member names, by making them different from each other.