### PR TITLE
fix(minifier): fix `KATAKANA MIDDLE DOT` syntax error for unicode 4.1 to 15

### DIFF
--- a/crates/oxc_minifier/src/ctx.rs
+++ b/crates/oxc_minifier/src/ctx.rs
@@ -9,7 +9,10 @@ use oxc_ecmascript::{
 };
 use oxc_semantic::{IsGlobalReference, Scoping, SymbolId};
 use oxc_span::format_atom;
-use oxc_syntax::reference::ReferenceId;
+use oxc_syntax::{
+    identifier::{is_identifier_part, is_identifier_start},
+    reference::ReferenceId,
+};
 
 use crate::{options::CompressOptions, state::MinifierState, symbol_value::SymbolValue};
 
@@ -240,5 +243,15 @@ impl<'a> Ctx<'a, '_> {
             })?;
         }
         Some(f64::from(int_value))
+    }
+
+    /// `is_identifier_name` patched with KATAKANA MIDDLE DOT and HALFWIDTH KATAKANA MIDDLE DOT
+    /// Otherwise `({ 'x・': 0 })` gets converted to `({ x・: 0 })`, which breaks in Unicode 4.1 to
+    /// 15.
+    /// <https://github.com/oxc-project/unicode-id-start/pull/3>
+    pub fn is_identifier_name_patched(s: &str) -> bool {
+        let mut chars = s.chars();
+        chars.next().is_some_and(is_identifier_start)
+            && chars.all(|c| is_identifier_part(c) && c != '・' && c != '･')
     }
 }

--- a/crates/oxc_minifier/src/peephole/convert_to_dotted_properties.rs
+++ b/crates/oxc_minifier/src/peephole/convert_to_dotted_properties.rs
@@ -1,6 +1,5 @@
 use oxc_allocator::TakeIn;
 use oxc_ast::ast::*;
-use oxc_syntax::identifier::is_identifier_name;
 
 use crate::ctx::Ctx;
 
@@ -17,7 +16,7 @@ impl<'a> LatePeepholeOptimizations {
     pub fn convert_to_dotted_properties(expr: &mut MemberExpression<'a>, ctx: &mut Ctx<'a, '_>) {
         let MemberExpression::ComputedMemberExpression(e) = expr else { return };
         let Expression::StringLiteral(s) = &e.expression else { return };
-        if is_identifier_name(&s.value) {
+        if Ctx::is_identifier_name_patched(&s.value) {
             let property = ctx.ast.identifier_name(s.span, s.value);
             *expr =
                 MemberExpression::StaticMemberExpression(ctx.ast.alloc_static_member_expression(


### PR DESCRIPTION
fixes https://github.com/rolldown/rolldown/issues/5591