### PR TITLE
feat(codegen): keep function expression PIFEs

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -687,7 +687,8 @@ impl Gen for VariableDeclarator<'_> {
 impl Gen for Function<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         let n = p.code_len();
-        let wrap = self.is_expression() && (p.start_of_stmt == n || p.start_of_default_export == n);
+        let wrap = self.is_expression()
+            && ((p.start_of_stmt == n || p.start_of_default_export == n) || self.pife);
         p.wrap(wrap, |p| {
             p.print_space_before_identifier();
             p.add_source_mapping(self.span);
@@ -2195,9 +2196,16 @@ impl GenExpr for TSAsExpression<'_> {
 impl GenExpr for TSSatisfiesExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         p.print_ascii_byte(b'(');
-        p.print_ascii_byte(b'(');
-        self.expression.print_expr(p, precedence, Context::default());
-        p.print_ascii_byte(b')');
+        let should_wrap =
+            if let Expression::FunctionExpression(func) = &self.expression.without_parentheses() {
+                // pife is handled on Function side
+                !func.pife
+            } else {
+                true
+            };
+        p.wrap(should_wrap, |p| {
+            self.expression.print_expr(p, precedence, Context::default());
+        });
         p.print_str(" satisfies ");
         self.type_annotation.print(p, ctx);
         p.print_ascii_byte(b')');

--- a/crates/oxc_codegen/tests/integration/esbuild.rs
+++ b/crates/oxc_codegen/tests/integration/esbuild.rs
@@ -557,9 +557,9 @@ fn test_pure_comment() {
     test("(function* () {})", "(function* () {});\n");
     test("(function* foo() {})", "(function* foo() {});\n");
 
-    test("new (function() {})", "new function() {}();\n");
-    test("new (function() {})()", "new function() {}();\n");
-    test("/*@__PURE__*/new (function() {})()", "/* @__PURE__ */ new function() {}();\n");
+    test("new (function() {})", "new (function() {})();\n");
+    test("new (function() {})()", "new (function() {})();\n");
+    test("/*@__PURE__*/new (function() {})()", "/* @__PURE__ */ new (function() {})();\n");
 
     test("export default (function() { foo() })", "export default (function() {\n\tfoo();\n});\n");
     test(

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -421,6 +421,10 @@ fn pife() {
     test_minify_same("foo((()=>0));");
     test_same("(() => 0)();\n");
     test_minify_same("(()=>0)();");
+    test_same("foo((function() {\n\treturn 0;\n}));\n");
+    test_minify_same("foo((function(){return0}));");
+    test_same("(function() {\n\treturn 0;\n})();\n");
+    test_minify_same("(function(){return0})();");
 }
 
 // followup from https://github.com/oxc-project/oxc/pull/6422

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -1431,7 +1431,7 @@ mod test {
     fn test_fold_logical_op2() {
         fold("x = function(){} && x", "x=x");
         fold("x = true && function(){}", "x=function(){}");
-        fold("x = [(function(){alert(x)})()] && x", "x=(function(){alert(x)}(),x)");
+        fold("x = [(function(){alert(x)})()] && x", "x=((function(){alert(x)})(),x)");
     }
 
     #[test]

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -232,8 +232,10 @@ impl<'a> ParserImpl<'a> {
             self.ast.expression_sequence(expr_span, expressions)
         };
 
-        if let Expression::ArrowFunctionExpression(arrow_expr) = &mut expression {
-            arrow_expr.pife = true;
+        match &mut expression {
+            Expression::ArrowFunctionExpression(arrow_expr) => arrow_expr.pife = true,
+            Expression::FunctionExpression(func_expr) => func_expr.pife = true,
+            _ => {}
         }
 
         if self.options.preserve_parens {

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -1928,9 +1928,9 @@ Object.defineProperty(__vite_ssr_exports__, 'default', {
                return __vite_ssr_export_default__;
        }
 });
-const __vite_ssr_export_default__ = function getRandom() {
+const __vite_ssr_export_default__ = (function getRandom() {
   return Math.random();
-};
+});
 ",
         );
 

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -5,23 +5,23 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 173.90 kB  | 59.51 kB   | 59.82 kB   | 19.18 kB   | 19.33 kB   | moment.js 
 
-287.63 kB  | 89.33 kB   | 90.07 kB   | 30.95 kB   | 31.95 kB   | jquery.js 
+287.63 kB  | 89.34 kB   | 90.07 kB   | 30.94 kB   | 31.95 kB   | jquery.js 
 
 342.15 kB  | 117.22 kB  | 118.14 kB  | 43.27 kB   | 44.37 kB   | vue.js    
 
 544.10 kB  | 71.38 kB   | 72.48 kB   | 25.85 kB   | 26.20 kB   | lodash.js 
 
-555.77 kB  | 270.83 kB  | 270.13 kB  | 88.25 kB   | 90.80 kB   | d3.js     
+555.77 kB  | 270.91 kB  | 270.13 kB  | 88.27 kB   | 90.80 kB   | d3.js     
 
-1.01 MB    | 440.17 kB  | 458.89 kB  | 122.37 kB  | 126.71 kB  | bundle.min.js
+1.01 MB    | 440.19 kB  | 458.89 kB  | 122.39 kB  | 126.71 kB  | bundle.min.js
 
-1.25 MB    | 647 kB     | 646.76 kB  | 160.28 kB  | 163.73 kB  | three.js  
+1.25 MB    | 647.00 kB  | 646.76 kB  | 160.27 kB  | 163.73 kB  | three.js  
 
-2.14 MB    | 716.12 kB  | 724.14 kB  | 161.80 kB  | 181.07 kB  | victory.js
+2.14 MB    | 717.56 kB  | 724.14 kB  | 161.88 kB  | 181.07 kB  | victory.js
 
-3.20 MB    | 1.01 MB    | 1.01 MB    | 324.08 kB  | 331.56 kB  | echarts.js
+3.20 MB    | 1.01 MB    | 1.01 MB    | 324.10 kB  | 331.56 kB  | echarts.js
 
-6.69 MB    | 2.25 MB    | 2.31 MB    | 463.06 kB  | 488.28 kB  | antd.js   
+6.69 MB    | 2.25 MB    | 2.31 MB    | 463.15 kB  | 488.28 kB  | antd.js   
 
-10.95 MB   | 3.35 MB    | 3.49 MB    | 860.95 kB  | 915.50 kB  | typescript.js
+10.95 MB   | 3.35 MB    | 3.49 MB    | 860.96 kB  | 915.50 kB  | typescript.js
 

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/refresh/react-refresh/ignores-complex-definitions/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/refresh/react-refresh/ignores-complex-definitions/output.js
@@ -2,9 +2,9 @@ import { jsx as _jsx } from "react/jsx-runtime";
 let A = foo ? () => {
   return /* @__PURE__ */ _jsx("h1", { children: "Hi" });
 } : null;
-const B = function Foo() {
+const B = (function Foo() {
   return /* @__PURE__ */ _jsx("h1", { children: "Hi" });
-}();
+})();
 let C = () => () => {
   return /* @__PURE__ */ _jsx("h1", { children: "Hi" });
 };

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/refresh/react-refresh/ignores-higher-order-functions-that-are-not-hocs/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/refresh/react-refresh/ignores-higher-order-functions-that-are-not-hocs/output.js
@@ -1,9 +1,9 @@
 const throttledAlert = throttle(function() {
   alert("Hi");
 });
-const TooComplex = function() {
+const TooComplex = (function() {
   return hello;
-}(() => {});
+})(() => {});
 if (cond) {
   const Foo = thing(() => {});
 }

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/redeclaration-with-enum/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/redeclaration-with-enum/output.js
@@ -3,10 +3,10 @@ let x;
   console.log(x, y);
 })(x || (x = {}));
 
-x = /* @__PURE__ */ (function (x) {
+x = /* @__PURE__ */ function (x) {
   x[x["y"] = 123] = "y";
   return x;
-})(x || {});
+}(x || {});
 
 var y = /* @__PURE__ */ function (y) {
   y[y["y"] = 123] = "y";


### PR DESCRIPTION
Made function expression PIFEs to be kept. Similar to #12353 but for function expressions.

The minsize for victory is bigger because webpack's output contains many PIFEs (some shouldn't be written as PIFEs though).

refs #12353 
