### PR TITLE
refactor(linter): `ContextSubHost` hold owned `Semantic`

### DIFF
--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -25,9 +25,9 @@ use super::{LintContext, plugin_name_to_prefix};
 
 /// Stores shared information about a script block being linted.
 pub struct ContextSubHost<'a> {
-    /// Shared semantic information about the file being linted, which includes scopes, symbols
-    /// and AST nodes. See [`Semantic`].
-    pub(super) semantic: Rc<Semantic<'a>>,
+    /// Semantic information about the file being linted, which includes scopes, symbols and AST nodes.
+    /// See [`Semantic`].
+    pub(super) semantic: Semantic<'a>,
     /// Cross module information.
     pub(super) module_record: Arc<ModuleRecord>,
     /// Information about specific rules that should be disabled or enabled, via comment directives like
@@ -41,7 +41,7 @@ pub struct ContextSubHost<'a> {
 
 impl<'a> ContextSubHost<'a> {
     pub fn new(
-        semantic: Rc<Semantic<'a>>,
+        semantic: Semantic<'a>,
         module_record: Arc<ModuleRecord>,
         source_text_offset: u32,
     ) -> Self {
@@ -56,7 +56,7 @@ impl<'a> ContextSubHost<'a> {
     /// # Panics
     /// If `semantic.cfg()` is `None`.
     pub fn new_with_framework_options(
-        semantic: Rc<Semantic<'a>>,
+        semantic: Semantic<'a>,
         module_record: Arc<ModuleRecord>,
         source_text_offset: u32,
         frameworks_options: FrameworkOptions,
@@ -82,7 +82,7 @@ impl<'a> ContextSubHost<'a> {
 
     /// Shared reference to the [`Semantic`] analysis
     #[inline]
-    pub fn semantic(&self) -> &Rc<Semantic<'a>> {
+    pub fn semantic(&self) -> &Semantic<'a> {
         &self.semantic
     }
 
@@ -180,7 +180,7 @@ impl<'a> ContextHost<'a> {
 
     /// Shared reference to the [`Semantic`] analysis of current script block.
     #[inline]
-    pub fn semantic(&self) -> &Rc<Semantic<'a>> {
+    pub fn semantic(&self) -> &Semantic<'a> {
         &self.current_sub_host().semantic
     }
 

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -105,7 +105,7 @@ impl<'a> LintContext<'a> {
     ///
     /// Refer to [`Semantic`]'s documentation for more information.
     #[inline]
-    pub fn semantic(&self) -> &Rc<Semantic<'a>> {
+    pub fn semantic(&self) -> &Semantic<'a> {
         self.parent.semantic()
     }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -301,12 +301,7 @@ impl NoUnusedVars {
                 });
             }
             AstKind::FormalParameter(param) => {
-                if self.is_allowed_argument(
-                    ctx.semantic().as_ref(),
-                    ctx.module_record(),
-                    symbol,
-                    param,
-                ) {
+                if self.is_allowed_argument(ctx.semantic(), ctx.module_record(), symbol, param) {
                     return;
                 }
                 ctx.diagnostic(diagnostic::param(symbol, &self.args_ignore_pattern));

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -4,7 +4,6 @@ use std::{
     fs,
     mem::take,
     path::{Path, PathBuf},
-    rc::Rc,
     sync::{Arc, mpsc},
 };
 
@@ -604,7 +603,7 @@ impl Runtime {
                         .zip(dep.section_contents.drain(..))
                         .filter_map(|(record_result, section)| match record_result {
                             Ok(module_record) => Some(ContextSubHost::new_with_framework_options(
-                                Rc::new(section.semantic.unwrap()),
+                                section.semantic.unwrap(),
                                 Arc::clone(&module_record),
                                 section.source.start,
                                 section.source.framework_options,
@@ -701,7 +700,7 @@ impl Runtime {
                             .filter_map(|(record_result, section)| match record_result {
                                 Ok(module_record) => {
                                     Some(ContextSubHost::new_with_framework_options(
-                                        Rc::new(section.semantic.unwrap()),
+                                        section.semantic.unwrap(),
                                         Arc::clone(&module_record),
                                         section.source.start,
                                         section.source.framework_options,
@@ -779,7 +778,7 @@ impl Runtime {
                             .zip(section_contents.drain(..))
                             .filter_map(|(record_result, section)| match record_result {
                                 Ok(module_record) => Some(ContextSubHost::new_with_framework_options(
-                                    Rc::new(section.semantic.unwrap()),
+                                    section.semantic.unwrap(),
                                     Arc::clone(&module_record),
                                     section.source.start,
                                     section.source.framework_options

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -316,20 +316,15 @@ mod test {
     #[test]
     fn test_is_jest_file() {
         let allocator = Allocator::default();
-        let source_type = SourceType::default();
-        let parser_ret = Parser::new(&allocator, "", source_type).parse();
-        let semantic_ret =
-            SemanticBuilder::new().with_cfg(true).build(&parser_ret.program).semantic;
-        let semantic_ret = Rc::new(semantic_ret);
 
         let build_ctx = |path: &'static str| {
+            let source_type = SourceType::default();
+            let parser_ret = Parser::new(&allocator, "", source_type).parse();
+            let program = allocator.alloc(parser_ret.program);
+            let semantic = SemanticBuilder::new().with_cfg(true).build(program).semantic;
             Rc::new(ContextHost::new(
                 path,
-                vec![ContextSubHost::new(
-                    Rc::clone(&semantic_ret),
-                    Arc::new(ModuleRecord::default()),
-                    0,
-                )],
+                vec![ContextSubHost::new(semantic, Arc::new(ModuleRecord::default()), 0)],
                 LintOptions::default(),
                 Arc::default(),
             ))

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -1,7 +1,6 @@
 use std::{
     cell::Cell,
     path::{Path, PathBuf},
-    rc::Rc,
     sync::Arc,
 };
 
@@ -295,7 +294,7 @@ impl Oxc {
         if run_options.lint.unwrap_or_default() && self.diagnostics.is_empty() {
             let external_plugin_store = ExternalPluginStore::default();
             let semantic_ret = SemanticBuilder::new().with_cfg(true).build(program);
-            let semantic = Rc::new(semantic_ret.semantic);
+            let semantic = semantic_ret.semantic;
             let lint_config = if linter_options.config.is_some() {
                 let oxlintrc =
                     Oxlintrc::from_string(&linter_options.config.as_ref().unwrap().to_string())
@@ -319,7 +318,7 @@ impl Oxc {
             )
             .run(
                 path,
-                vec![ContextSubHost::new(Rc::clone(&semantic), Arc::clone(module_record), 0)],
+                vec![ContextSubHost::new(semantic, Arc::clone(module_record), 0)],
                 allocator,
             );
             self.diagnostics.extend(linter_ret.into_iter().map(|e| e.error));

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -1,4 +1,4 @@
-use std::{path::Path, rc::Rc, sync::Arc};
+use std::{path::Path, sync::Arc};
 
 use rustc_hash::FxHashMap;
 
@@ -39,7 +39,6 @@ fn bench_linter(criterion: &mut Criterion) {
                 let semantic = semantic_ret.semantic;
                 let module_record =
                     Arc::new(ModuleRecord::new(path, &parser_ret.module_record, &semantic));
-                let semantic = Rc::new(semantic);
                 let external_plugin_store = ExternalPluginStore::default();
                 let lint_config = ConfigStoreBuilder::all().build(&external_plugin_store).unwrap();
                 let linter = Linter::new(
@@ -52,11 +51,7 @@ fn bench_linter(criterion: &mut Criterion) {
                 runner.run(|| {
                     linter.run(
                         path,
-                        vec![ContextSubHost::new(
-                            Rc::clone(&semantic),
-                            Arc::clone(&module_record),
-                            0,
-                        )],
+                        vec![ContextSubHost::new(semantic, Arc::clone(&module_record), 0)],
                         &allocator,
                     )
                 });


### PR DESCRIPTION
`ContextSubHost` does not share `Semantic` with any other structure, so `Rc<Semantic>` is unnecessary overhead. Make it contain owned `Semantic` instead.