### PR TITLE
refactor(linter): introduce `ContextSubHost` for cross script block analyse

### DIFF
--- a/crates/oxc_linter/src/frameworks.rs
+++ b/crates/oxc_linter/src/frameworks.rs
@@ -95,3 +95,10 @@ pub fn has_vitest_imports(module_record: &ModuleRecord) -> bool {
 pub fn has_jest_imports(module_record: &ModuleRecord) -> bool {
     module_record.import_entries.iter().any(|entry| entry.module_request.name() == "@jest/globals")
 }
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+
+pub enum FrameworkOptions {
+    Default,  // default
+    VueSetup, // context is inside `<script setup>`
+}

--- a/crates/oxc_linter/src/loader/source.rs
+++ b/crates/oxc_linter/src/loader/source.rs
@@ -1,5 +1,7 @@
 use oxc_span::SourceType;
 
+use crate::frameworks::FrameworkOptions;
+
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 pub struct JavaScriptSource<'a> {
@@ -10,15 +12,38 @@ pub struct JavaScriptSource<'a> {
     pub start: u32,
     #[expect(dead_code)]
     is_partial: bool,
+
+    // some partial sources can have special options defined, like Vue's `<script setup>`.
+    pub framework_options: FrameworkOptions,
 }
 
 impl<'a> JavaScriptSource<'a> {
     pub fn new(source_text: &'a str, source_type: SourceType) -> Self {
-        Self { source_text, source_type, start: 0, is_partial: false }
+        Self {
+            source_text,
+            source_type,
+            start: 0,
+            is_partial: false,
+            framework_options: FrameworkOptions::Default,
+        }
     }
 
     pub fn partial(source_text: &'a str, source_type: SourceType, start: u32) -> Self {
-        Self { source_text, source_type, start, is_partial: true }
+        Self::partial_with_framework_options(
+            source_text,
+            source_type,
+            FrameworkOptions::Default,
+            start,
+        )
+    }
+
+    pub fn partial_with_framework_options(
+        source_text: &'a str,
+        source_type: SourceType,
+        framework_options: FrameworkOptions,
+        start: u32,
+    ) -> Self {
+        Self { source_text, source_type, start, is_partial: true, framework_options }
     }
 
     pub fn as_str(&self) -> &'a str {

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -311,7 +311,7 @@ mod test {
     use oxc_semantic::SemanticBuilder;
     use oxc_span::SourceType;
 
-    use crate::{ContextHost, ModuleRecord, options::LintOptions};
+    use crate::{ContextHost, ModuleRecord, context::ContextSubHost, options::LintOptions};
 
     #[test]
     fn test_is_jest_file() {
@@ -325,8 +325,11 @@ mod test {
         let build_ctx = |path: &'static str| {
             Rc::new(ContextHost::new(
                 path,
-                Rc::clone(&semantic_ret),
-                Arc::new(ModuleRecord::default()),
+                vec![ContextSubHost::new(
+                    Rc::clone(&semantic_ret),
+                    Arc::new(ModuleRecord::default()),
+                    0,
+                )],
                 LintOptions::default(),
                 Arc::default(),
             ))


### PR DESCRIPTION
Another approach to https://github.com/oxc-project/oxc/pull/12541 stack.
Because `vue/valid-define-emit` and other rules required the semantics of the other script block.

## The Goal:
`Linter.run` should run with the complete file context. In `vue` files and others, there can be multiple Semantics / Module Records.
Because `vue` requires some magic compiler rules, the linter should have access to the complete file.
This will also fix the offset bug in #12758. ~~**Don't** merge both stacks without rebasing.~~

I do not like the loop part. Maybe you guys have some better ideas.

---

<img width="1160" height="422" alt="benchmark results" src="https://github.com/user-attachments/assets/88702a01-eeb2-4a4f-8d80-c5236d3fa8cc" />

