### PR TITLE
docs(allocator): document all cargo features

### DIFF
--- a/crates/oxc_allocator/README.md
+++ b/crates/oxc_allocator/README.md
@@ -25,7 +25,15 @@ This approach is significantly faster than using the system allocator for AST op
 
 ## Features
 
-- `serialize` - Enables serialization support for `Box` and `Vec` with `serde`
-- `from_raw_parts` - Adds unsafe `from_raw_parts` method (not recommended for general use)
-- `track_allocations` - For internal use only. The APIs provided by this feature are sketchy at best,
-  and possibly undefined behavior. Do not enable this feature under any circumstances in production code.
+- `serialize` - Enables serialization support for `Box` and `Vec` with `serde` and `oxc_estree`.
+- `from_raw_parts` - Adds unsafe `from_raw_parts` method (not recommended for general use).
+- `fixed_size` - Makes `AllocatorPool` create large fixed-size allocators, instead of flexibly-sized ones.
+  Only supported on 64-bit little-endian platforms at present.
+  Usage of this feature is not advisable, and it will be removed as soon as we're able to.
+- `track_allocations` - Count allocations and reallocations.
+  For internal use only. The APIs provided by this feature are sketchy at best, and possibly
+  undefined behavior. Do not enable this feature under any circumstances in production code.
+- `disable_fixed_size` - Disables `fixed_size` feature.
+  Purpose is to prevent `--all-features` enabling fixed sized allocators.
+- `disable_track_allocations` - Disables `track_allocations` feature.
+  Purpose is to prevent `--all-features` enabling allocation tracking.

--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -24,8 +24,15 @@
 //!   Only supported on 64-bit little-endian platforms at present.
 //!   Usage of this feature is not advisable, and it will be removed as soon as we're able to.
 //!
+//! * `track_allocations` - Count allocations and reallocations.
+//!   For internal use only. The APIs provided by this feature are sketchy at best, and possibly
+//!   undefined behavior. Do not enable this feature under any circumstances in production code.
+//!
 //! * `disable_fixed_size` - Disables `fixed_size` feature.
 //!   Purpose is to prevent `--all-features` enabling fixed sized allocators.
+//!
+//! * `disable_track_allocations` - Disables `track_allocations` feature.
+//!   Purpose is to prevent `--all-features` enabling allocation tracking.
 
 #![warn(missing_docs)]
 


### PR DESCRIPTION
`README` and doc comment in `lib.rs` were out of sync and both missed out some of `oxc_allocator`'s cargo features. Document all the features in both places.