### PR TITLE
docs(allocator): correct and expand safety comments on `Allocator` methods

### DIFF
--- a/crates/oxc_allocator/src/pool_fixed_size.rs
+++ b/crates/oxc_allocator/src/pool_fixed_size.rs
@@ -283,6 +283,8 @@ impl FixedSizeAllocator {
         // SAFETY: Fixed-size allocators have data pointer originally aligned on `BLOCK_ALIGN`,
         // and size less than `BLOCK_ALIGN`. So we can restore original data pointer by rounding down
         // to next multiple of `BLOCK_ALIGN`.
+        // We're restoring the original data pointer, so it cannot break invariants about alignment,
+        // being within the chunk's allocation, or being before cursor pointer.
         unsafe {
             let data_ptr = self.allocator.data_ptr();
             let offset = data_ptr.as_ptr() as usize % BLOCK_ALIGN;


### PR DESCRIPTION
Correct safety comments on unsafe methods of `Allocator`, as suggested by AI in https://github.com/oxc-project/oxc/pull/13134#pullrequestreview-3125823899.

Also expand the safety comments for `Allocator::set_data_ptr`, and add comments on how its invariants are upheld at call sites.

Also correct typos and improve comment formatting.