### PR TITLE
fix(linter/jsx-key): check if element in push call

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -210,6 +210,12 @@ fn is_in_array_or_iter<'a, 'b>(
                             })
                         {
                             return Some(InsideArrayOrIterator::Iterator(span));
+                        } else if ident == "push"
+                            && argument.is_some_and(|argument| {
+                                v.arguments.iter().any(|arg| argument.span() == arg.span())
+                            })
+                        {
+                            return Some(InsideArrayOrIterator::Array);
                         }
                     }
                 }
@@ -505,6 +511,8 @@ fn test() {
            }))}
         ",
         r"const DummyComponent: FC<{ children: ReactNode }> = ({ children }) => { const wrappedChildren = Children.map(children, (child) => { return <div>{child}</div>; }); return <main>{wrappedChildren}</main>; };",
+        "const arr = [];arr.push(<div key={0} />);",
+        "const arr = [];arr.push(<div key={0} />, <div key={1} />);",
     ];
 
     let fail = vec![
@@ -618,6 +626,10 @@ fn test() {
         Children.toArray([1, 2 ,3].map(x => <App />));
         Children.toArray(Array.from([1, 2 ,3], x => <App />));
         ",
+        "const arr = [];arr.push(<div />);",
+        "const arr = [];arr.push(<div key={0} />, <div />);",
+        "const arr = [];arr.push(<div />, <div key={0} />);",
+        "const arr = [];arr.push(<div />, <div />);",
     ];
 
     Tester::new(JsxKey::NAME, JsxKey::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/react_jsx_key.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_key.snap
@@ -346,3 +346,33 @@ source: crates/oxc_linter/src/tester.rs
  12 │         
     ╰────
   help: Add a "key" prop to the element in the iterator (https://react.dev/learn/rendering-lists#keeping-list-items-in-order-with-key).
+
+  ⚠ eslint-plugin-react(jsx-key): Missing "key" prop for element in array.
+   ╭─[jsx_key.tsx:1:26]
+ 1 │ const arr = [];arr.push(<div />);
+   ·                          ───
+   ╰────
+
+  ⚠ eslint-plugin-react(jsx-key): Missing "key" prop for element in array.
+   ╭─[jsx_key.tsx:1:43]
+ 1 │ const arr = [];arr.push(<div key={0} />, <div />);
+   ·                                           ───
+   ╰────
+
+  ⚠ eslint-plugin-react(jsx-key): Missing "key" prop for element in array.
+   ╭─[jsx_key.tsx:1:26]
+ 1 │ const arr = [];arr.push(<div />, <div key={0} />);
+   ·                          ───
+   ╰────
+
+  ⚠ eslint-plugin-react(jsx-key): Missing "key" prop for element in array.
+   ╭─[jsx_key.tsx:1:26]
+ 1 │ const arr = [];arr.push(<div />, <div />);
+   ·                          ───
+   ╰────
+
+  ⚠ eslint-plugin-react(jsx-key): Missing "key" prop for element in array.
+   ╭─[jsx_key.tsx:1:35]
+ 1 │ const arr = [];arr.push(<div />, <div />);
+   ·                                   ───
+   ╰────


### PR DESCRIPTION
`react/jsx-key` should check if the jsx element is inside an `Array.prototype.push` call. This PR adds support for checking that.
