### PR TITLE
fix(ecmascript): skip array length evaluation if there are any spread elements

### DIFF
--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -1778,6 +1778,7 @@ mod test {
         // Cannot fold
         fold("x = [foo(), 0].length", "x = [foo(),0].length");
         fold_same("x = y.length");
+        fold_same("[...[1, 2, 3]].length");
     }
 
     #[test]


### PR DESCRIPTION
https://github.com/oxc-project/oxc/blob/4d0a05e1e7c06598fc92b41bbf785eb6dc6e36fa/crates/oxc_ecmascript/src/constant_evaluation/mod.rs#L501-L502

If there are spread elements in an array, say `[...[1, 2, 3]]`, then `arr.elements.len()` no longer represents the value of `.length` property of the array, which will cause mis-optimization.

<details>
  <summary>PoC of the bug</summary>

`test.js`:
``` js
let k = [...[1, 2, 3]].length;
console.log(k);
```

```
$ node test.js
3

$ cargo run --example minifier -- test.js
    Finished `dev` profile [unoptimized] target(s) in 0.08s
     Running `target/debug/examples/minifier`
console.log(1);
```
</details>


This bug was originally discovered in https://github.com/vitejs/rolldown-vite/issues/375.

Maybe sometimes the `.length` can be evaluated recursively, but here we just skip the evaluation as a quick fix.

What's more, I think it would be better to add some tests like `test_eval("[1, 2, 3].length", Some(Number(3.0)))` and `test_eval("[...a].length", None)`, but I cannot find a suitable place and found it's not trivial to implement one `Ctx` for `evaluate_value` in test files. Please let me know if you have any comments. Thanks.