### PR TITLE
refactor(napi/oxlint): diagnostics communicate which rule via rule index, not rule ID

### DIFF
--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -286,7 +286,10 @@ impl ConfigStore {
     }
 
     #[cfg_attr(not(all(feature = "oxlint2", not(feature = "disable_oxlint2"))), expect(dead_code))]
-    pub(crate) fn resolve_plugin_rule_names(&self, external_rule_id: u32) -> Option<(&str, &str)> {
+    pub(crate) fn resolve_plugin_rule_names(
+        &self,
+        external_rule_id: ExternalRuleId,
+    ) -> (/* plugin name */ &str, /* rule name */ &str) {
         self.external_plugin_store.resolve_plugin_rule_names(external_rule_id)
     }
 }

--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -42,7 +42,7 @@ pub enum PluginLoadResult {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LintResult {
-    pub external_rule_id: u32,
+    pub rule_index: u32,
     pub message: String,
     pub loc: Loc,
 }

--- a/crates/oxc_linter/src/external_plugin_store.rs
+++ b/crates/oxc_linter/src/external_plugin_store.rs
@@ -79,11 +79,13 @@ impl ExternalPluginStore {
         })
     }
 
-    pub fn resolve_plugin_rule_names(&self, external_rule_id: u32) -> Option<(&str, &str)> {
-        let external_rule = self.rules.get(ExternalRuleId::from_raw(external_rule_id))?;
+    pub fn resolve_plugin_rule_names(
+        &self,
+        external_rule_id: ExternalRuleId,
+    ) -> (/* plugin name */ &str, /* rule name */ &str) {
+        let external_rule = &self.rules[external_rule_id];
         let plugin = &self.plugins[external_rule.plugin_id];
-
-        Some((&plugin.name, &external_rule.name))
+        (&plugin.name, &external_rule.name)
     }
 }
 


### PR DESCRIPTION
Related to #12437.

Diagnostics sent from JS to Rust specify which rule the diagnostic relates to via an index into `external_rules`, instead of the `ExternalRuleId`. This allows removing the loop over `external_rules` on Rust side to find the relevant rule.
