### PR TITLE
feat(formatter): support ignore comment

### DIFF
--- a/crates/oxc_formatter/src/formatter/comments/mod.rs
+++ b/crates/oxc_formatter/src/formatter/comments/mod.rs
@@ -326,6 +326,12 @@ impl<'a> Comments<'a> {
         self.printed_count += 1;
     }
 
+    /// Increases the printed count by the given amount.
+    #[inline]
+    pub fn increase_printed_count_by(&mut self, count: usize) {
+        self.printed_count += count;
+    }
+
     pub fn get_trailing_comments(
         &self,
         enclosing_node: &SiblingNode<'a>,
@@ -475,6 +481,14 @@ impl<'a> Comments<'a> {
         }
 
         &[]
+    }
+
+    /// Check whether the node has an ignore comment.
+    pub fn is_suppressed(&self, start: u32) -> bool {
+        self.comments_before(start).iter().any(|comment| {
+            // TODO: should replace `prettier-ignore` with `oxc-formatter-ignore` or something else later.
+            comment.content_span().source_text(self.source_text).trim() == "prettier-ignore"
+        })
     }
 }
 

--- a/crates/oxc_formatter/src/formatter/context.rs
+++ b/crates/oxc_formatter/src/formatter/context.rs
@@ -91,10 +91,6 @@ impl<'ast> FormatContext<'ast> {
         self.cached_elements.insert(key.span(), formatted);
     }
 
-    pub(crate) fn increment_printed_count(&mut self) {
-        self.comments.increment_printed_count();
-    }
-
     pub fn allocator(&self) -> &'ast Allocator {
         self.allocator
     }

--- a/crates/oxc_formatter/src/formatter/trivia.rs
+++ b/crates/oxc_formatter/src/formatter/trivia.rs
@@ -62,7 +62,7 @@ impl<'a> Format<'a> for FormatLeadingComments<'a> {
         ) -> FormatResult<()> {
             let mut leading_comments_iter = comments.into_iter().peekable();
             while let Some(comment) = leading_comments_iter.next() {
-                f.context_mut().increment_printed_count();
+                f.context_mut().comments_mut().increment_printed_count();
                 write!(f, comment)?;
 
                 match comment.kind {
@@ -137,7 +137,7 @@ impl<'a> Format<'a> for FormatTrailingComments<'a, '_> {
             let mut previous_comment: Option<&Comment> = None;
 
             for comment in comments {
-                f.context_mut().increment_printed_count();
+                f.context_mut().comments_mut().increment_printed_count();
 
                 let lines_before = get_lines_before(comment.span, f);
                 total_lines_before += lines_before;
@@ -310,7 +310,7 @@ impl<'a> Format<'a> for FormatDanglingComments<'a> {
                 let mut previous_comment: Option<&Comment> = None;
 
                 for comment in comments {
-                    f.context_mut().increment_printed_count();
+                    f.context_mut().comments_mut().increment_printed_count();
 
                     let should_nestle = previous_comment.is_some_and(|previous_comment| {
                         should_nestle_adjacent_doc_comments(

--- a/crates/oxc_formatter/src/generated/format.rs
+++ b/crates/oxc_formatter/src/generated/format.rs
@@ -3,11 +3,13 @@
 
 #![expect(clippy::match_same_arms)]
 use oxc_ast::ast::*;
+use oxc_span::GetSpan;
 
 use crate::{
     formatter::{Buffer, Format, FormatResult, Formatter, trivia::FormatTrailingComments},
     generated::ast_nodes::{AstNode, AstNodes, transmute_self},
     parentheses::NeedsParentheses,
+    utils::suppressed::FormatSuppressedNode,
     write::{FormatFunctionOptions, FormatJsArrowFunctionExpressionOptions, FormatWrite},
 };
 
@@ -360,8 +362,10 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, IdentifierName<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -369,12 +373,14 @@ impl<'a> Format<'a> for AstNode<'a, IdentifierName<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, IdentifierReference<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -385,8 +391,10 @@ impl<'a> Format<'a> for AstNode<'a, IdentifierReference<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, BindingIdentifier<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -394,8 +402,10 @@ impl<'a> Format<'a> for AstNode<'a, BindingIdentifier<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, LabelIdentifier<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -403,12 +413,14 @@ impl<'a> Format<'a> for AstNode<'a, LabelIdentifier<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ThisExpression> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -419,12 +431,14 @@ impl<'a> Format<'a> for AstNode<'a, ThisExpression> {
 
 impl<'a> Format<'a> for AstNode<'a, ArrayExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -472,8 +486,10 @@ impl<'a> Format<'a> for AstNode<'a, ArrayExpressionElement<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, Elision> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -481,12 +497,14 @@ impl<'a> Format<'a> for AstNode<'a, Elision> {
 
 impl<'a> Format<'a> for AstNode<'a, ObjectExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -523,8 +541,10 @@ impl<'a> Format<'a> for AstNode<'a, ObjectPropertyKind<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ObjectProperty<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -569,12 +589,14 @@ impl<'a> Format<'a> for AstNode<'a, PropertyKey<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TemplateLiteral<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -585,12 +607,14 @@ impl<'a> Format<'a> for AstNode<'a, TemplateLiteral<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TaggedTemplateExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -601,7 +625,14 @@ impl<'a> Format<'a> for AstNode<'a, TaggedTemplateExpression<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TemplateElement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        self.write(f)
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if is_suppressed {
+            self.format_leading_comments(f)?;
+            FormatSuppressedNode(self.span()).fmt(f)?;
+            self.format_trailing_comments(f)
+        } else {
+            self.write(f)
+        }
     }
 }
 
@@ -641,12 +672,14 @@ impl<'a> Format<'a> for AstNode<'a, MemberExpression<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ComputedMemberExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -657,12 +690,14 @@ impl<'a> Format<'a> for AstNode<'a, ComputedMemberExpression<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, StaticMemberExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -673,12 +708,14 @@ impl<'a> Format<'a> for AstNode<'a, StaticMemberExpression<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, PrivateFieldExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -689,12 +726,14 @@ impl<'a> Format<'a> for AstNode<'a, PrivateFieldExpression<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, CallExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -705,12 +744,14 @@ impl<'a> Format<'a> for AstNode<'a, CallExpression<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, NewExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -721,12 +762,14 @@ impl<'a> Format<'a> for AstNode<'a, NewExpression<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, MetaProperty<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -737,8 +780,10 @@ impl<'a> Format<'a> for AstNode<'a, MetaProperty<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, SpreadElement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -775,12 +820,14 @@ impl<'a> Format<'a> for AstNode<'a, Argument<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, UpdateExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -791,12 +838,14 @@ impl<'a> Format<'a> for AstNode<'a, UpdateExpression<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, UnaryExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -807,12 +856,14 @@ impl<'a> Format<'a> for AstNode<'a, UnaryExpression<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, BinaryExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -823,12 +874,14 @@ impl<'a> Format<'a> for AstNode<'a, BinaryExpression<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, PrivateInExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -839,12 +892,14 @@ impl<'a> Format<'a> for AstNode<'a, PrivateInExpression<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, LogicalExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -855,12 +910,14 @@ impl<'a> Format<'a> for AstNode<'a, LogicalExpression<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ConditionalExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -871,12 +928,14 @@ impl<'a> Format<'a> for AstNode<'a, ConditionalExpression<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, AssignmentExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -1006,8 +1065,10 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTargetPattern<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ArrayAssignmentTarget<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1015,8 +1076,10 @@ impl<'a> Format<'a> for AstNode<'a, ArrayAssignmentTarget<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ObjectAssignmentTarget<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1024,8 +1087,10 @@ impl<'a> Format<'a> for AstNode<'a, ObjectAssignmentTarget<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, AssignmentTargetRest<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1062,8 +1127,10 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTargetMaybeDefault<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, AssignmentTargetWithDefault<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1097,8 +1164,10 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTargetProperty<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, AssignmentTargetPropertyIdentifier<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1106,8 +1175,10 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTargetPropertyIdentifier<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, AssignmentTargetPropertyProperty<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1115,12 +1186,14 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTargetPropertyProperty<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, SequenceExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -1131,12 +1204,14 @@ impl<'a> Format<'a> for AstNode<'a, SequenceExpression<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, Super> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -1147,12 +1222,14 @@ impl<'a> Format<'a> for AstNode<'a, Super> {
 
 impl<'a> Format<'a> for AstNode<'a, AwaitExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -1163,12 +1240,14 @@ impl<'a> Format<'a> for AstNode<'a, AwaitExpression<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ChainExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -1216,12 +1295,14 @@ impl<'a> Format<'a> for AstNode<'a, ChainElement<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ParenthesizedExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -1408,8 +1489,10 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, Directive<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1417,8 +1500,10 @@ impl<'a> Format<'a> for AstNode<'a, Directive<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, Hashbang<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1426,8 +1511,10 @@ impl<'a> Format<'a> for AstNode<'a, Hashbang<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, BlockStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1509,8 +1596,10 @@ impl<'a> Format<'a> for AstNode<'a, Declaration<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, VariableDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1518,8 +1607,10 @@ impl<'a> Format<'a> for AstNode<'a, VariableDeclaration<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, VariableDeclarator<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1527,8 +1618,10 @@ impl<'a> Format<'a> for AstNode<'a, VariableDeclarator<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, EmptyStatement> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1536,8 +1629,10 @@ impl<'a> Format<'a> for AstNode<'a, EmptyStatement> {
 
 impl<'a> Format<'a> for AstNode<'a, ExpressionStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1545,8 +1640,10 @@ impl<'a> Format<'a> for AstNode<'a, ExpressionStatement<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, IfStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1554,8 +1651,10 @@ impl<'a> Format<'a> for AstNode<'a, IfStatement<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, DoWhileStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1563,8 +1662,10 @@ impl<'a> Format<'a> for AstNode<'a, DoWhileStatement<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, WhileStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1572,8 +1673,10 @@ impl<'a> Format<'a> for AstNode<'a, WhileStatement<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ForStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1610,8 +1713,10 @@ impl<'a> Format<'a> for AstNode<'a, ForStatementInit<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ForInStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1648,8 +1753,10 @@ impl<'a> Format<'a> for AstNode<'a, ForStatementLeft<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ForOfStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1657,8 +1764,10 @@ impl<'a> Format<'a> for AstNode<'a, ForOfStatement<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ContinueStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1666,8 +1775,10 @@ impl<'a> Format<'a> for AstNode<'a, ContinueStatement<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, BreakStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1675,8 +1786,10 @@ impl<'a> Format<'a> for AstNode<'a, BreakStatement<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ReturnStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1684,8 +1797,10 @@ impl<'a> Format<'a> for AstNode<'a, ReturnStatement<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, WithStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1693,8 +1808,10 @@ impl<'a> Format<'a> for AstNode<'a, WithStatement<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, SwitchStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1702,8 +1819,10 @@ impl<'a> Format<'a> for AstNode<'a, SwitchStatement<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, SwitchCase<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1711,8 +1830,10 @@ impl<'a> Format<'a> for AstNode<'a, SwitchCase<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, LabeledStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1720,8 +1841,10 @@ impl<'a> Format<'a> for AstNode<'a, LabeledStatement<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ThrowStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1729,8 +1852,10 @@ impl<'a> Format<'a> for AstNode<'a, ThrowStatement<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TryStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1738,20 +1863,36 @@ impl<'a> Format<'a> for AstNode<'a, TryStatement<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, CatchClause<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        self.write(f)
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if is_suppressed {
+            self.format_leading_comments(f)?;
+            FormatSuppressedNode(self.span()).fmt(f)?;
+            self.format_trailing_comments(f)
+        } else {
+            self.write(f)
+        }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, CatchParameter<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        self.write(f)
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if is_suppressed {
+            self.format_leading_comments(f)?;
+            FormatSuppressedNode(self.span()).fmt(f)?;
+            self.format_trailing_comments(f)
+        } else {
+            self.write(f)
+        }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, DebuggerStatement> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1759,8 +1900,10 @@ impl<'a> Format<'a> for AstNode<'a, DebuggerStatement> {
 
 impl<'a> Format<'a> for AstNode<'a, BindingPattern<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1810,8 +1953,10 @@ impl<'a> Format<'a> for AstNode<'a, BindingPatternKind<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, AssignmentPattern<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1819,8 +1964,10 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentPattern<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ObjectPattern<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1828,8 +1975,10 @@ impl<'a> Format<'a> for AstNode<'a, ObjectPattern<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, BindingProperty<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1837,8 +1986,10 @@ impl<'a> Format<'a> for AstNode<'a, BindingProperty<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ArrayPattern<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1846,8 +1997,10 @@ impl<'a> Format<'a> for AstNode<'a, ArrayPattern<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, BindingRestElement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1855,12 +2008,14 @@ impl<'a> Format<'a> for AstNode<'a, BindingRestElement<'a>> {
 
 impl<'a> Format<'a, FormatFunctionOptions> for AstNode<'a, Function<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -1873,12 +2028,17 @@ impl<'a> Format<'a, FormatFunctionOptions> for AstNode<'a, Function<'a>> {
         options: FormatFunctionOptions,
         f: &mut Formatter<'_, 'a>,
     ) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write_with_options(options, f);
+        let result = if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f)
+        } else {
+            self.write_with_options(options, f)
+        };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -1889,14 +2049,23 @@ impl<'a> Format<'a, FormatFunctionOptions> for AstNode<'a, Function<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, FormalParameters<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        self.write(f)
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if is_suppressed {
+            self.format_leading_comments(f)?;
+            FormatSuppressedNode(self.span()).fmt(f)?;
+            self.format_trailing_comments(f)
+        } else {
+            self.write(f)
+        }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, FormalParameter<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -1904,7 +2073,14 @@ impl<'a> Format<'a> for AstNode<'a, FormalParameter<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, FunctionBody<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        self.write(f)
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if is_suppressed {
+            self.format_leading_comments(f)?;
+            FormatSuppressedNode(self.span()).fmt(f)?;
+            self.format_trailing_comments(f)
+        } else {
+            self.write(f)
+        }
     }
 }
 
@@ -1912,12 +2088,14 @@ impl<'a> Format<'a, FormatJsArrowFunctionExpressionOptions>
     for AstNode<'a, ArrowFunctionExpression<'a>>
 {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -1930,12 +2108,17 @@ impl<'a> Format<'a, FormatJsArrowFunctionExpressionOptions>
         options: FormatJsArrowFunctionExpressionOptions,
         f: &mut Formatter<'_, 'a>,
     ) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write_with_options(options, f);
+        let result = if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f)
+        } else {
+            self.write_with_options(options, f)
+        };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -1946,12 +2129,14 @@ impl<'a> Format<'a, FormatJsArrowFunctionExpressionOptions>
 
 impl<'a> Format<'a> for AstNode<'a, YieldExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -1962,12 +2147,14 @@ impl<'a> Format<'a> for AstNode<'a, YieldExpression<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, Class<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -1978,7 +2165,14 @@ impl<'a> Format<'a> for AstNode<'a, Class<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ClassBody<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        self.write(f)
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if is_suppressed {
+            self.format_leading_comments(f)?;
+            FormatSuppressedNode(self.span()).fmt(f)?;
+            self.format_trailing_comments(f)
+        } else {
+            self.write(f)
+        }
     }
 }
 
@@ -2034,8 +2228,10 @@ impl<'a> Format<'a> for AstNode<'a, ClassElement<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, MethodDefinition<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2043,8 +2239,10 @@ impl<'a> Format<'a> for AstNode<'a, MethodDefinition<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, PropertyDefinition<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2052,8 +2250,10 @@ impl<'a> Format<'a> for AstNode<'a, PropertyDefinition<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, PrivateIdentifier<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2061,8 +2261,10 @@ impl<'a> Format<'a> for AstNode<'a, PrivateIdentifier<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, StaticBlock<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2128,8 +2330,10 @@ impl<'a> Format<'a> for AstNode<'a, ModuleDeclaration<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, AccessorProperty<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2137,12 +2341,14 @@ impl<'a> Format<'a> for AstNode<'a, AccessorProperty<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ImportExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -2153,8 +2359,10 @@ impl<'a> Format<'a> for AstNode<'a, ImportExpression<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ImportDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2196,8 +2404,10 @@ impl<'a> Format<'a> for AstNode<'a, ImportDeclarationSpecifier<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ImportSpecifier<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2205,8 +2415,10 @@ impl<'a> Format<'a> for AstNode<'a, ImportSpecifier<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ImportDefaultSpecifier<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2214,8 +2426,10 @@ impl<'a> Format<'a> for AstNode<'a, ImportDefaultSpecifier<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ImportNamespaceSpecifier<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2223,8 +2437,10 @@ impl<'a> Format<'a> for AstNode<'a, ImportNamespaceSpecifier<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, WithClause<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2232,8 +2448,10 @@ impl<'a> Format<'a> for AstNode<'a, WithClause<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ImportAttribute<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2267,20 +2485,36 @@ impl<'a> Format<'a> for AstNode<'a, ImportAttributeKey<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ExportNamedDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        self.write(f)
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if is_suppressed {
+            self.format_leading_comments(f)?;
+            FormatSuppressedNode(self.span()).fmt(f)?;
+            self.format_trailing_comments(f)
+        } else {
+            self.write(f)
+        }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ExportDefaultDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        self.write(f)
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if is_suppressed {
+            self.format_leading_comments(f)?;
+            FormatSuppressedNode(self.span()).fmt(f)?;
+            self.format_trailing_comments(f)
+        } else {
+            self.write(f)
+        }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ExportAllDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2288,8 +2522,10 @@ impl<'a> Format<'a> for AstNode<'a, ExportAllDeclaration<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ExportSpecifier<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2376,12 +2612,14 @@ impl<'a> Format<'a> for AstNode<'a, ModuleExportName<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, V8IntrinsicExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -2392,12 +2630,14 @@ impl<'a> Format<'a> for AstNode<'a, V8IntrinsicExpression<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, BooleanLiteral> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -2408,12 +2648,14 @@ impl<'a> Format<'a> for AstNode<'a, BooleanLiteral> {
 
 impl<'a> Format<'a> for AstNode<'a, NullLiteral> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -2424,12 +2666,14 @@ impl<'a> Format<'a> for AstNode<'a, NullLiteral> {
 
 impl<'a> Format<'a> for AstNode<'a, NumericLiteral<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -2440,12 +2684,14 @@ impl<'a> Format<'a> for AstNode<'a, NumericLiteral<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, StringLiteral<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -2456,12 +2702,14 @@ impl<'a> Format<'a> for AstNode<'a, StringLiteral<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, BigIntLiteral<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -2472,12 +2720,14 @@ impl<'a> Format<'a> for AstNode<'a, BigIntLiteral<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, RegExpLiteral<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -2502,8 +2752,10 @@ impl<'a> Format<'a> for AstNode<'a, JSXElement<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, JSXOpeningElement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2511,8 +2763,10 @@ impl<'a> Format<'a> for AstNode<'a, JSXOpeningElement<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, JSXClosingElement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2534,8 +2788,10 @@ impl<'a> Format<'a> for AstNode<'a, JSXFragment<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, JSXOpeningFragment> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2543,8 +2799,10 @@ impl<'a> Format<'a> for AstNode<'a, JSXOpeningFragment> {
 
 impl<'a> Format<'a> for AstNode<'a, JSXClosingFragment> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2602,8 +2860,10 @@ impl<'a> Format<'a> for AstNode<'a, JSXElementName<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, JSXNamespacedName<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2611,8 +2871,10 @@ impl<'a> Format<'a> for AstNode<'a, JSXNamespacedName<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, JSXMemberExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2654,8 +2916,10 @@ impl<'a> Format<'a> for AstNode<'a, JSXMemberExpressionObject<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, JSXExpressionContainer<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2692,8 +2956,10 @@ impl<'a> Format<'a> for AstNode<'a, JSXExpression<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, JSXEmptyExpression> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2727,8 +2993,10 @@ impl<'a> Format<'a> for AstNode<'a, JSXAttributeItem<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, JSXAttribute<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2736,8 +3004,10 @@ impl<'a> Format<'a> for AstNode<'a, JSXAttribute<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, JSXSpreadAttribute<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2813,8 +3083,10 @@ impl<'a> Format<'a> for AstNode<'a, JSXAttributeValue<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, JSXIdentifier<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2872,8 +3144,10 @@ impl<'a> Format<'a> for AstNode<'a, JSXChild<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, JSXSpreadChild<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2881,8 +3155,10 @@ impl<'a> Format<'a> for AstNode<'a, JSXSpreadChild<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, JSXText<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2890,8 +3166,10 @@ impl<'a> Format<'a> for AstNode<'a, JSXText<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSThisParameter<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2899,8 +3177,10 @@ impl<'a> Format<'a> for AstNode<'a, TSThisParameter<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSEnumDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2908,8 +3188,10 @@ impl<'a> Format<'a> for AstNode<'a, TSEnumDeclaration<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSEnumBody<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2917,8 +3199,10 @@ impl<'a> Format<'a> for AstNode<'a, TSEnumBody<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSEnumMember<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2968,8 +3252,10 @@ impl<'a> Format<'a> for AstNode<'a, TSEnumMemberName<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSTypeAnnotation<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -2977,8 +3263,10 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeAnnotation<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSLiteralType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3350,8 +3638,10 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSConditionalType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3359,8 +3649,10 @@ impl<'a> Format<'a> for AstNode<'a, TSConditionalType<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSUnionType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3368,8 +3660,10 @@ impl<'a> Format<'a> for AstNode<'a, TSUnionType<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSIntersectionType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3377,8 +3671,10 @@ impl<'a> Format<'a> for AstNode<'a, TSIntersectionType<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSParenthesizedType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3386,8 +3682,10 @@ impl<'a> Format<'a> for AstNode<'a, TSParenthesizedType<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSTypeOperator<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3395,8 +3693,10 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeOperator<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSArrayType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3404,8 +3704,10 @@ impl<'a> Format<'a> for AstNode<'a, TSArrayType<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSIndexedAccessType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3413,8 +3715,10 @@ impl<'a> Format<'a> for AstNode<'a, TSIndexedAccessType<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSTupleType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3422,8 +3726,10 @@ impl<'a> Format<'a> for AstNode<'a, TSTupleType<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSNamedTupleMember<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3431,8 +3737,10 @@ impl<'a> Format<'a> for AstNode<'a, TSNamedTupleMember<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSOptionalType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3440,8 +3748,10 @@ impl<'a> Format<'a> for AstNode<'a, TSOptionalType<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSRestType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3486,8 +3796,10 @@ impl<'a> Format<'a> for AstNode<'a, TSTupleElement<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSAnyKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3495,8 +3807,10 @@ impl<'a> Format<'a> for AstNode<'a, TSAnyKeyword> {
 
 impl<'a> Format<'a> for AstNode<'a, TSStringKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3504,8 +3818,10 @@ impl<'a> Format<'a> for AstNode<'a, TSStringKeyword> {
 
 impl<'a> Format<'a> for AstNode<'a, TSBooleanKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3513,8 +3829,10 @@ impl<'a> Format<'a> for AstNode<'a, TSBooleanKeyword> {
 
 impl<'a> Format<'a> for AstNode<'a, TSNumberKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3522,8 +3840,10 @@ impl<'a> Format<'a> for AstNode<'a, TSNumberKeyword> {
 
 impl<'a> Format<'a> for AstNode<'a, TSNeverKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3531,8 +3851,10 @@ impl<'a> Format<'a> for AstNode<'a, TSNeverKeyword> {
 
 impl<'a> Format<'a> for AstNode<'a, TSIntrinsicKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3540,8 +3862,10 @@ impl<'a> Format<'a> for AstNode<'a, TSIntrinsicKeyword> {
 
 impl<'a> Format<'a> for AstNode<'a, TSUnknownKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3549,8 +3873,10 @@ impl<'a> Format<'a> for AstNode<'a, TSUnknownKeyword> {
 
 impl<'a> Format<'a> for AstNode<'a, TSNullKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3558,8 +3884,10 @@ impl<'a> Format<'a> for AstNode<'a, TSNullKeyword> {
 
 impl<'a> Format<'a> for AstNode<'a, TSUndefinedKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3567,8 +3895,10 @@ impl<'a> Format<'a> for AstNode<'a, TSUndefinedKeyword> {
 
 impl<'a> Format<'a> for AstNode<'a, TSVoidKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3576,8 +3906,10 @@ impl<'a> Format<'a> for AstNode<'a, TSVoidKeyword> {
 
 impl<'a> Format<'a> for AstNode<'a, TSSymbolKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3585,8 +3917,10 @@ impl<'a> Format<'a> for AstNode<'a, TSSymbolKeyword> {
 
 impl<'a> Format<'a> for AstNode<'a, TSThisType> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3594,8 +3928,10 @@ impl<'a> Format<'a> for AstNode<'a, TSThisType> {
 
 impl<'a> Format<'a> for AstNode<'a, TSObjectKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3603,8 +3939,10 @@ impl<'a> Format<'a> for AstNode<'a, TSObjectKeyword> {
 
 impl<'a> Format<'a> for AstNode<'a, TSBigIntKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3612,8 +3950,10 @@ impl<'a> Format<'a> for AstNode<'a, TSBigIntKeyword> {
 
 impl<'a> Format<'a> for AstNode<'a, TSTypeReference<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3655,8 +3995,10 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeName<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSQualifiedName<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3664,8 +4006,10 @@ impl<'a> Format<'a> for AstNode<'a, TSQualifiedName<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSTypeParameterInstantiation<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3673,8 +4017,10 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeParameterInstantiation<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSTypeParameter<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3682,8 +4028,10 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeParameter<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSTypeParameterDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3691,8 +4039,10 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeParameterDeclaration<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSTypeAliasDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3700,14 +4050,23 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeAliasDeclaration<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSClassImplements<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        self.write(f)
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if is_suppressed {
+            self.format_leading_comments(f)?;
+            FormatSuppressedNode(self.span()).fmt(f)?;
+            self.format_trailing_comments(f)
+        } else {
+            self.write(f)
+        }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSInterfaceDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3715,8 +4074,10 @@ impl<'a> Format<'a> for AstNode<'a, TSInterfaceDeclaration<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSInterfaceBody<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3724,8 +4085,10 @@ impl<'a> Format<'a> for AstNode<'a, TSInterfaceBody<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSPropertySignature<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3783,8 +4146,10 @@ impl<'a> Format<'a> for AstNode<'a, TSSignature<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSIndexSignature<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3792,8 +4157,10 @@ impl<'a> Format<'a> for AstNode<'a, TSIndexSignature<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSCallSignatureDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3801,8 +4168,10 @@ impl<'a> Format<'a> for AstNode<'a, TSCallSignatureDeclaration<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSMethodSignature<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3810,8 +4179,10 @@ impl<'a> Format<'a> for AstNode<'a, TSMethodSignature<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSConstructSignatureDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3819,8 +4190,10 @@ impl<'a> Format<'a> for AstNode<'a, TSConstructSignatureDeclaration<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSIndexSignatureName<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3828,8 +4201,10 @@ impl<'a> Format<'a> for AstNode<'a, TSIndexSignatureName<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSInterfaceHeritage<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3837,8 +4212,10 @@ impl<'a> Format<'a> for AstNode<'a, TSInterfaceHeritage<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSTypePredicate<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3872,8 +4249,10 @@ impl<'a> Format<'a> for AstNode<'a, TSTypePredicateName<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSModuleDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3933,8 +4312,10 @@ impl<'a> Format<'a> for AstNode<'a, TSModuleDeclarationBody<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSModuleBlock<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3942,8 +4323,10 @@ impl<'a> Format<'a> for AstNode<'a, TSModuleBlock<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSTypeLiteral<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3951,8 +4334,10 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeLiteral<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSInferType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3960,8 +4345,10 @@ impl<'a> Format<'a> for AstNode<'a, TSInferType<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSTypeQuery<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -3998,8 +4385,10 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeQueryExprName<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSImportType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -4033,8 +4422,10 @@ impl<'a> Format<'a> for AstNode<'a, TSImportTypeQualifier<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSImportTypeQualifiedName<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -4042,8 +4433,10 @@ impl<'a> Format<'a> for AstNode<'a, TSImportTypeQualifiedName<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSFunctionType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -4051,8 +4444,10 @@ impl<'a> Format<'a> for AstNode<'a, TSFunctionType<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSConstructorType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -4060,8 +4455,10 @@ impl<'a> Format<'a> for AstNode<'a, TSConstructorType<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSMappedType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -4069,8 +4466,10 @@ impl<'a> Format<'a> for AstNode<'a, TSMappedType<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSTemplateLiteralType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -4078,12 +4477,14 @@ impl<'a> Format<'a> for AstNode<'a, TSTemplateLiteralType<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSAsExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -4094,12 +4495,14 @@ impl<'a> Format<'a> for AstNode<'a, TSAsExpression<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSSatisfiesExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -4110,12 +4513,14 @@ impl<'a> Format<'a> for AstNode<'a, TSSatisfiesExpression<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSTypeAssertion<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -4126,8 +4531,10 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeAssertion<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSImportEqualsDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -4164,8 +4571,10 @@ impl<'a> Format<'a> for AstNode<'a, TSModuleReference<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSExternalModuleReference<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -4173,12 +4582,14 @@ impl<'a> Format<'a> for AstNode<'a, TSExternalModuleReference<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSNonNullExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -4189,14 +4600,23 @@ impl<'a> Format<'a> for AstNode<'a, TSNonNullExpression<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, Decorator<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        self.write(f)
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if is_suppressed {
+            self.format_leading_comments(f)?;
+            FormatSuppressedNode(self.span()).fmt(f)?;
+            self.format_trailing_comments(f)
+        } else {
+            self.write(f)
+        }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSExportAssignment<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -4204,8 +4624,10 @@ impl<'a> Format<'a> for AstNode<'a, TSExportAssignment<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSNamespaceExportDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -4213,12 +4635,14 @@ impl<'a> Format<'a> for AstNode<'a, TSNamespaceExportDeclaration<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, TSInstantiationExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
         }
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         if needs_parentheses {
             ")".fmt(f)?;
         }
@@ -4229,8 +4653,10 @@ impl<'a> Format<'a> for AstNode<'a, TSInstantiationExpression<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, JSDocNullableType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -4238,8 +4664,10 @@ impl<'a> Format<'a> for AstNode<'a, JSDocNullableType<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, JSDocNonNullableType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }
@@ -4247,8 +4675,10 @@ impl<'a> Format<'a> for AstNode<'a, JSDocNonNullableType<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, JSDocUnknownType> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f)?;
-        let result = self.write(f);
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
         self.format_trailing_comments(f)?;
         result
     }

--- a/crates/oxc_formatter/src/utils/assignment_like.rs
+++ b/crates/oxc_formatter/src/utils/assignment_like.rs
@@ -284,11 +284,6 @@ impl<'a> AssignmentLike<'a, '_> {
             return AssignmentLikeLayout::OnlyLeft;
         }
 
-        // if let RightAssignmentLike::JsInitializerClause(initializer) = &right {
-        //     if f.context().comments().is_suppressed(initializer.syntax()) {
-        //         return Ok(AssignmentLikeLayout::SuppressedInitializer);
-        //     }
-        // }
         let right_expression = self.get_right_expression();
 
         if let Some(layout) = right_expression.and_then(|expr| self.chain_formatting_layout(expr)) {

--- a/crates/oxc_formatter/src/utils/jsx.rs
+++ b/crates/oxc_formatter/src/utils/jsx.rs
@@ -44,30 +44,6 @@ pub fn is_meaningful_jsx_text(text: &str) -> bool {
     !has_newline
 }
 
-/// Tests if a JSX element has a suppression comment or not.
-///
-/// Suppression for JSX elements differs from regular nodes if they are inside of a JSXFragment or JSXElement children
-/// because they can then not be preceded by a comment.
-///
-/// A JSX element inside of a JSX children list is suppressed if its first preceding sibling (that contains meaningful text)
-/// is a JSXExpressionContainer, not containing any expression, with a dangling suppression comment.
-///
-/// ```javascript
-/// <div>
-///   {/* oxc-formatter-ignore */}
-///   <div a={  some} />
-///   </div>
-/// ```
-pub fn is_jsx_suppressed<'a>(
-    element: &AstNode<'a, JSXElement<'a>>,
-    comments: &crate::formatter::comments::Comments<'a>,
-) -> bool {
-    // TODO: Implement suppression logic for OXC
-    // This is a placeholder - need to implement proper suppression detection
-    // based on OXC's comment system
-    false
-}
-
 /// Indicates that an element should always be wrapped in parentheses, should be wrapped
 /// only when it's line broken, or should not be wrapped at all.
 #[derive(Copy, Clone, Debug)]

--- a/crates/oxc_formatter/src/utils/mod.rs
+++ b/crates/oxc_formatter/src/utils/mod.rs
@@ -6,6 +6,7 @@ pub mod jsx;
 pub mod member_chain;
 pub mod object;
 pub mod string_utils;
+pub mod suppressed;
 
 use oxc_allocator::Address;
 use oxc_ast::{AstKind, ast::CallExpression};

--- a/crates/oxc_formatter/src/utils/suppressed.rs
+++ b/crates/oxc_formatter/src/utils/suppressed.rs
@@ -1,0 +1,31 @@
+use oxc_span::{GetSpan, Span};
+
+use crate::{
+    Buffer, Format, FormatResult, format_args,
+    formatter::{Formatter, prelude::*, trivia::FormatLeadingComments},
+    write,
+};
+
+pub struct FormatSuppressedNode(pub Span);
+
+impl FormatSuppressedNode {
+    pub fn new(span: Span) -> Self {
+        Self(span)
+    }
+}
+
+impl<'a> Format<'a> for FormatSuppressedNode {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        write!(f, [dynamic_text(self.0.span().source_text(f.source_text()))]);
+
+        // The suppressed node contains comments that should be marked as printed.
+        mark_comments_as_printed_before(self.0.end, f);
+
+        Ok(())
+    }
+}
+
+fn mark_comments_as_printed_before(end: u32, f: &mut Formatter<'_, '_>) {
+    let count = f.comments().unprinted_comments().iter().take_while(|c| c.span.end <= end).count();
+    f.context_mut().comments_mut().increase_printed_count_by(count);
+}

--- a/crates/oxc_formatter/src/write/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/write/arrow_function_expression.rs
@@ -309,10 +309,7 @@ impl<'a, 'b> ArrowFunctionLayout<'a, 'b> {
                         if matches!(
                             options.call_arg_layout,
                             None | Some(GroupedCallArgumentLayout::GroupedLastArgument)
-                        )
-                        // TODO: Unsupported yet
-                        //  && !comments.is_suppressed(next.span())
-                        {
+                        ) {
                             should_break = should_break || Self::should_break_chain(current);
 
                             should_break = should_break || Self::should_break_chain(next);

--- a/crates/oxc_formatter/src/write/block_statement.rs
+++ b/crates/oxc_formatter/src/write/block_statement.rs
@@ -63,13 +63,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, BlockStatement<'a>> {
 }
 
 pub fn is_empty_block(block: &[Statement<'_>], f: &Formatter<'_, '_>) -> bool {
-    block.is_empty()
-        || block.iter().all(|s| {
-            matches!(s, Statement::EmptyStatement(_))
-            // TODO: it seems removing `has_comments` doesn't break anything, needs to check further
-            // && !f.comments().has_comments(s.span())
-            // && !f.comments().is_suppressed(s.span())
-        })
+    block.is_empty() || block.iter().all(|s| matches!(s, Statement::EmptyStatement(_)))
 }
 
 /// Formatting of curly braces for an:

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 639/699 (91.42%)
+js compatibility: 645/699 (92.27%)
 
 # Failed
 
@@ -8,7 +8,6 @@ js compatibility: 639/699 (91.42%)
 | js/comments/empty-statements.js | 💥💥 | 90.91% |
 | js/comments/export.js | 💥💥 | 97.37% |
 | js/comments/function-declaration.js | 💥💥 | 92.80% |
-| js/comments/last-arg.js | 💥💥 | 80.65% |
 | js/comments/return-statement.js | 💥💥 | 98.85% |
 | js/comments/html-like/comment.js | 💥 | 0.00% |
 | js/comments-closure-typecast/binary-expr.js | 💥 | 0.00% |
@@ -30,7 +29,6 @@ js compatibility: 639/699 (91.42%)
 | js/conditional/new-ternary-examples.js | 💥✨ | 20.14% |
 | js/conditional/new-ternary-spec.js | 💥✨ | 24.35% |
 | js/conditional/postfix-ternary-regressions.js | 💥✨ | 20.77% |
-| js/destructuring-ignore/ignore.js | 💥💥💥 | 83.33% |
 | js/explicit-resource-management/valid-await-using-comments.js | 💥 | 91.89% |
 | js/for/for-in-with-initializer.js | 💥 | 37.50% |
 | js/for/parentheses.js | 💥 | 96.00% |
@@ -41,13 +39,10 @@ js compatibility: 639/699 (91.42%)
 | js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 22.22% |
 | js/logical_expressions/issue-7024.js | 💥 | 66.67% |
 | js/object-multiline/multiline.js | 💥✨ | 22.22% |
-| js/object-property-ignore/ignore.js | 💥💥💥 | 84.78% |
-| js/object-property-ignore/issue-5678.js | 💥💥💥 | 52.50% |
 | js/quote-props/classes.js | 💥💥✨✨ | 47.06% |
 | js/quote-props/objects.js | 💥💥✨✨ | 45.10% |
 | js/quote-props/with_numbers.js | 💥💥✨✨ | 46.43% |
 | js/quotes/objects.js | 💥💥 | 80.00% |
-| js/sequence-expression/ignore.js | 💥 | 42.86% |
 | js/ternaries/binary.js | 💥💥💥💥✨✨✨✨ | 18.42% |
 | js/ternaries/func-call.js | 💥💥💥💥✨✨✨✨ | 25.00% |
 | js/ternaries/indent-after-paren.js | 💥💥💥💥✨✨✨✨ | 24.59% |
@@ -60,7 +55,6 @@ js compatibility: 639/699 (91.42%)
 | js/test-declarations/angularjs_inject.js | 💥💥 | 91.53% |
 | jsx/expression-with-types/expression.js | 💥💥💥💥 | 0.00% |
 | jsx/fbt/test.js | 💥 | 84.06% |
-| jsx/ignore/jsx_ignore.js | 💥 | 82.57% |
 | jsx/jsx/quotes.js | 💥💥💥💥 | 79.41% |
 | jsx/single-attribute-per-line/single-attribute-per-line.js | 💥✨ | 43.37% |
 | jsx/text-wrap/test.js | 💥 | 99.56% |

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 330/573 (57.59%)
+ts compatibility: 331/573 (57.77%)
 
 # Failed
 
@@ -6,7 +6,6 @@ ts compatibility: 330/573 (57.59%)
 | :-------- | :--------------: | :---------: |
 | jsx/expression-with-types/expression.js | 💥💥💥💥 | 0.00% |
 | jsx/fbt/test.js | 💥 | 84.06% |
-| jsx/ignore/jsx_ignore.js | 💥 | 82.57% |
 | jsx/jsx/quotes.js | 💥💥💥💥 | 79.41% |
 | jsx/single-attribute-per-line/single-attribute-per-line.js | 💥✨ | 43.37% |
 | jsx/text-wrap/test.js | 💥 | 99.56% |
@@ -152,7 +151,7 @@ ts compatibility: 330/573 (57.59%)
 | typescript/infer-extends/basic.ts | 💥 | 66.67% |
 | typescript/interface/comments-generic.ts | 💥💥 | 30.00% |
 | typescript/interface/generic.ts | 💥💥 | 75.00% |
-| typescript/interface/ignore.ts | 💥💥 | 83.57% |
+| typescript/interface/ignore.ts | 💥💥 | 94.84% |
 | typescript/interface/long-extends.ts | 💥💥 | 72.22% |
 | typescript/interface/separator.ts | 💥✨ | 36.11% |
 | typescript/interface/long-type-parameters/long-type-parameters.ts | 💥💥 | 41.46% |
@@ -191,8 +190,8 @@ ts compatibility: 330/573 (57.59%)
 | typescript/optional-variance/with-jsx.tsx | 💥 | 59.02% |
 | typescript/override-modifiers/override-modifier.ts | 💥 | 25.00% |
 | typescript/predicate-types/predicate-types.ts | 💥 | 50.00% |
-| typescript/prettier-ignore/mapped-types.ts | 💥 | 58.49% |
-| typescript/prettier-ignore/prettier-ignore-nested-unions.ts | 💥 | 5.56% |
+| typescript/prettier-ignore/mapped-types.ts | 💥 | 54.72% |
+| typescript/prettier-ignore/prettier-ignore-nested-unions.ts | 💥 | 15.79% |
 | typescript/prettier-ignore/prettier-ignore-parenthesized-type.ts | 💥 | 0.00% |
 | typescript/quote-props/types.ts | 💥💥💥 | 55.56% |
 | typescript/readonly/array.ts | 💥 | 0.00% |
@@ -241,7 +240,7 @@ ts compatibility: 330/573 (57.59%)
 | typescript/union/union-parens.ts | 💥 | 54.00% |
 | typescript/union/with-type-params.ts | 💥 | 0.00% |
 | typescript/union/consistent-with-flow/comment.ts | 💥 | 0.00% |
-| typescript/union/consistent-with-flow/prettier-ignore.ts | 💥 | 10.00% |
+| typescript/union/consistent-with-flow/prettier-ignore.ts | 💥 | 19.05% |
 | typescript/union/consistent-with-flow/single-type.ts | 💥 | 3.39% |
 | typescript/union/consistent-with-flow/within-tuple.ts | 💥 | 16.51% |
 | typescript/union/single-type/single-type.ts | 💥 | 33.33% |


### PR DESCRIPTION
Support ignores comments like `// prettier-ignore` and `/* prettier-ignore */ to disable formatting, but do not add support for something like `oxc-formatter-ignore` yet.

Unfortunately, this less important feature slightly hurts performance, as we need to check whether there is an ignored comment at the start of each node. I will come back to improve performance when I finish the last typecast comment feature.