### PR TITLE
refactor(linter): create `AllocatorPool` in `Runtime::new`

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -13,7 +13,6 @@ use ignore::{gitignore::Gitignore, overrides::OverrideBuilder};
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde_json::Value;
 
-use oxc_allocator::AllocatorPool;
 use oxc_diagnostics::{DiagnosticSender, DiagnosticService, GraphicalReportHandler, OxcDiagnostic};
 use oxc_linter::{
     AllowWarnDeny, Config, ConfigStore, ConfigStoreBuilder, ExternalLinter, ExternalPluginStore,
@@ -338,11 +337,9 @@ impl LintRunner {
 
         let number_of_rules = linter.number_of_rules(self.options.type_aware);
 
-        let allocator_pool = AllocatorPool::new(rayon::current_num_threads());
-
         // Spawn linting in another thread so diagnostics can be printed immediately from diagnostic_service.run.
         rayon::spawn(move || {
-            let mut lint_service = LintService::new(linter, allocator_pool, options);
+            let mut lint_service = LintService::new(linter, options);
             lint_service.with_paths(paths);
 
             // Use `RawTransferFileSystem` if `oxlint2` feature is enabled.

--- a/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
+++ b/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
@@ -10,7 +10,7 @@ use tower_lsp_server::{
     lsp_types::{self, DiagnosticRelatedInformation, DiagnosticSeverity, Uri},
 };
 
-use oxc_allocator::{Allocator, AllocatorPool};
+use oxc_allocator::Allocator;
 use oxc_linter::{
     ConfigStore, LINTABLE_EXTENSIONS, LintOptions, LintService, LintServiceOptions, Linter,
     MessageWithPosition, loader::Loader, read_to_arena_str,
@@ -76,7 +76,7 @@ impl IsolatedLintHandler {
             lint_service_options = lint_service_options.with_tsconfig(tsconfig_path);
         }
 
-        let service = LintService::new(linter, AllocatorPool::default(), lint_service_options);
+        let service = LintService::new(linter, lint_service_options);
 
         Self { service }
     }

--- a/crates/oxc_linter/src/service/mod.rs
+++ b/crates/oxc_linter/src/service/mod.rs
@@ -66,12 +66,8 @@ pub struct LintService {
 }
 
 impl LintService {
-    pub fn new(
-        linter: Linter,
-        allocator_pool: oxc_allocator::AllocatorPool,
-        options: LintServiceOptions,
-    ) -> Self {
-        let runtime = Runtime::new(linter, allocator_pool, options);
+    pub fn new(linter: Linter, options: LintServiceOptions) -> Self {
+        let runtime = Runtime::new(linter, options);
         Self { runtime }
     }
 

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -240,14 +240,14 @@ mod message_cloner {
 use message_cloner::MessageCloner;
 
 impl Runtime {
-    pub(super) fn new(
-        linter: Linter,
-        allocator_pool: AllocatorPool,
-        options: LintServiceOptions,
-    ) -> Self {
+    pub(super) fn new(linter: Linter, options: LintServiceOptions) -> Self {
+        let thread_count = rayon::current_num_threads();
+        let allocator_pool = AllocatorPool::new(thread_count);
+
         let resolver = options.cross_module.then(|| {
             Self::get_resolver(options.tsconfig.or_else(|| Some(options.cwd.join("tsconfig.json"))))
         });
+
         Self {
             allocator_pool,
             cwd: options.cwd,

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -11,7 +11,7 @@ use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
-use oxc_allocator::{Allocator, AllocatorPool};
+use oxc_allocator::Allocator;
 use oxc_diagnostics::{GraphicalReportHandler, GraphicalTheme, NamedSource};
 
 use crate::{
@@ -545,7 +545,7 @@ impl Tester {
         let cwd = self.current_working_directory.clone();
         let paths = vec![Arc::<OsStr>::from(path_to_lint.as_os_str())];
         let options = LintServiceOptions::new(cwd).with_cross_module(self.plugins.has_import());
-        let mut lint_service = LintService::new(linter, AllocatorPool::default(), options);
+        let mut lint_service = LintService::new(linter, options);
         lint_service
             .with_file_system(Box::new(TesterFileSystem::new(
                 path_to_lint,


### PR DESCRIPTION
Move creation of `AllocatorPool` into just one place. Previously it was created in various places and passed in to `LintService::new` which passed it to `Runtime::new`. Just create it in `Runtime::new` instead.

This does have one substantive effect. Language server was creating `AllocatorPool` with `AllocatorPool::default` (0 slots for `Allocator`s) whereas now it's created with `rayon::current_num_threads()` slots.

This doesn't make much difference at present, because the pool creates allocators on demand. But it's going to become important when running JS plugins multi-threaded. At that point it'll be essential that the `AllocatorPool` is created with an accurate thread count, and undefined behavior may result if it isn't.
