### PR TITLE
refactor(cfg, formatter): remove unnecessary `return` statements

### DIFF
--- a/crates/oxc_cfg/src/lib.rs
+++ b/crates/oxc_cfg/src/lib.rs
@@ -146,7 +146,7 @@ impl ControlFlowGraph {
                 if unreachable {
                     Control::Prune
                 } else if b == to {
-                    return Control::Break(true);
+                    Control::Break(true)
                 } else {
                     Control::Continue
                 }

--- a/crates/oxc_formatter/src/write/type_parameters.rs
+++ b/crates/oxc_formatter/src/write/type_parameters.rs
@@ -64,7 +64,7 @@ impl<'a> Format<'a> for FormatTsTypeParameters<'a, '_> {
         if self.decl.params().is_empty() && self.options.is_type_or_interface_decl {
             write!(f, "<>")
         } else if self.decl.params().is_empty() {
-            return Err(FormatError::SyntaxError);
+            Err(FormatError::SyntaxError)
         } else {
             write!(
                 f,


### PR DESCRIPTION
The explicit `return`s here are not required. Found by clippy in #12873.