### PR TITLE
fix(allocator): remove `Clone` impl from `Vec`

### DIFF
--- a/crates/oxc_allocator/src/vec2/mod.rs
+++ b/crates/oxc_allocator/src/vec2/mod.rs
@@ -2067,26 +2067,6 @@ impl<'a, T: 'a + PartialEq, A: Alloc> Vec<'a, T, A> {
 // Common trait implementations for Vec
 ////////////////////////////////////////////////////////////////////////////////
 
-impl<'a, T: 'a + Clone, A: Alloc> Clone for Vec<'a, T, A> {
-    #[cfg(not(test))]
-    fn clone(&self) -> Vec<'a, T, A> {
-        let mut v = Vec::with_capacity_in(self.len_usize(), self.buf.bump());
-        v.extend(self.iter().cloned());
-        v
-    }
-
-    // HACK(japaric): with cfg(test) the inherent `[T]::to_vec` method, which is
-    // required for this method definition, is not available. Instead use the
-    // `slice::to_vec`  function which is only available with cfg(test)
-    // NB see the slice::hack module in slice.rs for more information
-    #[cfg(test)]
-    fn clone(&self) -> Vec<'a, T, A> {
-        let mut v = Vec::new_in(self.buf.bump());
-        v.extend(self.iter().cloned());
-        v
-    }
-}
-
 impl<'a, T: 'a + Hash, A: Alloc> Hash for Vec<'a, T, A> {
     #[inline]
     fn hash<H: hash::Hasher>(&self, state: &mut H) {


### PR DESCRIPTION
`Vec::clone` method is unsound, for the same reasons as `Vec::bump` is (#13039).

`clone` only takes a `&self` and then uses it to access the `&Bump` contained in `Vec`, and allocates into that arena. Because `Vec` is `Sync`, that can result in 2 threads allocating into same `Bump` simultaneously, which is UB.

`Clone` is of limited use, because usually usually the contents of the `Vec` aren't `Clone`. We have `CloneIn` trait for this purpose.

We don't currently use `Clone` anywhere, so we can remove it.