### PR TITLE
fix(linter): resolve configured rules for every file linted by `tsgolint`

### DIFF
--- a/apps/oxlint/fixtures/tsgolint/no-floating-promises/src/.oxlintrc.json
+++ b/apps/oxlint/fixtures/tsgolint/no-floating-promises/src/.oxlintrc.json
@@ -1,0 +1,16 @@
+{
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    "typescript/no-floating-promises": "warn"
+  },
+  "overrides": [
+    {
+      "files": ["overrides.ts"],
+      "rules": {
+        "typescript/no-floating-promises": "error"
+      }
+    }
+  ]
+}

--- a/apps/oxlint/fixtures/tsgolint/no-floating-promises/src/index.ts
+++ b/apps/oxlint/fixtures/tsgolint/no-floating-promises/src/index.ts
@@ -1,0 +1,14 @@
+const promise = new Promise((resolve, _reject) => resolve("value"));
+promise;
+
+async function returnsPromise() {
+  return "value";
+}
+
+returnsPromise().then(() => {});
+
+Promise.reject("value").catch();
+
+Promise.reject("value").finally();
+
+[1, 2, 3].map(async (x) => x + 1);

--- a/apps/oxlint/fixtures/tsgolint/no-floating-promises/src/overrides.ts
+++ b/apps/oxlint/fixtures/tsgolint/no-floating-promises/src/overrides.ts
@@ -1,0 +1,4 @@
+async function returnsPromise() {
+  return "value";
+}
+returnsPromise().then(() => {});

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1219,7 +1219,7 @@ mod test {
     #[test]
     #[cfg(not(any(target_os = "windows", target_endian = "big")))]
     fn test_tsgolint() {
-        let args = &["--type-aware", "-c", ".oxlintrc.json"];
+        let args = &["--type-aware"];
         Tester::new().with_cwd("fixtures/tsgolint".into()).test_and_snapshot(args);
     }
 }

--- a/apps/oxlint/src/snapshots/fixtures__tsgolint_--type-aware@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__tsgolint_--type-aware@oxlint.snap
@@ -2,13 +2,13 @@
 source: apps/oxlint/src/tester.rs
 ---
 ########## 
-arguments: fixtures/tsgolint --type-aware
-working directory: 
+arguments: --type-aware
+working directory: fixtures/tsgolint
 ----------
 
   x typescript-eslint(no-floating-promises): Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void`
   | operator.
-   ,-[fixtures/tsgolint/no-floating-promises/index.ts:2:1]
+   ,-[no-floating-promises/index.ts:2:1]
  1 | const promise = new Promise((resolve, _reject) => resolve("value"));
  2 | promise;
    : ^^^^^^^^
@@ -17,7 +17,7 @@ working directory:
 
   x typescript-eslint(no-floating-promises): Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void`
   | operator.
-   ,-[fixtures/tsgolint/no-floating-promises/index.ts:8:1]
+   ,-[no-floating-promises/index.ts:8:1]
  7 | 
  8 | returnsPromise().then(() => {});
    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ working directory:
 
   x typescript-eslint(no-floating-promises): Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void`
   | operator.
-    ,-[fixtures/tsgolint/no-floating-promises/index.ts:10:1]
+    ,-[no-floating-promises/index.ts:10:1]
   9 | 
  10 | Promise.reject("value").catch();
     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -35,7 +35,7 @@ working directory:
 
   x typescript-eslint(no-floating-promises): Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void`
   | operator.
-    ,-[fixtures/tsgolint/no-floating-promises/index.ts:12:1]
+    ,-[no-floating-promises/index.ts:12:1]
  11 | 
  12 | Promise.reject("value").finally();
     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ working directory:
 
   x typescript-eslint(no-floating-promises): An array of Promises may be unintentional. Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking
   | the expression as ignored with the `void` operator.
-    ,-[fixtures/tsgolint/no-floating-promises/index.ts:14:1]
+    ,-[no-floating-promises/index.ts:14:1]
  13 | 
  14 | [1, 2, 3].map(async (x) => x + 1);
     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -52,7 +52,7 @@ working directory:
 
   ! typescript-eslint(no-floating-promises): Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void`
   | operator.
-   ,-[fixtures/tsgolint/no-floating-promises/src/index.ts:2:1]
+   ,-[no-floating-promises/src/index.ts:2:1]
  1 | const promise = new Promise((resolve, _reject) => resolve("value"));
  2 | promise;
    : ^^^^^^^^
@@ -61,7 +61,7 @@ working directory:
 
   ! typescript-eslint(no-floating-promises): Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void`
   | operator.
-   ,-[fixtures/tsgolint/no-floating-promises/src/index.ts:8:1]
+   ,-[no-floating-promises/src/index.ts:8:1]
  7 | 
  8 | returnsPromise().then(() => {});
    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -70,7 +70,7 @@ working directory:
 
   ! typescript-eslint(no-floating-promises): Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void`
   | operator.
-    ,-[fixtures/tsgolint/no-floating-promises/src/index.ts:10:1]
+    ,-[no-floating-promises/src/index.ts:10:1]
   9 | 
  10 | Promise.reject("value").catch();
     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -79,7 +79,7 @@ working directory:
 
   ! typescript-eslint(no-floating-promises): Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void`
   | operator.
-    ,-[fixtures/tsgolint/no-floating-promises/src/index.ts:12:1]
+    ,-[no-floating-promises/src/index.ts:12:1]
  11 | 
  12 | Promise.reject("value").finally();
     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -88,7 +88,7 @@ working directory:
 
   ! typescript-eslint(no-floating-promises): An array of Promises may be unintentional. Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking
   | the expression as ignored with the `void` operator.
-    ,-[fixtures/tsgolint/no-floating-promises/src/index.ts:14:1]
+    ,-[no-floating-promises/src/index.ts:14:1]
  13 | 
  14 | [1, 2, 3].map(async (x) => x + 1);
     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -96,14 +96,21 @@ working directory:
 
   x typescript-eslint(no-floating-promises): Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void`
   | operator.
-   ,-[fixtures/tsgolint/no-floating-promises/src/overrides.ts:4:1]
+   ,-[no-floating-promises/src/overrides.ts:4:1]
  3 | }
  4 | returnsPromise().then(() => {});
    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    `----
 
-Found 5 warnings and 6 errors.
-Finished in <variable>ms on 3 files using 1 threads.
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[non-tsgolint.ts:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Remove the debugger statement
+
+Found 5 warnings and 7 errors.
+Finished in <variable>ms on 4 files using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------


### PR DESCRIPTION
The previous implementation of config resolution was simply incorrect. It did not resolve rule severities and overrides and nested configs properly. Now, although inefficient, we resolve the config file for every path that we will lint with `tsgolint` to correctly account for any possible nested configs, overrides, and so on. 