### PR TITLE
feat(allocator, linter): store worker thread flags in `FixedSizeAllocator`

### DIFF
--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -252,6 +252,8 @@ impl Runtime {
         // > In the future, the default behavior may change to dynamically add or remove threads as needed.
         // https://docs.rs/rayon/1.11.0/rayon/struct.ThreadPoolBuilder.html#method.num_threads
         //
+        // That behavior change would break the assumption that number of threads is constant after
+        // this call, which could result in writing out of bounds of the worker threads flags array.
         // However, I (@overlookmotel) assume that would be considered a breaking change,
         // so we don't have to worry about it until Rayon v2.
         // When Rayon v2 is released and we upgrade to it, we'll need to revisit this and make sure


### PR DESCRIPTION
Prepare the way for running JS linter plugins on multiple threads.

Previously we only had to track whether an `Allocator`'s memory was shared with JS main thread or not, so a single flag was sufficient. Once we have plugins running on multiple worker threads, we need to track for each `Allocator` which JS threads it's been shared with, so can avoid sending the same buffer to the same thread twice.

Store this info as a series of `bool`s stored at the end of the `Allocator`'s memory. `FixedAllocator::new` initializes all these flags as `false` when the `Allocator` is created, and linter checks the flag for the specific thread when it wants to share data with that thread, and sets it to `true` once buffer has been sent to that thread.