### PR TITLE
fix(semantic): allow `super` in object method in js but not in ts

### DIFF
--- a/tasks/coverage/misc/fail/oxc-13284.ts
+++ b/tasks/coverage/misc/fail/oxc-13284.ts
@@ -1,0 +1,9 @@
+class C {
+  foo() {
+    return {
+      bar() {
+        super.bar();
+      },
+    };
+  }
+}

--- a/tasks/coverage/misc/pass/oxc-13284.js
+++ b/tasks/coverage/misc/pass/oxc-13284.js
@@ -1,0 +1,9 @@
+class C {
+  foo() {
+    return {
+      bar() {
+        super.bar();
+      },
+    };
+  }
+}

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 46/46 (100.00%)
-Positive Passed: 46/46 (100.00%)
+AST Parsed     : 47/47 (100.00%)
+Positive Passed: 47/47 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
-AST Parsed     : 46/46 (100.00%)
-Positive Passed: 46/46 (100.00%)
-Negative Passed: 54/54 (100.00%)
+AST Parsed     : 47/47 (100.00%)
+Positive Passed: 47/47 (100.00%)
+Negative Passed: 55/55 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -225,6 +225,14 @@ Negative Passed: 54/54 (100.00%)
    ╭─[misc/fail/oxc-12612-4.ts:1:2]
  1 │ (foo() as number as any) = 123;
    ·  ──────────────────────
+   ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+   ╭─[misc/fail/oxc-13284.ts:5:9]
+ 4 │       bar() {
+ 5 │         super.bar();
+   ·         ─────
+ 6 │       },
    ╰────
 
   × Unexpected token

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 46/46 (100.00%)
-Positive Passed: 30/46 (65.22%)
+AST Parsed     : 47/47 (100.00%)
+Positive Passed: 31/47 (65.96%)
 semantic Error: tasks/coverage/misc/pass/oxc-11593.ts
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 46/46 (100.00%)
-Positive Passed: 46/46 (100.00%)
+AST Parsed     : 47/47 (100.00%)
+Positive Passed: 47/47 (100.00%)


### PR DESCRIPTION
closes #13284

Either TypeScript implemented the spec incorrectly or made it more
strict.

```js
class C {
  foo() {
    return {
      bar() {
        super.bar(); // syntax error in ts but not in js
      },
    };
  }
}
```