### PR TITLE
refactor(linter): use `u32` to keep track of last fixed source text position

### DIFF
--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -372,7 +372,7 @@ impl<'a> Fixer<'a> {
         self.messages.sort_unstable_by_key(|m| m.fixes.span());
         let mut fixed = false;
         let mut output = String::with_capacity(source_text.len());
-        let mut last_pos: i64 = -1;
+        let mut last_pos: u32 = 0;
 
         // only keep messages that were not fixed
         let mut filtered_messages = Vec::with_capacity(self.messages.len());
@@ -396,21 +396,20 @@ impl<'a> Fixer<'a> {
                 filtered_messages.push(m);
                 continue;
             }
-            if i64::from(start) < last_pos {
+            if start < last_pos {
                 filtered_messages.push(m);
                 continue;
             }
 
             m.fixed = true;
             fixed = true;
-            let offset = usize::try_from(last_pos.max(0)).ok().unwrap();
+            let offset = last_pos as usize;
             output.push_str(&source_text[offset..start as usize]);
             output.push_str(content);
-            last_pos = i64::from(end);
+            last_pos = end;
         }
 
-        let offset = usize::try_from(last_pos.max(0)).ok().unwrap();
-        output.push_str(&source_text[offset..]);
+        output.push_str(&source_text[last_pos as usize..]);
 
         filtered_messages.sort_unstable_by_key(GetSpan::span);
         FixResult { fixed, fixed_code: Cow::Owned(output), messages: filtered_messages }


### PR DESCRIPTION
Only use case I could think about, where something bigger then u32 is needed:
Parsing an under `u32` size file and fixing it will exceed `u32` file size.
