### PR TITLE
refactor(linter): add `setup` detection for vue files

### DIFF
--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -9,7 +9,7 @@ use crate::{
     config::LintConfig,
     disable_directives::{DisableDirectives, DisableDirectivesBuilder, RuleCommentType},
     fixer::{Fix, FixKind, Message, PossibleFixes},
-    frameworks,
+    frameworks::{self, FrameworkOptions},
     module_record::ModuleRecord,
     options::LintOptions,
     rules::RuleEnum,
@@ -63,6 +63,8 @@ pub struct ContextHost<'a> {
     pub(super) config: Arc<LintConfig>,
     /// Front-end frameworks that might be in use in the target file.
     pub(super) frameworks: FrameworkFlags,
+    // Specific framework options, for example, whether the context is inside `<script setup>` in Vue files.
+    pub(super) frameworks_options: FrameworkOptions,
 }
 
 impl<'a> ContextHost<'a> {
@@ -74,6 +76,7 @@ impl<'a> ContextHost<'a> {
         module_record: Arc<ModuleRecord>,
         options: LintOptions,
         config: Arc<LintConfig>,
+        frameworks_options: FrameworkOptions,
     ) -> Self {
         const DIAGNOSTICS_INITIAL_CAPACITY: usize = 512;
 
@@ -98,6 +101,7 @@ impl<'a> ContextHost<'a> {
             file_path,
             config,
             frameworks: options.framework_hints,
+            frameworks_options,
         }
         .sniff_for_frameworks()
     }

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -17,6 +17,7 @@ use crate::{
     config::GlobalValue,
     disable_directives::DisableDirectives,
     fixer::{Fix, FixKind, Message, PossibleFixes, RuleFix, RuleFixer},
+    frameworks::FrameworkOptions,
 };
 
 mod host;
@@ -112,6 +113,10 @@ impl<'a> LintContext<'a> {
     #[inline]
     pub fn module_record(&self) -> &ModuleRecord {
         self.parent.module_record()
+    }
+
+    pub fn frameworks_options(&self) -> &FrameworkOptions {
+        &self.parent.frameworks_options
     }
 
     /// Get the control flow graph for the current program.

--- a/crates/oxc_linter/src/frameworks.rs
+++ b/crates/oxc_linter/src/frameworks.rs
@@ -95,3 +95,9 @@ pub fn has_vitest_imports(module_record: &ModuleRecord) -> bool {
 pub fn has_jest_imports(module_record: &ModuleRecord) -> bool {
     module_record.import_entries.iter().any(|entry| entry.module_request.name() == "@jest/globals")
 }
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum FrameworkOptions {
+    None,     // default
+    VueSetup, // context is inside `<script setup>`
+}

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -50,7 +50,7 @@ pub use crate::{
     },
     external_plugin_store::{ExternalPluginStore, ExternalRuleId},
     fixer::FixKind,
-    frameworks::FrameworkFlags,
+    frameworks::{FrameworkFlags, FrameworkOptions},
     loader::LINTABLE_EXTENSIONS,
     module_record::ModuleRecord,
     options::LintOptions,
@@ -127,12 +127,19 @@ impl Linter {
         path: &Path,
         semantic: Rc<Semantic<'a>>,
         module_record: Arc<ModuleRecord>,
+        framework_options: FrameworkOptions,
         allocator: &Allocator,
     ) -> Vec<Message<'a>> {
         let ResolvedLinterState { rules, config, external_rules } = self.config.resolve(path);
 
-        let ctx_host =
-            Rc::new(ContextHost::new(path, semantic, module_record, self.options, config));
+        let ctx_host = Rc::new(ContextHost::new(
+            path,
+            semantic,
+            module_record,
+            self.options,
+            config,
+            framework_options,
+        ));
 
         let rules = rules
             .iter()

--- a/crates/oxc_linter/src/loader/partial_loader/astro.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/astro.rs
@@ -2,7 +2,7 @@ use memchr::memmem::Finder;
 
 use oxc_span::{SourceType, Span};
 
-use crate::loader::JavaScriptSource;
+use crate::{frameworks::FrameworkOptions, loader::JavaScriptSource};
 
 use super::{SCRIPT_END, SCRIPT_START};
 
@@ -47,7 +47,7 @@ impl<'a> AstroPartialLoader<'a> {
         // move start to the end of the ASTRO_SPLIT
         let start = start + ASTRO_SPLIT.len() as u32;
         let js_code = Span::new(start, end).source_text(self.source_text);
-        Some(JavaScriptSource::partial(js_code, SourceType::ts(), start))
+        Some(JavaScriptSource::partial(js_code, SourceType::ts(), FrameworkOptions::None, start))
     }
 
     /// In .astro files, you can add client-side JavaScript by adding one (or more) `<script>` tags.
@@ -94,6 +94,7 @@ impl<'a> AstroPartialLoader<'a> {
             results.push(JavaScriptSource::partial(
                 &self.source_text[js_start..js_end],
                 SourceType::ts(),
+                FrameworkOptions::None,
                 js_start as u32,
             ));
         }

--- a/crates/oxc_linter/src/loader/partial_loader/svelte.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/svelte.rs
@@ -2,7 +2,7 @@ use memchr::memmem::Finder;
 
 use oxc_span::SourceType;
 
-use crate::loader::JavaScriptSource;
+use crate::{frameworks::FrameworkOptions, loader::JavaScriptSource};
 
 use super::{SCRIPT_END, SCRIPT_START, find_script_closing_angle};
 
@@ -62,7 +62,12 @@ impl<'a> SveltePartialLoader<'a> {
 
         // NOTE: loader checked that source_text.len() is less than u32::MAX
         #[expect(clippy::cast_possible_truncation)]
-        Some(JavaScriptSource::partial(source_text, source_type, js_start as u32))
+        Some(JavaScriptSource::partial(
+            source_text,
+            source_type,
+            FrameworkOptions::None,
+            js_start as u32,
+        ))
     }
 }
 

--- a/crates/oxc_linter/src/loader/source.rs
+++ b/crates/oxc_linter/src/loader/source.rs
@@ -1,5 +1,7 @@
 use oxc_span::SourceType;
 
+use crate::frameworks::FrameworkOptions;
+
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 pub struct JavaScriptSource<'a> {
@@ -10,15 +12,29 @@ pub struct JavaScriptSource<'a> {
     pub start: u32,
     #[expect(dead_code)]
     is_partial: bool,
+
+    // some partial sources can have special options defined, like Vue's `<script setup>`.
+    pub framework_options: FrameworkOptions,
 }
 
 impl<'a> JavaScriptSource<'a> {
     pub fn new(source_text: &'a str, source_type: SourceType) -> Self {
-        Self { source_text, source_type, start: 0, is_partial: false }
+        Self {
+            source_text,
+            source_type,
+            start: 0,
+            is_partial: false,
+            framework_options: FrameworkOptions::None,
+        }
     }
 
-    pub fn partial(source_text: &'a str, source_type: SourceType, start: u32) -> Self {
-        Self { source_text, source_type, start, is_partial: true }
+    pub fn partial(
+        source_text: &'a str,
+        source_type: SourceType,
+        framework_options: FrameworkOptions,
+        start: u32,
+    ) -> Self {
+        Self { source_text, source_type, start, is_partial: true, framework_options }
     }
 
     pub fn as_str(&self) -> &'a str {

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -25,6 +25,7 @@ use oxc_span::{CompactStr, SourceType, VALID_EXTENSIONS};
 use crate::{
     Fixer, Linter, Message,
     fixer::PossibleFixes,
+    frameworks::FrameworkOptions,
     loader::{JavaScriptSource, LINT_PARTIAL_LOADER_EXTENSIONS, PartialLoader},
     module_record::ModuleRecord,
     utils::read_to_arena_str,
@@ -524,6 +525,7 @@ impl Runtime {
                                 path,
                                 Rc::new(section.semantic.unwrap()),
                                 Arc::clone(&module_record),
+                                section.source.framework_options,
                                 allocator_guard,
                             ),
                             Err(errors) => errors
@@ -640,6 +642,7 @@ impl Runtime {
                                     Path::new(&module.path),
                                     Rc::new(section.semantic.unwrap()),
                                     Arc::clone(&module_record),
+                                    section.source.framework_options,
                                     allocator_guard,
                                 ),
                             };
@@ -763,6 +766,7 @@ impl Runtime {
                                         Path::new(&module.path),
                                         Rc::new(section.semantic.unwrap()),
                                         Arc::clone(&module_record),
+                                        section.source.framework_options,
                                         allocator_guard,
                                     ),
                                     Err(errors) => errors
@@ -893,8 +897,9 @@ impl Runtime {
         allocator: &'a Allocator,
         mut out_sections: Option<&mut SectionContents<'a>>,
     ) -> SmallVec<[Result<ResolvedModuleRecord, Vec<OxcDiagnostic>>; 1]> {
-        let section_sources = PartialLoader::parse(ext, source_text)
-            .unwrap_or_else(|| vec![JavaScriptSource::partial(source_text, source_type, 0)]);
+        let section_sources = PartialLoader::parse(ext, source_text).unwrap_or_else(|| {
+            vec![JavaScriptSource::partial(source_text, source_type, FrameworkOptions::None, 0)]
+        });
 
         let mut section_module_records = SmallVec::<
             [Result<ResolvedModuleRecord, Vec<OxcDiagnostic>>; 1],

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -311,7 +311,7 @@ mod test {
     use oxc_semantic::SemanticBuilder;
     use oxc_span::SourceType;
 
-    use crate::{ContextHost, ModuleRecord, options::LintOptions};
+    use crate::{ContextHost, ModuleRecord, frameworks::FrameworkOptions, options::LintOptions};
 
     #[test]
     fn test_is_jest_file() {
@@ -329,6 +329,7 @@ mod test {
                 Arc::new(ModuleRecord::default()),
                 LintOptions::default(),
                 Arc::default(),
+                FrameworkOptions::None,
             ))
             .spawn_for_test()
         };

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -30,8 +30,8 @@ use oxc::{
 use oxc_formatter::{FormatOptions, Formatter};
 use oxc_index::Idx;
 use oxc_linter::{
-    ConfigStore, ConfigStoreBuilder, ExternalPluginStore, LintOptions, Linter, ModuleRecord,
-    Oxlintrc,
+    ConfigStore, ConfigStoreBuilder, ExternalPluginStore, FrameworkOptions, LintOptions, Linter,
+    ModuleRecord, Oxlintrc,
 };
 use oxc_napi::{Comment, OxcError, convert_utf8_to_utf16};
 
@@ -315,7 +315,13 @@ impl Oxc {
                 ConfigStore::new(lint_config, FxHashMap::default(), ExternalPluginStore::default()),
                 None,
             )
-            .run(path, Rc::clone(&semantic), Arc::clone(module_record), allocator);
+            .run(
+                path,
+                Rc::clone(&semantic),
+                Arc::clone(module_record),
+                FrameworkOptions::None,
+                allocator,
+            );
             self.diagnostics.extend(linter_ret.into_iter().map(|e| e.error));
         }
     }

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -5,8 +5,8 @@ use rustc_hash::FxHashMap;
 use oxc_allocator::Allocator;
 use oxc_benchmark::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use oxc_linter::{
-    ConfigStore, ConfigStoreBuilder, ExternalPluginStore, FixKind, LintOptions, Linter,
-    ModuleRecord,
+    ConfigStore, ConfigStoreBuilder, ExternalPluginStore, FixKind, FrameworkOptions, LintOptions,
+    Linter, ModuleRecord,
 };
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
@@ -39,7 +39,13 @@ fn bench_linter(criterion: &mut Criterion) {
         .with_fix(FixKind::All);
         group.bench_function(id, |b| {
             b.iter(|| {
-                linter.run(path, Rc::clone(&semantic), Arc::clone(&module_record), &allocator)
+                linter.run(
+                    path,
+                    Rc::clone(&semantic),
+                    Arc::clone(&module_record),
+                    FrameworkOptions::None,
+                    &allocator,
+                )
             });
         });
     }


### PR DESCRIPTION
Some Vue ESLint rules are only executed in script / non-script blocks. 
[valid-define-emits](https://github.com/vuejs/eslint-plugin-vue/blob/fe0ce5a0590ee8b7aec57712f56f0d1d557035cb/lib/rules/valid-define-emits.js#L32-L35) is one rule example.

Defined it as a "general" `FrameworkOptions` option. 
Maybe there are some `astro` rules which are only applied inside the [frontmatter](https://github.com/oxc-project/oxc/blob/main/crates/oxc_linter/src/loader/partial_loader/astro.rs#L129-L151)