### PR TITLE
refactor(transformer): shorten code

### DIFF
--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -841,7 +841,7 @@ impl<'a> LegacyDecorator<'a, '_> {
         // are identified by having an "unspanned" span. According to TypeScript's legacy
         // decorator semantics, metadata decorators must be applied *after* all parameter
         // decorators, so we separate them here and will insert them last.
-        let mut method_decorators = method.decorators.take_in(ctx.ast.allocator);
+        let mut method_decorators = method.decorators.take_in(ctx.ast);
         let metadata_position = method_decorators
             .iter()
             .position(|decorator| {

--- a/crates/oxc_transformer/src/plugins/styled_components.rs
+++ b/crates/oxc_transformer/src/plugins/styled_components.rs
@@ -407,7 +407,7 @@ impl<'a> StyledComponents<'a, '_> {
             tag,
             quasi: TemplateLiteral { span: quasi_span, quasis, expressions },
             type_arguments,
-        } = expr.take_in(ctx.ast.allocator);
+        } = expr.take_in(ctx.ast);
 
         let quasis_elements = ctx.ast.vec_from_iter(quasis.into_iter().map(|quasi| {
             ArrayExpressionElement::from(ctx.ast.expression_string_literal(

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -224,7 +224,7 @@ impl<'a> TypeScriptEnum<'a> {
 
         let mut prev_member_name = None;
 
-        for member in members.take_in(ctx.ast.allocator) {
+        for member in members.take_in(ctx.ast) {
             let member_name = member.id.static_name();
 
             let init = if let Some(mut initializer) = member.initializer {


### PR DESCRIPTION
Pure refactor. Shorten code. `AstBuilder::take_in` can take `ctx.ast`, no need for longer `ctx.ast.allocator`.