### PR TITLE
fix(vscode): fix statusbar icon order

### DIFF
--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -317,7 +317,7 @@ function updateStatsBar(
     icon = '$(check-all)';
   }
 
-  myStatusBarItem.text = `oxc: ${icon}`;
+  myStatusBarItem.text = `${icon} oxc`;
   myStatusBarItem.backgroundColor = new ThemeColor(bgColor);
 }
 


### PR DESCRIPTION
Change the order of the status bar to be icon first then text.

I don't know if there is a reason behind this or an oversight. Other plugins like typescript and prettier show the icon on the left and the text on the right:
<img width="371" height="40" alt="image" src="https://github.com/user-attachments/assets/b7c59527-e130-4b51-936a-54c1559eaf8c" />




