### PR TITLE
fix(isolated-declarations): optional parameter property misses `undefined` type

### DIFF
--- a/crates/oxc_isolated_declarations/src/function.rs
+++ b/crates/oxc_isolated_declarations/src/function.rs
@@ -62,7 +62,10 @@ impl<'a> IsolatedDeclarations<'a> {
 
         FormalParameterBindingPattern::remove_assignments_from_kind(self.ast, &mut pattern.kind);
 
-        if is_assignment_pattern || pattern.type_annotation.is_none() {
+        if is_assignment_pattern
+            || pattern.type_annotation.is_none()
+            || (param.pattern.optional && param.has_modifier())
+        {
             let type_annotation = pattern
                 .type_annotation
                 .as_ref()
@@ -78,7 +81,9 @@ impl<'a> IsolatedDeclarations<'a> {
                 .map(|ts_type| {
                     // jf next param is not optional and current param is assignment pattern
                     // we need to add undefined to it's type
-                    if is_remaining_params_have_required {
+                    if is_remaining_params_have_required
+                        || (param.pattern.optional && param.has_modifier())
+                    {
                         if matches!(ts_type, TSType::TSTypeReference(_)) {
                             self.error(implicitly_adding_undefined_to_type(param.span));
                         } else if !ts_type.is_maybe_undefined() {

--- a/crates/oxc_isolated_declarations/tests/snapshots/class.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/class.snap
@@ -94,9 +94,9 @@ export declare class PrivateConstructorWithOverloads {
 	private constructor();
 }
 export declare class PrivateConstructorWithOptionalParameters {
-	publicOptional?: boolean;
+	publicOptional?: boolean | undefined;
 	private privateOptional?;
-	readonly readonlyOptional?: number;
+	readonly readonlyOptional?: number | undefined;
 	private constructor();
 }
 export declare class PrivateConstructorWithRestParameters {


### PR DESCRIPTION
[TypeScript Playground](https://www.typescriptlang.org/play/?#code/KYDwDg9gTgLgBAYwDYEMDOa4AUoEsBuKMwAwhAHZoxQCuCM0A6rjABYDyYMuFKSWKKCgC2wYlEwBvAFABIMHkLFEFKrXrQAFHNlRgARxq49AEwBccNbnIBzADQ6IXHuT4B+C+RrCARsCgOsvI0Pki4CHBgIWEInNy8SB5wPhAQSMAo5IHyikTAkbnEcS7uFla22XooJhRIAJ5wVTXk9cUJSV6+-oEAlHCSAL7SA0A)

Input: 
```ts
export class PrivateConstructorWithOptionalParameters {
	private constructor(
		required: string,
		optional?: number,
		public publicOptional?: boolean,
		private privateOptional?: string,
		readonly readonlyOptional?: number,
	) {}
}
```

Output:

```ts
export declare class PrivateConstructorWithOptionalParameters {
    publicOptional?: boolean | undefined;
    private privateOptional?;
    readonly readonlyOptional?: number | undefined;
    private constructor();
}
```

optional parameter property should union the original type with `undefined`