### PR TITLE
fix(semantic): fix reference type flags when visiting `TSImportType`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -172,6 +172,11 @@ fn test() {
         ("function resolve<T>(path: string): T { return { path } as T; }", None, None),
         ("let xyz: NodeListOf<HTMLElement>", None, None),
         ("type Foo = Record<string, unknown>;", None, None),
+        (
+            "export interface StoreImpl { onOutputBlobs: (callback: (blobs: MediaSetBlobs) => void) => import('rxjs').Subscription; }",
+            None,
+            None,
+        ),
     ];
 
     let fail = vec![

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -1368,6 +1368,24 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.leave_node(kind);
     }
 
+    fn visit_ts_import_type(&mut self, it: &TSImportType<'a>) {
+        let kind = AstKind::TSImportType(self.alloc(it));
+        self.current_reference_flags = ReferenceFlags::Type;
+        self.enter_node(kind);
+        self.visit_span(&it.span);
+        self.visit_ts_type(&it.argument);
+        if let Some(options) = &it.options {
+            self.visit_object_expression(options);
+        }
+        if let Some(qualifier) = &it.qualifier {
+            self.visit_ts_type_name(qualifier);
+        }
+        if let Some(type_arguments) = &it.type_arguments {
+            self.visit_ts_type_parameter_instantiation(type_arguments);
+        }
+        self.leave_node(kind);
+    }
+
     fn visit_throw_statement(&mut self, stmt: &ThrowStatement<'a>) {
         let kind = AstKind::ThrowStatement(self.alloc(stmt));
         self.enter_node(kind);

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -158,35 +158,23 @@ after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/import/input.js
-Symbol reference IDs mismatch for "Y":
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
 Unresolved references mismatch:
-after transform: ["foo"]
+after transform: ["Y", "foo"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/import-babel-7/input.js
-Symbol reference IDs mismatch for "Y":
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
 Unresolved references mismatch:
-after transform: ["foo"]
+after transform: ["Y", "foo"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/import-with-options/input.js
-Symbol reference IDs mismatch for "Y":
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
 Unresolved references mismatch:
-after transform: ["foo"]
+after transform: ["Y", "foo"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/import-with-options-babel-7/input.js
-Symbol reference IDs mismatch for "Y":
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
 Unresolved references mismatch:
-after transform: ["foo"]
+after transform: ["Y", "foo"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/instantiation-expression-optional-chain/input.ts
@@ -2653,19 +2641,13 @@ after transform: ScopeId(0): ["A", "B", "T", "Types"]
 rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/import-type-dynamic/input.ts
-Symbol reference IDs mismatch for "Y":
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
 Unresolved references mismatch:
-after transform: ["foo"]
+after transform: ["Y", "foo"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/import-type-dynamic-babel-7/input.ts
-Symbol reference IDs mismatch for "Y":
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
 Unresolved references mismatch:
-after transform: ["foo"]
+after transform: ["Y", "foo"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/indexed/input.ts

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -18893,7 +18893,7 @@ rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsDocDeclarationEmitDoesNotUseNodeModulesPathWithoutError.ts
 Unresolved references mismatch:
-after transform: ["LionRequestInit"]
+after transform: ["Object"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsEmitIntersectionProperty.ts
@@ -47392,9 +47392,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/moduleResoluti
 Bindings mismatch:
 after transform: ScopeId(0): ["User", "getUser", "user"]
 rebuilt        : ScopeId(0): ["getUser", "user"]
-Unresolved references mismatch:
-after transform: ["User"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/bundler/bundlerDirectoryModule.ts
 Bindings mismatch:


### PR DESCRIPTION
```
type k = import ('foo').bar
```


@Dunqing previously, the `bar` reference would have `ReferenceFlags::read`, but since it's only used as a type i think it should only have the type reference flags?

fixes #12693