### PR TITLE
feat(napi/oxlint): add `filename` property to `Context`

### DIFF
--- a/napi/oxlint2/src-js/index.js
+++ b/napi/oxlint2/src-js/index.js
@@ -75,6 +75,8 @@ class Context {
   // Index into `ruleIds` sent from Rust. Set before calling `rule`'s `create` method.
   #ruleIndex;
   // Absolute path of file being linted. Set before calling `rule`'s `create` method.
+  filename;
+  // Absolute path of file being linted. Set before calling `rule`'s `create` method.
   physicalFilename;
 
   /**
@@ -117,6 +119,7 @@ class Context {
      */
     setupContextForFile = (context, ruleIndex, filePath) => {
       context.#ruleIndex = ruleIndex;
+      context.filename = filePath;
       context.physicalFilename = filePath;
     };
   }

--- a/napi/oxlint2/test/__snapshots__/e2e.test.ts.snap
+++ b/napi/oxlint2/test/__snapshots__/e2e.test.ts.snap
@@ -330,6 +330,12 @@ exports[`oxlint2 CLI > should receive data via \`context\` 1`] = `
    : ^
    \`----
 
+  x context-plugin(log-context): filename: files/1.js
+   ,-[files/1.js:1:1]
+ 1 | let x;
+   : ^
+   \`----
+
   x context-plugin(log-context): physicalFilename: files/1.js
    ,-[files/1.js:1:1]
  1 | let x;
@@ -342,13 +348,19 @@ exports[`oxlint2 CLI > should receive data via \`context\` 1`] = `
    : ^
    \`----
 
+  x context-plugin(log-context): filename: files/2.js
+   ,-[files/2.js:1:1]
+ 1 | let y;
+   : ^
+   \`----
+
   x context-plugin(log-context): physicalFilename: files/2.js
    ,-[files/2.js:1:1]
  1 | let y;
    : ^
    \`----
 
-Found 0 warnings and 4 errors.
+Found 0 warnings and 6 errors.
 Finished in Xms on 2 files using X threads."
 `;
 

--- a/napi/oxlint2/test/fixtures/context_properties/test_plugin/index.js
+++ b/napi/oxlint2/test/fixtures/context_properties/test_plugin/index.js
@@ -21,6 +21,11 @@ export default {
         });
 
         context.report({
+          message: `filename: ${relativePath(context.filename)}`,
+          node: SPAN,
+        });
+
+        context.report({
           message: `physicalFilename: ${relativePath(context.physicalFilename)}`,
           node: SPAN,
         });


### PR DESCRIPTION
Add `filename` property to `Context`, to match ESLint's API.

[ESLint's docs](https://eslint.org/docs/latest/extend/custom-rules#the-context-object) do draw a distinction between `filename` and `physicalFilename`:

> `filename`: (string) The filename associated with the source.
> `physicalFilename`: (string) When linting a file, it provides the full path of the file on disk without any code block information. When linting text, it provides the value passed to `—stdin-filename` or `<text>` if not specified.

However, it's unclear to me if that difference applies in the context of Oxlint. So just make them both absolute file path for now. Testing ESLint locally, that's what both properties contain.
