### PR TITLE
fix(oxlint)!: do not ignore hidden dot directories by default

### DIFF
--- a/apps/oxlint/fixtures/dot_folder/.a_dot_folder/index.ts
+++ b/apps/oxlint/fixtures/dot_folder/.a_dot_folder/index.ts
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1170,6 +1170,11 @@ mod test {
         Tester::new().with_cwd("fixtures/issue_11644".into()).test_and_snapshot(args);
     }
 
+    #[test]
+    fn test_dot_folder() {
+        Tester::new().with_cwd("fixtures/dot_folder".into()).test_and_snapshot(&[]);
+    }
+
     // ToDo: `tsgolint` does not support `big-endian`?
     #[test]
     #[cfg(not(target_endian = "big"))]

--- a/apps/oxlint/src/snapshots/fixtures__dot_folder_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__dot_folder_@oxlint.snap
@@ -1,0 +1,20 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: 
+working directory: fixtures/dot_folder
+----------
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[.a_dot_folder/index.ts:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Remove the debugger statement
+
+Found 1 warning and 0 errors.
+Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/walk.rs
+++ b/apps/oxlint/src/walk.rs
@@ -92,7 +92,8 @@ impl Walk {
             }
         }
 
-        let inner = inner.ignore(false).git_global(false).follow_links(true).build_parallel();
+        let inner =
+            inner.ignore(false).git_global(false).follow_links(true).hidden(false).build_parallel();
         Self { inner, extensions: Extensions::default() }
     }
 


### PR DESCRIPTION
closes #13183
Or should we introduce a new CLI flag?