### PR TITLE
refactor(linter): store `ExternalRuleId` in `OxlintOverrides` not raw names

### DIFF
--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -522,7 +522,8 @@ impl Tester {
                         self.plugins.builtin.union(BuiltinLintPlugins::from(self.plugin_name)),
                     )
                     .with_rule(rule, AllowWarnDeny::Warn)
-                    .build(),
+                    .build(&external_plugin_store)
+                    .unwrap(),
                 FxHashMap::default(),
                 external_plugin_store,
             ),

--- a/napi/oxlint2/test/__snapshots__/e2e.test.ts.snap
+++ b/napi/oxlint2/test/__snapshots__/e2e.test.ts.snap
@@ -364,6 +364,13 @@ Found 0 warnings and 6 errors.
 Finished in Xms on 2 files using X threads."
 `;
 
+exports[`oxlint2 CLI > should report an error if a a rule is not found within a custom plugin (via overrides) 1`] = `
+"Failed to build configuration.
+
+  x Rule 'missing' not found in plugin 'basic-custom-plugin'
+"
+`;
+
 exports[`oxlint2 CLI > should report an error if a custom plugin cannot be loaded 1`] = `
 "Failed to parse configuration file.
 

--- a/napi/oxlint2/test/e2e.test.ts
+++ b/napi/oxlint2/test/e2e.test.ts
@@ -84,6 +84,15 @@ describe('oxlint2 CLI', () => {
     expect(normalizeOutput(stdout)).toMatchSnapshot();
   });
 
+  it('should report an error if a a rule is not found within a custom plugin (via overrides)', async () => {
+    const { stdout, exitCode } = await runOxlint(
+      'test/fixtures/custom_plugin_via_overrides_missing_rule',
+    );
+
+    expect(exitCode).toBe(1);
+    expect(normalizeOutput(stdout)).toMatchSnapshot();
+  });
+
   it('should report the correct severity when using a custom plugin', async () => {
     const { stdout, exitCode } = await runOxlint(
       'test/fixtures/basic_custom_plugin_warn_severity',

--- a/napi/oxlint2/test/fixtures/custom_plugin_via_overrides_missing_rule/.oxlintrc.json
+++ b/napi/oxlint2/test/fixtures/custom_plugin_via_overrides_missing_rule/.oxlintrc.json
@@ -1,0 +1,15 @@
+{
+  "rules": {
+    "no-debugger": "off",
+  },
+  "overrides": [
+    {
+      "files": ["*.js"],
+      "plugins": ["./test_plugin"],
+      "rules": {
+        "basic-custom-plugin/missing": "error"
+      }
+    }
+  ],
+  "ignorePatterns": ["test_plugin"]
+}

--- a/napi/oxlint2/test/fixtures/custom_plugin_via_overrides_missing_rule/index.js
+++ b/napi/oxlint2/test/fixtures/custom_plugin_via_overrides_missing_rule/index.js
@@ -1,0 +1,1 @@
+debugger;

--- a/napi/oxlint2/test/fixtures/custom_plugin_via_overrides_missing_rule/test_plugin/index.js
+++ b/napi/oxlint2/test/fixtures/custom_plugin_via_overrides_missing_rule/test_plugin/index.js
@@ -1,0 +1,19 @@
+export default {
+  meta: {
+    name: "basic-custom-plugin",
+  },
+  rules: {
+    "no-debugger": {
+      create(context) {
+        return {
+          DebuggerStatement(debuggerStatement) {
+            context.report({
+              message: "Unexpected Debugger Statement",
+              node: debuggerStatement,
+            });
+          },
+        };
+      },
+    },
+  },
+};

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -293,6 +293,7 @@ impl Oxc {
     ) {
         // Only lint if there are no syntax errors
         if run_options.lint.unwrap_or_default() && self.diagnostics.is_empty() {
+            let external_plugin_store = ExternalPluginStore::default();
             let semantic_ret = SemanticBuilder::new().with_cfg(true).build(program);
             let semantic = Rc::new(semantic_ret.semantic);
             let lint_config = if linter_options.config.is_some() {
@@ -306,13 +307,14 @@ impl Oxc {
                     &mut ExternalPluginStore::default(),
                 )
                 .unwrap_or_default();
-                config_builder.build()
+                config_builder.build(&external_plugin_store)
             } else {
-                ConfigStoreBuilder::default().build()
+                ConfigStoreBuilder::default().build(&external_plugin_store)
             };
+            let lint_config = lint_config.unwrap();
             let linter_ret = Linter::new(
                 LintOptions::default(),
-                ConfigStore::new(lint_config, FxHashMap::default(), ExternalPluginStore::default()),
+                ConfigStore::new(lint_config, FxHashMap::default(), external_plugin_store),
                 None,
             )
             .run(path, Rc::clone(&semantic), Arc::clone(module_record), allocator);

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -30,10 +30,11 @@ fn bench_linter(criterion: &mut Criterion) {
         let semantic = semantic_ret.semantic;
         let module_record = Arc::new(ModuleRecord::new(path, &ret.module_record, &semantic));
         let semantic = Rc::new(semantic);
-        let lint_config = ConfigStoreBuilder::all().build();
+        let external_plugin_store = ExternalPluginStore::default();
+        let lint_config = ConfigStoreBuilder::all().build(&external_plugin_store).unwrap();
         let linter = Linter::new(
             LintOptions::default(),
-            ConfigStore::new(lint_config, FxHashMap::default(), ExternalPluginStore::default()),
+            ConfigStore::new(lint_config, FxHashMap::default(), external_plugin_store),
             None,
         )
         .with_fix(FixKind::All);


### PR DESCRIPTION
fixes #12653