### PR TITLE
refactor(napi/oxlint2): fix lint errors

### DIFF
--- a/napi/oxlint2/src-js/index.ts
+++ b/napi/oxlint2/src-js/index.ts
@@ -138,7 +138,7 @@ class Context {
   physicalFilename: string;
 
   /**
-   * @constructor
+   * @class
    * @param fullRuleName - Rule name, in form `<plugin>/<rule>`
    */
   constructor(fullRuleName: string) {

--- a/napi/oxlint2/src-js/types.ts
+++ b/napi/oxlint2/src-js/types.ts
@@ -8,7 +8,7 @@ export type VisitFn = (node: Node) => void;
 
 // AST node type.
 // We'll make this type a union later on.
-export type Node = Object;
+export type Node = { type: string; start: number; end: number; [key: string]: unknown };
 
 // Element of compiled visitor array.
 // * `VisitFn | null` for leaf nodes.

--- a/napi/oxlint2/src-js/utils.ts
+++ b/napi/oxlint2/src-js/utils.ts
@@ -29,4 +29,5 @@ export function getErrorMessage(err: unknown): string {
  *
  * @param value - Value
  */
+// oxlint-disable-next-line no-unused-vars
 export function assertIs<T>(value: unknown): asserts value is T {}

--- a/napi/oxlint2/src-js/visitor.ts
+++ b/napi/oxlint2/src-js/visitor.ts
@@ -377,6 +377,7 @@ function createMerger(fnCount: number): Merger {
   }
   body += '}';
   args.push(body);
+  // oxlint-disable-next-line typescript-eslint/no-implied-eval
   return new Function(...args) as Merger;
 }
 

--- a/napi/oxlint2/test/compile-visitor.test.ts
+++ b/napi/oxlint2/test/compile-visitor.test.ts
@@ -21,10 +21,12 @@ describe('compile visitor', () => {
   it('throws if visitor is not an object', () => {
     const expectedErr = new TypeError('Visitor returned from `create` method must be an object');
     expect(() => (addVisitorToCompiled as any)()).toThrow(expectedErr);
+    // oxlint-disable typescript-eslint/no-confusing-void-expression
     expect(() => addVisitorToCompiled(null)).toThrow(expectedErr);
     expect(() => addVisitorToCompiled(undefined)).toThrow(expectedErr);
     expect(() => addVisitorToCompiled(true as any)).toThrow(expectedErr);
     expect(() => addVisitorToCompiled('xyz' as any)).toThrow(expectedErr);
+    // oxlint-enable typescript-eslint/no-confusing-void-expression
   });
 
   it('throws if unknown visitor key', () => {
@@ -34,10 +36,12 @@ describe('compile visitor', () => {
 
   it('throws if visitor property is not a function', () => {
     const expectedErr = new TypeError("'Program' property of visitor object is not a function");
+    // oxlint-disable typescript-eslint/no-confusing-void-expression
     expect(() => addVisitorToCompiled({ Program: null })).toThrow(expectedErr);
     expect(() => addVisitorToCompiled({ Program: undefined })).toThrow(expectedErr);
     expect(() => addVisitorToCompiled({ Program: true } as any)).toThrow(expectedErr);
     expect(() => addVisitorToCompiled({ Program: {} } as any)).toThrow(expectedErr);
+    // oxlint-enable typescript-eslint/no-confusing-void-expression
   });
 
   describe('registers enter visitor', () => {
@@ -86,7 +90,7 @@ describe('compile visitor', () => {
         addVisitorToCompiled({ EmptyStatement: enter, 'EmptyStatement:exit': exit });
         expect(finalizeCompiledVisitor()).toBe(true);
 
-        const node = {};
+        const node = { type: 'EmptyStatement', start: 0, end: 0 };
         (compiledVisitor[EMPTY_STMT_TYPE_ID] as VisitFn)(node);
         expect(enter).toHaveBeenCalledWith(node);
         expect(exit).toHaveBeenCalledWith(node);
@@ -99,7 +103,7 @@ describe('compile visitor', () => {
         addVisitorToCompiled({ 'EmptyStatement:exit': exit, EmptyStatement: enter });
         expect(finalizeCompiledVisitor()).toBe(true);
 
-        const node = {};
+        const node = { type: 'EmptyStatement', start: 0, end: 0 };
         (compiledVisitor[EMPTY_STMT_TYPE_ID] as VisitFn)(node);
         expect(enter).toHaveBeenCalledWith(node);
         expect(exit).toHaveBeenCalledWith(node);
@@ -147,7 +151,7 @@ describe('compile visitor', () => {
 
         expect(finalizeCompiledVisitor()).toBe(true);
 
-        const node = {};
+        const node = { type: 'EmptyStatement', start: 0, end: 0 };
         (compiledVisitor[EMPTY_STMT_TYPE_ID] as VisitFn)(node);
         expect(enter1).toHaveBeenCalledWith(node);
         expect(exit1).toHaveBeenCalledWith(node);
@@ -169,7 +173,7 @@ describe('compile visitor', () => {
 
         expect(finalizeCompiledVisitor()).toBe(true);
 
-        const node = {};
+        const node = { type: 'EmptyStatement', start: 0, end: 0 };
         (compiledVisitor[EMPTY_STMT_TYPE_ID] as VisitFn)(node);
         expect(enter1).toHaveBeenCalledWith(node);
         expect(exit1).toHaveBeenCalledWith(node);
@@ -191,7 +195,7 @@ describe('compile visitor', () => {
 
         expect(finalizeCompiledVisitor()).toBe(true);
 
-        const node = {};
+        const node = { type: 'EmptyStatement', start: 0, end: 0 };
         (compiledVisitor[EMPTY_STMT_TYPE_ID] as VisitFn)(node);
         expect(enter1).toHaveBeenCalledWith(node);
         expect(exit1).toHaveBeenCalledWith(node);
@@ -213,7 +217,7 @@ describe('compile visitor', () => {
 
         expect(finalizeCompiledVisitor()).toBe(true);
 
-        const node = {};
+        const node = { type: 'EmptyStatement', start: 0, end: 0 };
         (compiledVisitor[EMPTY_STMT_TYPE_ID] as VisitFn)(node);
         expect(enter1).toHaveBeenCalledWith(node);
         expect(exit1).toHaveBeenCalledWith(node);
@@ -239,12 +243,12 @@ describe('compile visitor', () => {
 
         const enterExit = compiledVisitor[PROGRAM_TYPE_ID] as EnterExit;
 
-        const enterNode = {};
+        const enterNode = { type: 'Program', start: 0, end: 0 };
         enterExit.enter(enterNode);
         expect(enter1).toHaveBeenCalledWith(enterNode);
         expect(enter2).toHaveBeenCalledWith(enterNode);
 
-        const exitNode = {};
+        const exitNode = { type: 'Program', start: 0, end: 0 };
         enterExit.exit(exitNode);
         expect(exit1).toHaveBeenCalledWith(exitNode);
         expect(exit2).toHaveBeenCalledWith(exitNode);
@@ -263,12 +267,12 @@ describe('compile visitor', () => {
 
         const enterExit = compiledVisitor[PROGRAM_TYPE_ID] as EnterExit;
 
-        const enterNode = {};
+        const enterNode = { type: 'Program', start: 0, end: 0 };
         enterExit.enter(enterNode);
         expect(enter1).toHaveBeenCalledWith(enterNode);
         expect(enter2).toHaveBeenCalledWith(enterNode);
 
-        const exitNode = {};
+        const exitNode = { type: 'Program', start: 0, end: 0 };
         enterExit.exit(exitNode);
         expect(exit1).toHaveBeenCalledWith(exitNode);
         expect(exit2).toHaveBeenCalledWith(exitNode);
@@ -287,12 +291,12 @@ describe('compile visitor', () => {
 
         const enterExit = compiledVisitor[PROGRAM_TYPE_ID] as EnterExit;
 
-        const enterNode = {};
+        const enterNode = { type: 'Program', start: 0, end: 0 };
         enterExit.enter(enterNode);
         expect(enter1).toHaveBeenCalledWith(enterNode);
         expect(enter2).toHaveBeenCalledWith(enterNode);
 
-        const exitNode = {};
+        const exitNode = { type: 'Program', start: 0, end: 0 };
         enterExit.exit(exitNode);
         expect(exit1).toHaveBeenCalledWith(exitNode);
         expect(exit2).toHaveBeenCalledWith(exitNode);
@@ -311,12 +315,12 @@ describe('compile visitor', () => {
 
         const enterExit = compiledVisitor[PROGRAM_TYPE_ID] as EnterExit;
 
-        const enterNode = {};
+        const enterNode = { type: 'Program', start: 0, end: 0 };
         enterExit.enter(enterNode);
         expect(enter1).toHaveBeenCalledWith(enterNode);
         expect(enter2).toHaveBeenCalledWith(enterNode);
 
-        const exitNode = {};
+        const exitNode = { type: 'Program', start: 0, end: 0 };
         enterExit.exit(exitNode);
         expect(exit1).toHaveBeenCalledWith(exitNode);
         expect(exit2).toHaveBeenCalledWith(exitNode);
@@ -350,7 +354,7 @@ describe('compile visitor', () => {
 
       expect(finalizeCompiledVisitor()).toBe(true);
 
-      const node = {};
+      const node = { type: 'EmptyStatement', start: 0, end: 0 };
       (compiledVisitor[EMPTY_STMT_TYPE_ID] as VisitFn)(node);
 
       expect(enter1).toHaveBeenCalledWith(node);


### PR DESCRIPTION
#13173 enabled Oxlint for all the repo, but we currently skip `napi` directory.

Fix all errors that Oxlint flags in `napi/oxlint2`.

We currently can't turn on Oxlint for the directory, because `oxlint-disable` comments don't work for type-aware rules, but we should be able to once that's fixed.
