### PR TITLE
refactor(transformer/object-rest-spread): extract unboxed field earlier

### DIFF
--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -326,7 +326,7 @@ impl<'a> ObjectRestSpread<'a, '_> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Option<SpreadPair<'a>> {
         let rest = object_assignment_target.rest.take()?;
-        let rest_target = rest.unbox();
+        let rest_target = rest.unbox().target;
         let mut all_primitives = true;
         let keys =
             ctx.ast.vec_from_iter(object_assignment_target.properties.iter_mut().filter_map(|e| {
@@ -348,7 +348,7 @@ impl<'a> ObjectRestSpread<'a, '_> {
                 }
             }));
         Some(SpreadPair {
-            lhs: BindingPatternOrAssignmentTarget::AssignmentTarget(rest_target.target),
+            lhs: BindingPatternOrAssignmentTarget::AssignmentTarget(rest_target),
             keys,
             has_no_properties: object_assignment_target.is_empty(),
             all_primitives,


### PR DESCRIPTION
Pure refactor. Follow-on after #12698.

We only need the `target` field, so no need bring the whole of `AssignmentTargetRest` onto the stack. Possibly compiler will have optimized this already, but better to be explicit and make it easier for compiler to apply the optimization.
