### PR TITLE
feat(linter): add react/jsx-fragments rule

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -300,6 +300,7 @@ mod react {
     pub mod jsx_boolean_value;
     pub mod jsx_curly_brace_presence;
     pub mod jsx_filename_extension;
+    pub mod jsx_fragments;
     pub mod jsx_key;
     pub mod jsx_no_comment_textnodes;
     pub mod jsx_no_duplicate_props;
@@ -921,6 +922,7 @@ oxc_macros::declare_all_lint_rules! {
     react::forbid_elements,
     react::forward_ref_uses_ref,
     react::iframe_missing_sandbox,
+    react::jsx_fragments,
     react::jsx_filename_extension,
     react::jsx_boolean_value,
     react::jsx_curly_brace_presence,

--- a/crates/oxc_linter/src/rules/react/jsx_fragments.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_fragments.rs
@@ -5,29 +5,59 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
+use serde_json::Value;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
-fn jsx_fragments_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Shorthand form for React fragments is preferred")
-        .with_help("Use <></> instead of <React.Fragment></React.Fragment>")
-        .with_label(span)
+fn jsx_fragments_diagnostic(span: Span, mode: FragmentMode) -> OxcDiagnostic {
+    let msg = if mode == FragmentMode::Element {
+        "Standard form for React fragments is preferred"
+    } else {
+        "Shorthand form for React fragments is preferred"
+    };
+    let help = if mode == FragmentMode::Element {
+        "Use <React.Fragment></React.Fragment> instead of <></>"
+    } else {
+        "Use <></> instead of <React.Fragment></React.Fragment>"
+    };
+    OxcDiagnostic::warn(msg).with_help(help).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]
-pub struct JsxFragments;
+pub struct JsxFragments {
+    mode: FragmentMode,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Copy)]
+pub enum FragmentMode {
+    #[default]
+    Syntax,
+    Element,
+}
+
+impl From<&str> for FragmentMode {
+    fn from(value: &str) -> Self {
+        if value == "element" { Self::Element } else { Self::Syntax }
+    }
+}
 
 // See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Enforces the shorthand form for React fragments
+    /// Enforces the shorthand or standard form for React Fragments.
     ///
     /// ### Why is this bad?
     ///
-    /// Shorthand form is much more succinct and readable than the fully qualified element name.
+    /// Makes code using fragments more consistent one way or the other.
     ///
-    /// ### Examples
+    /// ### Options
+    ///
+    /// `{ "mode": "syntax" | "element" }`
+    ///
+    /// #### `syntax` mode
+    /// This is the default mode. It will enforce the shorthand syntax for React fragments, with one exception.
+    /// Keys or attributes are not supported by the shorthand syntax, so the rule will not warn on standard-form fragments that use those.
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx
@@ -42,6 +72,23 @@ declare_oxc_lint!(
     /// ```jsx
     /// <React.Fragment key="key"><Foo /></React.Fragment>
     /// ```
+    ///
+    /// #### `element` mode
+    /// This mode enforces the standard form for React fragments.
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// <><Foo /></>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// <React.Fragment><Foo /></React.Fragment>
+    /// ```
+    ///
+    /// ```jsx
+    /// <React.Fragment key="key"><Foo /></React.Fragment>
+    /// ```
     JsxFragments,
     react,
     style,
@@ -49,19 +96,30 @@ declare_oxc_lint!(
 );
 
 impl Rule for JsxFragments {
+    fn from_configuration(value: Value) -> Self {
+        let obj = value.get(0);
+        Self {
+            mode: obj
+                .and_then(|v| v.get("mode"))
+                .and_then(Value::as_str)
+                .map(FragmentMode::from)
+                .unwrap_or_default(),
+        }
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
-            AstKind::JSXElement(jsx_elem) => {
+            AstKind::JSXElement(jsx_elem) if self.mode == FragmentMode::Syntax => {
                 let Some(closing_element) = &jsx_elem.closing_element else {
                     return;
                 };
                 if !is_jsx_fragment(&jsx_elem.opening_element)
-                    || jsx_elem.opening_element.attributes.len() > 0
+                    || !jsx_elem.opening_element.attributes.is_empty()
                 {
                     return;
                 }
                 ctx.diagnostic_with_fix(
-                    jsx_fragments_diagnostic(jsx_elem.opening_element.name.span()),
+                    jsx_fragments_diagnostic(jsx_elem.opening_element.name.span(), self.mode),
                     |fixer| {
                         let before_opening_tag = ctx.source_range(Span::new(
                             jsx_elem.span().start,
@@ -76,12 +134,38 @@ impl Rule for JsxFragments {
                             jsx_elem.span().end,
                         ));
                         let mut replacement = String::new();
-                        replacement.push_str(&before_opening_tag);
+                        replacement.push_str(before_opening_tag);
                         replacement.push_str("<>");
-                        replacement.push_str(&between_opening_tag_and_closing_tag);
+                        replacement.push_str(between_opening_tag_and_closing_tag);
                         replacement.push_str("</>");
-                        replacement.push_str(&after_closing_tag);
+                        replacement.push_str(after_closing_tag);
                         fixer.replace(jsx_elem.span(), replacement)
+                    },
+                );
+            }
+            AstKind::JSXFragment(jsx_frag) if self.mode == FragmentMode::Element => {
+                ctx.diagnostic_with_fix(
+                    jsx_fragments_diagnostic(jsx_frag.opening_fragment.span(), self.mode),
+                    |fixer| {
+                        let before_opening_tag = ctx.source_range(Span::new(
+                            jsx_frag.span().start,
+                            jsx_frag.opening_fragment.span().start,
+                        ));
+                        let between_opening_tag_and_closing_tag = ctx.source_range(Span::new(
+                            jsx_frag.opening_fragment.span().end,
+                            jsx_frag.closing_fragment.span().start,
+                        ));
+                        let after_closing_tag = ctx.source_range(Span::new(
+                            jsx_frag.closing_fragment.span().end,
+                            jsx_frag.span().end,
+                        ));
+                        let mut replacement = String::new();
+                        replacement.push_str(before_opening_tag);
+                        replacement.push_str("<React.Fragment>");
+                        replacement.push_str(between_opening_tag_and_closing_tag);
+                        replacement.push_str("</React.Fragment>");
+                        replacement.push_str(after_closing_tag);
+                        fixer.replace(jsx_frag.span(), replacement)
                     },
                 );
             }
@@ -113,20 +197,31 @@ fn is_jsx_fragment(elem: &JSXOpeningElement) -> bool {
 #[test]
 fn test() {
     use crate::tester::Tester;
+    use serde_json::json;
 
     let pass = vec![
-        "<><Foo /></>",
-        "<Fragment key=\"key\"><Foo /></Fragment>",
-        "<React.Fragment key=\"key\"><Foo /></React.Fragment>",
-        "<Fragment />",
-        "<React.Fragment />",
+        ("<><Foo /></>", None),
+        (r#"<Fragment key="key"><Foo /></Fragment>"#, None),
+        (r#"<React.Fragment key="key"><Foo /></React.Fragment>"#, None),
+        ("<Fragment />", None),
+        ("<React.Fragment />", None),
+        ("<React.Fragment><Foo /></React.Fragment>", Some(json!([{"mode": "element"}]))),
     ];
 
-    let fail = vec!["<Fragment><Foo /></Fragment>", "<React.Fragment><Foo /></React.Fragment>"];
+    let fail = vec![
+        ("<Fragment><Foo /></Fragment>", None),
+        ("<React.Fragment><Foo /></React.Fragment>", None),
+        ("<><Foo /></>", Some(json!([{"mode": "element"}]))),
+    ];
 
     let fix = vec![
-        ("<Fragment><Foo /></Fragment>", "<><Foo /></>"),
-        ("<React.Fragment><Foo /></React.Fragment>", "<><Foo /></>"),
+        ("<Fragment><Foo /></Fragment>", "<><Foo /></>", None),
+        ("<React.Fragment><Foo /></React.Fragment>", "<><Foo /></>", None),
+        (
+            "<><Foo /></>",
+            "<React.Fragment><Foo /></React.Fragment>",
+            Some(json!([{"mode": "element"}])),
+        ),
     ];
     Tester::new(JsxFragments::NAME, JsxFragments::PLUGIN, pass, fail)
         .expect_fix(fix)

--- a/crates/oxc_linter/src/rules/react/jsx_fragments.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_fragments.rs
@@ -1,0 +1,134 @@
+use oxc_ast::{
+    AstKind,
+    ast::{JSXElementName, JSXMemberExpressionObject, JSXOpeningElement},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn jsx_fragments_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Shorthand form for React fragments is preferred")
+        .with_help("Use <></> instead of <React.Fragment></React.Fragment>")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct JsxFragments;
+
+// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces the shorthand form for React fragments
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Shorthand form is much more succinct and readable than the fully qualified element name.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// <React.Fragment><Foo /></React.Fragment>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// <><Foo /></>
+    /// ```
+    ///
+    /// ```jsx
+    /// <React.Fragment key="key"><Foo /></React.Fragment>
+    /// ```
+    JsxFragments,
+    react,
+    style,
+    fix
+);
+
+impl Rule for JsxFragments {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::JSXElement(jsx_elem) => {
+                let Some(closing_element) = &jsx_elem.closing_element else {
+                    return;
+                };
+                if !is_jsx_fragment(&jsx_elem.opening_element)
+                    || jsx_elem.opening_element.attributes.len() > 0
+                {
+                    return;
+                }
+                ctx.diagnostic_with_fix(
+                    jsx_fragments_diagnostic(jsx_elem.opening_element.name.span()),
+                    |fixer| {
+                        let before_opening_tag = ctx.source_range(Span::new(
+                            jsx_elem.span().start,
+                            jsx_elem.opening_element.span().start,
+                        ));
+                        let between_opening_tag_and_closing_tag = ctx.source_range(Span::new(
+                            jsx_elem.opening_element.span().end,
+                            closing_element.span().start,
+                        ));
+                        let after_closing_tag = ctx.source_range(Span::new(
+                            closing_element.span().end,
+                            jsx_elem.span().end,
+                        ));
+                        let mut replacement = String::new();
+                        replacement.push_str(&before_opening_tag);
+                        replacement.push_str("<>");
+                        replacement.push_str(&between_opening_tag_and_closing_tag);
+                        replacement.push_str("</>");
+                        replacement.push_str(&after_closing_tag);
+                        fixer.replace(jsx_elem.span(), replacement)
+                    },
+                );
+            }
+            _ => {}
+        }
+    }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.source_type().is_jsx()
+    }
+}
+
+fn is_jsx_fragment(elem: &JSXOpeningElement) -> bool {
+    match &elem.name {
+        JSXElementName::IdentifierReference(ident) => ident.name == "Fragment",
+        JSXElementName::MemberExpression(mem_expr) => {
+            if let JSXMemberExpressionObject::IdentifierReference(ident) = &mem_expr.object {
+                ident.name == "React" && mem_expr.property.name == "Fragment"
+            } else {
+                false
+            }
+        }
+        JSXElementName::NamespacedName(_)
+        | JSXElementName::Identifier(_)
+        | JSXElementName::ThisExpression(_) => false,
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "<><Foo /></>",
+        "<Fragment key=\"key\"><Foo /></Fragment>",
+        "<React.Fragment key=\"key\"><Foo /></React.Fragment>",
+        "<Fragment />",
+        "<React.Fragment />",
+    ];
+
+    let fail = vec!["<Fragment><Foo /></Fragment>", "<React.Fragment><Foo /></React.Fragment>"];
+
+    let fix = vec![
+        ("<Fragment><Foo /></Fragment>", "<><Foo /></>"),
+        ("<React.Fragment><Foo /></React.Fragment>", "<><Foo /></>"),
+    ];
+    Tester::new(JsxFragments::NAME, JsxFragments::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/react_jsx_fragments.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_fragments.snap
@@ -14,3 +14,10 @@ source: crates/oxc_linter/src/tester.rs
    ·  ──────────────
    ╰────
   help: Use <></> instead of <React.Fragment></React.Fragment>
+
+  ⚠ eslint-plugin-react(jsx-fragments): Standard form for React fragments is preferred
+   ╭─[jsx_fragments.tsx:1:1]
+ 1 │ <><Foo /></>
+   · ──
+   ╰────
+  help: Use <React.Fragment></React.Fragment> instead of <></>

--- a/crates/oxc_linter/src/snapshots/react_jsx_fragments.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_fragments.snap
@@ -1,0 +1,16 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint-plugin-react(jsx-fragments): Shorthand form for React fragments is preferred
+   ╭─[jsx_fragments.tsx:1:2]
+ 1 │ <Fragment><Foo /></Fragment>
+   ·  ────────
+   ╰────
+  help: Use <></> instead of <React.Fragment></React.Fragment>
+
+  ⚠ eslint-plugin-react(jsx-fragments): Shorthand form for React fragments is preferred
+   ╭─[jsx_fragments.tsx:1:2]
+ 1 │ <React.Fragment><Foo /></React.Fragment>
+   ·  ──────────────
+   ╰────
+  help: Use <></> instead of <React.Fragment></React.Fragment>


### PR DESCRIPTION
Adds the [`react/jsx-fragments`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-fragments.md) rule. Replaced the eslint auto-generated tests with much simpler ones since the ones there seem outdated and/or esoteric. It might be worth checking if the import renames `Fragment` to something else, but we don't do this for `react/jsx-no-useless-fragment` (see https://github.com/oxc-project/oxc/blob/234abd465396c799f7cea1f6e41d44fcda6f54eb/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs#L324-L338). Thus, not gonna do it here. Might be worth adding a utility function file for `is_jsx_fragment` since I copy-pasted it, but seems pedantic imo.

works towards https://github.com/oxc-project/oxc/issues/1022