### PR TITLE
fix(linter): `react/jsx-curly-brace-presence` report for JSXAttributeItem with padding space

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
@@ -495,7 +495,7 @@ fn is_allowed_string_like<'a>(
         || is_line_break(s)
         || contains_html_entity(s)
         || !is_prop && contains_disallowed_jsx_text_chars(s)
-        || s.trim() != s
+        || !is_prop && s.trim() != s
         || contains_multiline_comment(s)
         || contains_line_break_literal(s)
         || contains_utf8_escape(s)

--- a/crates/oxc_linter/src/snapshots/react_jsx_curly_brace_presence.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_curly_brace_presence.snap
@@ -255,6 +255,12 @@ source: crates/oxc_linter/src/tester.rs
    ·            ─────
    ╰────
 
+  ⚠ eslint-plugin-react(jsx-curly-brace-presence): Curly braces are unnecessary here.
+   ╭─[jsx_curly_brace_presence.tsx:1:25]
+ 1 │ <App prop={'foo'} attr={" foo "} />
+   ·                         ───────
+   ╰────
+
   ⚠ eslint-plugin-react(jsx-curly-brace-presence): Curly braces are required here.
    ╭─[jsx_curly_brace_presence.tsx:1:11]
  1 │ <App prop='foo' attr="bar" />


### PR DESCRIPTION
This should be fixable, so report it too.
https://github.com/oxc-project/oxc/blob/d94209bfd11e980a826f78d316a7a13f0ccfa8bd/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs#L1149-L1150