### PR TITLE
test(napi/parser): disable raw transfer tests by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,8 @@ jobs:
         if: steps.filter.outputs.src == 'true'
       - if: steps.filter.outputs.src == 'true'
         name: Run tests in workspace
+        env:
+          RUN_RAW_TESTS: "true"
         run: |
           rustup target add wasm32-wasip1-threads
           pnpm run build-test

--- a/napi/parser/vitest.config.mts
+++ b/napi/parser/vitest.config.mts
@@ -1,16 +1,18 @@
 import { defineConfig } from 'vitest/config';
 
-const RUN_LAZY_TESTS = process.env.RUN_LAZY_TESTS === 'true';
+const { env } = process;
+let exclude;
+if (env.RUN_LAZY_TESTS !== 'true') {
+  exclude = ['lazy-deserialization.test.ts'];
+  if (env.RUN_RAW_TESTS !== 'true') exclude.push('parse-raw.test.ts');
+}
 
 export default defineConfig({
   test: {
     diff: {
       expand: false,
     },
-    ...(
-      !RUN_LAZY_TESTS &&
-      { exclude: ['lazy-deserialization.test.ts'] }
-    ),
+    exclude,
   },
   plugins: [
     // Enable Codspeed plugin in CI only


### PR DESCRIPTION
See: https://github.com/oxc-project/oxc/issues/12435#issuecomment-3144750987

Disable raw transfer tests by default. To run them locally, use `RUN_RAW_TESTS` env:

```sh
RUN_RAW_TESTS=true pnpm test
```

Raw transfer tests are still enabled in CI.
