### PR TITLE
refactor(allocator)!: put `AllocatorPool` behind `pool` feature

### DIFF
--- a/crates/oxc_allocator/Cargo.toml
+++ b/crates/oxc_allocator/Cargo.toml
@@ -36,9 +36,10 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 [features]
-fixed_size = ["from_raw_parts", "dep:oxc_ast_macros"]
+fixed_size = ["from_raw_parts", "pool", "dep:oxc_ast_macros"]
 disable_fixed_size = []
 from_raw_parts = []
+pool = []
 serialize = ["dep:serde", "oxc_estree/serialize"]
 track_allocations = []
 disable_track_allocations = []

--- a/crates/oxc_allocator/README.md
+++ b/crates/oxc_allocator/README.md
@@ -26,6 +26,7 @@ This approach is significantly faster than using the system allocator for AST op
 ## Features
 
 - `serialize` - Enables serialization support for `Box` and `Vec` with `serde` and `oxc_estree`.
+- `pool` - Enables `AllocatorPool`.
 - `from_raw_parts` - Adds unsafe `from_raw_parts` method (not recommended for general use).
 - `fixed_size` - Makes `AllocatorPool` create large fixed-size allocators, instead of flexibly-sized ones.
   Only supported on 64-bit little-endian platforms at present.

--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -16,6 +16,8 @@
 //!
 //! * `serialize` - Enables serialization support for [`Box`] and [`Vec`] with `serde` and `oxc_estree`.
 //!
+//! * `pool` - Enables [`AllocatorPool`].
+//!
 //! * `from_raw_parts` - Adds [`Allocator::from_raw_parts`] method.
 //!   Usage of this feature is not advisable, and it will be removed as soon as we're able to.
 //!
@@ -67,15 +69,19 @@ pub use vec::Vec;
 
 // Fixed size allocators are only supported on 64-bit little-endian platforms at present
 
-#[cfg(not(all(
-    feature = "fixed_size",
-    not(feature = "disable_fixed_size"),
-    target_pointer_width = "64",
-    target_endian = "little"
-)))]
+#[cfg(all(
+    feature = "pool",
+    not(all(
+        feature = "fixed_size",
+        not(feature = "disable_fixed_size"),
+        target_pointer_width = "64",
+        target_endian = "little"
+    ))
+))]
 mod pool;
 
 #[cfg(all(
+    feature = "pool",
     feature = "fixed_size",
     not(feature = "disable_fixed_size"),
     target_pointer_width = "64",
@@ -83,6 +89,7 @@ mod pool;
 ))]
 mod pool_fixed_size;
 #[cfg(all(
+    feature = "pool",
     feature = "fixed_size",
     not(feature = "disable_fixed_size"),
     target_pointer_width = "64",
@@ -94,6 +101,7 @@ use pool_fixed_size as pool;
 // so this is required to avoid unused vars lint warning in release mode.
 #[cfg(all(
     debug_assertions,
+    feature = "pool",
     feature = "fixed_size",
     not(feature = "disable_fixed_size"),
     target_pointer_width = "64",
@@ -102,6 +110,7 @@ use pool_fixed_size as pool;
 use pool_fixed_size::FixedSizeAllocatorMetadata;
 // Export so can be used in `napi/oxlint2`
 #[cfg(all(
+    feature = "pool",
     feature = "fixed_size",
     not(feature = "disable_fixed_size"),
     target_pointer_width = "64",
@@ -109,16 +118,20 @@ use pool_fixed_size::FixedSizeAllocatorMetadata;
 ))]
 pub use pool_fixed_size::free_fixed_size_allocator;
 
+#[cfg(feature = "pool")]
 pub use pool::{AllocatorGuard, AllocatorPool};
 
 // Dummy implementations of interfaces from `pool_fixed_size`, just to stop clippy complaining.
 // Seems to be necessary due to feature unification.
-#[cfg(not(all(
-    feature = "fixed_size",
-    not(feature = "disable_fixed_size"),
-    target_pointer_width = "64",
-    target_endian = "little"
-)))]
+#[cfg(all(
+    feature = "pool",
+    not(all(
+        feature = "fixed_size",
+        not(feature = "disable_fixed_size"),
+        target_pointer_width = "64",
+        target_endian = "little"
+    ))
+))]
 #[allow(missing_docs, clippy::missing_safety_doc, clippy::unused_self, clippy::allow_attributes)]
 mod dummies {
     use std::{ptr::NonNull, sync::atomic::AtomicBool};
@@ -144,15 +157,19 @@ mod dummies {
         }
     }
 }
-#[cfg(not(all(
-    feature = "fixed_size",
-    not(feature = "disable_fixed_size"),
-    target_pointer_width = "64",
-    target_endian = "little"
-)))]
+#[cfg(all(
+    feature = "pool",
+    not(all(
+        feature = "fixed_size",
+        not(feature = "disable_fixed_size"),
+        target_pointer_width = "64",
+        target_endian = "little"
+    ))
+))]
 pub use dummies::*;
 
 #[cfg(all(
+    feature = "pool",
     feature = "fixed_size",
     not(feature = "disable_fixed_size"),
     target_pointer_width = "64",
@@ -164,6 +181,7 @@ mod generated {
     pub mod fixed_size_constants;
 }
 #[cfg(all(
+    feature = "pool",
     feature = "fixed_size",
     not(feature = "disable_fixed_size"),
     target_pointer_width = "64",

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -28,7 +28,7 @@ workspace = true
 doctest = true
 
 [dependencies]
-oxc_allocator = { workspace = true }
+oxc_allocator = { workspace = true, features = ["pool"] }
 oxc_ast = { workspace = true }
 oxc_ast_macros = { workspace = true, optional = true }
 oxc_ast_visit = { workspace = true }


### PR DESCRIPTION
`AllocatorPool` is only used in linter. Parser, transformer, minifier etc don't need it. So put it behind a `pool` cargo feature.

This complicates the many `#[cfg]` attrs even further, but this is preparation for merging the 2 `AllocatorPool` implementations, and removing the `fixed_size` feature, which will remove a lot of this `#[cfg]` mess.