### PR TITLE
docs(linter): Fix doc code block in `eslint/func-style` rule

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/func_style.rs
+++ b/crates/oxc_linter/src/rules/eslint/func_style.rs
@@ -74,6 +74,7 @@ declare_oxc_lint!(
     /// You can specify which you prefer in the configuration.
     ///
     /// ### Examples
+    /// ```js
     /// // function declaration
     /// function doSomething() {
     ///     // ...
@@ -88,6 +89,7 @@ declare_oxc_lint!(
     /// const doSomethingAgain = function() {
     ///     // ...
     /// };
+    /// ```
     ///
     /// Examples of incorrect code for this rule with the default "expression" option:
     /// ```js
@@ -132,6 +134,7 @@ declare_oxc_lint!(
     /// var foo = function() {
     ///     // ...
     /// };
+    /// ```
     ///
     /// Examples of correct code for this rule with the "declaration" option:
     /// ```js


### PR DESCRIPTION
https://oxc.rs/docs/guide/usage/linter/rules/eslint/func-style.html#examples

This PR fixes 

<img width="744" height="259" alt="image" src="https://github.com/user-attachments/assets/8d70ae0b-6a48-4902-9b92-7bf5cee486ec" />

and

<img width="747" height="291" alt="image" src="https://github.com/user-attachments/assets/b783d076-6e28-4efd-a3bd-4fdf280c96c8" />
