### PR TITLE
refactor(tasks/track_memory_allocations): shorten code

### DIFF
--- a/tasks/track_memory_allocations/src/lib.rs
+++ b/tasks/track_memory_allocations/src/lib.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use humansize::{DECIMAL, format_size};
+use mimalloc_safe::MiMalloc;
 
 use oxc_allocator::Allocator;
 use oxc_parser::{ParseOptions, Parser};
@@ -38,7 +39,7 @@ fn reset_global_allocs() {
 #[expect(unsafe_code, clippy::undocumented_unsafe_blocks)]
 unsafe impl GlobalAlloc for TrackedAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        let ret = unsafe { mimalloc_safe::MiMalloc.alloc(layout) };
+        let ret = unsafe { MiMalloc.alloc(layout) };
         if !ret.is_null() {
             NUM_ALLOC.fetch_add(1, SeqCst);
         }
@@ -46,20 +47,19 @@ unsafe impl GlobalAlloc for TrackedAllocator {
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        unsafe {
-            mimalloc_safe::MiMalloc.dealloc(ptr, layout);
-        }
+        unsafe { MiMalloc.dealloc(ptr, layout) };
     }
 
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
-        let ret = unsafe { mimalloc_safe::MiMalloc.alloc_zeroed(layout) };
+        let ret = unsafe { MiMalloc.alloc_zeroed(layout) };
         if !ret.is_null() {
             NUM_ALLOC.fetch_add(1, SeqCst);
         }
         ret
     }
+
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        let ret = unsafe { mimalloc_safe::MiMalloc.realloc(ptr, layout, new_size) };
+        let ret = unsafe { MiMalloc.realloc(ptr, layout, new_size) };
         if !ret.is_null() {
             NUM_REALLOC.fetch_add(1, SeqCst);
         }


### PR DESCRIPTION
Pure refactor. Shorten code by hoisting import of `MiMalloc` to top level, and tweak formatting.