### PR TITLE
refactor(transformer/legacy-decorator): eliminate unreliable identification of metadata

### DIFF
--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -40311,7 +40311,7 @@ after transform: ScopeId(0): ["_C", "_decorateMetadata", "_defineProperty", "_ge
 rebuilt        : ScopeId(0): ["_C", "_decorateMetadata", "_defineProperty", "_get_x", "_method", "_set_x", "_y"]
 Symbol reference IDs mismatch for "_decorateMetadata":
 after transform: SymbolId(10): [ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(32), ReferenceId(34), ReferenceId(35), ReferenceId(37), ReferenceId(39), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(49), ReferenceId(51), ReferenceId(52), ReferenceId(54), ReferenceId(56)]
-rebuilt        : SymbolId(1): [ReferenceId(8), ReferenceId(10), ReferenceId(11), ReferenceId(14), ReferenceId(16), ReferenceId(17), ReferenceId(20), ReferenceId(22), ReferenceId(24), ReferenceId(27), ReferenceId(31)]
+rebuilt        : SymbolId(1): [ReferenceId(14), ReferenceId(18)]
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -40350,16 +40350,10 @@ after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Function", "Number", "Object", "require"]
-rebuilt        : ["Function", "Number", "Object", "dec", "require"]
-Unresolved reference IDs mismatch for "Function":
-after transform: [ReferenceId(23), ReferenceId(27), ReferenceId(31), ReferenceId(40), ReferenceId(44), ReferenceId(48)]
-rebuilt        : [ReferenceId(9), ReferenceId(15), ReferenceId(21)]
+rebuilt        : ["Object", "dec", "require"]
 Unresolved reference IDs mismatch for "Object":
 after transform: [ReferenceId(36), ReferenceId(38), ReferenceId(53), ReferenceId(55)]
-rebuilt        : [ReferenceId(28), ReferenceId(32)]
-Unresolved reference IDs mismatch for "Number":
-after transform: [ReferenceId(33), ReferenceId(50)]
-rebuilt        : [ReferenceId(23)]
+rebuilt        : [ReferenceId(15), ReferenceId(19)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.1.ts
 Bindings mismatch:

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -592,6 +592,12 @@ rebuilt        : ScopeId(0): ["Foo"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
+Symbol span mismatch for "Foo":
+after transform: SymbolId(4): Span { start: 107, end: 110 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol span mismatch for "Foo":
+after transform: SymbolId(11): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(1): Span { start: 107, end: 110 }
 Reference symbol mismatch for "methodDecorator":
 after transform: SymbolId(0) "methodDecorator"
 rebuilt        : <None>
@@ -606,6 +612,9 @@ after transform: SymbolId(0) "methodDecorator"
 rebuilt        : <None>
 Reference symbol mismatch for "methodDecorator":
 after transform: SymbolId(0) "methodDecorator"
+rebuilt        : <None>
+Reference symbol mismatch for "paramDecorator":
+after transform: SymbolId(2) "paramDecorator"
 rebuilt        : <None>
 Reference symbol mismatch for "paramDecorator":
 after transform: SymbolId(2) "paramDecorator"
@@ -617,8 +626,8 @@ Reference symbol mismatch for "paramDecorator":
 after transform: SymbolId(2) "paramDecorator"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Boolean", "Function", "String", "babelHelpers"]
-rebuilt        : ["Boolean", "Function", "String", "babelHelpers", "methodDecorator", "paramDecorator"]
+after transform: ["Boolean", "Function", "Number", "String", "babelHelpers"]
+rebuilt        : ["Boolean", "Function", "Number", "String", "babelHelpers", "methodDecorator", "paramDecorator"]
 
 * oxc/metadata/this/input.ts
 Symbol span mismatch for "Example":

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/params/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/params/input.ts
@@ -14,6 +14,10 @@ export class Foo {
     return !!param
   }
 
+  constructor(@paramDecorator param: number) {
+
+  }
+
   method3(@paramDecorator param: string): boolean {
     return !!param
   }

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/params/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/params/output.js
@@ -1,10 +1,11 @@
-export class Foo {
+let Foo = class Foo {
 	method1(param) {
 		return !!param;
 	}
 	method2(param) {
 		return !!param;
 	}
+  constructor(param) {}
 	method3(param) {
 		return !!param;
 	}
@@ -64,3 +65,5 @@ babelHelpers.decorate(
 	"method4",
 	null,
 );
+Foo = babelHelpers.decorate([babelHelpers.decorateParam(0, paramDecorator), babelHelpers.decorateMetadata("design:paramtypes", [Number])], Foo);
+export { Foo };


### PR DESCRIPTION
Fixes: https://github.com/oxc-project/oxc/pull/13215#pullrequestreview-3132979634

Collect metadata and store them in a `VecDeque`, and take them when transforming the class decorators in the `exit_class` side, which can eliminate the unreliable check of `span.is_unspanned` for metadata decorators. However, it introduces a little complexity.