### PR TITLE
feat(minifier): compress `return void foo()` => `foo(); return`

### DIFF
--- a/crates/oxc_minifier/src/ctx.rs
+++ b/crates/oxc_minifier/src/ctx.rs
@@ -13,6 +13,7 @@ use oxc_syntax::{
     identifier::{is_identifier_part, is_identifier_start},
     reference::ReferenceId,
 };
+use oxc_traverse::Ancestor;
 
 use crate::{options::CompressOptions, state::MinifierState, symbol_value::SymbolValue};
 
@@ -252,5 +253,9 @@ impl<'a> Ctx<'a, '_> {
         let mut chars = s.chars();
         chars.next().is_some_and(is_identifier_start)
             && chars.all(|c| is_identifier_part(c) && c != '・' && c != '･')
+    }
+
+    pub fn is_in_async_generator(&self) -> bool {
+        self.ancestors().any(|ancestor| matches!(ancestor, Ancestor::FunctionBody(body) if *body.r#async() && *body.generator()))
     }
 }

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -790,12 +790,8 @@ impl<'a> PeepholeOptimizations {
             return;
         }
         // `return undefined` has a different semantic in async generator function.
-        for ancestor in ctx.ancestors() {
-            if let Ancestor::FunctionBody(func) = ancestor {
-                if *func.r#async() && *func.generator() {
-                    return;
-                }
-            }
+        if ctx.is_in_async_generator() {
+            return;
         }
         stmt.argument = None;
         ctx.state.changed = true;
@@ -1482,7 +1478,7 @@ mod test {
         test("function f(){return !1;}", "function f(){return !1}");
         test("function f(){return null;}", "function f(){return null}");
         test("function f(){return void 0;}", "function f(){}");
-        test("function f(){return void foo();}", "function f(){return void foo()}");
+        test("function f(){return void foo();}", "function f(){foo()}");
         test("function f(){return undefined;}", "function f(){}");
         test("function f(){if(a()){return undefined;}}", "function f(){a()}");
         test_same("function a(undefined) { return undefined; }");

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -23,5 +23,5 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 6.69 MB    | 2.23 MB    | 2.31 MB    | 461.69 kB  | 488.28 kB  |          3 | antd.js    
 
-10.95 MB   | 3.35 MB    | 3.49 MB    | 860.59 kB  | 915.50 kB  |          2 | typescript.js 
+10.95 MB   | 3.35 MB    | 3.49 MB    | 860.58 kB  | 915.50 kB  |          2 | typescript.js 
 


### PR DESCRIPTION
Compress `return void foo()` => `foo(); return`.
`return void 0` and `return undefined` was handled but this wasn't.
