### PR TITLE
refactor(ast): shorten serialize code using let chains

### DIFF
--- a/crates/oxc_ast/src/serialize/mod.rs
+++ b/crates/oxc_ast/src/serialize/mod.rs
@@ -193,27 +193,25 @@ fn get_ts_start_span(program: &Program<'_>) -> u32 {
         return program.span.end;
     };
 
+    let start = first_stmt.span().start;
     match first_stmt {
         Statement::ExportNamedDeclaration(decl) => {
-            let start = decl.span.start;
-            if let Some(Declaration::ClassDeclaration(class)) = &decl.declaration {
-                if let Some(decorator) = class.decorators.first() {
-                    return cmp::min(start, decorator.span.start);
-                }
+            if let Some(Declaration::ClassDeclaration(class)) = &decl.declaration
+                && let Some(decorator) = class.decorators.first()
+            {
+                return cmp::min(start, decorator.span.start);
             }
-            start
         }
         Statement::ExportDefaultDeclaration(decl) => {
-            let start = decl.span.start;
-            if let ExportDefaultDeclarationKind::ClassDeclaration(class) = &decl.declaration {
-                if let Some(decorator) = class.decorators.first() {
-                    return cmp::min(start, decorator.span.start);
-                }
+            if let ExportDefaultDeclarationKind::ClassDeclaration(class) = &decl.declaration
+                && let Some(decorator) = class.decorators.first()
+            {
+                return cmp::min(start, decorator.span.start);
             }
-            start
         }
-        _ => first_stmt.span().start,
+        _ => {}
     }
+    start
 }
 
 /// Serialize `value` field of `Comment`.


### PR DESCRIPTION
Refactor. Shorten some ESTree serialization code by using `let` chains.

It may also be marginally faster, due to only fetching `start` in one place (`first_stmt.span()` should be branchless and just a couple of ops, as every struct has `span` field in same position).