### PR TITLE
refactor(allocator, linter): add ref counter to `FixedSizeAllocator`

### DIFF
--- a/crates/oxc_allocator/src/generated/assert_layouts.rs
+++ b/crates/oxc_allocator/src/generated/assert_layouts.rs
@@ -9,22 +9,22 @@ use crate::*;
 
 #[cfg(target_pointer_width = "64")]
 const _: () = {
-    // Padding: 3 bytes
+    // Padding: 0 bytes
     assert!(size_of::<FixedSizeAllocatorMetadata>() == 16);
     assert!(align_of::<FixedSizeAllocatorMetadata>() == 8);
     assert!(offset_of!(FixedSizeAllocatorMetadata, id) == 8);
     assert!(offset_of!(FixedSizeAllocatorMetadata, alloc_ptr) == 0);
-    assert!(offset_of!(FixedSizeAllocatorMetadata, is_double_owned) == 12);
+    assert!(offset_of!(FixedSizeAllocatorMetadata, ref_count) == 12);
 };
 
 #[cfg(target_pointer_width = "32")]
 const _: () = {
-    // Padding: 3 bytes
+    // Padding: 0 bytes
     assert!(size_of::<FixedSizeAllocatorMetadata>() == 12);
     assert!(align_of::<FixedSizeAllocatorMetadata>() == 4);
     assert!(offset_of!(FixedSizeAllocatorMetadata, id) == 4);
     assert!(offset_of!(FixedSizeAllocatorMetadata, alloc_ptr) == 0);
-    assert!(offset_of!(FixedSizeAllocatorMetadata, is_double_owned) == 8);
+    assert!(offset_of!(FixedSizeAllocatorMetadata, ref_count) == 8);
 };
 
 #[cfg(not(any(target_pointer_width = "64", target_pointer_width = "32")))]

--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -121,7 +121,7 @@ pub use pool::{AllocatorGuard, AllocatorPool};
 )))]
 #[allow(missing_docs, clippy::missing_safety_doc, clippy::unused_self, clippy::allow_attributes)]
 mod dummies {
-    use std::{ptr::NonNull, sync::atomic::AtomicBool};
+    use std::{ptr::NonNull, sync::atomic::AtomicU32};
 
     use super::Allocator;
 
@@ -129,7 +129,7 @@ mod dummies {
     pub struct FixedSizeAllocatorMetadata {
         pub id: u32,
         pub alloc_ptr: NonNull<u8>,
-        pub is_double_owned: AtomicBool,
+        pub ref_count: AtomicU32,
     }
 
     #[doc(hidden)]


### PR DESCRIPTION
Linter previously tracked whether an `Allocator`'s memory is shared between Rust and JS with an `AtomicBool` flag.

Replace this flag with an `AtomicU32` reference counter. This prepares the way for sharing the memory owned by a `FixedSizeAllocator` with *multiple* JS threads, and tracking when it's been released by all JS threads, and Rust.