### PR TITLE
test(coverage): clarify code

### DIFF
--- a/tasks/coverage/src/runtime/mod.rs
+++ b/tasks/coverage/src/runtime/mod.rs
@@ -235,13 +235,12 @@ impl Test262RuntimeCase {
             Ok(output) => {
                 if output.is_empty() {
                     TestResult::Passed
+                } else if let Some(negative) = &self.base.meta().negative
+                    && negative.phase.is_runtime()
+                    && output.starts_with(&negative.error_type.to_string())
+                {
+                    TestResult::Passed
                 } else {
-                    if let Some(negative) = &self.base.meta().negative
-                        && negative.phase.is_runtime()
-                        && output.starts_with(&negative.error_type.to_string())
-                    {
-                        return TestResult::Passed;
-                    }
                     TestResult::GenericError(case, output)
                 }
             }

--- a/tasks/transform_conformance/src/lib.rs
+++ b/tasks/transform_conformance/src/lib.rs
@@ -109,9 +109,10 @@ impl TestRunner {
                     if let Some(filter) = &options.filter
                         && !e.path().to_string_lossy().contains(filter)
                     {
-                        return false;
+                        false
+                    } else {
+                        true
                     }
-                    true
                 })
                 .filter_map(|e| TestCase::new(cwd, e.path()))
                 .filter(|test_case| !test_case.skip_test_case())

--- a/tasks/transform_conformance/src/test_case.rs
+++ b/tasks/transform_conformance/src/test_case.rs
@@ -121,10 +121,10 @@ impl TestCase {
         if let Some(output_path) = Self::convert_to_override_path(&babel_output_path)
             && output_path.exists()
         {
-            return Some(output_path);
+            Some(output_path)
+        } else {
+            Some(babel_output_path)
         }
-
-        Some(babel_output_path)
     }
 
     pub fn write_override_output(&self) {


### PR DESCRIPTION
We can now use `if let` chains. Previously we had to use an early return pattern in some places because one branch had multiple nested `if` statements. Now that they're combined into a single `if`, we don't need to use this pattern any more, and can convert to `if` / `else`. Usually this is shorter, but even when it's not, in my opinion it's a bit clearer.