### PR TITLE
fix(transformer/class-properties): preserve computed keys if they may have side effects when `remove_class_fields_without_initializer` is enabled

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -119,7 +119,7 @@ impl<'a> ClassProperties<'a, '_> {
                 None if self.set_public_class_fields
                     && self.remove_class_fields_without_initializer =>
                 {
-                    return;
+                    return self.extract_computed_key(prop, ctx);
                 }
                 None => ctx.ast.void_0(SPAN),
             };

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/class-fields-with-computed-key/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/class-fields-with-computed-key/input.ts
@@ -2,4 +2,7 @@ import { Collection } from './collection.ts';
 
 export class Obj {
   public readonly [Collection.identifier] = true;
+  public readonly [Collection.identifier2];
+  public static readonly [Collection.identifier3] = true;
+  public static readonly  [Collection.identifier4];
 }

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/class-fields-with-computed-key/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/class-fields-with-computed-key/output.js
@@ -1,8 +1,12 @@
 import { Collection } from "./collection.ts";
-let _Collection$identifie;
+let _Collection$identifie, _Collection$identifie2;
 _Collection$identifie = Collection.identifier;
+Collection.identifier2;
+_Collection$identifie2 = Collection.identifier3;
+Collection.identifier4;
 export class Obj {
   constructor() {
     this[_Collection$identifie] = true;
   }
 }
+Obj[_Collection$identifie2] = true;


### PR DESCRIPTION
When `remove_class_fields_without_initializer` is enabled, fields without initializers would be removed. However, if the key is computed, and it may have side effects, then we should extract it and place it before class, so that it can keep the same behavior as before.

**Example:** 

Input:
```ts
import { Collection } from './collection.ts';

export class Obj {
  public readonly [Collection.identifier] = true;
  public readonly [Collection.identifier2];
  public static readonly [Collection.identifier3] = true;
  public static readonly  [Collection.identifier4];
}
```

Options:
```json
{
  "assumptions": {
    "setPublicClassFields": true
  },
  "plugins": [
    "transform-class-properties",
    [
      "transform-typescript",
      {
        "removeClassFieldsWithoutInitializer": true
      }
    ]
  ]
}
```

Output:
```js
import { Collection } from "./collection.ts";
let _Collection$identifie, _Collection$identifie2;
_Collection$identifie = Collection.identifier;
Collection.identifier2;
_Collection$identifie2 = Collection.identifier3;
Collection.identifier4;
export class Obj {
  constructor() {
    this[_Collection$identifie] = true;
  }
}
Obj[_Collection$identifie2] = true;
```
