### PR TITLE
build(napi/oxlint): enable syntax minification

### DIFF
--- a/napi/oxlint2/tsdown.config.ts
+++ b/napi/oxlint2/tsdown.config.ts
@@ -17,4 +17,7 @@ export default defineConfig({
     // These are generated (also used by oxc-parser, so we'll copy them separately)
     /..\/parser\/.*/,
   ],
+  // At present only compress syntax.
+  // Don't mangle identifiers or remove whitespace, so `dist` code remains somewhat readable.
+  minify: { compress: true },
 });


### PR DESCRIPTION
Enable syntax minification in TSDown.

Oxc minification is in alpha, but our tests run on the minified code, so I think we can be fairly confident that minification isn't breaking the code.