### PR TITLE
test(napi/parser): ensure `target` dir exists

### DIFF
--- a/napi/parser/test/parse-raw.test.ts
+++ b/napi/parser/test/parse-raw.test.ts
@@ -1,6 +1,6 @@
 // Tests for raw transfer.
 
-import { readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { basename, join as pathJoin } from 'node:path';
 import Tinypool from 'tinypool';
 import { describe, expect, it } from 'vitest';
@@ -71,6 +71,8 @@ const benchFixtureUrls = [
   // ES5 (3.9M)
   'https://cdn.jsdelivr.net/npm/antd@5.12.5/dist/antd.js',
 ];
+
+await mkdir(TARGET_DIR_PATH, { recursive: true });
 
 const benchFixturePaths = await Promise.all(benchFixtureUrls.map(async (url) => {
   const filename = url.split('/').at(-1),


### PR DESCRIPTION
In tests for `napi/parser`, don't assume `target` dir exists. It generally should, because you'll have built the `.node` binary. But it `cargo clean` will remove it, and it can also not exist on CI if running build and test in separate jobs.