### PR TITLE
feat(minifier): implement basic single use variable inlining

### DIFF
--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1538,7 +1538,7 @@ mod test {
         );
         test(
             "async function* foo() { let bar = () => { return void 0 }; return bar }",
-            "async function* foo() { let bar = () => {}; return bar }",
+            "async function* foo() { return () => {} }",
         );
     }
 

--- a/crates/oxc_minifier/tests/peephole/inline_single_use_variable.rs
+++ b/crates/oxc_minifier/tests/peephole/inline_single_use_variable.rs
@@ -1,0 +1,7 @@
+use super::test_same;
+
+#[test]
+fn test_inline_single_use_variable() {
+    test_same("function wrapper(arg0, arg1) {using x = foo; return x}");
+    test_same("async function wrapper(arg0, arg1) { await using x = foo; return x}");
+}

--- a/crates/oxc_minifier/tests/peephole/mod.rs
+++ b/crates/oxc_minifier/tests/peephole/mod.rs
@@ -1,6 +1,7 @@
 mod collapse_variable_declarations;
 mod dead_code_elimination;
 mod esbuild;
+mod inline_single_use_variable;
 mod minimize_exit_points;
 mod obscure_edge_cases;
 mod oxc;

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -1,27 +1,27 @@
            | Oxc        | ESBuild    | Oxc        | ESBuild    |
 Original   | minified   | minified   | gzip       | gzip       | Iterations | File      
 -------------------------------------------------------------------------------------
-72.14 kB   | 23.34 kB   | 23.70 kB   | 8.43 kB    | 8.54 kB    |          2 | react.development.js 
+72.14 kB   | 23.33 kB   | 23.70 kB   | 8.43 kB    | 8.54 kB    |          2 | react.development.js 
 
 173.90 kB  | 59.48 kB   | 59.82 kB   | 19.18 kB   | 19.33 kB   |          2 | moment.js  
 
 287.63 kB  | 89.34 kB   | 90.07 kB   | 30.94 kB   | 31.95 kB   |          2 | jquery.js  
 
-342.15 kB  | 117.22 kB  | 118.14 kB  | 43.27 kB   | 44.37 kB   |          2 | vue.js     
+342.15 kB  | 117.21 kB  | 118.14 kB  | 43.27 kB   | 44.37 kB   |          2 | vue.js     
 
 544.10 kB  | 71.38 kB   | 72.48 kB   | 25.85 kB   | 26.20 kB   |          1 | lodash.js  
 
 555.77 kB  | 270.86 kB  | 270.13 kB  | 88.23 kB   | 90.80 kB   |          2 | d3.js      
 
-1.01 MB    | 440.04 kB  | 458.89 kB  | 122.28 kB  | 126.71 kB  |          2 | bundle.min.js 
+1.01 MB    | 440.01 kB  | 458.89 kB  | 122.27 kB  | 126.71 kB  |          2 | bundle.min.js 
 
-1.25 MB    | 646.98 kB  | 646.76 kB  | 160.27 kB  | 163.73 kB  |          2 | three.js   
+1.25 MB    | 646.91 kB  | 646.76 kB  | 160.25 kB  | 163.73 kB  |          2 | three.js   
 
-2.14 MB    | 715.37 kB  | 724.14 kB  | 161.66 kB  | 181.07 kB  |          2 | victory.js 
+2.14 MB    | 715.35 kB  | 724.14 kB  | 161.65 kB  | 181.07 kB  |          2 | victory.js 
 
-3.20 MB    | 1.01 MB    | 1.01 MB    | 324.01 kB  | 331.56 kB  |          2 | echarts.js 
+3.20 MB    | 1.01 MB    | 1.01 MB    | 323.94 kB  | 331.56 kB  |          2 | echarts.js 
 
-6.69 MB    | 2.23 MB    | 2.31 MB    | 461.08 kB  | 488.28 kB  |          4 | antd.js    
+6.69 MB    | 2.23 MB    | 2.31 MB    | 460.92 kB  | 488.28 kB  |          4 | antd.js    
 
-10.95 MB   | 3.34 MB    | 3.49 MB    | 857.08 kB  | 915.50 kB  |          3 | typescript.js 
+10.95 MB   | 3.34 MB    | 3.49 MB    | 856.93 kB  | 915.50 kB  |          3 | typescript.js 
 


### PR DESCRIPTION
Ported the basic parts of esbuild's `substituteSingleUseSymbolInStmt`.
This would allow compressing
```js
let x = fn();
return x;
```
into
```js
return fn();
```
