### PR TITLE
refactor(website): clarify code

### DIFF
--- a/tasks/website/src/linter/cli.rs
+++ b/tasks/website/src/linter/cli.rs
@@ -44,10 +44,10 @@ fn generate_cli() -> String {
             if let Some(line) = line.strip_prefix("**")
                 && let Some(line) = line.strip_suffix("**")
             {
-                return format!("## {line}");
+                format!("## {line}")
+            } else {
+                line.to_string()
             }
-
-            line.to_string()
         })
         .collect::<Vec<_>>()
         .join("\n")


### PR DESCRIPTION
Tiny refactor. Clarify code using `if let` chain by converting to an `if` / `else` statement, rather than using early return. In my opinion it's a bit clearer.