### PR TITLE
fix(formatter): is_long_curried_call cannot handle cases where the parent node is not a CallExpression

### DIFF
--- a/crates/oxc_formatter/src/utils/member_chain/mod.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/mod.rs
@@ -199,7 +199,7 @@ impl<'a> Format<'a> for MemberChain<'a, '_> {
         });
 
         if self.tail.len() <= 1 && !has_comments {
-            return if is_long_curried_call(self.root.parent) {
+            return if is_long_curried_call(self.root) {
                 write!(f, [format_one_line])
             } else if is_test_call_expression(self.root) && self.head.members().len() >= 2 {
                 write!(f, [self.head, soft_line_indent_or_space(&self.tail)])

--- a/crates/oxc_formatter/src/utils/mod.rs
+++ b/crates/oxc_formatter/src/utils/mod.rs
@@ -8,7 +8,7 @@ use oxc_ast::{AstKind, ast::CallExpression};
 use crate::{
     Format, FormatResult, FormatTrailingCommas, format_args,
     formatter::{Formatter, prelude::soft_line_break_or_space},
-    generated::ast_nodes::AstNodes,
+    generated::ast_nodes::{AstNode, AstNodes},
 };
 
 /// This function is in charge to format the call arguments.
@@ -40,12 +40,10 @@ where
 /// ```javascript
 /// `connect(a, b, c)(d)`
 /// ```
-pub fn is_long_curried_call(parent: &AstNodes<'_>) -> bool {
-    if let AstNodes::CallExpression(call) = parent {
-        if let AstNodes::CallExpression(parent_call) = call.parent {
-            return call.arguments().len() > parent_call.arguments().len()
-                && !parent_call.arguments().is_empty();
-        }
+pub fn is_long_curried_call(call: &AstNode<'_, CallExpression<'_>>) -> bool {
+    if let AstNodes::CallExpression(parent_call) = call.parent {
+        return call.arguments().len() > parent_call.arguments().len()
+            && !parent_call.arguments().is_empty();
     }
 
     false

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 438/699 (62.66%)
+js compatibility: 439/699 (62.80%)
 
 # Failed
 
@@ -124,7 +124,6 @@ js compatibility: 438/699 (62.66%)
 | js/for/in.js | 💥 | 50.00% |
 | js/for/parentheses.js | 💥 | 72.00% |
 | js/for-of/async-identifier.js | 💥 | 90.00% |
-| js/functional-composition/ramda_compose.js | 💥 | 92.47% |
 | js/identifier/for-of/await.js | 💥 | 33.33% |
 | js/identifier/for-of/let.js | 💥 | 61.54% |
 | js/identifier/parentheses/let.js | 💥💥 | 79.55% |


### PR DESCRIPTION
The previous implementation only considers the situation that the parent node is a CallExpression, but this turns out to be incorrect. We have to deal with some cases where the current node is a `CallExpression` rather than the parent node.