### PR TITLE
test(oxlint): add test for ignorePatterns whitelist

### DIFF
--- a/apps/oxlint/fixtures/ignore_patterns_whitelist/.oxlintrc.json
+++ b/apps/oxlint/fixtures/ignore_patterns_whitelist/.oxlintrc.json
@@ -1,0 +1,9 @@
+{
+  "rules": {
+    "no-debugger": "error"
+  },
+  "ignorePatterns": [
+    "*.ts",
+    "!*.whitelist.ts"
+  ]
+}

--- a/apps/oxlint/fixtures/ignore_patterns_whitelist/index.ts
+++ b/apps/oxlint/fixtures/ignore_patterns_whitelist/index.ts
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/fixtures/ignore_patterns_whitelist/index.whitelist.ts
+++ b/apps/oxlint/fixtures/ignore_patterns_whitelist/index.whitelist.ts
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -719,6 +719,15 @@ mod test {
     }
 
     #[test]
+    fn ignore_patterns_whitelist() {
+        let args1 = &[];
+        let args2 = &["."];
+        Tester::new()
+            .with_cwd("fixtures/ignore_patterns_whitelist".into())
+            .test_and_snapshot_multiple(&[args1, args2]);
+    }
+
+    #[test]
     fn filter_allow_all() {
         let args = &["-A", "all", "fixtures/linter"];
         Tester::new().test_and_snapshot(args);

--- a/apps/oxlint/src/snapshots/fixtures__ignore_patterns_whitelist_ .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__ignore_patterns_whitelist_ .@oxlint.snap
@@ -1,0 +1,38 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: 
+working directory: fixtures/ignore_patterns_whitelist
+----------
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[index.whitelist.ts:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Remove the debugger statement
+
+Found 0 warnings and 1 error.
+Finished in <variable>ms on 1 file using 1 threads.
+----------
+CLI result: LintFoundErrors
+----------
+
+########## 
+arguments: .
+working directory: fixtures/ignore_patterns_whitelist
+----------
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[index.whitelist.ts:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Remove the debugger statement
+
+Found 0 warnings and 1 error.
+Finished in <variable>ms on 1 file using 1 threads.
+----------
+CLI result: LintFoundErrors
+----------


### PR DESCRIPTION
closes #8842

Because of the fix in #13221 we support now allowlist too.
