### PR TITLE
test(oxlint): fix `--type-aware` test on `big-endian` and skip for `windows`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
+      - uses: oxc-project/setup-node@f42e3bda950c7454575e78ee4eaac880a077700c # v1.0.0
       - uses: oxc-project/setup-rust@cd82e1efec7fef815e2c23d296756f31c7cdc03d # v1.0.0
         with:
           save-cache: ${{ github.ref_name == 'main' }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Clone submodules
         uses: ./.github/actions/clone-submodules
 
+      - uses: oxc-project/setup-node@f42e3bda950c7454575e78ee4eaac880a077700c # v1.0.0
+
       - uses: oxc-project/setup-rust@cd82e1efec7fef815e2c23d296756f31c7cdc03d # v1.0.0
         with:
           cache-key: codecov

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1215,6 +1215,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(target_os = "windows"))] // ToDo: my guess is the missing `.exe` suffix when searching
     fn test_tsgolint() {
         let args = &["--type-aware", "-c", ".oxlintrc.json"];
         Tester::new().with_cwd("fixtures/tsgolint".into()).test_and_snapshot(args);


### PR DESCRIPTION
https://github.com/oxc-project/oxc/actions/runs/16831534930/job/47680206750
https://github.com/oxc-project/oxc/actions/runs/16831534945/job/47680206813
https://github.com/oxc-project/oxc/actions/runs/16831534945/job/47680206827