### PR TITLE
fix(rulegen): tests with backslash should be raw string literals

### DIFF
--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -160,8 +160,10 @@ fn format_code_snippet(code: &str) -> String {
         return code;
     }
 
-    // "debugger" => "debugger"
-    if !code.contains('"') {
+    // `debugger` => `debugger`
+    // `"debugger"` => `r#"\"debugger\""#`
+    // `\u1234` => `r#"\u1234"`
+    if !code.contains('"') && !code.contains('\\') {
         return format!("\"{code}\"");
     }
 


### PR DESCRIPTION
Needed to fix some test cases:

<img width="1253" height="145" alt="grafik" src="https://github.com/user-attachments/assets/7119b11b-07e5-4cf4-9b29-a6dbb7659b65" />

https://github.com/oxc-project/oxc/pull/12835