### PR TITLE
fix(transformer/styled-components): do not insert space when removing block comments in CSS minification

### DIFF
--- a/crates/oxc_transformer/src/plugins/styled_components.rs
+++ b/crates/oxc_transformer/src/plugins/styled_components.rs
@@ -920,26 +920,11 @@ fn minify_template_literal<'a>(lit: &mut TemplateLiteral<'a>, ast: AstBuilder<'a
 
                 // Find end of comment
                 let start_index = if is_block_comment {
-                    let Some(mut pos) = bytes.windows(2).position(|q| q == b"*/") else {
+                    let Some(pos) = bytes.windows(2).position(|q| q == b"*/") else {
                         // Comment contains whole of this quasi
                         continue;
                     };
-
-                    pos += 2;
-                    if pos == bytes.len() {
-                        // Comment ends at end of quasi
-                        comment_type = None;
-                        continue;
-                    }
-
-                    // Add a space when this is a own line block comment
-                    if !bytes[pos].is_ascii_whitespace()
-                        && output.last().is_some_and(|&last| last != b' ')
-                    {
-                        output.push(b' ');
-                    }
-
-                    pos
+                    pos + 2
                 } else {
                     let Some(pos) = bytes.iter().position(|&b| matches!(b, b'\n' | b'\r')) else {
                         // Comment contains whole of this quasi
@@ -1019,18 +1004,6 @@ fn minify_template_literal<'a>(lit: &mut TemplateLiteral<'a>, ast: AstBuilder<'a
                                             bytes[i + 2..].windows(2).position(|q| q == b"*/");
                                         if let Some(end_index) = end_index {
                                             i += end_index + 4; // After `*/`
-
-                                            if i == bytes.len() {
-                                                // Comment ends at end of quasi
-                                                break;
-                                            }
-
-                                            // Add a space when this is a own line block comment
-                                            if !bytes[i].is_ascii_whitespace()
-                                                && output.last().is_some_and(|&last| last != b' ')
-                                            {
-                                                output.push(b' ');
-                                            }
                                             continue;
                                         }
 
@@ -1215,7 +1188,7 @@ mod tests {
         #[test]
         fn removes_multi_line_comments() {
             let input = "this is a/* ignore me please */test";
-            let expected = "this is a test";
+            let expected = "this is atest";
             let actual = minify_raw(input);
             debug_assert_eq!(actual, expected);
         }

--- a/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/input.js
+++ b/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/input.js
@@ -14,10 +14,12 @@ const Bar = styled.div`
 
 const Qux = styled.div`
   color: /* blah */ red;
+  width/* big */: 1000px;
   .a /* blah */ { color: blue; }
 `;
 
 const Bing = styled.div`
   color: /* ${123} */ red;
+  width/* ${'big'} */: 1000px;
   .a /* ${123} */ { color: blue; }
 `;

--- a/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/output.js
+++ b/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/output.js
@@ -2,5 +2,5 @@ import styled from 'styled-components';
 const Button = styled.div`${x}${z}`;
 const Foo = styled.div`.a{color:red;}`;
 const Bar = styled.div`.a{color:red;}`;
-const Qux = styled.div`color:red;.a{color:blue;}`;
-const Bing = styled.div`color:red;.a{color:blue;}`;
+const Qux = styled.div`color:red;width:1000px;.a{color:blue;}`;
+const Bing = styled.div`color:red;width:1000px;.a{color:blue;}`;


### PR DESCRIPTION
Previously we inserted a space in place of a block comment. I think it's *probably* unnecessary.

Input:

```js
styled.div`width/* big */: 1000px;`;
styled.div`x/* blah */y`;
styled.div`${x}/* blah */${y}`;
```

Previous output post-minification:

```js
styled.div`width :1000px;`;
styled.div`x y`;
styled.div`${x} ${y}`;
```

After this PR:

```js
styled.div`width:1000px;`;
styled.div`xy`;
styled.div`${x}${y}`;
```

I'M NOT COMPLETELY SURE ABOUT THIS ONE. That behavior and the "Add a space when this is a own line block comment" comment were there in the original version before I refactored it in #12224, but I never understood its purpose.

There may be a good reason that I'm missing why it needs to be as it is, in which case this PR is wrong. All the conformance tests still pass (maybe just be due to inadequate test coverage), but there's a unit test showing the old behavior.

@Dunqing Can you advise?

Edit: Yes, I think this change is wrong. In browser, CSS `padding: 10/* */0` behaves like `padding: 10 0`, not `padding: 100`.