### PR TITLE
chore(deps): raise MSRV to 1.87.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ repository = "https://github.com/oxc-project/oxc"
 description = "A collection of JavaScript tools written in Rust."
 
 edition = "2024"
-# MSRV Policy N-2 (12 weeks) starting from v1.87.0
+# MSRV Policy N-2 (12 weeks).
 # Balance between the core contributors enjoying the latest version of rustc, while waiting for dependents to catch up.
-rust-version = "1.86.0"
+rust-version = "1.87.0"
 
 # <https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html>
 [workspace.lints.rust]

--- a/crates/oxc_data_structures/src/pointer_ext.rs
+++ b/crates/oxc_data_structures/src/pointer_ext.rs
@@ -85,7 +85,7 @@ trait PointerExtImpl: Sized {
 
 /// Native version - just delegates to Rust's methods.
 #[rustversion::since(1.87.0)]
-#[expect(clippy::incompatible_msrv, clippy::undocumented_unsafe_blocks)]
+#[expect(clippy::undocumented_unsafe_blocks)]
 const _: () = {
     impl<T> PointerExtImpl for *const T {
         #[inline(always)]


### PR DESCRIPTION
#12873 bumped Rust version to 1.89.0. In line with our N-2 MSRV policy, raise MSRV to 1.87.0.