### PR TITLE
fix(transformer/styled-components): remove unnecessary whitespace around block comments in CSS minification

### DIFF
--- a/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/input.js
+++ b/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/input.js
@@ -11,3 +11,13 @@ const Bar = styled.div`
   .a // ${123}
   { color: red; }
 `;
+
+const Qux = styled.div`
+  color: /* blah */ red;
+  .a /* blah */ { color: blue; }
+`;
+
+const Bing = styled.div`
+  color: /* ${123} */ red;
+  .a /* ${123} */ { color: blue; }
+`;

--- a/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/output.js
+++ b/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/output.js
@@ -2,3 +2,5 @@ import styled from 'styled-components';
 const Button = styled.div`${x}${z}`;
 const Foo = styled.div`.a{color:red;}`;
 const Bar = styled.div`.a{color:red;}`;
+const Qux = styled.div`color:red;.a{color:blue;}`;
+const Bing = styled.div`color:red;.a{color:blue;}`;


### PR DESCRIPTION
Previously we included whitespace around block comments when the following character means it could have been removed. e.g.:

Input:

```js
styled.div`.a /* blah */ { color: blue }`
```

Previous output post-minification:

```js
styled.div`.a {color:blue}`
```

After this PR:

```js
styled.div`.a{color:blue}`
```

This is achieved by a significant change to how spaces are inserted.

Previous logic: When encountering whitespace, determine whether to print a space or not based on what came before it, and what's after it. Problem is that this doesn't work correctly when the whitespace is followed by a block comment, because next char is `/` (start of the comment) - whereas what you really want to know is what's *after* the comment.

New logic: When encountering whitespace, print a space if the preceding character isn't `:`, `;`, etc. Don't take into account what the next char is. But later on when encounter e.g. `{`, check if previous character is a space, and if so, remove it. So in the case of `.a /* blah */ {}`, a space gets printed after `.a`, but then it gets deleted again when `{` is found after the comment.

This also has the benefit of making the code simpler.