### PR TITLE
fix(ast): correct logic in `Expression::is_call_like_expression`

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -341,7 +341,7 @@ impl<'a> Expression<'a> {
     /// or [`ImportExpression`].
     pub fn is_call_like_expression(&self) -> bool {
         self.is_call_expression()
-            && matches!(self, Expression::NewExpression(_) | Expression::ImportExpression(_))
+            || matches!(self, Expression::NewExpression(_) | Expression::ImportExpression(_))
     }
 
     /// Returns `true` if this [`Expression`] is a [`BinaryExpression`] or [`LogicalExpression`].


### PR DESCRIPTION
The `is_call_like_expression` function is intended to identify expressions that are function calls, new expressions, or import expressions. The previous implementation incorrectly used a logical AND (`&&`) to combine these checks. This would always evaluate to false, since an expression cannot be a `CallExpression` *and* a `NewExpression` or `ImportExpression` simultaneously.

This pull request corrects the logic by replacing the logical AND (`&&`) with a logical OR (`||`). This ensures the function accurately returns `true` if an expression is any of the call-like types, aligning with its intended purpose.