### PR TITLE
fix(semantic): flag `super` in function inside `ObjectExpression`

### DIFF
--- a/tasks/coverage/misc/fail/oxc-13323.js
+++ b/tasks/coverage/misc/fail/oxc-13323.js
@@ -1,0 +1,17 @@
+o = {
+  foo: function() {
+    super.foo;
+  },
+
+  bar() {
+    return function() {
+      super.bar;
+    };
+  },
+
+  [ function() { super.qux; } ]() {},
+
+  get [ function() { super.bing; } ]() {},
+
+  set [ function() { super.bong; } ](v) {},
+};

--- a/tasks/coverage/misc/pass/oxc-13323.js
+++ b/tasks/coverage/misc/pass/oxc-13323.js
@@ -1,0 +1,16 @@
+o = {
+  foo() {
+    super.foo();
+    return () => super.foo();
+  },
+
+  get bar() {
+    const f = () => super.bar;
+    return super.bar;
+  },
+
+  set bar(v) {
+    const f = () => super.bar;
+    super.bar = v;
+  },
+};

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 47/47 (100.00%)
-Positive Passed: 47/47 (100.00%)
+AST Parsed     : 48/48 (100.00%)
+Positive Passed: 48/48 (100.00%)

--- a/tasks/coverage/snapshots/formatter_misc.snap
+++ b/tasks/coverage/snapshots/formatter_misc.snap
@@ -1,6 +1,6 @@
 formatter_misc Summary:
-AST Parsed     : 47/47 (100.00%)
-Positive Passed: 44/47 (93.62%)
+AST Parsed     : 48/48 (100.00%)
+Positive Passed: 45/48 (93.75%)
 Expect to Parse: tasks/coverage/misc/pass/oxc-12612.ts
 
 Expect to Parse: tasks/coverage/misc/pass/oxc-2592.ts

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -3,7 +3,7 @@ commit: 41d96516
 parser_babel Summary:
 AST Parsed     : 2407/2423 (99.34%)
 Positive Passed: 2385/2423 (98.43%)
-Negative Passed: 1645/1755 (93.73%)
+Negative Passed: 1646/1755 (93.79%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/invalid-startindex-and-startline-specified-without-startcolumn/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/startline-and-startcolumn-specified/input.js
@@ -19,8 +19,6 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/co
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/sourcetype-commonjs/invalid-allowReturnOutsideFunction-false/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/sourcetype-commonjs/invalid-allowReturnOutsideFunction-true/input.js
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/class-methods/direct-super-in-object-method/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/destructuring/error-operator-for-default/input.js
 
@@ -2961,6 +2959,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/class/invalid-escape-static/input.js:1:11]
  1 │ class X { st\u0061tic y() {} }
    ·           ───────────
+   ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+   ╭─[babel/packages/babel-parser/test/fixtures/es2015/class-methods/direct-super-in-object-method/input.js:4:14]
+ 3 │     get: function(){
+ 4 │       return super.foo;
+   ·              ─────
+ 5 │     }
    ╰────
 
   × Super calls are not permitted outside constructors or in nested functions inside constructors.

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
-AST Parsed     : 47/47 (100.00%)
-Positive Passed: 47/47 (100.00%)
-Negative Passed: 77/77 (100.00%)
+AST Parsed     : 48/48 (100.00%)
+Positive Passed: 48/48 (100.00%)
+Negative Passed: 78/78 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -444,6 +444,46 @@ Negative Passed: 77/77 (100.00%)
    ·         ─────
  6 │       },
    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+   ╭─[misc/fail/oxc-13323.js:3:5]
+ 2 │   foo: function() {
+ 3 │     super.foo;
+   ·     ─────
+ 4 │   },
+   ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+   ╭─[misc/fail/oxc-13323.js:8:7]
+ 7 │     return function() {
+ 8 │       super.bar;
+   ·       ─────
+ 9 │     };
+   ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13323.js:12:18]
+ 11 │ 
+ 12 │   [ function() { super.qux; } ]() {},
+    ·                  ─────
+ 13 │ 
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13323.js:14:22]
+ 13 │ 
+ 14 │   get [ function() { super.bing; } ]() {},
+    ·                      ─────
+ 15 │ 
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13323.js:16:22]
+ 15 │ 
+ 16 │   set [ function() { super.bong; } ](v) {},
+    ·                      ─────
+ 17 │ };
+    ╰────
 
   × Unexpected token
    ╭─[misc/fail/oxc-169.js:2:1]

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -13202,6 +13202,30 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
   help: replace with `super()` or `super.prop` or `super[prop]`
 
   × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[typescript/tests/cases/compiler/superInObjectLiterals_ES5.ts:17:9]
+ 16 │     p1: function () {
+ 17 │         super.method();
+    ·         ─────
+ 18 │     },
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[typescript/tests/cases/compiler/superInObjectLiterals_ES5.ts:20:9]
+ 19 │     p2: function f() {
+ 20 │         super.method();
+    ·         ─────
+ 21 │     },
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[typescript/tests/cases/compiler/superInObjectLiterals_ES5.ts:23:9]
+ 22 │     p3: () => {
+ 23 │         super.method();
+    ·         ─────
+ 24 │     }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
     ╭─[typescript/tests/cases/compiler/superInObjectLiterals_ES5.ts:39:17]
  38 │             method() {
  39 │                 super.method();
@@ -13239,6 +13263,30 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  52 │                 super.method();
     ·                 ─────
  53 │             },
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[typescript/tests/cases/compiler/superInObjectLiterals_ES6.ts:17:9]
+ 16 │     p1: function () {
+ 17 │         super.method();
+    ·         ─────
+ 18 │     },
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[typescript/tests/cases/compiler/superInObjectLiterals_ES6.ts:20:9]
+ 19 │     p2: function f() {
+ 20 │         super.method();
+    ·         ─────
+ 21 │     },
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[typescript/tests/cases/compiler/superInObjectLiterals_ES6.ts:23:9]
+ 22 │     p3: () => {
+ 23 │         super.method();
+    ·         ─────
+ 24 │     }
     ╰────
 
   × 'super' can only be referenced in members of derived classes or object literal expressions.
@@ -13307,6 +13355,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  9 │     }
    ╰────
   help: replace with `super()` or `super.prop` or `super[prop]`
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[typescript/tests/cases/compiler/super_inside-object-literal-getters-and-setters.ts:11:20]
+ 10 │         test: function () {
+ 11 │             return super._foo;
+    ·                    ─────
+ 12 │         }
+    ╰────
 
   × 'super' can only be referenced in members of derived classes or object literal expressions.
     ╭─[typescript/tests/cases/compiler/super_inside-object-literal-getters-and-setters.ts:21:24]

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 47/47 (100.00%)
-Positive Passed: 31/47 (65.96%)
+AST Parsed     : 48/48 (100.00%)
+Positive Passed: 32/48 (66.67%)
 semantic Error: tasks/coverage/misc/pass/oxc-11593.ts
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 47/47 (100.00%)
-Positive Passed: 47/47 (100.00%)
+AST Parsed     : 48/48 (100.00%)
+Positive Passed: 48/48 (100.00%)


### PR DESCRIPTION
Fix #13323.

Make semantic raise errors for the following illegal `super` uses:

```js
o = {
  foo: function() {
    super.foo;
  },

  bar() {
    return function() {
      super.bar;
    };
  },

  [ function() { super.qux; } ]() {},

  get [ function() { super.bing; } ]() {},

  set [ function() { super.bong; } ](v) {},
};
```