### PR TITLE
fix(napi/oxlint): call `create` with rule as `this`

### DIFF
--- a/napi/oxlint2/src-js/index.js
+++ b/napi/oxlint2/src-js/index.js
@@ -176,9 +176,9 @@ function lintFile([filePath, bufferId, buffer, ruleIds]) {
   initCompiledVisitor();
   for (let i = 0; i < ruleIds.length; i++) {
     const ruleId = ruleIds[i];
-    const { rule: { create }, context } = registeredRules[ruleId];
+    const { rule, context } = registeredRules[ruleId];
     setupContextForFile(context, i, filePath);
-    const visitor = create(context);
+    const visitor = rule.create(context);
     addVisitorToCompiled(visitor);
   }
   const needsVisit = finalizeCompiledVisitor();

--- a/napi/oxlint2/test/fixtures/context_properties/test_plugin/index.js
+++ b/napi/oxlint2/test/fixtures/context_properties/test_plugin/index.js
@@ -8,30 +8,34 @@ const relativePath = sep === '/'
   ? path => path.slice(PARENT_DIR_PATH_LEN)
   : path => path.slice(PARENT_DIR_PATH_LEN).replace(/\\/g, '/');
 
+const rule = {
+  create(context) {
+    context.report({
+      message: `id: ${context.id}`,
+      node: SPAN,
+    });
+
+    context.report({
+      message: `filename: ${relativePath(context.filename)}`,
+      node: SPAN,
+    });
+
+    context.report({
+      message: `physicalFilename: ${relativePath(context.physicalFilename)}`,
+      node: SPAN,
+    });
+
+    if (this !== rule) context.report({ message: 'this !== rule', node: SPAN });
+
+    return {};
+  },
+};
+
 export default {
   meta: {
     name: "context-plugin",
   },
   rules: {
-    "log-context": {
-      create(context) {
-        context.report({
-          message: `id: ${context.id}`,
-          node: SPAN,
-        });
-
-        context.report({
-          message: `filename: ${relativePath(context.filename)}`,
-          node: SPAN,
-        });
-
-        context.report({
-          message: `physicalFilename: ${relativePath(context.physicalFilename)}`,
-          node: SPAN,
-        });
-
-        return {};
-      },
-    },
+    "log-context": rule,
   },
 };


### PR DESCRIPTION
Call JS plugin rules' `create` methods with the rule object as `this` - to match ESLint's API.
