### PR TITLE
ci(napi): NAPI tests skip Babel + Prettier submodules

### DIFF
--- a/.github/actions/clone-submodules/action.yml
+++ b/.github/actions/clone-submodules/action.yml
@@ -2,10 +2,42 @@ name: Clone submodules
 
 description: Clone submodules
 
+inputs:
+  test262:
+    default: true
+    required: false
+    type: boolean
+    description: Whether to clone test262 submodule
+
+  babel:
+    default: true
+    required: false
+    type: boolean
+    description: Whether to clone babel submodule
+
+  typescript:
+    default: true
+    required: false
+    type: boolean
+    description: Whether to clone typescript submodule
+
+  prettier:
+    default: true
+    required: false
+    type: boolean
+    description: Whether to clone prettier submodule
+
+  acorn-test262:
+    default: true
+    required: false
+    type: boolean
+    description: Whether to clone acorn-test262 submodule
+
 runs:
   using: composite
   steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      if: ${{ inputs.test262 == 'true' }}
       with:
         show-progress: false
         repository: tc39/test262
@@ -13,6 +45,7 @@ runs:
         ref: 4b5d36ab6ef2f59d0a8902cd383762547a3a74c4
 
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      if: ${{ inputs.babel == 'true' }}
       with:
         show-progress: false
         repository: babel/babel
@@ -20,6 +53,7 @@ runs:
         ref: 1d4546bcb80009303aab386b59f4df1fd335c1d5
 
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      if: ${{ inputs.typescript == 'true' }}
       with:
         show-progress: false
         repository: microsoft/TypeScript
@@ -27,6 +61,7 @@ runs:
         ref: 81c951894e93bdc37c6916f18adcd80de76679bc
 
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      if: ${{ inputs.prettier == 'true' }}
       with:
         show-progress: false
         repository: prettier/prettier
@@ -34,6 +69,7 @@ runs:
         ref: 7584432401a47a26943dd7a9ca9a8e032ead7285 # v3.5.0
 
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      if: ${{ inputs.acorn-test262 == 'true' }}
       with:
         show-progress: false
         repository: oxc-project/acorn-test262

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,9 @@ jobs:
               - '!editors/**'
       - uses: ./.github/actions/clone-submodules
         if: steps.filter.outputs.src == 'true'
+        with:
+          babel: false
+          prettier: false
       - uses: oxc-project/setup-rust@cd82e1efec7fef815e2c23d296756f31c7cdc03d # v1.0.0
         if: steps.filter.outputs.src == 'true'
         with:


### PR DESCRIPTION
Cloning submodules takes a bit of time. Skip cloning `babel` and `prettier` repos in NAPI tests, because they doesn't need them. NAPI parser tests only need the other 3 submodules.