### PR TITLE
fix(linter): correct `array-type` handling of `default: 'array-simple'`

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/array_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/array_type.rs
@@ -511,7 +511,7 @@ fn is_simple_type(ts_type: &TSType) -> bool {
                     if node.type_arguments.is_some() {
                         return false;
                     }
-                    if let TSTypeName::IdentifierReference(_) = &node.type_name {
+                    if node.type_name.is_identifier() || node.type_name.is_qualified_name() {
                         return true;
                     }
                     return false;
@@ -970,9 +970,13 @@ export const test = testFn<{name: string}>({name: 'test'});",
 const instance = new MyClass<number>(42);",
             Some(serde_json::json!([{"default":"generic"}])),
         ),
+        // https://github.com/oxc-project/oxc/issues/12605
+        ("let a: factories.User[] = [];", Some(serde_json::json!([{"default":"array-simple"}]))),
+        ("let a: factories.TT.User[] = [];", Some(serde_json::json!([{"default":"array-simple"}]))),
     ];
 
     let fail = vec![
+        ("let a: factories.User[] = [];", Some(serde_json::json!([{"default":"generic"}]))),
         ("let a: Array<number> = [];", Some(serde_json::json!([{"default":"array"}]))),
         ("let a: Array<string | number> = [];", Some(serde_json::json!([{"default":"array"}]))),
         ("let a: ReadonlyArray<number> = [];", Some(serde_json::json!([{"default":"array"}]))),

--- a/crates/oxc_linter/src/rules/typescript/array_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/array_type.rs
@@ -973,6 +973,10 @@ const instance = new MyClass<number>(42);",
         // https://github.com/oxc-project/oxc/issues/12605
         ("let a: factories.User[] = [];", Some(serde_json::json!([{"default":"array-simple"}]))),
         ("let a: factories.TT.User[] = [];", Some(serde_json::json!([{"default":"array-simple"}]))),
+        (
+            "let z: readonly factories.User[] = [];",
+            Some(serde_json::json!([{"readonly":"array-simple"}])),
+        ),
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/snapshots/typescript_array_type.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_array_type.snap
@@ -1,6 +1,13 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
+  ⚠ typescript-eslint(array-type): Array type using 'factories.User[]' is forbidden. Use 'Array<factories.User>' instead.
+   ╭─[array_type.ts:1:8]
+ 1 │ let a: factories.User[] = [];
+   ·        ────────────────
+   ╰────
+  help: Replace `factories.User[]` with `Array<factories.User>`.
+
   ⚠ typescript-eslint(array-type): Array type using 'Array<number>' is forbidden. Use 'number[]' instead.
    ╭─[array_type.ts:1:8]
  1 │ let a: Array<number> = [];


### PR DESCRIPTION
Fixes #12605 


