### PR TITLE
fix(transformer/typescript): don't remove class fields without initializers when class-properties plugin is enabled

### DIFF
--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -132,7 +132,12 @@ impl<'a> Traverse<'a, TransformState<'a>> for TypeScript<'a, '_> {
 
     fn exit_class(&mut self, class: &mut Class<'a>, ctx: &mut TraverseCtx<'a>) {
         self.annotations.exit_class(class, ctx);
-        self.transform_class_on_exit(class, ctx);
+
+        // Avoid converting class fields when class-properties plugin is enabled, that plugin has covered all
+        // this transformation does.
+        if !self.ctx.is_class_properties_plugin_enabled {
+            self.transform_class_on_exit(class, ctx);
+        }
     }
 
     fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 1d4546bc
 
-Passed: 181/301
+Passed: 182/302
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -20,7 +20,7 @@ Passed: 181/301
 * regexp
 
 
-# babel-plugin-transform-class-properties (22/28)
+# babel-plugin-transform-class-properties (23/29)
 * private-field-resolve-to-method/input.js
 x Output mismatch
 

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/class-fields-with-computed-key/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/class-fields-with-computed-key/input.ts
@@ -1,0 +1,5 @@
+import { Collection } from './collection.ts';
+
+export class Obj {
+  public readonly [Collection.identifier] = true;
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/class-fields-with-computed-key/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/class-fields-with-computed-key/options.json
@@ -1,0 +1,14 @@
+{
+  "assumptions": {
+    "setPublicClassFields": true
+  },
+  "plugins": [
+    "transform-class-properties",
+    [
+      "transform-typescript",
+      {
+        "removeClassFieldsWithoutInitializer": true
+      }
+    ]
+  ]
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/class-fields-with-computed-key/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/class-fields-with-computed-key/output.js
@@ -1,0 +1,8 @@
+import { Collection } from "./collection.ts";
+let _Collection$identifie;
+_Collection$identifie = Collection.identifier;
+export class Obj {
+  constructor() {
+    this[_Collection$identifie] = true;
+  }
+}


### PR DESCRIPTION
* close #12770

Both `typescript` and `class-properties` have the similar transformation for class fields. They would conflict when both are run, so we have to stop transforming class fields in the `typescript` plugin when `class-properties` is enabled. 