### PR TITLE
feat(oxfmt): Introduce --write options

### DIFF
--- a/apps/oxfmt/src/command.rs
+++ b/apps/oxfmt/src/command.rs
@@ -21,8 +21,8 @@ const PATHS_ERROR_MESSAGE: &str = "PATH must not contain \"..\"";
 #[derive(Debug, Clone, Bpaf)]
 #[bpaf(options, version(VERSION))]
 pub struct FormatCommand {
-    #[bpaf(external)]
-    pub basic_options: BasicOptions,
+    #[bpaf(external, fallback(OutputOptions::Default))]
+    pub output_options: OutputOptions,
 
     #[bpaf(external)]
     pub misc_options: MiscOptions,
@@ -32,12 +32,14 @@ pub struct FormatCommand {
     pub paths: Vec<PathBuf>,
 }
 
-/// Basic Configuration
+/// Output Options
 #[derive(Debug, Clone, Bpaf)]
-pub struct BasicOptions {
-    /// TODO: docs
-    #[bpaf(switch)]
-    pub check: bool,
+pub enum OutputOptions {
+    #[bpaf(hide)]
+    Default,
+    /// Write mode - write formatted code back
+    #[bpaf(long, short)]
+    Write,
 }
 
 /// Miscellaneous

--- a/apps/oxfmt/src/format.rs
+++ b/apps/oxfmt/src/format.rs
@@ -24,7 +24,7 @@ impl FormatRunner {
 
     pub(crate) fn run(self, stdout: &mut dyn Write) -> CliRunResult {
         let cwd = self.cwd;
-        let FormatCommand { paths, basic_options: _, .. } = self.options;
+        let FormatCommand { paths, output_options, .. } = self.options;
 
         let (exclude_patterns, regular_paths): (Vec<_>, Vec<_>) =
             paths.into_iter().partition(|p| p.to_string_lossy().starts_with('!'));
@@ -66,7 +66,7 @@ impl FormatRunner {
         let (mut diagnostic_service, tx_error) = DiagnosticService::new(reporter);
 
         rayon::spawn(move || {
-            let mut format_service = FormatService::new(cwd);
+            let mut format_service = FormatService::new(cwd, &output_options);
             format_service.with_paths(files_to_format);
             format_service.run(&tx_error);
         });

--- a/apps/oxfmt/src/reporter.rs
+++ b/apps/oxfmt/src/reporter.rs
@@ -8,15 +8,17 @@ pub struct DefaultReporter;
 
 impl DiagnosticReporter for DefaultReporter {
     fn render_error(&mut self, error: Error) -> Option<String> {
-        let prefix = match error.severity().unwrap_or_default() {
-            Severity::Error => "[ERROR] ",
-            Severity::Warning => "[WARN] ",
-            Severity::Advice => "",
-        };
         if error.labels().is_some() {
             // TODO: GraphicalReporter should be used
-            return Some(format!("{prefix}{error:?}\n"));
+            return Some(format!("{error:?}\n"));
         }
+
+        let prefix = match error.severity().unwrap_or_default() {
+            Severity::Warning => "[warn] ",
+            _ => "",
+        };
+        // NOTE: Formatted `path` should be inlined in `error`,
+        // there is no way to get here since we do not have `labels`
         Some(format!("{prefix}{error}\n"))
     }
 


### PR DESCRIPTION
Part of #10573

- Support `-w, --write` CLI flag
  - And also `--default` if not presented

Since I'm undecided whether to implement the exact same arguments as the Prettier CLI, so for now.
