### PR TITLE
feat(minifier): use `is_literal_value` in `substitute_single_use_symbol_in_expression`

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -4,7 +4,7 @@ use oxc_allocator::{Box, TakeIn, Vec};
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ecmascript::{
-    constant_evaluation::{DetermineValueType, ValueType},
+    constant_evaluation::{DetermineValueType, IsLiteralValue, ValueType},
     side_effects::MayHaveSideEffects,
 };
 use oxc_semantic::ScopeId;
@@ -1618,8 +1618,7 @@ impl<'a> PeepholeOptimizations {
         }
 
         // We can always reorder past primitive values
-        // TODO(sapphi-red): we may use is_literal_value after I checked if it handles edge cases properly
-        if replacement.is_literal() || target_expr.is_literal() {
+        if replacement.is_literal_value(false, ctx) || target_expr.is_literal_value(false, ctx) {
             return None;
         }
 

--- a/crates/oxc_minifier/tests/peephole/inline_single_use_variable.rs
+++ b/crates/oxc_minifier/tests/peephole/inline_single_use_variable.rs
@@ -132,6 +132,10 @@ fn test_inline_single_use_variable() {
         "function wrapper(arg0, arg1) { return (arg0(), 1);}",
     );
     test_same("function wrapper(arg0, arg1) { let x = arg0; return (foo(), x(), 1);}");
+    test(
+        "function wrapper() { let x = [0, 1, 2]; return foo.bar(x);}",
+        "function wrapper() { return foo.bar([0, 1, 2]);}",
+    );
 }
 
 #[test]

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -13,15 +13,15 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 555.77 kB  | 270.78 kB  | 270.13 kB  | 88.19 kB   | 90.80 kB   |          2 | d3.js      
 
-1.01 MB    | 439.60 kB  | 458.89 kB  | 122.16 kB  | 126.71 kB  |          2 | bundle.min.js 
+1.01 MB    | 439.58 kB  | 458.89 kB  | 122.15 kB  | 126.71 kB  |          2 | bundle.min.js 
 
-1.25 MB    | 645.68 kB  | 646.76 kB  | 159.55 kB  | 163.73 kB  |          2 | three.js   
+1.25 MB    | 645.65 kB  | 646.76 kB  | 159.55 kB  | 163.73 kB  |          2 | three.js   
 
-2.14 MB    | 713.72 kB  | 724.14 kB  | 161.06 kB  | 181.07 kB  |          2 | victory.js 
+2.14 MB    | 713.64 kB  | 724.14 kB  | 161.04 kB  | 181.07 kB  |          2 | victory.js 
 
-3.20 MB    | 1.00 MB    | 1.01 MB    | 323.15 kB  | 331.56 kB  |          3 | echarts.js 
+3.20 MB    | 1.00 MB    | 1.01 MB    | 323.13 kB  | 331.56 kB  |          3 | echarts.js 
 
-6.69 MB    | 2.22 MB    | 2.31 MB    | 459.60 kB  | 488.28 kB  |          4 | antd.js    
+6.69 MB    | 2.22 MB    | 2.31 MB    | 459.59 kB  | 488.28 kB  |          4 | antd.js    
 
-10.95 MB   | 3.34 MB    | 3.49 MB    | 855.44 kB  | 915.50 kB  |          4 | typescript.js 
+10.95 MB   | 3.34 MB    | 3.49 MB    | 855.39 kB  | 915.50 kB  |          4 | typescript.js 
 


### PR DESCRIPTION
Use `is_literal_value` instead of `is_literal` to allow more cases to be inlined.