### PR TITLE
docs(linter/no-console): correct typo in correct code example

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -81,7 +81,7 @@ declare_oxc_lint!(
     /// console.log('foo');
     /// ```
     ///
-    /// Example of **incorrect** code for this option:
+    /// Example of **correct** code for this option:
     /// ```javascript
     /// console.info('foo');
     /// ```


### PR DESCRIPTION
closes https://github.com/oxc-project/oxc-project.github.io/pull/457