### PR TITLE
fix(linter): fix no-fallthrough rule, when the default condition is not last

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
@@ -471,7 +471,7 @@ fn get_switch_semantic_cases(
                 (cfg_ids, conds, exit)
             } else {
                 if has_default {
-                    cfg_ids.push(target)
+                    cfg_ids.push(target);
                 }
                 (cfg_ids, conds, Some(target))
             }

--- a/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
@@ -477,11 +477,7 @@ fn get_switch_semantic_cases(
             }
         });
 
-    let (default, exit) = if has_default {
-        (exit, None)
-    } else {
-        (None, exit)
-    };
+    let (default, exit) = if has_default { (exit, None) } else { (None, exit) };
     cfg_ids.reverse();
     (cfg_ids, FxHashMap::from_iter(tests), default, exit)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
@@ -437,12 +437,12 @@ fn get_switch_semantic_cases(
     let cfg = ctx.cfg();
     let graph = cfg.graph();
     let has_default = switch.cases.iter().any(SwitchCase::is_default_case);
-    let (tests, exit) = graph
+    let (mut cfg_ids, tests, exit) = graph
         .edges_directed(node.cfg_id(), Direction::Outgoing)
-        .fold((Vec::new(), None), |(mut conds, exit), it| {
+        .fold((Vec::new(), Vec::new(), None), |(mut cfg_ids, mut conds, exit), it| {
             let target = it.target();
             if !matches!(it.weight(), EdgeType::Normal) {
-                (conds, exit)
+                (cfg_ids, conds, exit)
             } else if cfg
                 .basic_block(target)
                 .instructions()
@@ -466,22 +466,23 @@ fn get_switch_semantic_cases(
                             })
                     })
                     .is_some_and(|it| it.consequent.is_empty() || it.consequent.iter().exactly_one().is_ok_and(|it| matches!(it, Statement::BlockStatement(b) if b.body.is_empty())));
+                cfg_ids.push(target);
                 conds.push((target, is_empty));
-                (conds, exit)
+                (cfg_ids, conds, exit)
             } else {
-                (conds, Some(target))
+                if has_default {
+                    cfg_ids.push(target)
+                }
+                (cfg_ids, conds, Some(target))
             }
         });
 
-    let mut cfg_ids: Vec<_> = tests.iter().rev().map(|it| it.0).collect();
     let (default, exit) = if has_default {
-        if let Some(exit) = exit {
-            cfg_ids.push(exit);
-        }
         (exit, None)
     } else {
         (None, exit)
     };
+    cfg_ids.reverse();
     (cfg_ids, FxHashMap::from_iter(tests), default, exit)
 }
 
@@ -535,6 +536,7 @@ fn test() {
             "switch (foo) { case 0: a(); \n// eslint-disable-next-line no-fallthrough\n case 1: }",
             None,
         ),
+        ("switch(foo) { case 0: default: a(); break; case 1: b(); }", None),
         (
             "switch(foo) { case 0: a(); /* no break */ case 1: b(); }",
             Some(serde_json::json!([{


### PR DESCRIPTION
In the previous implementation, if the default condition was not the last one, the order of cfg_ids was incorrect

fixes #12793