### PR TITLE
refactor(ast_visit): clarify code

### DIFF
--- a/crates/oxc_ast_visit/src/utf8_to_utf16.rs
+++ b/crates/oxc_ast_visit/src/utf8_to_utf16.rs
@@ -419,7 +419,7 @@ const CHUNK_SIZE: usize = 32;
 const CHUNK_ALIGNMENT: usize = align_of::<AlignedChunk>();
 const _: () = {
     assert!(CHUNK_SIZE >= CHUNK_ALIGNMENT);
-    assert!(CHUNK_SIZE % CHUNK_ALIGNMENT == 0);
+    assert!(CHUNK_SIZE.is_multiple_of(CHUNK_ALIGNMENT));
     assert!(CHUNK_SIZE == size_of::<AlignedChunk>());
 };
 


### PR DESCRIPTION
Pure refactor. Prefer `x.is_multiple_of(y)` over `x % y == 0`, because its intent is clearer. `is_multiple_of` method wasn't available when this code was written originally.