### PR TITLE
fix(semantic): label redeclaration check for crossing boundary on arrow function (#12679)

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -765,7 +765,9 @@ pub fn check_labeled_statement(stmt: &LabeledStatement, ctx: &SemanticBuilder<'_
     for node_kind in ctx.nodes.ancestor_kinds(ctx.current_node_id) {
         match node_kind {
             // label cannot cross boundary on function or static block
-            AstKind::Function(_) | AstKind::ArrowFunctionExpression(_) | AstKind::StaticBlock(_) => break,
+            AstKind::Function(_)
+            | AstKind::ArrowFunctionExpression(_)
+            | AstKind::StaticBlock(_) => break,
             // check label name redeclaration
             AstKind::LabeledStatement(label_stmt) if stmt.label.name == label_stmt.label.name => {
                 return ctx.error(label_redeclaration(

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -765,7 +765,7 @@ pub fn check_labeled_statement(stmt: &LabeledStatement, ctx: &SemanticBuilder<'_
     for node_kind in ctx.nodes.ancestor_kinds(ctx.current_node_id) {
         match node_kind {
             // label cannot cross boundary on function or static block
-            AstKind::Function(_) | AstKind::StaticBlock(_) => break,
+            AstKind::Function(_) | AstKind::ArrowFunctionExpression(_) | AstKind::StaticBlock(_) => break,
             // check label name redeclaration
             AstKind::LabeledStatement(label_stmt) if stmt.label.name == label_stmt.label.name => {
                 return ctx.error(label_redeclaration(

--- a/tasks/coverage/misc/pass/oxc-12679.js
+++ b/tasks/coverage/misc/pass/oxc-12679.js
@@ -1,0 +1,5 @@
+label: while (true) {
+  (() => {
+    label: while (false) {}
+  })();
+}

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 45/45 (100.00%)
-Positive Passed: 45/45 (100.00%)
+AST Parsed     : 46/46 (100.00%)
+Positive Passed: 46/46 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 45/45 (100.00%)
-Positive Passed: 45/45 (100.00%)
+AST Parsed     : 46/46 (100.00%)
+Positive Passed: 46/46 (100.00%)
 Negative Passed: 54/54 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 45/45 (100.00%)
-Positive Passed: 29/45 (64.44%)
+AST Parsed     : 46/46 (100.00%)
+Positive Passed: 30/46 (65.22%)
 semantic Error: tasks/coverage/misc/pass/oxc-11593.ts
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 45/45 (100.00%)
-Positive Passed: 45/45 (100.00%)
+AST Parsed     : 46/46 (100.00%)
+Positive Passed: 46/46 (100.00%)


### PR DESCRIPTION
In the previous implementation, check label cross boundary on function or static block, but ignore arrow function

fixes #12679 