### PR TITLE
fix(minifier): fix string concatenation for lone surrogates

### DIFF
--- a/crates/oxc_ecmascript/src/to_big_int.rs
+++ b/crates/oxc_ecmascript/src/to_big_int.rs
@@ -47,10 +47,17 @@ impl<'a> ToBigInt<'a> for Expression<'a> {
                 _ => None,
             },
             Expression::StringLiteral(string_literal) => {
+                // Lone surrogates cannot be converted to BigInt.
+                if string_literal.lone_surrogates {
+                    return None;
+                }
                 string_literal.value.as_str().string_to_big_int()
             }
             Expression::TemplateLiteral(_) => {
-                self.to_js_string(ctx).and_then(|value| value.as_ref().string_to_big_int())
+                self.to_js_string(ctx).and_then(|(value, lone_surrogates)| {
+                    // Lone surrogates cannot be converted to BigInt.
+                    if lone_surrogates { None } else { value.as_ref().string_to_big_int() }
+                })
             }
             _ => None,
         }

--- a/crates/oxc_ecmascript/src/to_string.rs
+++ b/crates/oxc_ecmascript/src/to_string.rs
@@ -14,11 +14,17 @@ use crate::{
 ///
 /// <https://tc39.es/ecma262/multipage/abstract-operations.html#sec-tostring>
 pub trait ToJsString<'a> {
-    fn to_js_string(&self, ctx: &impl GlobalContext<'a>) -> Option<Cow<'a, str>>;
+    fn to_js_string(
+        &self,
+        ctx: &impl GlobalContext<'a>,
+    ) -> Option<(Cow<'a, str>, /* lone_surrogates */ bool)>;
 }
 
 impl<'a> ToJsString<'a> for Expression<'a> {
-    fn to_js_string(&self, ctx: &impl GlobalContext<'a>) -> Option<Cow<'a, str>> {
+    fn to_js_string(
+        &self,
+        ctx: &impl GlobalContext<'a>,
+    ) -> Option<(Cow<'a, str>, /* lone_surrogates */ bool)> {
         match self {
             Expression::StringLiteral(lit) => lit.to_js_string(ctx),
             Expression::TemplateLiteral(lit) => lit.to_js_string(ctx),
@@ -37,14 +43,17 @@ impl<'a> ToJsString<'a> for Expression<'a> {
 }
 
 impl<'a> ToJsString<'a> for ArrayExpressionElement<'a> {
-    fn to_js_string(&self, ctx: &impl GlobalContext<'a>) -> Option<Cow<'a, str>> {
+    fn to_js_string(
+        &self,
+        ctx: &impl GlobalContext<'a>,
+    ) -> Option<(Cow<'a, str>, /* lone_surrogates */ bool)> {
         match self {
             ArrayExpressionElement::SpreadElement(_) => None,
-            ArrayExpressionElement::Elision(_) => Some(Cow::Borrowed("")),
+            ArrayExpressionElement::Elision(_) => Some((Cow::Borrowed(""), false)),
             expr @ match_expression!(ArrayExpressionElement) => {
                 let expr = expr.as_expression()?;
                 match expr.value_type(ctx) {
-                    ValueType::Undefined | ValueType::Null => Some(Cow::Borrowed("")),
+                    ValueType::Undefined | ValueType::Null => Some((Cow::Borrowed(""), false)),
                     ValueType::Undetermined => None,
                     _ => expr.to_js_string(ctx),
                 }
@@ -54,97 +63,137 @@ impl<'a> ToJsString<'a> for ArrayExpressionElement<'a> {
 }
 
 impl<'a> ToJsString<'a> for StringLiteral<'a> {
-    fn to_js_string(&self, _ctx: &impl GlobalContext<'a>) -> Option<Cow<'a, str>> {
-        Some(Cow::Borrowed(self.value.as_str()))
+    fn to_js_string(
+        &self,
+        _ctx: &impl GlobalContext<'a>,
+    ) -> Option<(Cow<'a, str>, /* lone_surrogates */ bool)> {
+        Some((Cow::Borrowed(self.value.as_str()), self.lone_surrogates))
     }
 }
 
 impl<'a> ToJsString<'a> for TemplateLiteral<'a> {
-    fn to_js_string(&self, ctx: &impl GlobalContext<'a>) -> Option<Cow<'a, str>> {
+    fn to_js_string(
+        &self,
+        ctx: &impl GlobalContext<'a>,
+    ) -> Option<(Cow<'a, str>, /* lone_surrogates */ bool)> {
         let mut str = String::new();
+        let mut lone_surrogates = false;
         for (i, quasi) in self.quasis.iter().enumerate() {
             str.push_str(quasi.value.cooked.as_ref()?);
+            lone_surrogates |= quasi.lone_surrogates;
 
             if i < self.expressions.len() {
                 let expr = &self.expressions[i];
-                let value = expr.to_js_string(ctx)?;
+                let (value, ls) = expr.to_js_string(ctx)?;
+                lone_surrogates |= ls;
                 str.push_str(&value);
             }
         }
-        Some(Cow::Owned(str))
+        Some((Cow::Owned(str), lone_surrogates))
     }
 }
 
 impl<'a> ToJsString<'a> for IdentifierReference<'a> {
-    fn to_js_string(&self, ctx: &impl GlobalContext<'a>) -> Option<Cow<'a, str>> {
+    fn to_js_string(
+        &self,
+        ctx: &impl GlobalContext<'a>,
+    ) -> Option<(Cow<'a, str>, /* lone_surrogates */ bool)> {
         let name = self.name.as_str();
         (matches!(name, "undefined" | "Infinity" | "NaN") && ctx.is_global_reference(self))
-            .then_some(Cow::Borrowed(name))
+            .then_some((Cow::Borrowed(name), false))
     }
 }
 
 impl<'a> ToJsString<'a> for NumericLiteral<'a> {
-    fn to_js_string(&self, _ctx: &impl GlobalContext<'a>) -> Option<Cow<'a, str>> {
+    fn to_js_string(
+        &self,
+        _ctx: &impl GlobalContext<'a>,
+    ) -> Option<(Cow<'a, str>, /* lone_surrogates */ bool)> {
         use oxc_syntax::number::ToJsString;
         let value = self.value;
-        Some(if value == 0.0 { Cow::Borrowed("0") } else { Cow::Owned(value.to_js_string()) })
+        Some(if value == 0.0 {
+            (Cow::Borrowed("0"), false)
+        } else {
+            (Cow::Owned(value.to_js_string()), false)
+        })
     }
 }
 
 /// <https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-bigint.prototype.tostring>
 impl<'a> ToJsString<'a> for BigIntLiteral<'a> {
-    fn to_js_string(&self, _ctx: &impl GlobalContext<'a>) -> Option<Cow<'a, str>> {
-        Some(Cow::Borrowed(self.value.as_str()))
+    fn to_js_string(
+        &self,
+        _ctx: &impl GlobalContext<'a>,
+    ) -> Option<(Cow<'a, str>, /* lone_surrogates */ bool)> {
+        Some((Cow::Borrowed(self.value.as_str()), false))
     }
 }
 
 impl<'a> ToJsString<'a> for BooleanLiteral {
-    fn to_js_string(&self, _ctx: &impl GlobalContext<'a>) -> Option<Cow<'a, str>> {
-        Some(Cow::Borrowed(if self.value { "true" } else { "false" }))
+    fn to_js_string(
+        &self,
+        _ctx: &impl GlobalContext<'a>,
+    ) -> Option<(Cow<'a, str>, /* lone_surrogates */ bool)> {
+        Some((Cow::Borrowed(if self.value { "true" } else { "false" }), false))
     }
 }
 
 impl<'a> ToJsString<'a> for NullLiteral {
-    fn to_js_string(&self, _ctx: &impl GlobalContext<'a>) -> Option<Cow<'a, str>> {
-        Some(Cow::Borrowed("null"))
+    fn to_js_string(
+        &self,
+        _ctx: &impl GlobalContext<'a>,
+    ) -> Option<(Cow<'a, str>, /* lone_surrogates */ bool)> {
+        Some((Cow::Borrowed("null"), false))
     }
 }
 
 impl<'a> ToJsString<'a> for UnaryExpression<'a> {
-    fn to_js_string(&self, ctx: &impl GlobalContext<'a>) -> Option<Cow<'a, str>> {
+    fn to_js_string(
+        &self,
+        ctx: &impl GlobalContext<'a>,
+    ) -> Option<(Cow<'a, str>, /* lone_surrogates */ bool)> {
         match self.operator {
-            UnaryOperator::Void => Some(Cow::Borrowed("undefined")),
+            UnaryOperator::Void => Some((Cow::Borrowed("undefined"), false)),
             UnaryOperator::LogicalNot => self
                 .argument
                 .to_boolean(ctx)
-                .map(|boolean| Cow::Borrowed(if boolean { "false" } else { "true" })),
+                .map(|boolean| (Cow::Borrowed(if boolean { "false" } else { "true" }), false)),
             _ => None,
         }
     }
 }
 
 impl<'a> ToJsString<'a> for ArrayExpression<'a> {
-    fn to_js_string(&self, ctx: &impl GlobalContext<'a>) -> Option<Cow<'a, str>> {
-        self.array_join(ctx, Some(",")).map(Cow::Owned)
+    fn to_js_string(
+        &self,
+        ctx: &impl GlobalContext<'a>,
+    ) -> Option<(Cow<'a, str>, /* lone_surrogates */ bool)> {
+        self.array_join(ctx, Some(",")).map(|value| (Cow::Owned(value), false))
     }
 }
 
 impl<'a> ToJsString<'a> for ObjectExpression<'a> {
-    fn to_js_string(&self, _ctx: &impl GlobalContext<'a>) -> Option<Cow<'a, str>> {
+    fn to_js_string(
+        &self,
+        _ctx: &impl GlobalContext<'a>,
+    ) -> Option<(Cow<'a, str>, /* lone_surrogates */ bool)> {
         if maybe_object_with_to_primitive_related_properties_overridden(self) {
             None
         } else {
-            Some(Cow::Borrowed("[object Object]"))
+            Some((Cow::Borrowed("[object Object]"), false))
         }
     }
 }
 
 impl<'a> ToJsString<'a> for RegExpLiteral<'a> {
-    fn to_js_string(&self, _ctx: &impl GlobalContext<'a>) -> Option<Cow<'a, str>> {
+    fn to_js_string(
+        &self,
+        _ctx: &impl GlobalContext<'a>,
+    ) -> Option<(Cow<'a, str>, /* lone_surrogates */ bool)> {
         if let Some(raw) = self.raw.as_ref() {
-            Some(Cow::Borrowed(raw.as_str()))
+            Some((Cow::Borrowed(raw.as_str()), false))
         } else {
-            Some(Cow::Owned(self.regex.to_string()))
+            Some((Cow::Owned(self.regex.to_string()), false))
         }
     }
 }

--- a/crates/oxc_minifier/src/ctx.rs
+++ b/crates/oxc_minifier/src/ctx.rs
@@ -141,8 +141,13 @@ impl<'a> Ctx<'a, '_> {
                 let value = format_atom!(self.ast.allocator, "{bigint}");
                 self.ast.expression_big_int_literal(span, value, None, BigintBase::Decimal)
             }
-            ConstantValue::String(s) => {
-                self.ast.expression_string_literal(span, self.ast.atom_from_cow(&s), None)
+            ConstantValue::String((s, lone_surrogates)) => {
+                self.ast.expression_string_literal_with_lone_surrogates(
+                    span,
+                    self.ast.atom_from_cow(&s),
+                    None,
+                    lone_surrogates,
+                )
             }
             ConstantValue::Boolean(b) => self.ast.expression_boolean_literal(span, b),
             ConstantValue::Undefined => self.ast.void_0(span),

--- a/crates/oxc_minifier/src/peephole/inline.rs
+++ b/crates/oxc_minifier/src/peephole/inline.rs
@@ -38,7 +38,7 @@ impl<'a> PeepholeOptimizations {
             || match cv {
                 ConstantValue::Number(n) => n.fract() == 0.0 && *n >= -99.0 && *n <= 999.0,
                 ConstantValue::BigInt(_) => false,
-                ConstantValue::String(s) => s.len() <= 3,
+                ConstantValue::String((s, _)) => s.len() <= 3,
                 ConstantValue::Boolean(_) | ConstantValue::Undefined | ConstantValue::Null => true,
             }
         {

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -1634,9 +1634,11 @@ mod test {
         test("x = encodeURI('hello\\t\\n')", "x = 'hello%09%0A'");
         test("x = encodeURI('café')", "x = 'caf%C3%A9'"); // spellchecker:disable-line
         test("x = encodeURI('测试')", "x = '%E6%B5%8B%E8%AF%95'");
+        test("x = encodeURI('\\uD800\\uDE00')", "x = '%F0%90%88%80'");
 
         test_same("x = encodeURI('a', 'b')");
         test_same("x = encodeURI(x)");
+        test_same("x = encodeURI('\\uD800')"); // URI malformed
     }
 
     #[test]
@@ -1653,9 +1655,11 @@ mod test {
         test("x = encodeURIComponent('hello<>\"')", "x = 'hello%3C%3E%22'");
         test("x = encodeURIComponent('café')", "x = 'caf%C3%A9'"); // spellchecker:disable-line
         test("x = encodeURIComponent('测试')", "x = '%E6%B5%8B%E8%AF%95'");
+        test("x = encodeURIComponent('\\uD800\\uDE00')", "x = '%F0%90%88%80'");
 
         test_same("x = encodeURIComponent('a', 'b')");
         test_same("x = encodeURIComponent(x)");
+        test_same("x = encodeURIComponent('\\uD800')"); // URI malformed
     }
 
     #[test]
@@ -1674,6 +1678,7 @@ mod test {
         test("x = decodeURI('hello%09%0A')", "x = 'hello\\t\\n'");
         test("x = decodeURI('caf%C3%A9')", "x = 'café'"); // spellchecker:disable-line
         test("x = decodeURI('%E6%B5%8B%E8%AF%95')", "x = '测试'");
+        test("x = decodeURI('\\uD800')", "x = '\\uD800'");
 
         test_same("x = decodeURI('%ZZ')"); // URIError
         test_same("x = decodeURI('%A')"); // URIError
@@ -1697,6 +1702,7 @@ mod test {
         test("x = decodeURIComponent('hello%09%0A')", "x = 'hello\\t\\n'");
         test("x = decodeURIComponent('caf%C3%A9')", "x = 'café'"); // spellchecker:disable-line
         test("x = decodeURIComponent('%E6%B5%8B%E8%AF%95')", "x = '测试'");
+        test("x = decodeURIComponent('\\uD800')", "x = '\\uD800'");
 
         test_same("x = decodeURIComponent('%ZZ')"); // URIError
         test_same("x = decodeURIComponent('%A')"); // URIError

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1092,7 +1092,11 @@ impl<'a> PeepholeOptimizations {
 
     pub fn substitute_template_literal(expr: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) {
         let Expression::TemplateLiteral(t) = expr else { return };
-        let Some(val) = t.to_js_string(ctx) else { return };
+        let Some((val, lone_surrogates)) = t.to_js_string(ctx) else { return };
+        // TODO: Handle lone surrogates
+        if lone_surrogates {
+            return;
+        }
         *expr = ctx.ast.expression_string_literal(t.span(), ctx.ast.atom_from_cow(&val), None);
         ctx.state.changed = true;
     }

--- a/crates/oxc_minifier/tests/ecmascript/to_string.rs
+++ b/crates/oxc_minifier/tests/ecmascript/to_string.rs
@@ -39,10 +39,10 @@ fn test() {
         bigint_with_separators.to_js_string(&WithoutGlobalReferenceInformation {});
 
     assert_eq!(shadowed_undefined_string, None);
-    assert_eq!(global_undefined_string, Some("undefined".into()));
-    assert_eq!(empty_object_string, Some("[object Object]".into()));
+    assert_eq!(global_undefined_string, Some(("undefined".into(), false)));
+    assert_eq!(empty_object_string, Some(("[object Object]".into(), false)));
     assert_eq!(object_with_to_string_string, None);
-    assert_eq!(bigint_with_separators_string, Some("10".into()));
+    assert_eq!(bigint_with_separators_string, Some(("10".into(), false)));
 
     let num_cases = [
         (0.0, "0"),
@@ -58,7 +58,7 @@ fn test() {
         let num_lit = ast.expression_numeric_literal(SPAN, num, None, NumberBase::Decimal);
         assert_eq!(
             num_lit.to_js_string(&WithoutGlobalReferenceInformation {}),
-            Some(expected.into())
+            Some((expected.into(), false))
         );
     }
 }

--- a/crates/oxc_minifier/tests/peephole/mod.rs
+++ b/crates/oxc_minifier/tests/peephole/mod.rs
@@ -26,3 +26,12 @@ fn test(source_text: &str, expected: &str) {
 fn test_same(source_text: &str) {
     test(source_text, source_text);
 }
+
+#[track_caller]
+fn test_output(source_text: &str, expected: &str) {
+    let options = default_options();
+    let actual = crate::run(source_text, oxc_span::SourceType::default(), Some(options))
+        .trim_end()
+        .to_string();
+    assert_eq!(actual, expected, "\nfor source\n{source_text}\nexpect\n{expected}\ngot\n{actual}");
+}

--- a/crates/oxc_minifier/tests/peephole/obscure_edge_cases.rs
+++ b/crates/oxc_minifier/tests/peephole/obscure_edge_cases.rs
@@ -1,4 +1,4 @@
-use super::{test, test_same};
+use super::{test, test_output, test_same};
 
 /// Tests for edge cases that should reveal minification problems
 /// Focus on cases where optimizations might be unsafe or incorrect
@@ -34,6 +34,10 @@ fn test_string_concatenation_edge_cases() {
     test("return 'hello ' + 'world'", "return 'hello world'"); // string literal concatenation
     test("return 'count: ' + 42", "return 'count: 42'"); // string + number concatenation
     test("return 42 + ' items'", "return '42 items'"); // number + string concatenation
+
+    // Test cases where string lone surrogates is optimized
+    test_output("return '\\uD83D' + '\\uDD25';", "return '\\ud83d\\udd25';");
+    test_output("return `\\uD83D` + `\\uDD25`;", "return '\\ud83d\\udd25';");
 
     // Test with complex expressions - should not optimize if there are side effects
     test_same("return getValue() + 'suffix'");

--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -1011,7 +1011,11 @@ impl<'a> ObjectRestSpread<'a, '_> {
                 // `let { [1], ... rest }`
                 if expr.is_literal() {
                     let span = expr.span();
-                    let s = expr.to_js_string(&WithoutGlobalReferenceInformation {}).unwrap();
+                    let (s, ls) = expr.to_js_string(&WithoutGlobalReferenceInformation {}).unwrap();
+                    // TODO: Handle lone surrogate.
+                    if ls {
+                        return None;
+                    }
                     let s = ctx.ast.atom_from_cow(&s);
                     let expr = ctx.ast.expression_string_literal(span, s, None);
                     return Some(ArrayExpressionElement::from(expr));


### PR DESCRIPTION
Fixes a simple [use case](https://playground.oxc.rs/#eNpNkUFvwyAMhf9K5dOqRdPWqVKVc9Trpu3KIYQ4ERLBkYFuVdX/PhOWbCdseHzvGW5goAZDPpDDJ0fjQ6tUak6vp3b3uFvq5nBs98r/1yj4FSkQVelEpmAPFRDUN+Dk8xKuPupvqCMnrMBZH9c6GJpxa65TR27tImsfBuIJ6kG7gPcKZs0BORO1c/T1gTGxf0sx2B7PyZtoSfzK9ZlRtBd814w+lF1BZPMFIfXmUJhR84iSDDAcnl+OMoOVUXXEvkHjNOuMF9KaxlCPIy4Dotedw09KbHDS8+Y2WW8HW/CGppzpL4o8ZWRyZ5kkn1+QOwryGIWf8y1/UkzuP5yFkg8=) in optimizing lone surrogates. Also initialized and pinpointed some places that need a fix in future PRs.

With input:
```js
'\uD83D' + '\uDD25'
`\uD83D` + `\uDD25`
```

Previously outputs:

```js
"�d838�dd25"
"�d838�dd25"
```

Now outputs:

```js
"\ud83d\udd25"
"\ud83d\udd25"
```

Ported some optimization fixes I made in https://github.com/swc-project/swc/pull/10987 and I'm really appreciate the job you all have done. Without the previous investigation made by @overlookmotel, @Boshen and Oxc team, this will not happen.