### PR TITLE
refactor(napi/parser): fix lint errors

### DIFF
--- a/napi/parser/bench.bench.mjs
+++ b/napi/parser/bench.bench.mjs
@@ -62,28 +62,33 @@ const fixtures = await Promise.all(fixtureUrls.map(async (url) => {
 
 // Run benchmarks
 for (const { filename, code } of fixtures) {
+  // oxlint-disable-next-line jest/valid-title
   describe(filename, () => {
     benchStandard('parser_napi', () => {
       const ret = parseSync(filename, code);
       // Read returned object's properties to execute getters which deserialize
+      // oxlint-disable-next-line no-unused-vars
       const { program, comments, module, errors } = ret;
     });
 
     benchRaw('parser_napi_raw', () => {
       const ret = parseSync(filename, code, { experimentalRawTransfer: true });
       // Read returned object's properties to execute getters
+      // oxlint-disable-next-line no-unused-vars
       const { program, comments, module, errors } = ret;
     });
 
     benchStandard('parser_napi_async', async () => {
       const ret = await parseAsync(filename, code);
       // Read returned object's properties to execute getters which deserialize
+      // oxlint-disable-next-line no-unused-vars
       const { program, comments, module, errors } = ret;
     });
 
     benchRaw('parser_napi_async_raw', async () => {
       const ret = await parseAsync(filename, code, { experimentalRawTransfer: true });
       // Read returned object's properties to execute getters
+      // oxlint-disable-next-line no-unused-vars
       const { program, comments, module, errors } = ret;
     });
 
@@ -105,22 +110,24 @@ for (const { filename, code } of fixtures) {
     // Create visitors
     const Visitor = experimentalGetLazyVisitor();
 
+    // oxlint-disable-next-line no-unused-vars
     let debuggerCount = 0;
     const debuggerVisitor = new Visitor({
-      DebuggerStatement(debuggerStmt) {
+      DebuggerStatement(_debuggerStmt) {
         debuggerCount++;
       },
     });
 
+    // oxlint-disable-next-line no-unused-vars
     let identCount = 0;
     const identVisitor = new Visitor({
-      BindingIdentifier(ident) {
+      BindingIdentifier(_ident) {
         identCount++;
       },
-      IdentifierReference(ident) {
+      IdentifierReference(_ident) {
         identCount++;
       },
-      IdentifierName(ident) {
+      IdentifierName(_ident) {
         identCount++;
       },
     });
@@ -143,7 +150,7 @@ for (const { filename, code } of fixtures) {
       const { visit, dispose } = parseSync(filename, code, { experimentalLazy: true });
       debuggerCount = 0;
       const debuggerVisitor = new Visitor({
-        DebuggerStatement(debuggerStmt) {
+        DebuggerStatement(_debuggerStmt) {
           debuggerCount++;
         },
       });
@@ -155,13 +162,13 @@ for (const { filename, code } of fixtures) {
       const { visit, dispose } = parseSync(filename, code, { experimentalLazy: true });
       identCount = 0;
       const identVisitor = new Visitor({
-        BindingIdentifier(ident) {
+        BindingIdentifier(_ident) {
           identCount++;
         },
-        IdentifierReference(ident) {
+        IdentifierReference(_ident) {
           identCount++;
         },
-        IdentifierName(ident) {
+        IdentifierName(_ident) {
           identCount++;
         },
       });

--- a/napi/parser/build-browser-bundle.mjs
+++ b/napi/parser/build-browser-bundle.mjs
@@ -59,4 +59,4 @@ async function main() {
   }
 }
 
-main();
+await main();

--- a/napi/parser/example.mjs
+++ b/napi/parser/example.mjs
@@ -24,6 +24,7 @@ function main() {
   const file = args.positionals[0] ?? 'test.js';
   const code = fs.readFileSync(file, 'utf-8');
   const result = parseSync(file, code, args.values);
+  // oxlint-disable-next-line typescript-eslint/no-misused-spread
   console.dir({ ...result }, { depth: Infinity });
 }
 

--- a/napi/parser/raw-transfer/node-array.js
+++ b/napi/parser/raw-transfer/node-array.js
@@ -33,7 +33,7 @@ class NodeArray extends Array {
    * The proxy intercepts accesses to elements and lazily deserializes them,
    * and blocks mutation of elements or `length` property.
    *
-   * @constructor
+   * @class
    * @param {number} pos - Buffer position of first element
    * @param {number} length - Number of elements
    * @param {number} stride - Element size in bytes

--- a/napi/parser/raw-transfer/supported.js
+++ b/napi/parser/raw-transfer/supported.js
@@ -35,7 +35,7 @@ function rawTransferRuntimeSupported() {
   let global;
   try {
     global = globalThis;
-  } catch (e) {
+  } catch (_err) { // oxlint-disable-line no-unused-vars
     return false;
   }
 

--- a/napi/parser/raw-transfer/visitor.js
+++ b/napi/parser/raw-transfer/visitor.js
@@ -34,7 +34,7 @@ class Visitor {
    * });
    * ```
    *
-   * @constructor
+   * @class
    * @param {Object} visitor - Object defining visit functions for AST nodes
    * @returns {Visitor}
    */
@@ -60,7 +60,7 @@ module.exports = { Visitor, getVisitorsArr };
  *   where each property is either a visitor function or `null`.
  *
  * @param {Object} visitor - Visitors object from user
- * @returns {Array<Object|function|null>} - Array of visitors
+ * @returns {Array<Object|Function|null>} - Array of visitors
  */
 function createVisitorsArr(visitor) {
   if (visitor === null || typeof visitor !== 'object') {

--- a/napi/parser/test/esm.test.ts
+++ b/napi/parser/test/esm.test.ts
@@ -53,6 +53,8 @@ export { default as name1 } from "module-name";
     expect(ret.errors.length).toBe(0);
     expect(JSON.stringify(ret.module, null, 2)).toMatchSnapshot();
     expect(ret.module.hasModuleSyntax).toBe(true);
+
+    // oxlint-disable jest/no-conditional-expect
     if (s.startsWith('import')) {
       expect(ret.module.staticImports.length).toBe(1);
       expect(ret.module.staticExports.length).toBe(0);
@@ -61,6 +63,7 @@ export { default as name1 } from "module-name";
       expect(ret.module.staticImports.length).toBe(0);
       expect(ret.module.staticExports.length).toBe(1);
     }
+    // oxlint-enable jest/no-conditional-expect
   });
 });
 

--- a/napi/parser/test/lazy-deserialization.test.ts
+++ b/napi/parser/test/lazy-deserialization.test.ts
@@ -12,8 +12,10 @@ function parseSyncLazy(filename, code, options = null) {
 
 // Get `NodeArray` constructor
 const NodeArray = Object.getPrototypeOf(parseSyncLazy('test.js', '').program.body).constructor;
+// oxlint-disable eslint-plugin-jest/no-standalone-expect
 expect(NodeArray).not.toBe(Array);
 expect(NodeArray.toString().startsWith('class NodeArray extends Array {')).toBe(true);
+// oxlint-enable eslint-plugin-jest/no-standalone-expect
 
 it('parses', () => {
   const { program } = parseSyncLazy('test.js', 'let x = y + z;');
@@ -177,7 +179,9 @@ describe('NodeArray', () => {
 
     it('join', () => {
       const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      // oxlint-disable-next-line typescript-eslint/no-base-to-string
       expect(body.join()).toBe('[object Object],[object Object]');
+      // oxlint-disable-next-line typescript-eslint/no-base-to-string
       expect(body.join(' x ')).toBe('[object Object] x [object Object]');
     });
 
@@ -390,6 +394,7 @@ describe('NodeArray', () => {
 
     it('sort (throws)', () => {
       const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      // oxlint-disable-next-line typescript-eslint/require-array-sort-compare
       expect(() => body.sort()).toThrow(new TypeError('Cannot redefine property: 0'));
     });
 
@@ -404,6 +409,7 @@ describe('NodeArray', () => {
 
     it('toLocaleString', () => {
       const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      // oxlint-disable-next-line typescript-eslint/no-base-to-string
       expect(body.toLocaleString()).toBe('[object Object],[object Object]');
     });
 
@@ -442,6 +448,7 @@ describe('NodeArray', () => {
 
     it('toString', () => {
       const { body } = parseSyncLazy('test.js', 'let x = 1; x = 2;').program;
+      // oxlint-disable-next-line typescript-eslint/no-base-to-string
       expect(body.toString()).toBe('[object Object],[object Object]');
     });
 

--- a/napi/parser/test/parse-raw-worker.mjs
+++ b/napi/parser/test/parse-raw-worker.mjs
@@ -72,7 +72,10 @@ async function runTest262Case(path, lazy, expect) {
 
   const sourceType = getSourceTypeFromJSON(acornJson);
 
-  if (lazy) return testLazy(filename, sourceText, { sourceType });
+  if (lazy) {
+    testLazy(filename, sourceText, { sourceType });
+    return;
+  }
 
   // @ts-ignore
   const { program } = parseSync(filename, sourceText, { sourceType, experimentalRawTransfer: true });
@@ -91,7 +94,10 @@ async function runJsxCase(filename, lazy, expect) {
 
   const sourceType = getSourceTypeFromJSON(acornJson);
 
-  if (lazy) return testLazy(filename, sourceText, { sourceType });
+  if (lazy) {
+    testLazy(filename, sourceText, { sourceType });
+    return;
+  }
 
   // @ts-ignore
   const { program } = parseSync(filename, sourceText, { sourceType, experimentalRawTransfer: true });
@@ -143,7 +149,7 @@ async function runTsCase(path, lazy, expect) {
 
     try {
       expect(oxcJson).toEqual(estreeJson);
-    } catch (err) {
+    } catch {
       // Fall back to comparing to AST parsed via JSON transfer.
       // We can fail to match the TS-ESLint snapshots where there are syntax errors,
       // because our parser is not recoverable.

--- a/napi/parser/test/parse-raw.test.ts
+++ b/napi/parser/test/parse-raw.test.ts
@@ -47,13 +47,10 @@ async function runCaseInWorker(type, props) {
   // to get a nice diff and stack trace
   if (!success) {
     if (!runCase) ({ runCase } = await import('./parse-raw-worker.mjs'));
-    try {
-      type |= TEST_TYPE_PRETTY;
-      await runCase({ type, props }, expect);
-      throw new Error('Failed on worker but unexpectedly passed on main thread');
-    } catch (err) {
-      throw err;
-    }
+
+    type |= TEST_TYPE_PRETTY;
+    await runCase({ type, props }, expect);
+    throw new Error('Failed on worker but unexpectedly passed on main thread');
   }
 }
 
@@ -102,11 +99,13 @@ for (let path of await readdir(ACORN_TEST262_DIR_PATH, { recursive: true })) {
 }
 
 describe.concurrent('test262', () => {
+  // oxlint-disable-next-line jest/expect-expect
   it.each(test262FixturePaths)('%s', path => runCaseInWorker(TEST_TYPE_TEST262, path));
 });
 
 // Check lazy deserialization doesn't throw
 describeLazy.concurrent('lazy test262', () => {
+  // oxlint-disable-next-line jest/expect-expect
   it.each(test262FixturePaths)('%s', path => runCaseInWorker(TEST_TYPE_TEST262 | TEST_TYPE_LAZY, path));
 });
 
@@ -119,11 +118,13 @@ const jsxFixturePaths = (await readdir(JSX_DIR_PATH, { recursive: true }))
   .filter(path => path.endsWith('.jsx') && !jsxFailPaths.has(path));
 
 describe.concurrent('JSX', () => {
+  // oxlint-disable-next-line jest/expect-expect
   it.each(jsxFixturePaths)('%s', filename => runCaseInWorker(TEST_TYPE_JSX, filename));
 });
 
 // Check lazy deserialization doesn't throw
 describeLazy.concurrent('lazy JSX', () => {
+  // oxlint-disable-next-line jest/expect-expect
   it.each(jsxFixturePaths)('%s', filename => runCaseInWorker(TEST_TYPE_JSX | TEST_TYPE_LAZY, filename));
 });
 
@@ -140,11 +141,13 @@ const tsFixturePaths = (await readdir(TS_ESTREE_DIR_PATH, { recursive: true }))
   .filter(path => path.endsWith('.md') && !tsFailPaths.has(path.slice(0, -3)));
 
 describe.concurrent('TypeScript', () => {
+  // oxlint-disable-next-line jest/expect-expect
   it.each(tsFixturePaths)('%s', path => runCaseInWorker(TEST_TYPE_TS, path));
 });
 
 // Check lazy deserialization doesn't throw
 describeLazy.concurrent('lazy TypeScript', () => {
+  // oxlint-disable-next-line jest/expect-expect
   it.each(tsFixturePaths)('%s', path => runCaseInWorker(TEST_TYPE_TS | TEST_TYPE_LAZY, path));
 });
 
@@ -168,7 +171,9 @@ describe.concurrent('edge cases', () => {
     '#!/usr/bin/env node\nlet x;',
     '#!/usr/bin/env node\nlet x;\n// foo',
   ])('%s', (sourceText) => {
+    // oxlint-disable-next-line jest/expect-expect
     it('JS', () => runCaseInWorker(TEST_TYPE_INLINE_FIXTURE, { filename: 'dummy.js', sourceText }));
+    // oxlint-disable-next-line jest/expect-expect
     it('TS', () => runCaseInWorker(TEST_TYPE_INLINE_FIXTURE, { filename: 'dummy.ts', sourceText }));
 
     itLazy(
@@ -184,11 +189,13 @@ describe.concurrent('edge cases', () => {
 
 // Test raw transfer output matches standard (via JSON) output for some large files
 describe.concurrent('fixtures', () => {
+  // oxlint-disable-next-line jest/expect-expect
   it.each(benchFixturePaths)('%s', path => runCaseInWorker(TEST_TYPE_FIXTURE, path));
 });
 
 // Check lazy deserialization doesn't throw
 describeLazy.concurrent('lazy fixtures', () => {
+  // oxlint-disable-next-line jest/expect-expect
   it.each(benchFixturePaths)('%s', path => runCaseInWorker(TEST_TYPE_FIXTURE | TEST_TYPE_LAZY, path));
 });
 
@@ -216,6 +223,7 @@ describe.concurrent('`parseAsync`', () => {
     expect(programRaw).toEqual(programStandard);
   });
 
+  // oxlint-disable-next-line jest/expect-expect
   it('processes multiple files', async () => {
     await testMultiple(4);
   });
@@ -223,6 +231,7 @@ describe.concurrent('`parseAsync`', () => {
   // This is primarily testing the queuing mechanism.
   // At least on Mac OS, this test does not cause out-of-memory without the queue implemented,
   // but the test doesn't complete in a reasonable time (I gave up waiting after 20 minutes).
+  // oxlint-disable-next-line jest/expect-expect
   it('does not exhaust memory when called huge number of times in succession', async () => {
     await testMultiple(10_000);
   });

--- a/napi/parser/test/parser.test-d.ts
+++ b/napi/parser/test/parser.test-d.ts
@@ -11,6 +11,7 @@ describe('parse', () => {
     assertType<Statement>(ret.program.body[0]);
   });
 
+  // oxlint-disable-next-line jest/expect-expect
   it('Node type', () => {
     function example(node: Node) {
       node.type satisfies string;

--- a/napi/parser/test/typescript-make-units-from-test.cjs
+++ b/napi/parser/test/typescript-make-units-from-test.cjs
@@ -112,7 +112,7 @@ function getErrorFiles(filePath, options) {
         const errorFile = fs.readFileSync(errorPath, 'utf8');
         errorFiles.push(errorFile);
       }
-    } catch (e) {
+    } catch {
       // Skip if file doesn't exist or can't be read
     }
   }

--- a/napi/parser/wrap.cjs
+++ b/napi/parser/wrap.cjs
@@ -51,7 +51,7 @@ function applyFix(program, fixPath) {
   } else {
     try {
       node.value = RegExp(node.regex.pattern, node.regex.flags);
-    } catch (_err) {
+    } catch (_err) { // oxlint-disable-line no-unused-vars
       // Invalid regexp, or valid regexp using syntax not supported by this version of NodeJS
     }
   }

--- a/napi/parser/wrap.mjs
+++ b/napi/parser/wrap.mjs
@@ -53,7 +53,7 @@ function applyFix(program, fixPath) {
   } else {
     try {
       node.value = RegExp(node.regex.pattern, node.regex.flags);
-    } catch (_err) {
+    } catch (_err) { // oxlint-disable-line no-unused-vars
       // Invalid regexp, or valid regexp using syntax not supported by this version of NodeJS
     }
   }


### PR DESCRIPTION
Same as #13184.

#13173 enabled Oxlint for all the repo, but we currently skip `napi` directory.

Fix all errors that Oxlint flags in `napi/parser`.

We currently can't turn on Oxlint for the directory, because `oxlint-disable` comments don't work for type-aware rules, but we should be able to once that's fixed.
