### PR TITLE
perf(napi/oxlint): recycle arrays

### DIFF
--- a/napi/oxlint2/src-js/visitor.ts
+++ b/napi/oxlint2/src-js/visitor.ts
@@ -241,8 +241,8 @@ export function addVisitorToCompiled(visitor: Visitor): void {
       } else {
         // Same as above, enter visitor is put to front of list to make sure enter is called before exit
         (compiledVisitor[typeId] as CompilingLeafVisitorEntry) = isExit
-          ? [existing as unknown as VisitFn, visitFn]
-          : [visitFn, existing as unknown as VisitFn];
+          ? createVisitFnArray(existing as unknown as VisitFn, visitFn)
+          : createVisitFnArray(visitFn, existing as unknown as VisitFn);
         mergedLeafVisitorTypeIds.push(typeId);
       }
     } else {


### PR DESCRIPTION
All arrays of visit functions are meant to be recycled using the `visitFnArrayCache` pool. I somehow missed these 2 previously.