### PR TITLE
test(transformer/styled-components): fix test case

### DIFF
--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 41d96516
 
-Passed: 184/308
+Passed: 185/308
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -1612,7 +1612,7 @@ after transform: ["Function", "babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 
-# plugin-styled-components (22/38)
+# plugin-styled-components (23/38)
 * minify-comments/input.js
 Unresolved references mismatch:
 after transform: ["x", "y", "z"]
@@ -1637,9 +1637,6 @@ x Output mismatch
 x Output mismatch
 
 * styled-components/does-not-replace-native-with-no-tags/input.js
-x Output mismatch
-
-* styled-components/minify-single-line-comments-with-interpolations/input.js
 x Output mismatch
 
 * styled-components/pre-transpiled/input.js

--- a/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/styled-components/minify-single-line-comments-with-interpolations/output.js
+++ b/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/styled-components/minify-single-line-comments-with-interpolations/output.js
@@ -10,7 +10,7 @@ const Test6 = styled.div.withConfig({ displayName: "input__Test6", componentId: 
   'green',
 );
 const Test7 = styled.div.withConfig({ displayName: "input__Test7", componentId: "sc-lh68ek-6" })(
-  ["background:url(\"https://google.com\");width:", ";", "height:", ";"],
+  ["background:url(\"https://google.com\");width:", ";", " height:", ";"],
   p => p.props.width,
   'green',
   p => p.props.height,


### PR DESCRIPTION
Fix a test case which was previously failing. The original test case in `babel-plugin-styled-components` *does* include a space before `height:`. Our copy of the test had got changed somehow (wrongly). This PR brings the case back into alignment with the original and, thanks to #13346, it now passes.

https://github.com/styled-components/babel-plugin-styled-components/blob/4e2eb388d9c90f2921c306c760657d059d01a518/test/fixtures/minify-single-line-comments-with-interpolations/output.js#L26-L29