### PR TITLE
fix(minifier): do not remove non-plain empty functions

### DIFF
--- a/crates/oxc_ecmascript/src/side_effects/may_have_side_effects.rs
+++ b/crates/oxc_ecmascript/src/side_effects/may_have_side_effects.rs
@@ -357,7 +357,11 @@ impl<'a> MayHaveSideEffects<'a> for Class<'a> {
         // Example cases: `class A extends 0 {}`, `class A extends (async function() {}) {}`
         // Considering these cases is difficult and requires to de-opt most classes with a super class.
         // To allow classes with a super class to be removed, we ignore this side effect.
-        if self.super_class.as_ref().is_some_and(|sup| sup.may_have_side_effects(ctx)) {
+        if self.super_class.as_ref().is_some_and(|sup| {
+            // `(class C extends (() => {}))` is TypeError.
+            matches!(sup.without_parentheses(), Expression::ArrowFunctionExpression(_))
+                || sup.may_have_side_effects(ctx)
+        }) {
             return true;
         }
 

--- a/crates/oxc_minifier/src/peephole/remove_unused_variable_declaration.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_variable_declaration.rs
@@ -160,6 +160,12 @@ mod test {
         test_options("var x = foo", "foo", &options);
         test_same_options("var x; foo(x)", &options);
         test_same_options("export var x", &options);
+        // TypeError
+        test_options(
+            "var x = class extends (() => {}) {}",
+            "(class extends (() => {}) {})",
+            &options,
+        );
     }
 
     #[test]

--- a/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
+++ b/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
@@ -642,6 +642,7 @@ fn test_class_expression() {
     test("(@foo class {})", true);
     test("(class extends a {})", false); // this may have a side effect, but ignored by the assumption
     test("(class extends foo() {})", true);
+    test("(class extends (() => {}) {})", true);
     test("(class { static {} })", false);
     test("(class { static { foo(); } })", true);
     test("(class { a() {} })", false);

--- a/tasks/coverage/snapshots/runtime.snap
+++ b/tasks/coverage/snapshots/runtime.snap
@@ -2,7 +2,7 @@ commit: 4b5d36ab
 
 runtime Summary:
 AST Parsed     : 18254/18254 (100.00%)
-Positive Passed: 17310/18254 (94.83%)
+Positive Passed: 17309/18254 (94.82%)
 codegen Error: tasks/coverage/test262/test/language/eval-code/direct/var-env-func-init-global-update-configurable.js
 Test262Error: obj['f'] descriptor should be enumerable; obj['f'] descriptor should be writable
 
@@ -2183,6 +2183,9 @@ Test262Error: Expected SameValue(«"_"», «"#field"») to be true
 
 transform Error: tasks/coverage/test262/test/language/statements/class/elements/static-field-init-with-this.js
 Test262Error: Expected SameValue(«"undefinedtest"», «"test262test"») to be true
+
+minify Error: tasks/coverage/test262/test/language/statements/class/name-binding/in-extends-expression-assigned.js
+Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
 
 minify Error: tasks/coverage/test262/test/language/statements/class/name-binding/in-extends-expression-grouped.js
 Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all

--- a/tasks/coverage/src/runtime/mod.rs
+++ b/tasks/coverage/src/runtime/mod.rs
@@ -201,7 +201,7 @@ impl Test262RuntimeCase {
         };
 
         let mut text = Codegen::new()
-            .with_options(CodegenOptions { minify, ..CodegenOptions::default() })
+            .with_options(if minify { CodegenOptions::minify() } else { CodegenOptions::default() })
             .with_scoping(symbol_table)
             .build(&program)
             .code;


### PR DESCRIPTION
Do not remove empty function calls if the function is async or generator or args can cause type error.

From test262:

```js
function fn({}) {}

assert.throws(TypeError, function() {
  fn(null);
});
```