### PR TITLE
docs(ecmascript): correct docs for `GlobalContext::is_global_reference`

### DIFF
--- a/crates/oxc_ecmascript/src/global_context.rs
+++ b/crates/oxc_ecmascript/src/global_context.rs
@@ -5,10 +5,6 @@ use crate::constant_evaluation::ConstantValue;
 
 pub trait GlobalContext<'a>: Sized {
     /// Whether the reference is a global reference.
-    ///
-    /// - None means it is unknown.
-    /// - Some(true) means it is a global reference.
-    /// - Some(false) means it is not a global reference.
     fn is_global_reference(&self, reference: &IdentifierReference<'a>) -> bool;
 
     fn is_global_expr(&self, name: &str, expr: &Expression<'a>) -> bool {


### PR DESCRIPTION
#12953 altered the return type of `GlobalContext::is_global_reference`. Update docs accordingly.

@Boshen is this correct? Or does `false` now mean "not a global reference *or* unknown if is a global reference"?
