### PR TITLE
refactor(linter): remove `#[must_use]` from `LintService::with_*` methods

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -321,14 +321,14 @@ impl LintRunner {
         // Spawn linting in another thread so diagnostics can be printed immediately from diagnostic_service.run.
         rayon::spawn(move || {
             let mut lint_service = LintService::new(linter, allocator_pool, options);
-            let _ = lint_service.with_paths(paths);
+            lint_service.with_paths(paths);
 
             // Use `RawTransferFileSystem` if `oxlint2` feature is enabled.
             // This reads the source text into start of allocator, instead of the end.
             #[cfg(all(feature = "oxlint2", not(feature = "disable_oxlint2")))]
             {
                 use crate::raw_fs::RawTransferFileSystem;
-                let _ = lint_service.with_file_system(Box::new(RawTransferFileSystem));
+                lint_service.with_file_system(Box::new(RawTransferFileSystem));
             }
 
             lint_service.run(&tx_error);

--- a/crates/oxc_linter/src/service/mod.rs
+++ b/crates/oxc_linter/src/service/mod.rs
@@ -75,7 +75,6 @@ impl LintService {
         Self { runtime }
     }
 
-    #[must_use]
     pub fn with_file_system(
         &mut self,
         file_system: Box<dyn RuntimeFileSystem + Sync + Send>,
@@ -84,7 +83,6 @@ impl LintService {
         self
     }
 
-    #[must_use]
     pub fn with_paths(&mut self, paths: Vec<Arc<OsStr>>) -> &mut Self {
         self.runtime.with_paths(paths);
         self

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -195,12 +195,12 @@ impl Runtime {
     pub fn with_file_system(
         &mut self,
         file_system: Box<dyn RuntimeFileSystem + Sync + Send>,
-    ) -> &Self {
+    ) -> &mut Self {
         self.file_system = file_system;
         self
     }
 
-    pub fn with_paths(&mut self, paths: Vec<Arc<OsStr>>) -> &Self {
+    pub fn with_paths(&mut self, paths: Vec<Arc<OsStr>>) -> &mut Self {
         self.paths = paths.into_iter().collect();
         self
     }

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -545,7 +545,7 @@ impl Tester {
         let paths = vec![Arc::<OsStr>::from(path_to_lint.as_os_str())];
         let options = LintServiceOptions::new(cwd).with_cross_module(self.plugins.has_import());
         let mut lint_service = LintService::new(linter, AllocatorPool::default(), options);
-        let _ = lint_service
+        lint_service
             .with_file_system(Box::new(TesterFileSystem::new(
                 path_to_lint,
                 source_text.to_string(),


### PR DESCRIPTION
Pure refactor. Remove `#[must_use]` from `LintService::with_paths` and `LintService::with_file_system`. I assume these are left over from a past time when these methods took and returned `self`.

Also, make these same methods on `Runtime` return `&mut Self` not `&Self`. We don't use the return value of these methods, but presumably they're meant to support chaining.