### PR TITLE
chore(ci): remove paths ignore list in CI task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,19 +6,9 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize]
-    paths-ignore:
-      - "**/*.md"
-      - "**/*.yml"
-      - "!.github/workflows/ci.yml"
-      - "!.github/actions/clone-submodules/action.yml"
   push:
     branches:
       - main
-    paths-ignore:
-      - "**/*.md"
-      - "**/*.yml"
-      - "!.github/workflows/ci.yml"
-      - "!.github/actions/clone-submodules/action.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}


### PR DESCRIPTION
Remove the `paths-ignore` list from `CI` job.

It's ideal to skip running CI when a PR only touches `.md` files. But problem is that these jobs are marked as "required", so CI task *has* to run, or the PR can't be merged.

Maybe we can remove the requirement that these jobs complete before a PR can be merged, but for now this is the best solution.
