### PR TITLE
refactor(linter): pass paths to `TsGoLintState.lint` method

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -304,8 +304,8 @@ impl LintRunner {
         // Run type-aware linting through tsgolint
         // TODO: Add a warning message if `tsgolint` cannot be found, but type-aware rules are enabled
         if self.options.type_aware {
-            if let Err(err) = TsGoLintState::new(options.cwd(), config_store.clone(), &paths)
-                .lint(tx_error.clone())
+            if let Err(err) = TsGoLintState::new(options.cwd(), config_store.clone())
+                .lint(&paths, tx_error.clone())
             {
                 print_and_flush_stdout(stdout, &err);
                 return CliRunResult::TsGoLintError;


### PR DESCRIPTION
The language server does need to hold all paths. It will lint when the client is requesting a file