### PR TITLE
chore(justfile): add watch-test command for running cargo tests

### DIFF
--- a/justfile
+++ b/justfile
@@ -51,6 +51,9 @@ install-hook:
 watch *args='':
   watchexec --no-vcs-ignore {{args}}
 
+watch-test *args='':
+  watchexec --no-vcs-ignore -- cargo test {{args}}
+
 watch-check:
   just watch "'cargo check; cargo clippy'"
 


### PR DESCRIPTION
## 🚀 Description

This pull request adds a new convenience command to the `justfile` for running tests automatically when files change.

New command for automated test running:

* Added a `watch-test` recipe to the `justfile` that uses `watchexec` to run `cargo test` whenever files change, making it easier to continuously run tests during development.

## 💡 Why this change ?

While running the `just watch "test -p oxc_linter -- no-console"` command as stated in the [Linter Contribution Guide](https://oxc.rs/docs/contribute/linter.html), I stepped into the following error : 

```
watchexec --no-vcs-ignore test -p oxc_linter -- no-console
[Running: test -p oxc_linter -- no-console]
zsh:test:1: too many arguments
[Command exited with 2
```

… because zsh interprets test as its builtin test command instead of cargo test.

To avoid this conflict, a dedicated watch-test recipe was added that explicitly prefixes the command with cargo. This ensures that just watch-test always executes cargo test ... as intended.

---

> [!IMPORTANT] 
> The [Linter Contribution Guide](https://oxc.rs/docs/contribute/linter.html) will have to be updated accordingly.