### PR TITLE
fix(minifier): keep variables that are modified by `typeof foo === 'object' && foo !== null` compression (2)

### DIFF
--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -431,7 +431,7 @@ impl<'a> PeepholeOptimizations {
             return None;
         }
 
-        let mut new_left_expr = typeof_binary_expr.clone_in(ctx.ast.allocator);
+        let mut new_left_expr = typeof_binary_expr.clone_in_with_semantic_ids(ctx.ast.allocator);
         if let Expression::BinaryExpression(new_left_expr_binary) = &mut new_left_expr {
             new_left_expr_binary.operator =
                 if inversed { BinaryOperator::Inequality } else { BinaryOperator::Equality };

--- a/crates/oxc_minifier/tests/peephole/inline_single_use_variable.rs
+++ b/crates/oxc_minifier/tests/peephole/inline_single_use_variable.rs
@@ -167,15 +167,14 @@ fn integration() {
         }
     ",
     );
-    // FIXME
-    // test(
-    //     "
-    //     var bar = foo.bar;
-    //     if (typeof bar !== 'object' || bar === null) console.log('foo')
-    //     ",
-    //     "
-    //     var bar = foo.bar;
-    //     (typeof bar != 'object' || !bar) && console.log('foo')
-    //     ",
-    // );
+    test(
+        "
+        var bar = foo.bar;
+        if (typeof bar !== 'object' || bar === null) console.log('foo')
+        ",
+        "
+        var bar = foo.bar;
+        (typeof bar != 'object' || !bar) && console.log('foo')
+        ",
+    );
 }


### PR DESCRIPTION
`typeof foo === 'object' && foo !== null` compression was not keeping the reference information and that caused used variables to be removed, similar to #13290.
```js
var bar = foo.bar;
if (typeof bar !== 'object' || bar === null) console.log('foo')
```
was compressed into
```js
if (typeof foo.bar !== 'object' || bar === null) console.log('foo')
```

refs #13290