### PR TITLE
feat(ast_visit): add `walk_children_*` methods

### DIFF
--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -1340,6 +1340,12 @@ pub mod walk {
     pub fn walk_program<'a, V: Visit<'a>>(visitor: &mut V, it: &Program<'a>) {
         let kind = AstKind::Program(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_program(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_program<'a, V: Visit<'a>>(visitor: &mut V, it: &Program<'a>) {
         visitor.enter_scope(
             {
                 let mut flags = ScopeFlags::Top;
@@ -1357,7 +1363,6 @@ pub mod walk {
         visitor.visit_directives(&it.directives);
         visitor.visit_statements(&it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     pub fn walk_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &Expression<'a>) {
@@ -1420,8 +1425,16 @@ pub mod walk {
     pub fn walk_identifier_name<'a, V: Visit<'a>>(visitor: &mut V, it: &IdentifierName<'a>) {
         let kind = AstKind::IdentifierName(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_identifier_name(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_identifier_name<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &IdentifierName<'a>,
+    ) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
@@ -1431,41 +1444,78 @@ pub mod walk {
     ) {
         let kind = AstKind::IdentifierReference(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_identifier_reference(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_identifier_reference<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &IdentifierReference<'a>,
+    ) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_binding_identifier<'a, V: Visit<'a>>(visitor: &mut V, it: &BindingIdentifier<'a>) {
         let kind = AstKind::BindingIdentifier(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_binding_identifier(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_binding_identifier<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &BindingIdentifier<'a>,
+    ) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_label_identifier<'a, V: Visit<'a>>(visitor: &mut V, it: &LabelIdentifier<'a>) {
         let kind = AstKind::LabelIdentifier(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_label_identifier(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_label_identifier<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &LabelIdentifier<'a>,
+    ) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_this_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &ThisExpression) {
         let kind = AstKind::ThisExpression(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_this_expression(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_this_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &ThisExpression) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_array_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &ArrayExpression<'a>) {
         let kind = AstKind::ArrayExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_array_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_array_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ArrayExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_array_expression_elements(&it.elements);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1487,17 +1537,30 @@ pub mod walk {
     pub fn walk_elision<'a, V: Visit<'a>>(visitor: &mut V, it: &Elision) {
         let kind = AstKind::Elision(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_elision(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_elision<'a, V: Visit<'a>>(visitor: &mut V, it: &Elision) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_object_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &ObjectExpression<'a>) {
         let kind = AstKind::ObjectExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_object_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_object_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ObjectExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_object_property_kinds(&it.properties);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1516,10 +1579,18 @@ pub mod walk {
     pub fn walk_object_property<'a, V: Visit<'a>>(visitor: &mut V, it: &ObjectProperty<'a>) {
         let kind = AstKind::ObjectProperty(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_object_property(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_object_property<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ObjectProperty<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_property_key(&it.key);
         visitor.visit_expression(&it.value);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1536,10 +1607,18 @@ pub mod walk {
     pub fn walk_template_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &TemplateLiteral<'a>) {
         let kind = AstKind::TemplateLiteral(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_template_literal(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_template_literal<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TemplateLiteral<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_template_elements(&it.quasis);
         visitor.visit_expressions(&it.expressions);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1549,21 +1628,37 @@ pub mod walk {
     ) {
         let kind = AstKind::TaggedTemplateExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_tagged_template_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_tagged_template_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TaggedTemplateExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.tag);
         if let Some(type_arguments) = &it.type_arguments {
             visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
         visitor.visit_template_literal(&it.quasi);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_template_element<'a, V: Visit<'a>>(visitor: &mut V, it: &TemplateElement<'a>) {
         let kind = AstKind::TemplateElement(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_template_element(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_template_element<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TemplateElement<'a>,
+    ) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
@@ -1589,10 +1684,18 @@ pub mod walk {
     ) {
         let kind = AstKind::ComputedMemberExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_computed_member_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_computed_member_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ComputedMemberExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.object);
         visitor.visit_expression(&it.expression);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1602,10 +1705,18 @@ pub mod walk {
     ) {
         let kind = AstKind::StaticMemberExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_static_member_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_static_member_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &StaticMemberExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.object);
         visitor.visit_identifier_name(&it.property);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1615,55 +1726,86 @@ pub mod walk {
     ) {
         let kind = AstKind::PrivateFieldExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_private_field_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_private_field_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &PrivateFieldExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.object);
         visitor.visit_private_identifier(&it.field);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_call_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &CallExpression<'a>) {
         let kind = AstKind::CallExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_call_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_call_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &CallExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.callee);
         if let Some(type_arguments) = &it.type_arguments {
             visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
         visitor.visit_arguments(&it.arguments);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_new_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &NewExpression<'a>) {
         let kind = AstKind::NewExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_new_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_new_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &NewExpression<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.callee);
         if let Some(type_arguments) = &it.type_arguments {
             visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
         visitor.visit_arguments(&it.arguments);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_meta_property<'a, V: Visit<'a>>(visitor: &mut V, it: &MetaProperty<'a>) {
         let kind = AstKind::MetaProperty(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_meta_property(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_meta_property<'a, V: Visit<'a>>(visitor: &mut V, it: &MetaProperty<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_identifier_name(&it.meta);
         visitor.visit_identifier_name(&it.property);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_spread_element<'a, V: Visit<'a>>(visitor: &mut V, it: &SpreadElement<'a>) {
         let kind = AstKind::SpreadElement(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_spread_element(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_spread_element<'a, V: Visit<'a>>(visitor: &mut V, it: &SpreadElement<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.argument);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1681,28 +1823,52 @@ pub mod walk {
     pub fn walk_update_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &UpdateExpression<'a>) {
         let kind = AstKind::UpdateExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_update_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_update_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &UpdateExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_simple_assignment_target(&it.argument);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_unary_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &UnaryExpression<'a>) {
         let kind = AstKind::UnaryExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_unary_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_unary_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &UnaryExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.argument);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_binary_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &BinaryExpression<'a>) {
         let kind = AstKind::BinaryExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_binary_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_binary_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &BinaryExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.left);
         visitor.visit_expression(&it.right);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1712,20 +1878,36 @@ pub mod walk {
     ) {
         let kind = AstKind::PrivateInExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_private_in_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_private_in_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &PrivateInExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_private_identifier(&it.left);
         visitor.visit_expression(&it.right);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_logical_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &LogicalExpression<'a>) {
         let kind = AstKind::LogicalExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_logical_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_logical_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &LogicalExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.left);
         visitor.visit_expression(&it.right);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1735,11 +1917,19 @@ pub mod walk {
     ) {
         let kind = AstKind::ConditionalExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_conditional_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_conditional_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ConditionalExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.test);
         visitor.visit_expression(&it.consequent);
         visitor.visit_expression(&it.alternate);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1749,10 +1939,18 @@ pub mod walk {
     ) {
         let kind = AstKind::AssignmentExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_assignment_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_assignment_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &AssignmentExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_assignment_target(&it.left);
         visitor.visit_expression(&it.right);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1814,6 +2012,15 @@ pub mod walk {
     ) {
         let kind = AstKind::ArrayAssignmentTarget(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_array_assignment_target(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_array_assignment_target<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ArrayAssignmentTarget<'a>,
+    ) {
         visitor.visit_span(&it.span);
         for el in it.elements.iter().flatten() {
             visitor.visit_assignment_target_maybe_default(el);
@@ -1821,7 +2028,6 @@ pub mod walk {
         if let Some(rest) = &it.rest {
             visitor.visit_assignment_target_rest(rest);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1831,12 +2037,20 @@ pub mod walk {
     ) {
         let kind = AstKind::ObjectAssignmentTarget(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_object_assignment_target(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_object_assignment_target<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ObjectAssignmentTarget<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_assignment_target_properties(&it.properties);
         if let Some(rest) = &it.rest {
             visitor.visit_assignment_target_rest(rest);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1846,9 +2060,17 @@ pub mod walk {
     ) {
         let kind = AstKind::AssignmentTargetRest(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_assignment_target_rest(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_assignment_target_rest<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &AssignmentTargetRest<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_assignment_target(&it.target);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1874,10 +2096,18 @@ pub mod walk {
     ) {
         let kind = AstKind::AssignmentTargetWithDefault(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_assignment_target_with_default(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_assignment_target_with_default<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &AssignmentTargetWithDefault<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_assignment_target(&it.binding);
         visitor.visit_expression(&it.init);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1903,12 +2133,20 @@ pub mod walk {
     ) {
         let kind = AstKind::AssignmentTargetPropertyIdentifier(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_assignment_target_property_identifier(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_assignment_target_property_identifier<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &AssignmentTargetPropertyIdentifier<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_identifier_reference(&it.binding);
         if let Some(init) = &it.init {
             visitor.visit_expression(init);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1918,10 +2156,18 @@ pub mod walk {
     ) {
         let kind = AstKind::AssignmentTargetPropertyProperty(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_assignment_target_property_property(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_assignment_target_property_property<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &AssignmentTargetPropertyProperty<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_property_key(&it.name);
         visitor.visit_assignment_target_maybe_default(&it.binding);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1931,35 +2177,64 @@ pub mod walk {
     ) {
         let kind = AstKind::SequenceExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_sequence_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_sequence_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &SequenceExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expressions(&it.expressions);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_super<'a, V: Visit<'a>>(visitor: &mut V, it: &Super) {
         let kind = AstKind::Super(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_super(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_super<'a, V: Visit<'a>>(visitor: &mut V, it: &Super) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_await_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &AwaitExpression<'a>) {
         let kind = AstKind::AwaitExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_await_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_await_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &AwaitExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.argument);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_chain_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &ChainExpression<'a>) {
         let kind = AstKind::ChainExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_chain_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_chain_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ChainExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_chain_element(&it.expression);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1981,9 +2256,17 @@ pub mod walk {
     ) {
         let kind = AstKind::ParenthesizedExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_parenthesized_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_parenthesized_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ParenthesizedExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.expression);
-        visitor.leave_node(kind);
     }
 
     pub fn walk_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &Statement<'a>) {
@@ -2018,28 +2301,46 @@ pub mod walk {
     pub fn walk_directive<'a, V: Visit<'a>>(visitor: &mut V, it: &Directive<'a>) {
         let kind = AstKind::Directive(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_directive(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_directive<'a, V: Visit<'a>>(visitor: &mut V, it: &Directive<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_string_literal(&it.expression);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_hashbang<'a, V: Visit<'a>>(visitor: &mut V, it: &Hashbang<'a>) {
         let kind = AstKind::Hashbang(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_hashbang(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_hashbang<'a, V: Visit<'a>>(visitor: &mut V, it: &Hashbang<'a>) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_block_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &BlockStatement<'a>) {
         let kind = AstKind::BlockStatement(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_block_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_block_statement<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &BlockStatement<'a>,
+    ) {
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_span(&it.span);
         visitor.visit_statements(&it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     pub fn walk_declaration<'a, V: Visit<'a>>(visitor: &mut V, it: &Declaration<'a>) {
@@ -2068,9 +2369,17 @@ pub mod walk {
     ) {
         let kind = AstKind::VariableDeclaration(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_variable_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_variable_declaration<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &VariableDeclaration<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_variable_declarators(&it.declarations);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2080,20 +2389,33 @@ pub mod walk {
     ) {
         let kind = AstKind::VariableDeclarator(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_variable_declarator(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_variable_declarator<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &VariableDeclarator<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_binding_pattern(&it.id);
         if let Some(init) = &it.init {
             visitor.visit_expression(init);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_empty_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &EmptyStatement) {
         let kind = AstKind::EmptyStatement(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_empty_statement(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_empty_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &EmptyStatement) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
@@ -2103,48 +2425,83 @@ pub mod walk {
     ) {
         let kind = AstKind::ExpressionStatement(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_expression_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_expression_statement<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ExpressionStatement<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.expression);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_if_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &IfStatement<'a>) {
         let kind = AstKind::IfStatement(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_if_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_if_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &IfStatement<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.test);
         visitor.visit_statement(&it.consequent);
         if let Some(alternate) = &it.alternate {
             visitor.visit_statement(alternate);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_do_while_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &DoWhileStatement<'a>) {
         let kind = AstKind::DoWhileStatement(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_do_while_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_do_while_statement<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &DoWhileStatement<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_statement(&it.body);
         visitor.visit_expression(&it.test);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_while_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &WhileStatement<'a>) {
         let kind = AstKind::WhileStatement(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_while_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_while_statement<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &WhileStatement<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.test);
         visitor.visit_statement(&it.body);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_for_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &ForStatement<'a>) {
         let kind = AstKind::ForStatement(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_for_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_for_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &ForStatement<'a>) {
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_span(&it.span);
         if let Some(init) = &it.init {
@@ -2158,7 +2515,6 @@ pub mod walk {
         }
         visitor.visit_statement(&it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2174,13 +2530,21 @@ pub mod walk {
     pub fn walk_for_in_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &ForInStatement<'a>) {
         let kind = AstKind::ForInStatement(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_for_in_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_for_in_statement<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ForInStatement<'a>,
+    ) {
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_span(&it.span);
         visitor.visit_for_statement_left(&it.left);
         visitor.visit_expression(&it.right);
         visitor.visit_statement(&it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2198,105 +2562,177 @@ pub mod walk {
     pub fn walk_for_of_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &ForOfStatement<'a>) {
         let kind = AstKind::ForOfStatement(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_for_of_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_for_of_statement<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ForOfStatement<'a>,
+    ) {
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_span(&it.span);
         visitor.visit_for_statement_left(&it.left);
         visitor.visit_expression(&it.right);
         visitor.visit_statement(&it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_continue_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &ContinueStatement<'a>) {
         let kind = AstKind::ContinueStatement(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_continue_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_continue_statement<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ContinueStatement<'a>,
+    ) {
         visitor.visit_span(&it.span);
         if let Some(label) = &it.label {
             visitor.visit_label_identifier(label);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_break_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &BreakStatement<'a>) {
         let kind = AstKind::BreakStatement(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_break_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_break_statement<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &BreakStatement<'a>,
+    ) {
         visitor.visit_span(&it.span);
         if let Some(label) = &it.label {
             visitor.visit_label_identifier(label);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_return_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &ReturnStatement<'a>) {
         let kind = AstKind::ReturnStatement(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_return_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_return_statement<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ReturnStatement<'a>,
+    ) {
         visitor.visit_span(&it.span);
         if let Some(argument) = &it.argument {
             visitor.visit_expression(argument);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_with_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &WithStatement<'a>) {
         let kind = AstKind::WithStatement(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_with_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_with_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &WithStatement<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.object);
         visitor.visit_statement(&it.body);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_switch_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &SwitchStatement<'a>) {
         let kind = AstKind::SwitchStatement(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_switch_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_switch_statement<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &SwitchStatement<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.discriminant);
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_switch_cases(&it.cases);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_switch_case<'a, V: Visit<'a>>(visitor: &mut V, it: &SwitchCase<'a>) {
         let kind = AstKind::SwitchCase(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_switch_case(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_switch_case<'a, V: Visit<'a>>(visitor: &mut V, it: &SwitchCase<'a>) {
         visitor.visit_span(&it.span);
         if let Some(test) = &it.test {
             visitor.visit_expression(test);
         }
         visitor.visit_statements(&it.consequent);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_labeled_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &LabeledStatement<'a>) {
         let kind = AstKind::LabeledStatement(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_labeled_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_labeled_statement<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &LabeledStatement<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_label_identifier(&it.label);
         visitor.visit_statement(&it.body);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_throw_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &ThrowStatement<'a>) {
         let kind = AstKind::ThrowStatement(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_throw_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_throw_statement<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ThrowStatement<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.argument);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_try_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &TryStatement<'a>) {
         let kind = AstKind::TryStatement(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_try_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_try_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &TryStatement<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_block_statement(&it.block);
         if let Some(handler) = &it.handler {
@@ -2305,13 +2741,18 @@ pub mod walk {
         if let Some(finalizer) = &it.finalizer {
             visitor.visit_block_statement(finalizer);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_catch_clause<'a, V: Visit<'a>>(visitor: &mut V, it: &CatchClause<'a>) {
         let kind = AstKind::CatchClause(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_catch_clause(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_catch_clause<'a, V: Visit<'a>>(visitor: &mut V, it: &CatchClause<'a>) {
         visitor.enter_scope(ScopeFlags::CatchClause, &it.scope_id);
         visitor.visit_span(&it.span);
         if let Some(param) = &it.param {
@@ -2319,29 +2760,52 @@ pub mod walk {
         }
         visitor.visit_block_statement(&it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_catch_parameter<'a, V: Visit<'a>>(visitor: &mut V, it: &CatchParameter<'a>) {
         let kind = AstKind::CatchParameter(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_catch_parameter(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_catch_parameter<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &CatchParameter<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_binding_pattern(&it.pattern);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_debugger_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &DebuggerStatement) {
         let kind = AstKind::DebuggerStatement(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_debugger_statement(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_debugger_statement<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &DebuggerStatement,
+    ) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_binding_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &BindingPattern<'a>) {
         // No `AstKind` for this type
+        walk_children_binding_pattern(visitor, it);
+    }
+
+    #[inline]
+    pub fn walk_children_binding_pattern<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &BindingPattern<'a>,
+    ) {
         visitor.visit_binding_pattern_kind(&it.kind);
         if let Some(type_annotation) = &it.type_annotation {
             visitor.visit_ts_type_annotation(type_annotation);
@@ -2366,38 +2830,65 @@ pub mod walk {
     pub fn walk_assignment_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &AssignmentPattern<'a>) {
         let kind = AstKind::AssignmentPattern(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_assignment_pattern(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_assignment_pattern<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &AssignmentPattern<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_binding_pattern(&it.left);
         visitor.visit_expression(&it.right);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_object_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &ObjectPattern<'a>) {
         let kind = AstKind::ObjectPattern(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_object_pattern(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_object_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &ObjectPattern<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_binding_properties(&it.properties);
         if let Some(rest) = &it.rest {
             visitor.visit_binding_rest_element(rest);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_binding_property<'a, V: Visit<'a>>(visitor: &mut V, it: &BindingProperty<'a>) {
         let kind = AstKind::BindingProperty(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_binding_property(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_binding_property<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &BindingProperty<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_property_key(&it.key);
         visitor.visit_binding_pattern(&it.value);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_array_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &ArrayPattern<'a>) {
         let kind = AstKind::ArrayPattern(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_array_pattern(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_array_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &ArrayPattern<'a>) {
         visitor.visit_span(&it.span);
         for el in it.elements.iter().flatten() {
             visitor.visit_binding_pattern(el);
@@ -2405,7 +2896,6 @@ pub mod walk {
         if let Some(rest) = &it.rest {
             visitor.visit_binding_rest_element(rest);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2415,14 +2905,32 @@ pub mod walk {
     ) {
         let kind = AstKind::BindingRestElement(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_binding_pattern(&it.argument);
+        walk_children_binding_rest_element(visitor, it);
         visitor.leave_node(kind);
     }
 
+    #[inline]
+    pub fn walk_children_binding_rest_element<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &BindingRestElement<'a>,
+    ) {
+        visitor.visit_span(&it.span);
+        visitor.visit_binding_pattern(&it.argument);
+    }
+
+    #[inline]
     pub fn walk_function<'a, V: Visit<'a>>(visitor: &mut V, it: &Function<'a>, flags: ScopeFlags) {
         let kind = AstKind::Function(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_function(visitor, it, flags);
+        visitor.leave_node(kind);
+    }
+
+    pub fn walk_children_function<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &Function<'a>,
+        flags: ScopeFlags,
+    ) {
         visitor.enter_scope(
             {
                 let mut flags = flags;
@@ -2451,39 +2959,59 @@ pub mod walk {
             visitor.visit_function_body(body);
         }
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_formal_parameters<'a, V: Visit<'a>>(visitor: &mut V, it: &FormalParameters<'a>) {
         let kind = AstKind::FormalParameters(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_formal_parameters(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_formal_parameters<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &FormalParameters<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_formal_parameter_list(&it.items);
         if let Some(rest) = &it.rest {
             visitor.visit_binding_rest_element(rest);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_formal_parameter<'a, V: Visit<'a>>(visitor: &mut V, it: &FormalParameter<'a>) {
         let kind = AstKind::FormalParameter(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_formal_parameter(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_formal_parameter<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &FormalParameter<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_decorators(&it.decorators);
         visitor.visit_binding_pattern(&it.pattern);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_function_body<'a, V: Visit<'a>>(visitor: &mut V, it: &FunctionBody<'a>) {
         let kind = AstKind::FunctionBody(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_function_body(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_function_body<'a, V: Visit<'a>>(visitor: &mut V, it: &FunctionBody<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_directives(&it.directives);
         visitor.visit_statements(&it.statements);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2493,6 +3021,15 @@ pub mod walk {
     ) {
         let kind = AstKind::ArrowFunctionExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_arrow_function_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_arrow_function_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ArrowFunctionExpression<'a>,
+    ) {
         visitor.enter_scope(
             {
                 let mut flags = ScopeFlags::Function | ScopeFlags::Arrow;
@@ -2513,23 +3050,36 @@ pub mod walk {
         }
         visitor.visit_function_body(&it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_yield_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &YieldExpression<'a>) {
         let kind = AstKind::YieldExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_yield_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_yield_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &YieldExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         if let Some(argument) = &it.argument {
             visitor.visit_expression(argument);
         }
-        visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_class<'a, V: Visit<'a>>(visitor: &mut V, it: &Class<'a>) {
         let kind = AstKind::Class(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_class(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    pub fn walk_children_class<'a, V: Visit<'a>>(visitor: &mut V, it: &Class<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_decorators(&it.decorators);
         if let Some(id) = &it.id {
@@ -2548,16 +3098,20 @@ pub mod walk {
         visitor.visit_ts_class_implements_list(&it.implements);
         visitor.visit_class_body(&it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_class_body<'a, V: Visit<'a>>(visitor: &mut V, it: &ClassBody<'a>) {
         let kind = AstKind::ClassBody(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_class_body(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_class_body<'a, V: Visit<'a>>(visitor: &mut V, it: &ClassBody<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_class_elements(&it.body);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2576,6 +3130,15 @@ pub mod walk {
     pub fn walk_method_definition<'a, V: Visit<'a>>(visitor: &mut V, it: &MethodDefinition<'a>) {
         let kind = AstKind::MethodDefinition(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_method_definition(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_method_definition<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &MethodDefinition<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_decorators(&it.decorators);
         visitor.visit_property_key(&it.key);
@@ -2588,7 +3151,6 @@ pub mod walk {
             };
             visitor.visit_function(&it.value, flags);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2598,6 +3160,15 @@ pub mod walk {
     ) {
         let kind = AstKind::PropertyDefinition(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_property_definition(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_property_definition<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &PropertyDefinition<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_decorators(&it.decorators);
         visitor.visit_property_key(&it.key);
@@ -2607,26 +3178,38 @@ pub mod walk {
         if let Some(value) = &it.value {
             visitor.visit_expression(value);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_private_identifier<'a, V: Visit<'a>>(visitor: &mut V, it: &PrivateIdentifier<'a>) {
         let kind = AstKind::PrivateIdentifier(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_private_identifier(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_private_identifier<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &PrivateIdentifier<'a>,
+    ) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_static_block<'a, V: Visit<'a>>(visitor: &mut V, it: &StaticBlock<'a>) {
         let kind = AstKind::StaticBlock(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_static_block(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_static_block<'a, V: Visit<'a>>(visitor: &mut V, it: &StaticBlock<'a>) {
         visitor.enter_scope(ScopeFlags::ClassStaticBlock, &it.scope_id);
         visitor.visit_span(&it.span);
         visitor.visit_statements(&it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     pub fn walk_module_declaration<'a, V: Visit<'a>>(visitor: &mut V, it: &ModuleDeclaration<'a>) {
@@ -2651,6 +3234,15 @@ pub mod walk {
     pub fn walk_accessor_property<'a, V: Visit<'a>>(visitor: &mut V, it: &AccessorProperty<'a>) {
         let kind = AstKind::AccessorProperty(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_accessor_property(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_accessor_property<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &AccessorProperty<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_decorators(&it.decorators);
         visitor.visit_property_key(&it.key);
@@ -2660,25 +3252,41 @@ pub mod walk {
         if let Some(value) = &it.value {
             visitor.visit_expression(value);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_import_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &ImportExpression<'a>) {
         let kind = AstKind::ImportExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_import_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_import_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ImportExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.source);
         if let Some(options) = &it.options {
             visitor.visit_expression(options);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_import_declaration<'a, V: Visit<'a>>(visitor: &mut V, it: &ImportDeclaration<'a>) {
         let kind = AstKind::ImportDeclaration(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_import_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_import_declaration<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ImportDeclaration<'a>,
+    ) {
         visitor.visit_span(&it.span);
         if let Some(specifiers) = &it.specifiers {
             visitor.visit_import_declaration_specifiers(specifiers);
@@ -2687,7 +3295,6 @@ pub mod walk {
         if let Some(with_clause) = &it.with_clause {
             visitor.visit_with_clause(with_clause);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2711,10 +3318,18 @@ pub mod walk {
     pub fn walk_import_specifier<'a, V: Visit<'a>>(visitor: &mut V, it: &ImportSpecifier<'a>) {
         let kind = AstKind::ImportSpecifier(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_import_specifier(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_import_specifier<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ImportSpecifier<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_module_export_name(&it.imported);
         visitor.visit_binding_identifier(&it.local);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2724,9 +3339,17 @@ pub mod walk {
     ) {
         let kind = AstKind::ImportDefaultSpecifier(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_import_default_specifier(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_import_default_specifier<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ImportDefaultSpecifier<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_binding_identifier(&it.local);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2736,29 +3359,50 @@ pub mod walk {
     ) {
         let kind = AstKind::ImportNamespaceSpecifier(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_import_namespace_specifier(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_import_namespace_specifier<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ImportNamespaceSpecifier<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_binding_identifier(&it.local);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_with_clause<'a, V: Visit<'a>>(visitor: &mut V, it: &WithClause<'a>) {
         let kind = AstKind::WithClause(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_with_clause(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_with_clause<'a, V: Visit<'a>>(visitor: &mut V, it: &WithClause<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_identifier_name(&it.attributes_keyword);
         visitor.visit_import_attributes(&it.with_entries);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_import_attribute<'a, V: Visit<'a>>(visitor: &mut V, it: &ImportAttribute<'a>) {
         let kind = AstKind::ImportAttribute(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_import_attribute(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_import_attribute<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ImportAttribute<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_import_attribute_key(&it.key);
         visitor.visit_string_literal(&it.value);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2780,6 +3424,15 @@ pub mod walk {
     ) {
         let kind = AstKind::ExportNamedDeclaration(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_export_named_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_export_named_declaration<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ExportNamedDeclaration<'a>,
+    ) {
         visitor.visit_span(&it.span);
         if let Some(declaration) = &it.declaration {
             visitor.visit_declaration(declaration);
@@ -2791,7 +3444,6 @@ pub mod walk {
         if let Some(with_clause) = &it.with_clause {
             visitor.visit_with_clause(with_clause);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2801,10 +3453,18 @@ pub mod walk {
     ) {
         let kind = AstKind::ExportDefaultDeclaration(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_export_default_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_export_default_declaration<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ExportDefaultDeclaration<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_module_export_name(&it.exported);
         visitor.visit_export_default_declaration_kind(&it.declaration);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2814,6 +3474,15 @@ pub mod walk {
     ) {
         let kind = AstKind::ExportAllDeclaration(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_export_all_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_export_all_declaration<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ExportAllDeclaration<'a>,
+    ) {
         visitor.visit_span(&it.span);
         if let Some(exported) = &it.exported {
             visitor.visit_module_export_name(exported);
@@ -2822,17 +3491,24 @@ pub mod walk {
         if let Some(with_clause) = &it.with_clause {
             visitor.visit_with_clause(with_clause);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_export_specifier<'a, V: Visit<'a>>(visitor: &mut V, it: &ExportSpecifier<'a>) {
         let kind = AstKind::ExportSpecifier(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_export_specifier(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_export_specifier<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ExportSpecifier<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_module_export_name(&it.local);
         visitor.visit_module_export_name(&it.exported);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2873,120 +3549,209 @@ pub mod walk {
     ) {
         let kind = AstKind::V8IntrinsicExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_v_8_intrinsic_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_v_8_intrinsic_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &V8IntrinsicExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_identifier_name(&it.name);
         visitor.visit_arguments(&it.arguments);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_boolean_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &BooleanLiteral) {
         let kind = AstKind::BooleanLiteral(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_boolean_literal(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_boolean_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &BooleanLiteral) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_null_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &NullLiteral) {
         let kind = AstKind::NullLiteral(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_null_literal(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_null_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &NullLiteral) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_numeric_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &NumericLiteral<'a>) {
         let kind = AstKind::NumericLiteral(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_numeric_literal(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_numeric_literal<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &NumericLiteral<'a>,
+    ) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_string_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &StringLiteral<'a>) {
         let kind = AstKind::StringLiteral(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_string_literal(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_string_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &StringLiteral<'a>) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_big_int_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &BigIntLiteral<'a>) {
         let kind = AstKind::BigIntLiteral(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_big_int_literal(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_big_int_literal<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &BigIntLiteral<'a>,
+    ) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_reg_exp_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &RegExpLiteral<'a>) {
         let kind = AstKind::RegExpLiteral(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_reg_exp_literal(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_reg_exp_literal<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &RegExpLiteral<'a>,
+    ) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_jsx_element<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXElement<'a>) {
         let kind = AstKind::JSXElement(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_jsx_element(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_element<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXElement<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_jsx_opening_element(&it.opening_element);
         visitor.visit_jsx_children(&it.children);
         if let Some(closing_element) = &it.closing_element {
             visitor.visit_jsx_closing_element(closing_element);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_jsx_opening_element<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXOpeningElement<'a>) {
         let kind = AstKind::JSXOpeningElement(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_jsx_opening_element(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_opening_element<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &JSXOpeningElement<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_jsx_element_name(&it.name);
         if let Some(type_arguments) = &it.type_arguments {
             visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
         visitor.visit_jsx_attribute_items(&it.attributes);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_jsx_closing_element<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXClosingElement<'a>) {
         let kind = AstKind::JSXClosingElement(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_jsx_closing_element(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_closing_element<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &JSXClosingElement<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_jsx_element_name(&it.name);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_jsx_fragment<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXFragment<'a>) {
         let kind = AstKind::JSXFragment(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_jsx_fragment(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_fragment<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXFragment<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_jsx_opening_fragment(&it.opening_fragment);
         visitor.visit_jsx_children(&it.children);
         visitor.visit_jsx_closing_fragment(&it.closing_fragment);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_jsx_opening_fragment<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXOpeningFragment) {
         let kind = AstKind::JSXOpeningFragment(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_jsx_opening_fragment(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_opening_fragment<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &JSXOpeningFragment,
+    ) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_jsx_closing_fragment<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXClosingFragment) {
         let kind = AstKind::JSXClosingFragment(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_jsx_closing_fragment(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_closing_fragment<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &JSXClosingFragment,
+    ) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
@@ -3005,10 +3770,18 @@ pub mod walk {
     pub fn walk_jsx_namespaced_name<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXNamespacedName<'a>) {
         let kind = AstKind::JSXNamespacedName(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_jsx_namespaced_name(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_namespaced_name<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &JSXNamespacedName<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_jsx_identifier(&it.namespace);
         visitor.visit_jsx_identifier(&it.name);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3018,10 +3791,18 @@ pub mod walk {
     ) {
         let kind = AstKind::JSXMemberExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_jsx_member_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_member_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &JSXMemberExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_jsx_member_expression_object(&it.object);
         visitor.visit_jsx_identifier(&it.property);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3048,9 +3829,17 @@ pub mod walk {
     ) {
         let kind = AstKind::JSXExpressionContainer(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_jsx_expression_container(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_expression_container<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &JSXExpressionContainer<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_jsx_expression(&it.expression);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3066,8 +3855,16 @@ pub mod walk {
     pub fn walk_jsx_empty_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXEmptyExpression) {
         let kind = AstKind::JSXEmptyExpression(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_jsx_empty_expression(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_empty_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &JSXEmptyExpression,
+    ) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
@@ -3083,12 +3880,17 @@ pub mod walk {
     pub fn walk_jsx_attribute<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXAttribute<'a>) {
         let kind = AstKind::JSXAttribute(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_jsx_attribute(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_attribute<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXAttribute<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_jsx_attribute_name(&it.name);
         if let Some(value) = &it.value {
             visitor.visit_jsx_attribute_value(value);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3098,9 +3900,17 @@ pub mod walk {
     ) {
         let kind = AstKind::JSXSpreadAttribute(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_jsx_spread_attribute(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_spread_attribute<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &JSXSpreadAttribute<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.argument);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3129,8 +3939,13 @@ pub mod walk {
     pub fn walk_jsx_identifier<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXIdentifier<'a>) {
         let kind = AstKind::JSXIdentifier(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_jsx_identifier(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_identifier<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXIdentifier<'a>) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
@@ -3149,62 +3964,101 @@ pub mod walk {
     pub fn walk_jsx_spread_child<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXSpreadChild<'a>) {
         let kind = AstKind::JSXSpreadChild(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_jsx_spread_child(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_spread_child<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &JSXSpreadChild<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.expression);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_jsx_text<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXText<'a>) {
         let kind = AstKind::JSXText(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_jsx_text(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_text<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXText<'a>) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_ts_this_parameter<'a, V: Visit<'a>>(visitor: &mut V, it: &TSThisParameter<'a>) {
         let kind = AstKind::TSThisParameter(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_this_parameter(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_this_parameter<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSThisParameter<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_span(&it.this_span);
         if let Some(type_annotation) = &it.type_annotation {
             visitor.visit_ts_type_annotation(type_annotation);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_enum_declaration<'a, V: Visit<'a>>(visitor: &mut V, it: &TSEnumDeclaration<'a>) {
         let kind = AstKind::TSEnumDeclaration(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_enum_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_enum_declaration<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSEnumDeclaration<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_binding_identifier(&it.id);
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_ts_enum_body(&it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_enum_body<'a, V: Visit<'a>>(visitor: &mut V, it: &TSEnumBody<'a>) {
         let kind = AstKind::TSEnumBody(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_enum_body(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_enum_body<'a, V: Visit<'a>>(visitor: &mut V, it: &TSEnumBody<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_enum_members(&it.members);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_enum_member<'a, V: Visit<'a>>(visitor: &mut V, it: &TSEnumMember<'a>) {
         let kind = AstKind::TSEnumMember(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_enum_member(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_enum_member<'a, V: Visit<'a>>(visitor: &mut V, it: &TSEnumMember<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_enum_member_name(&it.id);
         if let Some(initializer) = &it.initializer {
             visitor.visit_expression(initializer);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3222,18 +4076,34 @@ pub mod walk {
     pub fn walk_ts_type_annotation<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeAnnotation<'a>) {
         let kind = AstKind::TSTypeAnnotation(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_type_annotation(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_type_annotation<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSTypeAnnotation<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_type(&it.type_annotation);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_literal_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSLiteralType<'a>) {
         let kind = AstKind::TSLiteralType(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_literal_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_literal_type<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSLiteralType<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_literal(&it.literal);
-        visitor.leave_node(kind);
     }
 
     pub fn walk_ts_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &TSLiteral<'a>) {
@@ -3295,6 +4165,15 @@ pub mod walk {
     pub fn walk_ts_conditional_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSConditionalType<'a>) {
         let kind = AstKind::TSConditionalType(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_conditional_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_conditional_type<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSConditionalType<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_type(&it.check_type);
         visitor.enter_scope(ScopeFlags::TsConditional, &it.scope_id);
@@ -3302,16 +4181,20 @@ pub mod walk {
         visitor.visit_ts_type(&it.true_type);
         visitor.leave_scope();
         visitor.visit_ts_type(&it.false_type);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_union_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSUnionType<'a>) {
         let kind = AstKind::TSUnionType(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_union_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_union_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSUnionType<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_types(&it.types);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3321,9 +4204,17 @@ pub mod walk {
     ) {
         let kind = AstKind::TSIntersectionType(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_intersection_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_intersection_type<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSIntersectionType<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_types(&it.types);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3333,27 +4224,48 @@ pub mod walk {
     ) {
         let kind = AstKind::TSParenthesizedType(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_parenthesized_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_parenthesized_type<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSParenthesizedType<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_type(&it.type_annotation);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_type_operator<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeOperator<'a>) {
         let kind = AstKind::TSTypeOperator(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_type_operator(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_type_operator<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSTypeOperator<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_type(&it.type_annotation);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_array_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSArrayType<'a>) {
         let kind = AstKind::TSArrayType(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_array_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_array_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSArrayType<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_type(&it.element_type);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3363,19 +4275,32 @@ pub mod walk {
     ) {
         let kind = AstKind::TSIndexedAccessType(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_indexed_access_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_indexed_access_type<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSIndexedAccessType<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_type(&it.object_type);
         visitor.visit_ts_type(&it.index_type);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_tuple_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTupleType<'a>) {
         let kind = AstKind::TSTupleType(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_tuple_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_tuple_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTupleType<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_tuple_elements(&it.element_types);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3385,28 +4310,49 @@ pub mod walk {
     ) {
         let kind = AstKind::TSNamedTupleMember(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_named_tuple_member(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_named_tuple_member<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSNamedTupleMember<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_identifier_name(&it.label);
         visitor.visit_ts_tuple_element(&it.element_type);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_optional_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSOptionalType<'a>) {
         let kind = AstKind::TSOptionalType(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_optional_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_optional_type<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSOptionalType<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_type(&it.type_annotation);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_rest_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSRestType<'a>) {
         let kind = AstKind::TSRestType(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_rest_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_rest_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSRestType<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_type(&it.type_annotation);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3423,124 +4369,229 @@ pub mod walk {
     pub fn walk_ts_any_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSAnyKeyword) {
         let kind = AstKind::TSAnyKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_ts_any_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_any_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSAnyKeyword) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_ts_string_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSStringKeyword) {
         let kind = AstKind::TSStringKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_ts_string_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_string_keyword<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSStringKeyword,
+    ) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_ts_boolean_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSBooleanKeyword) {
         let kind = AstKind::TSBooleanKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_ts_boolean_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_boolean_keyword<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSBooleanKeyword,
+    ) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_ts_number_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSNumberKeyword) {
         let kind = AstKind::TSNumberKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_ts_number_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_number_keyword<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSNumberKeyword,
+    ) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_ts_never_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSNeverKeyword) {
         let kind = AstKind::TSNeverKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_ts_never_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_never_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSNeverKeyword) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_ts_intrinsic_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSIntrinsicKeyword) {
         let kind = AstKind::TSIntrinsicKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_ts_intrinsic_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_intrinsic_keyword<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSIntrinsicKeyword,
+    ) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_ts_unknown_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSUnknownKeyword) {
         let kind = AstKind::TSUnknownKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_ts_unknown_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_unknown_keyword<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSUnknownKeyword,
+    ) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_ts_null_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSNullKeyword) {
         let kind = AstKind::TSNullKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_ts_null_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_null_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSNullKeyword) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_ts_undefined_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSUndefinedKeyword) {
         let kind = AstKind::TSUndefinedKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_ts_undefined_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_undefined_keyword<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSUndefinedKeyword,
+    ) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_ts_void_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSVoidKeyword) {
         let kind = AstKind::TSVoidKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_ts_void_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_void_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSVoidKeyword) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_ts_symbol_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSSymbolKeyword) {
         let kind = AstKind::TSSymbolKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_ts_symbol_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_symbol_keyword<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSSymbolKeyword,
+    ) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_ts_this_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSThisType) {
         let kind = AstKind::TSThisType(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_ts_this_type(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_this_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSThisType) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_ts_object_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSObjectKeyword) {
         let kind = AstKind::TSObjectKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_ts_object_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_object_keyword<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSObjectKeyword,
+    ) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_ts_big_int_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSBigIntKeyword) {
         let kind = AstKind::TSBigIntKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_ts_big_int_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_big_int_keyword<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSBigIntKeyword,
+    ) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_ts_type_reference<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeReference<'a>) {
         let kind = AstKind::TSTypeReference(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_type_reference(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_type_reference<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSTypeReference<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_type_name(&it.type_name);
         if let Some(type_arguments) = &it.type_arguments {
             visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3557,10 +4608,18 @@ pub mod walk {
     pub fn walk_ts_qualified_name<'a, V: Visit<'a>>(visitor: &mut V, it: &TSQualifiedName<'a>) {
         let kind = AstKind::TSQualifiedName(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_qualified_name(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_qualified_name<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSQualifiedName<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_type_name(&it.left);
         visitor.visit_identifier_name(&it.right);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3570,15 +4629,32 @@ pub mod walk {
     ) {
         let kind = AstKind::TSTypeParameterInstantiation(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_type_parameter_instantiation(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_type_parameter_instantiation<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSTypeParameterInstantiation<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_types(&it.params);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_type_parameter<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeParameter<'a>) {
         let kind = AstKind::TSTypeParameter(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_type_parameter(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_type_parameter<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSTypeParameter<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_binding_identifier(&it.name);
         if let Some(constraint) = &it.constraint {
@@ -3587,7 +4663,6 @@ pub mod walk {
         if let Some(default) = &it.default {
             visitor.visit_ts_type(default);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3597,9 +4672,17 @@ pub mod walk {
     ) {
         let kind = AstKind::TSTypeParameterDeclaration(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_type_parameter_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_type_parameter_declaration<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSTypeParameterDeclaration<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_type_parameters(&it.params);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3609,6 +4692,15 @@ pub mod walk {
     ) {
         let kind = AstKind::TSTypeAliasDeclaration(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_type_alias_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_type_alias_declaration<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSTypeAliasDeclaration<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_binding_identifier(&it.id);
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
@@ -3617,19 +4709,26 @@ pub mod walk {
         }
         visitor.visit_ts_type(&it.type_annotation);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_class_implements<'a, V: Visit<'a>>(visitor: &mut V, it: &TSClassImplements<'a>) {
         let kind = AstKind::TSClassImplements(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_class_implements(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_class_implements<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSClassImplements<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_type_name(&it.expression);
         if let Some(type_arguments) = &it.type_arguments {
             visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3639,6 +4738,15 @@ pub mod walk {
     ) {
         let kind = AstKind::TSInterfaceDeclaration(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_interface_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_interface_declaration<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSInterfaceDeclaration<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_binding_identifier(&it.id);
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
@@ -3648,16 +4756,23 @@ pub mod walk {
         visitor.visit_ts_interface_heritages(&it.extends);
         visitor.visit_ts_interface_body(&it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_interface_body<'a, V: Visit<'a>>(visitor: &mut V, it: &TSInterfaceBody<'a>) {
         let kind = AstKind::TSInterfaceBody(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_interface_body(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_interface_body<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSInterfaceBody<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_signatures(&it.body);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3667,12 +4782,20 @@ pub mod walk {
     ) {
         let kind = AstKind::TSPropertySignature(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_property_signature(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_property_signature<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSPropertySignature<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_property_key(&it.key);
         if let Some(type_annotation) = &it.type_annotation {
             visitor.visit_ts_type_annotation(type_annotation);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3695,10 +4818,18 @@ pub mod walk {
     pub fn walk_ts_index_signature<'a, V: Visit<'a>>(visitor: &mut V, it: &TSIndexSignature<'a>) {
         let kind = AstKind::TSIndexSignature(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_index_signature(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_index_signature<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSIndexSignature<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_index_signature_names(&it.parameters);
         visitor.visit_ts_type_annotation(&it.type_annotation);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3708,6 +4839,15 @@ pub mod walk {
     ) {
         let kind = AstKind::TSCallSignatureDeclaration(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_call_signature_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_call_signature_declaration<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSCallSignatureDeclaration<'a>,
+    ) {
         visitor.visit_span(&it.span);
         if let Some(type_parameters) = &it.type_parameters {
             visitor.visit_ts_type_parameter_declaration(type_parameters);
@@ -3719,12 +4859,20 @@ pub mod walk {
         if let Some(return_type) = &it.return_type {
             visitor.visit_ts_type_annotation(return_type);
         }
-        visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_method_signature<'a, V: Visit<'a>>(visitor: &mut V, it: &TSMethodSignature<'a>) {
         let kind = AstKind::TSMethodSignature(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_method_signature(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    pub fn walk_children_ts_method_signature<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSMethodSignature<'a>,
+    ) {
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_span(&it.span);
         visitor.visit_property_key(&it.key);
@@ -3739,7 +4887,6 @@ pub mod walk {
             visitor.visit_ts_type_annotation(return_type);
         }
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3749,6 +4896,15 @@ pub mod walk {
     ) {
         let kind = AstKind::TSConstructSignatureDeclaration(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_construct_signature_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_construct_signature_declaration<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSConstructSignatureDeclaration<'a>,
+    ) {
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_span(&it.span);
         if let Some(type_parameters) = &it.type_parameters {
@@ -3759,7 +4915,6 @@ pub mod walk {
             visitor.visit_ts_type_annotation(return_type);
         }
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3769,9 +4924,17 @@ pub mod walk {
     ) {
         let kind = AstKind::TSIndexSignatureName(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_index_signature_name(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_index_signature_name<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSIndexSignatureName<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_type_annotation(&it.type_annotation);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3781,24 +4944,40 @@ pub mod walk {
     ) {
         let kind = AstKind::TSInterfaceHeritage(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_interface_heritage(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_interface_heritage<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSInterfaceHeritage<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.expression);
         if let Some(type_arguments) = &it.type_arguments {
             visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_type_predicate<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypePredicate<'a>) {
         let kind = AstKind::TSTypePredicate(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_type_predicate(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_type_predicate<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSTypePredicate<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_type_predicate_name(&it.parameter_name);
         if let Some(type_annotation) = &it.type_annotation {
             visitor.visit_ts_type_annotation(type_annotation);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3820,6 +4999,15 @@ pub mod walk {
     ) {
         let kind = AstKind::TSModuleDeclaration(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_module_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_module_declaration<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSModuleDeclaration<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_module_declaration_name(&it.id);
         visitor.enter_scope(
@@ -3836,7 +5024,6 @@ pub mod walk {
             visitor.visit_ts_module_declaration_body(body);
         }
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3869,40 +5056,66 @@ pub mod walk {
     pub fn walk_ts_module_block<'a, V: Visit<'a>>(visitor: &mut V, it: &TSModuleBlock<'a>) {
         let kind = AstKind::TSModuleBlock(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_module_block(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_module_block<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSModuleBlock<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_directives(&it.directives);
         visitor.visit_statements(&it.body);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_type_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeLiteral<'a>) {
         let kind = AstKind::TSTypeLiteral(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_type_literal(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_type_literal<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSTypeLiteral<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_signatures(&it.members);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_infer_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSInferType<'a>) {
         let kind = AstKind::TSInferType(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_infer_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_infer_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSInferType<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_type_parameter(&it.type_parameter);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_type_query<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeQuery<'a>) {
         let kind = AstKind::TSTypeQuery(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_type_query(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_type_query<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeQuery<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_type_query_expr_name(&it.expr_name);
         if let Some(type_arguments) = &it.type_arguments {
             visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3923,6 +5136,12 @@ pub mod walk {
     pub fn walk_ts_import_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSImportType<'a>) {
         let kind = AstKind::TSImportType(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_import_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_import_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSImportType<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_type(&it.argument);
         if let Some(options) = &it.options {
@@ -3934,13 +5153,21 @@ pub mod walk {
         if let Some(type_arguments) = &it.type_arguments {
             visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_function_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSFunctionType<'a>) {
         let kind = AstKind::TSFunctionType(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_function_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_function_type<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSFunctionType<'a>,
+    ) {
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_span(&it.span);
         if let Some(type_parameters) = &it.type_parameters {
@@ -3952,26 +5179,39 @@ pub mod walk {
         visitor.visit_formal_parameters(&it.params);
         visitor.visit_ts_type_annotation(&it.return_type);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_constructor_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSConstructorType<'a>) {
         let kind = AstKind::TSConstructorType(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_constructor_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_constructor_type<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSConstructorType<'a>,
+    ) {
         visitor.visit_span(&it.span);
         if let Some(type_parameters) = &it.type_parameters {
             visitor.visit_ts_type_parameter_declaration(type_parameters);
         }
         visitor.visit_formal_parameters(&it.params);
         visitor.visit_ts_type_annotation(&it.return_type);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_mapped_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSMappedType<'a>) {
         let kind = AstKind::TSMappedType(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_mapped_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_mapped_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSMappedType<'a>) {
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_span(&it.span);
         visitor.visit_ts_type_parameter(&it.type_parameter);
@@ -3982,7 +5222,6 @@ pub mod walk {
             visitor.visit_ts_type(type_annotation);
         }
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3992,20 +5231,36 @@ pub mod walk {
     ) {
         let kind = AstKind::TSTemplateLiteralType(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_template_literal_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_template_literal_type<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSTemplateLiteralType<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_template_elements(&it.quasis);
         visitor.visit_ts_types(&it.types);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_as_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &TSAsExpression<'a>) {
         let kind = AstKind::TSAsExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_as_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_as_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSAsExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.expression);
         visitor.visit_ts_type(&it.type_annotation);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4015,20 +5270,36 @@ pub mod walk {
     ) {
         let kind = AstKind::TSSatisfiesExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_satisfies_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_satisfies_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSSatisfiesExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.expression);
         visitor.visit_ts_type(&it.type_annotation);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_type_assertion<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeAssertion<'a>) {
         let kind = AstKind::TSTypeAssertion(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_type_assertion(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_type_assertion<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSTypeAssertion<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_type(&it.type_annotation);
         visitor.visit_expression(&it.expression);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4038,10 +5309,18 @@ pub mod walk {
     ) {
         let kind = AstKind::TSImportEqualsDeclaration(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_import_equals_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_import_equals_declaration<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSImportEqualsDeclaration<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_binding_identifier(&it.id);
         visitor.visit_ts_module_reference(&it.module_reference);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4064,9 +5343,17 @@ pub mod walk {
     ) {
         let kind = AstKind::TSExternalModuleReference(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_external_module_reference(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_external_module_reference<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSExternalModuleReference<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_string_literal(&it.expression);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4076,18 +5363,31 @@ pub mod walk {
     ) {
         let kind = AstKind::TSNonNullExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_non_null_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_non_null_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSNonNullExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.expression);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_decorator<'a, V: Visit<'a>>(visitor: &mut V, it: &Decorator<'a>) {
         let kind = AstKind::Decorator(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_decorator(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_decorator<'a, V: Visit<'a>>(visitor: &mut V, it: &Decorator<'a>) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.expression);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4097,9 +5397,17 @@ pub mod walk {
     ) {
         let kind = AstKind::TSExportAssignment(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_export_assignment(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_export_assignment<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSExportAssignment<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.expression);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4109,9 +5417,17 @@ pub mod walk {
     ) {
         let kind = AstKind::TSNamespaceExportDeclaration(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_namespace_export_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_namespace_export_declaration<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSNamespaceExportDeclaration<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_identifier_name(&it.id);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4121,10 +5437,18 @@ pub mod walk {
     ) {
         let kind = AstKind::TSInstantiationExpression(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_ts_instantiation_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_instantiation_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSInstantiationExpression<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.expression);
         visitor.visit_ts_type_parameter_instantiation(&it.type_arguments);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4134,9 +5458,17 @@ pub mod walk {
     ) {
         let kind = AstKind::JSDocNullableType(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_js_doc_nullable_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_js_doc_nullable_type<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &JSDocNullableType<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_type(&it.type_annotation);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4146,23 +5478,43 @@ pub mod walk {
     ) {
         let kind = AstKind::JSDocNonNullableType(visitor.alloc(it));
         visitor.enter_node(kind);
+        walk_children_js_doc_non_nullable_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_js_doc_non_nullable_type<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &JSDocNonNullableType<'a>,
+    ) {
         visitor.visit_span(&it.span);
         visitor.visit_ts_type(&it.type_annotation);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_js_doc_unknown_type<'a, V: Visit<'a>>(visitor: &mut V, it: &JSDocUnknownType) {
         let kind = AstKind::JSDocUnknownType(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
+        walk_children_js_doc_unknown_type(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_js_doc_unknown_type<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &JSDocUnknownType,
+    ) {
+        visitor.visit_span(&it.span);
     }
 
     #[inline]
     pub fn walk_span<'a, V: Visit<'a>>(visitor: &mut V, it: &Span) {
         // No `AstKind` for this type
+        walk_children_span(visitor, it);
     }
+
+    #[inline]
+    pub fn walk_children_span<'a, V: Visit<'a>>(visitor: &mut V, it: &Span) {}
 
     #[inline]
     pub fn walk_directives<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Directive<'a>>) {

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -1335,6 +1335,12 @@ pub mod walk_mut {
     pub fn walk_program<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Program<'a>) {
         let kind = AstType::Program;
         visitor.enter_node(kind);
+        walk_children_program(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_program<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Program<'a>) {
         visitor.enter_scope(
             {
                 let mut flags = ScopeFlags::Top;
@@ -1352,7 +1358,6 @@ pub mod walk_mut {
         visitor.visit_directives(&mut it.directives);
         visitor.visit_statements(&mut it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     pub fn walk_expression<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Expression<'a>) {
@@ -1415,8 +1420,16 @@ pub mod walk_mut {
     pub fn walk_identifier_name<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut IdentifierName<'a>) {
         let kind = AstType::IdentifierName;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_identifier_name(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_identifier_name<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut IdentifierName<'a>,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
@@ -1426,8 +1439,16 @@ pub mod walk_mut {
     ) {
         let kind = AstType::IdentifierReference;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_identifier_reference(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_identifier_reference<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut IdentifierReference<'a>,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
@@ -1437,8 +1458,16 @@ pub mod walk_mut {
     ) {
         let kind = AstType::BindingIdentifier;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_binding_identifier(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_binding_identifier<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut BindingIdentifier<'a>,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
@@ -1448,16 +1477,32 @@ pub mod walk_mut {
     ) {
         let kind = AstType::LabelIdentifier;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_label_identifier(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_label_identifier<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut LabelIdentifier<'a>,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
     pub fn walk_this_expression<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ThisExpression) {
         let kind = AstType::ThisExpression;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_this_expression(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_this_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ThisExpression,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
@@ -1467,9 +1512,17 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ArrayExpression;
         visitor.enter_node(kind);
+        walk_children_array_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_array_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ArrayExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_array_expression_elements(&mut it.elements);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1491,8 +1544,13 @@ pub mod walk_mut {
     pub fn walk_elision<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Elision) {
         let kind = AstType::Elision;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_elision(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_elision<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Elision) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
@@ -1502,9 +1560,17 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ObjectExpression;
         visitor.enter_node(kind);
+        walk_children_object_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_object_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ObjectExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_object_property_kinds(&mut it.properties);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1523,10 +1589,18 @@ pub mod walk_mut {
     pub fn walk_object_property<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ObjectProperty<'a>) {
         let kind = AstType::ObjectProperty;
         visitor.enter_node(kind);
+        walk_children_object_property(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_object_property<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ObjectProperty<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_property_key(&mut it.key);
         visitor.visit_expression(&mut it.value);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1546,10 +1620,18 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TemplateLiteral;
         visitor.enter_node(kind);
+        walk_children_template_literal(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_template_literal<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TemplateLiteral<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_template_elements(&mut it.quasis);
         visitor.visit_expressions(&mut it.expressions);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1559,13 +1641,21 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TaggedTemplateExpression;
         visitor.enter_node(kind);
+        walk_children_tagged_template_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_tagged_template_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TaggedTemplateExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.tag);
         if let Some(type_arguments) = &mut it.type_arguments {
             visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
         visitor.visit_template_literal(&mut it.quasi);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1575,8 +1665,16 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TemplateElement;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_template_element(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_template_element<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TemplateElement<'a>,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
@@ -1605,10 +1703,18 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ComputedMemberExpression;
         visitor.enter_node(kind);
+        walk_children_computed_member_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_computed_member_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ComputedMemberExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.object);
         visitor.visit_expression(&mut it.expression);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1618,10 +1724,18 @@ pub mod walk_mut {
     ) {
         let kind = AstType::StaticMemberExpression;
         visitor.enter_node(kind);
+        walk_children_static_member_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_static_member_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut StaticMemberExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.object);
         visitor.visit_identifier_name(&mut it.property);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1631,55 +1745,95 @@ pub mod walk_mut {
     ) {
         let kind = AstType::PrivateFieldExpression;
         visitor.enter_node(kind);
+        walk_children_private_field_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_private_field_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut PrivateFieldExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.object);
         visitor.visit_private_identifier(&mut it.field);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_call_expression<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut CallExpression<'a>) {
         let kind = AstType::CallExpression;
         visitor.enter_node(kind);
+        walk_children_call_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_call_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut CallExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.callee);
         if let Some(type_arguments) = &mut it.type_arguments {
             visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
         visitor.visit_arguments(&mut it.arguments);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_new_expression<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut NewExpression<'a>) {
         let kind = AstType::NewExpression;
         visitor.enter_node(kind);
+        walk_children_new_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_new_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut NewExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.callee);
         if let Some(type_arguments) = &mut it.type_arguments {
             visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
         visitor.visit_arguments(&mut it.arguments);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_meta_property<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut MetaProperty<'a>) {
         let kind = AstType::MetaProperty;
         visitor.enter_node(kind);
+        walk_children_meta_property(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_meta_property<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut MetaProperty<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_identifier_name(&mut it.meta);
         visitor.visit_identifier_name(&mut it.property);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_spread_element<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut SpreadElement<'a>) {
         let kind = AstType::SpreadElement;
         visitor.enter_node(kind);
+        walk_children_spread_element(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_spread_element<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut SpreadElement<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.argument);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1700,9 +1854,17 @@ pub mod walk_mut {
     ) {
         let kind = AstType::UpdateExpression;
         visitor.enter_node(kind);
+        walk_children_update_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_update_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut UpdateExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_simple_assignment_target(&mut it.argument);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1712,9 +1874,17 @@ pub mod walk_mut {
     ) {
         let kind = AstType::UnaryExpression;
         visitor.enter_node(kind);
+        walk_children_unary_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_unary_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut UnaryExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.argument);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1724,10 +1894,18 @@ pub mod walk_mut {
     ) {
         let kind = AstType::BinaryExpression;
         visitor.enter_node(kind);
+        walk_children_binary_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_binary_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut BinaryExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.left);
         visitor.visit_expression(&mut it.right);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1737,10 +1915,18 @@ pub mod walk_mut {
     ) {
         let kind = AstType::PrivateInExpression;
         visitor.enter_node(kind);
+        walk_children_private_in_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_private_in_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut PrivateInExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_private_identifier(&mut it.left);
         visitor.visit_expression(&mut it.right);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1750,10 +1936,18 @@ pub mod walk_mut {
     ) {
         let kind = AstType::LogicalExpression;
         visitor.enter_node(kind);
+        walk_children_logical_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_logical_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut LogicalExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.left);
         visitor.visit_expression(&mut it.right);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1763,11 +1957,19 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ConditionalExpression;
         visitor.enter_node(kind);
+        walk_children_conditional_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_conditional_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ConditionalExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.test);
         visitor.visit_expression(&mut it.consequent);
         visitor.visit_expression(&mut it.alternate);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1777,10 +1979,18 @@ pub mod walk_mut {
     ) {
         let kind = AstType::AssignmentExpression;
         visitor.enter_node(kind);
+        walk_children_assignment_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_assignment_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut AssignmentExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_assignment_target(&mut it.left);
         visitor.visit_expression(&mut it.right);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1845,6 +2055,15 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ArrayAssignmentTarget;
         visitor.enter_node(kind);
+        walk_children_array_assignment_target(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_array_assignment_target<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ArrayAssignmentTarget<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         for el in it.elements.iter_mut().flatten() {
             visitor.visit_assignment_target_maybe_default(el);
@@ -1852,7 +2071,6 @@ pub mod walk_mut {
         if let Some(rest) = &mut it.rest {
             visitor.visit_assignment_target_rest(rest);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1862,12 +2080,20 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ObjectAssignmentTarget;
         visitor.enter_node(kind);
+        walk_children_object_assignment_target(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_object_assignment_target<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ObjectAssignmentTarget<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_assignment_target_properties(&mut it.properties);
         if let Some(rest) = &mut it.rest {
             visitor.visit_assignment_target_rest(rest);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1877,9 +2103,17 @@ pub mod walk_mut {
     ) {
         let kind = AstType::AssignmentTargetRest;
         visitor.enter_node(kind);
+        walk_children_assignment_target_rest(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_assignment_target_rest<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut AssignmentTargetRest<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_assignment_target(&mut it.target);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1905,10 +2139,18 @@ pub mod walk_mut {
     ) {
         let kind = AstType::AssignmentTargetWithDefault;
         visitor.enter_node(kind);
+        walk_children_assignment_target_with_default(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_assignment_target_with_default<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut AssignmentTargetWithDefault<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_assignment_target(&mut it.binding);
         visitor.visit_expression(&mut it.init);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1934,12 +2176,20 @@ pub mod walk_mut {
     ) {
         let kind = AstType::AssignmentTargetPropertyIdentifier;
         visitor.enter_node(kind);
+        walk_children_assignment_target_property_identifier(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_assignment_target_property_identifier<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut AssignmentTargetPropertyIdentifier<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_identifier_reference(&mut it.binding);
         if let Some(init) = &mut it.init {
             visitor.visit_expression(init);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1949,10 +2199,18 @@ pub mod walk_mut {
     ) {
         let kind = AstType::AssignmentTargetPropertyProperty;
         visitor.enter_node(kind);
+        walk_children_assignment_target_property_property(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_assignment_target_property_property<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut AssignmentTargetPropertyProperty<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_property_key(&mut it.name);
         visitor.visit_assignment_target_maybe_default(&mut it.binding);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1962,17 +2220,30 @@ pub mod walk_mut {
     ) {
         let kind = AstType::SequenceExpression;
         visitor.enter_node(kind);
+        walk_children_sequence_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_sequence_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut SequenceExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expressions(&mut it.expressions);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_super<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Super) {
         let kind = AstType::Super;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_super(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_super<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Super) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
@@ -1982,9 +2253,17 @@ pub mod walk_mut {
     ) {
         let kind = AstType::AwaitExpression;
         visitor.enter_node(kind);
+        walk_children_await_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_await_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut AwaitExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.argument);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -1994,9 +2273,17 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ChainExpression;
         visitor.enter_node(kind);
+        walk_children_chain_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_chain_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ChainExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_chain_element(&mut it.expression);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2018,9 +2305,17 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ParenthesizedExpression;
         visitor.enter_node(kind);
+        walk_children_parenthesized_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_parenthesized_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ParenthesizedExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.expression);
-        visitor.leave_node(kind);
     }
 
     pub fn walk_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Statement<'a>) {
@@ -2055,28 +2350,46 @@ pub mod walk_mut {
     pub fn walk_directive<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Directive<'a>) {
         let kind = AstType::Directive;
         visitor.enter_node(kind);
+        walk_children_directive(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_directive<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Directive<'a>) {
         visitor.visit_span(&mut it.span);
         visitor.visit_string_literal(&mut it.expression);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_hashbang<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Hashbang<'a>) {
         let kind = AstType::Hashbang;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_hashbang(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_hashbang<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Hashbang<'a>) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
     pub fn walk_block_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut BlockStatement<'a>) {
         let kind = AstType::BlockStatement;
         visitor.enter_node(kind);
+        walk_children_block_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_block_statement<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut BlockStatement<'a>,
+    ) {
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_span(&mut it.span);
         visitor.visit_statements(&mut it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     pub fn walk_declaration<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Declaration<'a>) {
@@ -2105,9 +2418,17 @@ pub mod walk_mut {
     ) {
         let kind = AstType::VariableDeclaration;
         visitor.enter_node(kind);
+        walk_children_variable_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_variable_declaration<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut VariableDeclaration<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_variable_declarators(&mut it.declarations);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2117,20 +2438,36 @@ pub mod walk_mut {
     ) {
         let kind = AstType::VariableDeclarator;
         visitor.enter_node(kind);
+        walk_children_variable_declarator(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_variable_declarator<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut VariableDeclarator<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_binding_pattern(&mut it.id);
         if let Some(init) = &mut it.init {
             visitor.visit_expression(init);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_empty_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut EmptyStatement) {
         let kind = AstType::EmptyStatement;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_empty_statement(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_empty_statement<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut EmptyStatement,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
@@ -2140,22 +2477,38 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ExpressionStatement;
         visitor.enter_node(kind);
+        walk_children_expression_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_expression_statement<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ExpressionStatement<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.expression);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_if_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut IfStatement<'a>) {
         let kind = AstType::IfStatement;
         visitor.enter_node(kind);
+        walk_children_if_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_if_statement<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut IfStatement<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.test);
         visitor.visit_statement(&mut it.consequent);
         if let Some(alternate) = &mut it.alternate {
             visitor.visit_statement(alternate);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2165,26 +2518,51 @@ pub mod walk_mut {
     ) {
         let kind = AstType::DoWhileStatement;
         visitor.enter_node(kind);
+        walk_children_do_while_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_do_while_statement<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut DoWhileStatement<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_statement(&mut it.body);
         visitor.visit_expression(&mut it.test);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_while_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut WhileStatement<'a>) {
         let kind = AstType::WhileStatement;
         visitor.enter_node(kind);
+        walk_children_while_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_while_statement<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut WhileStatement<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.test);
         visitor.visit_statement(&mut it.body);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_for_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ForStatement<'a>) {
         let kind = AstType::ForStatement;
         visitor.enter_node(kind);
+        walk_children_for_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_for_statement<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ForStatement<'a>,
+    ) {
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_span(&mut it.span);
         if let Some(init) = &mut it.init {
@@ -2198,7 +2576,6 @@ pub mod walk_mut {
         }
         visitor.visit_statement(&mut it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2220,13 +2597,21 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ForInStatement;
         visitor.enter_node(kind);
+        walk_children_for_in_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_for_in_statement<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ForInStatement<'a>,
+    ) {
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_span(&mut it.span);
         visitor.visit_for_statement_left(&mut it.left);
         visitor.visit_expression(&mut it.right);
         visitor.visit_statement(&mut it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2250,13 +2635,21 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ForOfStatement;
         visitor.enter_node(kind);
+        walk_children_for_of_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_for_of_statement<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ForOfStatement<'a>,
+    ) {
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_span(&mut it.span);
         visitor.visit_for_statement_left(&mut it.left);
         visitor.visit_expression(&mut it.right);
         visitor.visit_statement(&mut it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2266,22 +2659,38 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ContinueStatement;
         visitor.enter_node(kind);
+        walk_children_continue_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_continue_statement<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ContinueStatement<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         if let Some(label) = &mut it.label {
             visitor.visit_label_identifier(label);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_break_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut BreakStatement<'a>) {
         let kind = AstType::BreakStatement;
         visitor.enter_node(kind);
+        walk_children_break_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_break_statement<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut BreakStatement<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         if let Some(label) = &mut it.label {
             visitor.visit_label_identifier(label);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2291,21 +2700,37 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ReturnStatement;
         visitor.enter_node(kind);
+        walk_children_return_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_return_statement<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ReturnStatement<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         if let Some(argument) = &mut it.argument {
             visitor.visit_expression(argument);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_with_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut WithStatement<'a>) {
         let kind = AstType::WithStatement;
         visitor.enter_node(kind);
+        walk_children_with_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_with_statement<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut WithStatement<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.object);
         visitor.visit_statement(&mut it.body);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2315,24 +2740,40 @@ pub mod walk_mut {
     ) {
         let kind = AstType::SwitchStatement;
         visitor.enter_node(kind);
+        walk_children_switch_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_switch_statement<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut SwitchStatement<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.discriminant);
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_switch_cases(&mut it.cases);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_switch_case<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut SwitchCase<'a>) {
         let kind = AstType::SwitchCase;
         visitor.enter_node(kind);
+        walk_children_switch_case(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_switch_case<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut SwitchCase<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         if let Some(test) = &mut it.test {
             visitor.visit_expression(test);
         }
         visitor.visit_statements(&mut it.consequent);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2342,25 +2783,50 @@ pub mod walk_mut {
     ) {
         let kind = AstType::LabeledStatement;
         visitor.enter_node(kind);
+        walk_children_labeled_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_labeled_statement<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut LabeledStatement<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_label_identifier(&mut it.label);
         visitor.visit_statement(&mut it.body);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_throw_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ThrowStatement<'a>) {
         let kind = AstType::ThrowStatement;
         visitor.enter_node(kind);
+        walk_children_throw_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_throw_statement<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ThrowStatement<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.argument);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_try_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TryStatement<'a>) {
         let kind = AstType::TryStatement;
         visitor.enter_node(kind);
+        walk_children_try_statement(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_try_statement<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TryStatement<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_block_statement(&mut it.block);
         if let Some(handler) = &mut it.handler {
@@ -2369,13 +2835,21 @@ pub mod walk_mut {
         if let Some(finalizer) = &mut it.finalizer {
             visitor.visit_block_statement(finalizer);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_catch_clause<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut CatchClause<'a>) {
         let kind = AstType::CatchClause;
         visitor.enter_node(kind);
+        walk_children_catch_clause(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_catch_clause<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut CatchClause<'a>,
+    ) {
         visitor.enter_scope(ScopeFlags::CatchClause, &it.scope_id);
         visitor.visit_span(&mut it.span);
         if let Some(param) = &mut it.param {
@@ -2383,16 +2857,23 @@ pub mod walk_mut {
         }
         visitor.visit_block_statement(&mut it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_catch_parameter<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut CatchParameter<'a>) {
         let kind = AstType::CatchParameter;
         visitor.enter_node(kind);
+        walk_children_catch_parameter(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_catch_parameter<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut CatchParameter<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_binding_pattern(&mut it.pattern);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2402,13 +2883,29 @@ pub mod walk_mut {
     ) {
         let kind = AstType::DebuggerStatement;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_debugger_statement(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_debugger_statement<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut DebuggerStatement,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
     pub fn walk_binding_pattern<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut BindingPattern<'a>) {
         // No `AstType` for this type
+        walk_children_binding_pattern(visitor, it);
+    }
+
+    #[inline]
+    pub fn walk_children_binding_pattern<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut BindingPattern<'a>,
+    ) {
         visitor.visit_binding_pattern_kind(&mut it.kind);
         if let Some(type_annotation) = &mut it.type_annotation {
             visitor.visit_ts_type_annotation(type_annotation);
@@ -2436,22 +2933,38 @@ pub mod walk_mut {
     ) {
         let kind = AstType::AssignmentPattern;
         visitor.enter_node(kind);
+        walk_children_assignment_pattern(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_assignment_pattern<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut AssignmentPattern<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_binding_pattern(&mut it.left);
         visitor.visit_expression(&mut it.right);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_object_pattern<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ObjectPattern<'a>) {
         let kind = AstType::ObjectPattern;
         visitor.enter_node(kind);
+        walk_children_object_pattern(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_object_pattern<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ObjectPattern<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_binding_properties(&mut it.properties);
         if let Some(rest) = &mut it.rest {
             visitor.visit_binding_rest_element(rest);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2461,16 +2974,33 @@ pub mod walk_mut {
     ) {
         let kind = AstType::BindingProperty;
         visitor.enter_node(kind);
+        walk_children_binding_property(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_binding_property<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut BindingProperty<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_property_key(&mut it.key);
         visitor.visit_binding_pattern(&mut it.value);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_array_pattern<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ArrayPattern<'a>) {
         let kind = AstType::ArrayPattern;
         visitor.enter_node(kind);
+        walk_children_array_pattern(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_array_pattern<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ArrayPattern<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         for el in it.elements.iter_mut().flatten() {
             visitor.visit_binding_pattern(el);
@@ -2478,7 +3008,6 @@ pub mod walk_mut {
         if let Some(rest) = &mut it.rest {
             visitor.visit_binding_rest_element(rest);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2488,11 +3017,20 @@ pub mod walk_mut {
     ) {
         let kind = AstType::BindingRestElement;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_binding_pattern(&mut it.argument);
+        walk_children_binding_rest_element(visitor, it);
         visitor.leave_node(kind);
     }
 
+    #[inline]
+    pub fn walk_children_binding_rest_element<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut BindingRestElement<'a>,
+    ) {
+        visitor.visit_span(&mut it.span);
+        visitor.visit_binding_pattern(&mut it.argument);
+    }
+
+    #[inline]
     pub fn walk_function<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut Function<'a>,
@@ -2500,6 +3038,15 @@ pub mod walk_mut {
     ) {
         let kind = AstType::Function;
         visitor.enter_node(kind);
+        walk_children_function(visitor, it, flags);
+        visitor.leave_node(kind);
+    }
+
+    pub fn walk_children_function<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Function<'a>,
+        flags: ScopeFlags,
+    ) {
         visitor.enter_scope(
             {
                 let mut flags = flags;
@@ -2528,7 +3075,6 @@ pub mod walk_mut {
             visitor.visit_function_body(body);
         }
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2538,12 +3084,20 @@ pub mod walk_mut {
     ) {
         let kind = AstType::FormalParameters;
         visitor.enter_node(kind);
+        walk_children_formal_parameters(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_formal_parameters<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut FormalParameters<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_formal_parameter_list(&mut it.items);
         if let Some(rest) = &mut it.rest {
             visitor.visit_binding_rest_element(rest);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2553,20 +3107,36 @@ pub mod walk_mut {
     ) {
         let kind = AstType::FormalParameter;
         visitor.enter_node(kind);
+        walk_children_formal_parameter(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_formal_parameter<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut FormalParameter<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_decorators(&mut it.decorators);
         visitor.visit_binding_pattern(&mut it.pattern);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_function_body<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut FunctionBody<'a>) {
         let kind = AstType::FunctionBody;
         visitor.enter_node(kind);
+        walk_children_function_body(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_function_body<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut FunctionBody<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_directives(&mut it.directives);
         visitor.visit_statements(&mut it.statements);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2576,6 +3146,15 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ArrowFunctionExpression;
         visitor.enter_node(kind);
+        walk_children_arrow_function_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_arrow_function_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ArrowFunctionExpression<'a>,
+    ) {
         visitor.enter_scope(
             {
                 let mut flags = ScopeFlags::Function | ScopeFlags::Arrow;
@@ -2596,7 +3175,6 @@ pub mod walk_mut {
         }
         visitor.visit_function_body(&mut it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2606,16 +3184,30 @@ pub mod walk_mut {
     ) {
         let kind = AstType::YieldExpression;
         visitor.enter_node(kind);
+        walk_children_yield_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_yield_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut YieldExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         if let Some(argument) = &mut it.argument {
             visitor.visit_expression(argument);
         }
-        visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_class<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Class<'a>) {
         let kind = AstType::Class;
         visitor.enter_node(kind);
+        walk_children_class(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    pub fn walk_children_class<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Class<'a>) {
         visitor.visit_span(&mut it.span);
         visitor.visit_decorators(&mut it.decorators);
         if let Some(id) = &mut it.id {
@@ -2634,16 +3226,20 @@ pub mod walk_mut {
         visitor.visit_ts_class_implements_list(&mut it.implements);
         visitor.visit_class_body(&mut it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_class_body<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ClassBody<'a>) {
         let kind = AstType::ClassBody;
         visitor.enter_node(kind);
+        walk_children_class_body(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_class_body<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ClassBody<'a>) {
         visitor.visit_span(&mut it.span);
         visitor.visit_class_elements(&mut it.body);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2665,6 +3261,15 @@ pub mod walk_mut {
     ) {
         let kind = AstType::MethodDefinition;
         visitor.enter_node(kind);
+        walk_children_method_definition(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_method_definition<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut MethodDefinition<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_decorators(&mut it.decorators);
         visitor.visit_property_key(&mut it.key);
@@ -2677,7 +3282,6 @@ pub mod walk_mut {
             };
             visitor.visit_function(&mut it.value, flags);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2687,6 +3291,15 @@ pub mod walk_mut {
     ) {
         let kind = AstType::PropertyDefinition;
         visitor.enter_node(kind);
+        walk_children_property_definition(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_property_definition<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut PropertyDefinition<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_decorators(&mut it.decorators);
         visitor.visit_property_key(&mut it.key);
@@ -2696,7 +3309,6 @@ pub mod walk_mut {
         if let Some(value) = &mut it.value {
             visitor.visit_expression(value);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2706,19 +3318,35 @@ pub mod walk_mut {
     ) {
         let kind = AstType::PrivateIdentifier;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_private_identifier(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_private_identifier<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut PrivateIdentifier<'a>,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
     pub fn walk_static_block<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut StaticBlock<'a>) {
         let kind = AstType::StaticBlock;
         visitor.enter_node(kind);
+        walk_children_static_block(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_static_block<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut StaticBlock<'a>,
+    ) {
         visitor.enter_scope(ScopeFlags::ClassStaticBlock, &it.scope_id);
         visitor.visit_span(&mut it.span);
         visitor.visit_statements(&mut it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     pub fn walk_module_declaration<'a, V: VisitMut<'a>>(
@@ -2749,6 +3377,15 @@ pub mod walk_mut {
     ) {
         let kind = AstType::AccessorProperty;
         visitor.enter_node(kind);
+        walk_children_accessor_property(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_accessor_property<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut AccessorProperty<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_decorators(&mut it.decorators);
         visitor.visit_property_key(&mut it.key);
@@ -2758,7 +3395,6 @@ pub mod walk_mut {
         if let Some(value) = &mut it.value {
             visitor.visit_expression(value);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2768,12 +3404,20 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ImportExpression;
         visitor.enter_node(kind);
+        walk_children_import_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_import_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ImportExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.source);
         if let Some(options) = &mut it.options {
             visitor.visit_expression(options);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2783,6 +3427,15 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ImportDeclaration;
         visitor.enter_node(kind);
+        walk_children_import_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_import_declaration<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ImportDeclaration<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         if let Some(specifiers) = &mut it.specifiers {
             visitor.visit_import_declaration_specifiers(specifiers);
@@ -2791,7 +3444,6 @@ pub mod walk_mut {
         if let Some(with_clause) = &mut it.with_clause {
             visitor.visit_with_clause(with_clause);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2818,10 +3470,18 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ImportSpecifier;
         visitor.enter_node(kind);
+        walk_children_import_specifier(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_import_specifier<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ImportSpecifier<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_module_export_name(&mut it.imported);
         visitor.visit_binding_identifier(&mut it.local);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2831,9 +3491,17 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ImportDefaultSpecifier;
         visitor.enter_node(kind);
+        walk_children_import_default_specifier(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_import_default_specifier<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ImportDefaultSpecifier<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_binding_identifier(&mut it.local);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2843,19 +3511,35 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ImportNamespaceSpecifier;
         visitor.enter_node(kind);
+        walk_children_import_namespace_specifier(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_import_namespace_specifier<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ImportNamespaceSpecifier<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_binding_identifier(&mut it.local);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_with_clause<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut WithClause<'a>) {
         let kind = AstType::WithClause;
         visitor.enter_node(kind);
+        walk_children_with_clause(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_with_clause<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut WithClause<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_identifier_name(&mut it.attributes_keyword);
         visitor.visit_import_attributes(&mut it.with_entries);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2865,10 +3549,18 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ImportAttribute;
         visitor.enter_node(kind);
+        walk_children_import_attribute(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_import_attribute<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ImportAttribute<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_import_attribute_key(&mut it.key);
         visitor.visit_string_literal(&mut it.value);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2890,6 +3582,15 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ExportNamedDeclaration;
         visitor.enter_node(kind);
+        walk_children_export_named_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_export_named_declaration<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ExportNamedDeclaration<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         if let Some(declaration) = &mut it.declaration {
             visitor.visit_declaration(declaration);
@@ -2901,7 +3602,6 @@ pub mod walk_mut {
         if let Some(with_clause) = &mut it.with_clause {
             visitor.visit_with_clause(with_clause);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2911,10 +3611,18 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ExportDefaultDeclaration;
         visitor.enter_node(kind);
+        walk_children_export_default_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_export_default_declaration<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ExportDefaultDeclaration<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_module_export_name(&mut it.exported);
         visitor.visit_export_default_declaration_kind(&mut it.declaration);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2924,6 +3632,15 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ExportAllDeclaration;
         visitor.enter_node(kind);
+        walk_children_export_all_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_export_all_declaration<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ExportAllDeclaration<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         if let Some(exported) = &mut it.exported {
             visitor.visit_module_export_name(exported);
@@ -2932,7 +3649,6 @@ pub mod walk_mut {
         if let Some(with_clause) = &mut it.with_clause {
             visitor.visit_with_clause(with_clause);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2942,10 +3658,18 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ExportSpecifier;
         visitor.enter_node(kind);
+        walk_children_export_specifier(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_export_specifier<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ExportSpecifier<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_module_export_name(&mut it.local);
         visitor.visit_module_export_name(&mut it.exported);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2989,71 +3713,132 @@ pub mod walk_mut {
     ) {
         let kind = AstType::V8IntrinsicExpression;
         visitor.enter_node(kind);
+        walk_children_v_8_intrinsic_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_v_8_intrinsic_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut V8IntrinsicExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_identifier_name(&mut it.name);
         visitor.visit_arguments(&mut it.arguments);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_boolean_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut BooleanLiteral) {
         let kind = AstType::BooleanLiteral;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_boolean_literal(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_boolean_literal<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut BooleanLiteral,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
     pub fn walk_null_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut NullLiteral) {
         let kind = AstType::NullLiteral;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_null_literal(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_null_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut NullLiteral) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
     pub fn walk_numeric_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut NumericLiteral<'a>) {
         let kind = AstType::NumericLiteral;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_numeric_literal(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_numeric_literal<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut NumericLiteral<'a>,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
     pub fn walk_string_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut StringLiteral<'a>) {
         let kind = AstType::StringLiteral;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_string_literal(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_string_literal<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut StringLiteral<'a>,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
     pub fn walk_big_int_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut BigIntLiteral<'a>) {
         let kind = AstType::BigIntLiteral;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_big_int_literal(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_big_int_literal<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut BigIntLiteral<'a>,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
     pub fn walk_reg_exp_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut RegExpLiteral<'a>) {
         let kind = AstType::RegExpLiteral;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_reg_exp_literal(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_reg_exp_literal<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut RegExpLiteral<'a>,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
     pub fn walk_jsx_element<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXElement<'a>) {
         let kind = AstType::JSXElement;
         visitor.enter_node(kind);
+        walk_children_jsx_element(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_element<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXElement<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_jsx_opening_element(&mut it.opening_element);
         visitor.visit_jsx_children(&mut it.children);
         if let Some(closing_element) = &mut it.closing_element {
             visitor.visit_jsx_closing_element(closing_element);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3063,13 +3848,21 @@ pub mod walk_mut {
     ) {
         let kind = AstType::JSXOpeningElement;
         visitor.enter_node(kind);
+        walk_children_jsx_opening_element(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_opening_element<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXOpeningElement<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_jsx_element_name(&mut it.name);
         if let Some(type_arguments) = &mut it.type_arguments {
             visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
         visitor.visit_jsx_attribute_items(&mut it.attributes);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3079,20 +3872,36 @@ pub mod walk_mut {
     ) {
         let kind = AstType::JSXClosingElement;
         visitor.enter_node(kind);
+        walk_children_jsx_closing_element(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_closing_element<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXClosingElement<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_jsx_element_name(&mut it.name);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_jsx_fragment<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXFragment<'a>) {
         let kind = AstType::JSXFragment;
         visitor.enter_node(kind);
+        walk_children_jsx_fragment(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_fragment<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXFragment<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_jsx_opening_fragment(&mut it.opening_fragment);
         visitor.visit_jsx_children(&mut it.children);
         visitor.visit_jsx_closing_fragment(&mut it.closing_fragment);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3102,8 +3911,16 @@ pub mod walk_mut {
     ) {
         let kind = AstType::JSXOpeningFragment;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_jsx_opening_fragment(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_opening_fragment<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXOpeningFragment,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
@@ -3113,8 +3930,16 @@ pub mod walk_mut {
     ) {
         let kind = AstType::JSXClosingFragment;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_jsx_closing_fragment(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_closing_fragment<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXClosingFragment,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
@@ -3139,10 +3964,18 @@ pub mod walk_mut {
     ) {
         let kind = AstType::JSXNamespacedName;
         visitor.enter_node(kind);
+        walk_children_jsx_namespaced_name(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_namespaced_name<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXNamespacedName<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_jsx_identifier(&mut it.namespace);
         visitor.visit_jsx_identifier(&mut it.name);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3152,10 +3985,18 @@ pub mod walk_mut {
     ) {
         let kind = AstType::JSXMemberExpression;
         visitor.enter_node(kind);
+        walk_children_jsx_member_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_member_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXMemberExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_jsx_member_expression_object(&mut it.object);
         visitor.visit_jsx_identifier(&mut it.property);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3182,9 +4023,17 @@ pub mod walk_mut {
     ) {
         let kind = AstType::JSXExpressionContainer;
         visitor.enter_node(kind);
+        walk_children_jsx_expression_container(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_expression_container<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXExpressionContainer<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_jsx_expression(&mut it.expression);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3203,8 +4052,16 @@ pub mod walk_mut {
     ) {
         let kind = AstType::JSXEmptyExpression;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_jsx_empty_expression(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_empty_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXEmptyExpression,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
@@ -3223,12 +4080,20 @@ pub mod walk_mut {
     pub fn walk_jsx_attribute<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXAttribute<'a>) {
         let kind = AstType::JSXAttribute;
         visitor.enter_node(kind);
+        walk_children_jsx_attribute(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_attribute<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXAttribute<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_jsx_attribute_name(&mut it.name);
         if let Some(value) = &mut it.value {
             visitor.visit_jsx_attribute_value(value);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3238,9 +4103,17 @@ pub mod walk_mut {
     ) {
         let kind = AstType::JSXSpreadAttribute;
         visitor.enter_node(kind);
+        walk_children_jsx_spread_attribute(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_spread_attribute<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXSpreadAttribute<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.argument);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3275,8 +4148,16 @@ pub mod walk_mut {
     pub fn walk_jsx_identifier<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXIdentifier<'a>) {
         let kind = AstType::JSXIdentifier;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_jsx_identifier(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_identifier<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXIdentifier<'a>,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
@@ -3298,17 +4179,30 @@ pub mod walk_mut {
     ) {
         let kind = AstType::JSXSpreadChild;
         visitor.enter_node(kind);
+        walk_children_jsx_spread_child(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_spread_child<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXSpreadChild<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.expression);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_jsx_text<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXText<'a>) {
         let kind = AstType::JSXText;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_jsx_text(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_jsx_text<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXText<'a>) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
@@ -3318,12 +4212,20 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSThisParameter;
         visitor.enter_node(kind);
+        walk_children_ts_this_parameter(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_this_parameter<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSThisParameter<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_span(&mut it.this_span);
         if let Some(type_annotation) = &mut it.type_annotation {
             visitor.visit_ts_type_annotation(type_annotation);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3333,33 +4235,57 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSEnumDeclaration;
         visitor.enter_node(kind);
+        walk_children_ts_enum_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_enum_declaration<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSEnumDeclaration<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_binding_identifier(&mut it.id);
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_ts_enum_body(&mut it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_enum_body<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSEnumBody<'a>) {
         let kind = AstType::TSEnumBody;
         visitor.enter_node(kind);
+        walk_children_ts_enum_body(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_enum_body<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSEnumBody<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_enum_members(&mut it.members);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_enum_member<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSEnumMember<'a>) {
         let kind = AstType::TSEnumMember;
         visitor.enter_node(kind);
+        walk_children_ts_enum_member(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_enum_member<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSEnumMember<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_enum_member_name(&mut it.id);
         if let Some(initializer) = &mut it.initializer {
             visitor.visit_expression(initializer);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3383,18 +4309,34 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSTypeAnnotation;
         visitor.enter_node(kind);
+        walk_children_ts_type_annotation(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_type_annotation<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSTypeAnnotation<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type(&mut it.type_annotation);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_literal_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSLiteralType<'a>) {
         let kind = AstType::TSLiteralType;
         visitor.enter_node(kind);
+        walk_children_ts_literal_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_literal_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSLiteralType<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_literal(&mut it.literal);
-        visitor.leave_node(kind);
     }
 
     pub fn walk_ts_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSLiteral<'a>) {
@@ -3459,6 +4401,15 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSConditionalType;
         visitor.enter_node(kind);
+        walk_children_ts_conditional_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_conditional_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSConditionalType<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type(&mut it.check_type);
         visitor.enter_scope(ScopeFlags::TsConditional, &it.scope_id);
@@ -3466,16 +4417,23 @@ pub mod walk_mut {
         visitor.visit_ts_type(&mut it.true_type);
         visitor.leave_scope();
         visitor.visit_ts_type(&mut it.false_type);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_union_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSUnionType<'a>) {
         let kind = AstType::TSUnionType;
         visitor.enter_node(kind);
+        walk_children_ts_union_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_union_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSUnionType<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_types(&mut it.types);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3485,9 +4443,17 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSIntersectionType;
         visitor.enter_node(kind);
+        walk_children_ts_intersection_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_intersection_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSIntersectionType<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_types(&mut it.types);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3497,9 +4463,17 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSParenthesizedType;
         visitor.enter_node(kind);
+        walk_children_ts_parenthesized_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_parenthesized_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSParenthesizedType<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type(&mut it.type_annotation);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3509,18 +4483,34 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSTypeOperator;
         visitor.enter_node(kind);
+        walk_children_ts_type_operator(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_type_operator<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSTypeOperator<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type(&mut it.type_annotation);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_array_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSArrayType<'a>) {
         let kind = AstType::TSArrayType;
         visitor.enter_node(kind);
+        walk_children_ts_array_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_array_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSArrayType<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type(&mut it.element_type);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3530,19 +4520,35 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSIndexedAccessType;
         visitor.enter_node(kind);
+        walk_children_ts_indexed_access_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_indexed_access_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSIndexedAccessType<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type(&mut it.object_type);
         visitor.visit_ts_type(&mut it.index_type);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_tuple_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSTupleType<'a>) {
         let kind = AstType::TSTupleType;
         visitor.enter_node(kind);
+        walk_children_ts_tuple_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_tuple_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSTupleType<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_tuple_elements(&mut it.element_types);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3552,10 +4558,18 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSNamedTupleMember;
         visitor.enter_node(kind);
+        walk_children_ts_named_tuple_member(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_named_tuple_member<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSNamedTupleMember<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_identifier_name(&mut it.label);
         visitor.visit_ts_tuple_element(&mut it.element_type);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3565,18 +4579,34 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSOptionalType;
         visitor.enter_node(kind);
+        walk_children_ts_optional_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_optional_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSOptionalType<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type(&mut it.type_annotation);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_rest_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSRestType<'a>) {
         let kind = AstType::TSRestType;
         visitor.enter_node(kind);
+        walk_children_ts_rest_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_rest_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSRestType<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type(&mut it.type_annotation);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3596,16 +4626,32 @@ pub mod walk_mut {
     pub fn walk_ts_any_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSAnyKeyword) {
         let kind = AstType::TSAnyKeyword;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_ts_any_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_any_keyword<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSAnyKeyword,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
     pub fn walk_ts_string_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSStringKeyword) {
         let kind = AstType::TSStringKeyword;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_ts_string_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_string_keyword<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSStringKeyword,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
@@ -3615,24 +4661,48 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSBooleanKeyword;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_ts_boolean_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_boolean_keyword<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSBooleanKeyword,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
     pub fn walk_ts_number_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSNumberKeyword) {
         let kind = AstType::TSNumberKeyword;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_ts_number_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_number_keyword<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSNumberKeyword,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
     pub fn walk_ts_never_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSNeverKeyword) {
         let kind = AstType::TSNeverKeyword;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_ts_never_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_never_keyword<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSNeverKeyword,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
@@ -3642,8 +4712,16 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSIntrinsicKeyword;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_ts_intrinsic_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_intrinsic_keyword<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSIntrinsicKeyword,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
@@ -3653,16 +4731,32 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSUnknownKeyword;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_ts_unknown_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_unknown_keyword<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSUnknownKeyword,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
     pub fn walk_ts_null_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSNullKeyword) {
         let kind = AstType::TSNullKeyword;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_ts_null_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_null_keyword<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSNullKeyword,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
@@ -3672,48 +4766,93 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSUndefinedKeyword;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_ts_undefined_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_undefined_keyword<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSUndefinedKeyword,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
     pub fn walk_ts_void_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSVoidKeyword) {
         let kind = AstType::TSVoidKeyword;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_ts_void_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_void_keyword<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSVoidKeyword,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
     pub fn walk_ts_symbol_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSSymbolKeyword) {
         let kind = AstType::TSSymbolKeyword;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_ts_symbol_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_symbol_keyword<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSSymbolKeyword,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
     pub fn walk_ts_this_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSThisType) {
         let kind = AstType::TSThisType;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_ts_this_type(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_this_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSThisType) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
     pub fn walk_ts_object_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSObjectKeyword) {
         let kind = AstType::TSObjectKeyword;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_ts_object_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_object_keyword<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSObjectKeyword,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
     pub fn walk_ts_big_int_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSBigIntKeyword) {
         let kind = AstType::TSBigIntKeyword;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_ts_big_int_keyword(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_big_int_keyword<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSBigIntKeyword,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
@@ -3723,12 +4862,20 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSTypeReference;
         visitor.enter_node(kind);
+        walk_children_ts_type_reference(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_type_reference<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSTypeReference<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type_name(&mut it.type_name);
         if let Some(type_arguments) = &mut it.type_arguments {
             visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3748,10 +4895,18 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSQualifiedName;
         visitor.enter_node(kind);
+        walk_children_ts_qualified_name(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_qualified_name<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSQualifiedName<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type_name(&mut it.left);
         visitor.visit_identifier_name(&mut it.right);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3761,9 +4916,17 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSTypeParameterInstantiation;
         visitor.enter_node(kind);
+        walk_children_ts_type_parameter_instantiation(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_type_parameter_instantiation<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSTypeParameterInstantiation<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_types(&mut it.params);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3773,6 +4936,15 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSTypeParameter;
         visitor.enter_node(kind);
+        walk_children_ts_type_parameter(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_type_parameter<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSTypeParameter<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_binding_identifier(&mut it.name);
         if let Some(constraint) = &mut it.constraint {
@@ -3781,7 +4953,6 @@ pub mod walk_mut {
         if let Some(default) = &mut it.default {
             visitor.visit_ts_type(default);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3791,9 +4962,17 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSTypeParameterDeclaration;
         visitor.enter_node(kind);
+        walk_children_ts_type_parameter_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_type_parameter_declaration<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSTypeParameterDeclaration<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type_parameters(&mut it.params);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3803,6 +4982,15 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSTypeAliasDeclaration;
         visitor.enter_node(kind);
+        walk_children_ts_type_alias_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_type_alias_declaration<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSTypeAliasDeclaration<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_binding_identifier(&mut it.id);
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
@@ -3811,7 +4999,6 @@ pub mod walk_mut {
         }
         visitor.visit_ts_type(&mut it.type_annotation);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3821,12 +5008,20 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSClassImplements;
         visitor.enter_node(kind);
+        walk_children_ts_class_implements(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_class_implements<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSClassImplements<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type_name(&mut it.expression);
         if let Some(type_arguments) = &mut it.type_arguments {
             visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3836,6 +5031,15 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSInterfaceDeclaration;
         visitor.enter_node(kind);
+        walk_children_ts_interface_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_interface_declaration<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSInterfaceDeclaration<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_binding_identifier(&mut it.id);
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
@@ -3845,7 +5049,6 @@ pub mod walk_mut {
         visitor.visit_ts_interface_heritages(&mut it.extends);
         visitor.visit_ts_interface_body(&mut it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3855,9 +5058,17 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSInterfaceBody;
         visitor.enter_node(kind);
+        walk_children_ts_interface_body(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_interface_body<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSInterfaceBody<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_signatures(&mut it.body);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3867,12 +5078,20 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSPropertySignature;
         visitor.enter_node(kind);
+        walk_children_ts_property_signature(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_property_signature<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSPropertySignature<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_property_key(&mut it.key);
         if let Some(type_annotation) = &mut it.type_annotation {
             visitor.visit_ts_type_annotation(type_annotation);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3898,10 +5117,18 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSIndexSignature;
         visitor.enter_node(kind);
+        walk_children_ts_index_signature(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_index_signature<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSIndexSignature<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_index_signature_names(&mut it.parameters);
         visitor.visit_ts_type_annotation(&mut it.type_annotation);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3911,6 +5138,15 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSCallSignatureDeclaration;
         visitor.enter_node(kind);
+        walk_children_ts_call_signature_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_call_signature_declaration<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSCallSignatureDeclaration<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         if let Some(type_parameters) = &mut it.type_parameters {
             visitor.visit_ts_type_parameter_declaration(type_parameters);
@@ -3922,15 +5158,23 @@ pub mod walk_mut {
         if let Some(return_type) = &mut it.return_type {
             visitor.visit_ts_type_annotation(return_type);
         }
-        visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_method_signature<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSMethodSignature<'a>,
     ) {
         let kind = AstType::TSMethodSignature;
         visitor.enter_node(kind);
+        walk_children_ts_method_signature(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    pub fn walk_children_ts_method_signature<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSMethodSignature<'a>,
+    ) {
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_span(&mut it.span);
         visitor.visit_property_key(&mut it.key);
@@ -3945,7 +5189,6 @@ pub mod walk_mut {
             visitor.visit_ts_type_annotation(return_type);
         }
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3955,6 +5198,15 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSConstructSignatureDeclaration;
         visitor.enter_node(kind);
+        walk_children_ts_construct_signature_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_construct_signature_declaration<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSConstructSignatureDeclaration<'a>,
+    ) {
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_span(&mut it.span);
         if let Some(type_parameters) = &mut it.type_parameters {
@@ -3965,7 +5217,6 @@ pub mod walk_mut {
             visitor.visit_ts_type_annotation(return_type);
         }
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3975,9 +5226,17 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSIndexSignatureName;
         visitor.enter_node(kind);
+        walk_children_ts_index_signature_name(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_index_signature_name<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSIndexSignatureName<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type_annotation(&mut it.type_annotation);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3987,12 +5246,20 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSInterfaceHeritage;
         visitor.enter_node(kind);
+        walk_children_ts_interface_heritage(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_interface_heritage<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSInterfaceHeritage<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.expression);
         if let Some(type_arguments) = &mut it.type_arguments {
             visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4002,12 +5269,20 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSTypePredicate;
         visitor.enter_node(kind);
+        walk_children_ts_type_predicate(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_type_predicate<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSTypePredicate<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type_predicate_name(&mut it.parameter_name);
         if let Some(type_annotation) = &mut it.type_annotation {
             visitor.visit_ts_type_annotation(type_annotation);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4029,6 +5304,15 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSModuleDeclaration;
         visitor.enter_node(kind);
+        walk_children_ts_module_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_module_declaration<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSModuleDeclaration<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_module_declaration_name(&mut it.id);
         visitor.enter_scope(
@@ -4045,7 +5329,6 @@ pub mod walk_mut {
             visitor.visit_ts_module_declaration_body(body);
         }
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4078,40 +5361,72 @@ pub mod walk_mut {
     pub fn walk_ts_module_block<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSModuleBlock<'a>) {
         let kind = AstType::TSModuleBlock;
         visitor.enter_node(kind);
+        walk_children_ts_module_block(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_module_block<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSModuleBlock<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_directives(&mut it.directives);
         visitor.visit_statements(&mut it.body);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_type_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSTypeLiteral<'a>) {
         let kind = AstType::TSTypeLiteral;
         visitor.enter_node(kind);
+        walk_children_ts_type_literal(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_type_literal<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSTypeLiteral<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_signatures(&mut it.members);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_infer_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSInferType<'a>) {
         let kind = AstType::TSInferType;
         visitor.enter_node(kind);
+        walk_children_ts_infer_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_infer_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSInferType<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type_parameter(&mut it.type_parameter);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_type_query<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSTypeQuery<'a>) {
         let kind = AstType::TSTypeQuery;
         visitor.enter_node(kind);
+        walk_children_ts_type_query(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_type_query<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSTypeQuery<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type_query_expr_name(&mut it.expr_name);
         if let Some(type_arguments) = &mut it.type_arguments {
             visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4132,6 +5447,15 @@ pub mod walk_mut {
     pub fn walk_ts_import_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSImportType<'a>) {
         let kind = AstType::TSImportType;
         visitor.enter_node(kind);
+        walk_children_ts_import_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_import_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSImportType<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type(&mut it.argument);
         if let Some(options) = &mut it.options {
@@ -4143,7 +5467,6 @@ pub mod walk_mut {
         if let Some(type_arguments) = &mut it.type_arguments {
             visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4153,6 +5476,15 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSFunctionType;
         visitor.enter_node(kind);
+        walk_children_ts_function_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_function_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSFunctionType<'a>,
+    ) {
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_span(&mut it.span);
         if let Some(type_parameters) = &mut it.type_parameters {
@@ -4164,7 +5496,6 @@ pub mod walk_mut {
         visitor.visit_formal_parameters(&mut it.params);
         visitor.visit_ts_type_annotation(&mut it.return_type);
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4174,19 +5505,36 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSConstructorType;
         visitor.enter_node(kind);
+        walk_children_ts_constructor_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_constructor_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSConstructorType<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         if let Some(type_parameters) = &mut it.type_parameters {
             visitor.visit_ts_type_parameter_declaration(type_parameters);
         }
         visitor.visit_formal_parameters(&mut it.params);
         visitor.visit_ts_type_annotation(&mut it.return_type);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_ts_mapped_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSMappedType<'a>) {
         let kind = AstType::TSMappedType;
         visitor.enter_node(kind);
+        walk_children_ts_mapped_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_mapped_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSMappedType<'a>,
+    ) {
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type_parameter(&mut it.type_parameter);
@@ -4197,7 +5545,6 @@ pub mod walk_mut {
             visitor.visit_ts_type(type_annotation);
         }
         visitor.leave_scope();
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4207,10 +5554,18 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSTemplateLiteralType;
         visitor.enter_node(kind);
+        walk_children_ts_template_literal_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_template_literal_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSTemplateLiteralType<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_template_elements(&mut it.quasis);
         visitor.visit_ts_types(&mut it.types);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4220,10 +5575,18 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSAsExpression;
         visitor.enter_node(kind);
+        walk_children_ts_as_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_as_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSAsExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.expression);
         visitor.visit_ts_type(&mut it.type_annotation);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4233,10 +5596,18 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSSatisfiesExpression;
         visitor.enter_node(kind);
+        walk_children_ts_satisfies_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_satisfies_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSSatisfiesExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.expression);
         visitor.visit_ts_type(&mut it.type_annotation);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4246,10 +5617,18 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSTypeAssertion;
         visitor.enter_node(kind);
+        walk_children_ts_type_assertion(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_type_assertion<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSTypeAssertion<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type(&mut it.type_annotation);
         visitor.visit_expression(&mut it.expression);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4259,10 +5638,18 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSImportEqualsDeclaration;
         visitor.enter_node(kind);
+        walk_children_ts_import_equals_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_import_equals_declaration<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSImportEqualsDeclaration<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_binding_identifier(&mut it.id);
         visitor.visit_ts_module_reference(&mut it.module_reference);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4288,9 +5675,17 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSExternalModuleReference;
         visitor.enter_node(kind);
+        walk_children_ts_external_module_reference(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_external_module_reference<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSExternalModuleReference<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_string_literal(&mut it.expression);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4300,18 +5695,31 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSNonNullExpression;
         visitor.enter_node(kind);
+        walk_children_ts_non_null_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_non_null_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSNonNullExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.expression);
-        visitor.leave_node(kind);
     }
 
     #[inline]
     pub fn walk_decorator<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Decorator<'a>) {
         let kind = AstType::Decorator;
         visitor.enter_node(kind);
+        walk_children_decorator(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_decorator<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Decorator<'a>) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.expression);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4321,9 +5729,17 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSExportAssignment;
         visitor.enter_node(kind);
+        walk_children_ts_export_assignment(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_export_assignment<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSExportAssignment<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.expression);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4333,9 +5749,17 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSNamespaceExportDeclaration;
         visitor.enter_node(kind);
+        walk_children_ts_namespace_export_declaration(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_namespace_export_declaration<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSNamespaceExportDeclaration<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_identifier_name(&mut it.id);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4345,10 +5769,18 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSInstantiationExpression;
         visitor.enter_node(kind);
+        walk_children_ts_instantiation_expression(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_ts_instantiation_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSInstantiationExpression<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.expression);
         visitor.visit_ts_type_parameter_instantiation(&mut it.type_arguments);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4358,9 +5790,17 @@ pub mod walk_mut {
     ) {
         let kind = AstType::JSDocNullableType;
         visitor.enter_node(kind);
+        walk_children_js_doc_nullable_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_js_doc_nullable_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSDocNullableType<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type(&mut it.type_annotation);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4370,9 +5810,17 @@ pub mod walk_mut {
     ) {
         let kind = AstType::JSDocNonNullableType;
         visitor.enter_node(kind);
+        walk_children_js_doc_non_nullable_type(visitor, it);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_js_doc_non_nullable_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSDocNonNullableType<'a>,
+    ) {
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type(&mut it.type_annotation);
-        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4382,14 +5830,26 @@ pub mod walk_mut {
     ) {
         let kind = AstType::JSDocUnknownType;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
+        walk_children_js_doc_unknown_type(visitor, it);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_children_js_doc_unknown_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSDocUnknownType,
+    ) {
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]
     pub fn walk_span<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Span) {
         // No `AstType` for this type
+        walk_children_span(visitor, it);
     }
+
+    #[inline]
+    pub fn walk_children_span<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Span) {}
 
     #[inline]
     pub fn walk_directives<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, Directive<'a>>) {

--- a/tasks/ast_tools/src/schema/extensions/visit.rs
+++ b/tasks/ast_tools/src/schema/extensions/visit.rs
@@ -7,7 +7,7 @@ use crate::utils::create_safe_ident;
 pub struct VisitStruct {
     /// Name of `visit_*` method and `walk_*` function.
     /// `None` if this struct is not visited.
-    pub visitor_names: Option<VisitorNames>,
+    pub visitor_names: Option<StructVisitorNames>,
     pub visit_args: Vec<(String, String)>,
     pub scope: Option<Scope>,
     /// `true` if this type has a scope, or any of its fields contain a scope.
@@ -24,7 +24,7 @@ impl VisitStruct {
     ///
     /// [`Ident`]: struct@Ident
     pub fn visitor_ident(&self) -> Option<Ident> {
-        self.visitor_names.as_ref().map(VisitorNames::visitor_ident)
+        self.visitor_names.as_ref().map(StructVisitorNames::visitor_ident)
     }
 }
 
@@ -89,6 +89,7 @@ pub struct VisitorNames {
 }
 
 impl VisitorNames {
+    /// Create [`VisitorNames`].
     pub fn from_snake_name(snake_name: &str) -> Self {
         Self { visit: format!("visit_{snake_name}"), walk: format!("walk_{snake_name}") }
     }
@@ -107,6 +108,49 @@ impl VisitorNames {
     pub fn walk_ident(&self) -> Ident {
         // Walk function names cannot be reserved words, as they begin with `walk_`
         create_safe_ident(&self.walk)
+    }
+}
+
+/// Names for visitor method, walk function, and walk children function.
+#[derive(Debug)]
+pub struct StructVisitorNames {
+    pub visit: String,
+    pub walk: String,
+    pub walk_children: String,
+}
+
+impl StructVisitorNames {
+    /// Create [`StructVisitorNames`].
+    pub fn from_snake_name(snake_name: &str) -> Self {
+        Self {
+            visit: format!("visit_{snake_name}"),
+            walk: format!("walk_{snake_name}"),
+            walk_children: format!("walk_children_{snake_name}"),
+        }
+    }
+
+    /// Get name of visitor method as an [`Ident`].
+    ///
+    /// [`Ident`]: struct@Ident
+    pub fn visitor_ident(&self) -> Ident {
+        // Visitor method names cannot be reserved words, as they begin with `visit_`
+        create_safe_ident(&self.visit)
+    }
+
+    /// Get name of walk function as an [`Ident`].
+    ///
+    /// [`Ident`]: struct@Ident
+    pub fn walk_ident(&self) -> Ident {
+        // Walk function names cannot be reserved words, as they begin with `walk_`
+        create_safe_ident(&self.walk)
+    }
+
+    /// Get name of walk children function as an [`Ident`].
+    ///
+    /// [`Ident`]: struct@Ident
+    pub fn walk_children_ident(&self) -> Ident {
+        // Walk children function names cannot be reserved words, as they begin with `walk_children_`
+        create_safe_ident(&self.walk_children)
     }
 }
 


### PR DESCRIPTION
Implementation of first suggested solution from oxc-project/backlog#186.

Split out walking children of AST nodes into separate `walk_children_*` functions. e.g.:

```rs
pub fn walk_block_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &BlockStatement<'a>) {
    let kind = AstKind::BlockStatement(visitor.alloc(it));
    visitor.enter_node(kind);
    walk_children_block_statement(visitor, it);
    visitor.leave_node(kind);
}

pub fn walk_children_block_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &BlockStatement<'a>) {
    visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
    visitor.visit_span(&it.span);
    visitor.visit_statements(&it.body);
    visitor.leave_scope();
}
```

#### Enter/leave scope

`enter_scope` and `leave_scope` calls are in `walk_children_*`, not in `walk_*`. So if you need some code to run after `enter_scope`, you'd still need to copy the code from `walk_children_*` into your `Visit::visit_*` impl.

Reason is that some AST types enter the scope late, or exit it early. e.g.:

https://github.com/oxc-project/oxc/blob/763a6189b87c2bd634a7cd37f45884c0d14a7c93/crates/oxc_ast/src/ast/ts.rs#L332-L345

Therefore it's not possible to have `enter_scope` + `leave_scope` calls in `walk_*` functions for all types. I think it'd be confusing if they were in *some* `walk_*` functions, but not in others, so have opted not to have them in *any* `walk_*` functions for consistency.

Most AST types don't have scopes, so hopefully the `walk_children_*` functions will still be useful in majority of cases.

#### Structs only

Only structs have `walk_children_*` functions, because once changes to `AstKind` are complete (#11490), no enums will have an `AstKind`. So `walk_*` and `walk_children_*` functions would be equivalent for all enums.