### PR TITLE
docs(tasks): correct comment to match code

### DIFF
--- a/tasks/common/src/request.rs
+++ b/tasks/common/src/request.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use ureq::{Agent, Proxy};
 
 /// detect proxy from environment variable in following order:
-/// ALL_PROXY | all_proxy | HTTPS_PROXY | https_proxy | HTTP_PROXY | http_proxy
+/// HTTPS_PROXY | https_proxy | HTTP_PROXY | http_proxy | ALL_PROXY | all_proxy
 fn detect_proxy() -> Option<Proxy> {
     for env in ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy"]
     {


### PR DESCRIPTION
Happened to come across this. The comment didn't match the code here.

I *assume* the code is right and the comment is outdated, so this PR amends the comment. But I don't know what this code does, so maybe it's the other way around and the code should be changed to match the comment?
