### PR TITLE
ci(napi): shard NAPI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,16 +153,61 @@ jobs:
           pnpm run test-browser
           pnpm build-browser-bundle --npmDir npm-dir
 
-  # NAPI tests are slow, so we shard them into multiple jobs.
-  # But we want to build all the packages together, so they share a single build cache.
-  #
-  # * `napi-build` - build all packages, and upload build files as an artifact.
-  # * In parallel:
-  #   * `napi-test` (sharded - 1 job per package)
-  #   * `napi-test-e2e`
-  # * `napi-cleanup` - deletes build files artifact
-  napi-build:
-    name: Build NAPI packages
+  # Sharded because these tests are slow
+  test-napi:
+    name: Test NAPI
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        component:
+          - oxlint2
+          - parser
+          - playground
+    steps:
+      - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          predicate-quantifier: "every"
+          filters: |
+            src:
+              - '!crates/oxc_linter/**'
+              - '!crates/oxc_language_server/**'
+              - '!editors/**'
+      # Submodules only needed for parser tests
+      - uses: ./.github/actions/clone-submodules
+        if: steps.filter.outputs.src == 'true' && matrix.component == 'parser'
+        with:
+          babel: false
+          prettier: false
+      - uses: oxc-project/setup-rust@cd82e1efec7fef815e2c23d296756f31c7cdc03d # v1.0.0
+        if: steps.filter.outputs.src == 'true'
+        with:
+          cache-key: napi-${{ matrix.component }}
+          save-cache: ${{ github.ref_name == 'main' }}
+      - uses: oxc-project/setup-node@f42e3bda950c7454575e78ee4eaac880a077700c # v1.0.0
+        if: steps.filter.outputs.src == 'true'
+      - if: steps.filter.outputs.src == 'true'
+        name: Build
+        working-directory: napi/${{ matrix.component }}
+        run: |
+          rustup target add wasm32-wasip1-threads
+          pnpm run build-test
+      - if: steps.filter.outputs.src == 'true' && matrix.component != 'playground'
+        name: Run tests
+        working-directory: napi/${{ matrix.component }}
+        env:
+          RUN_RAW_TESTS: "true"
+        run: |
+          pnpm run test
+      - if: steps.filter.outputs.src == 'true'
+        run: |
+          git diff --exit-code # Must commit everything
+
+  # Includes transformer and minifier
+  test-napi-e2e:
+    name: Test NAPI (e2e)
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
@@ -178,143 +223,43 @@ jobs:
       - uses: oxc-project/setup-rust@cd82e1efec7fef815e2c23d296756f31c7cdc03d # v1.0.0
         if: steps.filter.outputs.src == 'true'
         with:
-          cache-key: napi
+          cache-key: napi-e2e
           save-cache: ${{ github.ref_name == 'main' }}
       - uses: oxc-project/setup-node@f42e3bda950c7454575e78ee4eaac880a077700c # v1.0.0
         if: steps.filter.outputs.src == 'true'
-      - name: Install wasm32-wasip1-threads
-        if: steps.filter.outputs.src == 'true'
+      - if: steps.filter.outputs.src == 'true'
+        name: Install wasm32-wasip1-threads
         run: |
           rustup target add wasm32-wasip1-threads
-      - name: Build minify
-        if: steps.filter.outputs.src == 'true'
-        working-directory: napi/minify
-        run: |
-          pnpm run build-test
-      - name: Build oxlint2
-        if: steps.filter.outputs.src == 'true'
-        working-directory: napi/oxlint2
-        run: |
-          pnpm run build-test
-      - name: Build parser
-        if: steps.filter.outputs.src == 'true'
-        working-directory: napi/parser
-        run: |
-          pnpm run build-test
-      - name: Build playground
-        if: steps.filter.outputs.src == 'true'
-        working-directory: napi/playground
-        run: |
-          pnpm run build-test
-      - name: Build transform
-        if: steps.filter.outputs.src == 'true'
+      - if: steps.filter.outputs.src == 'true'
+        name: Build transformer
         working-directory: napi/transform
         run: |
           pnpm run build-test
-      - name: Check no uncommitted files
-        if: steps.filter.outputs.src == 'true'
-        run: |
-          git diff --exit-code # Must commit everything
-      - name: Upload build files
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          if-no-files-found: error
-          name: napi
-          path: |
-            napi/minify/*.node
-            napi/oxlint2/dist/
-            napi/parser/*.node
-            napi/transform/*.node
-          retention-days: 1
-
-  napi-test:
-    name: Test NAPI
-    runs-on: ubuntu-latest
-    needs: napi-build
-    strategy:
-      fail-fast: true
-      matrix:
-        component:
-          - minify
-          - oxlint2
-          - parser
-          - transform
-    steps:
-      - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: filter
-        with:
-          predicate-quantifier: "every"
-          filters: |
-            src:
-              - '!crates/oxc_linter/**'
-              - '!crates/oxc_language_server/**'
-              - '!editors/**'
-      - uses: oxc-project/setup-node@f42e3bda950c7454575e78ee4eaac880a077700c # v1.0.0
-        if: steps.filter.outputs.src == 'true'
-      - name: Download build files
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: napi
-          path: napi
-          pattern: ${{ matrix.component }}/**/*
-      # Submodules only needed for parser tests
-      - uses: ./.github/actions/clone-submodules
-        if: steps.filter.outputs.src == 'true' && matrix.component == 'parser'
-        with:
-          babel: false
-          prettier: false
-      - name: Run tests
-        if: steps.filter.outputs.src == 'true'
-        working-directory: napi/${{ matrix.component }}
-        env:
-          RUN_RAW_TESTS: "true"
+      - if: steps.filter.outputs.src == 'true'
+        name: Run transformer tests
+        working-directory: napi/transform
         run: |
           pnpm run test
-
-  napi-test-e2e:
-    name: Test NAPI (e2e)
-    runs-on: ubuntu-latest
-    needs: napi-build
-    steps:
-      - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: filter
-        with:
-          predicate-quantifier: "every"
-          filters: |
-            src:
-              - '!crates/oxc_linter/**'
-              - '!crates/oxc_language_server/**'
-              - '!editors/**'
-      - uses: oxc-project/setup-node@f42e3bda950c7454575e78ee4eaac880a077700c # v1.0.0
-        if: steps.filter.outputs.src == 'true'
-      - name: Download build files
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: napi
-          path: napi
-          pattern: "{minify,transform}/*.node"
-      - name: Install NPM packages
-        if: steps.filter.outputs.src == 'true'
+      - if: steps.filter.outputs.src == 'true'
+        name: Build minifier
+        working-directory: napi/minify
+        run: |
+          pnpm run build-test
+      - if: steps.filter.outputs.src == 'true'
+        name: Run minifier tests
+        working-directory: napi/minify
+        run: |
+          pnpm run test
+      - if: steps.filter.outputs.src == 'true'
+        name: Run e2e tests
         working-directory: tasks/e2e
         run: |
           pnpm install --frozen-lockfile
-      - name: Run tests
-        if: steps.filter.outputs.src == 'true'
-        working-directory: tasks/e2e
-        run: |
           pnpm run test
-
-  napi-cleanup:
-    name: Delete NAPI build artifacts
-    runs-on: ubuntu-latest
-    needs: [napi-test, napi-test-e2e]
-    steps:
-      - uses: geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b # v5.1.0
-        with:
-          name: napi
-          failOnError: false
+      - if: steps.filter.outputs.src == 'true'
+        run: |
+          git diff --exit-code # Must commit everything
 
   typos:
     name: Spell Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,7 @@ jobs:
         run: |
           rustup target add wasm32-wasip1-threads
           pnpm run build-test
+      # Playground has no tests
       - if: steps.filter.outputs.src == 'true' && matrix.component != 'playground'
         name: Run tests
         working-directory: napi/${{ matrix.component }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,12 +175,6 @@ jobs:
               - '!crates/oxc_linter/**'
               - '!crates/oxc_language_server/**'
               - '!editors/**'
-      # Submodules only needed for parser tests
-      - uses: ./.github/actions/clone-submodules
-        if: steps.filter.outputs.src == 'true' && matrix.component == 'parser'
-        with:
-          babel: false
-          prettier: false
       - uses: oxc-project/setup-rust@cd82e1efec7fef815e2c23d296756f31c7cdc03d # v1.0.0
         if: steps.filter.outputs.src == 'true'
         with:
@@ -194,6 +188,12 @@ jobs:
         run: |
           rustup target add wasm32-wasip1-threads
           pnpm run build-test
+      # Submodules only needed for parser tests
+      - uses: ./.github/actions/clone-submodules
+        if: steps.filter.outputs.src == 'true' && matrix.component == 'parser'
+        with:
+          babel: false
+          prettier: false
       # Playground has no tests
       - if: steps.filter.outputs.src == 'true' && matrix.component != 'playground'
         name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,8 +153,61 @@ jobs:
           pnpm run test-browser
           pnpm build-browser-bundle --npmDir npm-dir
 
+  # Sharded because these tests are slow
   test-napi:
     name: Test NAPI
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        component:
+          - oxlint2
+          - parser
+          - playground
+    steps:
+      - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          predicate-quantifier: "every"
+          filters: |
+            src:
+              - '!crates/oxc_linter/**'
+              - '!crates/oxc_language_server/**'
+              - '!editors/**'
+      # Submodules only needed for parser tests
+      - uses: ./.github/actions/clone-submodules
+        if: steps.filter.outputs.src == 'true' && matrix.component == 'parser'
+        with:
+          babel: false
+          prettier: false
+      - uses: oxc-project/setup-rust@cd82e1efec7fef815e2c23d296756f31c7cdc03d # v1.0.0
+        if: steps.filter.outputs.src == 'true'
+        with:
+          cache-key: napi-${{ matrix.component }}
+          save-cache: ${{ github.ref_name == 'main' }}
+      - uses: oxc-project/setup-node@f42e3bda950c7454575e78ee4eaac880a077700c # v1.0.0
+        if: steps.filter.outputs.src == 'true'
+      - if: steps.filter.outputs.src == 'true'
+        name: Build
+        working-directory: napi/${{ matrix.component }}
+        run: |
+          rustup target add wasm32-wasip1-threads
+          pnpm run build-test
+      - if: steps.filter.outputs.src == 'true' && matrix.component != 'playground'
+        name: Run tests
+        working-directory: napi/${{ matrix.component }}
+        env:
+          RUN_RAW_TESTS: "true"
+        run: |
+          pnpm run test
+      - if: steps.filter.outputs.src == 'true'
+        run: |
+          git diff --exit-code # Must commit everything
+
+  # Includes transformer and minifier
+  test-napi-e2e:
+    name: Test NAPI (e2e)
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
@@ -167,32 +220,43 @@ jobs:
               - '!crates/oxc_linter/**'
               - '!crates/oxc_language_server/**'
               - '!editors/**'
-      - uses: ./.github/actions/clone-submodules
-        if: steps.filter.outputs.src == 'true'
-        with:
-          babel: false
-          prettier: false
       - uses: oxc-project/setup-rust@cd82e1efec7fef815e2c23d296756f31c7cdc03d # v1.0.0
         if: steps.filter.outputs.src == 'true'
         with:
-          cache-key: napi
+          cache-key: napi-e2e
           save-cache: ${{ github.ref_name == 'main' }}
       - uses: oxc-project/setup-node@f42e3bda950c7454575e78ee4eaac880a077700c # v1.0.0
         if: steps.filter.outputs.src == 'true'
       - if: steps.filter.outputs.src == 'true'
-        name: Run tests in workspace
-        env:
-          RUN_RAW_TESTS: "true"
+        name: Install wasm32-wasip1-threads
         run: |
           rustup target add wasm32-wasip1-threads
+      - if: steps.filter.outputs.src == 'true'
+        name: Build transformer
+        working-directory: napi/transform
+        run: |
           pnpm run build-test
+      - if: steps.filter.outputs.src == 'true'
+        name: Run transformer tests
+        working-directory: napi/transform
+        run: |
+          pnpm run test
+      - if: steps.filter.outputs.src == 'true'
+        name: Build minifier
+        working-directory: napi/minify
+        run: |
+          pnpm run build-test
+      - if: steps.filter.outputs.src == 'true'
+        name: Run minifier tests
+        working-directory: napi/minify
+        run: |
           pnpm run test
       - if: steps.filter.outputs.src == 'true'
         name: Run e2e tests
+        working-directory: tasks/e2e
         run: |
           pnpm install --frozen-lockfile
           pnpm run test
-        working-directory: tasks/e2e
       - if: steps.filter.outputs.src == 'true'
         run: |
           git diff --exit-code # Must commit everything

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
         if: steps.filter.outputs.src == 'true'
         with:
           cache-key: napi-${{ matrix.component }}
-          save-cache: ${{ github.ref_name == 'main' }}
+          save-cache: true
       - uses: oxc-project/setup-node@f42e3bda950c7454575e78ee4eaac880a077700c # v1.0.0
         if: steps.filter.outputs.src == 'true'
       - if: steps.filter.outputs.src == 'true'
@@ -224,7 +224,7 @@ jobs:
         if: steps.filter.outputs.src == 'true'
         with:
           cache-key: napi-e2e
-          save-cache: ${{ github.ref_name == 'main' }}
+          save-cache: true
       - uses: oxc-project/setup-node@f42e3bda950c7454575e78ee4eaac880a077700c # v1.0.0
         if: steps.filter.outputs.src == 'true'
       - if: steps.filter.outputs.src == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
         if: steps.filter.outputs.src == 'true'
         with:
           cache-key: napi-${{ matrix.component }}
-          save-cache: true
+          save-cache: ${{ github.ref_name == 'main' }}
       - uses: oxc-project/setup-node@f42e3bda950c7454575e78ee4eaac880a077700c # v1.0.0
         if: steps.filter.outputs.src == 'true'
       - if: steps.filter.outputs.src == 'true'
@@ -224,7 +224,7 @@ jobs:
         if: steps.filter.outputs.src == 'true'
         with:
           cache-key: napi-e2e
-          save-cache: true
+          save-cache: ${{ github.ref_name == 'main' }}
       - uses: oxc-project/setup-node@f42e3bda950c7454575e78ee4eaac880a077700c # v1.0.0
         if: steps.filter.outputs.src == 'true'
       - if: steps.filter.outputs.src == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,17 +153,17 @@ jobs:
           pnpm run test-browser
           pnpm build-browser-bundle --npmDir npm-dir
 
-  # Sharded because these tests are slow
-  test-napi:
-    name: Test NAPI
+  # NAPI tests are slow, so we shard them into multiple jobs.
+  # But we want to build all the packages together, so they share a single build cache.
+  #
+  # * `napi-build` - build all packages, and upload build files as an artifact.
+  # * In parallel:
+  #   * `napi-test` (sharded - 1 job per package)
+  #   * `napi-test-e2e`
+  # * `napi-cleanup` - deletes build files artifact
+  napi-build:
+    name: Build NAPI packages
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        component:
-          - oxlint2
-          - parser
-          - playground
     steps:
       - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -175,40 +175,107 @@ jobs:
               - '!crates/oxc_linter/**'
               - '!crates/oxc_language_server/**'
               - '!editors/**'
+      - uses: oxc-project/setup-rust@cd82e1efec7fef815e2c23d296756f31c7cdc03d # v1.0.0
+        if: steps.filter.outputs.src == 'true'
+        with:
+          cache-key: napi
+          save-cache: ${{ github.ref_name == 'main' }}
+      - uses: oxc-project/setup-node@f42e3bda950c7454575e78ee4eaac880a077700c # v1.0.0
+        if: steps.filter.outputs.src == 'true'
+      - name: Install wasm32-wasip1-threads
+        if: steps.filter.outputs.src == 'true'
+        run: |
+          rustup target add wasm32-wasip1-threads
+      - name: Build minify
+        if: steps.filter.outputs.src == 'true'
+        working-directory: napi/minify
+        run: |
+          pnpm run build-test
+      - name: Build oxlint2
+        if: steps.filter.outputs.src == 'true'
+        working-directory: napi/oxlint2
+        run: |
+          pnpm run build-test
+      - name: Build parser
+        if: steps.filter.outputs.src == 'true'
+        working-directory: napi/parser
+        run: |
+          pnpm run build-test
+      - name: Build playground
+        if: steps.filter.outputs.src == 'true'
+        working-directory: napi/playground
+        run: |
+          pnpm run build-test
+      - name: Build transform
+        if: steps.filter.outputs.src == 'true'
+        working-directory: napi/transform
+        run: |
+          pnpm run build-test
+      - name: Check no uncommitted files
+        if: steps.filter.outputs.src == 'true'
+        run: |
+          git diff --exit-code # Must commit everything
+      - name: Upload build files
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          if-no-files-found: error
+          name: napi
+          path: |
+            napi/minify/*.node
+            napi/oxlint2/dist/
+            napi/parser/*.node
+            napi/transform/*.node
+          retention-days: 1
+
+  napi-test:
+    name: Test NAPI
+    runs-on: ubuntu-latest
+    needs: napi-build
+    strategy:
+      fail-fast: true
+      matrix:
+        component:
+          - minify
+          - oxlint2
+          - parser
+          - transform
+    steps:
+      - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          predicate-quantifier: "every"
+          filters: |
+            src:
+              - '!crates/oxc_linter/**'
+              - '!crates/oxc_language_server/**'
+              - '!editors/**'
+      - uses: oxc-project/setup-node@f42e3bda950c7454575e78ee4eaac880a077700c # v1.0.0
+        if: steps.filter.outputs.src == 'true'
+      - name: Download build files
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: napi
+          path: napi
+          pattern: ${{ matrix.component }}/**/*
       # Submodules only needed for parser tests
       - uses: ./.github/actions/clone-submodules
         if: steps.filter.outputs.src == 'true' && matrix.component == 'parser'
         with:
           babel: false
           prettier: false
-      - uses: oxc-project/setup-rust@cd82e1efec7fef815e2c23d296756f31c7cdc03d # v1.0.0
+      - name: Run tests
         if: steps.filter.outputs.src == 'true'
-        with:
-          cache-key: napi-${{ matrix.component }}
-          save-cache: ${{ github.ref_name == 'main' }}
-      - uses: oxc-project/setup-node@f42e3bda950c7454575e78ee4eaac880a077700c # v1.0.0
-        if: steps.filter.outputs.src == 'true'
-      - if: steps.filter.outputs.src == 'true'
-        name: Build
-        working-directory: napi/${{ matrix.component }}
-        run: |
-          rustup target add wasm32-wasip1-threads
-          pnpm run build-test
-      - if: steps.filter.outputs.src == 'true' && matrix.component != 'playground'
-        name: Run tests
         working-directory: napi/${{ matrix.component }}
         env:
           RUN_RAW_TESTS: "true"
         run: |
           pnpm run test
-      - if: steps.filter.outputs.src == 'true'
-        run: |
-          git diff --exit-code # Must commit everything
 
-  # Includes transformer and minifier
-  test-napi-e2e:
+  napi-test-e2e:
     name: Test NAPI (e2e)
     runs-on: ubuntu-latest
+    needs: napi-build
     steps:
       - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -220,46 +287,34 @@ jobs:
               - '!crates/oxc_linter/**'
               - '!crates/oxc_language_server/**'
               - '!editors/**'
-      - uses: oxc-project/setup-rust@cd82e1efec7fef815e2c23d296756f31c7cdc03d # v1.0.0
-        if: steps.filter.outputs.src == 'true'
-        with:
-          cache-key: napi-e2e
-          save-cache: ${{ github.ref_name == 'main' }}
       - uses: oxc-project/setup-node@f42e3bda950c7454575e78ee4eaac880a077700c # v1.0.0
         if: steps.filter.outputs.src == 'true'
-      - if: steps.filter.outputs.src == 'true'
-        name: Install wasm32-wasip1-threads
-        run: |
-          rustup target add wasm32-wasip1-threads
-      - if: steps.filter.outputs.src == 'true'
-        name: Build transformer
-        working-directory: napi/transform
-        run: |
-          pnpm run build-test
-      - if: steps.filter.outputs.src == 'true'
-        name: Run transformer tests
-        working-directory: napi/transform
-        run: |
-          pnpm run test
-      - if: steps.filter.outputs.src == 'true'
-        name: Build minifier
-        working-directory: napi/minify
-        run: |
-          pnpm run build-test
-      - if: steps.filter.outputs.src == 'true'
-        name: Run minifier tests
-        working-directory: napi/minify
-        run: |
-          pnpm run test
-      - if: steps.filter.outputs.src == 'true'
-        name: Run e2e tests
+      - name: Download build files
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: napi
+          path: napi
+          pattern: "{minify,transform}/*.node"
+      - name: Install NPM packages
+        if: steps.filter.outputs.src == 'true'
         working-directory: tasks/e2e
         run: |
           pnpm install --frozen-lockfile
-          pnpm run test
-      - if: steps.filter.outputs.src == 'true'
+      - name: Run tests
+        if: steps.filter.outputs.src == 'true'
+        working-directory: tasks/e2e
         run: |
-          git diff --exit-code # Must commit everything
+          pnpm run test
+
+  napi-cleanup:
+    name: Delete NAPI build artifacts
+    runs-on: ubuntu-latest
+    needs: [napi-test, napi-test-e2e]
+    steps:
+      - uses: geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b # v5.1.0
+        with:
+          name: napi
+          failOnError: false
 
   typos:
     name: Spell Check


### PR DESCRIPTION
Fix #12435.

Shard NAPI tests, because they're the slowest task in CI.

* Transformer, minifier, and E2E tests run in one task together, since E2E requires transformer and minifier NPM packages to be built.
* Parser, oxlint2, and playground each run in their own task.

This split seems fairly decent. Each task is now in the 1m40s - 2m40s range. Previously when they all ran in one task together, it was 7 mins+. This should get PRs through the merge queue a lot faster.