### PR TITLE
refactor(all): add missing lifetimes in function return types

### DIFF
--- a/apps/oxlint/src/output_formatter/xml_utils.rs
+++ b/apps/oxlint/src/output_formatter/xml_utils.rs
@@ -1,11 +1,11 @@
 use std::borrow::Cow;
 
 /// <https://github.com/tafia/quick-xml/blob/6e34a730853fe295d68dc28460153f08a5a12955/src/escapei.rs#L84-L86>
-pub fn xml_escape(raw: &str) -> Cow<str> {
+pub fn xml_escape(raw: &str) -> Cow<'_, str> {
     xml_escape_impl(raw, |ch| matches!(ch, b'<' | b'>' | b'&' | b'\'' | b'\"'))
 }
 
-fn xml_escape_impl<F: Fn(u8) -> bool>(raw: &str, escape_chars: F) -> Cow<str> {
+fn xml_escape_impl<F: Fn(u8) -> bool>(raw: &str, escape_chars: F) -> Cow<'_, str> {
     let bytes = raw.as_bytes();
     let mut escaped = None;
     let mut iter = bytes.iter();

--- a/crates/oxc_allocator/src/pool.rs
+++ b/crates/oxc_allocator/src/pool.rs
@@ -24,7 +24,7 @@ impl AllocatorPool {
     /// # Panics
     ///
     /// Panics if the underlying mutex is poisoned.
-    pub fn get(&self) -> AllocatorGuard {
+    pub fn get(&self) -> AllocatorGuard<'_> {
         let allocator = {
             let mut allocators = self.allocators.lock().unwrap();
             allocators.pop()

--- a/crates/oxc_allocator/src/pool_fixed_size.rs
+++ b/crates/oxc_allocator/src/pool_fixed_size.rs
@@ -45,7 +45,7 @@ impl AllocatorPool {
     /// # Panics
     ///
     /// Panics if the underlying mutex is poisoned.
-    pub fn get(&self) -> AllocatorGuard {
+    pub fn get(&self) -> AllocatorGuard<'_> {
         let allocator = {
             let mut allocators = self.allocators.lock().unwrap();
             allocators.pop()

--- a/crates/oxc_allocator/src/vec2/mod.rs
+++ b/crates/oxc_allocator/src/vec2/mod.rs
@@ -1621,7 +1621,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     /// v.drain(..);
     /// assert_eq!(v, &[]);
     /// ```
-    pub fn drain<R>(&mut self, range: R) -> Drain<T, A>
+    pub fn drain<R>(&mut self, range: R) -> Drain<'_, '_, T, A>
     where
         R: RangeBounds<usize>,
     {
@@ -2280,7 +2280,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     /// assert_eq!(u, &[1, 2]);
     /// ```
     #[inline]
-    pub fn splice<R, I>(&mut self, range: R, replace_with: I) -> Splice<I::IntoIter, A>
+    pub fn splice<R, I>(&mut self, range: R, replace_with: I) -> Splice<'_, '_, I::IntoIter, A>
     where
         R: RangeBounds<usize>,
         I: IntoIterator<Item = T>,

--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -786,7 +786,7 @@ impl CallExpression<'_> {
     /// require() // => false
     /// require(123) // => false
     /// ```
-    pub fn common_js_require(&self) -> Option<&StringLiteral> {
+    pub fn common_js_require(&self) -> Option<&StringLiteral<'_>> {
         if !(self.callee.is_specific_id("require") && self.arguments.len() == 1) {
             return None;
         }

--- a/crates/oxc_ast/src/ast_impl/literal.rs
+++ b/crates/oxc_ast/src/ast_impl/literal.rs
@@ -58,7 +58,7 @@ impl NumericLiteral<'_> {
 
     /// Return raw source code for `NumericLiteral`.
     /// If `raw` is `None` (node is generated, not parsed from source), fallback to formatting `value`.
-    pub fn raw_str(&self) -> Cow<str> {
+    pub fn raw_str(&self) -> Cow<'_, str> {
         match self.raw.as_ref() {
             Some(raw) => Cow::Borrowed(raw),
             None => Cow::Owned(format!("{}", self.value)),

--- a/crates/oxc_ast/src/ast_kind_impl.rs
+++ b/crates/oxc_ast/src/ast_kind_impl.rs
@@ -251,7 +251,7 @@ impl AstKind<'_> {
     ///
     /// Note that this method does not exist in release builds. Do not include
     /// usage of this method within your code.
-    pub fn debug_name(&self) -> std::borrow::Cow<str> {
+    pub fn debug_name(&self) -> std::borrow::Cow<'_, str> {
         use std::borrow::Cow;
 
         const COMPUTED: Cow<'static, str> = Cow::Borrowed("<computed>");

--- a/crates/oxc_ast_visit/src/utf8_to_utf16.rs
+++ b/crates/oxc_ast_visit/src/utf8_to_utf16.rs
@@ -59,7 +59,7 @@ impl Utf8ToUtf16 {
     /// It will also correctly handle offsets in any order, but at a performance cost.
     ///
     /// Returns `None` if the source text is entirely ASCII, and so requires no conversion.
-    pub fn converter(&self) -> Option<Utf8ToUtf16Converter> {
+    pub fn converter(&self) -> Option<Utf8ToUtf16Converter<'_>> {
         if self.translations.is_empty() {
             None
         } else {

--- a/crates/oxc_ecmascript/src/private_bound_identifiers.rs
+++ b/crates/oxc_ecmascript/src/private_bound_identifiers.rs
@@ -5,11 +5,11 @@ use oxc_ast::ast::{
 
 /// [`PrivateBoundIdentifiers`](https://tc39.es/ecma262/#sec-static-semantics-privateboundidentifiers)
 pub trait PrivateBoundIdentifiers {
-    fn private_bound_identifiers(&self) -> Option<PrivateIdentifier>;
+    fn private_bound_identifiers(&self) -> Option<PrivateIdentifier<'_>>;
 }
 
 impl PrivateBoundIdentifiers for ClassElement<'_> {
-    fn private_bound_identifiers(&self) -> Option<PrivateIdentifier> {
+    fn private_bound_identifiers(&self) -> Option<PrivateIdentifier<'_>> {
         match self {
             ClassElement::StaticBlock(_) | ClassElement::TSIndexSignature(_) => None,
             ClassElement::MethodDefinition(def) => def.private_bound_identifiers(),
@@ -20,7 +20,7 @@ impl PrivateBoundIdentifiers for ClassElement<'_> {
 }
 
 impl PrivateBoundIdentifiers for MethodDefinition<'_> {
-    fn private_bound_identifiers(&self) -> Option<PrivateIdentifier> {
+    fn private_bound_identifiers(&self) -> Option<PrivateIdentifier<'_>> {
         self.value.body.as_ref()?;
         if let PropertyKey::PrivateIdentifier(ident) = &self.key {
             return Some((*ident).clone());
@@ -30,7 +30,7 @@ impl PrivateBoundIdentifiers for MethodDefinition<'_> {
 }
 
 impl PrivateBoundIdentifiers for PropertyDefinition<'_> {
-    fn private_bound_identifiers(&self) -> Option<PrivateIdentifier> {
+    fn private_bound_identifiers(&self) -> Option<PrivateIdentifier<'_>> {
         if let PropertyKey::PrivateIdentifier(ident) = &self.key {
             return Some((*ident).clone());
         }
@@ -39,7 +39,7 @@ impl PrivateBoundIdentifiers for PropertyDefinition<'_> {
 }
 
 impl PrivateBoundIdentifiers for AccessorProperty<'_> {
-    fn private_bound_identifiers(&self) -> Option<PrivateIdentifier> {
+    fn private_bound_identifiers(&self) -> Option<PrivateIdentifier<'_>> {
         if let PropertyKey::PrivateIdentifier(ident) = &self.key {
             return Some((*ident).clone());
         }

--- a/crates/oxc_formatter/src/formatter/format_element/mod.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/mod.rs
@@ -169,7 +169,7 @@ pub const LINE_TERMINATORS: [char; 3] = ['\r', LINE_SEPARATOR, PARAGRAPH_SEPARAT
 
 /// Replace the line terminators matching the provided list with "\n"
 /// since its the only line break type supported by the printer
-pub fn normalize_newlines<const N: usize>(text: &str, terminators: [char; N]) -> Cow<str> {
+pub fn normalize_newlines<const N: usize>(text: &str, terminators: [char; N]) -> Cow<'_, str> {
     let mut result = String::new();
     let mut last_end = 0;
 

--- a/crates/oxc_formatter/src/formatter/formatter.rs
+++ b/crates/oxc_formatter/src/formatter/formatter.rs
@@ -57,7 +57,7 @@ impl<'buf, 'ast> Formatter<'buf, 'ast> {
 
     /// Returns the comments from the context.
     #[inline]
-    pub fn comments(&self) -> &Comments {
+    pub fn comments(&self) -> &Comments<'_> {
         self.context().comments()
     }
 

--- a/crates/oxc_formatter/src/formatter/token/string.rs
+++ b/crates/oxc_formatter/src/formatter/token/string.rs
@@ -49,7 +49,7 @@ pub fn normalize_string(
     raw_content: &str,
     preferred_quote: Quote,
     quotes_will_change: bool,
-) -> Cow<str> {
+) -> Cow<'_, str> {
     let alternate_quote = preferred_quote.other().as_byte();
     let preferred_quote = preferred_quote.as_byte();
     let mut reduced_string = String::new();

--- a/crates/oxc_formatter/src/formatter/trivia.rs
+++ b/crates/oxc_formatter/src/formatter/trivia.rs
@@ -367,7 +367,7 @@ impl<'a> Format<'a> for FormatDanglingComments<'a> {
 ///
 /// ## Warning
 /// It's your responsibility to format any skipped trivia.
-pub const fn format_trimmed_token(token: &SyntaxToken) -> FormatTrimmedToken {
+pub const fn format_trimmed_token(token: &SyntaxToken) -> FormatTrimmedToken<'_> {
     FormatTrimmedToken { token }
 }
 

--- a/crates/oxc_linter/src/config/settings/jsdoc.rs
+++ b/crates/oxc_linter/src/config/settings/jsdoc.rs
@@ -100,7 +100,7 @@ impl Default for JSDocPluginSettings {
 impl JSDocPluginSettings {
     /// Only for `check-tag-names` rule
     /// Return `Some(reason)` if blocked
-    pub fn check_blocked_tag_name(&self, tag_name: &str) -> Option<Cow<str>> {
+    pub fn check_blocked_tag_name(&self, tag_name: &str) -> Option<Cow<'_, str>> {
         match self.tag_name_preference.get(tag_name) {
             Some(TagNamePreference::FalseOnly(_)) => {
                 Some(Cow::Owned(format!("Unexpected tag `@{tag_name}`.")))
@@ -112,7 +112,7 @@ impl JSDocPluginSettings {
 
     /// Only for `check-tag-names` rule
     /// Return `Some(reason)` if replacement found or default aliased
-    pub fn check_preferred_tag_name(&self, original_name: &str) -> Option<Cow<str>> {
+    pub fn check_preferred_tag_name(&self, original_name: &str) -> Option<Cow<'_, str>> {
         let reason = |preferred_name: &str| -> Cow<str> {
             Cow::Owned(format!("Replace tag `@{original_name}` with `@{preferred_name}`."))
         };

--- a/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
+++ b/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
@@ -325,7 +325,7 @@ struct ParsedNumberLiteral<'n> {
     exponent_part: Option<&'n str>,
 }
 
-fn parse_number_literal(num: &str) -> ParsedNumberLiteral {
+fn parse_number_literal(num: &str) -> ParsedNumberLiteral<'_> {
     let mut parsed = ParsedNumberLiteral {
         integer_part: None,
         decimal_part: None,

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -795,7 +795,7 @@ impl Runtime {
         path: &Arc<OsStr>,
         check_syntax_errors: bool,
         tx_error: &DiagnosticSender,
-    ) -> ModuleProcessOutput {
+    ) -> ModuleProcessOutput<'_> {
         let default_output = || ModuleProcessOutput {
             path: Arc::clone(path),
             processed_module: ProcessedModule::default(),

--- a/crates/oxc_semantic/src/class/table.rs
+++ b/crates/oxc_semantic/src/class/table.rs
@@ -71,7 +71,7 @@ impl<'a> ClassTable<'a> {
     pub fn iter_private_identifiers(
         &self,
         class_id: ClassId,
-    ) -> impl Iterator<Item = &PrivateIdentifierReference> + '_ {
+    ) -> impl Iterator<Item = &PrivateIdentifierReference<'_>> + '_ {
         self.private_identifier_references[class_id].iter()
     }
 

--- a/crates/oxc_semantic/src/jsdoc/parser/parse.rs
+++ b/crates/oxc_semantic/src/jsdoc/parser/parse.rs
@@ -8,7 +8,10 @@ use super::{
 
 /// source_text: Inside of /**HERE*/, NOT includes `/**` and `*/`
 /// span_start: Global positioned `Span` start for this JSDoc comment
-pub fn parse_jsdoc(source_text: &str, jsdoc_span_start: u32) -> (JSDocCommentPart, Vec<JSDocTag>) {
+pub fn parse_jsdoc(
+    source_text: &str,
+    jsdoc_span_start: u32,
+) -> (JSDocCommentPart<'_>, Vec<JSDocTag<'_>>) {
     debug_assert!(!source_text.starts_with("/*"));
     debug_assert!(!source_text.ends_with("*/"));
 
@@ -115,7 +118,7 @@ pub fn parse_jsdoc(source_text: &str, jsdoc_span_start: u32) -> (JSDocCommentPar
 }
 
 /// tag_content: Starts with `@`, may be multiline
-fn parse_jsdoc_tag(tag_content: &str, jsdoc_tag_span: Span) -> JSDocTag {
+fn parse_jsdoc_tag(tag_content: &str, jsdoc_tag_span: Span) -> JSDocTag<'_> {
     debug_assert!(tag_content.starts_with('@'));
     // This surely exists, at least `@` itself
     let (k_start, k_end) = utils::find_token_range(tag_content).unwrap();

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -120,7 +120,7 @@ impl<'a> Semantic<'a> {
         (&mut self.scoping, &self.nodes)
     }
 
-    pub fn classes(&self) -> &ClassTable {
+    pub fn classes(&self) -> &ClassTable<'_> {
         &self.classes
     }
 

--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -472,7 +472,7 @@ impl Scoping {
     }
 
     #[inline]
-    pub fn root_unresolved_references(&self) -> &UnresolvedReferences {
+    pub fn root_unresolved_references(&self) -> &UnresolvedReferences<'_> {
         &self.cell.borrow_dependent().root_unresolved_references
     }
 
@@ -635,7 +635,7 @@ impl Scoping {
 
     /// Get all bound identifiers in a scope.
     #[inline]
-    pub fn get_bindings(&self, scope_id: ScopeId) -> &Bindings {
+    pub fn get_bindings(&self, scope_id: ScopeId) -> &Bindings<'_> {
         &self.cell.borrow_dependent().bindings[scope_id]
     }
 
@@ -652,7 +652,7 @@ impl Scoping {
     /// If you only want bindings in a specific scope, use [`iter_bindings_in`].
     ///
     /// [`iter_bindings_in`]: Scoping::iter_bindings_in
-    pub fn iter_bindings(&self) -> impl Iterator<Item = (ScopeId, &Bindings)> + '_ {
+    pub fn iter_bindings(&self) -> impl Iterator<Item = (ScopeId, &Bindings<'_>)> + '_ {
         self.cell.borrow_dependent().bindings.iter_enumerated()
     }
 

--- a/crates/oxc_semantic/tests/integration/util/mod.rs
+++ b/crates/oxc_semantic/tests/integration/util/mod.rs
@@ -208,7 +208,7 @@ impl<'a> SemanticTester<'a> {
     ///
     /// ## Fails
     /// If no symbol with the given name exists at the top-level scope.
-    pub fn has_root_symbol(&self, name: &str) -> SymbolTester {
+    pub fn has_root_symbol(&self, name: &str) -> SymbolTester<'_> {
         SymbolTester::new_at_root(self, self.build(), name)
     }
 
@@ -216,7 +216,7 @@ impl<'a> SemanticTester<'a> {
     ///
     /// ## Fails
     /// 1. No symbol with the given name exists,
-    pub fn has_symbol(&self, name: &str) -> SymbolTester {
+    pub fn has_symbol(&self, name: &str) -> SymbolTester<'_> {
         SymbolTester::new_first_binding(self, self.build(), name)
     }
 
@@ -224,7 +224,7 @@ impl<'a> SemanticTester<'a> {
     ///
     /// ## Fails
     /// If no class with the given name exists.
-    pub fn has_class(&self, name: &str) -> ClassTester {
+    pub fn has_class(&self, name: &str) -> ClassTester<'_> {
         ClassTester::has_class(self.build(), name)
     }
 
@@ -263,7 +263,7 @@ impl<'a> SemanticTester<'a> {
     /// 1. No symbol with the given name exists,
     /// 2. More than one symbol with the given name exists, so a symbol cannot
     ///    be uniquely obtained.
-    pub fn has_some_symbol(&self, name: &str) -> SymbolTester {
+    pub fn has_some_symbol(&self, name: &str) -> SymbolTester<'_> {
         SymbolTester::new_unique(self, self.build(), name)
     }
 

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -310,7 +310,7 @@ impl<'a, 'ctx> AutomaticModuleBindings<'a, 'ctx> {
 }
 
 #[inline]
-fn get_import_source(jsx_runtime_importer: &str, react_importer_len: u32) -> Atom {
+fn get_import_source(jsx_runtime_importer: &str, react_importer_len: u32) -> Atom<'_> {
     Atom::from(&jsx_runtime_importer[..react_importer_len as usize])
 }
 

--- a/tasks/ast_tools/src/parse/attr.rs
+++ b/tasks/ast_tools/src/parse/attr.rs
@@ -91,7 +91,7 @@ pub enum AttrLocation<'d> {
 
 impl AttrLocation<'_> {
     /// Convert `&mut AttrLocation` to `AttrLocation`.
-    pub fn unpack(&mut self) -> AttrLocation {
+    pub fn unpack(&mut self) -> AttrLocation<'_> {
         match self {
             AttrLocation::Struct(struct_def) => AttrLocation::Struct(struct_def),
             AttrLocation::Enum(enum_def) => AttrLocation::Enum(enum_def),


### PR DESCRIPTION
Where a type being returned by a function has lifetimes, specify them with `'_` instead of omitting them entirely. `Cow<str>` -> `Cow<'_, str>`.

This is split out from Rust upgrade PR #12873, so can see the diff in that PR more clearly.

Note: This is very slightly different from what was in #12873. Clippy auto-fix introduced a couple of unnecessary and weird-looking anonymous lifetimes in function params, which this PR skips.
