### PR TITLE
refactor(napi/oxlint): remove unused `@ts-expect-error` comment

### DIFF
--- a/napi/oxlint2/src-js/visitor.ts
+++ b/napi/oxlint2/src-js/visitor.ts
@@ -342,10 +342,7 @@ function mergeVisitFns(visitFns: Function[]): any {
     mergers.push(merger);
   } else {
     merger = mergers[numVisitFns];
-    if (merger === null) {
-      // @ts-expect-error
-      merger = mergers[numVisitFns] = createMerger(numVisitFns);
-    }
+    if (merger === null) merger = mergers[numVisitFns] = createMerger(numVisitFns);
   }
 
   // Merge functions


### PR DESCRIPTION
TypeScript is saying this comment is not necessary.