### PR TITLE
feat(minifier): remove unused assignments for vars

### DIFF
--- a/crates/oxc_minifier/src/peephole/inline.rs
+++ b/crates/oxc_minifier/src/peephole/inline.rs
@@ -10,12 +10,12 @@ impl<'a> PeepholeOptimizations {
     pub fn init_symbol_value(decl: &VariableDeclarator<'a>, ctx: &mut Ctx<'a, '_>) {
         let BindingPatternKind::BindingIdentifier(ident) = &decl.id.kind else { return };
         let Some(symbol_id) = ident.symbol_id.get() else { return };
-        // Skip for `var` declarations, due to TDZ problems.
-        if decl.kind.is_var() {
-            return;
-        }
-        let value =
-            decl.init.as_ref().map_or(Some(ConstantValue::Undefined), |e| e.evaluate_value(ctx));
+        let value = if decl.kind.is_var() {
+            // Skip constant value inlining for `var` declarations, due to TDZ problems.
+            None
+        } else {
+            decl.init.as_ref().map_or(Some(ConstantValue::Undefined), |e| e.evaluate_value(ctx))
+        };
         ctx.init_value(symbol_id, value);
     }
 

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -733,8 +733,8 @@ mod test {
     use crate::{
         CompressOptions, TreeShakeOptions,
         tester::{
-            default_options, test, test_options, test_same, test_same_options,
-            test_same_options_source_type,
+            default_options, test, test_options, test_options_source_type, test_same,
+            test_same_options, test_same_options_source_type,
         },
     };
 
@@ -1040,13 +1040,16 @@ mod test {
     fn remove_unused_assignment_expression() {
         use oxc_span::SourceType;
         let options = CompressOptions::smallest();
-        // Vars are not handled yet due to TDZ.
-        test_same_options("var x = 1; x = 2;", &options);
-        test_same_options("var x = 1; x = foo();", &options);
+        test_options("var x = 1; x = 2;", "", &options);
+        test_options("var x = 1; x = foo();", "foo()", &options);
         test_same_options("export var foo; foo = 0;", &options);
         test_same_options("var x = 1; x = 2, foo(x)", &options);
         test_same_options("function foo() { return t = x(); } foo();", &options);
-        test_same_options("function foo() { var t; return t = x(); } foo();", &options);
+        test_options(
+            "function foo() { var t; return t = x(); } foo();",
+            "function foo() { return x(); } foo();",
+            &options,
+        );
         test_same_options("function foo(t) { return t = x(); } foo();", &options);
 
         test_options("let x = 1; x = 2;", "", &options);
@@ -1081,8 +1084,9 @@ mod test {
         let source_type = SourceType::cjs();
         test_same_options_source_type("var x = 1; x = 2;", source_type, &options);
         test_same_options_source_type("var x = 1; x = 2, foo(x)", source_type, &options);
-        test_same_options_source_type(
+        test_options_source_type(
             "function foo() { var x = 1; x = 2, bar() } foo()",
+            "function foo() { bar() } foo()",
             source_type,
             &options,
         );

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -1,7 +1,7 @@
            | Oxc        | ESBuild    | Oxc        | ESBuild    |
 Original   | minified   | minified   | gzip       | gzip       | Iterations | File      
 -------------------------------------------------------------------------------------
-72.14 kB   | 23.38 kB   | 23.70 kB   | 8.45 kB    | 8.54 kB    |          2 | react.development.js 
+72.14 kB   | 23.34 kB   | 23.70 kB   | 8.43 kB    | 8.54 kB    |          2 | react.development.js 
 
 173.90 kB  | 59.48 kB   | 59.82 kB   | 19.18 kB   | 19.33 kB   |          2 | moment.js  
 
@@ -19,9 +19,9 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 2.14 MB    | 715.37 kB  | 724.14 kB  | 161.66 kB  | 181.07 kB  |          2 | victory.js 
 
-3.20 MB    | 1.01 MB    | 1.01 MB    | 323.98 kB  | 331.56 kB  |          2 | echarts.js 
+3.20 MB    | 1.01 MB    | 1.01 MB    | 324.01 kB  | 331.56 kB  |          2 | echarts.js 
 
-6.69 MB    | 2.23 MB    | 2.31 MB    | 461.69 kB  | 488.28 kB  |          3 | antd.js    
+6.69 MB    | 2.23 MB    | 2.31 MB    | 461.08 kB  | 488.28 kB  |          4 | antd.js    
 
-10.95 MB   | 3.35 MB    | 3.49 MB    | 860.58 kB  | 915.50 kB  |          2 | typescript.js 
+10.95 MB   | 3.34 MB    | 3.49 MB    | 857.11 kB  | 915.50 kB  |          3 | typescript.js 
 


### PR DESCRIPTION
I found that the temporary variable are kept. This change would remove them.
Variables that were declared with `var` did not have `SymbolValue` populated and that caused those variables to bail out at this line.
https://github.com/oxc-project/oxc/blob/2141c18540803218889aa3c3f1bca5f51cdb5daa/crates/oxc_minifier/src/peephole/remove_unused_expression.rs#L624-L626

I think TDZ needs to be considered when inlining the values, but does not affect removing the unused assignments.
