### PR TITLE
fix(linter/array-callback-return): fix handling of default case in switch statements for array-callback-return rule

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
@@ -311,6 +311,7 @@ fn test() {
             None,
         ),
         ("foo.every(function() { try { bar(); } finally { return true; } })", None),
+        ("foo.every(function() { switch (a) { default: case0: return true; } })", None),
         (
             "Array.from(x, function() { return; })",
             Some(serde_json::json!([{"allowImplicit": true}])),


### PR DESCRIPTION
fix handling of default case in switch statements for array-callback-return rule

- fixes(#13075)
- Consider cases following the default case in switch statements