### PR TITLE
refactor(allocator): remove `Default` impl for `AllocatorPool`

### DIFF
--- a/crates/oxc_allocator/src/pool.rs
+++ b/crates/oxc_allocator/src/pool.rs
@@ -5,7 +5,6 @@ use crate::Allocator;
 /// A thread-safe pool for reusing [`Allocator`] instances to reduce allocation overhead.
 ///
 /// Internally uses a `Vec` protected by a `Mutex` to store available allocators.
-#[derive(Default)]
 pub struct AllocatorPool {
     allocators: Mutex<Vec<Allocator>>,
 }

--- a/crates/oxc_allocator/src/pool_fixed_size.rs
+++ b/crates/oxc_allocator/src/pool_fixed_size.rs
@@ -22,7 +22,6 @@ const FOUR_GIB: usize = 1 << 32;
 /// A thread-safe pool for reusing [`Allocator`] instances to reduce allocation overhead.
 ///
 /// Internally uses a `Vec` protected by a `Mutex` to store available allocators.
-#[derive(Default)]
 pub struct AllocatorPool {
     /// Allocators in the pool
     allocators: Mutex<Vec<FixedSizeAllocator>>,


### PR DESCRIPTION
Since #13106, `Default` is not used, and it shouldn't be. Remove it.