### PR TITLE
refactor(linter): move `tsgolint.rs` to `oxc_linter` crate

### DIFF
--- a/apps/oxlint/src/lib.rs
+++ b/apps/oxlint/src/lib.rs
@@ -10,7 +10,6 @@ mod lint;
 mod output_formatter;
 mod result;
 mod tester;
-mod tsgolint;
 mod walk;
 
 pub mod cli {

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -17,12 +17,12 @@ use oxc_diagnostics::{DiagnosticSender, DiagnosticService, GraphicalReportHandle
 use oxc_linter::{
     AllowWarnDeny, Config, ConfigStore, ConfigStoreBuilder, ExternalLinter, ExternalPluginStore,
     InvalidFilterKind, LintFilter, LintOptions, LintService, LintServiceOptions, Linter, Oxlintrc,
+    TsGoLintState,
 };
 
 use crate::{
     cli::{CliRunResult, LintCommand, MiscOptions, ReportUnusedDirectives, WarningOptions},
     output_formatter::{LintCommandInfo, OutputFormatter},
-    tsgolint::TsGoLintState,
     walk::Walk,
 };
 

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -26,6 +26,7 @@ mod module_record;
 mod options;
 mod rule;
 mod service;
+mod tsgolint;
 mod utils;
 
 pub mod loader;
@@ -57,8 +58,8 @@ pub use crate::{
     options::{AllowWarnDeny, InvalidFilterKind, LintFilter, LintFilterKind},
     rule::{RuleCategory, RuleFixMeta, RuleMeta},
     service::{LintService, LintServiceOptions, RuntimeFileSystem},
-    utils::read_to_arena_str,
-    utils::read_to_string,
+    tsgolint::TsGoLintState,
+    utils::{read_to_arena_str, read_to_string},
 };
 use crate::{
     config::{LintConfig, OxlintEnv, OxlintGlobals, OxlintSettings},

--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -9,10 +9,9 @@ use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
 use oxc_diagnostics::{DiagnosticSender, DiagnosticService, OxcDiagnostic, Severity};
-use oxc_linter::{
-    AllowWarnDeny, ConfigStore, LintServiceOptions, ResolvedLinterState, read_to_string,
-};
 use oxc_span::{SourceType, Span};
+
+use super::{AllowWarnDeny, ConfigStore, LintServiceOptions, ResolvedLinterState, read_to_string};
 
 /// State required to initialize the `tsgolint` linter.
 #[derive(Debug, Clone)]
@@ -42,6 +41,13 @@ impl<'a> TsGoLintState<'a> {
         }
     }
 
+    /// # Panics
+    /// - when `stdin` of subprocess cannot be opened
+    /// - when `stdout` of subprocess cannot be opened
+    /// - when `tsgolint` process cannot be awaited
+    ///
+    /// # Errors
+    /// A human-readable error message indicating why the linting failed.
     pub fn lint(self, error_sender: DiagnosticSender) -> Result<(), String> {
         if self.paths.is_empty() {
             return Ok(());


### PR DESCRIPTION
The language server wants type aware feature too ❤️ 