### PR TITLE
refactor(ast_visit): remove custom offset conversion visitor for `WithClause`

### DIFF
--- a/crates/oxc_ast_visit/src/generated/utf8_to_utf16_converter.rs
+++ b/crates/oxc_ast_visit/src/generated/utf8_to_utf16_converter.rs
@@ -529,8 +529,9 @@ impl<'a> VisitMut<'a> for Utf8ToUtf16Converter<'_> {
     }
 
     fn visit_with_clause(&mut self, it: &mut WithClause<'a>) {
-        // Custom implementation
-        self.convert_with_clause(it);
+        self.convert_offset(&mut it.span.start);
+        walk_mut::walk_with_clause(self, it);
+        self.convert_offset(&mut it.span.end);
     }
 
     fn visit_import_attribute(&mut self, it: &mut ImportAttribute<'a>) {

--- a/crates/oxc_ast_visit/src/utf8_to_utf16/visit.rs
+++ b/crates/oxc_ast_visit/src/utf8_to_utf16/visit.rs
@@ -254,13 +254,6 @@ impl Utf8ToUtf16Converter<'_> {
         self.convert_offset(&mut specifier.span.end);
     }
 
-    pub(crate) fn convert_with_clause(&mut self, with_clause: &mut WithClause<'_>) {
-        // `WithClause::attributes_keyword` has a span before start of the `WithClause`.
-        // ESTree does not include that node, nor the span of the `WithClause` itself,
-        // so skip processing those spans.
-        self.visit_import_attributes(&mut with_clause.with_entries);
-    }
-
     pub(crate) fn convert_template_literal(&mut self, lit: &mut TemplateLiteral<'_>) {
         self.convert_offset(&mut lit.span.start);
 

--- a/tasks/ast_tools/src/generators/utf8_to_utf16.rs
+++ b/tasks/ast_tools/src/generators/utf8_to_utf16.rs
@@ -36,7 +36,6 @@ impl Generator for Utf8ToUtf16ConverterGenerator {
 /// The only exceptions are:
 ///
 /// * Types where a shorthand syntax means 2 nodes have same span e.g. `const {x} = y;`, `export {x}`.
-/// * `WithClause`, where `IdentifierName` for `with` keyword has span outside of the `WithClause`.
 /// * `TemplateLiteral`s and `TSTemplateLiteralType`s, where `quasis` and `expressions` are interleaved.
 /// * Decorators before `export` in `@dec export class C {}` / `@dec export default class {}`
 ///   have span before the start of `ExportNamedDeclaration` / `ExportDefaultDeclaration` span.
@@ -62,7 +61,6 @@ fn generate(schema: &Schema, codegen: &Codegen) -> TokenStream {
         "ExportDefaultDeclaration",
         "ExportSpecifier",
         "ImportSpecifier",
-        "WithClause",
         "TemplateLiteral",
         "TSTemplateLiteralType",
     ]


### PR DESCRIPTION
#12741 removed the `IdentifierName` representing the `with` keyword from `WithClause`.

Previously `WithClause` needed special handling in UTF8 -> UTF16 offset converter, but now that the `IdentifierName` (and the `Span` it contained) is gone, it no longer needs anything special.

So remove the custom visitor for `WithClause` from `Utf8ToUtf16Converter`.