### PR TITLE
test(linter): improve sorting diagnostics

### DIFF
--- a/apps/oxlint/src/output_formatter/default.rs
+++ b/apps/oxlint/src/output_formatter/default.rs
@@ -132,8 +132,18 @@ mod test_implementation {
             let handler = GraphicalReportHandler::new_themed(GraphicalTheme::none());
             let mut output = String::new();
 
-            self.diagnostics.sort_by_key(|diagnostic| Info::new(diagnostic).filename);
-            self.diagnostics.sort_by_key(|diagnostic| Info::new(diagnostic).start.line);
+            self.diagnostics.sort_by_cached_key(|diagnostic| {
+                let info = Info::new(diagnostic);
+                (
+                    info.filename,
+                    info.start.line,
+                    info.start.column,
+                    info.end.line,
+                    info.end.column,
+                    info.rule_id,
+                    info.message,
+                )
+            });
 
             for diagnostic in &self.diagnostics {
                 handler.render_report(&mut output, diagnostic.as_ref()).unwrap();

--- a/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json fixtures__typescript_eslint__test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json fixtures__typescript_eslint__test.ts@oxlint.snap
@@ -6,6 +6,14 @@ arguments: -c fixtures/typescript_eslint/eslintrc.json fixtures/typescript_eslin
 working directory: 
 ----------
 
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-namespace.html\typescript-eslint(no-namespace)]8;;\: ES2015 module syntax is preferred over namespaces.
+   ,-[fixtures/typescript_eslint/test.ts:1:1]
+ 1 | namespace X {
+   : ^^^^^^^^^
+ 2 | }
+   `----
+  help: Replace the namespace with an ES2015 module or use `declare module`
+
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html\eslint(no-unused-vars)]8;;\: Variable 'X' is declared but never used.
    ,-[fixtures/typescript_eslint/test.ts:1:11]
  1 | namespace X {
@@ -14,14 +22,6 @@ working directory:
  2 | }
    `----
   help: Consider removing this declaration.
-
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-namespace.html\typescript-eslint(no-namespace)]8;;\: ES2015 module syntax is preferred over namespaces.
-   ,-[fixtures/typescript_eslint/test.ts:1:1]
- 1 | namespace X {
-   : ^^^^^^^^^
- 2 | }
-   `----
-  help: Replace the namespace with an ES2015 module or use `declare module`
 
   x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-loss-of-precision.html\eslint(no-loss-of-precision)]8;;\: This number literal will lose precision at runtime.
    ,-[fixtures/typescript_eslint/test.ts:4:1]

--- a/apps/oxlint/src/snapshots/fixtures__overrides_env_globals_-c .oxlintrc.json .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__overrides_env_globals_-c .oxlintrc.json .@oxlint.snap
@@ -24,15 +24,6 @@ working directory: fixtures/overrides_env_globals
  3 | $ = 'abc';
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-global-assign.html\eslint(no-global-assign)]8;;\: Read-only global 'globalThis' should not be modified.
-   ,-[test.ts:2:1]
- 1 | // for env detection
- 2 | globalThis = 'abc';
-   : ^^^^^|^^^^
-   :      `-- Read-only global 'globalThis' should not be modified.
- 3 | $ = 'abc';
-   `----
-
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-global-assign.html\eslint(no-global-assign)]8;;\: Read-only global '$' should not be modified.
    ,-[test.js:3:1]
  2 | globalThis = 'abc';
@@ -48,6 +39,15 @@ working directory: fixtures/overrides_env_globals
  6 | Foo = 'readable';
    : ^|^
    :  `-- Read-only global 'Foo' should not be modified.
+   `----
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-global-assign.html\eslint(no-global-assign)]8;;\: Read-only global 'globalThis' should not be modified.
+   ,-[test.ts:2:1]
+ 1 | // for env detection
+ 2 | globalThis = 'abc';
+   : ^^^^^|^^^^
+   :      `-- Read-only global 'globalThis' should not be modified.
+ 3 | $ = 'abc';
    `----
 
 Found 5 warnings and 0 errors.

--- a/apps/oxlint/src/snapshots/fixtures__overrides_with_plugin_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__overrides_with_plugin_-c .oxlintrc.json@oxlint.snap
@@ -14,15 +14,6 @@ working directory: fixtures/overrides_with_plugin
    `----
   help: "Write a meaningful title for your test"
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html\eslint(no-unused-vars)]8;;\: Variable 'foo' is declared but never used. Unused variables should start with a '_'.
-   ,-[index.ts:1:7]
- 1 | const foo = 123;
-   :       ^|^
-   :        `-- 'foo' is declared here
- 2 | // no-unused-vars error expected as `eslint` plugin and `correctness` categories are on by default (override is not applied.)
-   `----
-  help: Consider removing this declaration.
-
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/jest/expect-expect.html\eslint-plugin-jest(expect-expect)]8;;\: Test has no assertions
    ,-[index.test.ts:4:3]
  3 | 
@@ -40,6 +31,15 @@ working directory: fixtures/overrides_with_plugin
  5 |   // ^ jest/no-valid-title error as explicitly set in the `.test.ts` override
    `----
   help: "Write a meaningful title for your test"
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html\eslint(no-unused-vars)]8;;\: Variable 'foo' is declared but never used. Unused variables should start with a '_'.
+   ,-[index.ts:1:7]
+ 1 | const foo = 123;
+   :       ^|^
+   :        `-- 'foo' is declared here
+ 2 | // no-unused-vars error expected as `eslint` plugin and `correctness` categories are on by default (override is not applied.)
+   `----
+  help: Consider removing this declaration.
 
 Found 2 warnings and 2 errors.
 Finished in <variable>ms on 2 files with 87 rules using 1 threads.

--- a/napi/oxlint2/test/__snapshots__/e2e.test.ts.snap
+++ b/napi/oxlint2/test/__snapshots__/e2e.test.ts.snap
@@ -20,18 +20,18 @@ Finished in Xms on 1 file using X threads."
 
 exports[`oxlint2 CLI > should load a custom plugin 1`] = `
 "
+  x basic-custom-plugin(no-debugger): Unexpected Debugger Statement
+   ,-[index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   \`----
+
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
    ,-[index.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    \`----
   help: Remove the debugger statement
-
-  x basic-custom-plugin(no-debugger): Unexpected Debugger Statement
-   ,-[index.js:1:1]
- 1 | debugger;
-   : ^^^^^^^^^
-   \`----
 
 Found 1 warning and 1 error.
 Finished in Xms on 1 file using X threads."
@@ -39,18 +39,18 @@ Finished in Xms on 1 file using X threads."
 
 exports[`oxlint2 CLI > should load a custom plugin when configured in overrides 1`] = `
 "
+  x basic-custom-plugin(no-debugger): Unexpected Debugger Statement
+   ,-[index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   \`----
+
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
    ,-[index.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    \`----
   help: Remove the debugger statement
-
-  x basic-custom-plugin(no-debugger): Unexpected Debugger Statement
-   ,-[index.js:1:1]
- 1 | debugger;
-   : ^^^^^^^^^
-   \`----
 
 Found 1 warning and 1 error.
 Finished in Xms on 1 file using X threads."
@@ -58,13 +58,6 @@ Finished in Xms on 1 file using X threads."
 
 exports[`oxlint2 CLI > should load a custom plugin with multiple files 1`] = `
 "
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
-   ,-[files/01.js:1:1]
- 1 | debugger;
-   : ^^^^^^^^^
-   \`----
-  help: Remove the debugger statement
-
   x basic-custom-plugin(no-debugger): Unexpected Debugger Statement
    ,-[files/01.js:1:1]
  1 | debugger;
@@ -72,7 +65,7 @@ exports[`oxlint2 CLI > should load a custom plugin with multiple files 1`] = `
    \`----
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
-   ,-[files/02.js:1:1]
+   ,-[files/01.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    \`----
@@ -85,7 +78,7 @@ exports[`oxlint2 CLI > should load a custom plugin with multiple files 1`] = `
    \`----
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
-   ,-[files/03.js:1:1]
+   ,-[files/02.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    \`----
@@ -98,7 +91,7 @@ exports[`oxlint2 CLI > should load a custom plugin with multiple files 1`] = `
    \`----
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
-   ,-[files/04.js:1:1]
+   ,-[files/03.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    \`----
@@ -111,7 +104,7 @@ exports[`oxlint2 CLI > should load a custom plugin with multiple files 1`] = `
    \`----
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
-   ,-[files/05.js:1:1]
+   ,-[files/04.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    \`----
@@ -124,7 +117,7 @@ exports[`oxlint2 CLI > should load a custom plugin with multiple files 1`] = `
    \`----
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
-   ,-[files/06.js:1:1]
+   ,-[files/05.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    \`----
@@ -137,7 +130,7 @@ exports[`oxlint2 CLI > should load a custom plugin with multiple files 1`] = `
    \`----
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
-   ,-[files/07.js:1:1]
+   ,-[files/06.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    \`----
@@ -150,7 +143,7 @@ exports[`oxlint2 CLI > should load a custom plugin with multiple files 1`] = `
    \`----
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
-   ,-[files/08.js:1:1]
+   ,-[files/07.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    \`----
@@ -163,7 +156,7 @@ exports[`oxlint2 CLI > should load a custom plugin with multiple files 1`] = `
    \`----
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
-   ,-[files/09.js:1:1]
+   ,-[files/08.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    \`----
@@ -176,7 +169,7 @@ exports[`oxlint2 CLI > should load a custom plugin with multiple files 1`] = `
    \`----
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
-   ,-[files/10.js:1:1]
+   ,-[files/09.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    \`----
@@ -189,7 +182,7 @@ exports[`oxlint2 CLI > should load a custom plugin with multiple files 1`] = `
    \`----
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
-   ,-[files/11.js:1:1]
+   ,-[files/10.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    \`----
@@ -202,7 +195,7 @@ exports[`oxlint2 CLI > should load a custom plugin with multiple files 1`] = `
    \`----
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
-   ,-[files/12.js:1:1]
+   ,-[files/11.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    \`----
@@ -215,7 +208,7 @@ exports[`oxlint2 CLI > should load a custom plugin with multiple files 1`] = `
    \`----
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
-   ,-[files/13.js:1:1]
+   ,-[files/12.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    \`----
@@ -228,7 +221,7 @@ exports[`oxlint2 CLI > should load a custom plugin with multiple files 1`] = `
    \`----
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
-   ,-[files/14.js:1:1]
+   ,-[files/13.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    \`----
@@ -241,7 +234,7 @@ exports[`oxlint2 CLI > should load a custom plugin with multiple files 1`] = `
    \`----
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
-   ,-[files/15.js:1:1]
+   ,-[files/14.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    \`----
@@ -254,7 +247,7 @@ exports[`oxlint2 CLI > should load a custom plugin with multiple files 1`] = `
    \`----
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
-   ,-[files/16.js:1:1]
+   ,-[files/15.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    \`----
@@ -267,7 +260,7 @@ exports[`oxlint2 CLI > should load a custom plugin with multiple files 1`] = `
    \`----
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
-   ,-[files/17.js:1:1]
+   ,-[files/16.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    \`----
@@ -280,7 +273,7 @@ exports[`oxlint2 CLI > should load a custom plugin with multiple files 1`] = `
    \`----
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
-   ,-[files/18.js:1:1]
+   ,-[files/17.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    \`----
@@ -293,7 +286,7 @@ exports[`oxlint2 CLI > should load a custom plugin with multiple files 1`] = `
    \`----
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
-   ,-[files/19.js:1:1]
+   ,-[files/18.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    \`----
@@ -306,7 +299,7 @@ exports[`oxlint2 CLI > should load a custom plugin with multiple files 1`] = `
    \`----
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
-   ,-[files/20.js:1:1]
+   ,-[files/19.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    \`----
@@ -317,6 +310,13 @@ exports[`oxlint2 CLI > should load a custom plugin with multiple files 1`] = `
  1 | debugger;
    : ^^^^^^^^^
    \`----
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
+   ,-[files/20.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   \`----
+  help: Remove the debugger statement
 
 Found 20 warnings and 20 errors.
 Finished in Xms on 20 files using X threads."
@@ -381,18 +381,18 @@ exports[`oxlint2 CLI > should report an error if a rule is not found within a cu
 
 exports[`oxlint2 CLI > should report the correct severity when using a custom plugin 1`] = `
 "
+  ! basic-custom-plugin(no-debugger): Unexpected Debugger Statement
+   ,-[index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   \`----
+
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
    ,-[index.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    \`----
   help: Remove the debugger statement
-
-  ! basic-custom-plugin(no-debugger): Unexpected Debugger Statement
-   ,-[index.js:1:1]
- 1 | debugger;
-   : ^^^^^^^^^
-   \`----
 
 Found 2 warnings and 0 errors.
 Finished in Xms on 1 file using X threads."
@@ -400,13 +400,12 @@ Finished in Xms on 1 file using X threads."
 
 exports[`oxlint2 CLI > should work with multiple rules 1`] = `
 "
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
+  x basic-custom-plugin(no-debugger): Unexpected Debugger Statement
    ,-[index.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
  2 | 
    \`----
-  help: Remove the debugger statement
 
   x basic-custom-plugin(no-debugger-2): Unexpected Debugger Statement
    ,-[index.js:1:1]
@@ -415,12 +414,13 @@ exports[`oxlint2 CLI > should work with multiple rules 1`] = `
  2 | 
    \`----
 
-  x basic-custom-plugin(no-debugger): Unexpected Debugger Statement
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
    ,-[index.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
  2 | 
    \`----
+  help: Remove the debugger statement
 
   x basic-custom-plugin(no-ident-references-named-foo): Unexpected Identifier Reference named foo
    ,-[index.js:3:1]


### PR DESCRIPTION
Improve (I think) ordering of diagnostic in test snapshots.

1. Sort by filename first, then position. I think this was probably the original intention.
2. Include start column and end line+column in sort, for more deterministic order.
3. Use `sort_by_cached_key`. `Info::new` creates up to 3 `String` allocations, so preferable to cache the result of the closure, to avoid making those allocations repeatedly. `sort_by_key` will likely call the closure many times for each element.

If I've understood right, this reporter is only used in tests, so this PR makes no difference to users.
