### PR TITLE
feat(formatter): support printing member chain

### DIFF
--- a/crates/oxc_formatter/src/formatter/comments/mod.rs
+++ b/crates/oxc_formatter/src/formatter/comments/mod.rs
@@ -45,6 +45,21 @@ impl<'a> Comments<'a> {
         &self.comments[..self.printed_count]
     }
 
+    /// Returns comments that are before the given `pos`.
+    pub fn comments_before(&self, pos: u32) -> &'a [Comment] {
+        let mut index = 0;
+
+        let comments = self.unprinted_comments();
+        for comment in comments {
+            if comment.span.end > pos {
+                break;
+            }
+            index += 1;
+        }
+
+        &comments[..index]
+    }
+
     /// Returns the comments that after the given `start` position, even if they were already printed.
     pub fn comments_after(&self, pos: u32) -> &'a [Comment] {
         let mut index = self.printed_count;

--- a/crates/oxc_formatter/src/formatter/format_element/tag.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/tag.rs
@@ -259,7 +259,8 @@ impl PartialEq for LabelId {
 }
 
 impl LabelId {
-    pub fn of<T: Label>(label: &T) -> Self {
+    #[expect(clippy::needless_pass_by_value)] // The `Label` trait is unnecessary, would refactor it later.
+    pub fn of<T: Label>(label: T) -> Self {
         Self {
             value: label.id(),
             #[cfg(debug_assertions)]

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -39,6 +39,8 @@ use crate::{
     generated::ast_nodes::{AstNode, AstNodes},
 };
 
+use self::formatter::prelude::tag::Label;
+
 pub struct Formatter<'a> {
     allocator: &'a Allocator,
     source_text: &'a str,
@@ -64,5 +66,22 @@ impl<'a> Formatter<'a> {
         )
         .unwrap();
         formatted.print().unwrap().into_code()
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum JsLabels {
+    MemberChain,
+}
+
+impl Label for JsLabels {
+    fn id(&self) -> u64 {
+        *self as u64
+    }
+
+    fn debug_name(&self) -> &'static str {
+        match self {
+            Self::MemberChain => "MemberChain",
+        }
     }
 }

--- a/crates/oxc_formatter/src/utils/member_chain/chain_member.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/chain_member.rs
@@ -1,0 +1,114 @@
+use crate::{
+    formatter::{Format, FormatResult, Formatter, prelude::*, trivia::FormatLeadingComments},
+    generated::ast_nodes::AstNode,
+    write,
+};
+use oxc_ast::{AstKind, ast::*};
+use oxc_span::GetSpan;
+
+#[derive(Copy, Clone, Debug)]
+pub enum CallExpressionPosition {
+    /// At the start of a call chain.
+    /// `of` in `of().test`
+    Start,
+
+    /// Somewhere in the middle.
+    ///
+    /// `b` in `a.b().c()`
+    Middle,
+
+    /// At the end of a call chain (root)
+    /// `c` in `a.b.c()`
+    End,
+}
+
+/// Data structure that holds the node with its formatted version
+#[derive(Clone, Debug)]
+pub enum ChainMember<'a, 'b> {
+    /// Holds onto a [oxc_ast::ast::StaticMemberExpression]
+    StaticMember(&'b AstNode<'a, StaticMemberExpression<'a>>),
+
+    /// Holds onto a [oxc_ast::ast::CallExpression]
+    CallExpression {
+        expression: &'b AstNode<'a, CallExpression<'a>>,
+        position: CallExpressionPosition,
+    },
+
+    /// Holds onto a [oxc_ast::ast::ComputedMemberExpression]
+    ComputedMember(&'b AstNode<'a, ComputedMemberExpression<'a>>),
+
+    TSNonNullExpression(&'b AstNode<'a, TSNonNullExpression<'a>>),
+
+    /// Any other node that are not [oxc_ast::ast::CallExpression] or [oxc_ast::ast::StaticMemberExpression]
+    /// Are tracked using this variant
+    Node(&'b AstNode<'a, Expression<'a>>),
+}
+
+impl ChainMember<'_, '_> {
+    pub(crate) const fn is_call_expression(&self) -> bool {
+        matches!(self, Self::CallExpression { .. })
+    }
+
+    pub const fn is_computed_expression(&self) -> bool {
+        matches!(self, Self::ComputedMember { .. })
+    }
+}
+
+impl<'a> Format<'a> for ChainMember<'a, '_> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        match self {
+            Self::StaticMember(e) => {
+                write!(
+                    f,
+                    [
+                        FormatLeadingComments::Comments(
+                            f.context().comments().comments_before(e.property().span().start)
+                        ),
+                        e.optional().then_some("?"),
+                        ".",
+                        e.property()
+                    ]
+                )?;
+                e.format_trailing_comments(f)
+            }
+
+            Self::TSNonNullExpression(e) => {
+                e.format_leading_comments(f)?;
+                write!(f, ["!"])?;
+                e.format_trailing_comments(f)
+            }
+
+            Self::CallExpression { expression, position } => match *position {
+                CallExpressionPosition::Start => write!(f, expression),
+                CallExpressionPosition::Middle => {
+                    expression.format_leading_comments(f);
+                    write!(
+                        f,
+                        [
+                            expression.optional().then_some("?."),
+                            expression.type_arguments(),
+                            expression.arguments()
+                        ]
+                    );
+                    expression.format_trailing_comments(f)
+                }
+                CallExpressionPosition::End => {
+                    write!(
+                        f,
+                        [
+                            expression.optional().then_some("?."),
+                            expression.type_arguments(),
+                            expression.arguments(),
+                        ]
+                    )
+                }
+            },
+            Self::ComputedMember(e) => {
+                e.format_leading_comments(f)?;
+                write!(f, [e.optional().then_some("?"), "[", e.expression(), "]"])?;
+                e.format_trailing_comments(f)
+            }
+            Self::Node(node) => write!(f, node),
+        }
+    }
+}

--- a/crates/oxc_formatter/src/utils/member_chain/groups.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/groups.rs
@@ -1,0 +1,244 @@
+use super::chain_member::ChainMember;
+use crate::{
+    formatter::{Format, FormatResult, Formatter, prelude::*},
+    generated::ast_nodes::AstNode,
+    parentheses::NeedsParentheses,
+    write,
+};
+use oxc_span::{GetSpan, Span};
+use std::cell::RefCell;
+
+#[derive(Default)]
+pub(super) struct MemberChainGroupsBuilder<'a, 'b> {
+    /// keeps track of the groups created
+    groups: Vec<MemberChainGroup<'a, 'b>>,
+    /// keeps track of the current group that is being created/updated
+    current_group: Option<MemberChainGroup<'a, 'b>>,
+}
+
+impl<'a, 'b> MemberChainGroupsBuilder<'a, 'b> {
+    /// starts a new group
+    pub fn start_group(&mut self, member: ChainMember<'a, 'b>) {
+        debug_assert!(self.current_group.is_none());
+        let mut group = MemberChainGroup::default();
+        group.members.push(member);
+        self.current_group = Some(group);
+    }
+
+    /// continues of starts a new group
+    pub fn start_or_continue_group(&mut self, member: ChainMember<'a, 'b>) {
+        match &mut self.current_group {
+            None => self.start_group(member),
+            Some(group) => group.members.push(member),
+        }
+    }
+
+    /// clears the current group, and adds it to the groups collection
+    pub fn close_group(&mut self) {
+        if let Some(group) = self.current_group.take() {
+            self.groups.push(group);
+        }
+    }
+
+    pub(super) fn finish(self) -> TailChainGroups<'a, 'b> {
+        let mut groups = self.groups;
+
+        if let Some(group) = self.current_group {
+            groups.push(group);
+        }
+
+        TailChainGroups { groups }
+    }
+}
+
+/// Groups following on the head group.
+///
+/// May be empty if all members are part of the head group
+#[derive(Debug)]
+pub(super) struct TailChainGroups<'a, 'b> {
+    groups: Vec<MemberChainGroup<'a, 'b>>,
+}
+
+impl<'a, 'b> TailChainGroups<'a, 'b> {
+    /// Returns `true` if there are no tail groups.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.groups.is_empty()
+    }
+
+    /// Returns the number of tail groups.
+    pub(crate) fn len(&self) -> usize {
+        self.groups.len()
+    }
+
+    /// Returns the first group
+    pub(crate) fn first(&self) -> Option<&MemberChainGroup<'a, 'b>> {
+        self.groups.first()
+    }
+
+    /// Returns the last group
+    pub(crate) fn last(&self) -> Option<&MemberChainGroup<'a, 'b>> {
+        self.groups.last()
+    }
+
+    /// Removes the first group and returns it
+    pub(super) fn pop_first(&mut self) -> Option<MemberChainGroup<'a, 'b>> {
+        if self.groups.is_empty() { None } else { Some(self.groups.remove(0)) }
+    }
+
+    /// Here we check if the length of the groups exceeds the cutoff or there are comments
+    /// This function is the inverse of the prettier function
+    /// [Prettier applies]: <https://github.com/prettier/prettier/blob/a043ac0d733c4d53f980aa73807a63fc914f23bd/src/language-js/print/member-chain.js#L342>
+    pub(crate) fn is_member_call_chain(&self, f: &Formatter) -> bool {
+        self.groups.len() > 1
+    }
+
+    /// Returns an iterator over the groups.
+    pub(super) fn iter(&self) -> impl Iterator<Item = &MemberChainGroup<'a, 'b>> {
+        self.groups.iter()
+    }
+
+    /// Test if any group except the last group [break](FormatElements::will_break).
+    pub(super) fn any_except_last_will_break(
+        &self,
+        f: &mut Formatter<'_, 'a>,
+    ) -> FormatResult<bool> {
+        for group in &self.groups[..self.groups.len().saturating_sub(1)] {
+            if group.will_break(f)? {
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }
+
+    /// Returns an iterator over all members
+    pub(super) fn members(&self) -> impl Iterator<Item = &ChainMember<'a, 'b>> {
+        self.groups.iter().flat_map(|group| group.members().iter())
+    }
+}
+
+impl<'a> Format<'a> for TailChainGroups<'a, '_> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        f.join().entries(self.groups.iter()).finish()
+    }
+}
+
+#[derive(Default)]
+pub(super) struct MemberChainGroup<'a, 'b> {
+    members: Vec<ChainMember<'a, 'b>>,
+
+    /// Stores the formatted result of this group.
+    ///
+    /// Manual implementation of `Memoized` to only memorizing the formatted result
+    /// if [MemberChainGroup::will_break] is called but not otherwise.
+    formatted: RefCell<Option<FormatElement<'a>>>,
+}
+
+impl<'a, 'b> MemberChainGroup<'a, 'b> {
+    pub(super) fn into_members(self) -> Vec<ChainMember<'a, 'b>> {
+        self.members
+    }
+
+    /// Returns the chain members of the group.
+    pub(super) fn members(&self) -> &[ChainMember<'a, 'b>] {
+        &self.members
+    }
+
+    /// Extends the members of this group with the passed in members
+    pub(super) fn extend_members(
+        &mut self,
+        members: impl IntoIterator<Item = ChainMember<'a, 'b>>,
+    ) {
+        self.members.extend(members);
+    }
+
+    /// Tests if the formatted result of this group results in a [break](FormatElements::will_break).
+    pub(super) fn will_break(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<bool> {
+        let mut cell = self.formatted.borrow_mut();
+        Ok(if let Some(formatted) = cell.as_ref() {
+            formatted.will_break()
+        } else {
+            let interned = f.intern(&FormatMemberChainGroup { group: self })?;
+
+            if let Some(interned) = interned {
+                let breaks = interned.will_break();
+                *cell = Some(interned);
+                breaks
+            } else {
+                false
+            }
+        })
+    }
+
+    pub(super) fn needs_empty_line_before(&self, f: &Formatter) -> bool {
+        // TODO: Needs to consider there is a comment around the `?`, `.` or `[` character.
+        let first = self.members.first();
+        first.is_some_and(|first| match first {
+            ChainMember::StaticMember(expression) => {
+                let object_end = expression.object().span().end;
+                let operator_byte = if expression.optional { b'?' } else { b'.' };
+                let operator_position = f.source_text().as_bytes()[(object_end as usize)..]
+                    .iter()
+                    .position(|&b| b == operator_byte)
+                    .unwrap();
+
+                // The `source_text` length is guaranteed to be less than `u32::MAX`.
+                #[expect(clippy::cast_possible_truncation)]
+                let start = object_end + operator_position as u32;
+                let end = start + if expression.optional { 2 } else { 1 };
+                let operator_span = Span::new(start, end);
+
+                get_lines_before(operator_span, f) > 1
+            }
+            ChainMember::ComputedMember(expression) => {
+                let object_end = expression.object().span().end;
+                let operator_byte = b'[';
+                let operator_position = f.source_text().as_bytes()[(object_end as usize)..]
+                    .iter()
+                    .position(|&b| b == operator_byte)
+                    .unwrap();
+
+                // The `source_text` length is guaranteed to be less than `u32::MAX`.
+                #[expect(clippy::cast_possible_truncation)]
+                let start = object_end + operator_position as u32;
+                let end = start + 1;
+                let operator_span = Span::new(start, end);
+
+                get_lines_before(operator_span, f) > 1
+            }
+            _ => false,
+        })
+    }
+}
+
+impl<'a, 'b> From<Vec<ChainMember<'a, 'b>>> for MemberChainGroup<'a, 'b> {
+    fn from(entries: Vec<ChainMember<'a, 'b>>) -> Self {
+        Self { members: entries, formatted: RefCell::new(None) }
+    }
+}
+
+impl std::fmt::Debug for MemberChainGroup<'_, '_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("MemberChainGroup").field(&self.members).finish()
+    }
+}
+
+impl<'a> Format<'a> for MemberChainGroup<'a, '_> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        if let Some(formatted) = self.formatted.borrow().as_ref() {
+            return f.write_element(formatted.clone());
+        }
+
+        FormatMemberChainGroup { group: self }.fmt(f)
+    }
+}
+
+pub struct FormatMemberChainGroup<'a, 'b> {
+    group: &'b MemberChainGroup<'a, 'b>,
+}
+
+impl<'a> Format<'a> for FormatMemberChainGroup<'a, '_> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        f.join().entries(self.group.members.iter()).finish()
+    }
+}

--- a/crates/oxc_formatter/src/utils/member_chain/mod.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/mod.rs
@@ -1,1 +1,452 @@
+pub mod chain_member;
+pub mod groups;
 pub mod simple_argument;
+
+use crate::{
+    JsLabels, best_fitting,
+    formatter::{Buffer, Format, FormatResult, Formatter, prelude::*},
+    generated::ast_nodes::{AstNode, AstNodes},
+    utils::{
+        call_expression::is_test_call_expression,
+        is_long_curried_call,
+        member_chain::{
+            chain_member::{CallExpressionPosition, ChainMember},
+            groups::{MemberChainGroup, MemberChainGroupsBuilder, TailChainGroups},
+            simple_argument::SimpleArgument,
+        },
+    },
+    write,
+};
+use oxc_ast::{AstKind, ast::*};
+use oxc_span::{GetSpan, Span};
+
+#[derive(Debug)]
+pub struct MemberChain<'a, 'b> {
+    root: &'b AstNode<'a, CallExpression<'a>>,
+    head: MemberChainGroup<'a, 'b>,
+    tail: TailChainGroups<'a, 'b>,
+}
+
+impl<'a, 'b> MemberChain<'a, 'b> {
+    pub(crate) fn from_call_expression(
+        call_expression: &'b AstNode<'a, CallExpression<'a>>,
+        f: &Formatter<'_, 'a>,
+    ) -> Self {
+        let parent = &call_expression.parent;
+        let mut chain_members = ChainMembersIterator::new(call_expression).collect::<Vec<_>>();
+        chain_members.reverse();
+
+        // as explained before, the first group is particular, so we calculate it
+        let (head_group, remaining_members) =
+            split_members_into_head_and_remaining_groups(chain_members);
+
+        // `flattened_items` now contains only the nodes that should have a sequence of
+        // `[ StaticMemberExpression -> AnyNode + CallExpression ]`
+        let tail_groups = compute_remaining_groups(remaining_members);
+
+        let mut member_chain = Self { head: head_group, tail: tail_groups, root: call_expression };
+
+        // Here we check if the first element of Groups::groups can be moved inside the head.
+        // If so, then we extract it and concatenate it together with the head.
+        member_chain.maybe_merge_with_first_group(parent, f);
+
+        member_chain
+    }
+
+    /// Here we check if the first group can be merged to the head. If so, then
+    /// we move out the first group out of the groups
+    fn maybe_merge_with_first_group(&mut self, parent: &AstNodes<'a>, f: &Formatter<'_, 'a>) {
+        if self.should_merge_tail_with_head(parent, f) {
+            let group = self.tail.pop_first().unwrap();
+            self.head.extend_members(group.into_members());
+        }
+    }
+
+    /// This function checks if the current grouping should be merged with the first group.
+    fn should_merge_tail_with_head(&self, parent: &AstNodes<'a>, f: &Formatter<'_, 'a>) -> bool {
+        let Some(first_group) = self.tail.first() else {
+            return false;
+        };
+
+        let has_comment = first_group.members().first().is_some_and(|member| {
+            matches!(member, ChainMember::StaticMember(expression)
+                if f.context().comments().has_comments_between(
+                    expression.object().span().end,
+                    expression.property().span.start
+                )
+            )
+        });
+
+        if has_comment {
+            return false;
+        }
+
+        let has_computed_property =
+            first_group.members().first().is_some_and(ChainMember::is_computed_expression);
+
+        if self.head.members().len() == 1
+            && let ChainMember::Node(node) = self.head.members()[0]
+        {
+            if let Expression::Identifier(identifier) = node.as_ref() {
+                has_computed_property ||
+                is_factory(&identifier.name) ||
+                // If an identifier has a name that is shorter than the tab with, then we join it with the "head"
+                (matches!(parent, AstNodes::ExpressionStatement(_))
+                    && has_short_name(&identifier.name, f.options().indent_width.value()))
+            } else {
+                matches!(node.as_ref(), Expression::ThisExpression(_))
+            }
+        } else if let Some(ChainMember::StaticMember(expression)) = self.head.members().last() {
+            has_computed_property || is_factory(&expression.property().name)
+        } else {
+            false
+        }
+    }
+
+    /// It tells if the groups should break on multiple lines
+    fn groups_should_break(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<bool> {
+        let mut call_expressions = self
+            .members()
+            .filter_map(|member| match member {
+                ChainMember::CallExpression { expression, .. } => Some(expression),
+                _ => None,
+            })
+            .peekable();
+
+        let mut calls_count = 0;
+        let mut has_function_like_argument = false;
+        let mut has_complex_args = false;
+
+        while let Some(call) = call_expressions.next() {
+            calls_count += 1;
+
+            if call_expressions.peek().is_some() {
+                has_function_like_argument =
+                    has_function_like_argument || has_arrow_or_function_expression_arg(call);
+            }
+
+            has_complex_args = has_complex_args || !has_simple_arguments(call);
+
+            if calls_count > 2 && has_complex_args {
+                return Ok(true);
+            }
+        }
+
+        if self.last_call_breaks(f)? && has_function_like_argument {
+            return Ok(true);
+        }
+
+        if !self.tail.is_empty() && self.head.will_break(f)? {
+            return Ok(true);
+        }
+
+        if self.tail.any_except_last_will_break(f)? {
+            return Ok(true);
+        }
+
+        Ok(self.tail.iter().skip(1).any(|group| group.needs_empty_line_before(f)))
+    }
+
+    /// We retrieve all the call expressions inside the group and we check if
+    /// their arguments are not simple.
+    fn last_call_breaks(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<bool> {
+        let last_group = self.last_group();
+
+        if matches!(last_group.members().last(), Some(ChainMember::CallExpression { .. })) {
+            last_group.will_break(f)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn last_group(&self) -> &MemberChainGroup<'a, 'b> {
+        self.tail.last().unwrap_or(&self.head)
+    }
+
+    /// Returns an iterator over all members in the member chain
+    fn members(&self) -> impl Iterator<Item = &ChainMember<'a, 'b>> {
+        self.head.members().iter().chain(self.tail.members())
+    }
+
+    fn has_comments(&self, f: &Formatter<'_, 'a>) -> bool {
+        let comments = f.comments();
+
+        for member in self.members() {
+            if matches!(
+                member,
+                ChainMember::StaticMember(member)
+                    if comments.has_comments_between(member.object().span().end, member.property().span.start)
+            ) {
+                return true;
+            }
+        }
+
+        false
+    }
+}
+
+impl<'a> Format<'a> for MemberChain<'a, '_> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let has_comments = self.has_comments(f);
+
+        let format_one_line = format_with(|f| {
+            let mut joiner = f.join();
+
+            joiner.entry(&self.head);
+            joiner.entries(self.tail.iter());
+
+            joiner.finish()
+        });
+
+        if self.tail.len() <= 1 && !has_comments {
+            return if is_long_curried_call(self.root.parent) {
+                write!(f, [format_one_line])
+            } else if is_test_call_expression(self.root) && self.head.members().len() >= 2 {
+                write!(f, [self.head, soft_line_indent_or_space(&self.tail)])
+            } else {
+                write!(f, [group(&format_one_line)])
+            };
+        }
+
+        let format_tail = format_with(|f| {
+            for group in self.tail.iter() {
+                if group.needs_empty_line_before(f) {
+                    write!(f, [empty_line()])?;
+                } else {
+                    write!(f, [hard_line_break()])?;
+                }
+                write!(f, [group])?;
+            }
+            Ok(())
+        });
+
+        let format_expanded = format_with(|f| write!(f, [self.head, indent(&group(&format_tail))]));
+
+        let format_content = format_with(|f| {
+            if has_comments || self.groups_should_break(f)? {
+                write!(f, [group(&format_expanded)])
+            } else {
+                // TODO: Comment out the following code without any effect in Biome.
+                let has_empty_line_before_tail =
+                    self.tail.first().is_some_and(|group| group.needs_empty_line_before(f));
+                if has_empty_line_before_tail || self.last_group().will_break(f)? {
+                    write!(f, [expand_parent()])?;
+                }
+
+                write!(f, [best_fitting!(format_one_line, format_expanded)])
+            }
+        });
+
+        write!(f, [labelled(LabelId::of(JsLabels::MemberChain), &format_content)])
+    }
+}
+
+/// Splits the members into two groups:
+/// * The head group that contains all nodes that are not a sequence of: `[ StaticMemberExpression -> AnyNode + CallExpression ]`
+/// * The remaining members
+fn split_members_into_head_and_remaining_groups<'a, 'b>(
+    mut members: Vec<ChainMember<'a, 'b>>,
+) -> (MemberChainGroup<'a, 'b>, Vec<ChainMember<'a, 'b>>) {
+    // This where we apply the first two points explained in the description of the main public function.
+    // We want to keep iterating over the items until we have call expressions
+    // - `something()()()()`
+    // - `something[1][2][4]`
+    // - `something[1]()[3]()`
+    // - `something()[2].something.else[0]`
+    let non_call_or_array_member_access_start = members
+        .iter()
+        // The first member is always part of the first group
+        .skip(1)
+        .position(|member| match member {
+            ChainMember::CallExpression { .. } | ChainMember::TSNonNullExpression(_) => false,
+            ChainMember::ComputedMember(expression) => {
+                !matches!(&expression.expression, Expression::NumericLiteral(_))
+            }
+            _ => true,
+        })
+        .map_or(members.len(), |index| {
+            // `skip(1)` causes the first member to be skipped, so we need to add 1 to the index
+            index + 1
+        });
+
+    let first_group_end_index = if members.first().is_some_and(ChainMember::is_call_expression) {
+        non_call_or_array_member_access_start
+    } else {
+        // Take as many member access chains as possible
+        let rest = &members[non_call_or_array_member_access_start..];
+
+        let member_end = rest
+            .iter()
+            .position(|member| {
+                !matches!(
+                    member,
+                    ChainMember::StaticMember { .. } | ChainMember::ComputedMember { .. }
+                )
+            })
+            .map_or(rest.len(), |index| {
+                // `index - 1` is the last member of the group
+                index - 1
+            });
+
+        non_call_or_array_member_access_start + member_end
+    };
+
+    let remaining = members.split_off(first_group_end_index);
+    (MemberChainGroup::from(members), remaining)
+}
+
+/// computes groups coming after the first group
+fn compute_remaining_groups<'a, 'b>(members: Vec<ChainMember<'a, 'b>>) -> TailChainGroups<'a, 'b> {
+    let mut has_seen_call_expression = false;
+    let mut groups_builder = MemberChainGroupsBuilder::default();
+
+    for member in members {
+        match member {
+            // [0] should be appended at the end of the group instead of the
+            // beginning of the next one
+            ChainMember::ComputedMember { .. } if is_computed_array_member_access(&member) => {
+                groups_builder.start_or_continue_group(member);
+            }
+            ChainMember::StaticMember { .. } | ChainMember::ComputedMember { .. } => {
+                // if we have seen a CallExpression, we want to close the group.
+                // The resultant group will be something like: [ . , then, () ];
+                // `.` and `then` belong to the previous StaticMemberExpression,
+                // and `()` belong to the call expression we just encountered
+                if has_seen_call_expression {
+                    groups_builder.close_group();
+                    groups_builder.start_group(member);
+                    has_seen_call_expression = false;
+                } else {
+                    groups_builder.start_or_continue_group(member);
+                }
+            }
+            ChainMember::CallExpression { .. } => {
+                groups_builder.start_or_continue_group(member);
+                has_seen_call_expression = true;
+            }
+            ChainMember::TSNonNullExpression { .. } => {
+                groups_builder.start_or_continue_group(member);
+            }
+            ChainMember::Node(_) => unreachable!("Remaining members never have a `Node` variant"),
+        }
+    }
+
+    groups_builder.finish()
+}
+
+fn is_computed_array_member_access(member: &ChainMember<'_, '_>) -> bool {
+    matches!(member, ChainMember::ComputedMember(expression)
+        if matches!(&expression.expression, Expression::NumericLiteral(_))
+    )
+}
+
+fn has_arrow_or_function_expression_arg(call: &AstNode<'_, CallExpression<'_>>) -> bool {
+    call.as_ref().arguments.iter().any(|argument| {
+        matches!(&argument, Argument::ArrowFunctionExpression(_) | Argument::FunctionExpression(_))
+    })
+}
+
+fn has_simple_arguments<'a>(call: &AstNode<'a, CallExpression<'a>>) -> bool {
+    call.arguments().iter().all(|argument| SimpleArgument::new(argument).is_simple())
+}
+
+/// In order to detect those cases, we use an heuristic: if the first
+/// node is an identifier with the name starting with a capital
+/// letter or just a sequence of _$. The rationale is that they are
+/// likely to be factories.
+fn is_factory(token: &str) -> bool {
+    let mut bytes = token.bytes();
+
+    match bytes.next() {
+        // Any sequence of '$' or '_' characters
+        Some(b'_' | b'$') => bytes.all(|b| matches!(b, b'_' | b'$')),
+        Some(c) => c.is_ascii_uppercase(),
+        _ => false,
+    }
+}
+
+/// Here we check if the length of the groups exceeds the cutoff or there are comments
+/// This function is the inverse of the prettier function
+/// [Prettier applies]: <https://github.com/prettier/prettier/blob/a043ac0d733c4d53f980aa73807a63fc914f23bd/src/language-js/print/member-chain.js#L342>
+pub fn is_member_call_chain<'a>(
+    expression: &AstNode<'a, CallExpression<'a>>,
+    f: &Formatter<'_, 'a>,
+) -> bool {
+    MemberChain::from_call_expression(expression, f).tail.is_member_call_chain(f)
+}
+
+fn has_short_name(name: &Atom, tab_width: u8) -> bool {
+    name.as_str().len() <= tab_width as usize
+}
+
+struct ChainMembersIterator<'a, 'b> {
+    root: Option<&'b AstNode<'a, CallExpression<'a>>>,
+    next: Option<&'b AstNode<'a, Expression<'a>>>,
+}
+
+impl<'a, 'b> ChainMembersIterator<'a, 'b> {
+    fn new(root: &'b AstNode<'a, CallExpression<'a>>) -> Self {
+        Self { root: Some(root), next: None }
+    }
+}
+
+impl<'a, 'b> Iterator for ChainMembersIterator<'a, 'b> {
+    type Item = ChainMember<'a, 'b>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut handle_call_expression =
+            |root: bool,
+             expr: &'b AstNode<'a, CallExpression<'a>>,
+             next: &mut Option<&'b AstNode<'a, Expression<'a>>>| {
+                let callee = expr.callee();
+
+                let is_chain = matches!(
+                    callee.as_ref(),
+                    Expression::StaticMemberExpression(_)
+                        | Expression::ComputedMemberExpression(_)
+                        | Expression::CallExpression(_)
+                );
+
+                if is_chain {
+                    *next = Some(callee);
+                }
+
+                let position = if root {
+                    CallExpressionPosition::End
+                } else if !is_chain {
+                    CallExpressionPosition::Start
+                } else {
+                    CallExpressionPosition::Middle
+                };
+
+                ChainMember::CallExpression { expression: expr, position }
+            };
+
+        if let Some(root) = self.root.take() {
+            return Some(handle_call_expression(true, root, &mut self.next));
+        }
+
+        let expression = self.next.take()?;
+
+        let member = match expression.as_ast_nodes() {
+            AstNodes::CallExpression(expr) => handle_call_expression(false, expr, &mut self.next),
+            AstNodes::StaticMemberExpression(expr) => {
+                self.next = Some(expr.object());
+                ChainMember::StaticMember(expr)
+            }
+            AstNodes::ComputedMemberExpression(expr) => {
+                self.next = Some(expr.object());
+                ChainMember::ComputedMember(expr)
+            }
+            AstNodes::TSNonNullExpression(expr) => {
+                self.next = Some(expr.expression());
+                ChainMember::TSNonNullExpression(expr)
+            }
+            _ => ChainMember::Node(expression),
+        };
+
+        Some(member)
+    }
+}
+
+impl std::iter::FusedIterator for ChainMembersIterator<'_, '_> {}

--- a/crates/oxc_formatter/src/write/mod.rs
+++ b/crates/oxc_formatter/src/write/mod.rs
@@ -43,7 +43,7 @@ use crate::{
     parentheses::NeedsParentheses,
     utils::{
         assignment_like::AssignmentLike, call_expression::is_test_call_expression,
-        write_arguments_multi_line,
+        member_chain::MemberChain, write_arguments_multi_line,
     },
     write,
     write::parameter_list::{can_avoid_parentheses, should_hug_function_parameters},
@@ -343,8 +343,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, CallExpression<'a>> {
             )
         }) && !callee.needs_parentheses(f)
         {
-            // TODO
-            write!(f, [callee, optional.then_some("?."), type_arguments, arguments])
+            MemberChain::from_call_expression(self, f).fmt(f)
         } else {
             let format_inner = format_with(|f| {
                 write!(f, [callee, optional.then_some("?."), type_arguments, arguments])

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 421/699 (60.23%)
+js compatibility: 438/699 (62.66%)
 
 # Failed
 
@@ -29,6 +29,8 @@ js compatibility: 421/699 (60.23%)
 | js/chain-expression/issue-15785-1.js | 💥 | 78.26% |
 | js/chain-expression/issue-15785-2.js | 💥 | 66.67% |
 | js/chain-expression/issue-15785-3.js | 💥 | 50.00% |
+| js/chain-expression/issue-15912.js | 💥 | 0.00% |
+| js/chain-expression/issue-15916.js | 💥 | 47.06% |
 | js/chain-expression/member-expression.js | 💥 | 45.83% |
 | js/chain-expression/test-3.js | 💥 | 75.00% |
 | js/chain-expression/test.js | 💥 | 25.00% |
@@ -57,7 +59,7 @@ js compatibility: 421/699 (60.23%)
 | js/comments/function-declaration.js | 💥💥 | 68.29% |
 | js/comments/if.js | 💥💥 | 38.16% |
 | js/comments/issue-3532.js | 💥💥 | 80.82% |
-| js/comments/issues.js | 💥💥 | 74.63% |
+| js/comments/issues.js | 💥💥 | 91.18% |
 | js/comments/jsdoc-nestled-dangling.js | 💥💥 | 93.02% |
 | js/comments/jsdoc-nestled.js | 💥💥 | 89.29% |
 | js/comments/jsdoc.js | 💥💥 | 47.83% |
@@ -90,8 +92,8 @@ js compatibility: 421/699 (60.23%)
 | js/comments-closure-typecast/superclass.js | 💥 | 0.00% |
 | js/comments-closure-typecast/ways-to-specify-type.js | 💥 | 15.38% |
 | js/conditional/comments.js | 💥💥 | 42.55% |
-| js/conditional/new-ternary-examples.js | 💥💥 | 23.60% |
-| js/conditional/new-ternary-spec.js | 💥💥 | 44.15% |
+| js/conditional/new-ternary-examples.js | 💥💥 | 23.20% |
+| js/conditional/new-ternary-spec.js | 💥💥 | 42.76% |
 | js/conditional/postfix-ternary-regressions.js | 💥💥 | 39.92% |
 | js/decorators/classes.js | 💥 | 66.67% |
 | js/decorators/comments.js | 💥 | 71.19% |
@@ -122,10 +124,7 @@ js compatibility: 421/699 (60.23%)
 | js/for/in.js | 💥 | 50.00% |
 | js/for/parentheses.js | 💥 | 72.00% |
 | js/for-of/async-identifier.js | 💥 | 90.00% |
-| js/functional-composition/functional_compose.js | 💥 | 93.20% |
-| js/functional-composition/pipe-function-calls-with-comments.js | 💥 | 77.08% |
-| js/functional-composition/pipe-function-calls.js | 💥 | 61.11% |
-| js/functional-composition/rxjs_pipe.js | 💥 | 45.45% |
+| js/functional-composition/ramda_compose.js | 💥 | 92.47% |
 | js/identifier/for-of/await.js | 💥 | 33.33% |
 | js/identifier/for-of/let.js | 💥 | 61.54% |
 | js/identifier/parentheses/let.js | 💥💥 | 79.55% |
@@ -141,7 +140,6 @@ js compatibility: 421/699 (60.23%)
 | js/import-attributes/keyword-detect.js | 💥 | 28.57% |
 | js/import-attributes/long-sources.js | 💥 | 48.48% |
 | js/label/comment.js | 💥 | 53.33% |
-| js/last-argument-expansion/arrow.js | 💥 | 11.43% |
 | js/last-argument-expansion/break-parent.js | 💥 | 57.14% |
 | js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 22.22% |
 | js/last-argument-expansion/edge_case.js | 💥 | 83.97% |
@@ -150,28 +148,13 @@ js compatibility: 421/699 (60.23%)
 | js/line-suffix-boundary/boundary.js | 💥 | 30.43% |
 | js/logical_expressions/issue-7024.js | 💥 | 66.67% |
 | js/member/conditional.js | 💥 | 0.00% |
-| js/member/expand.js | 💥 | 57.14% |
 | js/method-chain/bracket_0-1.js | 💥 | 0.00% |
 | js/method-chain/break-last-member.js | 💥 | 80.56% |
-| js/method-chain/comment.js | 💥 | 35.09% |
-| js/method-chain/computed-merge.js | 💥 | 41.38% |
-| js/method-chain/computed.js | 💥 | 0.00% |
+| js/method-chain/comment.js | 💥 | 78.33% |
 | js/method-chain/conditional.js | 💥 | 43.14% |
-| js/method-chain/d3.js | 💥 | 40.00% |
-| js/method-chain/first_long.js | 💥 | 89.23% |
-| js/method-chain/fluent-configuration.js | 💥 | 37.50% |
-| js/method-chain/inline_merge.js | 💥 | 80.00% |
-| js/method-chain/issue-11298.js | 💥 | 20.00% |
-| js/method-chain/issue-3594.js | 💥 | 50.00% |
-| js/method-chain/issue-4125.js | 💥 | 60.39% |
-| js/method-chain/logical.js | 💥 | 76.00% |
-| js/method-chain/multiple-members.js | 💥 | 45.65% |
-| js/method-chain/object-literal.js | 💥 | 7.69% |
+| js/method-chain/first_long.js | 💥 | 96.97% |
 | js/method-chain/pr-7889.js | 💥 | 33.33% |
-| js/method-chain/short-names.js | 💥 | 0.00% |
-| js/method-chain/square_0.js | 💥 | 13.33% |
-| js/method-chain/test.js | 💥 | 54.55% |
-| js/method-chain/this.js | 💥 | 0.00% |
+| js/method-chain/square_0.js | 💥 | 53.33% |
 | js/new-expression/new_expression.js | 💥 | 55.56% |
 | js/no-semi/class.js | 💥✨ | 46.55% |
 | js/no-semi/comments.js | 💥✨ | 36.36% |
@@ -186,8 +169,8 @@ js compatibility: 421/699 (60.23%)
 | js/object-property-ignore/issue-5678.js | 💥💥💥 | 52.50% |
 | js/objects/right-break.js | 💥 | 70.27% |
 | js/optional-chaining/chaining.js | 💥 | 59.77% |
-| js/optional-chaining/comments.js | 💥 | 16.90% |
-| js/preserve-line/member-chain.js | 💥 | 23.30% |
+| js/optional-chaining/comments.js | 💥 | 84.78% |
+| js/preserve-line/member-chain.js | 💥 | 92.19% |
 | js/quote-props/classes.js | 💥💥✨✨ | 47.06% |
 | js/quote-props/objects.js | 💥💥✨✨ | 45.10% |
 | js/quote-props/with_numbers.js | 💥💥✨✨ | 46.43% |
@@ -195,7 +178,7 @@ js compatibility: 421/699 (60.23%)
 | js/require/require.js | 💥 | 90.67% |
 | js/rest/trailing-commas.js | 💥 | 95.08% |
 | js/return/binaryish.js | 💥 | 90.91% |
-| js/return/comment.js | 💥 | 63.01% |
+| js/return/comment.js | 💥 | 60.53% |
 | js/sequence-break/break.js | 💥 | 46.85% |
 | js/sequence-expression/ignore.js | 💥 | 42.86% |
 | js/strings/escaped.js | 💥💥 | 73.68% |
@@ -208,13 +191,13 @@ js compatibility: 421/699 (60.23%)
 | js/template-align/indent.js | 💥💥 | 14.47% |
 | js/template-literals/binary-exporessions.js | 💥 | 0.00% |
 | js/template-literals/conditional-expressions.js | 💥 | 0.00% |
-| js/template-literals/expressions.js | 💥 | 84.80% |
+| js/template-literals/expressions.js | 💥 | 89.60% |
 | js/template-literals/indention.js | 💥 | 51.16% |
 | js/template-literals/logical-expressions.js | 💥 | 0.00% |
 | js/template-literals/sequence-expressions.js | 💥 | 0.00% |
 | js/ternaries/binary.js | 💥💥💥💥💥💥💥💥 | 39.12% |
 | js/ternaries/func-call.js | 💥💥💥💥💥💥💥💥 | 50.35% |
-| js/ternaries/indent-after-paren.js | 💥💥💥💥💥💥💥💥 | 37.67% |
+| js/ternaries/indent-after-paren.js | 💥💥💥💥💥💥💥💥 | 38.00% |
 | js/ternaries/indent.js | 💥💥💥💥💥💥💥💥 | 3.97% |
 | js/ternaries/nested-in-condition.js | 💥💥💥💥💥💥💥💥 | 18.37% |
 | js/ternaries/nested.js | 💥💥💥💥💥💥💥💥 | 22.56% |
@@ -223,11 +206,11 @@ js compatibility: 421/699 (60.23%)
 | js/ternaries/parenthesis/await-expression.js | 💥💥 | 0.00% |
 | js/test-declarations/angularjs_inject.js | 💥💥 | 91.53% |
 | js/test-declarations/jest-each-template-string.js | 💥💥 | 27.78% |
-| js/test-declarations/jest-each.js | 💥💥 | 64.66% |
+| js/test-declarations/jest-each.js | 💥💥 | 67.65% |
 | js/test-declarations/optional.js | 💥💥 | 0.00% |
 | js/test-declarations/test_declarations.js | 💥💥 | 75.81% |
 | js/throw_statement/binaryish.js | 💥 | 25.00% |
-| js/throw_statement/comment.js | 💥 | 43.24% |
+| js/throw_statement/comment.js | 💥 | 40.00% |
 | js/trailing-comma/dynamic-import.js | 💥💥💥 | 0.00% |
 | js/trailing-comma/jsx.js | 💥💥💥 | 0.00% |
 | js/try/catch.js | 💥 | 52.63% |
@@ -249,12 +232,12 @@ js compatibility: 421/699 (60.23%)
 | jsx/fbt/test.js | 💥 | 44.00% |
 | jsx/fragment/fragment.js | 💥 | 78.57% |
 | jsx/ignore/jsx_ignore.js | 💥 | 67.31% |
-| jsx/jsx/array-iter.js | 💥💥💥💥 | 24.53% |
+| jsx/jsx/array-iter.js | 💥💥💥💥 | 23.64% |
 | jsx/jsx/arrow.js | 💥💥💥💥 | 32.26% |
 | jsx/jsx/attr-comments.js | 💥💥💥💥 | 0.00% |
 | jsx/jsx/await.js | 💥💥💥💥 | 15.00% |
 | jsx/jsx/conditional-expression.js | 💥💥💥💥 | 64.10% |
-| jsx/jsx/expression.js | 💥💥💥💥 | 35.78% |
+| jsx/jsx/expression.js | 💥💥💥💥 | 36.36% |
 | jsx/jsx/flow_fix_me.js | 💥💥💥💥 | 0.00% |
 | jsx/jsx/html_escape.js | 💥💥✨✨ | 16.67% |
 | jsx/jsx/hug.js | 💥💥💥💥 | 29.03% |

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 243/573 (42.41%)
+ts compatibility: 247/573 (43.11%)
 
 # Failed
 
@@ -17,12 +17,12 @@ ts compatibility: 243/573 (42.41%)
 | jsx/fbt/test.js | 💥 | 44.00% |
 | jsx/fragment/fragment.js | 💥 | 78.57% |
 | jsx/ignore/jsx_ignore.js | 💥 | 67.31% |
-| jsx/jsx/array-iter.js | 💥💥💥💥 | 24.53% |
+| jsx/jsx/array-iter.js | 💥💥💥💥 | 23.64% |
 | jsx/jsx/arrow.js | 💥💥💥💥 | 32.26% |
 | jsx/jsx/attr-comments.js | 💥💥💥💥 | 0.00% |
 | jsx/jsx/await.js | 💥💥💥💥 | 15.00% |
 | jsx/jsx/conditional-expression.js | 💥💥💥💥 | 64.10% |
-| jsx/jsx/expression.js | 💥💥💥💥 | 35.78% |
+| jsx/jsx/expression.js | 💥💥💥💥 | 36.36% |
 | jsx/jsx/flow_fix_me.js | 💥💥💥💥 | 0.00% |
 | jsx/jsx/html_escape.js | 💥💥✨✨ | 16.67% |
 | jsx/jsx/hug.js | 💥💥💥💥 | 29.03% |
@@ -177,7 +177,6 @@ ts compatibility: 243/573 (42.41%)
 | typescript/custom/typeParameters/callAndConstructSignatureLong.ts | 💥 | 18.18% |
 | typescript/custom/typeParameters/functionTypeLong.ts | 💥 | 50.00% |
 | typescript/custom/typeParameters/typeParametersLong.ts | 💥 | 0.00% |
-| typescript/custom/typeParameters/variables.ts | 💥 | 91.80% |
 | typescript/declare/declare_class_fields.ts | 💥 | 91.67% |
 | typescript/declare/declare_enum.ts | 💥 | 0.00% |
 | typescript/declare/declare_function.ts | 💥 | 44.44% |
@@ -207,8 +206,6 @@ ts compatibility: 243/573 (42.41%)
 | typescript/function-type/consistent.ts | 💥 | 70.83% |
 | typescript/function-type/single-parameter.ts | 💥 | 50.00% |
 | typescript/function-type/type-annotation.ts | 💥 | 0.00% |
-| typescript/functional-composition/pipe-function-calls-with-comments.ts | 💥 | 77.08% |
-| typescript/functional-composition/pipe-function-calls.ts | 💥 | 41.67% |
 | typescript/generic/arrow-return-type.ts | 💥 | 80.77% |
 | typescript/generic/issue-6899.ts | 💥 | 21.05% |
 | typescript/generic/object-method.ts | 💥 | 72.73% |
@@ -246,7 +243,6 @@ ts compatibility: 243/573 (42.41%)
 | typescript/method/method-signature.ts | 💥 | 93.75% |
 | typescript/method/semi.ts | 💥 | 42.86% |
 | typescript/method/type_literal_optional_method.ts | 💥 | 0.00% |
-| typescript/method-chain/comment.ts | 💥 | 0.00% |
 | typescript/module/global.ts | 💥 | 75.00% |
 | typescript/module/namespace_function.ts | 💥 | 66.67% |
 | typescript/multiparser-css/issue-6259.ts | 💥 | 57.14% |
@@ -291,7 +287,7 @@ ts compatibility: 243/573 (42.41%)
 | typescript/template-literal-types/template-literal-types.ts | 💥 | 73.33% |
 | typescript/template-literals/as-expression.ts | 💥 | 14.29% |
 | typescript/template-literals/expressions.ts | 💥 | 0.00% |
-| typescript/ternaries/indent.ts | 💥 | 21.28% |
+| typescript/ternaries/indent.ts | 💥 | 29.79% |
 | typescript/test-declarations/test_declarations.ts | 💥💥 | 66.67% |
 | typescript/trailing-comma/arrow-functions.tsx | 💥💥💥 | 25.00% |
 | typescript/trailing-comma/trailing.ts | 💥💥💥 | 76.77% |
@@ -315,7 +311,7 @@ ts compatibility: 243/573 (42.41%)
 | typescript/type-arguments-bit-shift-left-like/4.ts | 💥 | 0.00% |
 | typescript/type-arguments-bit-shift-left-like/5.tsx | 💥 | 0.00% |
 | typescript/typeof/typeof.ts | 💥 | 25.00% |
-| typescript/typeparams/class-method.ts | 💥 | 82.32% |
+| typescript/typeparams/class-method.ts | 💥 | 84.18% |
 | typescript/typeparams/const.ts | 💥 | 86.15% |
 | typescript/typeparams/line-breaking-after-extends-2.ts | 💥 | 21.74% |
 | typescript/typeparams/line-breaking-after-extends.ts | 💥 | 17.14% |


### PR DESCRIPTION
Support printing `MemberChain`, which is a nested combination of any CallExpression + any node + MemberExpression.