### PR TITLE
perf(semantic): remove function stack

### DIFF
--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -23,7 +23,7 @@ oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_cfg = { workspace = true }
-oxc_data_structures = { workspace = true, features = ["assert_unchecked", "stack"] }
+oxc_data_structures = { workspace = true, features = ["assert_unchecked"] }
 oxc_diagnostics = { workspace = true }
 oxc_ecmascript = { workspace = true }
 oxc_index = { workspace = true }


### PR DESCRIPTION
Only purpose of `function_stack` in `SemanticBuilder` is to track the current function, in order to set `NodeFlags::HasYield` on it if it contains `yield`.

#12630 moved enter and exit logic into `visit_function`. So now we don't need a `Stack` to track the current function, we can use vars on the actual stack.

Also, it's unnecessary to update current function when entering/exiting arrow functions, as they can't contain `yield`.