### PR TITLE
refactor(allocator): rename vars and comments in `AllocatorPool`

### DIFF
--- a/crates/oxc_allocator/src/pool.rs
+++ b/crates/oxc_allocator/src/pool.rs
@@ -10,9 +10,9 @@ pub struct AllocatorPool {
 }
 
 impl AllocatorPool {
-    /// Creates a new [`AllocatorPool`] pre-filled with the given number of default [`Allocator`] instances.
-    pub fn new(size: usize) -> AllocatorPool {
-        let allocators = iter::repeat_with(Allocator::new).take(size).collect();
+    /// Creates a new [`AllocatorPool`] for use across the specified number of threads.
+    pub fn new(thread_count: usize) -> AllocatorPool {
+        let allocators = iter::repeat_with(Allocator::new).take(thread_count).collect();
         AllocatorPool { allocators: Mutex::new(allocators) }
     }
 

--- a/crates/oxc_allocator/src/pool_fixed_size.rs
+++ b/crates/oxc_allocator/src/pool_fixed_size.rs
@@ -30,10 +30,11 @@ pub struct AllocatorPool {
 }
 
 impl AllocatorPool {
-    /// Creates a new [`AllocatorPool`] with capacity for the given number of `FixedSizeAllocator` instances.
-    pub fn new(size: usize) -> AllocatorPool {
-        // Each allocator consumes a large block of memory, so create them on demand instead of upfront
-        let allocators = Vec::with_capacity(size);
+    /// Creates a new [`AllocatorPool`] for use across the specified number of threads.
+    pub fn new(thread_count: usize) -> AllocatorPool {
+        // Each allocator consumes a large block of memory, so create them on demand instead of upfront,
+        // in case not all threads end up being used (e.g. language server without `import` plugin)
+        let allocators = Vec::with_capacity(thread_count);
         AllocatorPool { allocators: Mutex::new(allocators), next_id: AtomicU32::new(0) }
     }
 


### PR DESCRIPTION
Pure refactor. Rename `AllocatorPool::new`'s `size` param to `thread_count`, which is more descriptive. Improve comments for this method.