### PR TITLE
fix(transformer/styled-components): fix block comment containing expression in CSS minification

### DIFF
--- a/crates/oxc_transformer/src/plugins/styled_components.rs
+++ b/crates/oxc_transformer/src/plugins/styled_components.rs
@@ -928,6 +928,7 @@ fn minify_template_literal<'a>(lit: &mut TemplateLiteral<'a>, ast: AstBuilder<'a
                     pos += 2;
                     if pos == bytes.len() {
                         // Comment ends at end of quasi
+                        comment_type = None;
                         continue;
                     }
 

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 41d96516
 
-Passed: 184/307
+Passed: 184/308
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -1612,7 +1612,12 @@ after transform: ["Function", "babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 
-# plugin-styled-components (22/37)
+# plugin-styled-components (22/38)
+* minify-comments/input.js
+Unresolved references mismatch:
+after transform: ["x", "y", "z"]
+rebuilt        : ["x", "z"]
+
 * styled-components/add-identifier-with-top-level-import-paths/input.js
 x Output mismatch
 

--- a/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/input.js
+++ b/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/input.js
@@ -1,0 +1,3 @@
+import styled from 'styled-components';
+
+const Button = styled.div`${x}/* ${y} */${z}`;

--- a/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/options.json
+++ b/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/options.json
@@ -1,0 +1,18 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "modules": false,
+        "targets": "defaults"
+      }
+    ]
+  ],
+  "plugins": [
+    ["styled-components", {
+      "ssr": false,
+      "displayName": false,
+      "transpileTemplateLiterals": false
+    }]
+  ]
+}

--- a/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/output.js
+++ b/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/output.js
@@ -1,0 +1,2 @@
+import styled from 'styled-components';
+const Button = styled.div`${x}${z}`;


### PR DESCRIPTION
Fix handling block comments which contain an expression. Previously if that block comment ended exactly before another expression, the comment wouldn't be considered closed, and all remaining parts of the template literal would be removed.

Input:

```js
styled.div`${x}/* ${y} */${z}`
```

Previous output post-minification:

```js
styled.div`${x}`
```

After this PR:

```js
styled.div`${x}${z}`
```

This bug was introduced way back in #12224 (my fault!), but had gone unnoticed.