### PR TITLE
feat(ast_visit): add `Utf8ToUtf16Converter::convert_program` method

### DIFF
--- a/crates/oxc_ast_visit/src/utf8_to_utf16/converter.rs
+++ b/crates/oxc_ast_visit/src/utf8_to_utf16/converter.rs
@@ -1,7 +1,10 @@
 use std::cmp::min;
 
+use oxc_ast::ast::Program;
 use oxc_span::Span;
 use oxc_syntax::module_record::VisitMutModuleRecord;
+
+use crate::VisitMut;
 
 use super::Translation;
 
@@ -278,6 +281,12 @@ impl<'t> Utf8ToUtf16Converter<'t> {
         // We started search at a non-zero index, so `next_index` cannot be 0.
         // `next_index <= translations.len()`.
         (next_index, range_end_utf8)
+    }
+
+    /// Convert all spans in AST to UTF-16.
+    #[inline] // Because it just delegates
+    pub fn convert_program(&mut self, program: &mut Program<'_>) {
+        self.visit_program(program);
     }
 
     /// Convert [`Span`] from UTF-8 offsets to UTF-16 offsets.

--- a/crates/oxc_ast_visit/src/utf8_to_utf16/mod.rs
+++ b/crates/oxc_ast_visit/src/utf8_to_utf16/mod.rs
@@ -4,8 +4,6 @@ use oxc_ast::ast::{Comment, Program};
 use oxc_span::Span;
 use oxc_syntax::module_record::{ModuleRecord, VisitMutModuleRecord};
 
-use crate::VisitMut;
-
 mod converter;
 mod translation;
 mod visit;
@@ -61,7 +59,7 @@ impl Utf8ToUtf16 {
     /// Convert all spans in AST to UTF-16.
     pub fn convert_program(&self, program: &mut Program<'_>) {
         if let Some(mut converter) = self.converter() {
-            converter.visit_program(program);
+            converter.convert_program(program);
         }
     }
 
@@ -86,7 +84,7 @@ impl Utf8ToUtf16 {
 
         // SAFETY: We just checked `translations` contains at least 2 entries
         let mut converter = unsafe { Utf8ToUtf16Converter::new(&self.translations, true) };
-        converter.visit_program(program);
+        converter.convert_program(program);
     }
 
     /// Convert all spans in comments to UTF-16.


### PR DESCRIPTION
`Utf8ToUtf16` already has a `convert_program` method. Add the same method to `Utf8ToUtf16Converter` (the struct that does the actual conversions).