### PR TITLE
fix(allocator): remove unsound `impl Sync for Allocator`

### DIFF
--- a/crates/oxc_allocator/src/allocator.rs
+++ b/crates/oxc_allocator/src/allocator.rs
@@ -642,11 +642,6 @@ impl Allocator {
     }
 }
 
-/// SAFETY: Not actually safe, but for enabling `Send` for downstream crates.
-unsafe impl Send for Allocator {}
-/// SAFETY: Not actually safe, but for enabling `Sync` for downstream crates.
-unsafe impl Sync for Allocator {}
-
 #[cfg(test)]
 mod test {
     use super::Allocator;


### PR DESCRIPTION
`Allocator` should not be `Sync`. `Allocator` is not thread-safe and allocating into it in multiple threads can cause data corruption or, in worst case, writing out of bounds.

Remove the unsound `impl Sync for Allocator`.

This PR also removes `impl Send for Allocator`, but that doesn't change anything. `bumpalo::Bump` is already `Send`, so `Allocator` is automatically `Send` too. It doesn't need an explicit `Send` impl.