### PR TITLE
perf(minifier): exit early in `is_closest_function_scope_an_async_generator`

### DIFF
--- a/crates/oxc_minifier/src/ctx.rs
+++ b/crates/oxc_minifier/src/ctx.rs
@@ -255,7 +255,14 @@ impl<'a> Ctx<'a, '_> {
             && chars.all(|c| is_identifier_part(c) && c != '・' && c != '･')
     }
 
-    pub fn is_in_async_generator(&self) -> bool {
-        self.ancestors().any(|ancestor| matches!(ancestor, Ancestor::FunctionBody(body) if *body.r#async() && *body.generator()))
+    /// Whether the closest function scope is created by an async generator
+    pub fn is_closest_function_scope_an_async_generator(&self) -> bool {
+        self.ancestors()
+            .find_map(|ancestor| match ancestor {
+                Ancestor::FunctionBody(body) => Some(*body.r#async() && *body.generator()),
+                Ancestor::ArrowFunctionExpressionBody(_) => Some(false),
+                _ => None,
+            })
+            .unwrap_or_default()
     }
 }

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -616,7 +616,7 @@ impl<'a> PeepholeOptimizations {
         if let Some(argument) = &mut ret_stmt.argument
             && argument.value_type(ctx) == ValueType::Undefined
             // `return undefined` has a different semantic in async generator function.
-            && !ctx.is_in_async_generator()
+            && !ctx.is_closest_function_scope_an_async_generator()
         {
             ctx.state.changed = true;
             if argument.may_have_side_effects(ctx) {

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -790,7 +790,7 @@ impl<'a> PeepholeOptimizations {
             return;
         }
         // `return undefined` has a different semantic in async generator function.
-        if ctx.is_in_async_generator() {
+        if ctx.is_closest_function_scope_an_async_generator() {
             return;
         }
         stmt.argument = None;
@@ -1490,6 +1490,14 @@ mod test {
         test("async function foo() { return undefined }", "async function foo() { }");
         test_same("async function* foo() { return void 0 }");
         test_same("class Foo { async * foo() { return void 0 } }");
+        test(
+            "async function* foo() { function bar () { return void 0 } return bar }",
+            "async function* foo() { function bar () {} return bar }",
+        );
+        test(
+            "async function* foo() { let bar = () => { return void 0 }; return bar }",
+            "async function* foo() { let bar = () => {}; return bar }",
+        );
     }
 
     #[test]


### PR DESCRIPTION
`ctx.is_in_async_generator` was searching for async generator in ancestors even though it's not needed if a normal function or an arrow function is found while searching for it.

I renamed to the method to `ctx.is_closest_function_scope_an_async_generator` and made it exit early if a normal function or an arrow function is found. This should help performance a bit in most cases as I assume there are normal functions in many places. This would also make some minor cases to be compressible (added as test cases).
