### PR TITLE
refactor(semantic)!: `AstNodes::program` return `&Program` not `Option<&Program>`

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -248,7 +248,7 @@ impl Linter {
         let external_linter = self.external_linter.as_ref().unwrap();
 
         // Write offset of `Program` in metadata at end of buffer
-        let program = semantic.nodes().program().unwrap();
+        let program = semantic.nodes().program();
         let program_offset = ptr::from_ref(program) as u32;
 
         let metadata = RawTransferMetadata::new(program_offset);

--- a/crates/oxc_linter/src/rules/eslint/sort_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_imports.rs
@@ -134,7 +134,7 @@ impl Rule for SortImports {
     }
 
     fn run_once(&self, ctx: &LintContext) {
-        let program = ctx.nodes().program().unwrap();
+        let program = ctx.nodes().program();
 
         let mut import_declarations = vec![];
 

--- a/crates/oxc_linter/src/rules/import/exports_last.rs
+++ b/crates/oxc_linter/src/rules/import/exports_last.rs
@@ -51,7 +51,7 @@ declare_oxc_lint!(
 impl Rule for ExportsLast {
     fn run_once(&self, ctx: &LintContext<'_>) {
         // find last non export declaration index
-        let program = ctx.nodes().program().unwrap();
+        let program = ctx.nodes().program();
         let body = &program.body;
         let find_res =
             body.iter().rev().find_position(|statement| !is_exports_declaration(statement));

--- a/crates/oxc_linter/src/rules/import/first.rs
+++ b/crates/oxc_linter/src/rules/import/first.rs
@@ -110,7 +110,7 @@ impl Rule for First {
         let mut non_import_count = 0;
         let mut any_relative = false;
 
-        let program = ctx.nodes().program().unwrap();
+        let program = ctx.nodes().program();
 
         for statement in &program.body {
             match statement {

--- a/crates/oxc_linter/src/rules/nextjs/no_async_client_component.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_async_client_component.rs
@@ -90,7 +90,7 @@ declare_oxc_lint!(
 
 impl Rule for NoAsyncClientComponent {
     fn run_once(&self, ctx: &LintContext) {
-        let program = ctx.nodes().program().unwrap();
+        let program = ctx.nodes().program();
 
         if program.directives.iter().any(|directive| directive.directive.as_str() == "use client") {
             for node in &program.body {

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -576,7 +576,7 @@ fn get_type_only_named_import<'a>(
     ctx: &LintContext<'a>,
     source: &str,
 ) -> Option<&'a ImportDeclaration<'a>> {
-    let program = ctx.nodes().program().unwrap();
+    let program = ctx.nodes().program();
 
     for stmt in &program.body {
         let Statement::ImportDeclaration(import_decl) = stmt else {

--- a/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
+++ b/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
@@ -106,7 +106,7 @@ impl Rule for TripleSlashReference {
     }
 
     fn run_once(&self, ctx: &LintContext) {
-        let program = ctx.nodes().program().unwrap();
+        let program = ctx.nodes().program();
 
         // We don't need to iterate over all comments since Triple-slash directives are only valid at the top of their containing file.
         // We are trying to get the first statement start potioin, falling back to the program end if statement does not exist

--- a/crates/oxc_linter/src/rules/unicorn/no_empty_file.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_empty_file.rs
@@ -43,7 +43,7 @@ declare_oxc_lint!(
 
 impl Rule for NoEmptyFile {
     fn run_once(&self, ctx: &LintContext) {
-        let program = ctx.nodes().program().unwrap();
+        let program = ctx.nodes().program();
         if program.body.iter().any(|node| !is_empty_stmt(node)) {
             return;
         }

--- a/crates/oxc_linter/src/rules/unicorn/no_process_exit.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_process_exit.rs
@@ -63,7 +63,7 @@ impl Rule for NoProcessExit {
 }
 
 fn has_hashbang(ctx: &LintContext) -> bool {
-    ctx.nodes().program().unwrap().hashbang.is_some()
+    ctx.nodes().program().hashbang.is_some()
 }
 
 fn is_inside_process_event_handler(ctx: &LintContext, node: &AstNode) -> bool {

--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -185,12 +185,10 @@ impl<'a> AstNodes<'a> {
     }
 
     /// Get the [`Program`] that's also the root of the AST.
-    ///
-    /// Returns [`None`] if root node isn't set. This will never happen if you
-    /// are obtaining an [`AstNodes`] that has already been constructed.
     #[inline]
-    pub fn program(&self) -> Option<&'a Program<'a>> {
-        self.program
+    pub fn program(&self) -> &'a Program<'a> {
+        #[expect(clippy::missing_panics_doc, reason = "self.program is always `Some`")]
+        self.program.as_ref().unwrap()
     }
 
     /// Create and add an [`AstNode`] to the [`AstNodes`] tree and get its [`NodeId`].

--- a/tasks/coverage/src/driver.rs
+++ b/tasks/coverage/src/driver.rs
@@ -92,9 +92,7 @@ impl CompilerInterface for Driver {
 
     fn after_semantic(&mut self, ret: &mut SemanticBuilderReturn) -> ControlFlow<()> {
         if self.check_semantic {
-            let Some(program) = ret.semantic.nodes().program() else {
-                return ControlFlow::Break(());
-            };
+            let program = ret.semantic.nodes().program();
             if let Some(errors) = check_semantic_ids(program) {
                 self.errors.extend(errors);
                 return ControlFlow::Break(());


### PR DESCRIPTION
#12193 made it so semantic analysis is run on all files (inc. `.d.ts`), so now `AstNodes::program` now always returns `Some`.

We always unwrap the value returned by `AstNodes::program`, so move the `unwrap` into the method itself.