### PR TITLE
feat(linter): add profiling support for tsgolint via environment variables

### DIFF
--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -72,16 +72,16 @@ impl TsGoLintState {
                 .stdout(std::process::Stdio::piped());
 
             if let Ok(trace_file) = std::env::var("OXLINT_TSGOLINT_TRACE") {
-                cmd.arg(format!("-trace={}", trace_file));
+                cmd.arg(format!("-trace={trace_file}"));
             }
             if let Ok(cpuprof_file) = std::env::var("OXLINT_TSGOLINT_CPU") {
-                cmd.arg(format!("-cpuprof={}", cpuprof_file));
+                cmd.arg(format!("-cpuprof={cpuprof_file}"));
             }
             if let Ok(heap_file) = std::env::var("OXLINT_TSGOLINT_HEAP") {
-                cmd.arg(format!("-heap={}", heap_file));
+                cmd.arg(format!("-heap={heap_file}"));
             }
             if let Ok(allocs_file) = std::env::var("OXLINT_TSGOLINT_ALLOCS") {
-                cmd.arg(format!("-allocs={}", allocs_file));
+                cmd.arg(format!("-allocs={allocs_file}"));
             }
 
             let child = cmd.spawn();

--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -66,11 +66,25 @@ impl TsGoLintState {
         let json_input = self.json_input(paths, &mut resolved_configs);
 
         let handler = std::thread::spawn(move || {
-            let child = std::process::Command::new(&self.executable_path)
-                .arg("headless")
+            let mut cmd = std::process::Command::new(&self.executable_path);
+            cmd.arg("headless")
                 .stdin(std::process::Stdio::piped())
-                .stdout(std::process::Stdio::piped())
-                .spawn();
+                .stdout(std::process::Stdio::piped());
+
+            if let Ok(trace_file) = std::env::var("OXLINT_TSGOLINT_TRACE") {
+                cmd.arg(format!("-trace={}", trace_file));
+            }
+            if let Ok(cpuprof_file) = std::env::var("OXLINT_TSGOLINT_CPU") {
+                cmd.arg(format!("-cpuprof={}", cpuprof_file));
+            }
+            if let Ok(heap_file) = std::env::var("OXLINT_TSGOLINT_HEAP") {
+                cmd.arg(format!("-heap={}", heap_file));
+            }
+            if let Ok(allocs_file) = std::env::var("OXLINT_TSGOLINT_ALLOCS") {
+                cmd.arg(format!("-allocs={}", allocs_file));
+            }
+
+            let child = cmd.spawn();
 
             let mut child = match child {
                 Ok(c) => c,


### PR DESCRIPTION
This PR adds support for Go profiling flags through environment variables:
- OXLINT_TSGOLINT_TRACE for execution traces
- OXLINT_TSGOLINT_CPU for CPU profiling
- OXLINT_TSGOLINT_HEAP for heap profiling
- OXLINT_TSGOLINT_ALLOCS for allocation profiling


Close #13234