### PR TITLE
fix(linter): default options for `eslint/yoda`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/yoda.rs
+++ b/crates/oxc_linter/src/rules/eslint/yoda.rs
@@ -19,11 +19,17 @@ fn yoda_diagnostic(span: Span, never: bool, operator: &str) -> OxcDiagnostic {
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct Yoda {
     never: bool,
     except_range: bool,
     only_equality: bool,
+}
+
+impl Default for Yoda {
+    fn default() -> Self {
+        Self { never: true, except_range: false, only_equality: false }
+    }
 }
 
 declare_oxc_lint!(
@@ -188,7 +194,7 @@ declare_oxc_lint!(
 
 impl Rule for Yoda {
     fn from_configuration(value: serde_json::Value) -> Self {
-        let mut config = Self { never: true, except_range: false, only_equality: false };
+        let mut config = Self::default();
 
         let Some(arr) = value.as_array() else {
             return config;


### PR DESCRIPTION
closes #12532