### PR TITLE
perf(diagnostics): `Info::new` trim string in place

### DIFF
--- a/crates/oxc_diagnostics/src/reporter.rs
+++ b/crates/oxc_diagnostics/src/reporter.rs
@@ -138,12 +138,17 @@ impl Info {
                         if matches!(diagnostic.severity(), Some(Severity::Error)) {
                             severity = Severity::Error;
                         }
-                        let msg = diagnostic.to_string();
 
-                        // Our messages usually comes with `eslint(rule): message`
-                        message = msg
-                            .split_once(':')
-                            .map_or_else(|| msg.to_string(), |(_, msg)| msg.trim().to_string());
+                        message = diagnostic.to_string();
+                        // Our messages usually are in format `eslint(rule): message`.
+                        // Trim off before the colon.
+                        if let Some((_, msg)) = message.split_once(':') {
+                            // Equivalent to `message = msg.trim().to_string()`, but operates in place
+                            let msg = msg.trim();
+                            let start = msg.as_ptr() as usize - message.as_str().as_ptr() as usize;
+                            message.truncate(start + msg.len());
+                            message.replace_range(..start, "");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Small optimization. `Info::new` trim message `String` in place, rather than creating a new `String` and dropping the old one.

Why doesn't Rust have `String::trim_in_place` and `String::trim_start_matches_in_place`?