### PR TITLE
feat(linter): convert spans to UTF-16 in JS plugins

### DIFF
--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -17,7 +17,7 @@ description.workspace = true
 default = []
 ruledocs = ["oxc_macros/ruledocs"] # Enables the `ruledocs` feature for conditional compilation
 language_server = ["oxc_data_structures/rope"] # For the Runtime to support needed information for the language server
-oxlint2 = ["dep:oxc_ast_macros", "tokio/rt-multi-thread"]
+oxlint2 = ["dep:oxc_ast_macros", "oxc_ast_visit/serialize", "tokio/rt-multi-thread"]
 disable_oxlint2 = []
 force_test_reporter = []
 

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -178,10 +178,21 @@ impl<'a> ContextHost<'a> {
         &self.sub_hosts[self.current_sub_host_index.get()]
     }
 
+    /// Get mutable reference to the current [`ContextSubHost`]
+    fn current_sub_host_mut(&mut self) -> &mut ContextSubHost<'a> {
+        &mut self.sub_hosts[self.current_sub_host_index.get()]
+    }
+
     /// Shared reference to the [`Semantic`] analysis of current script block.
     #[inline]
     pub fn semantic(&self) -> &Semantic<'a> {
         &self.current_sub_host().semantic
+    }
+
+    /// Mutable reference to the [`Semantic`] analysis of current script block.
+    #[inline]
+    pub fn semantic_mut(&mut self) -> &mut Semantic<'a> {
+        &mut self.current_sub_host_mut().semantic
     }
 
     /// Shared reference to the [`ModuleRecord`] of the current script block.

--- a/napi/oxlint2/test/__snapshots__/e2e.test.ts.snap
+++ b/napi/oxlint2/test/__snapshots__/e2e.test.ts.snap
@@ -1,5 +1,60 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`oxlint2 CLI > should have UTF-16 spans in AST 1`] = `
+"
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
+   ,-[index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+ 2 | // £
+   \`----
+  help: Remove the debugger statement
+
+  x utf16-plugin(no-debugger): Debugger at 0-9
+   ,-[index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+ 2 | // £
+   \`----
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
+   ,-[index.js:3:1]
+ 2 | // £
+ 3 | debugger;
+   : ^^^^^^^^^
+ 4 | // 🤨
+   \`----
+  help: Remove the debugger statement
+
+  x utf16-plugin(no-debugger): Debugger at 15-24
+   ,-[index.js:3:1]
+ 2 | // £
+ 3 | debugger;
+   : ^^^^^^^^^
+ 4 | // 🤨
+   \`----
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
+   ,-[index.js:6:3]
+ 5 | {
+ 6 |   debugger;
+   :   ^^^^^^^^^
+ 7 | }
+   \`----
+  help: Remove the debugger statement
+
+  x utf16-plugin(no-debugger): Debugger at 35-44
+   ,-[index.js:6:3]
+ 5 | {
+ 6 |   debugger;
+   :   ^^^^^^^^^
+ 7 | }
+   \`----
+
+Found 3 warnings and 3 errors.
+Finished in Xms on 1 file using X threads."
+`;
+
 exports[`oxlint2 CLI > should lint a directory with errors 1`] = `
 "
   x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed

--- a/napi/oxlint2/test/e2e.test.ts
+++ b/napi/oxlint2/test/e2e.test.ts
@@ -119,4 +119,13 @@ describe('oxlint2 CLI', () => {
     expect(exitCode).toBe(1);
     expect(normalizeOutput(stdout)).toMatchSnapshot();
   });
+
+  it('should have UTF-16 spans in AST', async () => {
+    const { stdout, exitCode } = await runOxlint(
+      'test/fixtures/utf16_offsets',
+    );
+
+    expect(exitCode).toBe(1);
+    expect(normalizeOutput(stdout)).toMatchSnapshot();
+  });
 });

--- a/napi/oxlint2/test/fixtures/utf16_offsets/.oxlintrc.json
+++ b/napi/oxlint2/test/fixtures/utf16_offsets/.oxlintrc.json
@@ -1,0 +1,7 @@
+{
+    "plugins": ["./test_plugin"],
+    "rules": {
+        "utf16-plugin/no-debugger": "error"
+    },
+    "ignorePatterns": ["test_plugin/**"]
+}

--- a/napi/oxlint2/test/fixtures/utf16_offsets/index.js
+++ b/napi/oxlint2/test/fixtures/utf16_offsets/index.js
@@ -1,0 +1,7 @@
+debugger;
+// £
+debugger;
+// 🤨
+{
+  debugger;
+}

--- a/napi/oxlint2/test/fixtures/utf16_offsets/test_plugin/index.js
+++ b/napi/oxlint2/test/fixtures/utf16_offsets/test_plugin/index.js
@@ -1,0 +1,19 @@
+export default {
+  meta: {
+    name: "utf16-plugin",
+  },
+  rules: {
+    "no-debugger": {
+      create(context) {
+        return {
+          DebuggerStatement(debuggerStatement) {
+            context.report({
+              message: `Debugger at ${debuggerStatement.start}-${debuggerStatement.end}`,
+              node: debuggerStatement,
+            });
+          },
+        };
+      },
+    },
+  },
+};


### PR DESCRIPTION
The AST on JS side in linter JS plugins previously had `start` and `end` as UTF-8 offsets.

Convert the AST to UTF-16 offsets prior to transferring it to JS, and convert offsets in any errors/warnings returned from JS side back to UTF-8 before creating `OxcDiagnostic`s from them.

The tricky part is that it's not possible to mutate the AST (convert offsets to UTF-16) while `Semantic` is alive, because you can't obtain a `&mut Program` due to aliasing rules. Work around this with some pointer juggling and by dropping `Semantic` before creating a `&mut Program`.

This is a bit sketchy, but is not (I believe) UB. Hopefully we can remove the need for this workaround later on by performing offset conversion during serialization / raw transfer deserialization, and so avoid the need to mutate the AST.
