### PR TITLE
refactor(codegen): reduce repeated code

### DIFF
--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -3,31 +3,15 @@ use std::{borrow::Cow, iter::FusedIterator};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_ast::{Comment, CommentKind, ast::Program};
-use oxc_syntax::identifier::{LS, PS, is_line_terminator};
+use oxc_syntax::identifier::is_line_terminator;
 
-use crate::{Codegen, LegalComment, options::CommentOptions};
+use crate::{
+    Codegen, LegalComment,
+    options::CommentOptions,
+    str::{LS_LAST_2_BYTES, LS_OR_PS_FIRST_BYTE, PS_LAST_2_BYTES},
+};
 
 pub type CommentsMap = FxHashMap</* attached_to */ u32, Vec<Comment>>;
-
-/// Convert `char` to UTF-8 bytes array.
-const fn to_bytes<const N: usize>(ch: char) -> [u8; N] {
-    assert!(ch.len_utf8() == N);
-    let mut bytes = [0u8; N];
-    ch.encode_utf8(&mut bytes);
-    bytes
-}
-
-/// `LS` character as UTF-8 bytes.
-const LS_BYTES: [u8; 3] = to_bytes(LS);
-/// `PS` character as UTF-8 bytes.
-const PS_BYTES: [u8; 3] = to_bytes(PS);
-
-const LS_OR_PS_FIRST_BYTE: u8 = 0xE2;
-
-const _: () = assert!(LS_BYTES[0] == LS_OR_PS_FIRST_BYTE);
-const _: () = assert!(PS_BYTES[0] == LS_OR_PS_FIRST_BYTE);
-const LS_LAST_2_BYTES: [u8; 2] = [LS_BYTES[1], LS_BYTES[2]];
-const PS_LAST_2_BYTES: [u8; 2] = [PS_BYTES[1], PS_BYTES[2]];
 
 /// Custom iterator that splits text on line terminators while handling CRLF as a single unit.
 /// This avoids creating empty strings between CR and LF characters.

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -6,11 +6,7 @@ use oxc_index::{Idx, IndexVec};
 use oxc_span::Span;
 use oxc_syntax::identifier::{LS, PS};
 
-// Irregular line breaks - '\u{2028}' (LS) and '\u{2029}' (PS)
-const LS_OR_PS_FIRST: u8 = 0xE2;
-const LS_OR_PS_SECOND: u8 = 0x80;
-const LS_THIRD: u8 = 0xA8;
-const PS_THIRD: u8 = 0xA9;
+use crate::str::{LS_LAST_2_BYTES, LS_OR_PS_FIRST_BYTE, PS_LAST_2_BYTES};
 
 /// Number of lines to check with linear search when translating byte position to line index
 const LINE_SEARCH_LINEAR_ITERATIONS: usize = 16;
@@ -268,12 +264,10 @@ impl<'a> SourcemapBuilder<'a> {
                 _ if b.is_ascii() => {
                     continue;
                 }
-                LS_OR_PS_FIRST => {
+                LS_OR_PS_FIRST_BYTE => {
                     let next_byte = *iter.next().unwrap();
                     let next_next_byte = *iter.next().unwrap();
-                    if next_byte != LS_OR_PS_SECOND
-                        || !matches!(next_next_byte, LS_THIRD | PS_THIRD)
-                    {
+                    if !matches!([next_byte, next_next_byte], LS_LAST_2_BYTES | PS_LAST_2_BYTES) {
                         last_line_is_ascii = false;
                         continue;
                     }

--- a/crates/oxc_codegen/src/str.rs
+++ b/crates/oxc_codegen/src/str.rs
@@ -281,6 +281,7 @@ impl PrintStringState<'_> {
 
 /// Convert `char` to UTF-8 bytes array.
 const fn to_bytes<const N: usize>(ch: char) -> [u8; N] {
+    assert!(ch.len_utf8() == N);
     let mut bytes = [0u8; N];
     ch.encode_utf8(&mut bytes);
     bytes
@@ -291,10 +292,16 @@ const LS_BYTES: [u8; 3] = to_bytes(LS);
 /// `PS` character as UTF-8 bytes.
 const PS_BYTES: [u8; 3] = to_bytes(PS);
 
-const _: () = assert!(LS_BYTES[0] == 0xE2);
-const _: () = assert!(PS_BYTES[0] == 0xE2);
-const LS_LAST_2_BYTES: [u8; 2] = [LS_BYTES[1], LS_BYTES[2]];
-const PS_LAST_2_BYTES: [u8; 2] = [PS_BYTES[1], PS_BYTES[2]];
+/// First byte of either `LS` or `PS`
+pub const LS_OR_PS_FIRST_BYTE: u8 = 0xE2;
+
+const _: () = assert!(LS_BYTES[0] == LS_OR_PS_FIRST_BYTE);
+const _: () = assert!(PS_BYTES[0] == LS_OR_PS_FIRST_BYTE);
+
+/// Last 2 bytes of `LS` character.
+pub const LS_LAST_2_BYTES: [u8; 2] = [LS_BYTES[1], LS_BYTES[2]];
+/// Last 2 bytes of `PS` character.
+pub const PS_LAST_2_BYTES: [u8; 2] = [PS_BYTES[1], PS_BYTES[2]];
 
 /// `NBSP` character as UTF-8 bytes.
 const NBSP_BYTES: [u8; 2] = to_bytes(NBSP);


### PR DESCRIPTION
Codegen contains the same code for getting the bytes of `PS` and `LS` characters in multiple places. Remove this repetition by exporting the consts from `str.rs` module, and using them everywhere else.
