### PR TITLE
chore(ecmascript): add missing `unsafe` block to inline assembly call

### DIFF
--- a/crates/oxc_ecmascript/src/to_int_32.rs
+++ b/crates/oxc_ecmascript/src/to_int_32.rs
@@ -44,11 +44,13 @@ unsafe fn f64_to_int32_arm64(number: f64) -> i32 {
     }
     let ret: i32;
     // SAFETY: Number is not nan so no floating-point exception should throw.
-    std::arch::asm!(
-        "fjcvtzs {dst:w}, {src:d}",
-        src = in(vreg) number,
-        dst = out(reg) ret,
-    );
+    unsafe {
+        std::arch::asm!(
+            "fjcvtzs {dst:w}, {src:d}",
+            src = in(vreg) number,
+            dst = out(reg) ret,
+        );
+    }
     ret
 }
 


### PR DESCRIPTION
Fixes the following warning when building oxlint

```
warning[E0133]: use of inline assembly is unsafe and requires unsafe block
  --> crates/oxc_ecmascript/src/to_int_32.rs:47:5
   |
47 | /     std::arch::asm!(
48 | |         "fjcvtzs {dst:w}, {src:d}",
49 | |         src = in(vreg) number,
50 | |         dst = out(reg) ret,
51 | |     );
   | |_____^ use of inline assembly
   |
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
   = note: inline assembly is entirely unchecked and can cause undefined behavior
note: an unsafe function restricts its caller, but its body is safe by default
  --> crates/oxc_ecmascript/src/to_int_32.rs:41:1
   |
41 | unsafe fn f64_to_int32_arm64(number: f64) -> i32 {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = note: requested on the command line with `-W unsafe-op-in-unsafe-fn`
```