### PR TITLE
refactor(linter, transformer): use `Scoping::symbol_is_unused`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
@@ -69,7 +69,7 @@ impl<'s, 'a> Symbol<'s, 'a> {
     /// check if a references is "used" under the criteria of this rule.
     #[inline]
     pub fn has_references(&self) -> bool {
-        !self.scoping().get_resolved_reference_ids(self.id).is_empty()
+        !self.scoping().symbol_is_unused(self.id)
     }
 
     #[inline]

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -629,7 +629,7 @@ impl<'a> ModuleRunnerTransform<'a> {
 
         let symbol_id = symbol_id.get().unwrap();
         // Do not need to insert if there no identifiers that point to this symbol
-        if !ctx.scoping().get_resolved_reference_ids(symbol_id).is_empty() {
+        if !ctx.scoping().symbol_is_unused(symbol_id) {
             self.import_bindings.insert(symbol_id, (binding.clone(), Some(key)));
         }
 


### PR DESCRIPTION
Pure refactor. Replace `scoping.get_resolved_reference_ids(symbol_id).is_empty()` with the shorter `scoping.symbol_is_unused(symbol_id)`. This is what `symbol_is_unused` is designed for.