### PR TITLE
perf(parser): remove a bound check in `match_keyword`

### DIFF
--- a/crates/oxc_parser/src/lexer/kind.rs
+++ b/crates/oxc_parser/src/lexer/kind.rs
@@ -418,9 +418,11 @@ impl Kind {
         matches!(self, LCurly | LBrack | PrivateIdentifier) || self.is_binding_identifier()
     }
 
+    #[cold]
     pub fn match_keyword(s: &str) -> Self {
         let len = s.len();
-        if len <= 1 || len >= 12 || !s.as_bytes()[0].is_ascii_lowercase() {
+        // SAFETY: Already checked `len <= 1`.
+        if len <= 1 || len >= 12 || !unsafe { s.as_bytes().get_unchecked(0) }.is_ascii_lowercase() {
             return Ident;
         }
         Self::match_keyword_impl(s)


### PR DESCRIPTION
This is on a really cold path, so no expected performance improvement.