### PR TITLE
fix(linter): default options for `unicorn/switch-case-braces`

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -23,9 +23,15 @@ fn switch_case_braces_diagnostic_unnecessary_braces(span: Span) -> OxcDiagnostic
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct SwitchCaseBraces {
     always_braces: bool,
+}
+
+impl Default for SwitchCaseBraces {
+    fn default() -> Self {
+        Self { always_braces: true }
+    }
 }
 
 declare_oxc_lint!(


### PR DESCRIPTION
related #12532