### PR TITLE
refactor(linter): remove `Runner` trait

### DIFF
--- a/apps/oxlint/src/lib.rs
+++ b/apps/oxlint/src/lib.rs
@@ -2,12 +2,11 @@ mod command;
 mod lint;
 mod output_formatter;
 mod result;
-mod runner;
 mod tester;
 mod walk;
 
 pub mod cli {
-    pub use crate::{command::*, lint::LintRunner, result::CliRunResult, runner::Runner};
+    pub use crate::{command::*, lint::LintRunner, result::CliRunResult};
 }
 
 pub use oxc_linter::{
@@ -21,7 +20,7 @@ mod raw_fs;
 #[global_allocator]
 static GLOBAL: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
 
-use cli::{CliRunResult, LintRunner, Runner};
+use cli::{CliRunResult, LintRunner};
 use std::{ffi::OsStr, io::BufWriter};
 
 pub fn lint(external_linter: Option<ExternalLinter>) -> CliRunResult {

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -20,7 +20,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use serde_json::Value;
 
 use crate::{
-    cli::{CliRunResult, LintCommand, MiscOptions, ReportUnusedDirectives, Runner, WarningOptions},
+    cli::{CliRunResult, LintCommand, MiscOptions, ReportUnusedDirectives, WarningOptions},
     output_formatter::{LintCommandInfo, OutputFormatter},
     walk::Walk,
 };
@@ -32,10 +32,8 @@ pub struct LintRunner {
     external_linter: Option<ExternalLinter>,
 }
 
-impl Runner for LintRunner {
-    type Options = LintCommand;
-
-    fn new(options: Self::Options, external_linter: Option<ExternalLinter>) -> Self {
+impl LintRunner {
+    pub(crate) fn new(options: LintCommand, external_linter: Option<ExternalLinter>) -> Self {
         Self {
             options,
             cwd: env::current_dir().expect("Failed to get current working directory"),
@@ -43,7 +41,7 @@ impl Runner for LintRunner {
         }
     }
 
-    fn run(self, stdout: &mut dyn Write) -> CliRunResult {
+    pub(crate) fn run(self, stdout: &mut dyn Write) -> CliRunResult {
         let format_str = self.options.output_options.format;
         let output_formatter = OutputFormatter::new(format_str);
 

--- a/apps/oxlint/src/tester.rs
+++ b/apps/oxlint/src/tester.rs
@@ -1,8 +1,6 @@
 #[cfg(test)]
 use crate::cli::{LintRunner, lint_command};
 #[cfg(test)]
-use crate::runner::Runner;
-#[cfg(test)]
 use cow_utils::CowUtils;
 #[cfg(test)]
 use lazy_regex::Regex;


### PR DESCRIPTION
Refactor. As far as I can see, this trait does not add any value, since it's only implemented by `LintRunner`. So remove it.