### PR TITLE
refactor(oxlint): pass `DiagnosticService` as a parameter for `TsGoLintState.lint()`

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -307,8 +307,8 @@ impl LintRunner {
         if let Some(ret) = self
             .options
             .type_aware
-            .then(|| TsGoLintState::new(tx_error.clone(), config_store.clone(), &paths, &options))
-            .and_then(|s| s.lint(stdout))
+            .then(|| TsGoLintState::new(config_store.clone(), &paths, &options))
+            .and_then(|s| s.lint(tx_error.clone(), stdout))
         {
             return ret;
         }


### PR DESCRIPTION
Started to refactor for the language server, but noticed it needs more to be done: https://github.com/oxc-project/tsgolint/issues/71
Still opened the PR to align with the service:

https://github.com/oxc-project/oxc/blob/ca91a261556d88cde7ece4314d905a78aca1cc76/crates/oxc_linter/src/service/mod.rs#L91-L102
