### PR TITLE
feat(minifier): remove unnecessary parenthesis from nested optional chaining

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -734,6 +734,18 @@ impl<'a> ChainElement<'a> {
     }
 }
 
+impl<'a> From<ChainElement<'a>> for Expression<'a> {
+    fn from(value: ChainElement<'a>) -> Self {
+        match value {
+            ChainElement::CallExpression(e) => Expression::CallExpression(e),
+            ChainElement::TSNonNullExpression(e) => Expression::TSNonNullExpression(e),
+            match_member_expression!(ChainElement) => {
+                Expression::from(value.into_member_expression())
+            }
+        }
+    }
+}
+
 impl CallExpression<'_> {
     /// Returns the static name of the callee, if it has one, or `None` otherwise.
     pub fn callee_name(&self) -> Option<&str> {

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -234,7 +234,7 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
             }
             Expression::ChainExpression(_) => {
                 Self::fold_chain_expr(expr, ctx);
-                Self::substitute_chain_call_expression(expr, ctx);
+                Self::substitute_chain_expression(expr, ctx);
             }
             Expression::CallExpression(_) => {
                 Self::fold_call_expression(expr, ctx);

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -23,5 +23,5 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 6.69 MB    | 2.23 MB    | 2.31 MB    | 461.08 kB  | 488.28 kB  |          4 | antd.js    
 
-10.95 MB   | 3.34 MB    | 3.49 MB    | 857.11 kB  | 915.50 kB  |          3 | typescript.js 
+10.95 MB   | 3.34 MB    | 3.49 MB    | 857.08 kB  | 915.50 kB  |          3 | typescript.js 
 


### PR DESCRIPTION
Flatten nested chain expressions like `(a?.b)?.c` to `a?.b?.c`.