### PR TITLE
feat(linter/jsx-a11y): add support for mapped attributes in label association checks

### DIFF
--- a/apps/oxlint/src/snapshots/_-A all --print-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-A all --print-config@oxlint.snap
@@ -16,7 +16,8 @@ working directory:
   "settings": {
     "jsx-a11y": {
       "polymorphicPropName": null,
-      "components": {}
+      "components": {},
+      "attributes": {}
     },
     "next": {
       "rootDir": []

--- a/apps/oxlint/src/snapshots/_-c fixtures__print_config__ban_rules__eslintrc.json -A all -D eqeqeq --print-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__print_config__ban_rules__eslintrc.json -A all -D eqeqeq --print-config@oxlint.snap
@@ -23,7 +23,8 @@ working directory:
   "settings": {
     "jsx-a11y": {
       "polymorphicPropName": null,
-      "components": {}
+      "components": {},
+      "attributes": {}
     },
     "next": {
       "rootDir": []

--- a/crates/oxc_linter/src/config/settings/jsx_a11y.rs
+++ b/crates/oxc_linter/src/config/settings/jsx_a11y.rs
@@ -45,4 +45,23 @@ pub struct JSXA11yPluginSettings {
     /// ```
     #[serde(default)]
     pub components: FxHashMap<CompactStr, CompactStr>,
+
+    /// Map of attribute names to their DOM equivalents.
+    /// This is useful for non-React frameworks that use different attribute names.
+    ///
+    /// Example:
+    ///
+    /// ```json
+    /// {
+    ///   "settings": {
+    ///     "jsx-a11y": {
+    ///       "attributes": {
+    ///         "for": ["htmlFor", "for"]
+    ///       }
+    ///     }
+    ///   }
+    /// }
+    /// ```
+    #[serde(default)]
+    pub attributes: FxHashMap<CompactStr, Vec<CompactStr>>,
 }

--- a/crates/oxc_linter/src/config/settings/mod.rs
+++ b/crates/oxc_linter/src/config/settings/mod.rs
@@ -125,5 +125,42 @@ mod test {
         let settings = OxlintSettings::default();
         assert!(settings.jsx_a11y.polymorphic_prop_name.is_none());
         assert!(settings.jsx_a11y.components.is_empty());
+        assert!(settings.jsx_a11y.attributes.is_empty());
+    }
+
+    #[test]
+    fn test_parse_jsx_a11y_attributes() {
+        let settings = OxlintSettings::deserialize(&serde_json::json!({
+            "jsx-a11y": {
+                "attributes": {
+                    "for": ["htmlFor", "for"],
+                    "class": ["className"]
+                }
+            }
+        }))
+        .unwrap();
+
+        let for_attrs = &settings.jsx_a11y.attributes["for"];
+        assert_eq!(for_attrs.len(), 2);
+        assert_eq!(for_attrs[0], "htmlFor");
+        assert_eq!(for_attrs[1], "for");
+
+        let class_attrs = &settings.jsx_a11y.attributes["class"];
+        assert_eq!(class_attrs.len(), 1);
+        assert_eq!(class_attrs[0], "className");
+
+        assert_eq!(settings.jsx_a11y.attributes.get("nonexistent"), None);
+    }
+
+    #[test]
+    fn test_parse_jsx_a11y_attributes_empty() {
+        let settings = OxlintSettings::deserialize(&serde_json::json!({
+            "jsx-a11y": {
+                "attributes": {}
+            }
+        }))
+        .unwrap();
+
+        assert!(settings.jsx_a11y.attributes.is_empty());
     }
 }

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_label_has_associated_control.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_label_has_associated_control.snap
@@ -622,3 +622,17 @@ source: crates/oxc_linter/src/tester.rs
    · ───────────────────────────────────────────────────────
    ╰────
   help: Ensure the label either has text inside it or is accessibly labelled using an attribute such as `aria-label`, or `aria-labelledby`. You can mark more attributes as accessible labels by configuring the `labelAttributes` option.
+
+  ⚠ eslint-plugin-jsx-a11y(label-has-associated-control): A form label must be associated with a control.
+   ╭─[label_has_associated_control.tsx:1:1]
+ 1 │ <label for="js_id">A label</label>
+   · ───────────────────
+   ╰────
+  help: Either give the label a `htmlFor` attribute with the id of the associated control, or wrap the label around the control.
+
+  ⚠ eslint-plugin-jsx-a11y(label-has-associated-control): A form label must be associated with a control.
+   ╭─[label_has_associated_control.tsx:1:1]
+ 1 │ <label for="js_id" aria-label="A label" />
+   · ──────────────────────────────────────────
+   ╰────
+  help: Either give the label a `htmlFor` attribute with the id of the associated control, or wrap the label around the control.

--- a/crates/oxc_linter/src/snapshots/schema_json.snap
+++ b/crates/oxc_linter/src/snapshots/schema_json.snap
@@ -83,7 +83,8 @@ expression: json
       "default": {
         "jsx-a11y": {
           "polymorphicPropName": null,
-          "components": {}
+          "components": {},
+          "attributes": {}
         },
         "next": {
           "rootDir": []
@@ -256,6 +257,17 @@ expression: json
       "description": "Configure JSX A11y plugin rules.\n\nSee\n[eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y#configurations)'s\nconfiguration for a full reference.",
       "type": "object",
       "properties": {
+        "attributes": {
+          "description": "Map of attribute names to their DOM equivalents.\nThis is useful for non-React frameworks that use different attribute names.\n\nExample:\n\n```json\n{\n\"settings\": {\n\"jsx-a11y\": {\n\"attributes\": {\n\"for\": [\"htmlFor\", \"for\"]\n}\n}\n}\n}\n```",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
         "components": {
           "description": "To have your custom components be checked as DOM elements, you can\nprovide a mapping of your component names to the DOM element name.\n\nExample:\n\n```json\n{\n\"settings\": {\n\"jsx-a11y\": {\n\"components\": {\n\"Link\": \"a\",\n\"IconButton\": \"button\"\n}\n}\n}\n}\n```",
           "default": {},
@@ -474,7 +486,8 @@ expression: json
         "jsx-a11y": {
           "default": {
             "polymorphicPropName": null,
-            "components": {}
+            "components": {},
+            "attributes": {}
           },
           "allOf": [
             {

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -79,7 +79,8 @@
       "default": {
         "jsx-a11y": {
           "polymorphicPropName": null,
-          "components": {}
+          "components": {},
+          "attributes": {}
         },
         "next": {
           "rootDir": []
@@ -252,6 +253,17 @@
       "description": "Configure JSX A11y plugin rules.\n\nSee\n[eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y#configurations)'s\nconfiguration for a full reference.",
       "type": "object",
       "properties": {
+        "attributes": {
+          "description": "Map of attribute names to their DOM equivalents.\nThis is useful for non-React frameworks that use different attribute names.\n\nExample:\n\n```json\n{\n\"settings\": {\n\"jsx-a11y\": {\n\"attributes\": {\n\"for\": [\"htmlFor\", \"for\"]\n}\n}\n}\n}\n```",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
         "components": {
           "description": "To have your custom components be checked as DOM elements, you can\nprovide a mapping of your component names to the DOM element name.\n\nExample:\n\n```json\n{\n\"settings\": {\n\"jsx-a11y\": {\n\"components\": {\n\"Link\": \"a\",\n\"IconButton\": \"button\"\n}\n}\n}\n}\n```",
           "default": {},
@@ -470,7 +482,8 @@
         "jsx-a11y": {
           "default": {
             "polymorphicPropName": null,
-            "components": {}
+            "components": {},
+            "attributes": {}
           },
           "allOf": [
             {

--- a/tasks/website/src/linter/snapshots/schema_markdown.snap
+++ b/tasks/website/src/linter/snapshots/schema_markdown.snap
@@ -359,6 +359,30 @@ See
 configuration for a full reference.
 
 
+#### settings.jsx-a11y.attributes
+
+type: `Record<string, array>`
+
+default: `{}`
+
+Map of attribute names to their DOM equivalents.
+This is useful for non-React frameworks that use different attribute names.
+
+Example:
+
+```json
+{
+"settings": {
+"jsx-a11y": {
+"attributes": {
+"for": ["htmlFor", "for"]
+}
+}
+}
+}
+```
+
+
 #### settings.jsx-a11y.components
 
 type: `Record<string, string>`


### PR DESCRIPTION
fixes #12507