### PR TITLE
fix(linter/no-unused-private-class-members): fix false positive with await expression

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
@@ -232,7 +232,8 @@ fn is_value_context(kind: &AstNode, semantic: &Semantic<'_>) -> bool {
         | AstKind::TSInstantiationExpression(_)
         | AstKind::TSNonNullExpression(_)
         | AstKind::TSTypeAssertion(_)
-        | AstKind::UpdateExpression(_) => {
+        | AstKind::UpdateExpression(_)
+        | AstKind::AwaitExpression(_) => {
             is_value_context(semantic.nodes().parent_node(kind.id()), semantic)
         }
 
@@ -452,6 +453,7 @@ fn test() {
         r"class C { #field = 1; static { const obj = new C(); console.log(obj.#field); } }",
         r"class C { #method() { return 42; } static { const obj = new C(); obj.#method(); } }",
         r"class C { #field = 1; static { const getField = obj => { return obj.#field; }; } }",
+        r"export class Database<const S extends idb.DBSchema> { readonly #db: Promise<idb.IDBPDatabase<S>>; constructor(name: string, version: number, hooks: idb.OpenDBCallbacks<S>) { this.#db = idb.openDB<S>(name, version, hooks); }  async read() { let db = await this.#db; } }",
     ];
 
     let fail = vec![
@@ -597,6 +599,7 @@ fn test() {
 			        }
 			    }
 			}",
+        r"class Foo { #awaitedMember; async method() { await this.#awaitedMember; } }",
     ];
 
     Tester::new(NoUnusedPrivateClassMembers::NAME, NoUnusedPrivateClassMembers::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/eslint_no_unused_private_class_members.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unused_private_class_members.snap
@@ -160,3 +160,9 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────────────────
  3 │ 
    ╰────
+
+  ⚠ eslint(no-unused-private-class-members): 'awaitedMember' is defined but never used.
+   ╭─[no_unused_private_class_members.tsx:1:13]
+ 1 │ class Foo { #awaitedMember; async method() { await this.#awaitedMember; } }
+   ·             ──────────────
+   ╰────


### PR DESCRIPTION
fixes #11039