### PR TITLE
fix(parser): prevent panic when parsing invalid extends clause

### DIFF
--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -201,6 +201,9 @@ impl<'a> ParserImpl<'a> {
             self.error(diagnostics::interface_implements(implements_kw_span));
         }
         for extend in &extends {
+            if self.fatal_error.is_some() {
+                break;
+            }
             if !extend.expression.is_entity_name_expression() {
                 self.error(diagnostics::interface_extend(extend.span));
             }

--- a/tasks/coverage/misc/fail/oxc-12546-1.ts
+++ b/tasks/coverage/misc/fail/oxc-12546-1.ts
@@ -1,0 +1,4 @@
+interface Props extends /MenuProps {
+  collapse?: boolean;
+  menus: MenuRecordRaw[];
+}

--- a/tasks/coverage/misc/fail/oxc-12546-2.ts
+++ b/tasks/coverage/misc/fail/oxc-12546-2.ts
@@ -1,0 +1,2 @@
+class Props extends /MenuProps {
+}

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 45/45 (100.00%)
 Positive Passed: 45/45 (100.00%)
-Negative Passed: 52/52 (100.00%)
+Negative Passed: 54/54 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -186,6 +186,21 @@ Negative Passed: 52/52 (100.00%)
    ╭─[misc/fail/oxc-11789-2.ts:1:14]
  1 │ interface i<>implements K {}
    ·              ──────────
+   ╰────
+
+  × Unterminated regular expression
+   ╭─[misc/fail/oxc-12546-1.ts:1:25]
+ 1 │ interface Props extends /MenuProps {
+   ·                         ─────────────
+ 2 │   collapse?: boolean;
+ 3 │   menus: MenuRecordRaw[];
+   ╰────
+
+  × Unterminated regular expression
+   ╭─[misc/fail/oxc-12546-2.ts:1:21]
+ 1 │ class Props extends /MenuProps {
+   ·                     ─────────────
+ 2 │ }
    ╰────
 
   × Cannot assign to this expression


### PR DESCRIPTION
fixes #12546