### PR TITLE
fix(rulegen): strip comments from config

### DIFF
--- a/tasks/rulegen/src/json.rs
+++ b/tasks/rulegen/src/json.rs
@@ -7,11 +7,10 @@ use lazy_regex::{Captures, regex};
 pub fn convert_config_to_json_literal(object: &str) -> String {
     let ident_matcher = regex!(r"(?P<ident>[[:alpha:]]\w*\s*):");
 
-    ident_matcher
-        .replace_all(object, |capture: &Captures| {
-            let ident = &capture["ident"];
-            Cow::Owned(format!(r#""{ident}":"#))
-        })
-        .replace('\'', "\"")
-        .replace('\n', "")
+    let after_ident = ident_matcher.replace_all(object, |capture: &Captures| {
+        let ident = &capture["ident"];
+        Cow::Owned(format!(r#""{ident}":"#))
+    });
+    let comment_matcher = regex!("//.*?\n");
+    comment_matcher.replace_all(&after_ident, "").replace('\'', "\"").replace('\n', "")
 }

--- a/tasks/rulegen/src/template.rs
+++ b/tasks/rulegen/src/template.rs
@@ -52,7 +52,9 @@ impl<'a> Template<'a> {
         let out_path = path.join(format!("{}.rs", self.context.snake_rule_name));
 
         File::create(out_path.clone())?.write_all(rendered.as_bytes())?;
-        format_rule_output(&out_path)?;
+        format_rule_output(&out_path).map(|mut child| {
+            child.wait().expect("failed to format");
+        })?;
 
         println!("Saved test file to {}", out_path.display());
 


### PR DESCRIPTION
Rule generation created invalid rust due to comments inside the configuration object. Additionally, the format was being called asynchronously which was causing errors to show up after the command finished and interrupted the shell prompt.

This PR fixes both of these issues by stripping the comments from the configuration object before converting it to a JSON literal and waiting for format to finish so that errors will pop up before the command finishes.