### PR TITLE
refactor(linter): rename var for consistency

### DIFF
--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -469,10 +469,10 @@ impl Runtime {
                         let dep_path = &request.resolved_requested_path;
                         if encountered_paths.insert(Arc::clone(dep_path)) {
                             scope.spawn({
-                                let tx_resolve_output = tx_process_output.clone();
+                                let tx_process_output = tx_process_output.clone();
                                 let dep_path = Arc::clone(dep_path);
                                 move |_| {
-                                    tx_resolve_output
+                                    tx_process_output
                                         .send(me.process_path(
                                             &dep_path,
                                             check_syntax_errors,


### PR DESCRIPTION
Nit. Rename var to `tx_process_output` for consistency with everywhere else in this function.

I assume the var was previously called `tx_resolve_output` everywhere, and this one slipped through the net when renaming the rest.
