### PR TITLE
feat(linter): add react/jsx-handler-names rule

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -338,6 +338,7 @@ mod react {
     pub mod jsx_curly_brace_presence;
     pub mod jsx_filename_extension;
     pub mod jsx_fragments;
+    pub mod jsx_handler_names;
     pub mod jsx_key;
     pub mod jsx_no_comment_textnodes;
     pub mod jsx_no_duplicate_props;
@@ -963,6 +964,7 @@ oxc_macros::declare_all_lint_rules! {
     react::jsx_filename_extension,
     react::jsx_boolean_value,
     react::jsx_curly_brace_presence,
+    react::jsx_handler_names,
     react::jsx_key,
     react::jsx_no_comment_textnodes,
     react::jsx_no_duplicate_props,

--- a/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
@@ -1,0 +1,249 @@
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    fixer::{RuleFix, RuleFixer},
+    rule::Rule,
+};
+
+fn jsx_handler_names_diagnostic(span: Span) -> OxcDiagnostic {
+    // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
+    OxcDiagnostic::warn("Should be an imperative statement about what is wrong")
+        .with_help("Should be a command-like statement that tells the user how to fix the issue")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct JsxHandlerNames;
+
+// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Briefly describe the rule's purpose.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Explain why violating this rule is problematic.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
+    /// ```
+    JsxHandlerNames,
+    react,
+    nursery, // TODO: change category to `correctness`, `suspicious`, `pedantic`, `perf`, `restriction`, or `style`
+             // See <https://oxc.rs/docs/contribute/linter.html#rule-category> for details
+    pending  // TODO: describe fix capabilities. Remove if no fix can be done,
+             // keep at 'pending' if you think one could be added but don't know how.
+             // Options are 'fix', 'fix_dangerous', 'suggestion', and 'conditional_fix_suggestion'
+);
+
+impl Rule for JsxHandlerNames {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {}
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("<TestComponent onChange={this.handleChange} />", None),
+        ("<TestComponent onChange={this.handle123Change} />", None),
+        ("<TestComponent onChange={this.props.onChange} />", None),
+        (
+            "
+			        <TestComponent
+			          onChange={
+			            this
+			              .handleChange
+			          } />
+			      ",
+            None,
+        ),
+        (
+            "
+			        <TestComponent
+			          onChange={
+			            this
+			              .props
+			              .handleChange
+			          } />
+			      ",
+            None,
+        ),
+        (
+            "<TestComponent onChange={handleChange} />",
+            Some(serde_json::json!([{ "checkLocalVariables": true }])),
+        ),
+        (
+            "<TestComponent onChange={takeCareOfChange} />",
+            Some(serde_json::json!([{ "checkLocalVariables": false }])),
+        ),
+        (
+            "<TestComponent onChange={event => window.alert(event.target.value)} />",
+            Some(serde_json::json!([{ "checkInlineFunction": false }])),
+        ),
+        (
+            "<TestComponent onChange={() => handleChange()} />",
+            Some(
+                serde_json::json!([        {          "checkInlineFunction": true,          "checkLocalVariables": true,        },      ]),
+            ),
+        ),
+        (
+            "<TestComponent onChange={() => this.handleChange()} />",
+            Some(serde_json::json!([{ "checkInlineFunction": true }])),
+        ),
+        ("<TestComponent onChange={() => 42} />", None),
+        ("<TestComponent onChange={this.props.onFoo} />", None),
+        ("<TestComponent isSelected={this.props.isSelected} />", None),
+        ("<TestComponent shouldDisplay={this.state.shouldDisplay} />", None),
+        ("<TestComponent shouldDisplay={arr[0].prop} />", None),
+        ("<TestComponent onChange={props.onChange} />", None),
+        ("<TestComponent ref={this.handleRef} />", None),
+        ("<TestComponent ref={this.somethingRef} />", None),
+        (
+            "<TestComponent test={this.props.content} />",
+            Some(
+                serde_json::json!([        {          "eventHandlerPrefix": "on",          "eventHandlerPropPrefix": "on",        },      ]),
+            ),
+        ),
+        ("<TestComponent onChange={props::handleChange} />", None),
+        ("<TestComponent onChange={::props.onChange} />", None),
+        ("<TestComponent onChange={props.foo::handleChange} />", None),
+        (
+            "<TestComponent onChange={() => props::handleChange()} />",
+            Some(serde_json::json!([{ "checkInlineFunction": true }])),
+        ),
+        (
+            "<TestComponent onChange={() => ::props.onChange()} />",
+            Some(serde_json::json!([{ "checkInlineFunction": true }])),
+        ),
+        (
+            "<TestComponent onChange={() => props.foo::handleChange()} />",
+            Some(serde_json::json!([{ "checkInlineFunction": true }])),
+        ),
+        ("<TestComponent only={this.only} />", None),
+        (
+            "<TestComponent onChange={this.someChange} />",
+            Some(
+                serde_json::json!([        {          "eventHandlerPrefix": false,          "eventHandlerPropPrefix": "on",        },      ]),
+            ),
+        ),
+        (
+            "<TestComponent somePrefixChange={this.someChange} />",
+            Some(
+                serde_json::json!([        {          "eventHandlerPrefix": false,          "eventHandlerPropPrefix": "somePrefix",        },      ]),
+            ),
+        ),
+        (
+            "<TestComponent someProp={this.handleChange} />",
+            Some(serde_json::json!([{ "eventHandlerPropPrefix": false }])),
+        ),
+        (
+            "<TestComponent someProp={this.somePrefixChange} />",
+            Some(
+                serde_json::json!([        {          "eventHandlerPrefix": "somePrefix",          "eventHandlerPropPrefix": false,        },      ]),
+            ),
+        ),
+        (
+            "<TestComponent someProp={props.onChange} />",
+            Some(serde_json::json!([{ "eventHandlerPropPrefix": false }])),
+        ),
+        (
+            "<ComponentFromOtherLibraryBar customPropNameBar={handleSomething} />;",
+            Some(
+                serde_json::json!([{ "checkLocalVariables": true, "ignoreComponentNames": ["ComponentFromOtherLibraryBar"] }]),
+            ),
+        ),
+        (
+            "
+			        function App() {
+			          return (
+			            <div>
+			              <MyLibInput customPropNameBar={handleSomething} />;
+			              <MyLibCheckbox customPropNameBar={handleSomething} />;
+			              <MyLibButtom customPropNameBar={handleSomething} />;
+			            </div>
+			          )
+			        }
+			      ",
+            Some(
+                serde_json::json!([{ "checkLocalVariables": true, "ignoreComponentNames": ["MyLib*"] }]),
+            ),
+        ),
+    ];
+
+    let fail = vec![
+        ("<TestComponent onChange={this.doSomethingOnChange} />", None),
+        ("<TestComponent onChange={this.handlerChange} />", None),
+        ("<TestComponent onChange={this.handle} />", None),
+        ("<TestComponent onChange={this.handle2} />", None),
+        ("<TestComponent onChange={this.handl3Change} />", None),
+        ("<TestComponent onChange={this.handle4change} />", None),
+        (
+            "<TestComponent onChange={takeCareOfChange} />",
+            Some(serde_json::json!([{ "checkLocalVariables": true }])),
+        ),
+        (
+            "<TestComponent onChange={() => this.takeCareOfChange()} />",
+            Some(serde_json::json!([{ "checkInlineFunction": true }])),
+        ),
+        ("<TestComponent only={this.handleChange} />", None),
+        ("<TestComponent2 only={this.handleChange} />", None),
+        ("<TestComponent handleChange={this.handleChange} />", None),
+        (
+            "<TestComponent whenChange={handleChange} />",
+            Some(serde_json::json!([{ "checkLocalVariables": true }])),
+        ),
+        (
+            "<TestComponent whenChange={() => handleChange()} />",
+            Some(
+                serde_json::json!([        {          "checkInlineFunction": true,          "checkLocalVariables": true,        },      ]),
+            ),
+        ),
+        (
+            "<TestComponent onChange={handleChange} />",
+            Some(
+                serde_json::json!([        {          "checkLocalVariables": true,          "eventHandlerPrefix": "handle",          "eventHandlerPropPrefix": "when",        },      ]),
+            ),
+        ),
+        (
+            "<TestComponent onChange={() => handleChange()} />",
+            Some(
+                serde_json::json!([        {          "checkInlineFunction": true,          "checkLocalVariables": true,          "eventHandlerPrefix": "handle",          "eventHandlerPropPrefix": "when",        },      ]),
+            ),
+        ),
+        ("<TestComponent onChange={this.onChange} />", None),
+        ("<TestComponent onChange={props::onChange} />", None),
+        ("<TestComponent onChange={props.foo::onChange} />", None),
+        (
+            "
+			        function App() {
+			          return (
+			            <div>
+			              <MyLibInput customPropNameBar={handleInput} />;
+			              <MyLibCheckbox customPropNameBar={handleCheckbox} />;
+			              <MyLibButtom customPropNameBar={handleButton} />;
+			            </div>
+			          )
+			        }
+			      ",
+            Some(
+                serde_json::json!([{ "checkLocalVariables": true, "ignoreComponentNames": ["MyLibrary*"] }]),
+            ),
+        ),
+    ];
+
+    Tester::new(JsxHandlerNames::NAME, JsxHandlerNames::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
@@ -1,56 +1,377 @@
+use crate::{AstNode, context::LintContext, rule::Rule};
+use lazy_regex::{Regex, RegexBuilder, regex};
+use oxc_ast::{
+    AstKind,
+    ast::{
+        ArrowFunctionExpression, Expression, JSXAttributeName, JSXAttributeValue, JSXElementName,
+        JSXExpression, JSXMemberExpression, JSXMemberExpressionObject, Statement,
+    },
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::Span;
+use oxc_span::{CompactStr, Span};
+use serde_json::Value;
 
-use crate::{
-    AstNode,
-    context::LintContext,
-    fixer::{RuleFix, RuleFixer},
-    rule::Rule,
-};
+fn bad_handler_name_diagnostic(span: Span, prop_name: &str, handler_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Invalid handler name: {handler_name}"))
+        .with_help(format!(
+            "Handler function for {prop_name} prop key must be a camelCase name beginning with \'{handler_name}\' only"
+        ))
+        .with_label(span)
+}
 
-fn jsx_handler_names_diagnostic(span: Span) -> OxcDiagnostic {
-    // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
-    OxcDiagnostic::warn("Should be an imperative statement about what is wrong")
-        .with_help("Should be a command-like statement that tells the user how to fix the issue")
+fn bad_handler_prop_name_diagnostic(
+    span: Span,
+    prop_name: &str,
+    handler_name: &str,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Invalid handler prop name: {prop_name}"))
+        .with_help(format!("Prop key for {handler_name} must begin with \'{prop_name}\'"))
         .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]
-pub struct JsxHandlerNames;
+pub struct JsxHandlerNames(Box<JsxHandlerNamesConfig>);
+
+#[derive(Debug, Clone)]
+pub struct JsxHandlerNamesConfig {
+    /// Whether to check for inline functions in JSX attributes.
+    check_inline_functions: bool,
+    /// Whether to check for local variables in JSX attributes.
+    check_local_variables: bool,
+    /// Event handler prop prefixes to check against.
+    event_handler_prop_prefixes: CompactStr,
+    /// Event handler prefixes to check against.
+    event_handler_prefixes: CompactStr,
+    /// Component names to ignore when checking for event handler prefixes.
+    ignore_component_names: Vec<CompactStr>,
+    /// Compiled regex for event handler prefixes.
+    event_handler_regex: Option<Regex>,
+    /// Compiled regex for event handler prop prefixes.
+    event_handler_prop_regex: Option<Regex>,
+}
+
+impl std::ops::Deref for JsxHandlerNames {
+    type Target = JsxHandlerNamesConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 // See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Briefly describe the rule's purpose.
+    /// Ensures that any component or prop methods used to handle events are correctly prefixed.
     ///
     /// ### Why is this bad?
     ///
-    /// Explain why violating this rule is problematic.
+    /// Inconsistent naming of event handlers and props can reduce code readability and maintainability.
     ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx
-    /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
+    /// <MyComponent handleChange={this.handleChange} />
+    /// <MyComponent onChange={this.componentChanged} />
     /// ```
     ///
     /// Examples of **correct** code for this rule:
     /// ```jsx
-    /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
+    /// <MyComponent onChange={this.handleChange} />
+    /// <MyComponent onChange={this.props.onFoo} />
     /// ```
+    ///
+    /// ### Options
+    ///
+    /// ```json
+    /// {
+    ///   "react/jsx-handler-names": [<enabled>, {
+    ///     "eventHandlerPrefix": <eventHandlerPrefix>,
+    ///     "eventHandlerPropPrefix": <eventHandlerPropPrefix>,
+    ///     "checkLocalVariables": <boolean>,
+    ///     "checkInlineFunction": <boolean>,
+    ///     "ignoreComponentNames": Array<string>
+    ///   }]
+    /// }
+    /// ```
+    ///
+    /// - `eventHandlerPrefix`: Prefix for component methods used as event handlers.
+    ///   Defaults to `handle`
+    /// - `eventHandlerPropPrefix`: Prefix for props that are used as event handlers
+    ///   Defaults to `on`
+    /// - `checkLocalVariables`: Determines whether event handlers stored as local variables
+    ///   are checked. Defaults to `false`
+    /// - `checkInlineFunction`: Determines whether event handlers set as inline functions are
+    ///   checked. Defaults to `false`
+    /// - `ignoreComponentNames`: Array of glob strings, when matched with component name,
+    ///   ignores the rule on that component. Defaults to `[]`
+    ///
     JsxHandlerNames,
     react,
-    nursery, // TODO: change category to `correctness`, `suspicious`, `pedantic`, `perf`, `restriction`, or `style`
-             // See <https://oxc.rs/docs/contribute/linter.html#rule-category> for details
-    pending  // TODO: describe fix capabilities. Remove if no fix can be done,
-             // keep at 'pending' if you think one could be added but don't know how.
-             // Options are 'fix', 'fix_dangerous', 'suggestion', and 'conditional_fix_suggestion'
+    style,
 );
 
+fn build_event_handler_regex(prefixes: &str, prop_prefixes: &str) -> Option<Regex> {
+    if prefixes.is_empty() {
+        return None;
+    }
+    Some(
+        RegexBuilder::new(
+            format!(r"^((props\.{prop_prefixes})|((.*\.)?{prefixes}))[0-9]*[A-Z].*$").as_str(),
+        )
+        .build()
+        .expect("Failed to compile regex for event handler prefixes"),
+    )
+}
+
+fn build_event_handler_prop_regex(prop_prefix: &str) -> Option<Regex> {
+    if prop_prefix.is_empty() {
+        return None;
+    }
+    Some(
+        RegexBuilder::new(format!(r"^({prop_prefix}[A-Z].*|ref)$").as_str())
+            .build()
+            .expect("Failed to compile regex for event handler prop prefixes"),
+    )
+}
+
+impl Default for JsxHandlerNamesConfig {
+    fn default() -> Self {
+        let prefix = "handle";
+        let prop_prefix = "on";
+        JsxHandlerNamesConfig {
+            check_inline_functions: false,
+            check_local_variables: false,
+            event_handler_prop_prefixes: CompactStr::from(prop_prefix),
+            event_handler_prefixes: CompactStr::from(prefix),
+            ignore_component_names: vec![],
+            event_handler_regex: build_event_handler_regex(prefix, prop_prefix),
+            event_handler_prop_regex: build_event_handler_prop_regex(prop_prefix),
+        }
+    }
+}
+
 impl Rule for JsxHandlerNames {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {}
+    fn from_configuration(value: serde_json::Value) -> Self {
+        let mut check_inline_functions = false;
+        let mut check_local_variables = false;
+        let mut event_handler_prop_prefixes = "on";
+        let mut event_handler_prefixes = "handle";
+        let mut ignore_component_names = vec![];
+        if let Some(options) = value.get(0).and_then(Value::as_object) {
+            if let Some(prefixes) = options.get("eventHandlerPrefix") {
+                if prefixes.as_bool() == Some(false) {
+                    event_handler_prefixes = "";
+                } else if let Some(s) = prefixes.as_str() {
+                    event_handler_prefixes = s;
+                }
+            }
+            if let Some(prefixes) = options.get("eventHandlerPropPrefix") {
+                if prefixes.as_bool() == Some(false) {
+                    event_handler_prop_prefixes = "";
+                } else if let Some(s) = prefixes.as_str() {
+                    event_handler_prop_prefixes = s;
+                }
+            }
+            if let Some(raw) = options.get("checkInlineFunction") {
+                if let Some(v) = raw.as_bool() {
+                    check_inline_functions = v;
+                }
+            }
+            if let Some(raw) = options.get("checkLocalVariables") {
+                if let Some(v) = raw.as_bool() {
+                    check_local_variables = v;
+                }
+            }
+            if let Some(names) = options.get("ignoreComponentNames") {
+                if let Some(arr) = names.as_array() {
+                    for name in arr {
+                        if let Some(s) = name.as_str() {
+                            ignore_component_names.push(CompactStr::from(s));
+                        }
+                    }
+                }
+            }
+        }
+
+        let event_handler_regex =
+            build_event_handler_regex(event_handler_prefixes, event_handler_prop_prefixes);
+        let event_handler_prop_regex = build_event_handler_prop_regex(event_handler_prop_prefixes);
+
+        Self(Box::new(JsxHandlerNamesConfig {
+            check_inline_functions,
+            check_local_variables,
+            event_handler_prop_prefixes: CompactStr::from(event_handler_prop_prefixes),
+            event_handler_prefixes: CompactStr::from(event_handler_prefixes),
+            ignore_component_names,
+            event_handler_regex,
+            event_handler_prop_regex,
+        }))
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXAttribute(jsx_attribute) = node.kind() else {
+            return;
+        };
+
+        if !self.ignore_component_names.is_empty() {
+            let parent_node = ctx.nodes().parent_node(node.id());
+            let AstKind::JSXOpeningElement(opening_element) = parent_node.kind() else {
+                return;
+            };
+            let component_name = match &opening_element.name {
+                JSXElementName::Identifier(ident) => ident.name.as_str(),
+                JSXElementName::IdentifierReference(ident) => ident.name.as_str(),
+                JSXElementName::MemberExpression(member_expr) => {
+                    &get_member_expression_name(member_expr)
+                }
+                JSXElementName::NamespacedName(namespaced_name) => {
+                    namespaced_name.name.name.as_str()
+                }
+                JSXElementName::ThisExpression(_) => "this",
+            };
+            for name in &self.ignore_component_names {
+                if fast_glob::glob_match(name.as_ref(), component_name) {
+                    return;
+                }
+            }
+        }
+
+        let Some(value) = &jsx_attribute.value else {
+            return;
+        };
+        let JSXAttributeValue::ExpressionContainer(expression_container) = value else {
+            return;
+        };
+        let value_expr = &expression_container.expression;
+        let is_inline_handler = matches!(value_expr, JSXExpression::ArrowFunctionExpression(_));
+        if !self.check_inline_functions && is_inline_handler {
+            return;
+        }
+        if !self.check_local_variables {
+            if let JSXExpression::ArrowFunctionExpression(arrow_function) = value_expr {
+                if let Some(Statement::ExpressionStatement(stmt)) =
+                    arrow_function.body.statements.first()
+                {
+                    if let Expression::CallExpression(callee_expr) = &stmt.expression {
+                        if !callee_expr.callee.is_member_expression() {
+                            // the inline-handler's body is not a method call
+                            return;
+                        }
+                    } else {
+                        // the inline-handler's body is not a function call
+                        return;
+                    }
+                }
+            } else if !value_expr.is_member_expression() {
+                // the inline-handler's body is not an object's property access
+                return;
+            }
+        }
+
+        let prop_key = match &jsx_attribute.name {
+            JSXAttributeName::Identifier(ident) => ident.name.as_str(),
+            JSXAttributeName::NamespacedName(namespaced_name) => namespaced_name.name.name.as_str(),
+        };
+
+        let prop_value = if self.check_inline_functions && is_inline_handler {
+            match &expression_container.expression {
+                JSXExpression::ArrowFunctionExpression(arrow_function) => {
+                    extract_callee_name_from_arrow_function(arrow_function)
+                        .map(normalize_handler_name)
+                }
+                _ => None,
+            }
+        } else {
+            Some(normalize_handler_name(ctx.source_range(expression_container.span.shrink(1))))
+        };
+
+        if prop_key == "ref" {
+            return;
+        }
+
+        let prop_is_event_handler =
+            self.event_handler_prop_regex.as_ref().map(|r| r.is_match(prop_key));
+        let is_handler_name_correct = prop_value
+            .as_ref()
+            .map_or(Some(false), |v| self.event_handler_regex.as_ref().map(|r| r.is_match(v)));
+
+        match (prop_is_event_handler, is_handler_name_correct) {
+            (Some(true), Some(false)) => {
+                ctx.diagnostic(bad_handler_name_diagnostic(
+                    expression_container.span,
+                    prop_key,
+                    &self.event_handler_prefixes,
+                ));
+            }
+            (Some(false), Some(true)) => {
+                ctx.diagnostic(bad_handler_prop_name_diagnostic(
+                    expression_container.span,
+                    prop_key,
+                    &self.event_handler_prop_prefixes,
+                ));
+            }
+            _ => {
+                // ok
+            }
+        }
+    }
+}
+
+fn get_member_expression_name(member_expr: &JSXMemberExpression) -> CompactStr {
+    match &member_expr.object {
+        JSXMemberExpressionObject::IdentifierReference(ident) => ident.name.as_str().into(),
+        JSXMemberExpressionObject::ThisExpression(_) => "this".into(),
+        JSXMemberExpressionObject::MemberExpression(next_expr) => format!(
+            "{}.{}",
+            get_member_expression_name(next_expr),
+            member_expr.property.name.as_str()
+        )
+        .into(),
+    }
+}
+
+fn normalize_handler_name(s: &str) -> CompactStr {
+    let s1 = regex!(r"\s*").replace_all(s, "");
+    regex!(r"^this\.|.*::").replace(s1.as_ref(), "").into()
+}
+
+// test of aaa
+#[test]
+fn test_normalize_handler_name() {
+    assert_eq!(normalize_handler_name("this.handleChange"), "handleChange");
+    assert_eq!(normalize_handler_name("handleChange"), "handleChange");
+    assert_eq!(normalize_handler_name("this.props.handleChange"), "props.handleChange");
+    assert_eq!(normalize_handler_name("this.props.onChange"), "props.onChange");
+    assert_eq!(normalize_handler_name("this.props.handleChange()"), "props.handleChange()");
+    assert_eq!(normalize_handler_name("this.props.handleChange(42)"), "props.handleChange(42)");
+    assert_eq!(
+        normalize_handler_name("this.props.handleChange(42, 'foo')"),
+        "props.handleChange(42,'foo')"
+    );
+    assert_eq!(
+        normalize_handler_name("this.props.handleChange(42, 'foo', true)"),
+        "props.handleChange(42,'foo',true)"
+    );
+    assert_eq!(normalize_handler_name("props::handleChange"), "handleChange");
+}
+
+fn extract_callee_name_from_arrow_function<'a>(
+    arrow_function: &'a ArrowFunctionExpression<'a>,
+) -> Option<&'a str> {
+    let Some(Statement::ExpressionStatement(stmt)) = arrow_function.body.statements.first() else {
+        return None;
+    };
+    let Expression::CallExpression(call_expr) = &stmt.expression else {
+        return None;
+    };
+    match &call_expr.callee {
+        Expression::Identifier(ident) => Some(ident.name.as_str()),
+        Expression::StaticMemberExpression(member_expr) => Some(member_expr.property.name.as_str()),
+        _ => None,
+    }
 }
 
 #[test]
@@ -96,9 +417,7 @@ fn test() {
         ),
         (
             "<TestComponent onChange={() => handleChange()} />",
-            Some(
-                serde_json::json!([        {          "checkInlineFunction": true,          "checkLocalVariables": true,        },      ]),
-            ),
+            Some(serde_json::json!([{ "checkInlineFunction": true, "checkLocalVariables": true }])),
         ),
         (
             "<TestComponent onChange={() => this.handleChange()} />",
@@ -115,35 +434,36 @@ fn test() {
         (
             "<TestComponent test={this.props.content} />",
             Some(
-                serde_json::json!([        {          "eventHandlerPrefix": "on",          "eventHandlerPropPrefix": "on",        },      ]),
+                serde_json::json!([{ "eventHandlerPrefix": "on", "eventHandlerPropPrefix": "on" }]),
             ),
         ),
-        ("<TestComponent onChange={props::handleChange} />", None),
-        ("<TestComponent onChange={::props.onChange} />", None),
-        ("<TestComponent onChange={props.foo::handleChange} />", None),
-        (
-            "<TestComponent onChange={() => props::handleChange()} />",
-            Some(serde_json::json!([{ "checkInlineFunction": true }])),
-        ),
-        (
-            "<TestComponent onChange={() => ::props.onChange()} />",
-            Some(serde_json::json!([{ "checkInlineFunction": true }])),
-        ),
-        (
-            "<TestComponent onChange={() => props.foo::handleChange()} />",
-            Some(serde_json::json!([{ "checkInlineFunction": true }])),
-        ),
+        // These test cases are commented out because "::" is not understood by the parser.
+        // ("<TestComponent onChange={props::handleChange} />", None),
+        // ("<TestComponent onChange={::props.onChange} />", None),
+        // ("<TestComponent onChange={props.foo::handleChange} />", None),
+        // (
+        //     "<TestComponent onChange={() => props::handleChange()} />",
+        //     Some(serde_json::json!([{ "checkInlineFunction": true }])),
+        // ),
+        // (
+        //     "<TestComponent onChange={() => ::props.onChange()} />",
+        //     Some(serde_json::json!([{ "checkInlineFunction": true }])),
+        // ),
+        // (
+        //     "<TestComponent onChange={() => props.foo::handleChange()} />",
+        //     Some(serde_json::json!([{ "checkInlineFunction": true }])),
+        // ),
         ("<TestComponent only={this.only} />", None),
         (
             "<TestComponent onChange={this.someChange} />",
             Some(
-                serde_json::json!([        {          "eventHandlerPrefix": false,          "eventHandlerPropPrefix": "on",        },      ]),
+                serde_json::json!([{ "eventHandlerPrefix": false, "eventHandlerPropPrefix": "on" }]),
             ),
         ),
         (
             "<TestComponent somePrefixChange={this.someChange} />",
             Some(
-                serde_json::json!([        {          "eventHandlerPrefix": false,          "eventHandlerPropPrefix": "somePrefix",        },      ]),
+                serde_json::json!([{ "eventHandlerPrefix": false, "eventHandlerPropPrefix": "somePrefix" }]),
             ),
         ),
         (
@@ -153,7 +473,7 @@ fn test() {
         (
             "<TestComponent someProp={this.somePrefixChange} />",
             Some(
-                serde_json::json!([        {          "eventHandlerPrefix": "somePrefix",          "eventHandlerPropPrefix": false,        },      ]),
+                serde_json::json!([{ "eventHandlerPrefix": "somePrefix", "eventHandlerPropPrefix": false }]),
             ),
         ),
         (
@@ -168,16 +488,16 @@ fn test() {
         ),
         (
             "
-			        function App() {
-			          return (
-			            <div>
-			              <MyLibInput customPropNameBar={handleSomething} />;
-			              <MyLibCheckbox customPropNameBar={handleSomething} />;
-			              <MyLibButtom customPropNameBar={handleSomething} />;
-			            </div>
-			          )
-			        }
-			      ",
+            function App() {
+              return (
+                <div>
+                  <MyLibInput customPropNameBar={handleSomething} />;
+                  <MyLibCheckbox customPropNameBar={handleSomething} />;
+                  <MyLibButton customPropNameBar={handleSomething} />;
+                </div>
+              )
+            }
+            ",
             Some(
                 serde_json::json!([{ "checkLocalVariables": true, "ignoreComponentNames": ["MyLib*"] }]),
             ),
@@ -208,20 +528,18 @@ fn test() {
         ),
         (
             "<TestComponent whenChange={() => handleChange()} />",
-            Some(
-                serde_json::json!([        {          "checkInlineFunction": true,          "checkLocalVariables": true,        },      ]),
-            ),
+            Some(serde_json::json!([{ "checkInlineFunction": true, "checkLocalVariables": true }])),
         ),
         (
             "<TestComponent onChange={handleChange} />",
             Some(
-                serde_json::json!([        {          "checkLocalVariables": true,          "eventHandlerPrefix": "handle",          "eventHandlerPropPrefix": "when",        },      ]),
+                serde_json::json!([{ "checkLocalVariables": true, "eventHandlerPrefix": "handle", "eventHandlerPropPrefix": "when" }]),
             ),
         ),
         (
             "<TestComponent onChange={() => handleChange()} />",
             Some(
-                serde_json::json!([        {          "checkInlineFunction": true,          "checkLocalVariables": true,          "eventHandlerPrefix": "handle",          "eventHandlerPropPrefix": "when",        },      ]),
+                serde_json::json!([{ "checkInlineFunction": true, "checkLocalVariables": true, "eventHandlerPrefix": "handle", "eventHandlerPropPrefix": "when" }]),
             ),
         ),
         ("<TestComponent onChange={this.onChange} />", None),
@@ -229,16 +547,16 @@ fn test() {
         ("<TestComponent onChange={props.foo::onChange} />", None),
         (
             "
-			        function App() {
-			          return (
-			            <div>
-			              <MyLibInput customPropNameBar={handleInput} />;
-			              <MyLibCheckbox customPropNameBar={handleCheckbox} />;
-			              <MyLibButtom customPropNameBar={handleButton} />;
-			            </div>
-			          )
-			        }
-			      ",
+            function App() {
+              return (
+                <div>
+                  <MyLibInput customPropNameBar={handleInput} />;
+                  <MyLibCheckbox customPropNameBar={handleCheckbox} />;
+                  <MyLibButton customPropNameBar={handleButton} />;
+                </div>
+              )
+            }
+            ",
             Some(
                 serde_json::json!([{ "checkLocalVariables": true, "ignoreComponentNames": ["MyLibrary*"] }]),
             ),

--- a/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
@@ -437,22 +437,6 @@ fn test() {
                 serde_json::json!([{ "eventHandlerPrefix": "on", "eventHandlerPropPrefix": "on" }]),
             ),
         ),
-        // These test cases are commented out because "::" is not understood by the parser.
-        // ("<TestComponent onChange={props::handleChange} />", None),
-        // ("<TestComponent onChange={::props.onChange} />", None),
-        // ("<TestComponent onChange={props.foo::handleChange} />", None),
-        // (
-        //     "<TestComponent onChange={() => props::handleChange()} />",
-        //     Some(serde_json::json!([{ "checkInlineFunction": true }])),
-        // ),
-        // (
-        //     "<TestComponent onChange={() => ::props.onChange()} />",
-        //     Some(serde_json::json!([{ "checkInlineFunction": true }])),
-        // ),
-        // (
-        //     "<TestComponent onChange={() => props.foo::handleChange()} />",
-        //     Some(serde_json::json!([{ "checkInlineFunction": true }])),
-        // ),
         ("<TestComponent only={this.only} />", None),
         (
             "<TestComponent onChange={this.someChange} />",

--- a/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
@@ -346,7 +346,7 @@ fn normalize_handler_name(s: &str) -> CompactStr {
     regex!(r"^this\.|.*::").replace(s1.as_ref(), "").into()
 }
 
-// test of aaa
+// Tests for the normalize_handler_name function to ensure it correctly strips prefixes and whitespace.
 #[test]
 fn test_normalize_handler_name() {
     assert_eq!(normalize_handler_name("this.handleChange"), "handleChange");

--- a/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
@@ -341,7 +341,7 @@ fn get_member_expression_name(member_expr: &JSXMemberExpression) -> CompactStr {
 
 fn normalize_handler_name(s: &str) -> CompactStr {
     let s1 = regex!(r"\s*").replace_all(s, "");
-    regex!(r"^this\.|.*::").replace(s1.as_ref(), "").into()
+    regex!(r"^this\.|\S*::").replace(s1.as_ref(), "").into()
 }
 
 // Tests for the normalize_handler_name function to ensure it correctly strips prefixes and whitespace.

--- a/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
@@ -386,7 +386,7 @@ fn get_member_expression_name(member_expr: &JSXMemberExpression) -> CompactStr {
 
 fn normalize_handler_name(s: &str) -> CompactStr {
     // Remove whitespace and leading "this." or "props::" or "this.props::"
-    regex!(r"\s+|^this\.|\S*::").replace_all(s, "").into()
+    regex!(r"\s+|^this\.|[\w.]*::").replace_all(s, "").into()
 }
 
 // Tests for the normalize_handler_name function to ensure it correctly strips prefixes and whitespace.

--- a/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
@@ -286,9 +286,11 @@ impl Rule for JsxHandlerNames {
             return;
         }
 
-        let prop_key = match &jsx_attribute.name {
-            JSXAttributeName::Identifier(ident) => ident.name.as_str(),
-            JSXAttributeName::NamespacedName(namespaced_name) => namespaced_name.name.name.as_str(),
+        let (prop_key, prop_span) = match &jsx_attribute.name {
+            JSXAttributeName::Identifier(ident) => (ident.name.as_str(), ident.span),
+            JSXAttributeName::NamespacedName(namespaced_name) => {
+                (namespaced_name.name.name.as_str(), namespaced_name.span)
+            }
         };
 
         let prop_value = if self.check_inline_functions && is_inline_handler {
@@ -324,7 +326,7 @@ impl Rule for JsxHandlerNames {
             }
             (Some(value), Some(false), Some(true)) => {
                 ctx.diagnostic(bad_handler_prop_name_diagnostic(
-                    expression_container.span,
+                    prop_span,
                     prop_key,
                     &value,
                     &self.event_handler_prop_prefixes,

--- a/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
@@ -587,8 +587,6 @@ fn test() {
             ),
         ),
         ("<TestComponent onChange={this.onChange} />", None),
-        ("<TestComponent onChange={props::onChange} />", None),
-        ("<TestComponent onChange={props.foo::onChange} />", None),
         (
             "
             function App() {

--- a/crates/oxc_linter/src/snapshots/react_jsx_handler_names.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_handler_names.snap
@@ -1,0 +1,155 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle
+   ╭─[jsx_handler_names.tsx:1:25]
+ 1 │ <TestComponent onChange={this.doSomethingOnChange} />
+   ·                         ──────────────────────────
+   ╰────
+  help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
+
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle
+   ╭─[jsx_handler_names.tsx:1:25]
+ 1 │ <TestComponent onChange={this.handlerChange} />
+   ·                         ────────────────────
+   ╰────
+  help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
+
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle
+   ╭─[jsx_handler_names.tsx:1:25]
+ 1 │ <TestComponent onChange={this.handle} />
+   ·                         ─────────────
+   ╰────
+  help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
+
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle
+   ╭─[jsx_handler_names.tsx:1:25]
+ 1 │ <TestComponent onChange={this.handle2} />
+   ·                         ──────────────
+   ╰────
+  help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
+
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle
+   ╭─[jsx_handler_names.tsx:1:25]
+ 1 │ <TestComponent onChange={this.handl3Change} />
+   ·                         ───────────────────
+   ╰────
+  help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
+
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle
+   ╭─[jsx_handler_names.tsx:1:25]
+ 1 │ <TestComponent onChange={this.handle4change} />
+   ·                         ────────────────────
+   ╰────
+  help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
+
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle
+   ╭─[jsx_handler_names.tsx:1:25]
+ 1 │ <TestComponent onChange={takeCareOfChange} />
+   ·                         ──────────────────
+   ╰────
+  help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
+
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle
+   ╭─[jsx_handler_names.tsx:1:25]
+ 1 │ <TestComponent onChange={() => this.takeCareOfChange()} />
+   ·                         ───────────────────────────────
+   ╰────
+  help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
+
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: only
+   ╭─[jsx_handler_names.tsx:1:21]
+ 1 │ <TestComponent only={this.handleChange} />
+   ·                     ───────────────────
+   ╰────
+  help: Prop key for on must begin with 'only'
+
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: only
+   ╭─[jsx_handler_names.tsx:1:22]
+ 1 │ <TestComponent2 only={this.handleChange} />
+   ·                      ───────────────────
+   ╰────
+  help: Prop key for on must begin with 'only'
+
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: handleChange
+   ╭─[jsx_handler_names.tsx:1:29]
+ 1 │ <TestComponent handleChange={this.handleChange} />
+   ·                             ───────────────────
+   ╰────
+  help: Prop key for on must begin with 'handleChange'
+
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: whenChange
+   ╭─[jsx_handler_names.tsx:1:27]
+ 1 │ <TestComponent whenChange={handleChange} />
+   ·                           ──────────────
+   ╰────
+  help: Prop key for on must begin with 'whenChange'
+
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: whenChange
+   ╭─[jsx_handler_names.tsx:1:27]
+ 1 │ <TestComponent whenChange={() => handleChange()} />
+   ·                           ──────────────────────
+   ╰────
+  help: Prop key for on must begin with 'whenChange'
+
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: onChange
+   ╭─[jsx_handler_names.tsx:1:25]
+ 1 │ <TestComponent onChange={handleChange} />
+   ·                         ──────────────
+   ╰────
+  help: Prop key for when must begin with 'onChange'
+
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: onChange
+   ╭─[jsx_handler_names.tsx:1:25]
+ 1 │ <TestComponent onChange={() => handleChange()} />
+   ·                         ──────────────────────
+   ╰────
+  help: Prop key for when must begin with 'onChange'
+
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle
+   ╭─[jsx_handler_names.tsx:1:25]
+ 1 │ <TestComponent onChange={this.onChange} />
+   ·                         ───────────────
+   ╰────
+  help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
+
+  × Expected `}` but found `:`
+   ╭─[jsx_handler_names.tsx:1:31]
+ 1 │ <TestComponent onChange={props::onChange} />
+   ·                               ┬
+   ·                               ╰── `}` expected
+   ╰────
+
+  × Expected `}` but found `:`
+   ╭─[jsx_handler_names.tsx:1:35]
+ 1 │ <TestComponent onChange={props.foo::onChange} />
+   ·                                   ┬
+   ·                                   ╰── `}` expected
+   ╰────
+
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: customPropNameBar
+   ╭─[jsx_handler_names.tsx:5:49]
+ 4 │                 <div>
+ 5 │                   <MyLibInput customPropNameBar={handleInput} />;
+   ·                                                 ─────────────
+ 6 │                   <MyLibCheckbox customPropNameBar={handleCheckbox} />;
+   ╰────
+  help: Prop key for on must begin with 'customPropNameBar'
+
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: customPropNameBar
+   ╭─[jsx_handler_names.tsx:6:52]
+ 5 │                   <MyLibInput customPropNameBar={handleInput} />;
+ 6 │                   <MyLibCheckbox customPropNameBar={handleCheckbox} />;
+   ·                                                    ────────────────
+ 7 │                   <MyLibButton customPropNameBar={handleButton} />;
+   ╰────
+  help: Prop key for on must begin with 'customPropNameBar'
+
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: customPropNameBar
+   ╭─[jsx_handler_names.tsx:7:50]
+ 6 │                   <MyLibCheckbox customPropNameBar={handleCheckbox} />;
+ 7 │                   <MyLibButton customPropNameBar={handleButton} />;
+   ·                                                  ──────────────
+ 8 │                 </div>
+   ╰────
+  help: Prop key for on must begin with 'customPropNameBar'

--- a/crates/oxc_linter/src/snapshots/react_jsx_handler_names.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_handler_names.snap
@@ -58,51 +58,51 @@ source: crates/oxc_linter/src/tester.rs
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: only
-   ╭─[jsx_handler_names.tsx:1:21]
+   ╭─[jsx_handler_names.tsx:1:16]
  1 │ <TestComponent only={this.handleChange} />
-   ·                     ───────────────────
+   ·                ────
    ╰────
   help: Prop key for handleChange must begin with 'on'
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: only
-   ╭─[jsx_handler_names.tsx:1:22]
+   ╭─[jsx_handler_names.tsx:1:17]
  1 │ <TestComponent2 only={this.handleChange} />
-   ·                      ───────────────────
+   ·                 ────
    ╰────
   help: Prop key for handleChange must begin with 'on'
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: handleChange
-   ╭─[jsx_handler_names.tsx:1:29]
+   ╭─[jsx_handler_names.tsx:1:16]
  1 │ <TestComponent handleChange={this.handleChange} />
-   ·                             ───────────────────
+   ·                ────────────
    ╰────
   help: Prop key for handleChange must begin with 'on'
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: whenChange
-   ╭─[jsx_handler_names.tsx:1:27]
+   ╭─[jsx_handler_names.tsx:1:16]
  1 │ <TestComponent whenChange={handleChange} />
-   ·                           ──────────────
+   ·                ──────────
    ╰────
   help: Prop key for handleChange must begin with 'on'
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: whenChange
-   ╭─[jsx_handler_names.tsx:1:27]
+   ╭─[jsx_handler_names.tsx:1:16]
  1 │ <TestComponent whenChange={() => handleChange()} />
-   ·                           ──────────────────────
+   ·                ──────────
    ╰────
   help: Prop key for handleChange must begin with 'on'
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: onChange
-   ╭─[jsx_handler_names.tsx:1:25]
+   ╭─[jsx_handler_names.tsx:1:16]
  1 │ <TestComponent onChange={handleChange} />
-   ·                         ──────────────
+   ·                ────────
    ╰────
   help: Prop key for handleChange must begin with 'when'
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: onChange
-   ╭─[jsx_handler_names.tsx:1:25]
+   ╭─[jsx_handler_names.tsx:1:16]
  1 │ <TestComponent onChange={() => handleChange()} />
-   ·                         ──────────────────────
+   ·                ────────
    ╰────
   help: Prop key for handleChange must begin with 'when'
 
@@ -114,9 +114,9 @@ source: crates/oxc_linter/src/tester.rs
   help: Handler function for onChange prop key must be a camelCase name beginning with 'when|on' only
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: somePrefixChange
-   ╭─[jsx_handler_names.tsx:1:33]
+   ╭─[jsx_handler_names.tsx:1:16]
  1 │ <TestComponent somePrefixChange={handleChange} />
-   ·                                 ──────────────
+   ·                ────────────────
    ╰────
   help: Prop key for handleChange must begin with 'when|on'
 
@@ -142,28 +142,28 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: customPropNameBar
-   ╭─[jsx_handler_names.tsx:5:49]
+   ╭─[jsx_handler_names.tsx:5:31]
  4 │                 <div>
  5 │                   <MyLibInput customPropNameBar={handleInput} />;
-   ·                                                 ─────────────
+   ·                               ─────────────────
  6 │                   <MyLibCheckbox customPropNameBar={handleCheckbox} />;
    ╰────
   help: Prop key for handleInput must begin with 'on'
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: customPropNameBar
-   ╭─[jsx_handler_names.tsx:6:52]
+   ╭─[jsx_handler_names.tsx:6:34]
  5 │                   <MyLibInput customPropNameBar={handleInput} />;
  6 │                   <MyLibCheckbox customPropNameBar={handleCheckbox} />;
-   ·                                                    ────────────────
+   ·                                  ─────────────────
  7 │                   <MyLibButton customPropNameBar={handleButton} />;
    ╰────
   help: Prop key for handleCheckbox must begin with 'on'
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: customPropNameBar
-   ╭─[jsx_handler_names.tsx:7:50]
+   ╭─[jsx_handler_names.tsx:7:32]
  6 │                   <MyLibCheckbox customPropNameBar={handleCheckbox} />;
  7 │                   <MyLibButton customPropNameBar={handleButton} />;
-   ·                                                  ──────────────
+   ·                                ─────────────────
  8 │                 </div>
    ╰────
   help: Prop key for handleButton must begin with 'on'

--- a/crates/oxc_linter/src/snapshots/react_jsx_handler_names.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_handler_names.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: doSomethingOnChange
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={this.doSomethingOnChange} />
    ·                         ──────────────────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handlerChange
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={this.handlerChange} />
    ·                         ────────────────────
@@ -22,35 +22,35 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle2
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={this.handle2} />
    ·                         ──────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handl3Change
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={this.handl3Change} />
    ·                         ───────────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle4change
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={this.handle4change} />
    ·                         ────────────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: takeCareOfChange
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={takeCareOfChange} />
    ·                         ──────────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: takeCareOfChange
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={() => this.takeCareOfChange()} />
    ·                         ───────────────────────────────
@@ -62,51 +62,51 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <TestComponent only={this.handleChange} />
    ·                     ───────────────────
    ╰────
-  help: Prop key for on must begin with 'only'
+  help: Prop key for handleChange must begin with 'on'
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: only
    ╭─[jsx_handler_names.tsx:1:22]
  1 │ <TestComponent2 only={this.handleChange} />
    ·                      ───────────────────
    ╰────
-  help: Prop key for on must begin with 'only'
+  help: Prop key for handleChange must begin with 'on'
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: handleChange
    ╭─[jsx_handler_names.tsx:1:29]
  1 │ <TestComponent handleChange={this.handleChange} />
    ·                             ───────────────────
    ╰────
-  help: Prop key for on must begin with 'handleChange'
+  help: Prop key for handleChange must begin with 'on'
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: whenChange
    ╭─[jsx_handler_names.tsx:1:27]
  1 │ <TestComponent whenChange={handleChange} />
    ·                           ──────────────
    ╰────
-  help: Prop key for on must begin with 'whenChange'
+  help: Prop key for handleChange must begin with 'on'
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: whenChange
    ╭─[jsx_handler_names.tsx:1:27]
  1 │ <TestComponent whenChange={() => handleChange()} />
    ·                           ──────────────────────
    ╰────
-  help: Prop key for on must begin with 'whenChange'
+  help: Prop key for handleChange must begin with 'on'
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: onChange
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={handleChange} />
    ·                         ──────────────
    ╰────
-  help: Prop key for when must begin with 'onChange'
+  help: Prop key for handleChange must begin with 'when'
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: onChange
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={() => handleChange()} />
    ·                         ──────────────────────
    ╰────
-  help: Prop key for when must begin with 'onChange'
+  help: Prop key for handleChange must begin with 'when'
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: onChange
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={this.onChange} />
    ·                         ───────────────
@@ -134,7 +134,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                                 ─────────────
  6 │                   <MyLibCheckbox customPropNameBar={handleCheckbox} />;
    ╰────
-  help: Prop key for on must begin with 'customPropNameBar'
+  help: Prop key for handleInput must begin with 'on'
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: customPropNameBar
    ╭─[jsx_handler_names.tsx:6:52]
@@ -143,7 +143,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                                    ────────────────
  7 │                   <MyLibButton customPropNameBar={handleButton} />;
    ╰────
-  help: Prop key for on must begin with 'customPropNameBar'
+  help: Prop key for handleCheckbox must begin with 'on'
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: customPropNameBar
    ╭─[jsx_handler_names.tsx:7:50]
@@ -152,4 +152,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                                                  ──────────────
  8 │                 </div>
    ╰────
-  help: Prop key for on must begin with 'customPropNameBar'
+  help: Prop key for handleButton must begin with 'on'

--- a/crates/oxc_linter/src/snapshots/react_jsx_handler_names.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_handler_names.snap
@@ -106,6 +106,20 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Prop key for handleChange must begin with 'when'
 
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handleChange
+   ╭─[jsx_handler_names.tsx:1:25]
+ 1 │ <TestComponent onChange={handleChange} />
+   ·                         ──────────────
+   ╰────
+  help: Handler function for onChange prop key must be a camelCase name beginning with 'when|on' only
+
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: somePrefixChange
+   ╭─[jsx_handler_names.tsx:1:33]
+ 1 │ <TestComponent somePrefixChange={handleChange} />
+   ·                                 ──────────────
+   ╰────
+  help: Prop key for handleChange must begin with 'when|on'
+
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: onChange
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={this.onChange} />

--- a/crates/oxc_linter/src/snapshots/react_jsx_handler_names.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_handler_names.snap
@@ -127,20 +127,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  × Expected `}` but found `:`
-   ╭─[jsx_handler_names.tsx:1:31]
- 1 │ <TestComponent onChange={props::onChange} />
-   ·                               ┬
-   ·                               ╰── `}` expected
-   ╰────
-
-  × Expected `}` but found `:`
-   ╭─[jsx_handler_names.tsx:1:35]
- 1 │ <TestComponent onChange={props.foo::onChange} />
-   ·                                   ┬
-   ·                                   ╰── `}` expected
-   ╰────
-
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: customPropNameBar
    ╭─[jsx_handler_names.tsx:5:31]
  4 │                 <div>


### PR DESCRIPTION
This PR adds the [react/jsx-handler-names](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-handler-names.md) rule.

## Dropped test cases

Test cases where the bind-this operator `::` is used are dropped because the current oxc parser doesn't seem to understand it.
For example, if you test the following code:
```tsx
<TestComponent onChange={props::handleChange} />
```
You'll get an output like this: 
```
-------- source --------

<TestComponent onChange={props::handleChange} />

-------- error --------

  × Expected `}` but found `:`
   ╭─[jsx_handler_names.tsx:1:31]
 1 │ <TestComponent onChange={props::handleChange} />
   ·                               ┬
   ·                               ╰── `}` expected
   ╰────
```
All the dropped test cases are in this commit: https://github.com/oxc-project/oxc/pull/13079/commits/d80dcfab8b1345be51b8e0370dcaddf308d48040

works towards https://github.com/oxc-project/oxc/issues/1022