### PR TITLE
feat(oxfmt): Add apps/oxfmt crate with minimum formatting usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2491,6 +2491,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxfmt"
+version = "0.1.0"
+dependencies = [
+ "bpaf",
+ "ignore",
+ "indexmap",
+ "mimalloc-safe",
+ "oxc_allocator",
+ "oxc_formatter",
+ "oxc_parser",
+ "oxc_span",
+ "rayon",
+ "rustc-hash",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "oxlint"
 version = "1.12.0"
 dependencies = [

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -1,0 +1,55 @@
+[package]
+name = "oxfmt"
+version = "0.1.0"
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+publish = false
+repository.workspace = true
+rust-version.workspace = true
+description.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+crate-type = ["lib"]
+path = "src/lib.rs"
+doctest = false
+
+[[bin]]
+name = "oxfmt"
+path = "src/main.rs"
+test = false
+doctest = false
+
+[dependencies]
+oxc_allocator = { workspace = true }
+oxc_formatter = { workspace = true }
+oxc_parser = { workspace = true }
+oxc_span = { workspace = true }
+
+bpaf = { workspace = true, features = ["autocomplete", "bright-color", "derive"] }
+ignore = { workspace = true, features = ["simd-accel"] }
+indexmap = { workspace = true }
+rayon = { workspace = true }
+rustc-hash = { workspace = true }
+tracing-subscriber = { workspace = true, features = [] } # Omit the `regex` feature
+
+[target.'cfg(not(any(target_os = "linux", target_os = "freebsd", target_arch = "arm", target_family = "wasm")))'.dependencies]
+mimalloc-safe = { workspace = true, optional = true, features = ["skip_collect_on_exit"] }
+
+[target.'cfg(all(target_os = "linux", not(target_arch = "arm"), not(target_arch = "aarch64")))'.dependencies]
+mimalloc-safe = { workspace = true, optional = true, features = ["skip_collect_on_exit", "local_dynamic_tls"] }
+
+[target.'cfg(all(target_os = "linux", target_arch = "aarch64"))'.dependencies]
+mimalloc-safe = { workspace = true, optional = true, features = ["skip_collect_on_exit", "local_dynamic_tls", "no_opt_arch"] }
+
+[dev-dependencies]
+
+[features]
+default = []
+allocator = ["dep:mimalloc-safe"]

--- a/apps/oxfmt/src/command.rs
+++ b/apps/oxfmt/src/command.rs
@@ -1,0 +1,93 @@
+use std::path::PathBuf;
+
+use bpaf::Bpaf;
+
+const VERSION: &str = match option_env!("OXC_VERSION") {
+    Some(v) => v,
+    None => "dev",
+};
+
+#[expect(clippy::ptr_arg)]
+fn validate_paths(paths: &Vec<PathBuf>) -> bool {
+    if paths.is_empty() {
+        true
+    } else {
+        paths.iter().all(|p| p.components().all(|c| c != std::path::Component::ParentDir))
+    }
+}
+
+const PATHS_ERROR_MESSAGE: &str = "PATH must not contain \"..\"";
+
+#[derive(Debug, Clone, Bpaf)]
+#[bpaf(options, version(VERSION))]
+pub struct FormatCommand {
+    #[bpaf(external)]
+    pub basic_options: BasicOptions,
+
+    #[bpaf(external)]
+    pub misc_options: MiscOptions,
+
+    /// Single file, single path or list of paths
+    #[bpaf(positional("PATH"), many, guard(validate_paths, PATHS_ERROR_MESSAGE))]
+    pub paths: Vec<PathBuf>,
+}
+
+/// Basic Configuration
+#[derive(Debug, Clone, Bpaf)]
+pub struct BasicOptions {
+    /// TODO: docs
+    #[bpaf(switch)]
+    pub check: bool,
+}
+
+/// Miscellaneous
+#[derive(Debug, Clone, Bpaf)]
+pub struct MiscOptions {
+    /// Number of threads to use. Set to 1 for using only 1 CPU core
+    #[bpaf(argument("INT"), hide_usage)]
+    pub threads: Option<usize>,
+}
+
+impl FormatCommand {
+    pub fn handle_threads(&self) {
+        Self::init_rayon_thread_pool(self.misc_options.threads);
+    }
+
+    /// Initialize Rayon global thread pool with specified number of threads.
+    ///
+    /// If `--threads` option is not used, or `--threads 0` is given,
+    /// default to the number of available CPU cores.
+    #[expect(clippy::print_stderr)]
+    fn init_rayon_thread_pool(threads: Option<usize>) {
+        // Always initialize thread pool, even if using default thread count,
+        // to ensure thread pool's thread count is locked after this point.
+        // `rayon::current_num_threads()` will always return the same number after this point.
+        //
+        // If you don't initialize the global thread pool explicitly, or don't specify `num_threads`,
+        // Rayon will initialize the thread pool when it's first used, with a thread count of
+        // `std::thread::available_parallelism()`, and that thread count won't change thereafter.
+        // So we don't *need* to initialize the thread pool here if we just want the default thread count.
+        //
+        // However, Rayon's docs state that:
+        // > In the future, the default behavior may change to dynamically add or remove threads as needed.
+        // https://docs.rs/rayon/1.11.0/rayon/struct.ThreadPoolBuilder.html#method.num_threads
+        //
+        // To ensure we continue to have a "locked" thread count, even after future Rayon upgrades,
+        // we always initialize the thread pool and explicitly specify thread count here.
+
+        let thread_count = if let Some(thread_count) = threads
+            && thread_count > 0
+        {
+            thread_count
+        } else if let Ok(thread_count) = std::thread::available_parallelism() {
+            thread_count.get()
+        } else {
+            eprintln!(
+                "Unable to determine available thread count. Defaulting to 1.\nConsider specifying the number of threads explicitly with `--threads` option."
+            );
+            1
+        };
+
+        rayon::ThreadPoolBuilder::new().num_threads(thread_count).build_global().unwrap();
+    }
+}

--- a/apps/oxfmt/src/format.rs
+++ b/apps/oxfmt/src/format.rs
@@ -1,0 +1,90 @@
+use std::{env, ffi::OsStr, io::Write, path::PathBuf, sync::Arc};
+
+use ignore::overrides::OverrideBuilder;
+
+use crate::{
+    cli::{CliRunResult, FormatCommand},
+    service::FormatService,
+    walk::Walk,
+};
+
+#[derive(Debug)]
+pub struct FormatRunner {
+    options: FormatCommand,
+    cwd: PathBuf,
+}
+
+impl FormatRunner {
+    pub(crate) fn new(options: FormatCommand) -> Self {
+        Self { options, cwd: env::current_dir().expect("Failed to get current working directory") }
+    }
+
+    pub(crate) fn run(self, stdout: &mut dyn Write) -> CliRunResult {
+        let cwd = self.cwd;
+        let FormatCommand { paths, basic_options: _, .. } = self.options;
+
+        let (exclude_patterns, regular_paths): (Vec<_>, Vec<_>) =
+            paths.into_iter().partition(|p| p.to_string_lossy().starts_with('!'));
+
+        // Need at least one regular path
+        if regular_paths.is_empty() {
+            print_and_flush_stdout(
+                stdout,
+                "Expected at least one target file/dir/glob(non-override pattern)\n",
+            );
+            return CliRunResult::FormatNoFilesFound;
+        }
+
+        // Build exclude patterns if any exist
+        let override_builder = (!exclude_patterns.is_empty())
+            .then(|| {
+                let mut builder = OverrideBuilder::new(cwd);
+                for pattern in exclude_patterns {
+                    builder.add(&pattern.to_string_lossy()).ok()?;
+                }
+                builder.build().ok()
+            })
+            .flatten();
+
+        let walker = Walk::new(&regular_paths, override_builder);
+        let paths = walker.paths();
+
+        let files_to_format = paths
+            .into_iter()
+            // .filter(|path| !config_store.should_ignore(Path::new(path)))
+            .collect::<Vec<Arc<OsStr>>>();
+
+        if files_to_format.is_empty() {
+            print_and_flush_stdout(stdout, "Expected at least one target file\n");
+            return CliRunResult::FormatNoFilesFound;
+        }
+
+        // let (mut diagnostic_service, tx_error) =
+        //     Self::get_diagnostic_service(&output_formatter, &warning_options, &misc_options);
+
+        // rayon::spawn(move || {
+        let mut format_service = FormatService::new();
+        format_service.with_paths(files_to_format);
+        format_service.run();
+        // });
+
+        // let diagnostic_result = diagnostic_service.run(stdout);
+
+        CliRunResult::FormatSucceeded
+    }
+}
+
+pub fn print_and_flush_stdout(stdout: &mut dyn Write, message: &str) {
+    use std::io::{Error, ErrorKind};
+    fn check_for_writer_error(error: Error) -> Result<(), Error> {
+        // Do not panic when the process is killed (e.g. piping into `less`).
+        if matches!(error.kind(), ErrorKind::Interrupted | ErrorKind::BrokenPipe) {
+            Ok(())
+        } else {
+            Err(error)
+        }
+    }
+
+    stdout.write_all(message.as_bytes()).or_else(check_for_writer_error).unwrap();
+    stdout.flush().unwrap();
+}

--- a/apps/oxfmt/src/lib.rs
+++ b/apps/oxfmt/src/lib.rs
@@ -1,0 +1,70 @@
+mod command;
+mod format;
+mod result;
+mod service;
+mod walk;
+
+pub mod cli {
+    pub use crate::{
+        command::{FormatCommand, format_command},
+        format::FormatRunner,
+        result::CliRunResult,
+    };
+}
+
+use std::io::BufWriter;
+
+use cli::{CliRunResult, FormatRunner, format_command};
+
+#[cfg(all(feature = "allocator", not(miri), not(target_family = "wasm")))]
+#[global_allocator]
+static GLOBAL: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
+
+pub fn format() -> CliRunResult {
+    init_tracing();
+
+    let mut args = std::env::args_os();
+    // If first arg is `node`, also skip script path (`node script.js ...`).
+    // Otherwise, just skip first arg (`oxfmt ...`).
+    if args.next().is_some_and(|arg| arg == "node") {
+        args.next();
+    }
+    let args = args.collect::<Vec<_>>();
+
+    let command = match format_command().run_inner(&*args) {
+        Ok(cmd) => cmd,
+        Err(e) => {
+            e.print_message(100);
+            return if e.exit_code() == 0 {
+                CliRunResult::FormatSucceeded
+            } else {
+                CliRunResult::InvalidOptionConfig
+            };
+        }
+    };
+    command.handle_threads();
+
+    // stdio is blocked by LineWriter, use a BufWriter to reduce syscalls.
+    // See `https://github.com/rust-lang/rust/issues/60673`.
+    let mut stdout = BufWriter::new(std::io::stdout());
+    FormatRunner::new(command).run(&mut stdout)
+}
+
+/// To debug `oxc_formatter`:
+/// `OXC_LOG=oxc_formatter oxfmt`
+fn init_tracing() {
+    use tracing_subscriber::{filter::Targets, prelude::*};
+
+    // Usage without the `regex` feature.
+    // <https://github.com/tokio-rs/tracing/issues/1436#issuecomment-918528013>
+    tracing_subscriber::registry()
+        .with(std::env::var("OXC_LOG").map_or_else(
+            |_| Targets::new(),
+            |env_var| {
+                use std::str::FromStr;
+                Targets::from_str(&env_var).unwrap()
+            },
+        ))
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+}

--- a/apps/oxfmt/src/main.rs
+++ b/apps/oxfmt/src/main.rs
@@ -1,0 +1,5 @@
+use oxfmt::{cli::CliRunResult, format};
+
+fn main() -> CliRunResult {
+    format()
+}

--- a/apps/oxfmt/src/result.rs
+++ b/apps/oxfmt/src/result.rs
@@ -1,0 +1,20 @@
+use std::process::{ExitCode, Termination};
+
+#[derive(Debug)]
+pub enum CliRunResult {
+    // Success
+    None,
+    FormatSucceeded,
+    // Failure
+    FormatNoFilesFound,
+    InvalidOptionConfig,
+}
+
+impl Termination for CliRunResult {
+    fn report(self) -> ExitCode {
+        match self {
+            Self::None | Self::FormatSucceeded => ExitCode::SUCCESS,
+            Self::FormatNoFilesFound | Self::InvalidOptionConfig => ExitCode::FAILURE,
+        }
+    }
+}

--- a/apps/oxfmt/src/service.rs
+++ b/apps/oxfmt/src/service.rs
@@ -1,0 +1,65 @@
+#![expect(clippy::print_stdout)] // TODO
+use std::{ffi::OsStr, fs, path::Path, sync::Arc};
+
+use indexmap::IndexSet;
+use oxc_allocator::Allocator;
+use oxc_formatter::{FormatOptions, Formatter};
+use oxc_parser::{ParseOptions, Parser};
+use oxc_span::SourceType;
+use rayon::prelude::*;
+use rustc_hash::FxBuildHasher;
+
+pub struct FormatService {
+    paths: IndexSet<Arc<OsStr>, FxBuildHasher>,
+}
+
+impl FormatService {
+    pub fn new() -> Self {
+        Self { paths: IndexSet::with_capacity_and_hasher(0, FxBuildHasher) }
+    }
+
+    pub fn with_paths(&mut self, paths: Vec<Arc<OsStr>>) -> &mut Self {
+        self.paths = paths.into_iter().collect();
+        self
+    }
+
+    // TODO: This should be check(), format(), write() ?
+    // TODO: tx_error
+    pub fn run(&self) {
+        self.paths.iter().par_bridge().for_each(|path| {
+            let path = Path::new(path);
+            let source_type =
+                SourceType::from_path(path).expect("`path` should be valid SourceType");
+            // TODO: AllocatorPool.get()?
+            let allocator = Allocator::new();
+            // TODO: read_to_arena_str()?
+            let source_text = fs::read_to_string(path).unwrap(); // TODO: OxcDiagnostic
+
+            let ret = Parser::new(&allocator, &source_text, source_type)
+                .with_options(ParseOptions {
+                    allow_v8_intrinsics: true,
+                    allow_return_outside_function: true,
+                    ..ParseOptions::default()
+                })
+                .parse();
+            if !ret.errors.is_empty() {
+                // TODO
+            }
+
+            let options = FormatOptions {
+                // semicolons: "always".parse().unwrap(),
+                semicolons: "as-needed".parse().unwrap(),
+                ..FormatOptions::default()
+            };
+            let code = Formatter::new(&allocator, options).build(&ret.program);
+
+            let is_changed = source_text != code;
+            println!("{}{}", path.display(), if is_changed { "" } else { " (unchanged)" });
+
+            // If --write
+            fs::write(path, code)
+                .map_err(|_| format!("Failed to write to '{}'", path.to_string_lossy()))
+                .unwrap();
+        });
+    }
+}

--- a/apps/oxfmt/src/walk.rs
+++ b/apps/oxfmt/src/walk.rs
@@ -1,0 +1,109 @@
+use std::{ffi::OsStr, path::PathBuf, sync::Arc, sync::mpsc};
+
+use ignore::{DirEntry, overrides::Override};
+use oxc_span::VALID_EXTENSIONS;
+
+// use crate::cli::IgnoreOptions;
+
+#[derive(Debug, Clone)]
+pub struct Extensions(pub Vec<&'static str>);
+
+impl Default for Extensions {
+    fn default() -> Self {
+        Self(VALID_EXTENSIONS.to_vec())
+    }
+}
+
+pub struct Walk {
+    inner: ignore::WalkParallel,
+    /// The file extensions to include during the traversal.
+    extensions: Extensions,
+}
+
+struct WalkBuilder {
+    sender: mpsc::Sender<Vec<Arc<OsStr>>>,
+    extensions: Extensions,
+}
+
+impl<'s> ignore::ParallelVisitorBuilder<'s> for WalkBuilder {
+    fn build(&mut self) -> Box<dyn ignore::ParallelVisitor + 's> {
+        Box::new(WalkCollector {
+            paths: vec![],
+            sender: self.sender.clone(),
+            extensions: self.extensions.clone(),
+        })
+    }
+}
+
+struct WalkCollector {
+    paths: Vec<Arc<OsStr>>,
+    sender: mpsc::Sender<Vec<Arc<OsStr>>>,
+    extensions: Extensions,
+}
+
+impl Drop for WalkCollector {
+    fn drop(&mut self) {
+        let paths = std::mem::take(&mut self.paths);
+        self.sender.send(paths).unwrap();
+    }
+}
+
+impl ignore::ParallelVisitor for WalkCollector {
+    fn visit(&mut self, entry: Result<ignore::DirEntry, ignore::Error>) -> ignore::WalkState {
+        match entry {
+            Ok(entry) => {
+                if Walk::is_wanted_entry(&entry, &self.extensions) {
+                    self.paths.push(entry.path().as_os_str().into());
+                }
+                ignore::WalkState::Continue
+            }
+            Err(_err) => ignore::WalkState::Skip,
+        }
+    }
+}
+impl Walk {
+    /// Will not canonicalize paths.
+    /// # Panics
+    pub fn new(paths: &[PathBuf], override_builder: Option<Override>) -> Self {
+        assert!(!paths.is_empty(), "At least one path must be provided to Walk::new");
+
+        let mut inner = ignore::WalkBuilder::new(
+            paths
+                .iter()
+                .next()
+                .expect("Expected paths parameter to Walk::new() to contain at least one path."),
+        );
+
+        if let Some(paths) = paths.get(1..) {
+            for path in paths {
+                inner.add(path);
+            }
+        }
+
+        if let Some(override_builder) = override_builder {
+            inner.overrides(override_builder);
+        }
+
+        let inner =
+            inner.ignore(false).git_global(false).follow_links(true).hidden(false).build_parallel();
+        Self { inner, extensions: Extensions::default() }
+    }
+
+    pub fn paths(self) -> Vec<Arc<OsStr>> {
+        let (sender, receiver) = mpsc::channel::<Vec<Arc<OsStr>>>();
+        let mut builder = WalkBuilder { sender, extensions: self.extensions };
+        self.inner.visit(&mut builder);
+        drop(builder);
+        receiver.into_iter().flatten().collect()
+    }
+
+    fn is_wanted_entry(dir_entry: &DirEntry, extensions: &Extensions) -> bool {
+        let Some(file_type) = dir_entry.file_type() else { return false };
+        if file_type.is_dir() {
+            return false;
+        }
+        let Some(extension) = dir_entry.path().extension() else { return false };
+        let extension = extension.to_string_lossy();
+        extensions.0.contains(&extension.as_ref())
+    }
+}


### PR DESCRIPTION
Part of #10573

- Add `apps/oxfmt` crate
- Copy minimum functionalities from `apps/oxlint`
  - Currently, these two are very similar
    - However, as following Prettier more, they may become different
    - There may still have in common, but at this point, it is unclear
  - `oxc_linter` also has many optimizations
- Format files with `oxc_formatter` and save
  - Usage not optimized