### PR TITLE
fix(parser): produce syntax error for `export enum` and similar ts syntaxes

### DIFF
--- a/crates/oxc_parser/src/lexer/kind.rs
+++ b/crates/oxc_parser/src/lexer/kind.rs
@@ -313,11 +313,6 @@ impl Kind {
         self.is_literal_property_name() || self == Self::PrivateIdentifier
     }
 
-    #[inline]
-    pub fn is_variable_declaration(self) -> bool {
-        matches!(self, Var | Let | Const)
-    }
-
     #[rustfmt::skip]
     #[inline]
     pub fn is_assignment_operator(self) -> bool {

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -3,7 +3,7 @@ commit: 98d18aa4
 parser_babel Summary:
 AST Parsed     : 2403/2419 (99.34%)
 Positive Passed: 2381/2419 (98.43%)
-Negative Passed: 1640/1756 (93.39%)
+Negative Passed: 1642/1756 (93.51%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/invalid-startindex-and-startline-specified-without-startcolumn/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/startline-and-startcolumn-specified/input.js
@@ -69,10 +69,6 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-private-property/typescript-invalid-abstract/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-private-property/typescript-invalid-abstract-babel-7/input.ts
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/flow/expect-plugin/export-interface/input.js
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/flow/expect-plugin/export-type/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/arrow-like-in-conditional-2/input.ts
 
@@ -12077,10 +12073,22 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
 
   × Unexpected token
-   ╭─[babel/packages/babel-parser/test/fixtures/flow/expect-plugin/export-type-named/input.js:2:13]
+   ╭─[babel/packages/babel-parser/test/fixtures/flow/expect-plugin/export-interface/input.js:1:8]
+ 1 │ export interface Foo {}
+   ·        ─────────
+   ╰────
+
+  × Unexpected token
+   ╭─[babel/packages/babel-parser/test/fixtures/flow/expect-plugin/export-type/input.js:1:8]
+ 1 │ export type Foo = number;
+   ·        ────
+   ╰────
+
+  × Unexpected token
+   ╭─[babel/packages/babel-parser/test/fixtures/flow/expect-plugin/export-type-named/input.js:2:8]
  1 │ var Foo;
  2 │ export type { Foo };
-   ·             ─
+   ·        ────
    ╰────
 
   × Unexpected token

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -8927,18 +8927,11 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ╰────
   help: Try insert a semicolon here
 
-  × Duplicated export 'foo'
-   ╭─[typescript/tests/cases/compiler/jsdocTypedefNoCrash2.ts:1:13]
+  × Unexpected token
+   ╭─[typescript/tests/cases/compiler/jsdocTypedefNoCrash2.ts:1:8]
  1 │ export type foo = 5;
-   ·             ─┬─
-   ·              ╰── Export has already been declared here
+   ·        ────
  2 │ /**
-   ╰────
-   ╭─[typescript/tests/cases/compiler/jsdocTypedefNoCrash2.ts:6:14]
- 5 │  */
- 6 │ export const foo = 5;
-   ·              ─┬─
-   ·               ╰── It cannot be redeclared here
    ╰────
 
   × Unexpected token
@@ -20723,9 +20716,9 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ╰────
 
   × Unexpected token
-   ╭─[typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace_js.ts:1:13]
+   ╭─[typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace_js.ts:1:8]
  1 │ export type * from './a';
-   ·             ─
+   ·        ────
    ╰────
 
   × TS(2207): The 'type' modifier cannot be used on a named export when 'export type' is used on its export statement.
@@ -21204,12 +21197,12 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ╰────
 
   × Unexpected token
-    ╭─[typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsEnums.ts:10:1]
-  9 │ 
- 10 │ enum C {}
-    · ────
- 11 │ 
-    ╰────
+   ╭─[typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsEnums.ts:4:8]
+ 3 │ 
+ 4 │ export enum A {}
+   ·        ────
+ 5 │ 
+   ╰────
 
   × TS(8002): 'import ... =' can only be used in TypeScript files.
    ╭─[typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsExportFormsErr.ts:1:1]
@@ -21226,27 +21219,19 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ╰────
 
   × Unexpected token
-   ╭─[typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsInterfaces.ts:7:8]
- 6 │ export interface B {
- 7 │     cat: string;
-   ·        ─
- 8 │ }
+   ╭─[typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsInterfaces.ts:4:8]
+ 3 │ 
+ 4 │ export interface A {}
+   ·        ─────────
+ 5 │ 
    ╰────
 
-  × 'export statement' declaration can only be used at the top level of a module
-    ╭─[typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypeReferences4.ts:10:9]
-  9 │         // @ts-ignore
- 10 │         export { thing };
-    ·         ──────
- 11 │     }
-    ╰────
-
-  × 'export statement' declaration can only be used at the top level of a module
-   ╭─[typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypeReferences4.ts:6:5]
+  × Unexpected token
+   ╭─[typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypeReferences4.ts:4:8]
+ 3 │ // @ts-ignore
+ 4 │ export namespace A {
+   ·        ─────────
  5 │     // @ts-ignore
- 6 │     export namespace B {
-   ·     ──────
- 7 │         const Something = require("fs").Something;
    ╰────
 
   × Identifier `err` has already been declared


### PR DESCRIPTION
fixes #13205
closes #13206