### PR TITLE
refactor(linter/no-eval): get source type from `Semantic`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_eval.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eval.rs
@@ -215,7 +215,7 @@ impl Rule for NoEval {
                     }
 
                     let is_valid = if scope_flags.is_top() {
-                        ctx.nodes().program().unwrap().source_type.is_script()
+                        ctx.semantic().source_type().is_script()
                     } else {
                         let node = ctx.nodes().get_node(ctx.scoping().get_node_id(scope_id));
                         ast_util::is_default_this_binding(ctx, node, true)


### PR DESCRIPTION
Small improvement to this rule. `Semantic` contains `SourceType`, so no need to go the more circuitous route of looking up the `Program` to get `SourceType`.