### PR TITLE
refactor(ast)!: remove `ExportDefaultDeclaration` `exported` field

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -2607,8 +2607,6 @@ pub struct ExportNamedDeclaration<'a> {
 #[estree(add_fields(exportKind = TsValue))]
 pub struct ExportDefaultDeclaration<'a> {
     pub span: Span,
-    #[estree(skip)]
-    pub exported: ModuleExportName<'a>, // the `default` Keyword
     pub declaration: ExportDefaultDeclarationKind<'a>,
 }
 

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -818,11 +818,10 @@ const _: () = {
     assert!(offset_of!(ExportNamedDeclaration, with_clause) == 96);
 
     // Padding: 0 bytes
-    assert!(size_of::<ExportDefaultDeclaration>() == 80);
+    assert!(size_of::<ExportDefaultDeclaration>() == 24);
     assert!(align_of::<ExportDefaultDeclaration>() == 8);
     assert!(offset_of!(ExportDefaultDeclaration, span) == 0);
-    assert!(offset_of!(ExportDefaultDeclaration, exported) == 8);
-    assert!(offset_of!(ExportDefaultDeclaration, declaration) == 64);
+    assert!(offset_of!(ExportDefaultDeclaration, declaration) == 8);
 
     // Padding: 7 bytes
     assert!(size_of::<ExportAllDeclaration>() == 128);
@@ -2423,11 +2422,10 @@ const _: () = {
     assert!(offset_of!(ExportNamedDeclaration, with_clause) == 60);
 
     // Padding: 0 bytes
-    assert!(size_of::<ExportDefaultDeclaration>() == 48);
+    assert!(size_of::<ExportDefaultDeclaration>() == 16);
     assert!(align_of::<ExportDefaultDeclaration>() == 4);
     assert!(offset_of!(ExportDefaultDeclaration, span) == 0);
-    assert!(offset_of!(ExportDefaultDeclaration, exported) == 8);
-    assert!(offset_of!(ExportDefaultDeclaration, declaration) == 40);
+    assert!(offset_of!(ExportDefaultDeclaration, declaration) == 8);
 
     // Padding: 3 bytes
     assert!(size_of::<ExportAllDeclaration>() == 76);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -7181,20 +7181,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `exported`
     /// * `declaration`
     #[inline]
     pub fn module_declaration_export_default_declaration(
         self,
         span: Span,
-        exported: ModuleExportName<'a>,
         declaration: ExportDefaultDeclarationKind<'a>,
     ) -> ModuleDeclaration<'a> {
-        ModuleDeclaration::ExportDefaultDeclaration(self.alloc_export_default_declaration(
-            span,
-            exported,
-            declaration,
-        ))
+        ModuleDeclaration::ExportDefaultDeclaration(
+            self.alloc_export_default_declaration(span, declaration),
+        )
     }
 
     /// Build a [`ModuleDeclaration::ExportNamedDeclaration`].
@@ -7839,16 +7835,14 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `exported`
     /// * `declaration`
     #[inline]
     pub fn export_default_declaration(
         self,
         span: Span,
-        exported: ModuleExportName<'a>,
         declaration: ExportDefaultDeclarationKind<'a>,
     ) -> ExportDefaultDeclaration<'a> {
-        ExportDefaultDeclaration { span, exported, declaration }
+        ExportDefaultDeclaration { span, declaration }
     }
 
     /// Build an [`ExportDefaultDeclaration`], and store it in the memory arena.
@@ -7858,16 +7852,14 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `exported`
     /// * `declaration`
     #[inline]
     pub fn alloc_export_default_declaration(
         self,
         span: Span,
-        exported: ModuleExportName<'a>,
         declaration: ExportDefaultDeclarationKind<'a>,
     ) -> Box<'a, ExportDefaultDeclaration<'a>> {
-        Box::new_in(self.export_default_declaration(span, exported, declaration), self.allocator)
+        Box::new_in(self.export_default_declaration(span, declaration), self.allocator)
     }
 
     /// Build an [`ExportAllDeclaration`].

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -4362,7 +4362,6 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExportDefaultDeclaration<'_> {
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExportDefaultDeclaration {
             span: CloneIn::clone_in(&self.span, allocator),
-            exported: CloneIn::clone_in(&self.exported, allocator),
             declaration: CloneIn::clone_in(&self.declaration, allocator),
         }
     }
@@ -4370,7 +4369,6 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExportDefaultDeclaration<'_> {
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExportDefaultDeclaration {
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            exported: CloneIn::clone_in_with_semantic_ids(&self.exported, allocator),
             declaration: CloneIn::clone_in_with_semantic_ids(&self.declaration, allocator),
         }
     }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -1360,8 +1360,7 @@ impl ContentEq for ExportNamedDeclaration<'_> {
 
 impl ContentEq for ExportDefaultDeclaration<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.exported, &other.exported)
-            && ContentEq::content_eq(&self.declaration, &other.declaration)
+        ContentEq::content_eq(&self.declaration, &other.declaration)
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_dummy.rs
+++ b/crates/oxc_ast/src/generated/derive_dummy.rs
@@ -1493,11 +1493,7 @@ impl<'a> Dummy<'a> for ExportDefaultDeclaration<'a> {
     ///
     /// Has cost of making 1 allocation (8 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self {
-            span: Dummy::dummy(allocator),
-            exported: Dummy::dummy(allocator),
-            declaration: Dummy::dummy(allocator),
-        }
+        Self { span: Dummy::dummy(allocator), declaration: Dummy::dummy(allocator) }
     }
 }
 

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -2811,7 +2811,6 @@ pub mod walk {
         let kind = AstKind::ExportDefaultDeclaration(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        visitor.visit_module_export_name(&it.exported);
         visitor.visit_export_default_declaration_kind(&it.declaration);
         visitor.leave_node(kind);
     }

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -2921,7 +2921,6 @@ pub mod walk_mut {
         let kind = AstType::ExportDefaultDeclaration;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        visitor.visit_module_export_name(&mut it.exported);
         visitor.visit_export_default_declaration_kind(&mut it.declaration);
         visitor.leave_node(kind);
     }

--- a/crates/oxc_formatter/src/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/generated/ast_nodes.rs
@@ -8972,17 +8972,6 @@ impl<'a> GetSpan for AstNode<'a, ExportNamedDeclaration<'a>> {
 
 impl<'a> AstNode<'a, ExportDefaultDeclaration<'a>> {
     #[inline]
-    pub fn exported(&self) -> &AstNode<'a, ModuleExportName<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.declaration));
-        self.allocator.alloc(AstNode {
-            inner: &self.inner.exported,
-            allocator: self.allocator,
-            parent: self.allocator.alloc(AstNodes::ExportDefaultDeclaration(transmute_self(self))),
-            following_node,
-        })
-    }
-
-    #[inline]
     pub fn declaration(&self) -> &AstNode<'a, ExportDefaultDeclarationKind<'a>> {
         let following_node = self.following_node;
         self.allocator.alloc(AstNode {

--- a/crates/oxc_isolated_declarations/src/module.rs
+++ b/crates/oxc_isolated_declarations/src/module.rs
@@ -57,8 +57,6 @@ impl<'a> IsolatedDeclarations<'a> {
         };
 
         declaration.map(|(var_decl, declaration)| {
-            let exported =
-                ModuleExportName::IdentifierName(self.ast.identifier_name(SPAN, "default"));
             // When `var_decl` is Some, the comments are moved to the variable declaration, otherwise
             // keep the comments on the export default declaration to avoid losing them.
             // ```ts
@@ -82,7 +80,7 @@ impl<'a> IsolatedDeclarations<'a> {
 
             let span = if var_decl.is_some() { SPAN } else { decl.span };
             let declaration =
-                self.ast.module_declaration_export_default_declaration(span, exported, declaration);
+                self.ast.module_declaration_export_default_declaration(span, declaration);
             (var_decl, Statement::from(declaration))
         })
     }

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -585,14 +585,14 @@ impl<'a> ParserImpl<'a> {
         decorators: Vec<'a, Decorator<'a>>,
         stmt_ctx: StatementContext,
     ) -> Box<'a, ExportDefaultDeclaration<'a>> {
-        let exported = self.parse_keyword_identifier(Kind::Default);
+        let default_keyword_span = self.cur_token().span();
+        self.bump_remap(Kind::Default);
         let declaration = self.parse_export_default_declaration_kind(decorators);
-        let exported = ModuleExportName::IdentifierName(exported);
         let span = self.end_span(span);
-        let export_default_decl =
-            self.ast.alloc_export_default_declaration(span, exported, declaration);
+        let export_default_decl = self.ast.alloc_export_default_declaration(span, declaration);
         if stmt_ctx.is_top_level() {
-            self.module_record_builder.visit_export_default_declaration(&export_default_decl);
+            self.module_record_builder
+                .visit_export_default_declaration(&export_default_decl, default_keyword_span);
         }
         export_default_decl
     }

--- a/crates/oxc_parser/src/module_record.rs
+++ b/crates/oxc_parser/src/module_record.rs
@@ -265,9 +265,11 @@ impl<'a> ModuleRecordBuilder<'a> {
         self.module_record.has_module_syntax = true;
     }
 
-    pub fn visit_export_default_declaration(&mut self, decl: &ExportDefaultDeclaration<'a>) {
-        let exported_name = &decl.exported;
-
+    pub fn visit_export_default_declaration(
+        &mut self,
+        decl: &ExportDefaultDeclaration<'a>,
+        default_keyword_span: Span,
+    ) {
         let local_name = match &decl.declaration {
             ExportDefaultDeclarationKind::Identifier(ident) => {
                 ExportLocalName::Default(NameSpan::new(ident.name, ident.span))
@@ -292,7 +294,7 @@ impl<'a> ModuleRecordBuilder<'a> {
             span: decl.declaration.span(),
             module_request: None,
             import_name: ExportImportName::default(),
-            export_name: ExportExportName::Default(exported_name.span()),
+            export_name: ExportExportName::Default(default_keyword_span),
             local_name,
             is_type: decl.is_typescript_syntax(),
         };

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/exports/default/type-alias.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/exports/default/type-alias.snap
@@ -27,7 +27,7 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/exports/default/type-alias
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
-            "node_id": 6
+            "node_id": 5
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-type.snap
@@ -27,7 +27,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "T",
-            "node_id": 11
+            "node_id": 10
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2.snap
@@ -19,7 +19,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 7
+            "node_id": 6
           }
         ]
       }

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -1032,7 +1032,6 @@ impl<'a> LegacyDecorator<'a, '_> {
     ) -> Statement<'a> {
         let export_default_class_reference = ctx.ast.module_declaration_export_default_declaration(
             SPAN,
-            ctx.ast.module_export_name_identifier_name(SPAN, "default"),
             ExportDefaultDeclarationKind::Identifier(
                 ctx.ast.alloc(class_binding.create_read_reference(ctx)),
             ),

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -550,7 +550,7 @@ impl<'a> ModuleRunnerTransform<'a> {
         export: ArenaBox<'a, ExportDefaultDeclaration<'a>>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        let ExportDefaultDeclaration { span, declaration, .. } = export.unbox();
+        let ExportDefaultDeclaration { span, declaration } = export.unbox();
         let expr = match declaration {
             ExportDefaultDeclarationKind::FunctionDeclaration(mut func) => {
                 if let Some(id) = &func.id {

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -183,141 +183,140 @@ pub(crate) enum AncestorType {
     ExportNamedDeclarationSpecifiers = 158,
     ExportNamedDeclarationSource = 159,
     ExportNamedDeclarationWithClause = 160,
-    ExportDefaultDeclarationExported = 161,
-    ExportDefaultDeclarationDeclaration = 162,
-    ExportAllDeclarationExported = 163,
-    ExportAllDeclarationSource = 164,
-    ExportAllDeclarationWithClause = 165,
-    ExportSpecifierLocal = 166,
-    ExportSpecifierExported = 167,
-    V8IntrinsicExpressionName = 168,
-    V8IntrinsicExpressionArguments = 169,
-    JSXElementOpeningElement = 170,
-    JSXElementChildren = 171,
-    JSXElementClosingElement = 172,
-    JSXOpeningElementName = 173,
-    JSXOpeningElementTypeArguments = 174,
-    JSXOpeningElementAttributes = 175,
-    JSXClosingElementName = 176,
-    JSXFragmentOpeningFragment = 177,
-    JSXFragmentChildren = 178,
-    JSXFragmentClosingFragment = 179,
-    JSXNamespacedNameNamespace = 180,
-    JSXNamespacedNameName = 181,
-    JSXMemberExpressionObject = 182,
-    JSXMemberExpressionProperty = 183,
-    JSXExpressionContainerExpression = 184,
-    JSXAttributeName = 185,
-    JSXAttributeValue = 186,
-    JSXSpreadAttributeArgument = 187,
-    JSXSpreadChildExpression = 188,
-    TSThisParameterTypeAnnotation = 189,
-    TSEnumDeclarationId = 190,
-    TSEnumDeclarationBody = 191,
-    TSEnumBodyMembers = 192,
-    TSEnumMemberId = 193,
-    TSEnumMemberInitializer = 194,
-    TSTypeAnnotationTypeAnnotation = 195,
-    TSLiteralTypeLiteral = 196,
-    TSConditionalTypeCheckType = 197,
-    TSConditionalTypeExtendsType = 198,
-    TSConditionalTypeTrueType = 199,
-    TSConditionalTypeFalseType = 200,
-    TSUnionTypeTypes = 201,
-    TSIntersectionTypeTypes = 202,
-    TSParenthesizedTypeTypeAnnotation = 203,
-    TSTypeOperatorTypeAnnotation = 204,
-    TSArrayTypeElementType = 205,
-    TSIndexedAccessTypeObjectType = 206,
-    TSIndexedAccessTypeIndexType = 207,
-    TSTupleTypeElementTypes = 208,
-    TSNamedTupleMemberLabel = 209,
-    TSNamedTupleMemberElementType = 210,
-    TSOptionalTypeTypeAnnotation = 211,
-    TSRestTypeTypeAnnotation = 212,
-    TSTypeReferenceTypeName = 213,
-    TSTypeReferenceTypeArguments = 214,
-    TSQualifiedNameLeft = 215,
-    TSQualifiedNameRight = 216,
-    TSTypeParameterInstantiationParams = 217,
-    TSTypeParameterName = 218,
-    TSTypeParameterConstraint = 219,
-    TSTypeParameterDefault = 220,
-    TSTypeParameterDeclarationParams = 221,
-    TSTypeAliasDeclarationId = 222,
-    TSTypeAliasDeclarationTypeParameters = 223,
-    TSTypeAliasDeclarationTypeAnnotation = 224,
-    TSClassImplementsExpression = 225,
-    TSClassImplementsTypeArguments = 226,
-    TSInterfaceDeclarationId = 227,
-    TSInterfaceDeclarationTypeParameters = 228,
-    TSInterfaceDeclarationExtends = 229,
-    TSInterfaceDeclarationBody = 230,
-    TSInterfaceBodyBody = 231,
-    TSPropertySignatureKey = 232,
-    TSPropertySignatureTypeAnnotation = 233,
-    TSIndexSignatureParameters = 234,
-    TSIndexSignatureTypeAnnotation = 235,
-    TSCallSignatureDeclarationTypeParameters = 236,
-    TSCallSignatureDeclarationThisParam = 237,
-    TSCallSignatureDeclarationParams = 238,
-    TSCallSignatureDeclarationReturnType = 239,
-    TSMethodSignatureKey = 240,
-    TSMethodSignatureTypeParameters = 241,
-    TSMethodSignatureThisParam = 242,
-    TSMethodSignatureParams = 243,
-    TSMethodSignatureReturnType = 244,
-    TSConstructSignatureDeclarationTypeParameters = 245,
-    TSConstructSignatureDeclarationParams = 246,
-    TSConstructSignatureDeclarationReturnType = 247,
-    TSIndexSignatureNameTypeAnnotation = 248,
-    TSInterfaceHeritageExpression = 249,
-    TSInterfaceHeritageTypeArguments = 250,
-    TSTypePredicateParameterName = 251,
-    TSTypePredicateTypeAnnotation = 252,
-    TSModuleDeclarationId = 253,
-    TSModuleDeclarationBody = 254,
-    TSModuleBlockDirectives = 255,
-    TSModuleBlockBody = 256,
-    TSTypeLiteralMembers = 257,
-    TSInferTypeTypeParameter = 258,
-    TSTypeQueryExprName = 259,
-    TSTypeQueryTypeArguments = 260,
-    TSImportTypeArgument = 261,
-    TSImportTypeOptions = 262,
-    TSImportTypeQualifier = 263,
-    TSImportTypeTypeArguments = 264,
-    TSImportTypeQualifiedNameLeft = 265,
-    TSImportTypeQualifiedNameRight = 266,
-    TSFunctionTypeTypeParameters = 267,
-    TSFunctionTypeThisParam = 268,
-    TSFunctionTypeParams = 269,
-    TSFunctionTypeReturnType = 270,
-    TSConstructorTypeTypeParameters = 271,
-    TSConstructorTypeParams = 272,
-    TSConstructorTypeReturnType = 273,
-    TSMappedTypeTypeParameter = 274,
-    TSMappedTypeNameType = 275,
-    TSMappedTypeTypeAnnotation = 276,
-    TSTemplateLiteralTypeQuasis = 277,
-    TSTemplateLiteralTypeTypes = 278,
-    TSAsExpressionExpression = 279,
-    TSAsExpressionTypeAnnotation = 280,
-    TSSatisfiesExpressionExpression = 281,
-    TSSatisfiesExpressionTypeAnnotation = 282,
-    TSTypeAssertionTypeAnnotation = 283,
-    TSTypeAssertionExpression = 284,
-    TSImportEqualsDeclarationId = 285,
-    TSImportEqualsDeclarationModuleReference = 286,
-    TSExternalModuleReferenceExpression = 287,
-    TSNonNullExpressionExpression = 288,
-    DecoratorExpression = 289,
-    TSExportAssignmentExpression = 290,
-    TSNamespaceExportDeclarationId = 291,
-    TSInstantiationExpressionExpression = 292,
-    TSInstantiationExpressionTypeArguments = 293,
-    JSDocNullableTypeTypeAnnotation = 294,
-    JSDocNonNullableTypeTypeAnnotation = 295,
+    ExportDefaultDeclarationDeclaration = 161,
+    ExportAllDeclarationExported = 162,
+    ExportAllDeclarationSource = 163,
+    ExportAllDeclarationWithClause = 164,
+    ExportSpecifierLocal = 165,
+    ExportSpecifierExported = 166,
+    V8IntrinsicExpressionName = 167,
+    V8IntrinsicExpressionArguments = 168,
+    JSXElementOpeningElement = 169,
+    JSXElementChildren = 170,
+    JSXElementClosingElement = 171,
+    JSXOpeningElementName = 172,
+    JSXOpeningElementTypeArguments = 173,
+    JSXOpeningElementAttributes = 174,
+    JSXClosingElementName = 175,
+    JSXFragmentOpeningFragment = 176,
+    JSXFragmentChildren = 177,
+    JSXFragmentClosingFragment = 178,
+    JSXNamespacedNameNamespace = 179,
+    JSXNamespacedNameName = 180,
+    JSXMemberExpressionObject = 181,
+    JSXMemberExpressionProperty = 182,
+    JSXExpressionContainerExpression = 183,
+    JSXAttributeName = 184,
+    JSXAttributeValue = 185,
+    JSXSpreadAttributeArgument = 186,
+    JSXSpreadChildExpression = 187,
+    TSThisParameterTypeAnnotation = 188,
+    TSEnumDeclarationId = 189,
+    TSEnumDeclarationBody = 190,
+    TSEnumBodyMembers = 191,
+    TSEnumMemberId = 192,
+    TSEnumMemberInitializer = 193,
+    TSTypeAnnotationTypeAnnotation = 194,
+    TSLiteralTypeLiteral = 195,
+    TSConditionalTypeCheckType = 196,
+    TSConditionalTypeExtendsType = 197,
+    TSConditionalTypeTrueType = 198,
+    TSConditionalTypeFalseType = 199,
+    TSUnionTypeTypes = 200,
+    TSIntersectionTypeTypes = 201,
+    TSParenthesizedTypeTypeAnnotation = 202,
+    TSTypeOperatorTypeAnnotation = 203,
+    TSArrayTypeElementType = 204,
+    TSIndexedAccessTypeObjectType = 205,
+    TSIndexedAccessTypeIndexType = 206,
+    TSTupleTypeElementTypes = 207,
+    TSNamedTupleMemberLabel = 208,
+    TSNamedTupleMemberElementType = 209,
+    TSOptionalTypeTypeAnnotation = 210,
+    TSRestTypeTypeAnnotation = 211,
+    TSTypeReferenceTypeName = 212,
+    TSTypeReferenceTypeArguments = 213,
+    TSQualifiedNameLeft = 214,
+    TSQualifiedNameRight = 215,
+    TSTypeParameterInstantiationParams = 216,
+    TSTypeParameterName = 217,
+    TSTypeParameterConstraint = 218,
+    TSTypeParameterDefault = 219,
+    TSTypeParameterDeclarationParams = 220,
+    TSTypeAliasDeclarationId = 221,
+    TSTypeAliasDeclarationTypeParameters = 222,
+    TSTypeAliasDeclarationTypeAnnotation = 223,
+    TSClassImplementsExpression = 224,
+    TSClassImplementsTypeArguments = 225,
+    TSInterfaceDeclarationId = 226,
+    TSInterfaceDeclarationTypeParameters = 227,
+    TSInterfaceDeclarationExtends = 228,
+    TSInterfaceDeclarationBody = 229,
+    TSInterfaceBodyBody = 230,
+    TSPropertySignatureKey = 231,
+    TSPropertySignatureTypeAnnotation = 232,
+    TSIndexSignatureParameters = 233,
+    TSIndexSignatureTypeAnnotation = 234,
+    TSCallSignatureDeclarationTypeParameters = 235,
+    TSCallSignatureDeclarationThisParam = 236,
+    TSCallSignatureDeclarationParams = 237,
+    TSCallSignatureDeclarationReturnType = 238,
+    TSMethodSignatureKey = 239,
+    TSMethodSignatureTypeParameters = 240,
+    TSMethodSignatureThisParam = 241,
+    TSMethodSignatureParams = 242,
+    TSMethodSignatureReturnType = 243,
+    TSConstructSignatureDeclarationTypeParameters = 244,
+    TSConstructSignatureDeclarationParams = 245,
+    TSConstructSignatureDeclarationReturnType = 246,
+    TSIndexSignatureNameTypeAnnotation = 247,
+    TSInterfaceHeritageExpression = 248,
+    TSInterfaceHeritageTypeArguments = 249,
+    TSTypePredicateParameterName = 250,
+    TSTypePredicateTypeAnnotation = 251,
+    TSModuleDeclarationId = 252,
+    TSModuleDeclarationBody = 253,
+    TSModuleBlockDirectives = 254,
+    TSModuleBlockBody = 255,
+    TSTypeLiteralMembers = 256,
+    TSInferTypeTypeParameter = 257,
+    TSTypeQueryExprName = 258,
+    TSTypeQueryTypeArguments = 259,
+    TSImportTypeArgument = 260,
+    TSImportTypeOptions = 261,
+    TSImportTypeQualifier = 262,
+    TSImportTypeTypeArguments = 263,
+    TSImportTypeQualifiedNameLeft = 264,
+    TSImportTypeQualifiedNameRight = 265,
+    TSFunctionTypeTypeParameters = 266,
+    TSFunctionTypeThisParam = 267,
+    TSFunctionTypeParams = 268,
+    TSFunctionTypeReturnType = 269,
+    TSConstructorTypeTypeParameters = 270,
+    TSConstructorTypeParams = 271,
+    TSConstructorTypeReturnType = 272,
+    TSMappedTypeTypeParameter = 273,
+    TSMappedTypeNameType = 274,
+    TSMappedTypeTypeAnnotation = 275,
+    TSTemplateLiteralTypeQuasis = 276,
+    TSTemplateLiteralTypeTypes = 277,
+    TSAsExpressionExpression = 278,
+    TSAsExpressionTypeAnnotation = 279,
+    TSSatisfiesExpressionExpression = 280,
+    TSSatisfiesExpressionTypeAnnotation = 281,
+    TSTypeAssertionTypeAnnotation = 282,
+    TSTypeAssertionExpression = 283,
+    TSImportEqualsDeclarationId = 284,
+    TSImportEqualsDeclarationModuleReference = 285,
+    TSExternalModuleReferenceExpression = 286,
+    TSNonNullExpressionExpression = 287,
+    DecoratorExpression = 288,
+    TSExportAssignmentExpression = 289,
+    TSNamespaceExportDeclarationId = 290,
+    TSInstantiationExpressionExpression = 291,
+    TSInstantiationExpressionTypeArguments = 292,
+    JSDocNullableTypeTypeAnnotation = 293,
+    JSDocNonNullableTypeTypeAnnotation = 294,
 }
 
 /// Ancestor type used in AST traversal.
@@ -624,8 +623,6 @@ pub enum Ancestor<'a, 't> {
         AncestorType::ExportNamedDeclarationSource as u16,
     ExportNamedDeclarationWithClause(ExportNamedDeclarationWithoutWithClause<'a, 't>) =
         AncestorType::ExportNamedDeclarationWithClause as u16,
-    ExportDefaultDeclarationExported(ExportDefaultDeclarationWithoutExported<'a, 't>) =
-        AncestorType::ExportDefaultDeclarationExported as u16,
     ExportDefaultDeclarationDeclaration(ExportDefaultDeclarationWithoutDeclaration<'a, 't>) =
         AncestorType::ExportDefaultDeclarationDeclaration as u16,
     ExportAllDeclarationExported(ExportAllDeclarationWithoutExported<'a, 't>) =
@@ -1403,11 +1400,7 @@ impl<'a, 't> Ancestor<'a, 't> {
 
     #[inline]
     pub fn is_export_default_declaration(self) -> bool {
-        matches!(
-            self,
-            Self::ExportDefaultDeclarationExported(_)
-                | Self::ExportDefaultDeclarationDeclaration(_)
-        )
+        matches!(self, Self::ExportDefaultDeclarationDeclaration(_))
     }
 
     #[inline]
@@ -2056,7 +2049,6 @@ impl<'a, 't> Ancestor<'a, 't> {
         matches!(
             self,
             Self::ImportSpecifierImported(_)
-                | Self::ExportDefaultDeclarationExported(_)
                 | Self::ExportAllDeclarationExported(_)
                 | Self::ExportSpecifierLocal(_)
                 | Self::ExportSpecifierExported(_)
@@ -2375,7 +2367,6 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::ExportNamedDeclarationSpecifiers(a) => a.address(),
             Self::ExportNamedDeclarationSource(a) => a.address(),
             Self::ExportNamedDeclarationWithClause(a) => a.address(),
-            Self::ExportDefaultDeclarationExported(a) => a.address(),
             Self::ExportDefaultDeclarationDeclaration(a) => a.address(),
             Self::ExportAllDeclarationExported(a) => a.address(),
             Self::ExportAllDeclarationSource(a) => a.address(),
@@ -10123,41 +10114,8 @@ impl<'a, 't> GetAddress for ExportNamedDeclarationWithoutWithClause<'a, 't> {
 
 pub(crate) const OFFSET_EXPORT_DEFAULT_DECLARATION_SPAN: usize =
     offset_of!(ExportDefaultDeclaration, span);
-pub(crate) const OFFSET_EXPORT_DEFAULT_DECLARATION_EXPORTED: usize =
-    offset_of!(ExportDefaultDeclaration, exported);
 pub(crate) const OFFSET_EXPORT_DEFAULT_DECLARATION_DECLARATION: usize =
     offset_of!(ExportDefaultDeclaration, declaration);
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct ExportDefaultDeclarationWithoutExported<'a, 't>(
-    pub(crate) *const ExportDefaultDeclaration<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> ExportDefaultDeclarationWithoutExported<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_EXPORT_DEFAULT_DECLARATION_SPAN) as *const Span)
-        }
-    }
-
-    #[inline]
-    pub fn declaration(self) -> &'t ExportDefaultDeclarationKind<'a> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_EXPORT_DEFAULT_DECLARATION_DECLARATION)
-                as *const ExportDefaultDeclarationKind<'a>)
-        }
-    }
-}
-
-impl<'a, 't> GetAddress for ExportDefaultDeclarationWithoutExported<'a, 't> {
-    #[inline]
-    fn address(&self) -> Address {
-        Address::from_ptr(self.0)
-    }
-}
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -10171,14 +10129,6 @@ impl<'a, 't> ExportDefaultDeclarationWithoutDeclaration<'a, 't> {
     pub fn span(self) -> &'t Span {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_EXPORT_DEFAULT_DECLARATION_SPAN) as *const Span)
-        }
-    }
-
-    #[inline]
-    pub fn exported(self) -> &'t ModuleExportName<'a> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_EXPORT_DEFAULT_DECLARATION_EXPORTED)
-                as *const ModuleExportName<'a>)
         }
     }
 }

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -2987,16 +2987,9 @@ unsafe fn walk_export_default_declaration<'a, State, Tr: Traverse<'a, State>>(
     ctx: &mut TraverseCtx<'a, State>,
 ) {
     traverser.enter_export_default_declaration(&mut *node, ctx);
-    let pop_token = ctx.push_stack(Ancestor::ExportDefaultDeclarationExported(
-        ancestor::ExportDefaultDeclarationWithoutExported(node, PhantomData),
+    let pop_token = ctx.push_stack(Ancestor::ExportDefaultDeclarationDeclaration(
+        ancestor::ExportDefaultDeclarationWithoutDeclaration(node, PhantomData),
     ));
-    walk_module_export_name(
-        traverser,
-        (node as *mut u8).add(ancestor::OFFSET_EXPORT_DEFAULT_DECLARATION_EXPORTED)
-            as *mut ModuleExportName,
-        ctx,
-    );
-    ctx.retag_stack(AncestorType::ExportDefaultDeclarationDeclaration);
     walk_export_default_declaration_kind(
         traverser,
         (node as *mut u8).add(ancestor::OFFSET_EXPORT_DEFAULT_DECLARATION_DECLARATION)

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -987,7 +987,7 @@ function deserializeExportNamedDeclaration(pos) {
 function deserializeExportDefaultDeclaration(pos) {
   return {
     type: 'ExportDefaultDeclaration',
-    declaration: deserializeExportDefaultDeclarationKind(pos + 64),
+    declaration: deserializeExportDefaultDeclarationKind(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -1116,7 +1116,7 @@ function deserializeExportNamedDeclaration(pos) {
 function deserializeExportDefaultDeclaration(pos) {
   return {
     type: 'ExportDefaultDeclaration',
-    declaration: deserializeExportDefaultDeclarationKind(pos + 64),
+    declaration: deserializeExportDefaultDeclarationKind(pos + 8),
     exportKind: 'value',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),

--- a/napi/parser/generated/lazy/constructors.js
+++ b/napi/parser/generated/lazy/constructors.js
@@ -5965,7 +5965,7 @@ class ExportDefaultDeclaration {
 
   get declaration() {
     const internal = this.#internal;
-    return constructExportDefaultDeclarationKind(internal.pos + 64, internal.ast);
+    return constructExportDefaultDeclarationKind(internal.pos + 8, internal.ast);
   }
 
   toJSON() {

--- a/napi/parser/generated/lazy/walk.js
+++ b/napi/parser/generated/lazy/walk.js
@@ -2438,7 +2438,7 @@ function walkExportDefaultDeclaration(pos, ast, visitors) {
     if (enter !== null) enter(node);
   }
 
-  walkExportDefaultDeclarationKind(pos + 64, ast, visitors);
+  walkExportDefaultDeclarationKind(pos + 8, ast, visitors);
 
   if (exit !== null) exit(node);
 }


### PR DESCRIPTION
We currently store the `default` keyword for `ExportDefaultDeclaration` as a `ModuleExportName`. This is overkill because the name is always, by definition, `default`.

The only place the `Span` of `default` keyword is used is in `ModuleRecordBuilder`. So essentially storing the span in AST is using the AST as temporary storage - it's only put there so that `ModuleRecordBuilder` can pull it out again.

After #12807, we can just pass the span direct to `ModuleRecordBuilder`, and so remove the need for it to be in the AST at all.

So we can remove the whole field.

This reduces size of `ExportDefaultDeclaration` from 80 bytes to 24. That has very limited impact, because each file can only have 1 `export default` statement. But still... less is more!

It also removes erroneous code in both isolated declarations and transformer, which both just gave the keyword an empty span. I think the fact that everywhere that does use this field uses it wrongly is good justification for its removal!

(alternative to #12803)