### PR TITLE
refactor(linter): move ignore logic to `LintIgnoreMatcher`

### DIFF
--- a/apps/oxlint/fixtures/ignore_patterns_empty_nested/.oxlintrc.json
+++ b/apps/oxlint/fixtures/ignore_patterns_empty_nested/.oxlintrc.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "no-debugger": "error"
+  },
+  "ignorePatterns": [
+    "**/*.ts"
+  ]
+}

--- a/apps/oxlint/fixtures/ignore_patterns_empty_nested/another_config/.oxlintrc.json
+++ b/apps/oxlint/fixtures/ignore_patterns_empty_nested/another_config/.oxlintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-debugger": "error"
+  }
+}

--- a/apps/oxlint/fixtures/ignore_patterns_empty_nested/another_config/not-ignored-file.ts
+++ b/apps/oxlint/fixtures/ignore_patterns_empty_nested/another_config/not-ignored-file.ts
@@ -1,0 +1,2 @@
+debugger;
+

--- a/apps/oxlint/fixtures/ignore_patterns_empty_nested/ignored-file.ts
+++ b/apps/oxlint/fixtures/ignore_patterns_empty_nested/ignored-file.ts
@@ -1,0 +1,2 @@
+debugger;
+

--- a/apps/oxlint/fixtures/ignore_patterns_mixed/.oxlintrc.json
+++ b/apps/oxlint/fixtures/ignore_patterns_mixed/.oxlintrc.json
@@ -1,0 +1,3 @@
+{
+  "ignorePatterns": ["*.ts"]
+}

--- a/apps/oxlint/fixtures/ignore_patterns_mixed/nested/.oxlintrc.json
+++ b/apps/oxlint/fixtures/ignore_patterns_mixed/nested/.oxlintrc.json
@@ -1,0 +1,3 @@
+{
+  "ignorePatterns": ["*.ts", "!should_not_be_ignored.ts"]
+}

--- a/apps/oxlint/fixtures/ignore_patterns_mixed/nested/should_be_ignored.ts
+++ b/apps/oxlint/fixtures/ignore_patterns_mixed/nested/should_be_ignored.ts
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/fixtures/ignore_patterns_mixed/nested/should_not_be_ignored.ts
+++ b/apps/oxlint/fixtures/ignore_patterns_mixed/nested/should_not_be_ignored.ts
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/fixtures/ignore_patterns_mixed/should_be_ignored.ts
+++ b/apps/oxlint/fixtures/ignore_patterns_mixed/should_be_ignored.ts
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/fixtures/ignore_patterns_relative/.oxlintrc.json
+++ b/apps/oxlint/fixtures/ignore_patterns_relative/.oxlintrc.json
@@ -1,0 +1,3 @@
+{
+  "ignorePatterns": ["nested/*.ts"]
+}

--- a/apps/oxlint/fixtures/ignore_patterns_relative/nested/should_be_ignored.ts
+++ b/apps/oxlint/fixtures/ignore_patterns_relative/nested/should_be_ignored.ts
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/fixtures/ignore_patterns_relative/nested/should_not_be_ignored.js
+++ b/apps/oxlint/fixtures/ignore_patterns_relative/nested/should_not_be_ignored.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/fixtures/ignore_patterns_relative/should_not_be_ignored.ts
+++ b/apps/oxlint/fixtures/ignore_patterns_relative/should_not_be_ignored.ts
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/src/snapshots/fixtures__ignore_patterns_empty_nested_ .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__ignore_patterns_empty_nested_ .@oxlint.snap
@@ -1,0 +1,40 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: 
+working directory: fixtures/ignore_patterns_empty_nested
+----------
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[another_config/not-ignored-file.ts:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+ 2 | 
+   `----
+  help: Remove the debugger statement
+
+Found 0 warnings and 1 error.
+Finished in <variable>ms on 1 file using 1 threads.
+----------
+CLI result: LintFoundErrors
+----------
+
+########## 
+arguments: .
+working directory: fixtures/ignore_patterns_empty_nested
+----------
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[another_config/not-ignored-file.ts:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+ 2 | 
+   `----
+  help: Remove the debugger statement
+
+Found 0 warnings and 1 error.
+Finished in <variable>ms on 1 file using 1 threads.
+----------
+CLI result: LintFoundErrors
+----------

--- a/apps/oxlint/src/snapshots/fixtures__ignore_patterns_relative_ .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__ignore_patterns_relative_ .@oxlint.snap
@@ -1,0 +1,52 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: 
+working directory: fixtures/ignore_patterns_relative
+----------
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[nested/should_not_be_ignored.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Remove the debugger statement
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[should_not_be_ignored.ts:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Remove the debugger statement
+
+Found 2 warnings and 0 errors.
+Finished in <variable>ms on 2 files using 1 threads.
+----------
+CLI result: LintSucceeded
+----------
+
+########## 
+arguments: .
+working directory: fixtures/ignore_patterns_relative
+----------
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[nested/should_not_be_ignored.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Remove the debugger statement
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[should_not_be_ignored.ts:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Remove the debugger statement
+
+Found 2 warnings and 0 errors.
+Finished in <variable>ms on 2 files using 1 threads.
+----------
+CLI result: LintSucceeded
+----------

--- a/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
+++ b/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
@@ -92,10 +92,6 @@ impl IsolatedLintHandler {
             return None;
         }
 
-        if self.service.should_ignore(&path) {
-            return None;
-        }
-
         let mut allocator = Allocator::default();
         let source_text = content.or_else(|| read_to_string(&path).ok())?;
         let errors = self.lint_path(&mut allocator, &path, source_text);

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -101,49 +101,6 @@ impl ConfigStoreBuilder {
         external_linter: Option<&ExternalLinter>,
         external_plugin_store: &mut ExternalPluginStore,
     ) -> Result<Self, ConfigBuilderError> {
-        let parent_path =
-            oxlintrc.path.parent().map_or_else(|| PathBuf::from("."), std::path::Path::to_path_buf);
-
-        Self::from_oxlintrc_with_ignore_root(
-            start_empty,
-            oxlintrc,
-            external_linter,
-            external_plugin_store,
-            parent_path.as_path(),
-        )
-    }
-
-    /// Similar to the [`ConfigStoreBuilder::from_oxlintrc`] method, but
-    /// applies the config on top of a default [`Oxlintrc`].
-    /// The ignore root of this file, should be the current working directory.
-    /// Even if the file is not located at the current working directory.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ConfigBuilderError::InvalidConfigFile`] if a referenced config file is not valid.
-    pub fn from_base_oxlintrc(
-        cwd: &Path,
-        start_empty: bool,
-        oxlintrc: Oxlintrc,
-        external_linter: Option<&ExternalLinter>,
-        external_plugin_store: &mut ExternalPluginStore,
-    ) -> Result<Self, ConfigBuilderError> {
-        Self::from_oxlintrc_with_ignore_root(
-            start_empty,
-            oxlintrc,
-            external_linter,
-            external_plugin_store,
-            cwd,
-        )
-    }
-
-    fn from_oxlintrc_with_ignore_root(
-        start_empty: bool,
-        oxlintrc: Oxlintrc,
-        external_linter: Option<&ExternalLinter>,
-        external_plugin_store: &mut ExternalPluginStore,
-        ignore_root: &Path,
-    ) -> Result<Self, ConfigBuilderError> {
         // TODO: this can be cached to avoid re-computing the same oxlintrc
         fn resolve_oxlintrc_config(
             config: Oxlintrc,
@@ -210,6 +167,7 @@ impl ConfigStoreBuilder {
 
             let resolver = Resolver::default();
 
+            #[expect(clippy::missing_panics_doc, reason = "oxlintrc.path is always a file path")]
             let oxlintrc_dir = oxlintrc.path.parent().unwrap();
 
             for plugin_specifier in &external_plugins {
@@ -241,10 +199,6 @@ impl ConfigStoreBuilder {
             settings: oxlintrc.settings,
             env: oxlintrc.env,
             globals: oxlintrc.globals,
-            ignore_patterns: LintConfig::resolve_oxlintrc_ignore_patterns(
-                &oxlintrc.ignore_patterns,
-                ignore_root,
-            ),
             path: Some(oxlintrc.path),
         };
 

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -7,7 +7,6 @@ use rustc_hash::FxHashMap;
 
 use crate::{
     AllowWarnDeny, LintPlugins,
-    config::ResolvedIgnorePatterns,
     external_plugin_store::{ExternalPluginStore, ExternalRuleId},
     rules::{RULES, RuleEnum},
 };
@@ -124,10 +123,6 @@ impl Config {
 
     pub fn rules(&self) -> &Arc<[(RuleEnum, AllowWarnDeny)]> {
         &self.base.rules
-    }
-
-    pub fn ignore_patterns(&self) -> Option<&ResolvedIgnorePatterns> {
-        self.base.config.ignore_patterns.as_ref()
     }
 
     pub fn number_of_rules(&self) -> usize {
@@ -327,12 +322,6 @@ impl ConfigStore {
         } else {
             &self.base
         }
-    }
-
-    pub fn should_ignore(&self, path: &Path) -> bool {
-        self.get_related_config(path).ignore_patterns().is_some_and(|ignore_patterns| {
-            ignore_patterns.matched_path_or_any_parents(path, false).is_ignore()
-        })
     }
 
     // NOTE: This function is not crate visible because it is used in `oxlint` as well to resolve configs
@@ -761,7 +750,6 @@ mod test {
             settings: OxlintSettings::default(),
             globals: OxlintGlobals::default(),
             path: None,
-            ignore_patterns: None,
         };
 
         // Set up categories to enable restriction rules
@@ -852,7 +840,6 @@ mod test {
             settings: OxlintSettings::default(),
             globals: OxlintGlobals::default(),
             path: None,
-            ignore_patterns: None,
         };
 
         // Set up categories
@@ -957,7 +944,6 @@ mod test {
             settings: OxlintSettings::default(),
             globals: OxlintGlobals::default(),
             path: None,
-            ignore_patterns: None,
         };
 
         // Set up categories

--- a/crates/oxc_linter/src/config/ignore_matcher.rs
+++ b/crates/oxc_linter/src/config/ignore_matcher.rs
@@ -1,0 +1,103 @@
+use std::path::{Path, PathBuf};
+
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
+
+/// Holds ignore matchers for base and nested configs, for fast filtering in lint.rs
+
+#[derive(Debug)]
+pub struct LintIgnoreMatcher {
+    base: Option<Gitignore>,
+    nested: Vec<(Option<Gitignore>, PathBuf)>,
+}
+
+impl LintIgnoreMatcher {
+    /// Create a matcher from the base patterns and all nested patterns.
+    /// Accepts patterns directly, builds Gitignore internally.
+    pub fn new(
+        base_patterns: &[String],
+        base_root: &Path,
+        mut nested: Vec<(Vec<String>, PathBuf)>,
+    ) -> Self {
+        let base_gi = {
+            let mut builder = GitignoreBuilder::new(base_root);
+            for pat in base_patterns {
+                let _ = builder.add_line(None, pat);
+            }
+            builder.build().ok()
+        };
+
+        // Sort nested configs deepest-to-shallowest for correct precedence
+        nested.sort_by(|a, b| {
+            let a_len = a.1.components().count();
+            let b_len = b.1.components().count();
+            b_len.cmp(&a_len)
+        });
+        let nested = nested
+            .into_iter()
+            .map(|(patterns, root)| {
+                if patterns.is_empty() {
+                    (None, root)
+                } else {
+                    let mut builder = GitignoreBuilder::new(&root);
+                    for pat in &patterns {
+                        let _ = builder.add_line(None, pat);
+                    }
+                    (builder.build().ok(), root)
+                }
+            })
+            .collect();
+        Self { base: base_gi, nested }
+    }
+
+    /// Returns true if the path should be ignored by any config.
+    /// Checks nested configs deepest-to-shallowest, so deepest config wins.
+    pub fn should_ignore(&self, path: &Path) -> bool {
+        // If a nested config matches, only use its ignore patterns (do not fall back to base)
+        for (ignore, root) in &self.nested {
+            if path.starts_with(root) {
+                return ignore
+                    .as_ref()
+                    .is_some_and(|gi| gi.matched_path_or_any_parents(path, false).is_ignore());
+            }
+        }
+        self.base
+            .as_ref()
+            .is_some_and(|base| base.matched_path_or_any_parents(path, false).is_ignore())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_deepest_config_precedence() {
+        // Base ignores all *.js
+        let base_patterns = vec!["*.js".to_string()];
+        let base_root = Path::new("/repo");
+
+        let nested1 = (vec![], PathBuf::from("/repo/all_allowed"));
+        let nested2 = (vec!["*.ts".to_string()], PathBuf::from("/repo/all_allowed/ts"));
+        let nested3 = (vec!["*.js".to_string()], PathBuf::from("/repo/all_allowed/ts/js"));
+
+        let matcher =
+            LintIgnoreMatcher::new(&base_patterns, base_root, vec![nested1, nested2, nested3]);
+
+        // Path in /repo/all_allowed/ts/js should be ignored by nested3 (deepest)
+        assert!(matcher.should_ignore(Path::new("/repo/all_allowed/ts/js/file.js")));
+        assert!(!matcher.should_ignore(Path::new("/repo/all_allowed/ts/js/file.ts")));
+
+        // Path in /repo/all_allowed/ts should be ignored by nested2 for *.ts, base for *.js
+        assert!(!matcher.should_ignore(Path::new("/repo/all_allowed/ts/file.js")));
+        assert!(matcher.should_ignore(Path::new("/repo/all_allowed/ts/file.ts")));
+
+        // Path in /repo/a should be ignored by base for *.js, not for *.ts
+        assert!(!matcher.should_ignore(Path::new("/repo/all_allowed/file.js")));
+        assert!(!matcher.should_ignore(Path::new("/repo/all_allowed/file.ts")));
+
+        // Path outside any nested config, only base applies
+        assert!(matcher.should_ignore(Path::new("/repo/file.js")));
+        assert!(!matcher.should_ignore(Path::new("/repo/file.ts")));
+    }
+}

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -44,7 +44,7 @@ mod generated {
 pub use crate::{
     config::{
         BuiltinLintPlugins, Config, ConfigBuilderError, ConfigStore, ConfigStoreBuilder,
-        ESLintRule, LintPlugins, Oxlintrc, ResolvedLinterState,
+        ESLintRule, LintIgnoreMatcher, LintPlugins, Oxlintrc, ResolvedLinterState,
     },
     context::LintContext,
     external_linter::{

--- a/crates/oxc_linter/src/service/mod.rs
+++ b/crates/oxc_linter/src/service/mod.rs
@@ -93,11 +93,6 @@ impl LintService {
         self.runtime.run_source(allocator)
     }
 
-    #[cfg(feature = "language_server")]
-    pub fn should_ignore(&self, path: &Path) -> bool {
-        self.runtime.linter.config.should_ignore(path)
-    }
-
     /// For tests
     #[cfg(test)]
     pub(crate) fn run_test_source<'a>(


### PR DESCRIPTION
Moved the logic into an own struct.
`oxlint` does it only need at the beginning for prefiltering the files.
`oxc_language_server` needs to keep the ignores alive.

Before the `LintConfig` would hold it, which is too long for `oxlint`. 