### PR TITLE
refactor(semantic)!: `Scoping::get_resolved_reference_ids` return slice

### DIFF
--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -332,7 +332,7 @@ impl Scoping {
     ///
     /// If you want direct access to a symbol's [`Reference`]s, use [`Scoping::get_resolved_references`].
     #[inline]
-    pub fn get_resolved_reference_ids(&self, symbol_id: SymbolId) -> &ArenaVec<'_, ReferenceId> {
+    pub fn get_resolved_reference_ids(&self, symbol_id: SymbolId) -> &[ReferenceId] {
         &self.cell.borrow_dependent().resolved_references[symbol_id.index()]
     }
 

--- a/tasks/transform_checker/src/lib.rs
+++ b/tasks/transform_checker/src/lib.rs
@@ -415,7 +415,7 @@ impl PostTransformChecker<'_, '_> {
 
             // Check resolved references match
             let reference_ids = self.get_pair(symbol_ids, |scoping, symbol_id| {
-                scoping.get_resolved_reference_ids(symbol_id).iter().copied().collect::<Vec<_>>()
+                scoping.get_resolved_reference_ids(symbol_id).to_vec()
             });
             if self.remap_reference_ids_sets(&reference_ids).is_mismatch() {
                 self.errors.push_mismatch(


### PR DESCRIPTION
It's more conventional for methods to return a `&[T]` instead of a `&Vec<T>`.