### PR TITLE
refactor(semantic): remove unnecessary lifetime extension

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -257,8 +257,6 @@ impl<'a> SemanticBuilder<'a> {
             stats.assert_accurate(actual_stats);
         }
 
-        let comments = self.alloc(&program.comments);
-
         debug_assert_eq!(self.unresolved_references.scope_depth(), 1);
         if self.check_syntax_error && !self.source_type.is_typescript() {
             checker::check_unresolved_exports(&self);
@@ -272,7 +270,7 @@ impl<'a> SemanticBuilder<'a> {
         let semantic = Semantic {
             source_text: self.source_text,
             source_type: self.source_type,
-            comments,
+            comments: &program.comments,
             irregular_whitespaces: [].into(),
             nodes: self.nodes,
             scoping: self.scoping,


### PR DESCRIPTION
`Visit::alloc` is unsound (https://github.com/oxc-project/backlog/issues/160), and it's preferable to not to use it unless unavoidable. Here it's not necessary, so remove it.
