### PR TITLE
fix(transformer/styled-components): remove space before line comment in CSS minification

### DIFF
--- a/crates/oxc_transformer/src/plugins/styled_components.rs
+++ b/crates/oxc_transformer/src/plugins/styled_components.rs
@@ -1045,6 +1045,12 @@ fn minify_template_literal<'a>(lit: &mut TemplateLiteral<'a>, ast: AstBuilder<'a
                             }
                             // Skip line comments, but be careful not to break URLs like `https://...`
                             b'/' if paren_depth == 0 && (i == 0 || bytes[i - 1] != b':') => {
+                                // Remove trailing space before comment.
+                                // Comment will end with a line break, so space will be added again if required.
+                                if output.last().is_some_and(|&last| last == b' ') {
+                                    output.pop();
+                                }
+
                                 let end_index =
                                     bytes[i + 2..].iter().position(|&b| matches!(b, b'\n' | b'\r'));
                                 if let Some(end_index) = end_index {

--- a/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/input.js
+++ b/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/input.js
@@ -1,3 +1,13 @@
 import styled from 'styled-components';
 
 const Button = styled.div`${x}/* ${y} */${z}`;
+
+const Foo = styled.div`
+  .a // comment
+  { color: red; }
+`;
+
+const Bar = styled.div`
+  .a // ${123}
+  { color: red; }
+`;

--- a/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/output.js
+++ b/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/output.js
@@ -1,2 +1,4 @@
 import styled from 'styled-components';
 const Button = styled.div`${x}${z}`;
+const Foo = styled.div`.a{color:red;}`;
+const Bar = styled.div`.a{color:red;}`;


### PR DESCRIPTION
Previously we'd include an unnecessary space when removing a line comment in cases like:

Input:

```js
styled.div`
  .a // comment
  { color: red; }
`
```

Previous output post-minification:

```js
styled.div`.a {color:red;}`
```

After this PR:

```js
styled.div`.a{color:red;}`
```

We still include excess spaces when removing block comments (e.g. ``styled.div`.a /* */ {}` `` -> ``styled.div`.a {}` ``), but that's more complicated to fix, so leaving it for now.