### PR TITLE
perf(napi/parser): raw transfer: reduce maths complexity

### DIFF
--- a/napi/parser/src/raw_transfer.rs
+++ b/napi/parser/src/raw_transfer.rs
@@ -189,7 +189,7 @@ unsafe fn parse_raw_impl(
     };
     let source_len = source_len as usize;
     let data_offset = source_len.next_multiple_of(BUMP_ALIGN);
-    let data_size = BUFFER_SIZE.saturating_sub(data_offset + RAW_METADATA_SIZE);
+    let data_size = (BUFFER_SIZE - RAW_METADATA_SIZE).saturating_sub(data_offset);
     assert!(data_size >= Allocator::RAW_MIN_SIZE, "Source text is too long");
 
     // Create `Allocator`.


### PR DESCRIPTION
Tiny perf optimization. 

Reduce complexity of maths by doing as much calculation as possible using consts.

Shaves off 1 operation! https://godbolt.org/z/5h4hzznxs

This change does not alter the result. `data_offset + RAW_METADATA_SIZE` couldn't overflow because `data_offset` was derived from a `u32`, and this code (raw transfer) is only run on 64-bit systems, so there's plenty of headroom in `usize`. But it does make it easier to support 32-bit in future.
