### PR TITLE
feat(semantic): derive `Default` for `Semantic`

### DIFF
--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -54,6 +54,7 @@ use class::ClassTable;
 /// [`Abstract Syntax Tree (AST)`]: crate::AstNodes
 /// [`scoping`]: crate::Scoping
 /// [`control flow graph (CFG)`]: crate::ControlFlowGraph
+#[derive(Default)]
 pub struct Semantic<'a> {
     /// Source code of the JavaScript/TypeScript program being analyzed.
     source_text: &'a str,


### PR DESCRIPTION
After #13336, we can derive `Default` on `Semantic`.

This is not so useful in most cases, but does allow using `std::mem::take` on a `&mut Semantic`, which is used in next PR in this stack.
