### PR TITLE
test(coverage/typescript): Update `2000-2330` error codes handling

### DIFF
--- a/tasks/coverage/snapshots/codegen_typescript.snap
+++ b/tasks/coverage/snapshots/codegen_typescript.snap
@@ -1,5 +1,5 @@
 commit: 81c95189
 
 codegen_typescript Summary:
-AST Parsed     : 6989/6989 (100.00%)
-Positive Passed: 6989/6989 (100.00%)
+AST Parsed     : 7894/7894 (100.00%)
+Positive Passed: 7894/7894 (100.00%)

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -1,8 +1,8 @@
 commit: 81c95189
 
 estree_typescript Summary:
-AST Parsed     : 6933/6933 (100.00%)
-Positive Passed: 6930/6933 (99.96%)
+AST Parsed     : 7834/7834 (100.00%)
+Positive Passed: 7831/7834 (99.96%)
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuite.tsx
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitEntities.tsx

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -1,9 +1,9 @@
 commit: 81c95189
 
 parser_typescript Summary:
-AST Parsed     : 6987/6989 (99.97%)
-Positive Passed: 6975/6989 (99.80%)
-Negative Passed: 1419/5307 (26.74%)
+AST Parsed     : 7892/7894 (99.97%)
+Positive Passed: 7878/7894 (99.80%)
+Negative Passed: 1415/4400 (32.16%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment8.ts
@@ -24,23 +24,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/abstractProp
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/accessInstanceMemberFromStaticMethod01.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/accessStaticMemberFromInstanceMethod01.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/accessorDeclarationEmitVisibilityErrors.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/accessorInferredReturnTypeErrorInReturnStatement.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/accessorsInAmbientContext.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/accessors_spec_section-4.5_error-cases.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/addMoreOverloadsToBaseSignature.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/aliasAssignments.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/aliasBug.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/aliasDoesNotDuplicateSignatures.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/aliasInstantiationExpressionGenericIntersectionNoCrash1.ts
 
@@ -50,23 +40,17 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/aliasOnMerge
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInOrExpression.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/aliasWithInterfaceExportAssignmentUsedInVarInitializer.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/aliasesInSystemModule1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/aliasesInSystemModule2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/allowImportClausesToMergeWithTypes.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/allowJscheckJsTypeParameterNoCrash.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports10.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports8.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ambientEnum1.ts
 
@@ -84,13 +68,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ambientGette
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ambientStatement1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ambiguousOverload.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/amdDependencyComment1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/amdDependencyComment2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/amdDependencyCommentName1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/amdDependencyCommentName2.ts
 
@@ -105,10 +83,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/anonymousCla
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/anyIdenticalToItself.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/anyIndexedAccessArrayNoException.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/arguments.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/argumentsBindsToFunctionScopeArgumentList.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/argumentsObjectIterator01_ES5.ts
 
@@ -140,31 +114,15 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/arrayAssignm
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest4.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest5.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/arrayCast.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/arrayDestructuringInSwitch2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/arrayFrom.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/arrayIndexWithArrayFails.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralAndArrayConstructorEquivalence1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralTypeInference.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/arrayOfSubtypeIsAssignableToReadonlyArray.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/arrayReferenceWithoutTypeArgs.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/arrayToLocaleStringES5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/arrowExpressionBodyJSDoc.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionInConstructorArgument1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/asiPublicPrivateProtected.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignLambdaToNominalSubtypeOfFunction.ts
 
@@ -172,13 +130,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignToEnum
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignToExistingClass.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignToFn.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignToModule.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assigningFromObjectToAnythingElse.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assigningFunctionToTupleIssuesError.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompat1.ts
 
@@ -190,93 +144,17 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCo
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatInterfaceWithStringIndexSignature.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatWithOverloads.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability11.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability12.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability13.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability14.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability15.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability16.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability17.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability18.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability19.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability20.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability21.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability22.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability23.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability24.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability25.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability26.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability27.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability28.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability29.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability30.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability31.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability32.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability33.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability34.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability35.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability37.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability38.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability39.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability40.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability41.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability42.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability43.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability44.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability45.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability46.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability_checking-apply-member-off-of-function-interface.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability_checking-call-member-off-of-function-interface.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentIndexedToPrimitives.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentRestElementWithErrorSourceType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentStricterConstraints.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentToAnyArrayRestParameters.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentToFunction.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentToObject.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentToObjectAndFunction.ts
 
@@ -312,8 +190,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/autolift3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/autolift4.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/avoidListingPropertiesForTypesWithOnlyCallOrConstructSignatures.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/awaitCallExpressionInSyncFunction.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/awaitedType.ts
@@ -331,8 +207,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/baseClassImp
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/baseConstraintOfDecorator.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/baseExpressionTypeParameters.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/baseTypePrivateMemberClash.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/bestCommonTypeWithContextualTyping.ts
 
@@ -356,8 +230,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/binaryArithm
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/binaryArithmatic4.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/bind1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/bindingPatternCannotBeOnlyInferenceSource.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/bitwiseCompoundAssignmentOperators.ts
@@ -378,8 +250,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/blockScopedF
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/blockScopedFunctionDeclarationStrictES5.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/blockScopedFunctionDeclarationStrictES6.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/blockScopedSameNameFunctionDeclarationES5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/blockScopedSameNameFunctionDeclarationES6.ts
@@ -392,29 +262,15 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/blockScopedV
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/bluebirdStaticThis.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/booleanAssignment.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/booleanLiteralsContextuallyTypedFromUnion.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/breakInIterationOrSwitchStatement4.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/builtinIterator.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution7.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution8.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution9.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/callConstructAssignment.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/callOnClass.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/callOnInstance.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/callOverloadViaElementAccessExpression.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/callOverloads1.ts
 
@@ -429,8 +285,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/callOverload
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/callSignaturesShouldBeResolvedBeforeSpecialization.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/callWithWrongNumberOfTypeArguments.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/callbackArgsDifferByOptionality.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/cannotIndexGenericWritingError.ts
 
@@ -466,8 +320,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/chainedAssig
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/chainedCallsWithTypeParameterConstrainedToOtherTypeParameter.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/chainedCallsWithTypeParameterConstrainedToOtherTypeParameter2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkDestructuringShorthandAssigment.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkDestructuringShorthandAssigment2.ts
@@ -476,27 +328,15 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkForObje
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkIndexConstraintOfJavascriptClassExpression.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkJsFiles.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkJsFiles2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkJsFiles3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkJsFiles4.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkJsFiles6.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkJsFiles_skipDiagnostics.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkJsObjectLiteralHasCheckedKeyof.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkJsdocTypeTagOnExportAssignment1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkJsdocTypeTagOnExportAssignment2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkJsdocTypeTagOnExportAssignment3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkJsdocTypeTagOnExportAssignment4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkJsdocTypeTagOnExportAssignment6.ts
 
@@ -520,25 +360,15 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkingObje
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/circularAccessorAnnotations.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/circularBaseConstraint.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/circularBaseTypes.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/circularConstraintYieldsAppropriateError.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/circularInlineMappedGenericTupleTypeNoCrash.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/circularModuleImports.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/circularOptionalityRemoval.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/circularResolvedSignature.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/circularlyConstrainedMappedTypeContainingConditionalNoInfiniteInstantiationDepth.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classDeclarationShouldBeOutOfScopeInComputedNames.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classExpressionAssignment.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classExpressionExtendingAbstractClass.ts
 
@@ -594,14 +424,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classIndexer
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classInheritence.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerScoping.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classMergedWithInterfaceMultipleBasesNoError.ts
@@ -612,19 +434,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classOverloa
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classOverloadForFunction2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classPropertyErrorOnNameOnly.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classSideInheritance1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classSideInheritance2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classSideInheritance3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classStaticInitializersUsePropertiesBeforeDeclaration.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classStaticPropertyAccess.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classTypeParametersInStatics.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classUsedBeforeInitializedVariables.ts
 
@@ -643,8 +459,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/cloduleWithD
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/cloduleWithPriorInstantiatedModule.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/clodulesDerivedClasses.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences6.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/collisionArgumentsArrowFunctions.ts
 
@@ -672,14 +486,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/commaOperato
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/commentOnImportStatement1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/commentOnImportStatement2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/commentOnImportStatement3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/commentsOnObjectLiteral1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/commentsOnObjectLiteral2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/compareTypeParameterConstrainedByLiteralToLiteral.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/complexClassRelationships.ts
@@ -687,8 +493,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/complexClass
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/complexRecursiveCollections.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/complicatedGenericRecursiveBaseClassReference.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/complicatedIndexedAccessKeyofReliesOnKeyofNeverUpperBound.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesInDestructuring1.ts
 
@@ -700,51 +504,15 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/computedProp
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/concatClassAndString.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conditionalAnyCheckTypePicksBothBranches.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conditionalDoesntLeakUninstantiatedTypeParameter.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conditionalEqualityOnLiteralObjects.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conditionalExpression1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine10.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine7.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine8.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine9.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conditionalReturnExpression.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeAssignabilityWhenDeferred.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeDoesntSpinForever.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeVarianceBigArrayConstraintsPerformance.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/configFileExtendsAsList.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conflictingDeclarationsImportFromNamespace1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conflictingDeclarationsImportFromNamespace2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conflictingMemberTypesInBases.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conflictingTypeParameterSymbolTransfer.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/consistentAliasVsNonAliasRecordBehavior.ts
 
@@ -770,13 +538,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constWithNon
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constantEnumAssert.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constraintErrors1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constraintWithIndexedAccess.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constraints0.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constructorAsType.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constructorInvocationWithTooFewTypeArgs.ts
 
@@ -788,29 +552,17 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constructorO
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads7.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constructorParametersInVariableDeclarations.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constructorParametersThatShadowExternalNamesInVariableDeclarations.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constructorReturnsInvalidType.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constructorsWithSpecializedSignatures.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualPropertyOfGenericFilteringMappedType.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstatiationContravariance.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTupleTypeParameterReadonly.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypeAny.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypeBasedOnIntersectionWithAnyInTheMix4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypeForInitalizedVariablesFiltersUndefined.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypeFunctionObjectPropertyIntersection.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypesNegatedTypeLikeConstraintInGenericMappedType2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTyping.ts
 
@@ -824,14 +576,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTy
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTyping20.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTyping21.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTyping24.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTyping30.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTyping33.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTyping39.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTyping4.ts
@@ -841,12 +585,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTy
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTyping5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTyping9.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypingArrayDestructuringWithDefaults.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfArrayLiterals1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfConditionalExpression2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfGenericFunctionTypedArguments1.ts
 
@@ -864,10 +602,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextually
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingOrOperator2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingRestParameters.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/continueInIterationStatement4.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/continueNotInIterationStatement4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowAliasedDiscriminants.ts
@@ -875,10 +609,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowA
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowArrayErrors.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowDestructuringVariablesInTryCatch.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowForIndexSignatures.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowForStatementContinueIntoIncrementor1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowLoopAnalysis.ts
 
@@ -898,11 +628,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/crashInEmitT
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/crashInYieldStarInAsyncFunction.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/crashInsourcePropertyIsRelatableToTargetProperty.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/crashIntypeCheckInvocationExpression.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/crashIntypeCheckObjectCreationExpression.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/crashRegressionTest.ts
 
@@ -918,8 +644,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationE
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitCommonJsModuleReferencedType.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedPropertyNameEnum2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedPropertyNameEnum3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringArrayPattern2.ts
@@ -931,10 +655,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationE
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringParameterProperties.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringWithOptionalBindingParameters.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends7.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionWithNonlocalPrivateUniqueSymbol.ts
 
@@ -952,10 +672,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationE
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias7.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitLambdaWithMissingTypeParameterNoCrash.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMappedPrivateTypeTypeParameter.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitObjectAssignedDefaultExport.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrivateSymbolCausesVarDeclarationEmit2.ts
@@ -963,8 +679,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationE
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitReexportedSymlinkReference3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitRelativeModuleError.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasTypeParameterExtendingUnknownSymbol.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitUnknownImport.ts
 
@@ -976,15 +690,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declareClass
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declareModifierOnImport1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataGenericTypeVariable.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataGenericTypeVariableDefault.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataGenericTypeVariableInScope.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataNoLibIsolatedModulesTypes.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataTypeOnlyImport.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataWithImportDeclarationNameCollision4.ts
 
@@ -996,29 +702,19 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/decoratorsOn
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/deduplicateImportsInSystem.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/deepComparisons.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/deepElaborationsIntoArrowExpressions.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/deepExcessPropertyCheckingWhenTargetIsIntersection.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/deepKeysIndexing.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedAssignabilityErrorsCombined.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedAssignabilityIssue.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedCheck.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/defaultArgsInFunctionExpressions.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/defaultArgsInOverloads.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/defaultBestCommonTypesHaveDecls.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/defaultIsNotVisibleInLocalScope.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/defaultValueInConstructorOverload1.ts
 
@@ -1048,8 +744,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/destructureC
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/destructuredLateBoundNameHasCorrectTypes.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/destructuringAssignmentWithDefault2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/destructuringAssignmentWithExportedName.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/destructuringAssignment_private.ts
@@ -1078,31 +772,15 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/discriminate
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/dissallowSymbolAsWeakType.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/distributiveConditionalTypeConstraints.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes5.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes6.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes8.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsVisibility1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/doNotElaborateAssignabilityToTypeParameters.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2023.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/doubleUnderStringLiteralAssignability.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreExportStarConflict.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst12.ts
 
@@ -1174,15 +852,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/duplicateVar
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/duplicateVarsAcrossFileBoundaries.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/dynamicImportInDefaultExportExpression.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/dynamicImportTrailingComma.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/dynamicNamesErrors.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/elaboratedErrors.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/elaboratedErrorsOnNullableTargets01.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/elaborationForPossiblyCallableTypeStillReferencesArgumentAtTopLevel.ts
 
@@ -1196,12 +870,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/emitDecorato
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/emptyGenericParamList.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/emptyModuleName.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/emptyObjectNotSubtypeOfIndexSignatureContainingObject1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/emptyObjectNotSubtypeOfIndexSignatureContainingObject2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/emptyThenWarning.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/emptyTypeArgumentList.ts
@@ -1209,16 +877,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/emptyTypeArg
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/emptyTypeArgumentListWithNew.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ensureNoCrashExportAssignmentDefineProperrtyPotentialMerge.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat6.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat7.ts
 
@@ -1228,8 +886,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/enumBasics2.
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/enumBasics3.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/enumLiteralAssignableToEnumInsideUnion.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/enumPropertyAccess.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/enumPropertyAccessBeforeInitalisation.ts
@@ -1237,8 +893,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/enumProperty
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/enumUsedBeforeDeclaration.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/enumWithComputedMember.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/enumWithExport.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/enumsWithMultipleDeclarations1.ts
 
@@ -1250,8 +904,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/erasableSynt
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorCause.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorElaborationDivesIntoApparentlyPresentPropsOnly.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorForBareSpecifierWithImplicitModuleResolutionNone.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorForConflictingExportEqualsValue.ts
@@ -1262,49 +914,23 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorForUsin
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorForwardReferenceForwadingConstructor.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorHandlingInInstanceOf.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorLocationForInterfaceExtension.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorMessageOnIntersectionsWithDiscriminants01.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorMessageOnObjectLiteralType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorMessagesIntersectionTypes01.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorMessagesIntersectionTypes02.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorMessagesIntersectionTypes03.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorMessagesIntersectionTypes04.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorOnContextuallyTypedReturnType.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorOnEnumReferenceInCondition.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorOnUnionVsObjectShouldDeeplyDisambiguate.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorOnUnionVsObjectShouldDeeplyDisambiguate2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorSupression1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorTypesAsTypeArguments.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorWithSameNameType.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorWithTruncatedType.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorsInGenericTypeReference.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorsOnImportedSymbol.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorsOnUnionsOfOverlappingObjects01.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorsWithInvokablesInUnions01.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es5-commonjs3.ts
 
@@ -1356,11 +982,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportEqu
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportEqualsExportModuleEs2015Error.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportNoExportMember.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportNoNamedExports.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es6MemberScoping.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleInternalNamedImports.ts
 
@@ -1368,13 +990,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es6ModuleInt
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropDefaultImports.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropImportDefaultWhenAllNamedAreDefaultAlias.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropPrettyErrorRelatedInformation.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropTslibHelpers.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropUsesExportStarWhenDefaultPlusNames.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/esmModeDeclarationFileWithExportAssignment.ts
 
@@ -1404,23 +1022,15 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/excessProper
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/excessPropertyErrorsSuppressed.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/excessiveStackDepthFlatArray.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/excessivelyLargeTupleSpread.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exhaustiveSwitchCheckCircularity.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionContextualTypesNoValue.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionNestedAssigments.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/experimentalDecoratorMetadataUnresolvedTypeObjectInEmit.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportAsNamespaceConflict.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportAsNamespace_augment.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentExpressionIsExpressionNode.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentImportMergeNoCrash.ts
 
@@ -1449,8 +1059,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportDefaul
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportDefaultInterfaceClassAndFunctionOverloads.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportDefaultInterfaceClassAndValue.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportDefaultMissingName.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportDefaultStripsFreshness.ts
 
@@ -1496,10 +1104,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/extendBaseCl
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/extendFromAny.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/extendGenericArray.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/extendGenericArray2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/extendGlobalThis2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/extendNonClassSymbol2.ts
@@ -1512,27 +1116,19 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/externSemant
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/externSyntax.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/externalModuleExportingGenericClass.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/externalModuleImmutableBindings.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/externalModuleRefernceResolutionOrderInImportDeclaration.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/extractInferenceImprovement.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/fakeInfinity1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/findLast.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/firstMatchRegExpMatchArray.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/fixTypeParameterInSignatureWithRestParameters.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/fixingTypeParametersRepeatedly2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/flatArrayNoExcessiveStackDepth.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/forIn2.ts
 
@@ -1626,15 +1222,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionOver
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionParameterArityMismatch.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionSignatureAssignmentCompat1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionToFunctionWithPropError.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionTypeArgumentArityErrors.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionTypeArgumentAssignmentCompat.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionVariableInReturnTypeAnnotation.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionsMissingReturnStatementsAndExpressionsStrictNullChecks.ts
 
@@ -1642,33 +1232,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/funduleSplit
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/fuzzy.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/generatorES6_5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/generatorReturnExpressionIsChecked.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericAndNonGenericInheritedSignature1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericAndNonGenericInheritedSignature2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericArgumentCallSigAssignmentCompat.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericArrayAssignment1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericArrayAssignmentCompatErrors.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericArrayExtenstions.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericArrayMethods1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericArrayWithoutTypeAnnotation.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericAssignmentCompatOfFunctionSignatures1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericAssignmentCompatWithInterfaces1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericCallSpecializedToTypeArg.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericCallWithObjectLiteralArguments1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericCallbackInvokedInsideItsContainingFunction1.ts
 
@@ -1676,25 +1246,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericChain
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericClassInheritsConstructorFromNonGenericClass.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericClassWithStaticsUsingTypeArguments.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericClassesRedeclaration.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericCloduleInModule2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericCloneReturnTypes.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericCloneReturnTypes2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericCombinators2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericConditionalConstrainedToUnknownNotAssignableToConcreteObject.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericConstraint1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericConstraint2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericConstraintSatisfaction1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericConstructInvocationWithNoTypeArg.ts
 
@@ -1703,12 +1261,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericConst
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericDefaults.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericDefaultsErrors.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericDerivedTypeWithSpecializedBase.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericDerivedTypeWithSpecializedBase2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericFunctionCallSignatureReturnTypeMismatch.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericFunctionInference1.ts
 
@@ -1720,43 +1272,21 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericFundu
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericFunduleInModule2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericGetter.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericGetter2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericGetter3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericImplements.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericIndexTypeHasSensibleErrorMessage.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericIndexedAccessVarianceComparisonResultCorrect.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericInterfacesWithoutTypeArguments.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericLambaArgWithoutTypeArguments.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericMappedTypeAsClause.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericMemberFunction.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericMergedDeclarationUsingTypeParameter.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericMergedDeclarationUsingTypeParameter2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericNewInterface.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericRecursiveImplicitConstructorErrors1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericRecursiveImplicitConstructorErrors3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericReduce.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericRestArgs.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericRestTypes.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericReturnTypeFromGetter1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericSignatureIdentity.ts
 
@@ -1778,12 +1308,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericTypeA
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericTypeConstraints.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericTypeReferencesRequireTypeArgs.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericTypeUsedWithoutTypeArguments1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericTypeUsedWithoutTypeArguments3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericTypeWithNonGenericBaseMisMatch.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericUnboundedTypeParamAssignability.ts
@@ -1796,17 +1320,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/generics1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/generics2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/generics4.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/generics5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericsWithDuplicateTypeParameters1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericsWithoutTypeParameters1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/getAndSetNotIdenticalType2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/getAndSetNotIdenticalType3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/getterControlFlowStrictNull.ts
 
@@ -1820,13 +1336,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/grammarAmbig
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/heterogeneousArrayAndOverloads.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/i3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/identityForSignaturesWithTypeParametersAndAny.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/identityForSignaturesWithTypeParametersSwitched.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ifElseWithStatements1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ignoredJsxAttributes.tsx
 
@@ -1906,33 +1418,21 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importNonExp
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember9.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importNotElidedWhenNotFound.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importTypeWithUnparenthesizedGenericFunctionParsed.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importUsedAsTypeWithErrors.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importWithTrailingSlash.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importWithTrailingSlash_noResolve.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importedEnumMemberMergedWithExportedAliasIsError.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importedModuleAddToGlobal.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inDoesNotOperateOnPrimitiveTypes.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inKeywordAndUnknown.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inOperator.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/incompatibleAssignmentOfIdenticallyNamedTypes.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/incompatibleExports1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/incompatibleExports2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/incompatibleGenericTypes.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/incompatibleTypes.ts
 
@@ -1943,10 +1443,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/incorrectRec
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/incrementOnTypeParameter.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/indexAt.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/indexIntoArraySubclass.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/indexSignatureAndMappedType.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/indexSignatureInOtherFile.ts
 
@@ -1960,21 +1456,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/indexWithUnd
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/indexWithUndefinedAndNullStrictNullChecks.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/indexWithoutParamType2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/indexedAccessConstraints.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/indexedAccessImplicitlyAny.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/indexedAccessRelation.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/indexedAccessWithFreshObjectLiteral.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/indexedAccessWithVariableElement.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/indexerConstraints.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/indirectDiscriminantAndExcessProperty.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/indirectSelfReference.ts
 
@@ -1982,15 +1470,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/indirectSelf
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inexistentPropertyInsideToStringType.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inferFromAnnotatedReturn1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inferFromGenericFunctionReturnTypes1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inferFromGenericFunctionReturnTypes3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inferFromNestedSameShapeTuple.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inferSetterParamType.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inferTypePredicates.ts
 
@@ -2000,19 +1482,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inferenceFro
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inferenceShouldFailOnEvolvingArrays.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithObjectLiteralProperties.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/infiniteConstraints.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inheritFromGenericTypeParameter.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inheritSameNamePrivatePropertiesFromDifferentOrigins.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inheritSameNamePropertiesWithDifferentOptionality.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inheritSameNamePropertiesWithDifferentVisibility.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inheritance.ts
 
@@ -2062,8 +1534,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/initializerW
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/innerAliases.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/innerTypeCheckOfLambdaArgument.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/instanceSubtypeCheck2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/instanceofOnInstantiationExpression.ts
@@ -2110,10 +1580,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/interfaceMem
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/interfaceNameAsIdentifier.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/interfacePropertiesWithSameName2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/interfacePropertiesWithSameName3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/interfaceWithMultipleDeclarations.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/interfacedeclWithIndexerErrors.ts
@@ -2142,8 +1608,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/intersection
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/intersectionWithConflictingPrivates.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/intersectionsAndOptionalProperties.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/intersectionsAndReadonlyProperties.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/intersectionsOfLargeUnions.ts
@@ -2158,11 +1622,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/invalidRefer
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/invalidStaticField.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/invalidSymbolInTypeParameter1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/invalidUseOfTypeAsNamespace.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/invariantGenericErrorElaboration.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/invocationExpressionInFunctionParameter.ts
 
@@ -2172,13 +1632,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/invokingNonG
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isLiteral1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorTypes1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsClasses.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationLazySymbols.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsAddUndefined2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesAmbientConstEnum.ts
 
@@ -2187,10 +1643,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedModu
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesExportImportUninstantiatedNamespace.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesGlobalNamespacesAndEnums.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesImportExportElision.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesNoEmitOnError.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesReExportType.ts
 
@@ -2206,13 +1658,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsExportMemb
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsExportMemberMergedWithModuleAugmentation2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsExtendsImplicitAny.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsFileClassPropertyType.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsFileClassPropertyType2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsFileClassPropertyType3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationBindDeepExportsAssignment.ts
 
@@ -2234,15 +1680,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsFileFuncti
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsFunctionWithPrototypeNoErrorTruncationNoCrash.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsPropertyAssignedAfterMethodDeclaration.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsdocArrayObjectPromiseNoImplicitAny.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsdocBracelessTypeTag1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsdocCallbackAndType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsdocClassMissingTypeArguments.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsdocFunctionTypeFalsePositive.ts
 
@@ -2258,21 +1696,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsdocPropert
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsdocReferenceGlobalTypeInCommonJs.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsdocResolveNameFailureInTypedef.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsdocRestParameter.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsdocTypeCast.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsdocTypeNongenericInstantiationAttempt.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxCallElaborationCheckNoCrash1.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxChildWrongType.tsx
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenArrayWrongType.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenIndividualErrorElaborations.tsx
 
@@ -2288,8 +1714,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxElementTy
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxElementTypeLiteralWithGeneric.tsx
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxEmptyExpressionNotCountedAsChild2.tsx
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxExcessPropsAndAssignability.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryIdentifierWithAbsentParameter.ts
@@ -2304,19 +1728,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryQu
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxFragmentFactoryReference.tsx
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxFragmentWrongType.tsx
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxImportSourceNonPragmaComment.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicDeclaredUsingTemplateLiteralTypeSignatures.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicElementsTypeArgumentErrors.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceElementChildrenAttributeIgnoredWhenReactJsx.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxNamespacePrefixIntrinsics.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxSpreadTag.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxViaImport.tsx
 
@@ -2335,8 +1753,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/lambdaPropSe
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/largeControlFlowGraph.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/lastPropertyInLiteralWins.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/lateBoundAssignmentCandidateJS3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/lateBoundDestructuringImplicitAnyError.ts
 
@@ -2360,49 +1776,23 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/letDeclarati
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-useBeforeDefinition2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/libTypeScriptOverrideSimple.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/libTypeScriptOverrideSimpleConfig.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/libTypeScriptSubfileResolving.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/libTypeScriptSubfileResolvingConfig.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/lift.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/limitDeepInstantiations.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/literalFreshnessPropagationOnNarrowing.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/literalTypeNameAssertionNotTriggered.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/literals-negative.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/logicalNotExpression1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypeAsStringTemplate.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypeGenericWithKnownKeys.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypeIndexedAccess.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypeIndexedAccessConstraint.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypeInferenceFromApparentType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypeNoTypeNoCrash.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypeNotMistakenlyHomomorphic.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypeRecursiveInference.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypeUnionConstrainTupleTreatedAsArrayLike.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypeWithAsClauseAndLateBoundProperty.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypeWithCombinedTypeMappers.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/matchReturnTypeInAllBranches.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/maxConstraints.ts
 
@@ -2430,11 +1820,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mergedClassW
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarationExports.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations7.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/metadataImportType.ts
 
@@ -2465,10 +1851,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/missingRequi
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/missingReturnStatement.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/missingReturnStatement1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/missingTypeArguments1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/missingTypeArguments2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mixedStaticAndInstanceClassMembers.ts
 
@@ -2516,8 +1898,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleAugmen
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationInDependency2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationWithNonExistentNamedImport.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleClassArrayCodeGenTest.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleCrashBug1.ts
@@ -2527,8 +1907,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleExport
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleImport.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleInTypePosition1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleMemberMissingErrorIsRelative.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleNewExportBug.ts
 
@@ -2540,17 +1918,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/modulePreser
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleProperty2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionAsTypeReferenceDirectiveScoped.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionNoTsCJS.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionNoTsESM.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_oneNotFound.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_threeLastIsBlank4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSymlinks_preserveSymlinks.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleVariableArrayIndexer.ts
 
@@ -2568,8 +1938,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/multiLineCon
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/multiLineErrors.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/multipleBaseInterfaesWithIncompatibleProperties.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/multipleClassPropertyModifiers.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/multipleExportAssignments.ts
@@ -2581,14 +1949,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/multipleExpo
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/multipleInheritance.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/multivar.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveCallbacks.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/namedFunctionExpressionCallErrors.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/namedImportNonExistentName.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/namespaceDisambiguationInUnion.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/namespaceMergedWithFunctionWithOverloadsUsage.ts
 
@@ -2604,19 +1964,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/narrowByClau
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue6.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue7.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/narrowByEquality.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/narrowingOfDottedNames.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/narrowingOfQualifiedNames.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/narrowingUnionToNeverAssigment.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/nativeToBoxedTypes.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/nestedCallbackErrorNotFlattened.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/nestedExcessPropertyChecking.ts
 
@@ -2640,17 +1992,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noCrashOnImp
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noCrashOnMixin.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noCrashOnNoLib.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noCrashOnParameterNamedRequire.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noCrashWithVerbatimModuleSyntaxAndImportsNotUsedAsValues.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noDefaultLib.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noEmitOnError.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noErrorTruncation.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noErrorUsingImportExportModuleAugmentationInDeclarationFile2.ts
 
@@ -2686,25 +2028,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noMappedGetS
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noRepeatedPropertyNames.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noStrictGenericChecks.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noSymbolForMergeCrash.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noTypeArgumentOnReturnType1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noUncheckedIndexedAccessCompoundAssignments.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/nodeNextImportModeImplicitIndexResolution.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/nodeNextImportModeImplicitIndexResolution2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/nodeNextModuleResolution1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDir.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDirDeclDir.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDirDeclDirNestedDirs.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/nonArrayRestArgs.ts
 
@@ -2728,19 +2056,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/nullableFunc
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/numberToString.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/numericIndexExpressions.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/numericIndexerTyping1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/numericIndexerTyping2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectCreate-errors.ts
 
@@ -2748,15 +2064,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectCreati
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectFreeze.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectFreezeLiteralsDontWiden.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectGroupBy.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectLitIndexerContextualType.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectLitStructuralTypeMismatch.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectLitTargetTypeCallSite.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectLiteralExcessProperties.ts
 
@@ -2770,15 +2080,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectLitera
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectLiteralMemberWithoutBlock1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectLiteralParameterResolution.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectLiteralReferencingInternalProperties.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectLiteralThisWidenedOnUse.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectLiteralWithNumericPropertyName.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectLiteralsAgainstUnionsOfArrays01.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/omitTypeHelperModifiers01.ts
 
@@ -2794,15 +2096,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/optionalArgs
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/optionalChainWithInstantiationExpression1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/optionalFunctionArgAssignability.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/optionalParamAssignmentCompat.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/optionalParamReferencingOtherParams2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/optionalParamReferencingOtherParams3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/optionalParamTypeComparison.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/optionalParameterInDestructuringWithInitializer.ts
 
@@ -2817,8 +2113,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/optionalProp
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/optionalSetterParam.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/overEagerReturnTypeSpecialization.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/overload1.ts
 
@@ -2839,8 +2133,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/overloadOnCo
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstantsInvalidOverload1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOnDefaultConstructor1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOverCTLambda.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionTest1.ts
 
@@ -2878,21 +2170,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/parseCommaSe
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/parseCommaSeparatedNewlineString.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/parseJsxExtends2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/parseTypes.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/partialDiscriminatedUnionMemberHasGoodError.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution_withExtension_failedLookup.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/potentiallyUncalledDecorators.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/predicateSemantics.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/prefixUnaryOperatorsOnExportedVariables.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/prettyFileWithErrorsAndTabs.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/primaryExpressionMods.ts
 
@@ -2922,12 +2204,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/privateNameW
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/privateVisibility.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/promiseChaining1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/promiseChaining2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/promiseEmptyTupleNoException.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/promiseIdentity.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/promiseIdentity2.ts
@@ -2943,8 +2219,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/promisePermu
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/promisePermutations2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/promisePermutations3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/promisesWithConstraints.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/propertiesAndIndexers.ts
 
@@ -2968,15 +2242,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/propertyAcce
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/propertyAccessibility2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/propertyAssignment.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/propertyIdentityWithPrivacyMismatch.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/propertyOrdering.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/propertyOrdering2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/propertyParameterWithQuestionMark.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/propertySignatures.ts
 
@@ -2985,8 +2255,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/protectedAcc
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/protectedMembers.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/protectedMembersThisParameter.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/protoAssignment.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/prototypes.ts
 
@@ -3007,8 +2275,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/quickInterse
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/quickinfoTypeAtReturnPositionsInaccurate.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/quotedModuleNameMustBeAmbient.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/raiseErrorOnParameterProperty.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reExportGlobalDeclaration1.ts
 
@@ -3062,55 +2328,19 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveCon
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalTypes.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType6.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveFunctionTypes.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveInheritance.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveInheritance3.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveInheritanceGeneric.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveLetConst.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveNamedLambdaCall.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveResolveTypeMembers.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveTupleTypeInference.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeComparison2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeParameterConstraintReferenceLacksTypeArgs.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursivelyExpandingUnionNoStackoverflow.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/redefineArray.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault7.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reexportedMissingAlias.ts
 
@@ -3126,11 +2356,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/renamingDest
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/renamingDestructuredPropertyInFunctionType3.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/requireOfAnEmptyFile1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileInJsFile.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileNonRelativeWithoutExtension.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithAmd.ts
 
@@ -3145,8 +2371,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/requireOfJso
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitNone.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithNoContent.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutExtension.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutResolveJsonModule.ts
 
@@ -3164,8 +2388,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reservedName
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/resolvingClassDeclarationWhenInBaseTypeResolution.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/restArgAssignmentCompat.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/restInvalidArgumentType.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/restParamsWithNonRestParams.ts
@@ -3176,19 +2398,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/returnInCons
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/returnTypeParameter.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/returnTypeTypeArguments.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/returnValueInSetter.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reuseTypeAnnotationImportTypeInGlobalThisTypeArgument.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeContextualTypeNotCircular.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeIntersectionConstraint.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeLimitedConstraint.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/satisfiesEmit.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/scopeCheckExtendedClassInsidePublicMethod2.ts
 
@@ -3202,10 +2416,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/scopeCheckSt
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/scopeTests.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/scopingInCatchBlocks.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/selfRef.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/selfReferencesInFunctionParameters.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/selfReferencingFile.ts
@@ -3213,8 +2423,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/selfReferenc
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/selfReferencingFile3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/semicolonsInModuleDeclarations.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/separate1-1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/setMethods.ts
 
@@ -3227,8 +2435,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/shorthand-pr
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/shorthand-property-es6-amd.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/shorthand-property-es6-es6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/shorthandPropertyAssignmentInES6Module.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/shorthandPropertyUndefined.ts
 
@@ -3248,29 +2454,21 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/signatureLen
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/simpleRecursionWithBaseCase1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/slightlyIndirectedDeepObjectLiteralElaborations.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/sourceMapSample.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationFor.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/specializedSignatureAsCallbackParameter1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionGlobal1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionGlobal2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionGlobal3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionGlobal4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionJSXAttribute.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionLeadingUnderscores01.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionModule.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/spliceTuples.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/spreadInvalidArgumentType.ts
 
@@ -3288,10 +2486,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticMember
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticMethodReferencingTypeArgument1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticMethodsReferencingClassTypeParameters.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticMismatchBecauseOfPrototype.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticMustPrecedePublic.ts
@@ -3308,15 +2502,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticVisibi
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/statics.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticsNotInScopeInClodule.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/strictFunctionTypesErrors.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/strictModeInConstructor.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/strictNullEmptyDestructuring.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/strictNullNotNullIndexTypeNoLib.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/strictOptionalProperties3.ts
 
@@ -3325,12 +2513,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/strictSubtyp
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/stringIndexerAndConstructor.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/stringIndexerAndConstructor1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/stringIndexerAssignments1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/stringIndexerAssignments2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/stringMappingAssignability.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/subclassThisTypeAssignable01.ts
 
@@ -3342,17 +2524,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/superAccess.
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/superCallArgsMustMatch.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/superCallAssignResult.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericTypeButWithIncorrectNumberOfTypeArguments1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericTypeButWithNoTypeArguments1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/superCallInsideClassDeclaration.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/superCallInsideClassExpression.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/superCallWithMissingBaseClass.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/superInConstructorParam1.ts
 
@@ -3396,13 +2570,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/systemModule
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/taggedTemplateWithoutDeclaredHelper.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/targetTypeBaseCalls.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/targetTypeTest1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/targetTypeTest3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/targetTypeVoidFunc.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/templateLiteralIntersection2.ts
 
@@ -3442,8 +2610,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/thisPredicat
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/thisShadowingErrorSpans.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/thisWhenTypeCheckFails.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/this_inside-enum-should-not-be-allowed.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/tooManyTypeParameters1.ts
@@ -3453,8 +2619,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/topFunctionT
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/topLevelLambda.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/topLevelLambda4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/trailingCommaInHeterogenousArrayLiteral1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/tripleSlashTypesReferenceWithMissingExports.ts
 
@@ -3470,27 +2634,19 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/tryCatchFina
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/tsconfigExtendsPackageJsonExportsWildcard.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/tslibInJs.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/tslibMissingHelper.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/tslibMultipleMissingHelper.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/tslibNotFoundDifferentModules.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/tsxDeepAttributeAssignabilityError.tsx
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/tsxInvokeComponentType.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/tsxNoTypeAnnotatedSFC.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/tsxNotUsingApparentTypeOfSFC.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/tsxTypeArgumentPartialDefinitionStillErrors.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/tupleTypes.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeAliasDeclarationEmit.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeAliasDeclarationEmit3.ts
 
@@ -3504,19 +2660,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeArgument
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeArgumentsOnFunctionsWithNoTypeParameters.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeArgumentsShouldDisallowNonGenericOverloads.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeAssertionToGenericFunctionType.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeAssignabilityErrorMessage.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeCheckExportsVariable.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeCheckTypeArgument.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeCheckingInsideFunctionExpressionInArray.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeComparisonCaching.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeGuardConstructorClassAndNumber.ts
 
@@ -3542,33 +2690,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeOfEnumAn
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeOfOnTypeArg.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeOfOperator1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParamExtendsOtherTypeParam.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEquivalence.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEquivalence2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEquivalence3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEquivalence4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEquivalence5.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterAsBaseClass.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterAssignmentCompat1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterConstrainedToOuterTypeParameter.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterConstraints1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterDiamond2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterDiamond3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterDiamond4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterExplicitlyExtendsAny.ts
 
@@ -3576,23 +2700,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParamete
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments3.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterHasSelfAsConstraint.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterWithInvalidConstraintType.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParametersAndParametersInComputedNames.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParametersInStaticAccessors.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParametersInStaticMethods.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParametersInStaticProperties.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParametersShouldNotBeEqual.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParametersShouldNotBeEqual2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParametersShouldNotBeEqual3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typePredicateInLoop.ts
 
@@ -3614,15 +2724,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeValueCon
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeValueConflict2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeVariableConstraintedToAliasNotAssignableToUnion.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typecheckCommaExpression.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typecheckIfCondition.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typedArrays-es5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typedArraysCrossAssignability01.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeofAmbientExternalModules.ts
 
@@ -3630,15 +2736,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeofClass.
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeofExternalModules.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeofInObjectLiteralType.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeofInternalModules.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeofProperty.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeofSimple.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeofUnknownSymbol.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/umdDependencyComment2.ts
 
@@ -3649,8 +2749,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/umdDependenc
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/umdGlobalAugmentationNoCrash.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/umdNamespaceMergedWithGlobalAugmentationIsNotCircular.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unaryOperators1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/uncalledFunctionChecksInConditional.ts
 
@@ -3664,13 +2762,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/undeclaredMo
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/undeclaredVarEmit.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/undefinedAssignableToGenericMappedIntersection.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/undefinedSymbolReferencedInArrayLiteral1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/undefinedTypeArgument1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/undefinedTypeArgument2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/undefinedTypeAssignment2.ts
 
@@ -3678,19 +2770,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/undefinedTyp
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/underscoreTest1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unionErrorMessageOnMatchingDiscriminant.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unionPropertyExistence.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unionPropertyOfProtectedAndIntersectionProperty.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unionSubtypeReductionErrors.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unionTypeErrorMessageTypeRefs01.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithRecursiveSubtypeReduction2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithRecursiveSubtypeReduction3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/uniqueSymbolAllowsIndexInObjectWithIndexSignature.ts
 
@@ -3698,17 +2782,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/uniqueSymbol
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/uniqueSymbolJs2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unknownSymbolInGenericReturnType.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unknownSymbolOffContextualType1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unknownSymbols1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unknownSymbols2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unknownTypeArgOnCall.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unknownTypeErrors.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unmetTypeConstraintInImportCall.ts
 
@@ -3717,8 +2795,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unmetTypeCon
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unqualifiedCallToClassStatic1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unresolvableSelfReferencingAwaitedUnion.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unresolvedTypeAssertionSymbol.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unspecializedConstraints.ts
 
@@ -3750,8 +2826,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/variableDecl
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/varianceAnnotationValidation.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/varianceMeasurement.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/varianceReferences.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/voidArrayLit.ts
@@ -3762,25 +2836,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/voidAsOperat
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/weakType.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/widenToAny1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/widenToAny2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/widenedTypes.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/wrappedRecursiveGenericType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/yieldExpression1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/Symbols/ES5SymbolProperty2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/Symbols/ES5SymbolProperty5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/Symbols/ES5SymbolProperty6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsPatterns_merging1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsPatterns_merging2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsPatterns_merging3.ts
 
@@ -3808,8 +2870,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es2
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration3_es2017.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration8_es2017.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncAliasReturnType_es5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction10_es5.ts
@@ -3817,8 +2877,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es5
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction3_es5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunctionCapturesArguments_es5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncAwaitIsolatedModules_es5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncDeclare_es5.ts
 
@@ -3829,8 +2887,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es5
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration16_es5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration3_es5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration8_es5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclarationCapturesArguments_es5.ts
 
@@ -3856,13 +2912,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es6
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration3_es6.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration8_es6.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/asyncGenerators/asyncGeneratorParameterEvaluation.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractAssignabilityConstructorFunction.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractClinterfaceAssignability.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractConstructorAssignability.ts
 
@@ -3948,8 +2998,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/c
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorOverloadsAccessibility.ts
@@ -3959,8 +3007,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/c
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorParametersAccessibility2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorDefaultValuesReferencingThis.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorImplementationWithDefaultValues2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorOverloadsWithDefaultValues.ts
 
@@ -3983,8 +3029,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/c
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/superCalls/derivedClassSuperStatementPosition.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/superCalls/superPropertyInConstructorBeforeSuperCall.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/indexMemberDeclarations/staticIndexers.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts
 
@@ -4028,15 +3072,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/m
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesProtectedMembers4.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithAny.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateInstanceShadowingProtectedInstance.ts
 
@@ -4045,8 +3081,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/m
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateStaticShadowingProtectedStatic.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateStaticShadowingPublicStatic.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedGenericClassWithAny.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/superInStaticMembers1.ts
 
@@ -4068,8 +3102,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/m
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers8.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInstanceMemberNarrowedWithLoopAntecedent.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAccessors.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndObjectRestSpread.ts
@@ -4083,8 +3115,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/m
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameDeclarationMerging.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameEmitHelpers.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldsESNext.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameMethod.ts
 
@@ -4116,8 +3146,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/m
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesAndStaticFields.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesAndkeyof.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesConstructorChain-1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesConstructorChain-2.ts
@@ -4126,15 +3154,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/m
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesInNestedClasses-2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUnique-1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUnique-2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUnique-3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUnique-4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUnique-5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUseBeforeDef.ts
 
@@ -4166,10 +3190,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/p
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorExperimentalDecorators.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/constructorParameterShadowsOuterScopes.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/constructorParameterShadowsOuterScopes2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/defineProperty.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/derivedUninitializedPropertyDeclaration.ts
@@ -4180,13 +3200,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/p
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/derivedTypeAccessesHiddenBaseCallViaSuperPropertyAccess.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/instanceMemberAssignsToClassPrototype.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPrivateOverloads.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPublicPrivateOverloads.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/staticMemberAssignsToConstructorFunctionMembers.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesAccessors.ts
 
@@ -4204,8 +3220,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/p
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/strictPropertyInitialization.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature3.ts
@@ -4222,8 +3236,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/constEnum
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnumNoObjectPrototypePropertyAccess.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnumPropertyAccess1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnumPropertyAccess2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/constEnums/importElisionConstEnumMerge1.ts
@@ -4231,8 +3243,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/constEnum
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/assertionTypePredicates1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowAliasing.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowBindingPatternOrder.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowDeleteOperator.ts
 
@@ -4254,13 +3264,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/controlFl
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowWhileStatement.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/dependentDestructuredVariables.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/exhaustiveSwitchStatements1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/typeGuardsAsAssertions.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typesVersionsDeclarationEmit.multiFileBackReferenceToSelf.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor7.ts
 
@@ -4290,15 +3296,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/decorator
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorCallGeneric.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/decorators/missingDecoratorType.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/directives/multiline.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/directives/ts-expect-error-js.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/directives/ts-expect-error.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/directives/ts-ignore.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionCheckReturntype1.ts
 
@@ -4317,8 +3319,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/enums/enu
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/enums/enumConstantMembers.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/enums/enumMergingErrors.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2017/assignSharedArrayBufferToArrayBuffer.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValuesAndEntries2.ts
 
@@ -4352,10 +3352,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2020/co
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2020/es2020IntlAPIs.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2020/modules/exportAsNamespace1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2020/modules/exportAsNamespace2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2020/modules/exportAsNamespace3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2020/modules/exportAsNamespace_exportAssignment.ts
@@ -4372,21 +3368,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2021/lo
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2021/logicalAssignment/logicalAssignment8.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2022/arbitraryModuleNamespaceIdentifiers/arbitraryModuleNamespaceIdentifiers_exportEmpty.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2022/arbitraryModuleNamespaceIdentifiers/arbitraryModuleNamespaceIdentifiers_importEmpty.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2022/es2024SharedMemory.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2023/intlNumberFormatES5UseGrouping.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es5/es5DateAPIs.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty10.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty12.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty17.ts
 
@@ -4406,8 +3392,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbo
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty34.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty35.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty36.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty39.ts
@@ -4415,10 +3399,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbo
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty42.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty44.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty46.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty47.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty52.ts
 
@@ -4429,8 +3409,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbo
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty59.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty7.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty9.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType1.ts
 
@@ -4443,10 +3421,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbo
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType13.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType14.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType15.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType3.ts
 
@@ -4468,11 +3442,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/arrow
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments01.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments01_ES6.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments02.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments02_ES6.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments03.ts
 
@@ -4556,10 +3526,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/compu
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames32_ES6.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames34_ES5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames34_ES6.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames35_ES5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames35_ES6.ts
@@ -4620,18 +3586,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/compu
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames9_ES6.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType10_ES5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType10_ES6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType8_ES5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType8_ES6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType9_ES5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType9_ES6.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit3_ES5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit3_ES6.ts
@@ -4680,8 +3634,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destr
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration5.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration8.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringParameterProperties1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringParameterProperties2.ts
@@ -4693,20 +3645,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destr
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringSpread.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_7.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVoidStrictNullChecks.ts
 
@@ -4738,13 +3676,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destr
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern29.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern6.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern7.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern8.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts
 
@@ -4756,10 +3688,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destr
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/optionalBindingParameters3.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/optionalBindingParametersInOverloads1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/optionalBindingParametersInOverloads2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/restElementWithAssignmentPattern2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/restElementWithAssignmentPattern4.ts
@@ -4768,19 +3696,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destr
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/restElementWithNullInitializer.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of10.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of11.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of12.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of14.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of15.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of16.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of17.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of29.ts
 
@@ -4788,27 +3708,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-o
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of39.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of46.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of47.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of48.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of55.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of7.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration13_es6.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration3_es6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration8_es6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/functionPropertyAssignments/FunctionPropertyAssignments5_es6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/memberFunctionDeclarations/MemberFunctionDeclaration3_es6.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/defaultExportsCannotMerge01.ts
 
@@ -4825,8 +3727,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/modul
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportStar-amd.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportStar.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/importEmptyFromModuleNotExisted.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/multipleDefaultExports01.ts
 
@@ -4851,8 +3751,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/sprea
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/spread/arraySpreadInCall.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray10.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray6.ts
 
@@ -4889,10 +3787,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/templ
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3_ES6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithTypeErrorInFunctionExpressionsInSubstitutionExpression.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithTypeErrorInFunctionExpressionsInSubstitutionExpressionES6.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateWithConstructableTag01.ts
 
@@ -4948,21 +3842,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/templ
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringWithEmbeddedInstanceOfES6.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringsWithTypeErrorInFunctionExpressionsInSubstitutionExpression.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringsWithTypeErrorInFunctionExpressionsInSubstitutionExpressionES6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression10_es6.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression11_es6.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression1_es6.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression6_es6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression8_es6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression9_es6.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldStarExpression1_es6.ts
 
@@ -4986,19 +3868,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yield
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck21.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck25.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck31.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck6.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck62.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck63.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck7.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck8.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck9.ts
 
@@ -5114,8 +3988,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/esDecorat
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiterals.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiterals3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperator2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperatorAmbiguity.ts
@@ -5125,8 +3997,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressio
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperatorNames.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentLHSCanBeAssigned.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentLHSCannotBeAssigned.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts
 
@@ -5188,8 +4058,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressio
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithValidOperands.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithInvalidOperands.es2015.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithInvalidOperands.ts
@@ -5202,10 +4070,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressio
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrOperatorWithEveryType.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorInvalidAssignmentType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorOtherInvalidOperation.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorConditionIsNumberType.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorConditionIsObjectType.ts
@@ -5214,17 +4078,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressio
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorConditoinIsStringType.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorWithoutIdenticalBCT.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/argumentExpressionContextualTyping.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/arrayLiteralExpressionContextualTyping.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/functionExpressionContextualTyping2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/generatedContextualTyping.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/getSetAccessorContextualTyping.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/objectLiteralContextualTyping.ts
 
@@ -5278,10 +4134,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressio
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperatorInParameterInitializer.2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/callChain.3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/delete/deleteChain.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/optionalChainingInParameterBindingPattern.2.ts
@@ -5317,8 +4169,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressio
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeAssertions/duplicatePropertiesInTypeAssertions02.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunctionOfFormThisErrors.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardInClass.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormThisMember.ts
 
@@ -5357,8 +4207,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressio
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_propertyNameFulfillment.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_propertyValueConformance3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_vacuousIntersectionOfContextualTypes.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithAnyOtherType.ts
 
@@ -5450,8 +4298,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalM
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportNonLocalDeclarations.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/importNonExternalModule.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/importTsBeforeDTs.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/importsImplicitlyReadonly.ts
@@ -5460,17 +4306,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalM
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension7.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension8.ts
 
@@ -5486,17 +4326,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalM
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/multipleExportDefault6.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/relativePathMustResolve.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/rewriteRelativeImportExtensions/cjsErrors.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/rewriteRelativeImportExtensions/emit.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/rewriteRelativeImportExtensions/emitModuleCommonJS.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/rewriteRelativeImportExtensions/packageJsonImportsErrors.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelFileModuleMissing.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelModuleDeclarationAndFile.ts
 
@@ -5506,11 +4338,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalM
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/chained2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/circular1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/circular2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/circular3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/circular4.ts
 
@@ -5568,8 +4396,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalM
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceImportTypeQuery.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceImportTypeQuery3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceImportTypeQuery4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceMemberAccess.ts
@@ -5624,12 +4450,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/functions
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/generators/generatorAssignability.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/generators/generatorExplicitReturnType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnContextualType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeFallback.2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/importAssertion/importAssertion2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/importAssertion/importAssertion3.ts
@@ -5638,11 +4458,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/importAtt
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/importAttributes/importAttributes3.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/importAttributes/importAttributes9.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterfaceWithTheSameName.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInheritedMembersSatisfyAbstractBase.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithConflictingPropertyNames.ts
 
@@ -5651,10 +4467,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/interface
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheritedPrivates.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheritedPrivates2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheritedPrivates3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithMultipleBases4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts
 
@@ -5673,8 +4485,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/interface
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceThatHidesBaseProperty2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceThatIndirectlyInheritsFromItself.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithAccessibilityModifiers.ts
 
@@ -5706,8 +4516,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/interface
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithProtecteds2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithModuleMemberThatUsesClassTypeParameter.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithModulesExportedGenericFunctionAndGenericClassStaticFunctionOfTheSameName.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithModulesExportedGenericFunctionAndNonGenericClassStaticFunctionOfTheSameName.ts
@@ -5729,8 +4537,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/internalM
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ModuleAndFunctionWithSameNameAndCommonRoot.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedClassesOfTheSameName.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedLocalVarsOfTheSameName.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/codeGeneration/importStatementsInterfaces.ts
 
@@ -5756,13 +4562,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/internalM
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/callOfPropertylessConstructorFunction.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/callbackTag2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkExportsObjectAssignProperty.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkExportsObjectAssignPrototypeProperty.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocOnEndOfFile.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocOptionalParamOrder.ts
 
@@ -5790,17 +4592,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/che
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag7.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag8.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag9.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypeTag2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypeTag4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypeTag5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypeTag6.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypeTagOnObjectProperty2.ts
 
@@ -5824,8 +4620,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/err
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/extendsTag5.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/extendsTagEmit.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag10.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag11.ts
@@ -5838,21 +4632,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/imp
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag15.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag17.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag22.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag23.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag24.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocAccessibilityTags.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocAugmentsMissingType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocAugments_errorInExtendsExpression.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocAugments_noExtends.ts
 
@@ -5872,8 +4658,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsd
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImplements_signatures.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocIndexSignature.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocOuterTypeParameters1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocOuterTypeParameters2.ts
@@ -5888,21 +4672,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsd
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocPrefixPostfixParsing.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocPrivateName1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocPrivateName2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocPrototypePropertyAccessWithType.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocReadonly.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateClass.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateConstructorFunction.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateConstructorFunction2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateTag.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateTag3.ts
 
@@ -5912,8 +4684,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsd
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateTagDefault.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTemplateTagNameResolution.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocThisType.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeFromChainedAssignment.ts
@@ -5922,13 +4692,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsd
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeTagCast.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeTagParameterType.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeTagRequiredParameters.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/noAssertForUnparseableTypedefs.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/noDuplicateJsdoc1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/overloadTag1.ts
 
@@ -5940,15 +4704,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/par
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/syntaxErrors.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/templateInsideCallback.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/thisTag3.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typeTagModuleExports.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typeTagNoErasure.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typeTagPrototypeAssignment.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typedefCrossModule2.ts
 
@@ -5962,10 +4720,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typ
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typedefMultipleTypeParameters.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typedefScope1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typedefTagTypeResolution.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typedefTagWrapping.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenCanBeTupleType.tsx
@@ -5974,8 +4728,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/check
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty14.tsx
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty15.tsx
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty2.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty4.tsx
@@ -5983,8 +4735,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/check
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty5.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty7.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxGenericTagHasCorrectInferences.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/correctlyMarkAliasAsReferences3.tsx
 
@@ -6006,17 +4756,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxs/
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformKeyPropCustomImportPragma.tsx
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeErrors.tsx
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution1.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution10.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution11.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution12.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution14.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution15.tsx
 
@@ -6030,12 +4770,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAt
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution6.tsx
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution7.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution9.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDefaultAttributesResolution3.tsx
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName2.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName3.tsx
@@ -6046,15 +4780,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEl
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution10.tsx
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution11.tsx
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution12.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution15.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution3.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution4.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution6.tsx
 
@@ -6068,23 +4796,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEm
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxIntrinsicAttributeErrors.tsx
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxNamespacedTagName2.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefaultTypeParameter3.tsx
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit4.tsx
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit7.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSfcReturnUndefinedStrictNullChecks.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution10.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution12.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution14.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution16.tsx
 
@@ -6096,8 +4814,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSp
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution5.tsx
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution6.tsx
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadInvalidType.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload1.tsx
@@ -6106,23 +4822,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSt
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload5.tsx
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentWithDefaultTypeParameter2.tsx
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponents2.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments2.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments4.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxTypeArgumentResolution.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType1.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType2.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType3.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType4.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType6.tsx
 
@@ -6132,25 +4836,15 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleRes
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/bundler/bundlerNodeModules1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/bundler/bundlerRelative1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/bundler/bundlerSyntaxRestrictions.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/importFromDot.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/node10AlternateResult_noResolution.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/node10Alternateresult_noTypes.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/nodeModulesAtTypesPriority.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/packageJsonMain_isNonRecursive.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolutionModeCache.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolutionModeTripleSlash1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolutionModeTripleSlash2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolutionModeTripleSlash3.ts
 
@@ -6178,8 +4872,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/allo
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/allowJs/nodeModulesAllowJsPackagePatternExports.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/allowJs/nodeModulesAllowJsPackagePatternExportsExclude.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/allowJs/nodeModulesAllowJsPackagePatternExportsTrailers.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/allowJs/nodeModulesAllowJsTopLevelAwait.ts
@@ -6206,15 +4898,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/node
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesExportsBlocksTypesVersions.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesExportsDoubleAsterisk.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesExportsSourceTs.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationConditions.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationDirectory.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationPattern.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesForbidenSyntax.ts
 
@@ -6244,11 +4928,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/node
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportModeDeclarationEmitErrors1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportResolutionNoCycle.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesJson.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesNoDirectoryModule.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesPackageExports.ts
 
@@ -6266,21 +4946,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/node
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTopLevelAwait.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride4.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverrideModeError.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodePackageSelfName.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodePackageSelfNameScoped.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/nonjsExtensions/declarationFileForTsJsImport.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/override/override11.ts
 
@@ -6308,23 +4978,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserSetAccessorWithTypeParameters1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression11.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression12.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression4.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression8.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression9.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/AutomaticSemicolonInsertion/parserAutomaticSemicolonInsertion1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/CatchClauses/parserCatchClauseWithTypeAnnotation1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClass1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClass2.ts
 
@@ -6336,23 +4992,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration7.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName10.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName7.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName8.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName9.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration10.ts
 
@@ -6370,8 +5010,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic7.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ParameterLists/parserErrorRecovery_ParameterList6.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserCommaInTypeMemberList2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnPropertySignature1.ts
@@ -6384,25 +5022,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnStatementInBlock4.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ExportAssignments/parserExportAssignment1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ExportAssignments/parserExportAssignment2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ExportAssignments/parserExportAssignment5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ExportAssignments/parserExportAssignment6.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ExportAssignments/parserExportAssignment7.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ExportAssignments/parserExportAssignment8.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ExportAssignments/parserExportAssignment9.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Expressions/parserConditionalExpression1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Expressions/parserInvocationOfMemberAccessOffOfObjectCreationExpression1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Expressions/parserObjectCreation2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration1.ts
 
@@ -6416,55 +5042,23 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration7.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguity1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguity2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguity3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserCastVersusArrowFunction1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserConstructorAmbiguity1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserConstructorAmbiguity2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserConstructorAmbiguity3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserConstructorAmbiguity4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint7.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInInterfaceDeclaration1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessExpression1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessOffOfGenericType1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserObjectCreation1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexSignatures/parserIndexSignature4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexSignatures/parserIndexSignature5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessor1.ts
 
@@ -6518,31 +5112,17 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509693.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509698.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser536727.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parserTernaryAndCommaOperators1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parseRegularExpressionMixedWithComments.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpression2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpression3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpression4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpression5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakInIterationOrSwitchStatement4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ContinueStatements/parser_continueInIterationStatement4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ContinueStatements/parser_continueNotInIterationStatement4.ts
 
@@ -6554,25 +5134,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement1.d.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement10.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement11.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement12.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement13.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement14.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement15.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement16.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement20.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement8.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement9.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserEmptyStatement1.d.ts
 
@@ -6586,15 +5148,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserForStatement1.d.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserForStatement2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserForStatement3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserForStatement5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserIfStatement1.d.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserIfStatement2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserLabeledStatement1.d.ts
 
@@ -6609,10 +5165,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserVariableStatement2.d.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserWhileStatement1.d.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode15-negative.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode16.ts
 
@@ -6644,33 +5196,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty9.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery7.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery8.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery9.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parser15.4.4.14-9-2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserAdditiveExpression1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserArgumentList1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserAstSpans1.ts
 
@@ -6678,17 +5208,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserNoASIOnCallAfterFunctionExpression1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserObjectCreationArrayLiteral2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserObjectCreationArrayLiteral4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserRealSource12.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserRealSource13.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserRealSource14.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserRealSource5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserRealSource6.ts
 
@@ -6702,93 +5224,19 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUnicode1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUsingConstructorAsIdentifier.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parservoidInQualifiedName2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName10.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName12.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName13.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName14.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName15.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName17.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName18.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName19.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName20.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName21.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName22.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName23.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName24.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName25.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName28.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName29.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName31.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName32.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName37.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName4.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName40.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName41.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName7.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName8.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName9.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement1.d.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement10.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement11.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement12.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement13.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement14.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement15.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement16.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement20.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement8.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement9.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/pedantic/noUncheckedIndexedAccess.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/pedantic/noUncheckedIndexedAccessDestructuring.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-15.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-5.ts
 
@@ -6796,15 +5244,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/ass
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/chainedPrototypeAssignment.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/checkSpecialPropertyAssignments.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/classCanExtendConstructorFunction.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/conflictingCommonJSES2015Exports.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/constructorFunctions.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/constructorFunctionsStrict.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/enumMergeWithExpando.ts
 
@@ -6812,15 +5256,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/exp
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/exportNestedNamespaces2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/exportPropertyAssignmentNameResolution.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/globalMergeWithCommonJSAssignmentDeclaration.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/importAliasModuleExports.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/inferringClassMembersFromAssignments.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/jsContainerMergeTsDeclaration2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/jsContainerMergeTsDeclaration3.ts
 
@@ -6842,13 +5278,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/mod
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportsAliasLoop2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/nestedDestructuringOfRequire.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/plainJSTypeErrors.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/propertyAssignmentOnUnresolvedImportedSymbol.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/propertyAssignmentUseParentType2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/prototypePropertyAssignmentMergeAcrossFiles2.ts
 
@@ -6860,21 +5290,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/thi
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromJSConstructor.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromJSInitializer.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromJSInitializer4.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment21.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment22.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment26.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment28.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment29.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment31.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment32.ts
 
@@ -6889,8 +5311,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/typ
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/typeLookupInIIFE.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript3/scannerES3NumericLiteral2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerAdditiveExpression1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerClass2.ts
 
@@ -6928,8 +5348,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statement
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.3.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.9.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsInForAwaitOf.2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsInForOf.4.ts
@@ -6943,10 +5361,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statement
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.10.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.14.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.9.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithImportHelpers.ts
 
@@ -6984,19 +5398,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statement
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of31.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of34.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of35.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of36.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of7.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of8.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck10.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck11.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck12.ts
 
@@ -7005,8 +5413,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statement
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck14.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck7.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck8.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck9.ts
 
@@ -7036,33 +5442,19 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/con
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/conditional/conditionalTypes2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/conditional/conditionalTypesExcessProperties.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypes1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypesInvalidExtendsDeclaration.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypesWithExtends2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/commaOperator/contextuallyTypeCommaOperator02.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes01.tsx
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes02.tsx
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/logicalAnd/contextuallyTypeLogicalAnd02.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/logicalAnd/contextuallyTypeLogicalAnd03.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedBindingInitializerNegative.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceError.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/forAwait/types.forAwait.es2018.2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/forAwait/types.forAwait.es2018.3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeAmbientMissing.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeGeneric.ts
 
@@ -7074,10 +5466,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/imp
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeNonString.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/intersection/commonTypeIntersection.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionAndUnionTypes.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionAsWeakTypeSource.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionNarrowing.ts
@@ -7088,19 +5476,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/int
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeAssignment.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeInference.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeReadonly.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionWithIndexSignatures.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionWithUnionConstraint.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/intersection/recursiveIntersectionTypes.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/keyof/circularIndexedAccessErrors.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts
 
@@ -7108,15 +5488,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/key
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/enumLiteralTypes3.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypesWidenInParameterPosition.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/numericLiteralTypes3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringEnumLiteralTypes3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringLiteralsAssertionsInEqualityComparisons02.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringLiteralsAssignedToStringMappings.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringLiteralsWithEqualityChecks01.ts
 
@@ -7134,49 +5510,29 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/lit
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringLiteralsWithSwitchStatements04.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringMappingOverPatternLiterals.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes4.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes7.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypesPatterns.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypesPatternsPrefixSuffixAssignability.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeAsClauseRelationships.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeAsClauses.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeConstraints2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeErrors.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeErrors2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeInferenceErrors.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeWithAny.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes6.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesAndObjects.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/recursiveMappedTypes.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/members/augmentedTypeAssignmentCompatIndexSignature.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/members/classWithPrivateProperty.ts
 
@@ -7188,15 +5544,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/mem
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeHidingMembersOfExtendedObject.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeHidingMembersOfObjectAssignmentCompat.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeHidingMembersOfObjectAssignmentCompat2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithCallSignatureHidingMembersOfFunctionAssignmentCompat.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithConstructSignatureAppearsToBeFunctionType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithConstructSignatureHidingMembersOfFunctionAssignmentCompat.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithStringAndNumberIndexSignatureToAny.ts
 
@@ -7220,13 +5570,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/nev
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAccessProperty.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAndTypeVariables.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAsProperty.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAssignError.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveConstraintOfIndexAccessType.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveInFunction.ts
 
@@ -7248,8 +5592,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/obj
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/constructSignatures/constructSignaturesWithOverloads2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/indexSignatures/multipleNumericIndexers.ts
@@ -7268,45 +5610,19 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/obj
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/objectTypeLiteralSyntax2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/assignFromBooleanInterface.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/assignFromBooleanInterface2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/boolInsteadOfBoolean.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/invalidBooleanAssignments.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/enum/invalidEnumAssignments.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/enum/validEnumAssignments.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/null/directReferenceToNull.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/null/validNullAssignments.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/assignFromNumberInterface.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/assignFromNumberInterface2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/invalidNumberAssignments.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/assignFromStringInterface.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/assignFromStringInterface2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/invalidStringAssignments.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/stringPropertyAccessWithError.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/directReferenceToUndefined.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/invalidUndefinedAssignments.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/void/invalidAssignmentsToVoid.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/void/invalidVoidAssignments.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/void/invalidVoidValues.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/rest/genericRestArity.ts
 
@@ -7334,8 +5650,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/spe
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofAnExportedType.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofClassWithPrivates.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofThis.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofTypeParameter.ts
@@ -7351,8 +5665,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/spe
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadNegative.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadSetonlyAccessor.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadStrictNull.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadDuplicate.ts
 
@@ -7372,15 +5684,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/spr
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadUnion3.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAndLogicalOrExpressions01.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignability01.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignability02.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads05.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesWithTemplateStrings02.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesWithVariousOperators02.ts
 
@@ -7434,12 +5738,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tup
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/variadicTuples2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/variadicTuples3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples4.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/directDependenceBetweenTypeAliases.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/intrinsicKeyword.ts
@@ -7462,19 +5760,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typ
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/wrappedAndRecursiveConstraints4.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterAsBaseType.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints5.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/staticMembersUsingClassTypeParameter.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiers.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterDirectlyConstrainedToItself.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typesWithDuplicateTypeParameters.ts
 
@@ -7482,71 +5772,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typ
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSupertype.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatBetweenTupleAndArray.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithOptionalParameters.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithRestParameters.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignaturesWithOptionalParameters.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithDiscriminatedUnion.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithEnumIndexer.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignatures2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignatures4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignaturesWithOptionalParameters.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithNumericIndexer.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithNumericIndexer2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithNumericIndexer3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers4.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersAccessibility.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersOptionality.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersOptionality2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersStringNumericNames.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithStringIndexer.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithStringIndexer2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithStringIndexer3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance.ts
 
@@ -7560,23 +5792,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typ
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance6.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/covariantCallbacks.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/enumAssignability.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/enumAssignabilityInInheritance.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/genericCallWithObjectTypeArgsAndInitializers.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/nullAssignedToUndefined.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/optionalPropertyAssignableToStringIndexSignature.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/unionTypesAssignability.ts
 
@@ -7597,18 +5815,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typ
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/typeAssertionsWithUnionTypes01.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/instanceOf/narrowingGenericTypeFromInstanceof01.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/infiniteExpansionThroughInstantiation.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedProperty.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedProperty2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedPropertyCheckedNominally.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/recursiveTypeReferences1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/recursiveTypeReferences2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/enumIsNotASubtypeOfAnythingButNumber.ts
 
@@ -7674,8 +5880,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typ
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/unionSubtypeIfEveryConstituentTypeIsSubtype.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithCallSignatures3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithPrivates3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/unionTypeIdentity.ts
@@ -7692,13 +5896,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typ
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments5.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectLiteralArgs.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgs.ts
 
@@ -7726,8 +5926,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typ
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/widenedTypes/initializersWidened.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/union/contextualTypeWithUnionTypeObjectLiteral.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/union/discriminatedUnionTypes1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/union/discriminatedUnionTypes2.ts
@@ -7743,8 +5941,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/uni
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeConstructSignatures.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeEquivalence.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeFromArrayLiteral.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeMembers.ts
 
@@ -7765,8 +5961,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/uni
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/unknown/unknownControlFlow.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/unknown/unknownType1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/unknown/unknownType2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/witness/witness.ts
 
@@ -8032,6 +6226,26 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/externalModul
  3 │ declare const await: any;
  4 │ declare class C extends await {}
    ·                         ─────
+   ╰────
+
+Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName11.ts
+
+  × Function implementation is missing or not immediately following the declaration.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName11.ts:2:5]
+ 1 │ class C {
+ 2 │    [e]();
+   ·     ─
+ 3 │ }
+   ╰────
+
+Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName11.ts
+
+  × Function implementation is missing or not immediately following the declaration.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName11.ts:2:5]
+ 1 │ class C {
+ 2 │    [e]();
+   ·     ─
+ 3 │ }
    ╰────
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/plainJSRedeclare3.ts
@@ -10622,11 +8836,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╭─[typescript/tests/cases/compiler/downlevelLetConst4.ts:1:7]
  1 │ const a: number
    ·       ─────────
-   ╰────
-
-  × Unexpected token
-   ╭─[typescript/tests/cases/compiler/downlevelLetConst6.ts:1:4]
- 1 │ let
    ╰────
 
   × Identifier `a` has already been declared
@@ -21646,11 +19855,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·       ─────────
    ╰────
 
-  × Unexpected token
-   ╭─[typescript/tests/cases/conformance/es6/variableDeclarations/VariableDeclaration6_es6.ts:1:4]
- 1 │ let
-   ╰────
-
   × A 'yield' expression is only allowed in a generator body.
    ╭─[typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression12_es6.ts:3:6]
  2 │   constructor() {
@@ -25636,14 +23840,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │ }
    ╰────
 
-  × Function implementation is missing or not immediately following the declaration.
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName11.ts:2:5]
- 1 │ class C {
- 2 │    [e]();
-   ·     ─
- 3 │ }
-   ╰────
-
   × TS(1164): Computed property names are not allowed in enums.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName6.ts:2:4]
  1 │ enum E {
@@ -27935,14 +26131,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  1 │ var v = { [e] };
    ·               ┬
    ·               ╰── `:` expected
-   ╰────
-
-  × Function implementation is missing or not immediately following the declaration.
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName11.ts:2:5]
- 1 │ class C {
- 2 │    [e]();
-   ·     ─
- 3 │ }
    ╰────
 
   × TS(1164): Computed property names are not allowed in enums.

--- a/tasks/coverage/snapshots/transformer_typescript.snap
+++ b/tasks/coverage/snapshots/transformer_typescript.snap
@@ -1,8 +1,8 @@
 commit: 81c95189
 
 transformer_typescript Summary:
-AST Parsed     : 6989/6989 (100.00%)
-Positive Passed: 6985/6989 (99.94%)
+AST Parsed     : 7894/7894 (100.00%)
+Positive Passed: 7890/7894 (99.95%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/esDecoratorsClassFieldsCrash.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor2.ts

--- a/tasks/coverage/src/typescript/mod.rs
+++ b/tasks/coverage/src/typescript/mod.rs
@@ -59,6 +59,9 @@ impl<T: Case> Suite<T> for TypeScriptSuite<T> {
             "TransportStream.ts",
             // Emits TS5052 (complains compilerOptions are invalid, which we do not support), also implies TS2564 but not emitted
             "esDecorators-emitDecoratorMetadata.ts",
+            // These tests just check `let` as variable name under `target:es6`
+            "downlevelLetConst6.ts",
+            "VariableDeclaration6_es6.ts",
         ]
         .iter()
         .any(|p| path.to_string_lossy().contains(p));
@@ -138,7 +141,27 @@ impl Case for TypeScriptCase {
 // spellchecker:off
 static NOT_SUPPORTED_ERROR_CODES: phf::Set<&'static str> = phf::phf_set![
     // TODO: More not-supported error codes here
-    "2315",  // Type 'U' is not generic.
+    "2011",  // Cannot convert 'string' to 'number'.
+    "2209", // The project root is ambiguous, but is required to resolve export map entry '.' in file 'package.json'. Supply the `rootDir` compiler option to disambiguate.
+    "2210", // The project root is ambiguous, but is required to resolve import map entry '.' in file 'package.json'. Supply the `rootDir` compiler option to disambiguate.
+    "2301", // Initializer of instance member variable 'y' cannot reference identifier 'aaa' declared in the constructor.
+    "2302", // Static members cannot reference class type parameters.
+    "2303", // Circular definition of import alias 'A'.
+    "2304", // Cannot find name 'a'.
+    "2305", // Module '"./b"' has no exported member 'default'.
+    "2306", // File '/node_modules/@types/react/index.d.ts' is not a module.
+    "2307", // Cannot find module './SubModule' or its corresponding type declarations.
+    "2308", // Module "./b" has already exported a member named '__foo'. Consider explicitly re-exporting to resolve the ambiguity.
+    "2310", // Type 'M2' recursively references itself as a base type.
+    "2312", // An interface can only extend an object type or intersection of object types with statically known members.
+    "2313", // Type parameter 'K' has a circular constraint.
+    "2314", // Generic type 'Array<T>' requires 1 type argument(s).
+    "2315", // Type 'D' is not generic.
+    "2317", // Global type 'Array' must have 1 type parameter(s).
+    "2318", // Cannot find global type 'AsyncDisposable'.
+    "2320", // Interface 'Z' cannot simultaneously extend types 'X' and 'Y'.
+    "2322", // Type 'number' is not assignable to type 'string'.
+    "2328", // Types of parameters 'f' and 'f' are incompatible.
     "2665", // Invalid module name in augmentation. Module 'foo' resolves to an untyped module at '/node_modules/foo/index.js', which cannot be augmented.
     "4023", // Exported variable 'foo' has or is using name 'Foo' from external module "type" but cannot be named.
     "4025", // Exported variable 'b' has or is using private name 'a'.


### PR DESCRIPTION
Part of #11582 

---

> Negative Passed: 1415/4400 (32.16%)

Now it's over 30%. ↗️