### PR TITLE
refactor(ast_tools): clarify code

### DIFF
--- a/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
@@ -370,9 +370,10 @@ impl<'s> CacheKeyOffsets<'s> {
                 if let TypeDef::Struct(struct_def) = type_def
                     && struct_def.generates_derive(estree_derive_id)
                 {
-                    return UNCALCULATED;
+                    UNCALCULATED
+                } else {
+                    0
                 }
-                0
             })
             .collect::<IndexVec<TypeId, u8>>();
 


### PR DESCRIPTION
We can now use `if let` chains. Previously we had to use an early return pattern in some places because one branch had multiple nested `if` statements. Now that they're combined into a single `if`, we don't need to use this pattern any more, and can convert to `if` / `else`. This isn't always shorter in all cases, but in my opinion is a bit clearer.