### PR TITLE
refactor(parser): add `StatementContext::TopLevelStatementList`

### DIFF
--- a/crates/oxc_parser/src/context.rs
+++ b/crates/oxc_parser/src/context.rs
@@ -150,17 +150,18 @@ impl Context {
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum StatementContext {
+    StatementList,
+    TopLevelStatementList,
     If,
     Label,
     Do,
     While,
     With,
     For,
-    StatementList,
 }
 
 impl StatementContext {
     pub(crate) fn is_single_statement(self) -> bool {
-        self != Self::StatementList
+        !matches!(self, Self::StatementList | Self::TopLevelStatementList)
     }
 }

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -36,12 +36,18 @@ impl<'a> ParserImpl<'a> {
         let mut directives = self.ast.vec();
         let mut statements = self.ast.vec();
 
+        let stmt_ctx = if is_top_level {
+            StatementContext::TopLevelStatementList
+        } else {
+            StatementContext::StatementList
+        };
+
         let mut expecting_directives = true;
         while !self.has_fatal_error() {
             if !is_top_level && self.at(Kind::RCurly) {
                 break;
             }
-            let stmt = self.parse_statement_list_item(StatementContext::StatementList);
+            let stmt = self.parse_statement_list_item(stmt_ctx);
 
             if is_top_level {
                 if let Some(module_decl) = stmt.as_module_declaration() {


### PR DESCRIPTION
Pure refactor. Allow parser functions to determine whether in top level context or not, by adding `TopLevelStatementList` variant to `StatementContext`.

Also, re-order the variants to make `StatementContext::is_single_statement` as cheap as possible - with `StatementList` and `TopLevelStatementList` as first 2 variants, `is_single_statement` boils down to `self as u8 < 2`.

This new variant is used in the next PR in this stack.