### PR TITLE
feat(linter): support `countVoidThis` option in `max-params` rule

### DIFF
--- a/crates/oxc_linter/src/snapshots/eslint_max_params.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_max_params.snap
@@ -71,3 +71,40 @@ source: crates/oxc_linter/src/tester.rs
  2 │                           // Just to make it longer
    ╰────
   help: This rule enforces a maximum number of parameters allowed in function definitions.
+
+  ⚠ eslint(max-params): Function 'testD' has too many parameters (3). Maximum allowed is 2.
+   ╭─[max_params.tsx:1:15]
+ 1 │ function testD(this: void, a, b) {}
+   ·               ──────────────────
+   ╰────
+  help: This rule enforces a maximum number of parameters allowed in function definitions.
+
+  ⚠ eslint(max-params): Function has too many parameters (2). Maximum allowed is 1.
+   ╭─[max_params.tsx:2:35]
+ 1 │ 
+ 2 │                 class Foo { method(this: void, a) {} }
+   ·                                   ───────────────
+ 3 │             
+   ╰────
+  help: This rule enforces a maximum number of parameters allowed in function definitions.
+
+  ⚠ eslint(max-params): Function has too many parameters (2). Maximum allowed is 1.
+   ╭─[max_params.tsx:1:24]
+ 1 │ const testE = function (this: void, a) {}
+   ·                        ───────────────
+   ╰────
+  help: This rule enforces a maximum number of parameters allowed in function definitions.
+
+  ⚠ eslint(max-params): Function has too many parameters (2). Maximum allowed is 1.
+   ╭─[max_params.tsx:1:24]
+ 1 │ const testE = function (this: any, a) {}
+   ·                        ──────────────
+   ╰────
+  help: This rule enforces a maximum number of parameters allowed in function definitions.
+
+  ⚠ eslint(max-params): Function has too many parameters (2). Maximum allowed is 1.
+   ╭─[max_params.tsx:1:24]
+ 1 │ const testE = function (this: any, a) {}
+   ·                        ──────────────
+   ╰────
+  help: This rule enforces a maximum number of parameters allowed in function definitions.


### PR DESCRIPTION
Implements the `countVoidThis` option for the `max-params` rule
Rule detail: https://eslint.org/docs/latest/rules/max-params#options

```typescript
/* max-params: ["error", { max: 2, countVoidThis: false }] */
function testD(this: void, a, b) {}
```
