### PR TITLE
feat(napi/oxlint): add `getFilename` + `getPhysicalFilename` methods to `Context`

### DIFF
--- a/napi/oxlint2/src-js/index.js
+++ b/napi/oxlint2/src-js/index.js
@@ -104,6 +104,24 @@ class Context {
     });
   }
 
+  /**
+   * Get the absolute path of the file being linted.
+   * @deprecated Use `filename` instead.
+   * @returns {string} - The absolute path of the file being linted.
+   */
+  getFilename() {
+    return this.filename;
+  }
+
+  /**
+   * Get the physical filename (absolute path) of the file being linted.
+   * @deprecated Use `physicalFilename` instead.
+   * @returns {string} - The physical filename of the file being linted.
+   */
+  getPhysicalFilename() {
+    return this.physicalFilename;
+  }
+
   static {
     /**
      * Update a `Context` with file-specific data.

--- a/napi/oxlint2/test/__snapshots__/e2e.test.ts.snap
+++ b/napi/oxlint2/test/__snapshots__/e2e.test.ts.snap
@@ -342,6 +342,18 @@ exports[`oxlint2 CLI > should receive data via \`context\` 1`] = `
    : ^
    \`----
 
+  x context-plugin(log-context): getFilename(): files/1.js
+   ,-[files/1.js:1:1]
+ 1 | let x;
+   : ^
+   \`----
+
+  x context-plugin(log-context): getPhysicalFilename(): files/1.js
+   ,-[files/1.js:1:1]
+ 1 | let x;
+   : ^
+   \`----
+
   x context-plugin(log-context): id: context-plugin/log-context
    ,-[files/2.js:1:1]
  1 | let y;
@@ -360,7 +372,19 @@ exports[`oxlint2 CLI > should receive data via \`context\` 1`] = `
    : ^
    \`----
 
-Found 0 warnings and 6 errors.
+  x context-plugin(log-context): getFilename(): files/2.js
+   ,-[files/2.js:1:1]
+ 1 | let y;
+   : ^
+   \`----
+
+  x context-plugin(log-context): getPhysicalFilename(): files/2.js
+   ,-[files/2.js:1:1]
+ 1 | let y;
+   : ^
+   \`----
+
+Found 0 warnings and 10 errors.
 Finished in Xms on 2 files using X threads."
 `;
 

--- a/napi/oxlint2/test/fixtures/context_properties/test_plugin/index.js
+++ b/napi/oxlint2/test/fixtures/context_properties/test_plugin/index.js
@@ -30,6 +30,16 @@ export default {
           node: SPAN,
         });
 
+        context.report({
+          message: `getFilename(): ${relativePath(context.getFilename())}`,
+          node: SPAN,
+        });
+
+        context.report({
+          message: `getPhysicalFilename(): ${relativePath(context.getPhysicalFilename())}`,
+          node: SPAN,
+        });
+
         return {};
       },
     },


### PR DESCRIPTION
Add `getFilename` and `getPhysicalFilename` methods to `Context`, to match ESLint's API.
