### PR TITLE
refactor(linter): run linter with `ContextSubHost`

### DIFF
--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -31,7 +31,6 @@ pub struct ContextSubHost<'a> {
     #[expect(dead_code)]
     pub(super) framework_options: FrameworkOptions,
     /// The source text offset of the sub host
-    #[expect(dead_code)]
     pub(super) source_text_offset: u32,
 }
 
@@ -197,12 +196,21 @@ impl<'a> ContextHost<'a> {
     /// Add a diagnostic message to the end of the list of diagnostics. Can be used
     /// by any rule to report issues.
     #[inline]
-    pub(crate) fn push_diagnostic(&self, diagnostic: Message<'a>) {
+    pub(crate) fn push_diagnostic(&self, mut diagnostic: Message<'a>) {
+        if self.current_sub_host().source_text_offset != 0 {
+            diagnostic.move_offset(self.current_sub_host().source_text_offset);
+        }
         self.diagnostics.borrow_mut().push(diagnostic);
     }
 
     // Append a list of diagnostics. Only used in report_unused_directives.
-    fn append_diagnostics(&self, diagnostics: Vec<Message<'a>>) {
+    fn append_diagnostics(&self, mut diagnostics: Vec<Message<'a>>) {
+        if self.current_sub_host().source_text_offset != 0 {
+            let offset = self.current_sub_host().source_text_offset;
+            for diagnostic in &mut diagnostics {
+                diagnostic.move_offset(offset);
+            }
+        }
         self.diagnostics.borrow_mut().extend(diagnostics);
     }
 

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -258,8 +258,7 @@ impl<'a> Message<'a> {
         Self { error, span: Span::new(start, end), fixes, fixed: false }
     }
 
-    /// move the offset of all spans (except fixes) to the right
-    /// for moving fixes use [`Message::move_fix_offset`].
+    /// move the offset of all spans to the right
     pub fn move_offset(&mut self, offset: u32) -> &mut Self {
         debug_assert!(offset != 0);
 
@@ -270,12 +269,6 @@ impl<'a> Message<'a> {
                 label.set_span_offset(label.offset().saturating_add(offset as usize));
             }
         }
-
-        self
-    }
-
-    pub fn move_fix_offset(&mut self, offset: u32) -> &mut Self {
-        debug_assert!(offset != 0);
 
         match &mut self.fixes {
             PossibleFixes::None => {}

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -30,8 +30,8 @@ use oxc::{
 use oxc_formatter::{FormatOptions, Formatter};
 use oxc_index::Idx;
 use oxc_linter::{
-    ConfigStore, ConfigStoreBuilder, ExternalPluginStore, LintOptions, Linter, ModuleRecord,
-    Oxlintrc,
+    ConfigStore, ConfigStoreBuilder, ContextSubHost, ExternalPluginStore, LintOptions, Linter,
+    ModuleRecord, Oxlintrc,
 };
 use oxc_napi::{Comment, OxcError, convert_utf8_to_utf16};
 
@@ -317,7 +317,11 @@ impl Oxc {
                 ConfigStore::new(lint_config, FxHashMap::default(), external_plugin_store),
                 None,
             )
-            .run(path, Rc::clone(&semantic), Arc::clone(module_record), allocator);
+            .run(
+                path,
+                vec![ContextSubHost::new(Rc::clone(&semantic), Arc::clone(module_record), 0)],
+                allocator,
+            );
             self.diagnostics.extend(linter_ret.into_iter().map(|e| e.error));
         }
     }

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -5,8 +5,8 @@ use rustc_hash::FxHashMap;
 use oxc_allocator::Allocator;
 use oxc_benchmark::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use oxc_linter::{
-    ConfigStore, ConfigStoreBuilder, ExternalPluginStore, FixKind, LintOptions, Linter,
-    ModuleRecord,
+    ConfigStore, ConfigStoreBuilder, ContextSubHost, ExternalPluginStore, FixKind, LintOptions,
+    Linter, ModuleRecord,
 };
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
@@ -40,7 +40,11 @@ fn bench_linter(criterion: &mut Criterion) {
         .with_fix(FixKind::All);
         group.bench_function(id, |b| {
             b.iter(|| {
-                linter.run(path, Rc::clone(&semantic), Arc::clone(&module_record), &allocator)
+                linter.run(
+                    path,
+                    vec![ContextSubHost::new(Rc::clone(&semantic), Arc::clone(&module_record), 0)],
+                    &allocator,
+                )
             });
         });
     }


### PR DESCRIPTION
Here we are not aligning every diagnostic to the source text offset. Later we could cross-reference with an extra method `push_diagnostic_without_adjustment` or something similar.