### PR TITLE
refactor(mangler): move `NodeId` lookup into `is_name_set_reference_node`

### DIFF
--- a/crates/oxc_mangler/src/keep_names.rs
+++ b/crates/oxc_mangler/src/keep_names.rs
@@ -1,6 +1,7 @@
-use oxc_ast::{AstKind, ast::*};
-use oxc_semantic::{AstNode, AstNodes, NodeId, ReferenceId, Scoping, SymbolId};
 use rustc_hash::FxHashSet;
+
+use oxc_ast::{AstKind, ast::*};
+use oxc_semantic::{AstNode, AstNodes, ReferenceId, Scoping, SymbolId};
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct MangleOptionsKeepNames {
@@ -73,10 +74,10 @@ impl<'a, 'b: 'a> NameSymbolCollector<'a, 'b> {
     }
 
     fn has_name_set_reference_node(&self, symbol_id: SymbolId) -> bool {
-        self.scoping.get_resolved_reference_ids(symbol_id).into_iter().any(|reference_id| {
-            let node_id = self.scoping.get_reference(*reference_id).node_id();
-            self.is_name_set_reference_node(node_id, *reference_id)
-        })
+        self.scoping
+            .get_resolved_reference_ids(symbol_id)
+            .iter()
+            .any(|&reference_id| self.is_name_set_reference_node(reference_id))
     }
 
     fn is_name_set_declare_node(&self, node: &'a AstNode, symbol_id: SymbolId) -> bool {
@@ -110,7 +111,8 @@ impl<'a, 'b: 'a> NameSymbolCollector<'a, 'b> {
         }
     }
 
-    fn is_name_set_reference_node(&self, node_id: NodeId, reference_id: ReferenceId) -> bool {
+    fn is_name_set_reference_node(&self, reference_id: ReferenceId) -> bool {
+        let node_id = self.scoping.get_reference(reference_id).node_id();
         let parent_node_id = self.ast_nodes.parent_id(node_id);
         match self.ast_nodes.kind(parent_node_id) {
             // Check for direct assignment: foo = function() {}


### PR DESCRIPTION
Pure refactor. Follow-on after #12663. Move looking up `NodeId` for a `Reference` into `is_name_set_reference_node`. This makes it clearer that the `ReferenceId` and `NodeId` are connected.