### PR TITLE
fix(minifier): keep variables that are modified by `typeof foo === 'object' && foo !== null` compression

### DIFF
--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -439,21 +439,19 @@ impl<'a> PeepholeOptimizations {
             unreachable!();
         }
 
+        let is_null_id_ref = ctx.ast.expression_identifier_with_reference_id(
+            is_null_id_ref.span,
+            is_null_id_ref.name,
+            is_null_id_ref.reference_id(),
+        );
+
         let new_right_expr = if inversed {
-            ctx.ast.expression_unary(
-                SPAN,
-                UnaryOperator::LogicalNot,
-                ctx.ast.expression_identifier(is_null_id_ref.span, is_null_id_ref.name),
-            )
+            ctx.ast.expression_unary(SPAN, UnaryOperator::LogicalNot, is_null_id_ref)
         } else {
             ctx.ast.expression_unary(
                 SPAN,
                 UnaryOperator::LogicalNot,
-                ctx.ast.expression_unary(
-                    SPAN,
-                    UnaryOperator::LogicalNot,
-                    ctx.ast.expression_identifier(is_null_id_ref.span, is_null_id_ref.name),
-                ),
+                ctx.ast.expression_unary(SPAN, UnaryOperator::LogicalNot, is_null_id_ref),
             )
         };
         Some(ctx.ast.expression_logical(

--- a/crates/oxc_minifier/tests/peephole/inline_single_use_variable.rs
+++ b/crates/oxc_minifier/tests/peephole/inline_single_use_variable.rs
@@ -147,4 +147,14 @@ fn integration() {
         }
     ",
     );
+    test(
+        "
+        var bar = foo.bar;
+        if (typeof bar !== 'object' || bar === null) console.log('foo')
+        ",
+        "
+        var bar = foo.bar;
+        (typeof bar != 'object' || !bar) && console.log('foo')
+        ",
+    );
 }


### PR DESCRIPTION
`typeof foo === 'object' && foo !== null` compression was not keeping the reference information and that caused used variables to be removed.
```js
var bar = foo.bar;
if (typeof bar !== 'object' || bar === null) console.log('foo')
```
was compressed into
```js
if (typeof foo.bar !== 'object' || bar === null) console.log('foo')
```
