### PR TITLE
refactor(napi/oxlint): rename `rules` to `ruleNames`

### DIFF
--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -475,8 +475,8 @@ impl ConfigStoreBuilder {
         }?;
 
         match result {
-            PluginLoadResult::Success { name, offset, rules } => {
-                external_plugin_store.register_plugin(plugin_path, name, offset, rules);
+            PluginLoadResult::Success { name, offset, rule_names } => {
+                external_plugin_store.register_plugin(plugin_path, name, offset, rule_names);
                 Ok(())
             }
             PluginLoadResult::Failure(e) => Err(ConfigBuilderError::PluginLoadFailed {

--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -30,7 +30,12 @@ pub type ExternalLinterCb = Arc<
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum PluginLoadResult {
-    Success { name: String, offset: usize, rules: Vec<String> },
+    #[serde(rename_all = "camelCase")]
+    Success {
+        name: String,
+        offset: usize,
+        rule_names: Vec<String>,
+    },
     Failure(String),
 }
 

--- a/crates/oxc_linter/src/external_plugin_store.rs
+++ b/crates/oxc_linter/src/external_plugin_store.rs
@@ -37,7 +37,7 @@ impl ExternalPluginStore {
         plugin_path: String,
         plugin_name: String,
         offset: usize,
-        rules: Vec<String>,
+        rule_names: Vec<String>,
     ) {
         let newly_inserted = self.registered_plugin_paths.insert(plugin_path);
         assert!(newly_inserted, "register_plugin: plugin already registered");
@@ -54,7 +54,7 @@ impl ExternalPluginStore {
             self.rules.len()
         );
 
-        for rule_name in rules {
+        for rule_name in rule_names {
             let rule_id = self.rules.push(ExternalRule { name: rule_name.clone(), plugin_id });
             self.plugins[plugin_id].rules.insert(rule_name, rule_id);
         }

--- a/napi/oxlint2/src-js/index.js
+++ b/napi/oxlint2/src-js/index.js
@@ -53,15 +53,15 @@ async function loadPluginImpl(path) {
 
   // TODO: Use a validation library to assert the shape of the plugin, and of rules
   let ruleId = registeredRules.length;
-  const rules = [];
+  const ruleNames = [];
   const ret = {
     name: plugin.meta.name,
     offset: ruleId,
-    rules,
+    ruleNames,
   };
 
   for (const [ruleName, rule] of Object.entries(plugin.rules)) {
-    rules.push(ruleName);
+    ruleNames.push(ruleName);
     registeredRules.push({ rule, context: new Context(ruleId) });
     ruleId++;
   }


### PR DESCRIPTION
Pure refactor - just renaming. Rename `rules` to `rule_names`, because that's what it is!