### PR TITLE
chore(oxc_minify_napi): expose more options struct

### DIFF
--- a/napi/minify/src/lib.rs
+++ b/napi/minify/src/lib.rs
@@ -23,7 +23,9 @@ use oxc_parser::Parser;
 use oxc_sourcemap::napi::SourceMap;
 use oxc_span::SourceType;
 
-pub use crate::options::MinifyOptions;
+pub use crate::options::{
+    CompressOptions, CompressOptionsKeepNames, MangleOptions, MangleOptionsKeepNames, MinifyOptions,
+};
 
 #[derive(Default)]
 #[napi(object)]


### PR DESCRIPTION
Allow the downstream user to construct a napi options on their own, a use case in rolldown https://github.com/rolldown/rolldown/pull/5804/files#diff-56038ed67657ce910f150123cdc2d8ab42bd9bcd9745192c3127f2d837c78865R248, we need to convert options back to `oxc_minify_napi`, since `oxc::minify::options` did not implement `toNapi` trait.