### PR TITLE
refactor(napi/oxlint): make `types.js` importable

### DIFF
--- a/napi/oxlint2/src-js/visitor.ts
+++ b/napi/oxlint2/src-js/visitor.ts
@@ -74,9 +74,7 @@
 
 // TODO(camc314): we need to generate `.d.ts` file for this module.
 // @ts-expect-error
-import types from '../dist/parser/generated/lazy/types.cjs';
-
-const { LEAF_NODE_TYPES_COUNT, NODE_TYPE_IDS_MAP, NODE_TYPES_COUNT } = types;
+import { LEAF_NODE_TYPES_COUNT, NODE_TYPE_IDS_MAP, NODE_TYPES_COUNT } from '../dist/parser/generated/lazy/types.cjs';
 
 const { isArray } = Array;
 

--- a/napi/parser/generated/lazy/types.js
+++ b/napi/parser/generated/lazy/types.js
@@ -187,8 +187,11 @@ const NODE_TYPE_IDS_MAP = new Map([
   ['JSDocNonNullableType', 177],
 ]);
 
+const NODE_TYPES_COUNT = 178,
+  LEAF_NODE_TYPES_COUNT = 38;
+
 module.exports = {
   NODE_TYPE_IDS_MAP,
-  NODE_TYPES_COUNT: 178,
-  LEAF_NODE_TYPES_COUNT: 38,
+  NODE_TYPES_COUNT,
+  LEAF_NODE_TYPES_COUNT,
 };

--- a/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
@@ -211,10 +211,13 @@ fn generate(
             {non_leaf_node_type_ids_map}
         ]);
 
+        const NODE_TYPES_COUNT = {nodes_count},
+            LEAF_NODE_TYPES_COUNT = {leaf_nodes_count};
+
         module.exports = {{
             NODE_TYPE_IDS_MAP,
-            NODE_TYPES_COUNT: {nodes_count},
-            LEAF_NODE_TYPES_COUNT: {leaf_nodes_count},
+            NODE_TYPES_COUNT,
+            LEAF_NODE_TYPES_COUNT,
         }};
     ");
 


### PR DESCRIPTION
Pure refactor. Alter format of `types.js` generated code, so it can be `import`ed.