### PR TITLE
refactor(tasks): always explicitly initialize Rayon thread pool

### DIFF
--- a/tasks/coverage/src/main.rs
+++ b/tasks/coverage/src/main.rs
@@ -1,6 +1,9 @@
-use oxc_coverage::AppArgs;
+use std::num::NonZeroUsize;
+
 use pico_args::Arguments;
 use rayon::ThreadPoolBuilder;
+
+use oxc_coverage::AppArgs;
 
 fn main() {
     let mut args = Arguments::from_env();
@@ -13,9 +16,13 @@ fn main() {
         diff: args.contains("--diff"),
     };
 
-    if args.debug {
-        ThreadPoolBuilder::new().num_threads(1).build_global().unwrap();
-    }
+    // Init rayon thread pool
+    let thread_count = if args.debug {
+        1
+    } else {
+        std::thread::available_parallelism().map(NonZeroUsize::get).unwrap_or(1)
+    };
+    ThreadPoolBuilder::new().num_threads(thread_count).build_global().unwrap();
 
     let task = command.as_deref().unwrap_or("default");
     match task {


### PR DESCRIPTION
Similar to #13122. Unconditionally initialize Rayon global thread pool in coverage runner.

The guarantees provided by explicitly initializing the thread pool are going to be critical for the linter.

Coverage currently doesn't cover linter, so it doesn't matter, but this doesn't hurt to do, and gives us greater safety if coverage does involve the linter at a later date.
