### PR TITLE
refactor(linter): use `fast-glob` instead of `globset` for `GlobSet`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,7 +2005,6 @@ dependencies = [
  "convert_case",
  "cow-utils",
  "fast-glob",
- "globset",
  "icu_segmenter",
  "indexmap",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,6 @@ fast-glob = "1.0.0"
 fixedbitset = "0.5.7"
 flate2 = "1.1.2"
 futures = "0.3.31"
-globset = "0.4.16"
 handlebars = "6.3.2"
 hashbrown = { version = "0.15.4", default-features = false }
 humansize = "2.1.3"

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -52,7 +52,6 @@ constcat = { workspace = true }
 convert_case = { workspace = true }
 cow-utils = { workspace = true }
 fast-glob = { workspace = true }
-globset = { workspace = true }
 icu_segmenter = { workspace = true }
 indexmap = { workspace = true, features = ["rayon"] }
 itertools = { workspace = true }

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -144,8 +144,9 @@ impl Config {
             })
             .unwrap_or(path);
 
+        let path = relative_path.to_string_lossy();
         let overrides_to_apply =
-            self.overrides.iter().filter(|config| config.files.is_match(relative_path));
+            self.overrides.iter().filter(|config| config.files.is_match(path.as_ref()));
 
         let mut overrides_to_apply = overrides_to_apply.peekable();
 
@@ -373,7 +374,7 @@ mod test {
         let base_rules = vec![no_explicit_any()];
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             env: None,
-            files: GlobSet::new(vec!["*.test.{ts,tsx}"]).unwrap(),
+            files: GlobSet::new(vec!["*.test.{ts,tsx}"]),
             plugins: None,
             globals: None,
             rules: ResolvedOxlintOverrideRules { builtin_rules: vec![], external_rules: vec![] },
@@ -404,7 +405,7 @@ mod test {
         let base_rules = vec![no_explicit_any()];
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             env: None,
-            files: GlobSet::new(vec!["*.test.{ts,tsx}"]).unwrap(),
+            files: GlobSet::new(vec!["*.test.{ts,tsx}"]),
             plugins: Some(LintPlugins::new(
                 BuiltinLintPlugins::REACT
                     .union(BuiltinLintPlugins::TYPESCRIPT)
@@ -441,7 +442,7 @@ mod test {
         let base_rules = vec![no_explicit_any()];
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             env: None,
-            files: GlobSet::new(vec!["*.test.{ts,tsx}"]).unwrap(),
+            files: GlobSet::new(vec!["*.test.{ts,tsx}"]),
             plugins: None,
             globals: None,
             rules: ResolvedOxlintOverrideRules {
@@ -478,7 +479,7 @@ mod test {
         let base_rules = vec![no_explicit_any()];
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             env: None,
-            files: GlobSet::new(vec!["src/**/*.{ts,tsx}"]).unwrap(),
+            files: GlobSet::new(vec!["src/**/*.{ts,tsx}"]),
             plugins: None,
             globals: None,
             rules: ResolvedOxlintOverrideRules {
@@ -515,7 +516,7 @@ mod test {
         let base_rules = vec![no_explicit_any()];
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             env: None,
-            files: GlobSet::new(vec!["src/**/*.{ts,tsx}"]).unwrap(),
+            files: GlobSet::new(vec!["src/**/*.{ts,tsx}"]),
             plugins: None,
             globals: None,
             rules: ResolvedOxlintOverrideRules {
@@ -561,7 +562,7 @@ mod test {
         let overrides = ResolvedOxlintOverrides::new(vec![
             ResolvedOxlintOverride {
                 env: None,
-                files: GlobSet::new(vec!["*.jsx", "*.tsx"]).unwrap(),
+                files: GlobSet::new(vec!["*.jsx", "*.tsx"]),
                 plugins: Some(LintPlugins::new(BuiltinLintPlugins::REACT, FxHashSet::default())),
                 globals: None,
                 rules: ResolvedOxlintOverrideRules {
@@ -571,7 +572,7 @@ mod test {
             },
             ResolvedOxlintOverride {
                 env: None,
-                files: GlobSet::new(vec!["*.ts", "*.tsx"]).unwrap(),
+                files: GlobSet::new(vec!["*.ts", "*.tsx"]),
                 plugins: Some(LintPlugins::new(
                     BuiltinLintPlugins::TYPESCRIPT,
                     FxHashSet::default(),
@@ -622,7 +623,7 @@ mod test {
         };
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             env: Some(OxlintEnv::from_iter(["es2024".to_string()])),
-            files: GlobSet::new(vec!["*.tsx"]).unwrap(),
+            files: GlobSet::new(vec!["*.tsx"]),
             plugins: None,
             globals: None,
             rules: ResolvedOxlintOverrideRules { builtin_rules: vec![], external_rules: vec![] },
@@ -649,7 +650,7 @@ mod test {
             path: None,
         };
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
-            files: GlobSet::new(vec!["*.tsx"]).unwrap(),
+            files: GlobSet::new(vec!["*.tsx"]),
             env: Some(from_json!({ "es2024": false })),
             plugins: None,
             globals: None,
@@ -678,7 +679,7 @@ mod test {
         };
 
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
-            files: GlobSet::new(vec!["*.tsx"]).unwrap(),
+            files: GlobSet::new(vec!["*.tsx"]),
             env: None,
             plugins: None,
             globals: Some(from_json!({ "React": "readonly", "Secret": "writeable" })),
@@ -712,7 +713,7 @@ mod test {
         };
 
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
-            files: GlobSet::new(vec!["*.tsx"]).unwrap(),
+            files: GlobSet::new(vec!["*.tsx"]),
             env: None,
             plugins: None,
             globals: Some(from_json!({ "React": "off", "Secret": "off" })),
@@ -761,7 +762,7 @@ mod test {
             // First override: typescript plugin for *.{ts,tsx,mts}
             ResolvedOxlintOverride {
                 env: None,
-                files: GlobSet::new(vec!["*.{ts,tsx,mts}"]).unwrap(),
+                files: GlobSet::new(vec!["*.{ts,tsx,mts}"]),
                 plugins: Some(LintPlugins::new(
                     BuiltinLintPlugins::TYPESCRIPT,
                     FxHashSet::default(),
@@ -775,7 +776,7 @@ mod test {
             // Second override: react plugin for *.{ts,tsx} with jsx-filename-extension turned off
             ResolvedOxlintOverride {
                 env: None,
-                files: GlobSet::new(vec!["*.{ts,tsx}"]).unwrap(),
+                files: GlobSet::new(vec!["*.{ts,tsx}"]),
                 plugins: Some(LintPlugins::new(BuiltinLintPlugins::REACT, FxHashSet::default())),
                 globals: None,
                 rules: ResolvedOxlintOverrideRules {
@@ -789,7 +790,7 @@ mod test {
             // Third override: unicorn plugin for *.{ts,tsx,mts}
             ResolvedOxlintOverride {
                 env: None,
-                files: GlobSet::new(vec!["*.{ts,tsx,mts}"]).unwrap(),
+                files: GlobSet::new(vec!["*.{ts,tsx,mts}"]),
                 plugins: Some(LintPlugins::new(BuiltinLintPlugins::UNICORN, FxHashSet::default())),
                 globals: None,
                 rules: ResolvedOxlintOverrideRules {
@@ -849,7 +850,7 @@ mod test {
         // Override adds react plugin (new plugin not in root)
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             env: None,
-            files: GlobSet::new(vec!["*.tsx"]).unwrap(),
+            files: GlobSet::new(vec!["*.tsx"]),
             plugins: Some(LintPlugins::new(BuiltinLintPlugins::REACT, FxHashSet::default())),
             globals: None,
             rules: ResolvedOxlintOverrideRules { builtin_rules: vec![], external_rules: vec![] },
@@ -897,7 +898,7 @@ mod test {
         // Override adds typescript plugin
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             env: None,
-            files: GlobSet::new(vec!["*.tsx"]).unwrap(),
+            files: GlobSet::new(vec!["*.tsx"]),
             plugins: Some(LintPlugins::new(BuiltinLintPlugins::TYPESCRIPT, FxHashSet::default())),
             globals: None,
             rules: ResolvedOxlintOverrideRules { builtin_rules: vec![], external_rules: vec![] },

--- a/crates/oxc_linter/src/snapshots/schema_json.snap
+++ b/crates/oxc_linter/src/snapshots/schema_json.snap
@@ -193,6 +193,7 @@ expression: json
       }
     },
     "GlobSet": {
+      "description": "A set of glob patterns.",
       "type": "array",
       "items": {
         "type": "string"

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -189,6 +189,7 @@
       }
     },
     "GlobSet": {
+      "description": "A set of glob patterns.",
       "type": "array",
       "items": {
         "type": "string"

--- a/tasks/website/src/linter/snapshots/schema_markdown.snap
+++ b/tasks/website/src/linter/snapshots/schema_markdown.snap
@@ -214,7 +214,7 @@ type: `object`
 type: `string[]`
 
 
-
+A set of glob patterns.
 
 
 #### overrides[n].rules


### PR DESCRIPTION
closes #12825 