### PR TITLE
fix(minifier): keep classes with static properties + side effect initializer

### DIFF
--- a/crates/oxc_minifier/src/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_declaration.rs
@@ -130,11 +130,13 @@ mod test {
         test_options("class C { foo }", "", &options);
         test_options("class C { foo = bar }", "", &options);
         test_options("class C { foo = 1 }", "", &options);
-        test_options("class C { static foo = bar }", "bar", &options);
+        // TODO: would be nice if this is removed but the one with `this` is kept.
+        test_same_options("class C { static foo = bar }", &options);
+        test_same_options("class C { static foo = this.bar = {} }", &options);
         test_options("class C { static foo = 1 }", "", &options);
         test_options("class C { [foo] = bar }", "foo", &options);
         test_options("class C { [foo] = 1 }", "foo", &options);
-        test_options("class C { static [foo] = bar }", "foo, bar", &options);
+        test_same_options("class C { static [foo] = bar }", &options);
         test_options("class C { static [foo] = 1 }", "foo", &options);
 
         // accessor
@@ -142,11 +144,7 @@ mod test {
         test_options("class C { accessor [foo] = 1 }", "foo", &options);
 
         // order
-        test_options(
-            "class _ extends A { static [B] = C; static [D]() {} }",
-            "A, B, C, D",
-            &options,
-        );
+        test_options("class _ extends A { [B] = C; [D]() {} }", "A, B, D", &options);
 
         // decorators
         test_same_options("class C { @dec foo() {} }", &options);

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -674,20 +674,29 @@ impl<'a> PeepholeOptimizations {
         {
             return None;
         }
-        // Keep the entire class if non-empty static block exists.
+        // Keep the entire class if there are class level side effects.
         for e in &c.body.body {
             match e {
                 e if e.has_decorator() => return None,
                 ClassElement::TSIndexSignature(_) => return None,
-                ClassElement::StaticBlock(block) => {
-                    if !block.body.is_empty() {
-                        return None;
-                    }
+                ClassElement::StaticBlock(block) if !block.body.is_empty() => return None,
+                ClassElement::PropertyDefinition(prop)
+                    if prop.r#static
+                        && prop.value.as_ref().is_some_and(|v| v.may_have_side_effects(ctx)) =>
+                {
+                    return None;
+                }
+                ClassElement::AccessorProperty(prop)
+                    if prop.r#static
+                        && prop.value.as_ref().is_some_and(|v| v.may_have_side_effects(ctx)) =>
+                {
+                    return None;
                 }
                 _ => {}
             }
         }
 
+        // Otherwise extract the expressions.
         let mut exprs = ctx.ast.vec();
 
         if let Some(e) = &mut c.super_class {
@@ -721,9 +730,8 @@ impl<'a> PeepholeOptimizations {
                     ClassElement::PropertyDefinition(def) => def.value.take(),
                     ClassElement::AccessorProperty(def) => def.value.take(),
                 } {
-                    if init.may_have_side_effects(ctx) {
-                        exprs.push(init);
-                    }
+                    // Already checked side effects above.
+                    exprs.push(init);
                 }
             }
         }
@@ -1115,11 +1123,13 @@ mod test {
         test_options("(class { foo })", "", &options);
         test_options("(class { foo = bar })", "", &options);
         test_options("(class { foo = 1 })", "", &options);
-        test_options("(class { static foo = bar })", "bar", &options);
+        // TODO: would be nice if this is removed but the one with `this` is kept.
+        test_same_options("(class { static foo = bar })", &options);
+        test_same_options("(class { static foo = this.bar = {} })", &options);
         test_options("(class { static foo = 1 })", "", &options);
         test_options("(class { [foo] = bar })", "foo", &options);
         test_options("(class { [foo] = 1 })", "foo", &options);
-        test_options("(class { static [foo] = bar })", "foo, bar", &options);
+        test_same_options("(class { static [foo] = bar })", &options);
         test_options("(class { static [foo] = 1 })", "foo", &options);
 
         // accessor
@@ -1127,11 +1137,7 @@ mod test {
         test_options("(class { accessor [foo] = 1 })", "foo", &options);
 
         // order
-        test_options(
-            "(class extends A { static [B] = C; static [D]() {} })",
-            "A, B, C, D",
-            &options,
-        );
+        test_options("(class extends A { [B] = C; [D]() {} })", "A, B, D", &options);
 
         // decorators
         test_same_options("(class { @dec foo() {} })", &options);


### PR DESCRIPTION
For the record, here's the whole process:

[TypeScript ES2022 + useDefineForClassFields = false](https://www.typescriptlang.org/play/?useDefineForClassFields=true&noUnusedLocals=true&noUnusedParameters=true&experimentalDecorators=true&emitDecoratorMetadata=true&target=9&jsx=0&module=0&stripInternal=false&isolatedModules=false&verbatimModuleSyntax=false&allowSyntheticDefaultImports=true&isolatedDeclarations=false&noCheck=false&lib=true&ts=5.9.2&filetype=ts#code/MYGwhgzhAEDC0G8BQ1oQC5nQS2NAZtALyIC+A3EqUA) transforms

(Note Oxc has the exact same transform)

```js
class C {
  static f = side_effect();
}
```

into 

```js
class C {
  static {
    this.f = side_effect();
  }
}
```

then babel [@babel/plugin-transform-class-static-block](https://babel.dev/repl#?corejs=3.21&spec=true&code_lz=MYGwhgzhAEDC0G8BQ1XQgFzBglsR0GAFjhAHQBm0AvIgL4Dc0dSdQA&forceAllTransforms=true&modules=commonjs&timeTravel=true&sourceType=module&lineWrap=true&presets=react%2Ctypescript&version=7.26.1&externalPlugins=%40babel%2Fplugin-transform-class-static-block%407.27.1) transforms to 

(Note Oxc has the exact same transform)

```js
class C {
  static #_ = this.f = side_effect();
}
```

and the minifier remove unused code trims it down to

```js
this.f = side_effect();
```

---

To eliminate this bug, we will temporary keep all classes that have static properties + side effect initializer.

i.e. 

```js
class C {
  static #_ = this.f = side_effect();
}
```

does not get trimmed down to `this.f = side_effect()`.

---

Also note, this came from a project with a tsconfig 

```js
"useDefineForClassFields": false
```

+ browserslist target `ios 16` where ES2022 `@babel/plugin-transform-class-properties` is off and ES2022 `@babel/plugin-transform-class-static-block` on.