### PR TITLE
refactor(linter): allow marking rule as a tsgolint rule

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -136,7 +136,7 @@ impl Linter {
 
         let rules = rules
             .iter()
-            .filter(|(rule, _)| rule.should_run(&ctx_host))
+            .filter(|(rule, _)| rule.should_run(&ctx_host) && !rule.is_tsgolint_rule())
             .map(|(rule, severity)| (rule, Rc::clone(&ctx_host).spawn(rule, *severity)));
 
         let semantic = ctx_host.semantic();

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -73,6 +73,8 @@ pub trait RuleMeta {
 
     const CATEGORY: RuleCategory;
 
+    const IS_TSGOLINT_RULE: bool = false;
+
     /// What kind of auto-fixing can this rule do?
     const FIX: RuleFixMeta = RuleFixMeta::None;
 

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -1112,10 +1112,3 @@ oxc_macros::declare_all_lint_rules! {
     vitest::prefer_to_be_truthy,
     vitest::require_local_test_context_for_concurrent_snapshots,
 }
-
-impl RuleEnum {
-    pub fn is_tsgolint_rule(&self) -> bool {
-        // TODO: Codegen this?
-        matches!(self, Self::TypescriptNoFloatingPromises(_) | Self::TypescriptNoMisusedPromises(_))
-    }
-}

--- a/crates/oxc_linter/src/rules/typescript/no_floating_promises.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_floating_promises.rs
@@ -70,14 +70,10 @@ declare_oxc_lint!(
     ///
     /// await Promise.all([1, 2, 3].map(async x => x + 1));
     /// ```
-    NoFloatingPromises,
+    NoFloatingPromises(tsgolint),
     typescript,
     suspicious,
     pending,
 );
 
-impl Rule for NoFloatingPromises {
-    fn should_run(&self, _ctx: &crate::context::ContextHost) -> bool {
-        false
-    }
-}
+impl Rule for NoFloatingPromises {}

--- a/crates/oxc_linter/src/rules/typescript/no_misused_promises.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_misused_promises.rs
@@ -51,14 +51,10 @@ declare_oxc_lint!(
     /// const getData = () => fetch('/');
     /// console.log({ foo: 42, ...(await getData()) });
     /// ```
-    NoMisusedPromises,
+    NoMisusedPromises(tsgolint),
     typescript,
     suspicious,
     pending,
 );
 
-impl Rule for NoMisusedPromises {
-    fn should_run(&self, _ctx: &crate::context::ContextHost) -> bool {
-        false
-    }
-}
+impl Rule for NoMisusedPromises {}

--- a/crates/oxc_macros/src/declare_all_lint_rules.rs
+++ b/crates/oxc_macros/src/declare_all_lint_rules.rs
@@ -177,6 +177,12 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
                     #(Self::#struct_names(rule) => rule.should_run(ctx)),*
                 }
             }
+
+            pub fn is_tsgolint_rule(&self) -> bool {
+                match self {
+                    #(Self::#struct_names(rule) => #struct_names::IS_TSGOLINT_RULE),*
+                }
+            }
         }
 
         impl std::hash::Hash for RuleEnum {

--- a/crates/oxc_macros/src/lib.rs
+++ b/crates/oxc_macros/src/lib.rs
@@ -47,6 +47,27 @@ mod declare_oxc_lint;
 /// - `dangerous_fix_dangerous_suggestion` (provides dangerous fixes and suggestions in all cases)
 ///
 /// `pending` and `none` are special cases that do not follow this pattern.
+///
+/// ## Integration markers
+/// You can optionally add an integration marker immediately after the rule's struct
+/// name in parentheses. Currently the only supported marker is `tsgolint`:
+///
+/// ```rust,ignore
+/// declare_oxc_lint!(
+///     /// Docs...
+///     MyRule(tsgolint),
+///     eslint,
+///     style,
+///     fix
+/// );
+/// ```
+///
+/// Adding `(tsgolint)` sets an internal `IS_TSGOLINT_RULE` flag to `true`, which
+/// allows the `oxlint` CLI to surface this rule to the external `tsgolint`
+/// executable. Rules without the marker keep the default `false` value and are
+/// ignored by that integration. Only one marker is allowed and any other value
+/// will result in a compile error.
+///
 /// # Example
 ///
 /// ```


### PR DESCRIPTION
Making it easier to add new `tsgolint` rules, which will make this more favorable for implementing new rules with AI to speed up importing all the type-aware rules. Adds the ability to add a `(tsgolint)` marker in the `declare_oxc_lint!` macro which generates the necessary code.