### PR TITLE
fix(napi/oxlint): `loadPlugin` never throw error

### DIFF
--- a/napi/oxlint2/src-js/index.js
+++ b/napi/oxlint2/src-js/index.js
@@ -1,6 +1,7 @@
 import { createRequire } from 'node:module';
 import { lint } from './bindings.js';
 import { DATA_POINTER_POS_32, SOURCE_LEN_POS_32 } from './generated/constants.cjs';
+import { getErrorMessage } from './utils.js';
 import { addVisitorToCompiled, compiledVisitor, finalizeCompiledVisitor, initCompiledVisitor } from './visitor.js';
 
 // Import methods and objects from `oxc-parser`.
@@ -34,11 +35,8 @@ const registeredRules = [];
 async function loadPlugin(path) {
   try {
     return await loadPluginImpl(path);
-  } catch (error) {
-    const errorMessage = 'message' in error && typeof error.message === 'string'
-      ? error.message
-      : 'An unknown error occurred';
-    return JSON.stringify({ Failure: errorMessage });
+  } catch (err) {
+    return JSON.stringify({ Failure: getErrorMessage(err) });
   }
 }
 

--- a/napi/oxlint2/src-js/utils.js
+++ b/napi/oxlint2/src-js/utils.js
@@ -1,0 +1,22 @@
+/**
+ * Get error message from an error.
+ *
+ * `err` is expected to be an `Error` object, but can be anything.
+ *
+ * This function will never throw, and always returns a string, even if:
+ *
+ * * `err` is `null` or `undefined`.
+ * * `err` is an object with a getter for `message` property which throws.
+ * * `err` has a getter for `message` property which returns a different value each time it's accessed.
+ *
+ * @param {*} err - Error
+ * @returns {string} - Error message
+ */
+export function getErrorMessage(err) {
+  try {
+    const { message } = err;
+    if (typeof message === 'string' && message !== '') return message;
+  } catch {}
+
+  return 'Unknown error';
+}


### PR DESCRIPTION
Fix an edge case bug. Ensure `loadPlugin` never throws, even if user code does something wacky like throwing `null` or `{ get message() { throw new Error("ha ha ha got you!") } }`.