### PR TITLE
test(linter/expect-expect): add test case for `expect` call in for loop

### DIFF
--- a/crates/oxc_linter/src/rules/jest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/expect_expect.rs
@@ -494,6 +494,7 @@ fn test() {
             "#,
             None,
         ),
+        ("it('test', async () => { const array = [1]; for (const element of array) { expect(element).toBe(1); } });", None)
     ];
 
     let mut fail = vec![


### PR DESCRIPTION
fixes #12905