### PR TITLE
test(napi): compile tests in debug mode

### DIFF
--- a/napi/minify/package.json
+++ b/napi/minify/package.json
@@ -5,7 +5,7 @@
   "browser": "browser.js",
   "scripts": {
     "build-dev": "napi build --platform",
-    "build-test": "pnpm run build",
+    "build-test": "pnpm run build-dev",
     "build": "pnpm run build-dev --features allocator --release",
     "postbuild-dev": "node patch.mjs",
     "test": "tsc && vitest run --dir ./test"

--- a/napi/oxlint2/package.json
+++ b/napi/oxlint2/package.json
@@ -8,7 +8,7 @@
     "build-dev": "pnpm run build-napi && pnpm run build-js",
     "build-test": "pnpm run build-napi-test && pnpm run build-js",
     "build-napi": "napi build --platform --js ./bindings.js --dts ./bindings.d.ts --output-dir src-js --no-dts-cache --esm",
-    "build-napi-test": "pnpm run build-napi --profile coverage --features force_test_reporter",
+    "build-napi-test": "pnpm run build-napi --features force_test_reporter",
     "build-napi-release": "pnpm run build-napi --release",
     "build-js": "node scripts/build.js",
     "test": "tsc && vitest --dir ./test run"

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -5,7 +5,7 @@
   "browser": "wasm.mjs",
   "scripts": {
     "build-dev": "napi build --platform --js bindings.js",
-    "build-test": "pnpm run build",
+    "build-test": "pnpm run build-dev --profile coverage",
     "build": "pnpm run build-dev --features allocator --release",
     "postbuild-dev": "node patch.mjs",
     "build-wasi": "pnpm run build-dev --release --target wasm32-wasip1-threads",

--- a/napi/playground/package.json
+++ b/napi/playground/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build-dev": "napi build --platform --target wasm32-wasip1-threads && node patch.mjs",
-    "build-test": "pnpm run build",
+    "build-test": "pnpm run build-dev",
     "build": "napi build --platform --release --target wasm32-wasip1-threads && node patch.mjs"
   },
   "dependencies": {

--- a/napi/transform/package.json
+++ b/napi/transform/package.json
@@ -5,7 +5,7 @@
   "browser": "browser.js",
   "scripts": {
     "build-dev": "napi build --platform",
-    "build-test": "pnpm run build",
+    "build-test": "pnpm run build-dev",
     "build": "pnpm run build-dev --features allocator --release",
     "postbuild-dev": "node patch.mjs",
     "test": "tsc && vitest run --dir ./test"


### PR DESCRIPTION
Compile NAPI tests in debug mode (not release mode), to speed up build in CI.

Only exception is `napi/parser` which is compiled with `--profile coverage`. The tests for this package are quite slow, so they'd take too long if package was compiled with no optimizations. `coverage` profile is closer to `--release`, but enables debug assertions, and has somewhat faster compilation (`-O 2` not `-O 3` etc).

In CI:

* Build time reduced by 1m30s.
* Test run time increased by 30s.
* Total reduction in CI time: 1 minute.

NAPI tests are still the slowest task in CI by a long margin. Trimming a minute off the time is something, but this task is still too slow.