### PR TITLE
fix(linter): parse `ignorePatterns` with gitignore syntax

### DIFF
--- a/apps/oxlint/fixtures/ignore_pattern_non_glob_syntax/.oxlintrc.json
+++ b/apps/oxlint/fixtures/ignore_pattern_non_glob_syntax/.oxlintrc.json
@@ -1,0 +1,5 @@
+{
+  "ignorePatterns": [
+    "ignored_dir"
+  ]
+}

--- a/apps/oxlint/fixtures/ignore_pattern_non_glob_syntax/ignored_dir/index.ts
+++ b/apps/oxlint/fixtures/ignore_pattern_non_glob_syntax/ignored_dir/index.ts
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/fixtures/ignore_pattern_non_glob_syntax/with_nested/.oxlintrc.json
+++ b/apps/oxlint/fixtures/ignore_pattern_non_glob_syntax/with_nested/.oxlintrc.json
@@ -1,0 +1,5 @@
+{
+  "ignorePatterns": [
+    "ignored_dir"
+  ]
+}

--- a/apps/oxlint/fixtures/ignore_pattern_non_glob_syntax/with_nested/ignored_dir/index.ts
+++ b/apps/oxlint/fixtures/ignore_pattern_non_glob_syntax/with_nested/ignored_dir/index.ts
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -205,7 +205,8 @@ impl LintRunner {
         } else {
             None
         };
-        let config_builder = match ConfigStoreBuilder::from_oxlintrc(
+        let config_builder = match ConfigStoreBuilder::from_base_oxlintrc(
+            &self.cwd,
             false,
             oxlintrc,
             external_linter,
@@ -664,6 +665,16 @@ mod test {
         let args2 = &["."];
         Tester::new()
             .with_cwd("fixtures/ignore_file_current_dir".into())
+            .test_and_snapshot_multiple(&[args1, args2]);
+    }
+
+    #[test]
+    // https://github.com/oxc-project/oxc/issues/13204
+    fn ignore_pattern_non_glob_syntax() {
+        let args1 = &[];
+        let args2 = &["."];
+        Tester::new()
+            .with_cwd("fixtures/ignore_pattern_non_glob_syntax".into())
             .test_and_snapshot_multiple(&[args1, args2]);
     }
 

--- a/apps/oxlint/src/snapshots/fixtures__ignore_pattern_non_glob_syntax_ .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__ignore_pattern_non_glob_syntax_ .@oxlint.snap
@@ -1,0 +1,22 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: 
+working directory: fixtures/ignore_pattern_non_glob_syntax
+----------
+Found 0 warnings and 0 errors.
+Finished in <variable>ms on 0 files using 1 threads.
+----------
+CLI result: LintSucceeded
+----------
+
+########## 
+arguments: .
+working directory: fixtures/ignore_pattern_non_glob_syntax
+----------
+Found 0 warnings and 0 errors.
+Finished in <variable>ms on 0 files using 1 threads.
+----------
+CLI result: LintSucceeded
+----------

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -49,7 +49,8 @@ impl ServerLinter {
             Oxlintrc::default()
         };
 
-        let config_builder = ConfigStoreBuilder::from_oxlintrc(
+        let config_builder = ConfigStoreBuilder::from_base_oxlintrc(
+            &root_path,
             false,
             oxlintrc,
             None,

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -330,9 +330,9 @@ impl ConfigStore {
     }
 
     pub fn should_ignore(&self, path: &Path) -> bool {
-        self.get_related_config(path)
-            .ignore_patterns()
-            .is_some_and(|ignore_patterns| ignore_patterns.matched(path, false).is_ignore())
+        self.get_related_config(path).ignore_patterns().is_some_and(|ignore_patterns| {
+            ignore_patterns.matched_path_or_any_parents(path, false).is_ignore()
+        })
     }
 
     // NOTE: This function is not crate visible because it is used in `oxlint` as well to resolve configs


### PR DESCRIPTION
closes #13204

Why I need now a `GitignoreBuilder` instead of `OverrideBuilder` like before #12210.
Because `Gitignore::matched_path_or_any_parents` only allows paths inside his root, I needed to "trick" a bit.
Or else the test with `--config another/directory/config.json` would fail.

Now, the base `ignorePatterns` will always be at the current working directory.