### PR TITLE
fix(linter): default options for `eslint/no-unneeded-ternary`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unneeded_ternary.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unneeded_ternary.rs
@@ -19,9 +19,15 @@ fn no_unneeded_ternary_conditional_expression_diagnostic(span: Span) -> OxcDiagn
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct NoUnneededTernary {
     default_assignment: bool,
+}
+
+impl Default for NoUnneededTernary {
+    fn default() -> Self {
+        Self { default_assignment: true }
+    }
 }
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/tests/rule_configuration_test.rs
+++ b/crates/oxc_linter/tests/rule_configuration_test.rs
@@ -25,7 +25,6 @@ fn test_rule_default_matches_from_configuration_null() {
     // 1. The Default implementation returns the same values as from_configuration(null), or
     // 2. The from_configuration method is updated to return Default::default() when given null
     let exceptions = [
-        "eslint/no-unneeded-ternary",
         "eslint/no-else-return",
         "import/extensions",
         "import/no-anonymous-default-export",


### PR DESCRIPTION
https://eslint.org/docs/latest/rules/no-unneeded-ternary#options