### PR TITLE
refactor(ecmascript)!: remove `PropertyReadSideEffects::OnlyMemberPropertyAccess`

### DIFF
--- a/crates/oxc_ecmascript/src/side_effects/context.rs
+++ b/crates/oxc_ecmascript/src/side_effects/context.rs
@@ -6,9 +6,6 @@ use crate::GlobalContext;
 pub enum PropertyReadSideEffects {
     /// Treat all property read accesses as side effect free.
     None,
-    /// Treat non-member property accesses as side effect free.
-    /// Member property accesses are still considered to have side effects.
-    OnlyMemberPropertyAccess,
     /// Treat all property read accesses as possible side effects.
     #[default]
     All,

--- a/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
+++ b/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
@@ -992,24 +992,17 @@ fn test_is_pure_call_support() {
 fn test_property_read_side_effects_support() {
     let all_ctx =
         Ctx { property_read_side_effects: PropertyReadSideEffects::All, ..Default::default() };
-    let only_member_ctx = Ctx {
-        property_read_side_effects: PropertyReadSideEffects::OnlyMemberPropertyAccess,
-        ..Default::default()
-    };
     let none_ctx =
         Ctx { property_read_side_effects: PropertyReadSideEffects::None, ..Default::default() };
 
     test_with_ctx("foo.bar", &all_ctx, true);
-    test_with_ctx("foo.bar", &only_member_ctx, true);
     test_with_ctx("foo.bar", &none_ctx, false);
     test_with_ctx("foo[0]", &none_ctx, false);
     test_with_ctx("foo[0n]", &none_ctx, false);
     test_with_ctx("foo[bar()]", &none_ctx, true);
     test_with_ctx("foo.#bar", &all_ctx, true);
-    test_with_ctx("foo.#bar", &only_member_ctx, true);
     test_with_ctx("foo.#bar", &none_ctx, false);
     test_with_ctx("({ bar } = foo)", &all_ctx, true);
-    // test_with_ctx("({ bar } = foo)", &only_member_ctx, false);
     // test_with_ctx("({ bar } = foo)", &none_ctx, false);
 }
 


### PR DESCRIPTION
In #10129, I introduced `PropertyReadSideEffects`. In that, I added `PropertyReadSideEffects::OnlyMemberPropertyAccess`. This was because I thought this was the default behavior of Rollup at that time.

But after re-reading the Rollup's code and checking the behavior in REPL while reviewing https://github.com/rolldown/rolldown/pull/5945, I noticed that I was wrong. Since this was added solely for Rolldown to add support for `treeshake.propertyReadSideEffects` and it's not useful for that usecase, I removed the value.

cc @IWANABETHATGUY 
