### PR TITLE
test(napi/oxlint): disable watch mode in `pnpm test`

### DIFF
--- a/napi/oxlint2/package.json
+++ b/napi/oxlint2/package.json
@@ -11,7 +11,7 @@
     "build-napi-test": "pnpm run build-napi --profile coverage --features force_test_reporter",
     "build-napi-release": "pnpm run build-napi --release",
     "build-js": "node scripts/build.js",
-    "test": "tsc && vitest"
+    "test": "tsc && vitest --dir ./test run"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
We now run tests against the build in `dist`, so running tests in watch mode is misleading - the code being tested doesn't update until you run `pnpm run build-test`.
