### PR TITLE
refactor(ast_tools/formatter): shorten code

### DIFF
--- a/tasks/ast_tools/src/generators/formatter/ast_nodes.rs
+++ b/tasks/ast_tools/src/generators/formatter/ast_nodes.rs
@@ -9,7 +9,7 @@ use crate::{
     Codegen, Generator,
     generators::define_generator,
     output::{Output, output_path},
-    schema::{self, Def, EnumDef, FieldDef, Schema, StructDef, TypeDef},
+    schema::{Def, EnumDef, FieldDef, Schema, StructDef, TypeDef, VariantDef},
 };
 
 pub fn get_node_type(ty: &TokenStream) -> TokenStream {
@@ -197,21 +197,8 @@ impl Generator for FormatterAstNodesGenerator {
 }
 
 fn get_all_statement_variants_names(schema: &Schema) -> Vec<&str> {
-    let Some(type_id) = schema.type_names.get("Statement") else {
-        return vec![];
-    };
-
-    let enum_def = schema.types.get(*type_id).unwrap().as_enum().unwrap();
-
-    enum_def
-        .variants
-        .iter()
-        .map(schema::VariantDef::name)
-        .chain(enum_def.inherits_types(schema).flat_map(|inherited_type| {
-            let inherited_enum_def = inherited_type.as_enum().unwrap();
-            inherited_enum_def.variants.iter().map(schema::VariantDef::name)
-        }))
-        .collect()
+    let statement_enum = schema.type_by_name("Statement").as_enum().unwrap();
+    statement_enum.all_variants(schema).map(VariantDef::name).collect()
 }
 
 fn generate_struct_impls(


### PR DESCRIPTION
Follow-on after #12864. Pure refactor, does not alter generated code.

Shorten code by using `Schema::type_by_name` and `EnumDef::all_variants` methods.

`EnumDef::all_variants` iterates over all variants of an enum, including inherited variants. As well as being shorter, it also correctly handles multiple layers of inheritance e.g. if `X` inherits variants from `Y`, and `Y` inherits variants from `Z`.

In the case of `Statement`, inheritance is only 1 level deep, so it makes no difference - but it might if we change the AST later on.
