### PR TITLE
refactor(semantic): store comments as a slice instead of `&Vec`

### DIFF
--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -69,7 +69,7 @@ pub struct Semantic<'a> {
     classes: ClassTable<'a>,
 
     /// Parsed comments.
-    comments: &'a oxc_allocator::Vec<'a, Comment>,
+    comments: &'a [Comment],
     irregular_whitespaces: Box<[Span]>,
 
     /// Parsed JSDoc comments.


### PR DESCRIPTION
`Semantic` storing comments as a `&Vec<Comment>` involves unnecessary indirection (pointer to a pointer). Store as `&[Comment]` slice instead.