### PR TITLE
refactor(minfier): consistent method names

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_conditional_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditional_expression.rs
@@ -20,12 +20,12 @@ impl<'a> PeepholeOptimizations {
         ctx: &mut Ctx<'a, '_>,
     ) -> Expression<'a> {
         let mut cond_expr = ctx.ast.conditional_expression(span, test, consequent, alternate);
-        Self::try_minimize_conditional(&mut cond_expr, ctx)
+        Self::minimize_conditional_expression(&mut cond_expr, ctx)
             .unwrap_or_else(|| Expression::ConditionalExpression(ctx.ast.alloc(cond_expr)))
     }
 
     /// `MangleIfExpr`: <https://github.com/evanw/esbuild/blob/v0.24.2/internal/js_ast/js_ast_helpers.go#L2745>
-    pub fn try_minimize_conditional(
+    pub fn minimize_conditional_expression(
         expr: &mut ConditionalExpression<'a>,
         ctx: &mut Ctx<'a, '_>,
     ) -> Option<Expression<'a>> {

--- a/crates/oxc_minifier/src/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditions.rs
@@ -66,7 +66,7 @@ impl<'a> PeepholeOptimizations {
     //  ^^^^^^^^^^^^^^ `ctx.expression_value_type(&e.left).is_boolean()` is `true`.
     // `x >> +y !== 0` -> `x >> +y`
     //  ^^^^^^^ ctx.expression_value_type(&e.left).is_number()` is `true`.
-    pub fn try_minimize_binary(expr: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) {
+    pub fn minimize_binary(expr: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) {
         let Expression::BinaryExpression(e) = expr else { return };
         if !e.operator.is_equality() {
             return;
@@ -123,7 +123,7 @@ impl<'a> PeepholeOptimizations {
     ///
     /// In `IsLooselyEqual`, `true` and `false` are converted to `1` and `0` first.
     /// <https://tc39.es/ecma262/multipage/abstract-operations.html#sec-islooselyequal>
-    pub fn try_compress_is_loose_boolean(e: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) {
+    pub fn minimize_loose_boolean(e: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) {
         let Expression::BinaryExpression(e) = e else { return };
         if !matches!(e.operator, BinaryOperator::Equality | BinaryOperator::Inequality) {
             return;
@@ -170,7 +170,7 @@ impl<'a> PeepholeOptimizations {
     /// Compress `a = a || b` to `a ||= b`
     ///
     /// This can only be done for resolved identifiers as this would avoid setting `a` when `a` is truthy.
-    pub fn try_compress_normal_assignment_to_combined_logical_assignment(
+    pub fn minimize_normal_assignment_to_combined_logical_assignment(
         expr: &mut AssignmentExpression<'a>,
         ctx: &mut Ctx<'a, '_>,
     ) {
@@ -207,7 +207,7 @@ impl<'a> PeepholeOptimizations {
     }
 
     /// Compress `a = a + b` to `a += b`
-    pub fn try_compress_normal_assignment_to_combined_assignment(
+    pub fn minimize_normal_assignment_to_combined_assignment(
         expr: &mut AssignmentExpression<'a>,
         ctx: &mut Ctx<'a, '_>,
     ) {
@@ -227,7 +227,7 @@ impl<'a> PeepholeOptimizations {
 
     /// Compress `a -= 1` to `--a` and `a -= -1` to `++a`
     #[expect(clippy::float_cmp)]
-    pub fn try_compress_assignment_to_update_expression(
+    pub fn minimize_assignment_to_update_expression(
         expr: &mut Expression<'a>,
         ctx: &mut Ctx<'a, '_>,
     ) {

--- a/crates/oxc_minifier/src/peephole/minimize_not_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_not_expression.rs
@@ -10,17 +10,17 @@ use super::PeepholeOptimizations;
 impl<'a> PeepholeOptimizations {
     pub fn minimize_not(span: Span, expr: Expression<'a>, ctx: &mut Ctx<'a, '_>) -> Expression<'a> {
         let mut unary = ctx.ast.expression_unary(span, UnaryOperator::LogicalNot, expr);
-        Self::try_minimize_not(&mut unary, ctx);
+        Self::minimize_unary(&mut unary, ctx);
         unary
     }
 
     /// `MaybeSimplifyNot`: <https://github.com/evanw/esbuild/blob/v0.24.2/internal/js_ast/js_ast_helpers.go#L73>
-    pub fn try_minimize_not(expr: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) {
+    pub fn minimize_unary(expr: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) {
         let Expression::UnaryExpression(e) = expr else { return };
         if !e.operator.is_not() {
             return;
         }
-        Self::try_fold_expr_in_boolean_context(&mut e.argument, ctx);
+        Self::minimize_expression_in_boolean_context(&mut e.argument, ctx);
         match &mut e.argument {
             // `!!true` -> `true`
             // `!!false` -> `false`

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -557,7 +557,7 @@ impl<'a> PeepholeOptimizations {
                         };
                         let test = if_stmt.test.take_in(ctx.ast);
                         let mut test = Self::minimize_not(test.span(), test, ctx);
-                        Self::try_fold_expr_in_boolean_context(&mut test, ctx);
+                        Self::minimize_expression_in_boolean_context(&mut test, ctx);
                         let consequent = if body.len() == 1 {
                             body.remove(0)
                         } else {

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -121,8 +121,8 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
     }
 
     fn exit_statements(&mut self, stmts: &mut Vec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {
-        let mut ctx = Ctx::new(ctx);
-        Self::minimize_statements(stmts, &mut ctx);
+        let ctx = &mut Ctx::new(ctx);
+        Self::minimize_statements(stmts, ctx);
     }
 
     fn enter_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
@@ -135,7 +135,7 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
         match stmt {
             Statement::BlockStatement(_) => Self::try_optimize_block(stmt, ctx),
             Statement::IfStatement(s) => {
-                Self::try_fold_expr_in_boolean_context(&mut s.test, ctx);
+                Self::minimize_expression_in_boolean_context(&mut s.test, ctx);
                 Self::try_fold_if(stmt, ctx);
                 if let Statement::IfStatement(if_stmt) = stmt {
                     if let Some(folded_stmt) = Self::try_minimize_if(if_stmt, ctx) {
@@ -145,16 +145,16 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
                 }
             }
             Statement::WhileStatement(s) => {
-                Self::try_fold_expr_in_boolean_context(&mut s.test, ctx);
+                Self::minimize_expression_in_boolean_context(&mut s.test, ctx);
             }
             Statement::ForStatement(s) => {
                 if let Some(test) = &mut s.test {
-                    Self::try_fold_expr_in_boolean_context(test, ctx);
+                    Self::minimize_expression_in_boolean_context(test, ctx);
                 }
                 Self::try_fold_for(stmt, ctx);
             }
             Statement::DoWhileStatement(s) => {
-                Self::try_fold_expr_in_boolean_context(&mut s.test, ctx);
+                Self::minimize_expression_in_boolean_context(&mut s.test, ctx);
             }
             Statement::TryStatement(_) => Self::try_fold_try(stmt, ctx),
             Statement::LabeledStatement(_) => Self::try_fold_labeled(stmt, ctx),
@@ -168,14 +168,14 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
     }
 
     fn exit_for_statement(&mut self, stmt: &mut ForStatement<'a>, ctx: &mut TraverseCtx<'a>) {
-        let mut ctx = Ctx::new(ctx);
-        Self::substitute_for_statement(stmt, &mut ctx);
-        Self::minimize_for_statement(stmt, &mut ctx);
+        let ctx = &mut Ctx::new(ctx);
+        Self::substitute_for_statement(stmt, ctx);
+        Self::minimize_for_statement(stmt, ctx);
     }
 
     fn exit_return_statement(&mut self, stmt: &mut ReturnStatement<'a>, ctx: &mut TraverseCtx<'a>) {
-        let mut ctx = Ctx::new(ctx);
-        Self::substitute_return_statement(stmt, &mut ctx);
+        let ctx = &mut Ctx::new(ctx);
+        Self::substitute_return_statement(stmt, ctx);
     }
 
     fn exit_variable_declaration(
@@ -183,8 +183,8 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
         decl: &mut VariableDeclaration<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        let mut ctx = Ctx::new(ctx);
-        Self::substitute_variable_declaration(decl, &mut ctx);
+        let ctx = &mut Ctx::new(ctx);
+        Self::substitute_variable_declaration(decl, ctx);
     }
 
     fn exit_variable_declarator(
@@ -192,8 +192,8 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
         decl: &mut VariableDeclarator<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        let mut ctx = Ctx::new(ctx);
-        Self::init_symbol_value(decl, &mut ctx);
+        let ctx = &mut Ctx::new(ctx);
+        Self::init_symbol_value(decl, ctx);
     }
 
     fn exit_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
@@ -201,74 +201,74 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
         match expr {
             Expression::TemplateLiteral(t) => {
                 Self::inline_template_literal(t, ctx);
-                Self::try_fold_template_literal(expr, ctx);
+                Self::substitute_template_literal(expr, ctx);
             }
             Expression::ObjectExpression(e) => Self::fold_object_exp(e, ctx),
             Expression::BinaryExpression(e) => {
-                Self::swap_binary_expressions(e);
+                Self::substitute_swap_binary_expressions(e);
                 Self::fold_binary_expr(expr, ctx);
                 Self::fold_binary_typeof_comparison(expr, ctx);
-                Self::try_compress_is_loose_boolean(expr, ctx);
-                Self::try_minimize_binary(expr, ctx);
-                Self::try_fold_loose_equals_undefined(expr, ctx);
-                Self::try_compress_typeof_undefined(expr, ctx);
+                Self::minimize_loose_boolean(expr, ctx);
+                Self::minimize_binary(expr, ctx);
+                Self::substitute_loose_equals_undefined(expr, ctx);
+                Self::substitute_typeof_undefined(expr, ctx);
             }
             Expression::UnaryExpression(_) => {
                 Self::fold_unary_expr(expr, ctx);
-                Self::try_minimize_not(expr, ctx);
-                Self::try_remove_unary_plus(expr, ctx);
+                Self::minimize_unary(expr, ctx);
+                Self::substitute_unary_plus(expr, ctx);
             }
             Expression::StaticMemberExpression(_) => {
                 Self::fold_static_member_expr(expr, ctx);
-                Self::try_fold_known_property_access(expr, ctx);
+                Self::replace_known_property_access(expr, ctx);
             }
             Expression::ComputedMemberExpression(_) => {
                 Self::fold_computed_member_expr(expr, ctx);
-                Self::try_fold_known_property_access(expr, ctx);
+                Self::replace_known_property_access(expr, ctx);
             }
             Expression::LogicalExpression(_) => {
                 Self::fold_logical_expr(expr, ctx);
                 Self::minimize_logical_expression(expr, ctx);
-                Self::try_compress_is_object_and_not_null(expr, ctx);
-                Self::try_rotate_logical_expression(expr, ctx);
+                Self::substitute_is_object_and_not_null(expr, ctx);
+                Self::substitute_rotate_logical_expression(expr, ctx);
             }
             Expression::ChainExpression(_) => {
                 Self::fold_chain_expr(expr, ctx);
-                Self::try_compress_chain_call_expression(expr, ctx);
+                Self::substitute_chain_call_expression(expr, ctx);
             }
             Expression::CallExpression(_) => {
                 Self::fold_call_expression(expr, ctx);
                 Self::remove_dead_code_call_expression(expr, ctx);
-                Self::try_fold_concat_chain(expr, ctx);
-                Self::try_fold_known_global_methods(expr, ctx);
-                Self::try_fold_simple_function_call(expr, ctx);
-                Self::try_fold_object_or_array_constructor(expr, ctx);
+                Self::replace_concat_chain(expr, ctx);
+                Self::replace_known_global_methods(expr, ctx);
+                Self::substitute_simple_function_call(expr, ctx);
+                Self::substitute_object_or_array_constructor(expr, ctx);
             }
             Expression::ConditionalExpression(logical_expr) => {
-                Self::try_fold_expr_in_boolean_context(&mut logical_expr.test, ctx);
-                if let Some(changed) = Self::try_minimize_conditional(logical_expr, ctx) {
+                Self::minimize_expression_in_boolean_context(&mut logical_expr.test, ctx);
+                if let Some(changed) = Self::minimize_conditional_expression(logical_expr, ctx) {
                     *expr = changed;
                     ctx.state.changed = true;
                 }
                 Self::try_fold_conditional_expression(expr, ctx);
             }
             Expression::AssignmentExpression(e) => {
-                Self::try_compress_normal_assignment_to_combined_logical_assignment(e, ctx);
-                Self::try_compress_normal_assignment_to_combined_assignment(e, ctx);
-                Self::try_compress_assignment_to_update_expression(expr, ctx);
+                Self::minimize_normal_assignment_to_combined_logical_assignment(e, ctx);
+                Self::minimize_normal_assignment_to_combined_assignment(e, ctx);
+                Self::minimize_assignment_to_update_expression(expr, ctx);
                 Self::remove_unused_assignment_expr(expr, ctx);
             }
-            Expression::SequenceExpression(_) => Self::try_fold_sequence_expression(expr, ctx),
-            Expression::ArrowFunctionExpression(e) => Self::try_compress_arrow_expression(e, ctx),
+            Expression::SequenceExpression(_) => Self::remove_sequence_expression(expr, ctx),
+            Expression::ArrowFunctionExpression(e) => Self::substitute_arrow_expression(e, ctx),
             Expression::FunctionExpression(e) => Self::try_remove_name_from_functions(e, ctx),
             Expression::ClassExpression(e) => Self::try_remove_name_from_classes(e, ctx),
             Expression::NewExpression(e) => {
-                Self::try_compress_typed_array_constructor(e, ctx);
-                Self::try_fold_new_expression(expr, ctx);
-                Self::try_fold_object_or_array_constructor(expr, ctx);
+                Self::substitute_typed_array_constructor(e, ctx);
+                Self::substitute_global_new_expression(expr, ctx);
+                Self::substitute_object_or_array_constructor(expr, ctx);
             }
-            Expression::BooleanLiteral(_) => Self::try_compress_boolean(expr, ctx),
-            Expression::ArrayExpression(_) => Self::try_compress_array_expression(expr, ctx),
+            Expression::BooleanLiteral(_) => Self::substitute_boolean(expr, ctx),
+            Expression::ArrayExpression(_) => Self::substitute_array_expression(expr, ctx),
             Expression::Identifier(_) => Self::inline_identifier_reference(expr, ctx),
             _ => {}
         }
@@ -276,26 +276,26 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
 
     fn exit_unary_expression(&mut self, expr: &mut UnaryExpression<'a>, ctx: &mut TraverseCtx<'a>) {
         if expr.operator.is_not() {
-            let mut ctx = Ctx::new(ctx);
-            Self::try_fold_expr_in_boolean_context(&mut expr.argument, &mut ctx);
+            let ctx = &mut Ctx::new(ctx);
+            Self::minimize_expression_in_boolean_context(&mut expr.argument, ctx);
         }
     }
 
     fn exit_call_expression(&mut self, e: &mut CallExpression<'a>, ctx: &mut TraverseCtx<'a>) {
-        let mut ctx = Ctx::new(ctx);
-        Self::substitute_call_expression(e, &mut ctx);
+        let ctx = &mut Ctx::new(ctx);
+        Self::substitute_call_expression(e, ctx);
         Self::remove_empty_spread_arguments(&mut e.arguments);
     }
 
     fn exit_new_expression(&mut self, e: &mut NewExpression<'a>, ctx: &mut TraverseCtx<'a>) {
-        let mut ctx = Ctx::new(ctx);
-        Self::substitute_new_expression(e, &mut ctx);
+        let ctx = &mut Ctx::new(ctx);
+        Self::substitute_new_expression(e, ctx);
         Self::remove_empty_spread_arguments(&mut e.arguments);
     }
 
     fn exit_object_property(&mut self, prop: &mut ObjectProperty<'a>, ctx: &mut TraverseCtx<'a>) {
-        let mut ctx = Ctx::new(ctx);
-        Self::substitute_object_property(prop, &mut ctx);
+        let ctx = &mut Ctx::new(ctx);
+        Self::substitute_object_property(prop, ctx);
     }
 
     fn exit_assignment_target_property(
@@ -303,8 +303,8 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
         node: &mut AssignmentTargetProperty<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        let mut ctx = Ctx::new(ctx);
-        Self::substitute_assignment_target_property(node, &mut ctx);
+        let ctx = &mut Ctx::new(ctx);
+        Self::substitute_assignment_target_property(node, ctx);
     }
 
     fn exit_assignment_target_property_property(
@@ -312,15 +312,13 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
         prop: &mut AssignmentTargetPropertyProperty<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        let mut ctx = Ctx::new(ctx);
-
-        Self::substitute_assignment_target_property_property(prop, &mut ctx);
+        let ctx = &mut Ctx::new(ctx);
+        Self::substitute_assignment_target_property_property(prop, ctx);
     }
 
     fn exit_binding_property(&mut self, prop: &mut BindingProperty<'a>, ctx: &mut TraverseCtx<'a>) {
-        let mut ctx = Ctx::new(ctx);
-
-        Self::substitute_binding_property(prop, &mut ctx);
+        let ctx = &mut Ctx::new(ctx);
+        Self::substitute_binding_property(prop, ctx);
     }
 
     fn exit_method_definition(
@@ -328,9 +326,8 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
         prop: &mut MethodDefinition<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        let mut ctx = Ctx::new(ctx);
-
-        Self::substitute_method_definition(prop, &mut ctx);
+        let ctx = &mut Ctx::new(ctx);
+        Self::substitute_method_definition(prop, ctx);
     }
 
     fn exit_property_definition(
@@ -338,9 +335,8 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
         prop: &mut PropertyDefinition<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        let mut ctx = Ctx::new(ctx);
-
-        Self::substitute_property_definition(prop, &mut ctx);
+        let ctx = &mut Ctx::new(ctx);
+        Self::substitute_property_definition(prop, ctx);
     }
 
     fn exit_accessor_property(
@@ -348,9 +344,8 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
         prop: &mut AccessorProperty<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        let mut ctx = Ctx::new(ctx);
-
-        Self::substitute_accessor_property(prop, &mut ctx);
+        let ctx = &mut Ctx::new(ctx);
+        Self::substitute_accessor_property(prop, ctx);
     }
 
     fn exit_member_expression(
@@ -363,8 +358,8 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
     }
 
     fn exit_class_body(&mut self, body: &mut ClassBody<'a>, ctx: &mut TraverseCtx<'a>) {
-        let mut ctx = Ctx::new(ctx);
-        Self::remove_dead_code_exit_class_body(body, &mut ctx);
+        let ctx = &mut Ctx::new(ctx);
+        Self::remove_dead_code_exit_class_body(body, ctx);
     }
 
     fn exit_catch_clause(&mut self, catch: &mut CatchClause<'a>, ctx: &mut TraverseCtx<'a>) {
@@ -437,8 +432,8 @@ impl<'a> Traverse<'a, MinifierState<'a>> for DeadCodeElimination {
         decl: &mut VariableDeclarator<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        let mut ctx = Ctx::new(ctx);
-        PeepholeOptimizations::init_symbol_value(decl, &mut ctx);
+        let ctx = &mut Ctx::new(ctx);
+        PeepholeOptimizations::init_symbol_value(decl, ctx);
     }
 
     fn exit_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
@@ -463,8 +458,8 @@ impl<'a> Traverse<'a, MinifierState<'a>> for DeadCodeElimination {
     }
 
     fn exit_statements(&mut self, stmts: &mut Vec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {
-        let mut ctx = Ctx::new(ctx);
-        PeepholeOptimizations::minimize_statements(stmts, &mut ctx);
+        let ctx = &mut Ctx::new(ctx);
+        PeepholeOptimizations::minimize_statements(stmts, ctx);
     }
 
     fn exit_expression(&mut self, e: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
@@ -495,7 +490,7 @@ impl<'a> Traverse<'a, MinifierState<'a>> for DeadCodeElimination {
                 PeepholeOptimizations::try_fold_conditional_expression(e, ctx);
             }
             Expression::SequenceExpression(_) => {
-                PeepholeOptimizations::try_fold_sequence_expression(e, ctx);
+                PeepholeOptimizations::remove_sequence_expression(e, ctx);
             }
             Expression::AssignmentExpression(_) => {
                 PeepholeOptimizations::remove_unused_assignment_expr(e, ctx);

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -298,7 +298,7 @@ impl<'a> PeepholeOptimizations {
         };
     }
 
-    pub fn try_fold_sequence_expression(expr: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) {
+    pub fn remove_sequence_expression(expr: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) {
         let Expression::SequenceExpression(e) = expr else { return };
         let should_keep_as_sequence_expr = e
             .expressions

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -67,7 +67,7 @@ impl<'a> PeepholeOptimizations {
     fn remove_unused_logical_expr(e: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) -> bool {
         let Expression::LogicalExpression(logical_expr) = e else { return false };
         if !logical_expr.operator.is_coalesce() {
-            Self::try_fold_expr_in_boolean_context(&mut logical_expr.left, ctx);
+            Self::minimize_expression_in_boolean_context(&mut logical_expr.left, ctx);
         }
         if Self::remove_unused_expression(&mut logical_expr.right, ctx) {
             Self::remove_unused_expression(&mut logical_expr.left, ctx);

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -22,7 +22,7 @@ type Arguments<'a> = oxc_allocator::Vec<'a, Argument<'a>>;
 /// Minimize With Known Methods
 /// <https://github.com/google/closure-compiler/blob/v20240609/src/com/google/javascript/jscomp/PeepholeReplaceKnownMethods.java>
 impl<'a> PeepholeOptimizations {
-    pub fn try_fold_known_global_methods(node: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) {
+    pub fn replace_known_global_methods(node: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) {
         let Expression::CallExpression(ce) = node else { return };
 
         // Use constant evaluation for known method calls
@@ -117,7 +117,7 @@ impl<'a> PeepholeOptimizations {
 
     /// `[].concat(a).concat(b)` -> `[].concat(a, b)`
     /// `"".concat(a).concat(b)` -> `"".concat(a, b)`
-    pub fn try_fold_concat_chain(node: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) {
+    pub fn replace_concat_chain(node: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) {
         let original_span = if let Expression::CallExpression(root_call_expr) = node {
             root_call_expr.span
         } else {
@@ -356,7 +356,7 @@ impl<'a> PeepholeOptimizations {
         }
     }
 
-    pub fn try_fold_known_property_access(node: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) {
+    pub fn replace_known_property_access(node: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) {
         let (name, object, span) = match node {
             Expression::StaticMemberExpression(member) if !member.optional => {
                 (member.property.name.as_str(), &member.object, member.span)


### PR DESCRIPTION
Consistent naming to understand where the methods are coming from, also enforce ordering.