### PR TITLE
test(estree, allocator): use `default` to create `ESTreeSerializer`s

### DIFF
--- a/crates/oxc_allocator/src/boxed.rs
+++ b/crates/oxc_allocator/src/boxed.rs
@@ -243,7 +243,7 @@ mod test {
         let allocator = Allocator::default();
         let b = Box::new_in("x", &allocator);
 
-        let mut serializer = CompactTSSerializer::new(false);
+        let mut serializer = CompactTSSerializer::default();
         b.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(s, r#""x""#);

--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -311,7 +311,7 @@ mod test {
         let mut v = Vec::new_in(&allocator);
         v.push("x");
 
-        let mut serializer = CompactTSSerializer::new(false);
+        let mut serializer = CompactTSSerializer::default();
         v.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(s, r#"["x"]"#);

--- a/crates/oxc_estree/src/serialize/blanket.rs
+++ b/crates/oxc_estree/src/serialize/blanket.rs
@@ -57,7 +57,7 @@ mod tests {
         let cases = [(&"foo", r#""foo""#), (&&"bar", r#""bar""#)];
 
         for (input, output) in cases {
-            let mut serializer = CompactTSSerializer::new(false);
+            let mut serializer = CompactTSSerializer::default();
             input.serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);
@@ -69,7 +69,7 @@ mod tests {
         let cases = [(&mut "foo", r#""foo""#), (&mut &mut "bar", r#""bar""#)];
 
         for (input, output) in cases {
-            let mut serializer = CompactTSSerializer::new(false);
+            let mut serializer = CompactTSSerializer::default();
             input.serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);
@@ -81,7 +81,7 @@ mod tests {
         let cases = [(None, "null"), (Some(123.0f64), "123")];
 
         for (input, output) in cases {
-            let mut serializer = CompactTSSerializer::new(false);
+            let mut serializer = CompactTSSerializer::default();
             input.serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);
@@ -94,7 +94,7 @@ mod tests {
             [(Cow::Borrowed("foo"), r#""foo""#), (Cow::Owned("bar".to_string()), r#""bar""#)];
 
         for (input, output) in cases {
-            let mut serializer = CompactTSSerializer::new(false);
+            let mut serializer = CompactTSSerializer::default();
             input.serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);

--- a/crates/oxc_estree/src/serialize/primitives.rs
+++ b/crates/oxc_estree/src/serialize/primitives.rs
@@ -71,7 +71,7 @@ mod tests {
 
     fn run_test<T: ESTree>(cases: &[(T, &str)]) {
         for (input, output) in cases {
-            let mut serializer = CompactTSSerializer::new(false);
+            let mut serializer = CompactTSSerializer::default();
             input.serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);

--- a/crates/oxc_estree/src/serialize/sequences.rs
+++ b/crates/oxc_estree/src/serialize/sequences.rs
@@ -121,12 +121,12 @@ mod tests {
 
         let foo = Foo { none: &[], one: &["one"], two: ["two one", "two two"] };
 
-        let mut serializer = CompactTSSerializer::new(false);
+        let mut serializer = CompactTSSerializer::default();
         foo.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(&s, r#"{"none":[],"one":["one"],"two":["two one","two two"]}"#);
 
-        let mut serializer = PrettyTSSerializer::new(false);
+        let mut serializer = PrettyTSSerializer::default();
         foo.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(

--- a/crates/oxc_estree/src/serialize/strings.rs
+++ b/crates/oxc_estree/src/serialize/strings.rs
@@ -467,7 +467,7 @@ mod tests {
         ];
 
         for (input, output) in cases {
-            let mut serializer = CompactTSSerializer::new(false);
+            let mut serializer = CompactTSSerializer::default();
             input.serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);
@@ -479,7 +479,7 @@ mod tests {
         let cases = [(String::new(), r#""""#), ("foobar".to_string(), r#""foobar""#)];
 
         for (input, output) in cases {
-            let mut serializer = CompactTSSerializer::new(false);
+            let mut serializer = CompactTSSerializer::default();
             input.to_string().serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);
@@ -491,7 +491,7 @@ mod tests {
         let cases = [("", r#""""#), ("a", r#""a""#), ("abc", r#""abc""#)];
 
         for (input, output) in cases {
-            let mut serializer = CompactTSSerializer::new(false);
+            let mut serializer = CompactTSSerializer::default();
             JsonSafeString(input).serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);
@@ -514,7 +514,7 @@ mod tests {
         ];
 
         for (input, output) in cases {
-            let mut serializer = CompactTSSerializer::new(false);
+            let mut serializer = CompactTSSerializer::default();
             LoneSurrogatesString(input).serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);

--- a/crates/oxc_estree/src/serialize/structs.rs
+++ b/crates/oxc_estree/src/serialize/structs.rs
@@ -405,7 +405,7 @@ mod tests {
             maybe_not_bar: None,
         };
 
-        let mut serializer = CompactTSSerializer::new(false);
+        let mut serializer = CompactTSSerializer::default();
         foo.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(
@@ -413,7 +413,7 @@ mod tests {
             r#"{"n":123,"u":12345,"bar":{"yes":"yup","no":"nope"},"empty":{},"hello":"hi!","maybe_bar":{"yes":"hell yeah!","no":"not a chance in a million, mate"},"maybe_not_bar":null}"#
         );
 
-        let mut serializer = PrettyTSSerializer::new(false);
+        let mut serializer = PrettyTSSerializer::default();
         foo.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(
@@ -494,7 +494,7 @@ mod tests {
             outer2: "out2",
         };
 
-        let mut serializer = CompactTSSerializer::new(false);
+        let mut serializer = CompactTSSerializer::default();
         outer.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(
@@ -502,7 +502,7 @@ mod tests {
             r#"{"outer1":"out1","inner1":"in1","innermost1":"inin1","innermost2":"inin2","inner2":"in2","outer2":"out2"}"#
         );
 
-        let mut serializer = PrettyTSSerializer::new(false);
+        let mut serializer = PrettyTSSerializer::default();
         outer.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(
@@ -540,12 +540,12 @@ mod tests {
 
         let foo = Foo { js: 1, ts: 2, js_only: 3, more_js: 4 };
 
-        let mut serializer = CompactTSSerializer::new(false);
+        let mut serializer = CompactTSSerializer::default();
         foo.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(&s, r#"{"js":1,"ts":2,"moreJs":4}"#);
 
-        let mut serializer = PrettyTSSerializer::new(false);
+        let mut serializer = PrettyTSSerializer::default();
         foo.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(
@@ -557,12 +557,12 @@ mod tests {
 }"#
         );
 
-        let mut serializer = CompactJSSerializer::new(false);
+        let mut serializer = CompactJSSerializer::default();
         foo.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(&s, r#"{"js":1,"jsOnly":3,"moreJs":4}"#);
 
-        let mut serializer = PrettyJSSerializer::new(false);
+        let mut serializer = PrettyJSSerializer::default();
         foo.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(


### PR DESCRIPTION
Pure refactor of tests related to `ESTree`.

`ESTreeSerializer` implements `Default`, so create `ESTreeSerializer`s with `default`, instead of explicitly passing `ranges: false`.
