### PR TITLE
refactor(napi/oxlint): reverse args of `ExternalLinter::new`

### DIFF
--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -61,7 +61,7 @@ pub struct ExternalLinter {
 }
 
 impl ExternalLinter {
-    pub fn new(run: ExternalLinterCb, load_plugin: ExternalLinterLoadPluginCb) -> Self {
+    pub fn new(load_plugin: ExternalLinterLoadPluginCb, run: ExternalLinterCb) -> Self {
         Self { load_plugin, run }
     }
 }

--- a/napi/oxlint2/src/lib.rs
+++ b/napi/oxlint2/src/lib.rs
@@ -161,5 +161,5 @@ pub async fn lint(load_plugin: JsLoadPluginCb, run: JsRunCb) -> bool {
     let rust_load_plugin = wrap_load_plugin(load_plugin);
     let rust_run = wrap_run(run);
 
-    oxlint_lint(Some(ExternalLinter::new(rust_run, rust_load_plugin))).report() == ExitCode::SUCCESS
+    oxlint_lint(Some(ExternalLinter::new(rust_load_plugin, rust_run))).report() == ExitCode::SUCCESS
 }


### PR DESCRIPTION
Pure refactor. Reverse order of arguments to `ExternalLinter::new`, to match order of fields in `ExternalLinter` struct.