### PR TITLE
refactor(napi/oxlint): use `assertIs` function instead of type assertions

### DIFF
--- a/napi/oxlint2/src-js/utils.ts
+++ b/napi/oxlint2/src-js/utils.ts
@@ -20,3 +20,13 @@ export function getErrorMessage(err: unknown): string {
 
   return 'Unknown error';
 }
+
+/**
+ * Assert a value is of a certain type.
+ *
+ * Has no runtime effect - only for guiding the type-checker.
+ * Minification removes this function and all calls to it, so it has zero runtime cost.
+ *
+ * @param value - Value
+ */
+export function assertIs<T>(value: unknown): asserts value is T {}

--- a/napi/oxlint2/src-js/visitor.ts
+++ b/napi/oxlint2/src-js/visitor.ts
@@ -75,6 +75,7 @@
 // TODO(camc314): we need to generate `.d.ts` file for this module.
 // @ts-expect-error
 import { LEAF_NODE_TYPES_COUNT, NODE_TYPE_IDS_MAP, NODE_TYPES_COUNT } from '../dist/parser/generated/lazy/types.cjs';
+import { assertIs } from './utils.js';
 
 import type { CompiledVisitorEntry, EnterExit, Node, VisitFn, Visitor } from './types.ts';
 
@@ -222,9 +223,9 @@ export function addVisitorToCompiled(visitor: Visitor): void {
 
     const existing = compiledVisitor[typeId] as CompilingNonLeafVisitorEntry;
     if (typeId < LEAF_NODE_TYPES_COUNT) {
-      // Leaf node - store just 1 function, not enter+exit pair.
-      // Note: `existing` here is actually `CompilingLeafVisitorEntry`, but can't tell TS compiler that
-      // without adding some code which would add (small) runtime cost.
+      // Leaf node - store just 1 function, not enter+exit pair
+      assertIs<CompilingLeafVisitorEntry>(existing);
+
       if (existing === null) {
         compiledVisitor[typeId] = visitFn;
       } else if (isArray(existing)) {
@@ -241,8 +242,8 @@ export function addVisitorToCompiled(visitor: Visitor): void {
       } else {
         // Same as above, enter visitor is put to front of list to make sure enter is called before exit
         (compiledVisitor[typeId] as CompilingLeafVisitorEntry) = isExit
-          ? createVisitFnArray(existing as unknown as VisitFn, visitFn)
-          : createVisitFnArray(visitFn, existing as unknown as VisitFn);
+          ? createVisitFnArray(existing, visitFn)
+          : createVisitFnArray(visitFn, existing);
         mergedLeafVisitorTypeIds.push(typeId);
       }
     } else {


### PR DESCRIPTION
Pure refactor, and only affects type-checking, not runtime behavior.

Replace various `as` type assertions by using an `assertIs` function which performs the same role. #12620 enabled syntax minification in TSDown, so these `assertIs<...>(...)` calls are removed in the build. This gives us better typing without any runtime cost.

It seems to work - I've checked that `assertIs` is not present in the bundled code in `dist`.
