### PR TITLE
refactor(semantic): `ArrowFunctionExpression` leave scope before leaving node

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -1775,8 +1775,8 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         });
         /* cfg */
 
-        self.leave_node(kind);
         self.leave_scope();
+        self.leave_node(kind);
     }
 
     fn visit_update_expression(&mut self, it: &UpdateExpression<'a>) {


### PR DESCRIPTION
Bring `Visit::visit_arrow_function_expression` in `SemanticBuilder` in line with `walk_arrow_function_expression` - leave scope before leaving node:

https://github.com/oxc-project/oxc/blob/fc4a327d464f2de5a387e1f7f0718bbcd32d7ac2/crates/oxc_ast_visit/src/generated/visit.rs#L2490-L2517

The order of calls makes no difference to logic in this case, but it's the only place where we had `leave_scope` and `leave_node` in opposite order in `SemanticBuilder`'s visitor. It's better to be consistent.
