### PR TITLE
refactor(napi/oxlint): simplify `ExternalLinterLintFileCb` type

### DIFF
--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -18,15 +18,8 @@ pub type ExternalLinterLoadPluginCb = Arc<
         + 'static,
 >;
 
-pub type ExternalLinterLintFileCb = Arc<
-    dyn Fn(
-            String,
-            Vec<u32>,
-            &Allocator,
-        ) -> Result<Vec<LintFileResult>, Box<dyn std::error::Error + Send + Sync>>
-        + Sync
-        + Send,
->;
+pub type ExternalLinterLintFileCb =
+    Arc<dyn Fn(String, Vec<u32>, &Allocator) -> Result<Vec<LintFileResult>, String> + Sync + Send>;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum PluginLoadResult {

--- a/napi/oxlint2/src/lib.rs
+++ b/napi/oxlint2/src/lib.rs
@@ -158,13 +158,13 @@ fn wrap_lint_file(cb: JsLintFileCb) -> ExternalLinterLintFileCb {
         );
 
         if status != Status::Ok {
-            return Err(format!("Failed to schedule callback: {status:?}").into());
+            return Err(format!("Failed to schedule callback: {status:?}"));
         }
 
         match rx.recv() {
             Ok(Ok(x)) => Ok(x),
-            Ok(Err(e)) => Err(format!("Callback reported error: {e}").into()),
-            Err(e) => Err(format!("Callback did not respond: {e}").into()),
+            Ok(Err(e)) => Err(format!("Callback reported error: {e}")),
+            Err(e) => Err(format!("Callback did not respond: {e}")),
         }
     })
 }


### PR DESCRIPTION
The function returned by `wrap_lint_file` only returns `String`s as errors, so no need to downcast return value to dynamic `Box<dyn std::error::Error + Send + Sync>` - just `String` is fine.