### PR TITLE
fix(linter/explicit-module-boundary-types): false positve with arrow fn in exported fn body

### DIFF
--- a/crates/oxc_linter/src/snapshots/typescript_explicit_module_boundary_types.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_explicit_module_boundary_types.snap
@@ -680,3 +680,9 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────
  6 │                 return a;
    ╰────
+
+  ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
+   ╭─[explicit_module_boundary_types.tsx:1:75]
+ 1 │ function Test(): void { const _x = () => { }; } function Test2() { return () => { }; } export { Test2 };
+   ·                                                                           ──
+   ╰────


### PR DESCRIPTION
fixes #13209