### PR TITLE
fix(tasks): propagate io::copy errors during benchmark file download

### DIFF
--- a/tasks/common/src/test_file.rs
+++ b/tasks/common/src/test_file.rs
@@ -113,7 +113,7 @@ impl TestFile {
 
                     let _drop = std::fs::remove_file(&file);
                     let mut writer = std::fs::File::create(&file).map_err(err_to_string)?;
-                    let _drop = std::io::copy(&mut reader, &mut writer);
+                    std::io::copy(&mut reader, &mut writer).map_err(err_to_string)?;
 
                     std::fs::read_to_string(&file)
                         .map_err(err_to_string)


### PR DESCRIPTION
Codspeed left this comment on my PR.

The perf increase is obviously wrong, the only way i could see this happening is if it failed to copy. this PR updates it to propogate the error so that we know when something fails, rather than having codspeed log incorrect perf differences

![Screenshot 2025-08-04 at 20.03.10.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/8ASanJZ3iQ7b9iVhlds7/ff7af92c-a344-477b-862c-06b1ebebef4a.png)

