### PR TITLE
fix(transformer/typescript): remove properties with definite assignment assertion

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -261,7 +261,7 @@ impl<'a> ClassProperties<'a, '_> {
             #[expect(clippy::match_same_arms)]
             match element {
                 ClassElement::PropertyDefinition(prop) => {
-                    if !prop.r#static {
+                    if !prop.definite && !prop.r#static {
                         self.convert_instance_property(prop, &mut instance_inits, ctx);
                     }
                 }

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -240,13 +240,12 @@ impl<'a> Traverse<'a, TransformState<'a>> for TypeScriptAnnotations<'a, '_> {
     }
 
     fn exit_class(&mut self, class: &mut Class<'a>, _: &mut TraverseCtx<'a>) {
-        // Remove `declare` properties from the class body, other ts-only properties have been removed in `enter_class`.
-        // The reason that removing `declare` properties here because the legacy-decorator plugin needs to transform
+        // Remove `declare` and `!` (definite assignment assertion) properties from the class body, other ts-only properties have been removed in `enter_class`.
+        // The reason that removing  properties here because the legacy-decorator plugin needs to transform
         // `declare` field in the `exit_class` phase, so we have to ensure this step is run after the legacy-decorator plugin.
-        class
-            .body
-            .body
-            .retain(|elem| !matches!(elem, ClassElement::PropertyDefinition(prop) if prop.declare));
+        class.body.body.retain(|elem| {
+            !matches!(elem, ClassElement::PropertyDefinition(prop) if prop.declare || prop.definite)
+        });
     }
 
     fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
@@ -354,7 +353,6 @@ impl<'a> Traverse<'a, TransformState<'a>> for TypeScriptAnnotations<'a, '_> {
         );
 
         def.accessibility = None;
-        def.definite = false;
         def.r#override = false;
         def.optional = false;
         def.readonly = false;

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -2223,7 +2223,7 @@ after transform: SymbolId(0): [ReferenceId(6), ReferenceId(8)]
 rebuilt        : SymbolId(1): []
 Symbol reference IDs mismatch for "Foo":
 after transform: SymbolId(5): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(2): [ReferenceId(3), ReferenceId(6)]
+rebuilt        : SymbolId(2): [ReferenceId(2), ReferenceId(5)]
 Reference symbol mismatch for "callme":
 after transform: SymbolId(2) "callme"
 rebuilt        : <None>
@@ -9039,8 +9039,8 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
+after transform: ScopeId(3): [ScopeId(4), ScopeId(5)]
+rebuilt        : ScopeId(1): [ScopeId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/deleteExpressionMustBeOptional.ts
 Bindings mismatch:
@@ -16890,20 +16890,20 @@ rebuilt        : SymbolId(4): [ReferenceId(4), ReferenceId(7)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/inferenceErasedSignatures.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["SomeAbstractClass", "SomeBaseClass", "SomeClass", "_asyncToGenerator", "_defineProperty"]
-rebuilt        : ScopeId(0): ["SomeAbstractClass", "SomeClass", "_asyncToGenerator", "_defineProperty"]
+after transform: ScopeId(0): ["SomeAbstractClass", "SomeBaseClass", "SomeClass", "_asyncToGenerator"]
+rebuilt        : ScopeId(0): ["SomeAbstractClass", "SomeClass", "_asyncToGenerator"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(23), ScopeId(25), ScopeId(30), ScopeId(32), ScopeId(33)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(34)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
+after transform: ScopeId(3): [ScopeId(4), ScopeId(5), ScopeId(6)]
+rebuilt        : ScopeId(1): []
 Symbol reference IDs mismatch for "SomeAbstractClass":
 after transform: SymbolId(4): [ReferenceId(8), ReferenceId(12), ReferenceId(15), ReferenceId(18)]
-rebuilt        : SymbolId(2): [ReferenceId(6)]
+rebuilt        : SymbolId(1): [ReferenceId(2)]
 Symbol reference IDs mismatch for "SomeClass":
 after transform: SymbolId(9): [ReferenceId(21), ReferenceId(23), ReferenceId(25)]
-rebuilt        : SymbolId(4): []
+rebuilt        : SymbolId(2): []
 Reference symbol mismatch for "SomeBaseClass":
 after transform: SymbolId(0) "SomeBaseClass"
 rebuilt        : <None>
@@ -19529,10 +19529,10 @@ rebuilt        : SymbolId(6): [ReferenceId(17), ReferenceId(19), ReferenceId(21)
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/localTypeParameterInferencePriority.ts
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Symbol reference IDs mismatch for "Table":
 after transform: SymbolId(4): [ReferenceId(14), ReferenceId(17), ReferenceId(22), ReferenceId(25)]
-rebuilt        : SymbolId(1): [ReferenceId(1), ReferenceId(3)]
+rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
 Unresolved references mismatch:
 after transform: ["Array", "Pick", "Record"]
 rebuilt        : []
@@ -30108,14 +30108,14 @@ rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/thisConditionalOnMethodReturnOfGenericInstance.ts
 Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(7)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
+after transform: ScopeId(1): [ScopeId(2)]
+rebuilt        : ScopeId(1): []
 Scope children mismatch:
 after transform: ScopeId(4): [ScopeId(5)]
-rebuilt        : ScopeId(4): []
+rebuilt        : ScopeId(3): []
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(5): [ReferenceId(5), ReferenceId(8)]
-rebuilt        : SymbolId(3): [ReferenceId(6)]
+rebuilt        : SymbolId(2): [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/thisExpressionOfGenericObject.ts
 Symbol reference IDs mismatch for "MyClass1":
@@ -32353,7 +32353,7 @@ after transform: SymbolId(3): [ReferenceId(0)]
 rebuilt        : SymbolId(1): []
 Symbol reference IDs mismatch for "Right":
 after transform: SymbolId(11): [ReferenceId(3), ReferenceId(29)]
-rebuilt        : SymbolId(5): [ReferenceId(8)]
+rebuilt        : SymbolId(5): [ReferenceId(4)]
 Symbol reference IDs mismatch for "Type":
 after transform: SymbolId(19): [ReferenceId(51), ReferenceId(60)]
 rebuilt        : SymbolId(9): []
@@ -32382,7 +32382,7 @@ after transform: SymbolId(3): [ReferenceId(0)]
 rebuilt        : SymbolId(1): []
 Symbol reference IDs mismatch for "Right":
 after transform: SymbolId(11): [ReferenceId(3), ReferenceId(29)]
-rebuilt        : SymbolId(5): [ReferenceId(8)]
+rebuilt        : SymbolId(5): [ReferenceId(4)]
 Symbol reference IDs mismatch for "Type":
 after transform: SymbolId(19): [ReferenceId(51), ReferenceId(60)]
 rebuilt        : SymbolId(9): []
@@ -34414,10 +34414,10 @@ after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Generic":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Generic":
 after transform: SymbolId(0): Span { start: 7, end: 14 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/indexersInClassType.ts
 Unresolved references mismatch:

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 1d4546bc
 
-Passed: 711/1200
+Passed: 710/1200
 
 # All Passed:
 * babel-plugin-transform-logical-assignment-operators
@@ -1343,7 +1343,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-typescript (48/158)
+# babel-plugin-transform-typescript (47/158)
 * cast/as-expression/input.ts
 Unresolved references mismatch:
 after transform: ["T", "x"]
@@ -1415,6 +1415,9 @@ after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
 
 * class/private-method-override-transform-private/input.ts
+x Output mismatch
+
+* class/uninitialized-definite/input.ts
 x Output mismatch
 
 * declarations/const-enum/input.ts

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 1d4546bc
 
-Passed: 181/301
+Passed: 183/303
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -20,7 +20,7 @@ Passed: 181/301
 * regexp
 
 
-# babel-plugin-transform-class-properties (22/28)
+# babel-plugin-transform-class-properties (23/29)
 * private-field-resolve-to-method/input.js
 x Output mismatch
 
@@ -44,7 +44,7 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), R
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(10)]
 
 
-# babel-plugin-transform-typescript (5/27)
+# babel-plugin-transform-typescript (6/28)
 * allow-declare-fields-false/input.ts
 Unresolved references mismatch:
 after transform: ["dce"]

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/definite-assignment-assertion/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/definite-assignment-assertion/input.ts
@@ -1,0 +1,9 @@
+class Foo {
+	// Property with definite assignment assertion
+	#a!: string;
+	b!: string;
+	method() {
+		this.#a = "hello";
+		this.b = "world";
+	}
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/definite-assignment-assertion/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/definite-assignment-assertion/output.js
@@ -1,0 +1,8 @@
+
+var _a = /* @__PURE__ */ new WeakMap();
+class Foo {
+  method() {
+    babelHelpers.classPrivateFieldSet2(_a, this, "hello");
+    this.b = "world";
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/remove-definite-assignment-assertion/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/remove-definite-assignment-assertion/input.ts
@@ -1,0 +1,13 @@
+class Foo {
+  // Regular uninitialized property
+  a: string;
+  
+  // Property with definite assignment assertion
+  b!: string;
+  
+  // Property with initializer (should be kept)
+  c = "hello";
+  
+  // Optional property
+  d?: string;
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/remove-definite-assignment-assertion/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/remove-definite-assignment-assertion/output.js
@@ -1,0 +1,5 @@
+class Foo {
+  a;
+  c = "hello";
+  d;
+}


### PR DESCRIPTION
close: https://github.com/rolldown/tsdown/issues/399


Here is a [TypeScript Playground](https://www.typescriptlang.org/play/?#code/KYDwDg9gTgLgBAYwDYEMDOa4FkCeBhVDOAbwCg44A7FAW2AEIAuONGKAS0oHNyXQmWbTjwC+pUrgLo0AOjBQIMRTjDAZ1OnAC8cAOQAvABYpuaE7on5Cs+YuWqZaUNr00USYBaA), which shows the expected output.

A Babel test failed because Babel's transforming behavior differs from TypeScript's. Additionally, ESBuild isn't the same.
See [Babel Playground](https://babeljs.io/repl#?browsers=defaults%2C%20not%20ie%2011%2C%20not%20ie_mob%2011&corejs=3.42&code_lz=MYGwhgzhAECC0G8BQ1oA8CEBuJBfJQA&sourceType=module&lineWrap=true&presets=env%2Ctypescript&version=7.28.2&externalPlugins=%40babel%2Fplugin-transform-class-properties%407.27.1)