### PR TITLE
refactor(allocator, napi/parser): use `usize::is_multiple_of`

### DIFF
--- a/crates/oxc_allocator/src/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/from_raw_parts.rs
@@ -76,8 +76,8 @@ impl Allocator {
         }
 
         // Debug assert that `ptr` and `size` fulfill size and alignment requirements
-        debug_assert!(is_multiple_of(ptr.as_ptr() as usize, MIN_ALIGN));
-        debug_assert!(is_multiple_of(size, MIN_ALIGN));
+        debug_assert!((ptr.as_ptr() as usize).is_multiple_of(MIN_ALIGN));
+        debug_assert!(size.is_multiple_of(MIN_ALIGN));
         debug_assert!(size >= CHUNK_FOOTER_SIZE);
 
         let current_chunk_footer_field_offset = get_current_chunk_footer_field_offset();
@@ -214,7 +214,7 @@ impl Allocator {
     ///
     /// [`RAW_MIN_ALIGN`]: Self::RAW_MIN_ALIGN
     pub unsafe fn set_data_ptr(&self, ptr: NonNull<u8>) {
-        debug_assert!(is_multiple_of(ptr.as_ptr() as usize, MIN_ALIGN));
+        debug_assert!((ptr.as_ptr() as usize).is_multiple_of(MIN_ALIGN));
 
         // SAFETY: Caller guarantees `Allocator` has at least 1 allocated chunk.
         // We don't take any action with the `Allocator` while the `&mut ChunkFooter` reference
@@ -401,9 +401,4 @@ fn get_current_chunk_footer_field_offset() -> usize {
             2
         }
     }
-}
-
-/// Returns `true` if `n` is a multiple of `divisor`.
-const fn is_multiple_of(n: usize, divisor: usize) -> bool {
-    n % divisor == 0
 }

--- a/napi/parser/src/raw_transfer.rs
+++ b/napi/parser/src/raw_transfer.rs
@@ -176,7 +176,7 @@ unsafe fn parse_raw_impl(
     // Check buffer has expected size and alignment
     assert_eq!(buffer.len(), BUFFER_SIZE);
     let buffer_ptr = ptr::from_mut(buffer).cast::<u8>();
-    assert!(is_multiple_of(buffer_ptr as usize, BUFFER_ALIGN));
+    assert!((buffer_ptr as usize).is_multiple_of(BUFFER_ALIGN));
 
     // Get offsets and size of data region to be managed by arena allocator.
     // Leave space for source before it, and space for metadata after it.
@@ -185,7 +185,7 @@ unsafe fn parse_raw_impl(
     const RAW_METADATA_SIZE: usize = size_of::<RawTransferMetadata>();
     const {
         assert!(RAW_METADATA_SIZE >= BUMP_ALIGN);
-        assert!(is_multiple_of(RAW_METADATA_SIZE, BUMP_ALIGN));
+        assert!(RAW_METADATA_SIZE.is_multiple_of(BUMP_ALIGN));
     };
     let source_len = source_len as usize;
     let data_offset = source_len.next_multiple_of(BUMP_ALIGN);
@@ -197,8 +197,8 @@ unsafe fn parse_raw_impl(
     // SAFETY: `data_offset` is less than `buffer.len()`, so `.add(data_offset)` cannot wrap
     // or be out of bounds.
     let data_ptr = unsafe { buffer_ptr.add(data_offset) };
-    debug_assert!(is_multiple_of(data_ptr as usize, BUMP_ALIGN));
-    debug_assert!(is_multiple_of(data_size, BUMP_ALIGN));
+    debug_assert!((data_ptr as usize).is_multiple_of(BUMP_ALIGN));
+    debug_assert!(data_size.is_multiple_of(BUMP_ALIGN));
     // SAFETY: `data_ptr` and `data_size` outline a section of the memory in `buffer`.
     // `data_ptr` and `data_size` are multiples of 16.
     // `data_size` is greater than `Allocator::MIN_SIZE`.
@@ -275,7 +275,7 @@ unsafe fn parse_raw_impl(
     #[allow(clippy::cast_possible_truncation)]
     let metadata = RawTransferMetadata::new(data_ptr as u32, ast_type == AstType::TypeScript);
     const RAW_METADATA_OFFSET: usize = BUFFER_SIZE - RAW_METADATA_SIZE;
-    const _: () = assert!(is_multiple_of(RAW_METADATA_OFFSET, BUMP_ALIGN));
+    const _: () = assert!(RAW_METADATA_OFFSET.is_multiple_of(BUMP_ALIGN));
     // SAFETY: `RAW_METADATA_OFFSET` is less than length of `buffer`.
     // `RAW_METADATA_OFFSET` is aligned on 16.
     #[expect(clippy::cast_ptr_alignment)]
@@ -291,9 +291,4 @@ unsafe fn parse_raw_impl(
 #[napi]
 pub fn raw_transfer_supported() -> bool {
     true
-}
-
-/// Returns `true` if `n` is a multiple of `divisor`.
-const fn is_multiple_of(n: usize, divisor: usize) -> bool {
-    n % divisor == 0
 }


### PR DESCRIPTION
Pure refactor. When this code was written, `usize::is_multiple_of` was not available in our MSRV. Now it is, so use it instead of writing the same function ourselves.
