### PR TITLE
style(semantic): reorder imports

### DIFF
--- a/crates/oxc_semantic/examples/cfg.rs
+++ b/crates/oxc_semantic/examples/cfg.rs
@@ -1,7 +1,10 @@
 #![expect(clippy::print_stdout)]
+
 use std::{env, path::Path, sync::Arc};
 
 use itertools::Itertools;
+use rustc_hash::FxHashMap;
+
 use oxc_allocator::Allocator;
 use oxc_cfg::{
     DisplayDot, EdgeType,
@@ -13,7 +16,6 @@ use oxc_cfg::{
 use oxc_parser::Parser;
 use oxc_semantic::{SemanticBuilder, dot::DebugDot};
 use oxc_span::SourceType;
-use rustc_hash::FxHashMap;
 
 // Instruction:
 // 1. create a `test.js`,

--- a/crates/oxc_semantic/examples/semantic.rs
+++ b/crates/oxc_semantic/examples/semantic.rs
@@ -1,7 +1,9 @@
 #![expect(clippy::print_stdout)]
+
 use std::{env, path::Path, sync::Arc};
 
 use itertools::Itertools;
+
 use oxc_allocator::Allocator;
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -6,8 +6,7 @@ use oxc_ecmascript::{BoundNames, IsSimpleParameterList};
 use oxc_span::GetSpan;
 use oxc_syntax::{node::NodeId, scope::ScopeFlags, symbol::SymbolFlags};
 
-use crate::SemanticBuilder;
-use crate::checker::is_function_part_of_if_statement;
+use crate::{SemanticBuilder, checker::is_function_part_of_if_statement};
 
 pub trait Binder<'a> {
     fn bind(&self, builder: &mut SemanticBuilder<'a>);

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -5,16 +5,16 @@ use std::{
     mem,
 };
 
-use oxc_allocator::Address;
-use oxc_data_structures::stack::Stack;
 use rustc_hash::FxHashMap;
 
+use oxc_allocator::Address;
 use oxc_ast::{AstKind, ast::*};
 use oxc_ast_visit::Visit;
 use oxc_cfg::{
     ControlFlowGraphBuilder, CtxCursor, CtxFlags, EdgeType, ErrorEdgeKind, InstructionKind,
     IterationInstructionKind, ReturnInstructionKind,
 };
+use oxc_data_structures::stack::Stack;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{Atom, SourceType, Span};
 use oxc_syntax::{

--- a/crates/oxc_semantic/src/checker/mod.rs
+++ b/crates/oxc_semantic/src/checker/mod.rs
@@ -5,13 +5,13 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::Span;
 
+use crate::builder::SemanticBuilder;
+
 mod javascript;
 mod typescript;
-
 use javascript as js;
 use typescript as ts;
 
-use crate::builder::SemanticBuilder;
 pub use javascript::is_function_part_of_if_statement;
 
 pub fn check<'a>(kind: AstKind<'a>, ctx: &SemanticBuilder<'a>) {

--- a/crates/oxc_semantic/src/class/table.rs
+++ b/crates/oxc_semantic/src/class/table.rs
@@ -1,5 +1,6 @@
-use rustc_hash::FxHashMap;
 use std::borrow::Cow;
+
+use rustc_hash::FxHashMap;
 
 use oxc_index::IndexVec;
 use oxc_span::{Atom, Span};

--- a/crates/oxc_semantic/tests/conformance/test_identifier_reference.rs
+++ b/crates/oxc_semantic/tests/conformance/test_identifier_reference.rs
@@ -4,8 +4,9 @@ use oxc_semantic::{NodeId, Reference};
 use oxc_span::GetSpan;
 use oxc_syntax::reference::ReferenceId;
 
-use super::{ConformanceTest, TestResult};
 use crate::Semantic;
+
+use super::{ConformanceTest, TestResult};
 
 /// Tests reflexivity between [`IdentifierReference`] AST nodes and their corresponding
 /// [`Reference`]s.

--- a/crates/oxc_semantic/tests/integration/util/mod.rs
+++ b/crates/oxc_semantic/tests/integration/util/mod.rs
@@ -1,16 +1,18 @@
-mod class_tester;
-mod expect;
-mod symbol_tester;
 use std::sync::Arc;
 
-pub use class_tester::ClassTester;
-pub use expect::Expect;
 use itertools::Itertools;
+
 use oxc_allocator::Allocator;
 use oxc_cfg::DisplayDot;
 use oxc_diagnostics::{Error, NamedSource, OxcDiagnostic};
 use oxc_semantic::{Semantic, SemanticBuilder, SemanticBuilderReturn, dot::DebugDot};
 use oxc_span::SourceType;
+
+mod class_tester;
+mod expect;
+mod symbol_tester;
+pub use class_tester::ClassTester;
+pub use expect::Expect;
 pub use symbol_tester::SymbolTester;
 
 #[must_use]

--- a/crates/oxc_semantic/tests/main.rs
+++ b/crates/oxc_semantic/tests/main.rs
@@ -1,13 +1,13 @@
-mod conformance;
-
 use std::{fs, path::Path};
 
-use conformance::SemanticConformance;
 use oxc_allocator::Allocator;
 use oxc_index::Idx;
 use oxc_parser::Parser;
 use oxc_semantic::{ScopeId, Semantic, SemanticBuilder};
 use oxc_span::SourceType;
+
+mod conformance;
+use conformance::SemanticConformance;
 
 /// A test case representing an input source file.
 struct TestContext<'a> {


### PR DESCRIPTION
Re-order imports in `oxc_semantic` in order of furthest away (`std`) to closest (`mod`).