### PR TITLE
chore(codegen): skip stacktrace tests on big endian test workflow

### DIFF
--- a/crates/oxc_codegen/tests/integration/sourcemap.rs
+++ b/crates/oxc_codegen/tests/integration/sourcemap.rs
@@ -32,6 +32,7 @@ fn incorrect_ast() {
 }
 
 #[test]
+#[cfg(not(target_endian = "big"))] // we run big endian tests on docker that does not have node installed
 fn stacktrace_is_correct() {
     let cases = &[
         "\


### PR DESCRIPTION
This PR tries to fix the following test failure.
https://github.com/oxc-project/oxc/actions/runs/17313194902/job/49151067079#step:5:325

This failure is probably happening because node binary is missing in the docker image that the test is running. While we can add the node binary in the docker container, I think we can skip the test as I guess there aren't any endian-specific code.
