### PR TITLE
fix(linter): prevent false positive in `no-unused-private-class-members` for compound assignments

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
@@ -236,7 +236,7 @@ fn is_compound_assignment_read(parent_id: NodeId, semantic: &Semantic) -> bool {
         .ancestors(parent_id)
         .tuple_windows::<(&AstNode<'_>, &AstNode<'_>)>()
         .next()
-        .is_some_and(|(_, grandparent)| is_value_context(grandparent, semantic))
+        .is_some_and(|(grandparent, _)| is_value_context(grandparent, semantic))
 }
 
 #[test]
@@ -244,6 +244,33 @@ fn test() {
     use crate::tester::Tester;
 
     let pass = vec![
+        r"
+            class Test {
+                #prop = undefined
+
+                getProp() {
+                    return this.#prop ??= 0
+                }
+            }
+        ",
+        r"
+            class Test {
+                #prop = undefined
+
+                getProp() {
+                    return this.#prop ||= 0
+                }
+            }
+        ",
+        r"
+            class Test {
+                #prop = undefined
+
+                getProp() {
+                    return this.#prop += 0
+                }
+            }
+        ",
         r"class Foo {}",
         r"class Foo {
         	    publicMember = 42;


### PR DESCRIPTION
fixes #13038 