### PR TITLE
feat(linter): add jest/padding-around-test-blocks rule

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -304,6 +304,7 @@ mod jest {
     pub mod no_test_prefixes;
     pub mod no_test_return_statement;
     pub mod no_untyped_mock_factory;
+    pub mod padding_around_test_blocks;
     pub mod prefer_called_with;
     pub mod prefer_comparison_matcher;
     pub mod prefer_each;
@@ -827,6 +828,7 @@ oxc_macros::declare_all_lint_rules! {
     jest::no_test_prefixes,
     jest::no_test_return_statement,
     jest::no_untyped_mock_factory,
+    jest::padding_around_test_blocks,
     jest::prefer_each,
     jest::prefer_called_with,
     jest::prefer_comparison_matcher,

--- a/crates/oxc_linter/src/rules/jest/padding_around_test_blocks.rs
+++ b/crates/oxc_linter/src/rules/jest/padding_around_test_blocks.rs
@@ -1,8 +1,10 @@
+use std::ops::Deref;
+
 use itertools::Itertools;
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{GetSpan, Span};
+use oxc_span::{CompactStr, GetSpan, Span};
 
 use crate::{
     AstNode,
@@ -14,9 +16,9 @@ use crate::{
     },
 };
 
-fn padding_around_test_blocks_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Missing padding before test/it block")
-        .with_help("Make sure there is an empty new line before the test/it block")
+fn padding_around_test_blocks_diagnostic(span: Span, name: &CompactStr) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Missing padding before {name} block"))
+        .with_help(format!("Make sure there is an empty new line before the {name} block"))
         .with_label(span)
 }
 
@@ -66,7 +68,7 @@ declare_oxc_lint!(
 );
 
 enum NodeType {
-    Test,
+    Test(CompactStr),
     Statement,
 }
 
@@ -80,12 +82,12 @@ impl Rule for PaddingAroundTestBlocks {
                     return None;
                 };
                 let jest_fn_call = parse_general_jest_fn_call(call_expr, possible_jest_node, ctx)?;
-                let ParsedGeneralJestFnCall { kind, .. } = &jest_fn_call;
+                let ParsedGeneralJestFnCall { kind, name, .. } = &jest_fn_call;
                 let kind = kind.to_general()?;
                 if kind != JestGeneralFnKind::Test {
                     return None;
                 }
-                Some((NodeType::Test, node))
+                Some((NodeType::Test(name.deref().into()), node))
             })
             .collect_vec();
         for node in ctx.nodes() {
@@ -97,7 +99,7 @@ impl Rule for PaddingAroundTestBlocks {
         let mut prev_node: Option<&AstNode<'_>> = None;
         for (node_type, node) in nodes {
             match node_type {
-                NodeType::Test => {
+                NodeType::Test(name) => {
                     if let Some(prev_node) = prev_node {
                         if prev_node.span().end > node.span().start {
                             continue;
@@ -126,15 +128,15 @@ impl Rule for PaddingAroundTestBlocks {
                         let span_between = Span::new(span_between_start, span_between_end);
                         let content = ctx.source_range(span_between);
                         if content.matches('\n').count() < 2 {
-                            let spaces_after_last_line = content
-                                .rfind('\n')
-                                .map_or("", |index| content.split_at(index + 1).1);
                             ctx.diagnostic_with_fix(
-                                padding_around_test_blocks_diagnostic(Span::new(
-                                    span_between_end,
-                                    span_between_end,
-                                )),
+                                padding_around_test_blocks_diagnostic(
+                                    Span::new(span_between_end, span_between_end),
+                                    &name,
+                                ),
                                 |fixer| {
+                                    let spaces_after_last_line = content
+                                        .rfind('\n')
+                                        .map_or("", |index| content.split_at(index + 1).1);
                                     fixer.replace(
                                         span_between,
                                         format!("\n\n{spaces_after_last_line}"),
@@ -170,6 +172,18 @@ fn test() {
         "test('foo', () => {});\ntest('bar', () => {});",
         "it('foo', () => {});\nfit('bar', () => {});\ntest('baz', () => {});",
         r"
+const foo = 'bar';
+const bar = 'baz';
+it('foo', () => {
+  // stuff
+});
+fit('bar', () => {
+  // stuff
+});
+test('foo foo', () => {});
+test('bar bar', () => {});
+
+// Nesting
  describe('other bar', () => {
      const thing = 123;
      test('is another bar w/ test', () => {
@@ -201,6 +215,18 @@ fn test() {
         ),
         (
             r"
+const foo = 'bar';
+const bar = 'baz';
+it('foo', () => {
+  // stuff
+});
+fit('bar', () => {
+  // stuff
+});
+test('foo foo', () => {});
+test('bar bar', () => {});
+
+// Nesting
 describe('other bar', () => {
     const thing = 123;
     test('is another bar w/ test', () => {
@@ -216,6 +242,22 @@ test
 xit('bar foo', () => {});
         ",
             r"
+const foo = 'bar';
+const bar = 'baz';
+
+it('foo', () => {
+  // stuff
+});
+
+fit('bar', () => {
+  // stuff
+});
+
+test('foo foo', () => {});
+
+test('bar bar', () => {});
+
+// Nesting
 describe('other bar', () => {
     const thing = 123;
 

--- a/crates/oxc_linter/src/rules/jest/padding_around_test_blocks.rs
+++ b/crates/oxc_linter/src/rules/jest/padding_around_test_blocks.rs
@@ -1,0 +1,246 @@
+use itertools::Itertools;
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        JestGeneralFnKind, ParsedGeneralJestFnCall, collect_possible_jest_call_node,
+        parse_general_jest_fn_call,
+    },
+};
+
+fn padding_around_test_blocks_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Missing padding before test/it block")
+        .with_help("Make sure there is an empty new line before the test/it block")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PaddingAroundTestBlocks;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// This rule enforces a line of padding before and after 1 or more test/it statements
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// const thing = 123;
+    /// test('foo', () => {});
+    /// test('bar', () => {});
+    /// ```
+    ///
+    /// ```js
+    /// const thing = 123;
+    /// it('foo', () => {});
+    /// it('bar', () => {});
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// const thing = 123;
+    ///
+    /// test('foo', () => {});
+    ///
+    /// test('bar', () => {});
+    /// ```
+    ///
+    /// ```js
+    /// const thing = 123;
+    ///
+    /// it('foo', () => {});
+    ///
+    /// it('bar', () => {});
+    /// ```
+    PaddingAroundTestBlocks,
+    jest,
+    style,
+    fix
+);
+
+enum NodeType {
+    Test,
+    Statement,
+}
+
+impl Rule for PaddingAroundTestBlocks {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let mut nodes = collect_possible_jest_call_node(ctx)
+            .iter()
+            .filter_map(|possible_jest_node| {
+                let node = possible_jest_node.node;
+                let AstKind::CallExpression(call_expr) = node.kind() else {
+                    return None;
+                };
+                let jest_fn_call = parse_general_jest_fn_call(call_expr, possible_jest_node, ctx)?;
+                let ParsedGeneralJestFnCall { kind, .. } = &jest_fn_call;
+                let kind = kind.to_general()?;
+                if kind != JestGeneralFnKind::Test {
+                    return None;
+                }
+                Some((NodeType::Test, node))
+            })
+            .collect_vec();
+        for node in ctx.nodes() {
+            if node.kind().is_statement() {
+                nodes.push((NodeType::Statement, node));
+            }
+        }
+        nodes.sort_by_key(|(_, node)| node.span().end);
+        let mut prev_node: Option<&AstNode<'_>> = None;
+        for (node_type, node) in nodes {
+            match node_type {
+                NodeType::Test => {
+                    if let Some(prev_node) = prev_node {
+                        if prev_node.span().end > node.span().start {
+                            continue;
+                        }
+                        let mut comments_range =
+                            ctx.comments_range(prev_node.span().end..node.span().start);
+                        let mut span_between_start = prev_node.span().end;
+                        let mut span_between_end = node.span().start;
+                        if let Some(last_comment_span) =
+                            comments_range.next_back().map(|comment| comment.span)
+                        {
+                            let space_after_last_comment = ctx
+                                .source_range(Span::new(last_comment_span.end, node.span().start));
+                            let space_before_last_comment = ctx.source_range(Span::new(
+                                prev_node.span().end,
+                                last_comment_span.start,
+                            ));
+                            if space_after_last_comment.matches('\n').count() > 1
+                                || space_before_last_comment.matches('\n').count() == 0
+                            {
+                                span_between_start = last_comment_span.end;
+                            } else {
+                                span_between_end = last_comment_span.start;
+                            }
+                        }
+                        let span_between = Span::new(span_between_start, span_between_end);
+                        let content = ctx.source_range(span_between);
+                        if content.matches('\n').count() < 2 {
+                            let spaces_after_last_line = content
+                                .rfind('\n')
+                                .map_or("", |index| content.split_at(index + 1).1);
+                            ctx.diagnostic_with_fix(
+                                padding_around_test_blocks_diagnostic(Span::new(
+                                    span_between_end,
+                                    span_between_end,
+                                )),
+                                |fixer| {
+                                    fixer.replace(
+                                        span_between,
+                                        format!("\n\n{spaces_after_last_line}"),
+                                    )
+                                },
+                            );
+                        }
+                    }
+                    prev_node = Some(node);
+                }
+                NodeType::Statement => {
+                    prev_node = Some(node);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "test('foo', () => {});",
+        "test('foo', () => {});\n\ntest('bar', () => {});",
+        "const thing = 123;\n\ntest('foo', () => {});",
+        "{ test('foo', () => {}); }",
+        "describe('foo', () => {\ntest('bar', () => {});\n});",
+    ];
+
+    let fail = vec![
+        "test('foo', () => {});test('bar', () => {});",
+        "test('foo', () => {});\ntest('bar', () => {});",
+        "it('foo', () => {});\nfit('bar', () => {});\ntest('baz', () => {});",
+        r"
+ describe('other bar', () => {
+     const thing = 123;
+     test('is another bar w/ test', () => {
+     });
+     // With a comment
+     it('is another bar w/ it', () => {
+     });
+     test.skip('skipping', () => {}); // Another comment
+     it.skip('skipping too', () => {});
+ });xtest('weird', () => {});
+ test
+   .skip('skippy skip', () => {});
+ xit('bar foo', () => {});
+            ",
+    ];
+
+    let fix = vec![
+        (
+            "test('foo', () => {});test('bar', () => {});",
+            "test('foo', () => {});\n\ntest('bar', () => {});",
+        ),
+        (
+            "test('foo', () => {});\ntest('bar', () => {});",
+            "test('foo', () => {});\n\ntest('bar', () => {});",
+        ),
+        (
+            "it('foo', () => {});\nfit('bar', () => {});\ntest('baz', () => {});",
+            "it('foo', () => {});\n\nfit('bar', () => {});\n\ntest('baz', () => {});",
+        ),
+        (
+            r"
+describe('other bar', () => {
+    const thing = 123;
+    test('is another bar w/ test', () => {
+    });
+    // With a comment
+    it('is another bar w/ it', () => {
+    });
+    test.skip('skipping', () => {}); // Another comment
+    it.skip('skipping too', () => {});
+});xtest('weird', () => {});
+test
+  .skip('skippy skip', () => {});
+xit('bar foo', () => {});
+        ",
+            r"
+describe('other bar', () => {
+    const thing = 123;
+
+    test('is another bar w/ test', () => {
+    });
+
+    // With a comment
+    it('is another bar w/ it', () => {
+    });
+
+    test.skip('skipping', () => {}); // Another comment
+
+    it.skip('skipping too', () => {});
+});
+
+xtest('weird', () => {});
+
+test
+  .skip('skippy skip', () => {});
+
+xit('bar foo', () => {});
+        ",
+        ),
+    ];
+    Tester::new(PaddingAroundTestBlocks::NAME, PaddingAroundTestBlocks::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/jest_padding_around_test_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/jest_padding_around_test_blocks.snap
@@ -33,15 +33,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Make sure there is an empty new line before the test block
 
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
-   ╭─[padding_around_test_blocks.tsx:4:1]
- 3 │ const bar = 'baz';
- 4 │ it('foo', () => {
-   · ▲
- 5 │   // stuff
-   ╰────
-  help: Make sure there is an empty new line before the it block
-
   ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before fit block
    ╭─[padding_around_test_blocks.tsx:7:1]
  6 │ });
@@ -50,6 +41,15 @@ source: crates/oxc_linter/src/tester.rs
  8 │   // stuff
    ╰────
   help: Make sure there is an empty new line before the fit block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before xit block
+    ╭─[padding_around_test_blocks.tsx:26:2]
+ 25 │    .skip('skippy skip', () => {});
+ 26 │  xit('bar foo', () => {});
+    ·  ▲
+ 27 │             
+    ╰────
+  help: Make sure there is an empty new line before the xit block
 
   ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test block
     ╭─[padding_around_test_blocks.tsx:10:1]
@@ -78,15 +78,6 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Make sure there is an empty new line before the test block
 
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
-    ╭─[padding_around_test_blocks.tsx:18:6]
- 17 │      });
- 18 │      // With a comment
-    ·      ▲
- 19 │      it('is another bar w/ it', () => {
-    ╰────
-  help: Make sure there is an empty new line before the it block
-
   ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test block
     ╭─[padding_around_test_blocks.tsx:21:6]
  20 │      });
@@ -95,24 +86,6 @@ source: crates/oxc_linter/src/tester.rs
  22 │      it.skip('skipping too', () => {});
     ╰────
   help: Make sure there is an empty new line before the test block
-
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
-    ╭─[padding_around_test_blocks.tsx:22:6]
- 21 │      test.skip('skipping', () => {}); // Another comment
- 22 │      it.skip('skipping too', () => {});
-    ·      ▲
- 23 │  });xtest('weird', () => {});
-    ╰────
-  help: Make sure there is an empty new line before the it block
-
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before xtest block
-    ╭─[padding_around_test_blocks.tsx:23:5]
- 22 │      it.skip('skipping too', () => {});
- 23 │  });xtest('weird', () => {});
-    ·     ▲
- 24 │  test
-    ╰────
-  help: Make sure there is an empty new line before the xtest block
 
   ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test block
     ╭─[padding_around_test_blocks.tsx:24:2]
@@ -123,11 +96,47 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Make sure there is an empty new line before the test block
 
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before xit block
-    ╭─[padding_around_test_blocks.tsx:26:2]
- 25 │    .skip('skippy skip', () => {});
- 26 │  xit('bar foo', () => {});
-    ·  ▲
- 27 │             
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before xtest block
+    ╭─[padding_around_test_blocks.tsx:23:5]
+ 22 │      it.skip('skipping too', () => {});
+ 23 │  });xtest('weird', () => {});
+    ·     ▲
+ 24 │  test
     ╰────
-  help: Make sure there is an empty new line before the xit block
+  help: Make sure there is an empty new line before the xtest block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
+   ╭─[padding_around_test_blocks.tsx:4:1]
+ 3 │ const bar = 'baz';
+ 4 │ it('foo', () => {
+   · ▲
+ 5 │   // stuff
+   ╰────
+  help: Make sure there is an empty new line before the it block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
+    ╭─[padding_around_test_blocks.tsx:18:6]
+ 17 │      });
+ 18 │      // With a comment
+    ·      ▲
+ 19 │      it('is another bar w/ it', () => {
+    ╰────
+  help: Make sure there is an empty new line before the it block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
+    ╭─[padding_around_test_blocks.tsx:22:6]
+ 21 │      test.skip('skipping', () => {}); // Another comment
+ 22 │      it.skip('skipping too', () => {});
+    ·      ▲
+ 23 │  });xtest('weird', () => {});
+    ╰────
+  help: Make sure there is an empty new line before the it block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
+   ╭─[padding_around_test_blocks.tsx:5:5]
+ 4 │     });
+ 5 │     it('is another bar w/ it', () => {
+   ·     ▲
+ 6 │     });
+   ╰────
+  help: Make sure there is an empty new line before the it block

--- a/crates/oxc_linter/src/snapshots/jest_padding_around_test_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/jest_padding_around_test_blocks.snap
@@ -1,97 +1,133 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test/it block
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test block
    ╭─[padding_around_test_blocks.tsx:1:23]
  1 │ test('foo', () => {});test('bar', () => {});
    ·                       ▲
    ╰────
-  help: Make sure there is an empty new line before the test/it block
+  help: Make sure there is an empty new line before the test block
 
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test/it block
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test block
    ╭─[padding_around_test_blocks.tsx:2:1]
  1 │ test('foo', () => {});
  2 │ test('bar', () => {});
    · ▲
    ╰────
-  help: Make sure there is an empty new line before the test/it block
+  help: Make sure there is an empty new line before the test block
 
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test/it block
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before fit block
    ╭─[padding_around_test_blocks.tsx:2:1]
  1 │ it('foo', () => {});
  2 │ fit('bar', () => {});
    · ▲
  3 │ test('baz', () => {});
    ╰────
-  help: Make sure there is an empty new line before the test/it block
+  help: Make sure there is an empty new line before the fit block
 
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test/it block
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test block
    ╭─[padding_around_test_blocks.tsx:3:1]
  2 │ fit('bar', () => {});
  3 │ test('baz', () => {});
    · ▲
    ╰────
-  help: Make sure there is an empty new line before the test/it block
+  help: Make sure there is an empty new line before the test block
 
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test/it block
-   ╭─[padding_around_test_blocks.tsx:4:6]
- 3 │      const thing = 123;
- 4 │      test('is another bar w/ test', () => {
-   ·      ▲
- 5 │      });
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
+   ╭─[padding_around_test_blocks.tsx:4:1]
+ 3 │ const bar = 'baz';
+ 4 │ it('foo', () => {
+   · ▲
+ 5 │   // stuff
    ╰────
-  help: Make sure there is an empty new line before the test/it block
+  help: Make sure there is an empty new line before the it block
 
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test/it block
-   ╭─[padding_around_test_blocks.tsx:6:6]
- 5 │      });
- 6 │      // With a comment
-   ·      ▲
- 7 │      it('is another bar w/ it', () => {
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before fit block
+   ╭─[padding_around_test_blocks.tsx:7:1]
+ 6 │ });
+ 7 │ fit('bar', () => {
+   · ▲
+ 8 │   // stuff
    ╰────
-  help: Make sure there is an empty new line before the test/it block
+  help: Make sure there is an empty new line before the fit block
 
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test/it block
-    ╭─[padding_around_test_blocks.tsx:9:6]
-  8 │      });
-  9 │      test.skip('skipping', () => {}); // Another comment
-    ·      ▲
- 10 │      it.skip('skipping too', () => {});
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test block
+    ╭─[padding_around_test_blocks.tsx:10:1]
+  9 │ });
+ 10 │ test('foo foo', () => {});
+    · ▲
+ 11 │ test('bar bar', () => {});
     ╰────
-  help: Make sure there is an empty new line before the test/it block
+  help: Make sure there is an empty new line before the test block
 
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test/it block
-    ╭─[padding_around_test_blocks.tsx:10:6]
-  9 │      test.skip('skipping', () => {}); // Another comment
- 10 │      it.skip('skipping too', () => {});
-    ·      ▲
- 11 │  });xtest('weird', () => {});
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test block
+    ╭─[padding_around_test_blocks.tsx:11:1]
+ 10 │ test('foo foo', () => {});
+ 11 │ test('bar bar', () => {});
+    · ▲
+ 12 │ 
     ╰────
-  help: Make sure there is an empty new line before the test/it block
+  help: Make sure there is an empty new line before the test block
 
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test/it block
-    ╭─[padding_around_test_blocks.tsx:11:5]
- 10 │      it.skip('skipping too', () => {});
- 11 │  });xtest('weird', () => {});
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test block
+    ╭─[padding_around_test_blocks.tsx:16:6]
+ 15 │      const thing = 123;
+ 16 │      test('is another bar w/ test', () => {
+    ·      ▲
+ 17 │      });
+    ╰────
+  help: Make sure there is an empty new line before the test block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
+    ╭─[padding_around_test_blocks.tsx:18:6]
+ 17 │      });
+ 18 │      // With a comment
+    ·      ▲
+ 19 │      it('is another bar w/ it', () => {
+    ╰────
+  help: Make sure there is an empty new line before the it block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test block
+    ╭─[padding_around_test_blocks.tsx:21:6]
+ 20 │      });
+ 21 │      test.skip('skipping', () => {}); // Another comment
+    ·      ▲
+ 22 │      it.skip('skipping too', () => {});
+    ╰────
+  help: Make sure there is an empty new line before the test block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
+    ╭─[padding_around_test_blocks.tsx:22:6]
+ 21 │      test.skip('skipping', () => {}); // Another comment
+ 22 │      it.skip('skipping too', () => {});
+    ·      ▲
+ 23 │  });xtest('weird', () => {});
+    ╰────
+  help: Make sure there is an empty new line before the it block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before xtest block
+    ╭─[padding_around_test_blocks.tsx:23:5]
+ 22 │      it.skip('skipping too', () => {});
+ 23 │  });xtest('weird', () => {});
     ·     ▲
- 12 │  test
+ 24 │  test
     ╰────
-  help: Make sure there is an empty new line before the test/it block
+  help: Make sure there is an empty new line before the xtest block
 
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test/it block
-    ╭─[padding_around_test_blocks.tsx:12:2]
- 11 │  });xtest('weird', () => {});
- 12 │  test
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test block
+    ╭─[padding_around_test_blocks.tsx:24:2]
+ 23 │  });xtest('weird', () => {});
+ 24 │  test
     ·  ▲
- 13 │    .skip('skippy skip', () => {});
+ 25 │    .skip('skippy skip', () => {});
     ╰────
-  help: Make sure there is an empty new line before the test/it block
+  help: Make sure there is an empty new line before the test block
 
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test/it block
-    ╭─[padding_around_test_blocks.tsx:14:2]
- 13 │    .skip('skippy skip', () => {});
- 14 │  xit('bar foo', () => {});
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before xit block
+    ╭─[padding_around_test_blocks.tsx:26:2]
+ 25 │    .skip('skippy skip', () => {});
+ 26 │  xit('bar foo', () => {});
     ·  ▲
- 15 │             
+ 27 │             
     ╰────
-  help: Make sure there is an empty new line before the test/it block
+  help: Make sure there is an empty new line before the xit block

--- a/crates/oxc_linter/src/snapshots/jest_padding_around_test_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/jest_padding_around_test_blocks.snap
@@ -1,0 +1,97 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test/it block
+   ╭─[padding_around_test_blocks.tsx:1:23]
+ 1 │ test('foo', () => {});test('bar', () => {});
+   ·                       ▲
+   ╰────
+  help: Make sure there is an empty new line before the test/it block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test/it block
+   ╭─[padding_around_test_blocks.tsx:2:1]
+ 1 │ test('foo', () => {});
+ 2 │ test('bar', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the test/it block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test/it block
+   ╭─[padding_around_test_blocks.tsx:2:1]
+ 1 │ it('foo', () => {});
+ 2 │ fit('bar', () => {});
+   · ▲
+ 3 │ test('baz', () => {});
+   ╰────
+  help: Make sure there is an empty new line before the test/it block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test/it block
+   ╭─[padding_around_test_blocks.tsx:3:1]
+ 2 │ fit('bar', () => {});
+ 3 │ test('baz', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the test/it block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test/it block
+   ╭─[padding_around_test_blocks.tsx:4:6]
+ 3 │      const thing = 123;
+ 4 │      test('is another bar w/ test', () => {
+   ·      ▲
+ 5 │      });
+   ╰────
+  help: Make sure there is an empty new line before the test/it block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test/it block
+   ╭─[padding_around_test_blocks.tsx:6:6]
+ 5 │      });
+ 6 │      // With a comment
+   ·      ▲
+ 7 │      it('is another bar w/ it', () => {
+   ╰────
+  help: Make sure there is an empty new line before the test/it block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test/it block
+    ╭─[padding_around_test_blocks.tsx:9:6]
+  8 │      });
+  9 │      test.skip('skipping', () => {}); // Another comment
+    ·      ▲
+ 10 │      it.skip('skipping too', () => {});
+    ╰────
+  help: Make sure there is an empty new line before the test/it block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test/it block
+    ╭─[padding_around_test_blocks.tsx:10:6]
+  9 │      test.skip('skipping', () => {}); // Another comment
+ 10 │      it.skip('skipping too', () => {});
+    ·      ▲
+ 11 │  });xtest('weird', () => {});
+    ╰────
+  help: Make sure there is an empty new line before the test/it block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test/it block
+    ╭─[padding_around_test_blocks.tsx:11:5]
+ 10 │      it.skip('skipping too', () => {});
+ 11 │  });xtest('weird', () => {});
+    ·     ▲
+ 12 │  test
+    ╰────
+  help: Make sure there is an empty new line before the test/it block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test/it block
+    ╭─[padding_around_test_blocks.tsx:12:2]
+ 11 │  });xtest('weird', () => {});
+ 12 │  test
+    ·  ▲
+ 13 │    .skip('skippy skip', () => {});
+    ╰────
+  help: Make sure there is an empty new line before the test/it block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test/it block
+    ╭─[padding_around_test_blocks.tsx:14:2]
+ 13 │    .skip('skippy skip', () => {});
+ 14 │  xit('bar foo', () => {});
+    ·  ▲
+ 15 │             
+    ╰────
+  help: Make sure there is an empty new line before the test/it block


### PR DESCRIPTION
Adds the [`jest/padding-around-test-blocks`](https://github.com/jest-community/eslint-plugin-jest/blob/v29.0.1/docs/rules/padding-around-test-blocks.md) rule. The jest plugin opts for abstracting away all the `padding-around-x` rules with a helper, but for my purposes, I only needed this specific rule. My opinion is that we can investigate generalizing this rule to the other padding plugin as a followup, if there is pull for it.

Works towards https://github.com/oxc-project/oxc/issues/492