### PR TITLE
perf(lexer): only check for hashbang at start of file

### DIFF
--- a/crates/oxc_parser/src/lexer/byte_handlers.rs
+++ b/crates/oxc_parser/src/lexer/byte_handlers.rs
@@ -241,13 +241,7 @@ ascii_byte_handler!(QOS(lexer) {
 // #
 ascii_byte_handler!(HAS(lexer) {
     lexer.consume_char();
-    // HashbangComment ::
-    //     `#!` SingleLineCommentChars?
-    if lexer.token.start() == 0 && lexer.next_ascii_byte_eq(b'!') {
-        lexer.read_hashbang_comment()
-    } else {
-        lexer.private_identifier()
-    }
+    lexer.private_identifier()
 });
 
 // `A..=Z`, `a..=z` (except special cases below), `_`, `$`

--- a/crates/oxc_parser/src/lexer/comment.rs
+++ b/crates/oxc_parser/src/lexer/comment.rs
@@ -180,15 +180,25 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    /// Section 12.5 Hashbang Comments
-    pub(super) fn read_hashbang_comment(&mut self) -> Kind {
+    /// Section 12.5 Hashbang Comments.
+    ///
+    /// # SAFETY
+    /// Next 2 bytes must be `#!`.
+    pub(super) unsafe fn read_hashbang_comment(&mut self) -> Kind {
+        debug_assert!(self.peek_2_bytes() == Some([b'#', b'!']));
+
+        // SAFETY: Caller guarantees next 2 bytes are `#!`
+        unsafe {
+            self.source.next_byte_unchecked();
+            self.source.next_byte_unchecked();
+        }
+
         while let Some(c) = self.peek_char() {
             if is_line_terminator(c) {
                 break;
             }
             self.consume_char();
         }
-        self.token.set_is_on_new_line(true);
         Kind::HashbangComment
     }
 }

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -513,8 +513,9 @@ impl<'a> ParserImpl<'a> {
 
     #[expect(clippy::cast_possible_truncation)]
     fn parse_program(&mut self) -> Program<'a> {
-        // initialize cur_token and prev_token by moving onto the first token
-        self.bump_any();
+        // Initialize by moving onto the first token.
+        // Checks for hashbang comment.
+        self.token = self.lexer.first_token();
 
         let hashbang = self.parse_hashbang();
         let (directives, statements) =

--- a/tasks/benchmark/benches/lexer.rs
+++ b/tasks/benchmark/benches/lexer.rs
@@ -52,7 +52,9 @@ fn bench_lexer(criterion: &mut Criterion) {
             let mut allocator = Allocator::default();
             b.iter(|| {
                 let mut lexer = Lexer::new_for_benchmarks(&allocator, source_text, source_type);
-                while lexer.next_token().kind() != Kind::Eof {}
+                if lexer.first_token().kind() != Kind::Eof {
+                    while lexer.next_token().kind() != Kind::Eof {}
+                }
                 allocator.reset();
             });
         });


### PR DESCRIPTION
Small optimization to lexer. A hashbang can only appear at very start of file, so only check for hashbang when getting first token. This streamlines the byte handler for `#`, because a `#` anywhere else can only be a private identifier.

Note: `self.token.set_is_on_new_line(true);` in `read_hashbang_comment` is not required, because it's always `true` already.