### PR TITLE
refactor(ast)!: replace `ExportDefaultDeclaration` `exported` field with `default_span`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -2607,8 +2607,9 @@ pub struct ExportNamedDeclaration<'a> {
 #[estree(add_fields(exportKind = TsValue))]
 pub struct ExportDefaultDeclaration<'a> {
     pub span: Span,
+    /// Span of the `default` keyword
     #[estree(skip)]
-    pub exported: ModuleExportName<'a>, // the `default` Keyword
+    pub default_span: Span,
     pub declaration: ExportDefaultDeclarationKind<'a>,
 }
 

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -818,11 +818,11 @@ const _: () = {
     assert!(offset_of!(ExportNamedDeclaration, with_clause) == 96);
 
     // Padding: 0 bytes
-    assert!(size_of::<ExportDefaultDeclaration>() == 80);
+    assert!(size_of::<ExportDefaultDeclaration>() == 32);
     assert!(align_of::<ExportDefaultDeclaration>() == 8);
     assert!(offset_of!(ExportDefaultDeclaration, span) == 0);
-    assert!(offset_of!(ExportDefaultDeclaration, exported) == 8);
-    assert!(offset_of!(ExportDefaultDeclaration, declaration) == 64);
+    assert!(offset_of!(ExportDefaultDeclaration, default_span) == 8);
+    assert!(offset_of!(ExportDefaultDeclaration, declaration) == 16);
 
     // Padding: 7 bytes
     assert!(size_of::<ExportAllDeclaration>() == 128);
@@ -2413,11 +2413,11 @@ const _: () = {
     assert!(offset_of!(ExportNamedDeclaration, with_clause) == 60);
 
     // Padding: 0 bytes
-    assert!(size_of::<ExportDefaultDeclaration>() == 48);
+    assert!(size_of::<ExportDefaultDeclaration>() == 24);
     assert!(align_of::<ExportDefaultDeclaration>() == 4);
     assert!(offset_of!(ExportDefaultDeclaration, span) == 0);
-    assert!(offset_of!(ExportDefaultDeclaration, exported) == 8);
-    assert!(offset_of!(ExportDefaultDeclaration, declaration) == 40);
+    assert!(offset_of!(ExportDefaultDeclaration, default_span) == 8);
+    assert!(offset_of!(ExportDefaultDeclaration, declaration) == 16);
 
     // Padding: 3 bytes
     assert!(size_of::<ExportAllDeclaration>() == 76);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -7181,18 +7181,18 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `exported`
+    /// * `default_span`: Span of the `default` keyword
     /// * `declaration`
     #[inline]
     pub fn module_declaration_export_default_declaration(
         self,
         span: Span,
-        exported: ModuleExportName<'a>,
+        default_span: Span,
         declaration: ExportDefaultDeclarationKind<'a>,
     ) -> ModuleDeclaration<'a> {
         ModuleDeclaration::ExportDefaultDeclaration(self.alloc_export_default_declaration(
             span,
-            exported,
+            default_span,
             declaration,
         ))
     }
@@ -7839,16 +7839,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `exported`
+    /// * `default_span`: Span of the `default` keyword
     /// * `declaration`
     #[inline]
     pub fn export_default_declaration(
         self,
         span: Span,
-        exported: ModuleExportName<'a>,
+        default_span: Span,
         declaration: ExportDefaultDeclarationKind<'a>,
     ) -> ExportDefaultDeclaration<'a> {
-        ExportDefaultDeclaration { span, exported, declaration }
+        ExportDefaultDeclaration { span, default_span, declaration }
     }
 
     /// Build an [`ExportDefaultDeclaration`], and store it in the memory arena.
@@ -7858,16 +7858,19 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `exported`
+    /// * `default_span`: Span of the `default` keyword
     /// * `declaration`
     #[inline]
     pub fn alloc_export_default_declaration(
         self,
         span: Span,
-        exported: ModuleExportName<'a>,
+        default_span: Span,
         declaration: ExportDefaultDeclarationKind<'a>,
     ) -> Box<'a, ExportDefaultDeclaration<'a>> {
-        Box::new_in(self.export_default_declaration(span, exported, declaration), self.allocator)
+        Box::new_in(
+            self.export_default_declaration(span, default_span, declaration),
+            self.allocator,
+        )
     }
 
     /// Build an [`ExportAllDeclaration`].

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -4362,7 +4362,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExportDefaultDeclaration<'_> {
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExportDefaultDeclaration {
             span: CloneIn::clone_in(&self.span, allocator),
-            exported: CloneIn::clone_in(&self.exported, allocator),
+            default_span: CloneIn::clone_in(&self.default_span, allocator),
             declaration: CloneIn::clone_in(&self.declaration, allocator),
         }
     }
@@ -4370,7 +4370,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExportDefaultDeclaration<'_> {
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExportDefaultDeclaration {
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            exported: CloneIn::clone_in_with_semantic_ids(&self.exported, allocator),
+            default_span: CloneIn::clone_in_with_semantic_ids(&self.default_span, allocator),
             declaration: CloneIn::clone_in_with_semantic_ids(&self.declaration, allocator),
         }
     }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -1360,8 +1360,7 @@ impl ContentEq for ExportNamedDeclaration<'_> {
 
 impl ContentEq for ExportDefaultDeclaration<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.exported, &other.exported)
-            && ContentEq::content_eq(&self.declaration, &other.declaration)
+        ContentEq::content_eq(&self.declaration, &other.declaration)
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_dummy.rs
+++ b/crates/oxc_ast/src/generated/derive_dummy.rs
@@ -1495,7 +1495,7 @@ impl<'a> Dummy<'a> for ExportDefaultDeclaration<'a> {
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
             span: Dummy::dummy(allocator),
-            exported: Dummy::dummy(allocator),
+            default_span: Dummy::dummy(allocator),
             declaration: Dummy::dummy(allocator),
         }
     }

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -2801,7 +2801,7 @@ pub mod walk {
         let kind = AstKind::ExportDefaultDeclaration(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        visitor.visit_module_export_name(&it.exported);
+        visitor.visit_span(&it.default_span);
         visitor.visit_export_default_declaration_kind(&it.declaration);
         visitor.leave_node(kind);
     }

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -2911,7 +2911,7 @@ pub mod walk_mut {
         let kind = AstType::ExportDefaultDeclaration;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        visitor.visit_module_export_name(&mut it.exported);
+        visitor.visit_span(&mut it.default_span);
         visitor.visit_export_default_declaration_kind(&mut it.declaration);
         visitor.leave_node(kind);
     }

--- a/crates/oxc_formatter/src/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/generated/ast_nodes.rs
@@ -8948,14 +8948,8 @@ impl<'a> GetSpan for AstNode<'a, ExportNamedDeclaration<'a>> {
 
 impl<'a> AstNode<'a, ExportDefaultDeclaration<'a>> {
     #[inline]
-    pub fn exported(&self) -> &AstNode<'a, ModuleExportName<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.declaration));
-        self.allocator.alloc(AstNode {
-            inner: &self.inner.exported,
-            allocator: self.allocator,
-            parent: self.allocator.alloc(AstNodes::ExportDefaultDeclaration(transmute_self(self))),
-            following_node,
-        })
+    pub fn default_span(&self) -> Span {
+        self.inner.default_span
     }
 
     #[inline]

--- a/crates/oxc_isolated_declarations/src/module.rs
+++ b/crates/oxc_isolated_declarations/src/module.rs
@@ -57,8 +57,6 @@ impl<'a> IsolatedDeclarations<'a> {
         };
 
         declaration.map(|(var_decl, declaration)| {
-            let exported =
-                ModuleExportName::IdentifierName(self.ast.identifier_name(SPAN, "default"));
             // When `var_decl` is Some, the comments are moved to the variable declaration, otherwise
             // keep the comments on the export default declaration to avoid losing them.
             // ```ts
@@ -82,7 +80,7 @@ impl<'a> IsolatedDeclarations<'a> {
 
             let span = if var_decl.is_some() { SPAN } else { decl.span };
             let declaration =
-                self.ast.module_declaration_export_default_declaration(span, exported, declaration);
+                self.ast.module_declaration_export_default_declaration(span, SPAN, declaration);
             (var_decl, Statement::from(declaration))
         })
     }

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -543,11 +543,11 @@ impl<'a> ParserImpl<'a> {
         span: u32,
         decorators: Vec<'a, Decorator<'a>>,
     ) -> Box<'a, ExportDefaultDeclaration<'a>> {
-        let exported = self.parse_keyword_identifier(Kind::Default);
+        let default_span = self.cur_token().span();
+        self.bump_remap(Kind::Default);
         let declaration = self.parse_export_default_declaration_kind(decorators);
-        let exported = ModuleExportName::IdentifierName(exported);
         let span = self.end_span(span);
-        self.ast.alloc_export_default_declaration(span, exported, declaration)
+        self.ast.alloc_export_default_declaration(span, default_span, declaration)
     }
 
     fn parse_export_default_declaration_kind(

--- a/crates/oxc_parser/src/module_record.rs
+++ b/crates/oxc_parser/src/module_record.rs
@@ -284,8 +284,6 @@ impl<'a> ModuleRecordBuilder<'a> {
     }
 
     fn visit_export_default_declaration(&mut self, decl: &ExportDefaultDeclaration<'a>) {
-        let exported_name = &decl.exported;
-
         let local_name = match &decl.declaration {
             ExportDefaultDeclarationKind::Identifier(ident) => {
                 ExportLocalName::Default(NameSpan::new(ident.name, ident.span))
@@ -310,7 +308,7 @@ impl<'a> ModuleRecordBuilder<'a> {
             span: decl.declaration.span(),
             module_request: None,
             import_name: ExportImportName::default(),
-            export_name: ExportExportName::Default(exported_name.span()),
+            export_name: ExportExportName::Default(decl.default_span),
             local_name,
             is_type: decl.is_typescript_syntax(),
         };

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/exports/default/type-alias.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/exports/default/type-alias.snap
@@ -27,7 +27,7 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/exports/default/type-alias
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
-            "node_id": 6
+            "node_id": 5
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-type.snap
@@ -27,7 +27,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "T",
-            "node_id": 11
+            "node_id": 10
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2.snap
@@ -19,7 +19,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 7
+            "node_id": 6
           }
         ]
       }

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -1032,7 +1032,7 @@ impl<'a> LegacyDecorator<'a, '_> {
     ) -> Statement<'a> {
         let export_default_class_reference = ctx.ast.module_declaration_export_default_declaration(
             SPAN,
-            ctx.ast.module_export_name_identifier_name(SPAN, "default"),
+            SPAN,
             ExportDefaultDeclarationKind::Identifier(
                 ctx.ast.alloc(class_binding.create_read_reference(ctx)),
             ),

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -183,139 +183,138 @@ pub(crate) enum AncestorType {
     ExportNamedDeclarationSpecifiers = 158,
     ExportNamedDeclarationSource = 159,
     ExportNamedDeclarationWithClause = 160,
-    ExportDefaultDeclarationExported = 161,
-    ExportDefaultDeclarationDeclaration = 162,
-    ExportAllDeclarationExported = 163,
-    ExportAllDeclarationSource = 164,
-    ExportAllDeclarationWithClause = 165,
-    ExportSpecifierLocal = 166,
-    ExportSpecifierExported = 167,
-    V8IntrinsicExpressionName = 168,
-    V8IntrinsicExpressionArguments = 169,
-    JSXElementOpeningElement = 170,
-    JSXElementChildren = 171,
-    JSXElementClosingElement = 172,
-    JSXOpeningElementName = 173,
-    JSXOpeningElementTypeArguments = 174,
-    JSXOpeningElementAttributes = 175,
-    JSXClosingElementName = 176,
-    JSXFragmentOpeningFragment = 177,
-    JSXFragmentChildren = 178,
-    JSXFragmentClosingFragment = 179,
-    JSXNamespacedNameNamespace = 180,
-    JSXNamespacedNameName = 181,
-    JSXMemberExpressionObject = 182,
-    JSXMemberExpressionProperty = 183,
-    JSXExpressionContainerExpression = 184,
-    JSXAttributeName = 185,
-    JSXAttributeValue = 186,
-    JSXSpreadAttributeArgument = 187,
-    JSXSpreadChildExpression = 188,
-    TSThisParameterTypeAnnotation = 189,
-    TSEnumDeclarationId = 190,
-    TSEnumDeclarationBody = 191,
-    TSEnumBodyMembers = 192,
-    TSEnumMemberId = 193,
-    TSEnumMemberInitializer = 194,
-    TSTypeAnnotationTypeAnnotation = 195,
-    TSLiteralTypeLiteral = 196,
-    TSConditionalTypeCheckType = 197,
-    TSConditionalTypeExtendsType = 198,
-    TSConditionalTypeTrueType = 199,
-    TSConditionalTypeFalseType = 200,
-    TSUnionTypeTypes = 201,
-    TSIntersectionTypeTypes = 202,
-    TSParenthesizedTypeTypeAnnotation = 203,
-    TSTypeOperatorTypeAnnotation = 204,
-    TSArrayTypeElementType = 205,
-    TSIndexedAccessTypeObjectType = 206,
-    TSIndexedAccessTypeIndexType = 207,
-    TSTupleTypeElementTypes = 208,
-    TSNamedTupleMemberLabel = 209,
-    TSNamedTupleMemberElementType = 210,
-    TSOptionalTypeTypeAnnotation = 211,
-    TSRestTypeTypeAnnotation = 212,
-    TSTypeReferenceTypeName = 213,
-    TSTypeReferenceTypeArguments = 214,
-    TSQualifiedNameLeft = 215,
-    TSQualifiedNameRight = 216,
-    TSTypeParameterInstantiationParams = 217,
-    TSTypeParameterName = 218,
-    TSTypeParameterConstraint = 219,
-    TSTypeParameterDefault = 220,
-    TSTypeParameterDeclarationParams = 221,
-    TSTypeAliasDeclarationId = 222,
-    TSTypeAliasDeclarationTypeParameters = 223,
-    TSTypeAliasDeclarationTypeAnnotation = 224,
-    TSClassImplementsExpression = 225,
-    TSClassImplementsTypeArguments = 226,
-    TSInterfaceDeclarationId = 227,
-    TSInterfaceDeclarationTypeParameters = 228,
-    TSInterfaceDeclarationExtends = 229,
-    TSInterfaceDeclarationBody = 230,
-    TSInterfaceBodyBody = 231,
-    TSPropertySignatureKey = 232,
-    TSPropertySignatureTypeAnnotation = 233,
-    TSIndexSignatureParameters = 234,
-    TSIndexSignatureTypeAnnotation = 235,
-    TSCallSignatureDeclarationTypeParameters = 236,
-    TSCallSignatureDeclarationThisParam = 237,
-    TSCallSignatureDeclarationParams = 238,
-    TSCallSignatureDeclarationReturnType = 239,
-    TSMethodSignatureKey = 240,
-    TSMethodSignatureTypeParameters = 241,
-    TSMethodSignatureThisParam = 242,
-    TSMethodSignatureParams = 243,
-    TSMethodSignatureReturnType = 244,
-    TSConstructSignatureDeclarationTypeParameters = 245,
-    TSConstructSignatureDeclarationParams = 246,
-    TSConstructSignatureDeclarationReturnType = 247,
-    TSIndexSignatureNameTypeAnnotation = 248,
-    TSInterfaceHeritageExpression = 249,
-    TSInterfaceHeritageTypeArguments = 250,
-    TSTypePredicateParameterName = 251,
-    TSTypePredicateTypeAnnotation = 252,
-    TSModuleDeclarationId = 253,
-    TSModuleDeclarationBody = 254,
-    TSModuleBlockDirectives = 255,
-    TSModuleBlockBody = 256,
-    TSTypeLiteralMembers = 257,
-    TSInferTypeTypeParameter = 258,
-    TSTypeQueryExprName = 259,
-    TSTypeQueryTypeArguments = 260,
-    TSImportTypeArgument = 261,
-    TSImportTypeOptions = 262,
-    TSImportTypeQualifier = 263,
-    TSImportTypeTypeArguments = 264,
-    TSFunctionTypeTypeParameters = 265,
-    TSFunctionTypeThisParam = 266,
-    TSFunctionTypeParams = 267,
-    TSFunctionTypeReturnType = 268,
-    TSConstructorTypeTypeParameters = 269,
-    TSConstructorTypeParams = 270,
-    TSConstructorTypeReturnType = 271,
-    TSMappedTypeTypeParameter = 272,
-    TSMappedTypeNameType = 273,
-    TSMappedTypeTypeAnnotation = 274,
-    TSTemplateLiteralTypeQuasis = 275,
-    TSTemplateLiteralTypeTypes = 276,
-    TSAsExpressionExpression = 277,
-    TSAsExpressionTypeAnnotation = 278,
-    TSSatisfiesExpressionExpression = 279,
-    TSSatisfiesExpressionTypeAnnotation = 280,
-    TSTypeAssertionTypeAnnotation = 281,
-    TSTypeAssertionExpression = 282,
-    TSImportEqualsDeclarationId = 283,
-    TSImportEqualsDeclarationModuleReference = 284,
-    TSExternalModuleReferenceExpression = 285,
-    TSNonNullExpressionExpression = 286,
-    DecoratorExpression = 287,
-    TSExportAssignmentExpression = 288,
-    TSNamespaceExportDeclarationId = 289,
-    TSInstantiationExpressionExpression = 290,
-    TSInstantiationExpressionTypeArguments = 291,
-    JSDocNullableTypeTypeAnnotation = 292,
-    JSDocNonNullableTypeTypeAnnotation = 293,
+    ExportDefaultDeclarationDeclaration = 161,
+    ExportAllDeclarationExported = 162,
+    ExportAllDeclarationSource = 163,
+    ExportAllDeclarationWithClause = 164,
+    ExportSpecifierLocal = 165,
+    ExportSpecifierExported = 166,
+    V8IntrinsicExpressionName = 167,
+    V8IntrinsicExpressionArguments = 168,
+    JSXElementOpeningElement = 169,
+    JSXElementChildren = 170,
+    JSXElementClosingElement = 171,
+    JSXOpeningElementName = 172,
+    JSXOpeningElementTypeArguments = 173,
+    JSXOpeningElementAttributes = 174,
+    JSXClosingElementName = 175,
+    JSXFragmentOpeningFragment = 176,
+    JSXFragmentChildren = 177,
+    JSXFragmentClosingFragment = 178,
+    JSXNamespacedNameNamespace = 179,
+    JSXNamespacedNameName = 180,
+    JSXMemberExpressionObject = 181,
+    JSXMemberExpressionProperty = 182,
+    JSXExpressionContainerExpression = 183,
+    JSXAttributeName = 184,
+    JSXAttributeValue = 185,
+    JSXSpreadAttributeArgument = 186,
+    JSXSpreadChildExpression = 187,
+    TSThisParameterTypeAnnotation = 188,
+    TSEnumDeclarationId = 189,
+    TSEnumDeclarationBody = 190,
+    TSEnumBodyMembers = 191,
+    TSEnumMemberId = 192,
+    TSEnumMemberInitializer = 193,
+    TSTypeAnnotationTypeAnnotation = 194,
+    TSLiteralTypeLiteral = 195,
+    TSConditionalTypeCheckType = 196,
+    TSConditionalTypeExtendsType = 197,
+    TSConditionalTypeTrueType = 198,
+    TSConditionalTypeFalseType = 199,
+    TSUnionTypeTypes = 200,
+    TSIntersectionTypeTypes = 201,
+    TSParenthesizedTypeTypeAnnotation = 202,
+    TSTypeOperatorTypeAnnotation = 203,
+    TSArrayTypeElementType = 204,
+    TSIndexedAccessTypeObjectType = 205,
+    TSIndexedAccessTypeIndexType = 206,
+    TSTupleTypeElementTypes = 207,
+    TSNamedTupleMemberLabel = 208,
+    TSNamedTupleMemberElementType = 209,
+    TSOptionalTypeTypeAnnotation = 210,
+    TSRestTypeTypeAnnotation = 211,
+    TSTypeReferenceTypeName = 212,
+    TSTypeReferenceTypeArguments = 213,
+    TSQualifiedNameLeft = 214,
+    TSQualifiedNameRight = 215,
+    TSTypeParameterInstantiationParams = 216,
+    TSTypeParameterName = 217,
+    TSTypeParameterConstraint = 218,
+    TSTypeParameterDefault = 219,
+    TSTypeParameterDeclarationParams = 220,
+    TSTypeAliasDeclarationId = 221,
+    TSTypeAliasDeclarationTypeParameters = 222,
+    TSTypeAliasDeclarationTypeAnnotation = 223,
+    TSClassImplementsExpression = 224,
+    TSClassImplementsTypeArguments = 225,
+    TSInterfaceDeclarationId = 226,
+    TSInterfaceDeclarationTypeParameters = 227,
+    TSInterfaceDeclarationExtends = 228,
+    TSInterfaceDeclarationBody = 229,
+    TSInterfaceBodyBody = 230,
+    TSPropertySignatureKey = 231,
+    TSPropertySignatureTypeAnnotation = 232,
+    TSIndexSignatureParameters = 233,
+    TSIndexSignatureTypeAnnotation = 234,
+    TSCallSignatureDeclarationTypeParameters = 235,
+    TSCallSignatureDeclarationThisParam = 236,
+    TSCallSignatureDeclarationParams = 237,
+    TSCallSignatureDeclarationReturnType = 238,
+    TSMethodSignatureKey = 239,
+    TSMethodSignatureTypeParameters = 240,
+    TSMethodSignatureThisParam = 241,
+    TSMethodSignatureParams = 242,
+    TSMethodSignatureReturnType = 243,
+    TSConstructSignatureDeclarationTypeParameters = 244,
+    TSConstructSignatureDeclarationParams = 245,
+    TSConstructSignatureDeclarationReturnType = 246,
+    TSIndexSignatureNameTypeAnnotation = 247,
+    TSInterfaceHeritageExpression = 248,
+    TSInterfaceHeritageTypeArguments = 249,
+    TSTypePredicateParameterName = 250,
+    TSTypePredicateTypeAnnotation = 251,
+    TSModuleDeclarationId = 252,
+    TSModuleDeclarationBody = 253,
+    TSModuleBlockDirectives = 254,
+    TSModuleBlockBody = 255,
+    TSTypeLiteralMembers = 256,
+    TSInferTypeTypeParameter = 257,
+    TSTypeQueryExprName = 258,
+    TSTypeQueryTypeArguments = 259,
+    TSImportTypeArgument = 260,
+    TSImportTypeOptions = 261,
+    TSImportTypeQualifier = 262,
+    TSImportTypeTypeArguments = 263,
+    TSFunctionTypeTypeParameters = 264,
+    TSFunctionTypeThisParam = 265,
+    TSFunctionTypeParams = 266,
+    TSFunctionTypeReturnType = 267,
+    TSConstructorTypeTypeParameters = 268,
+    TSConstructorTypeParams = 269,
+    TSConstructorTypeReturnType = 270,
+    TSMappedTypeTypeParameter = 271,
+    TSMappedTypeNameType = 272,
+    TSMappedTypeTypeAnnotation = 273,
+    TSTemplateLiteralTypeQuasis = 274,
+    TSTemplateLiteralTypeTypes = 275,
+    TSAsExpressionExpression = 276,
+    TSAsExpressionTypeAnnotation = 277,
+    TSSatisfiesExpressionExpression = 278,
+    TSSatisfiesExpressionTypeAnnotation = 279,
+    TSTypeAssertionTypeAnnotation = 280,
+    TSTypeAssertionExpression = 281,
+    TSImportEqualsDeclarationId = 282,
+    TSImportEqualsDeclarationModuleReference = 283,
+    TSExternalModuleReferenceExpression = 284,
+    TSNonNullExpressionExpression = 285,
+    DecoratorExpression = 286,
+    TSExportAssignmentExpression = 287,
+    TSNamespaceExportDeclarationId = 288,
+    TSInstantiationExpressionExpression = 289,
+    TSInstantiationExpressionTypeArguments = 290,
+    JSDocNullableTypeTypeAnnotation = 291,
+    JSDocNonNullableTypeTypeAnnotation = 292,
 }
 
 /// Ancestor type used in AST traversal.
@@ -622,8 +621,6 @@ pub enum Ancestor<'a, 't> {
         AncestorType::ExportNamedDeclarationSource as u16,
     ExportNamedDeclarationWithClause(ExportNamedDeclarationWithoutWithClause<'a, 't>) =
         AncestorType::ExportNamedDeclarationWithClause as u16,
-    ExportDefaultDeclarationExported(ExportDefaultDeclarationWithoutExported<'a, 't>) =
-        AncestorType::ExportDefaultDeclarationExported as u16,
     ExportDefaultDeclarationDeclaration(ExportDefaultDeclarationWithoutDeclaration<'a, 't>) =
         AncestorType::ExportDefaultDeclarationDeclaration as u16,
     ExportAllDeclarationExported(ExportAllDeclarationWithoutExported<'a, 't>) =
@@ -1397,11 +1394,7 @@ impl<'a, 't> Ancestor<'a, 't> {
 
     #[inline]
     pub fn is_export_default_declaration(self) -> bool {
-        matches!(
-            self,
-            Self::ExportDefaultDeclarationExported(_)
-                | Self::ExportDefaultDeclarationDeclaration(_)
-        )
+        matches!(self, Self::ExportDefaultDeclarationDeclaration(_))
     }
 
     #[inline]
@@ -2042,7 +2035,6 @@ impl<'a, 't> Ancestor<'a, 't> {
         matches!(
             self,
             Self::ImportSpecifierImported(_)
-                | Self::ExportDefaultDeclarationExported(_)
                 | Self::ExportAllDeclarationExported(_)
                 | Self::ExportSpecifierLocal(_)
                 | Self::ExportSpecifierExported(_)
@@ -2357,7 +2349,6 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::ExportNamedDeclarationSpecifiers(a) => a.address(),
             Self::ExportNamedDeclarationSource(a) => a.address(),
             Self::ExportNamedDeclarationWithClause(a) => a.address(),
-            Self::ExportDefaultDeclarationExported(a) => a.address(),
             Self::ExportDefaultDeclarationDeclaration(a) => a.address(),
             Self::ExportAllDeclarationExported(a) => a.address(),
             Self::ExportAllDeclarationSource(a) => a.address(),
@@ -10103,41 +10094,10 @@ impl<'a, 't> GetAddress for ExportNamedDeclarationWithoutWithClause<'a, 't> {
 
 pub(crate) const OFFSET_EXPORT_DEFAULT_DECLARATION_SPAN: usize =
     offset_of!(ExportDefaultDeclaration, span);
-pub(crate) const OFFSET_EXPORT_DEFAULT_DECLARATION_EXPORTED: usize =
-    offset_of!(ExportDefaultDeclaration, exported);
+pub(crate) const OFFSET_EXPORT_DEFAULT_DECLARATION_DEFAULT_SPAN: usize =
+    offset_of!(ExportDefaultDeclaration, default_span);
 pub(crate) const OFFSET_EXPORT_DEFAULT_DECLARATION_DECLARATION: usize =
     offset_of!(ExportDefaultDeclaration, declaration);
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct ExportDefaultDeclarationWithoutExported<'a, 't>(
-    pub(crate) *const ExportDefaultDeclaration<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> ExportDefaultDeclarationWithoutExported<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_EXPORT_DEFAULT_DECLARATION_SPAN) as *const Span)
-        }
-    }
-
-    #[inline]
-    pub fn declaration(self) -> &'t ExportDefaultDeclarationKind<'a> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_EXPORT_DEFAULT_DECLARATION_DECLARATION)
-                as *const ExportDefaultDeclarationKind<'a>)
-        }
-    }
-}
-
-impl<'a, 't> GetAddress for ExportDefaultDeclarationWithoutExported<'a, 't> {
-    #[inline]
-    fn address(&self) -> Address {
-        Address::from_ptr(self.0)
-    }
-}
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -10155,10 +10115,10 @@ impl<'a, 't> ExportDefaultDeclarationWithoutDeclaration<'a, 't> {
     }
 
     #[inline]
-    pub fn exported(self) -> &'t ModuleExportName<'a> {
+    pub fn default_span(self) -> &'t Span {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_EXPORT_DEFAULT_DECLARATION_EXPORTED)
-                as *const ModuleExportName<'a>)
+            &*((self.0 as *const u8).add(OFFSET_EXPORT_DEFAULT_DECLARATION_DEFAULT_SPAN)
+                as *const Span)
         }
     }
 }

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -2987,16 +2987,9 @@ unsafe fn walk_export_default_declaration<'a, State, Tr: Traverse<'a, State>>(
     ctx: &mut TraverseCtx<'a, State>,
 ) {
     traverser.enter_export_default_declaration(&mut *node, ctx);
-    let pop_token = ctx.push_stack(Ancestor::ExportDefaultDeclarationExported(
-        ancestor::ExportDefaultDeclarationWithoutExported(node, PhantomData),
+    let pop_token = ctx.push_stack(Ancestor::ExportDefaultDeclarationDeclaration(
+        ancestor::ExportDefaultDeclarationWithoutDeclaration(node, PhantomData),
     ));
-    walk_module_export_name(
-        traverser,
-        (node as *mut u8).add(ancestor::OFFSET_EXPORT_DEFAULT_DECLARATION_EXPORTED)
-            as *mut ModuleExportName,
-        ctx,
-    );
-    ctx.retag_stack(AncestorType::ExportDefaultDeclarationDeclaration);
     walk_export_default_declaration_kind(
         traverser,
         (node as *mut u8).add(ancestor::OFFSET_EXPORT_DEFAULT_DECLARATION_DECLARATION)

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -987,7 +987,7 @@ function deserializeExportNamedDeclaration(pos) {
 function deserializeExportDefaultDeclaration(pos) {
   return {
     type: 'ExportDefaultDeclaration',
-    declaration: deserializeExportDefaultDeclarationKind(pos + 64),
+    declaration: deserializeExportDefaultDeclarationKind(pos + 16),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -1116,7 +1116,7 @@ function deserializeExportNamedDeclaration(pos) {
 function deserializeExportDefaultDeclaration(pos) {
   return {
     type: 'ExportDefaultDeclaration',
-    declaration: deserializeExportDefaultDeclarationKind(pos + 64),
+    declaration: deserializeExportDefaultDeclarationKind(pos + 16),
     exportKind: 'value',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),

--- a/napi/parser/generated/lazy/constructors.js
+++ b/napi/parser/generated/lazy/constructors.js
@@ -5965,7 +5965,7 @@ class ExportDefaultDeclaration {
 
   get declaration() {
     const internal = this.#internal;
-    return constructExportDefaultDeclarationKind(internal.pos + 64, internal.ast);
+    return constructExportDefaultDeclarationKind(internal.pos + 16, internal.ast);
   }
 
   toJSON() {

--- a/napi/parser/generated/lazy/walk.js
+++ b/napi/parser/generated/lazy/walk.js
@@ -2437,7 +2437,7 @@ function walkExportDefaultDeclaration(pos, ast, visitors) {
     if (enter !== null) enter(node);
   }
 
-  walkExportDefaultDeclarationKind(pos + 64, ast, visitors);
+  walkExportDefaultDeclarationKind(pos + 16, ast, visitors);
 
   if (exit !== null) exit(node);
 }


### PR DESCRIPTION
We currently store the `default` keyword for `ExportDefaultDeclaration` as a `ModuleExportName`. This is overkill because the name is always, by definition, `default`.

Replace this field with `default_span: Span` which is enough to provides the only useful information.

This reduces size of `ExportDefaultDeclaration` from 80 bytes to 32. That has very limited impact, because each file can only have 1 `export default` statement. But still... less is more!

Ideally we'd get rid of this field entirely. Span of `default` keyword doesn't appear in ESTree AST, is not used in linter, and is ignored in codegen.

Only reason this span is present in AST is: parser records it temporarily in AST, so that `ModuleRecordBuilder` can pull it out again later to add it to module record. There is probably a way to achieve the same thing without using AST as a temporary storage location.

UPDATE: I found a way to remove the field entirely: #12808.