### PR TITLE
feat(oxfmt): Use GraphicalReporter for diagnostics

### DIFF
--- a/apps/oxfmt/src/format.rs
+++ b/apps/oxfmt/src/format.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::DiagnosticService;
 
 use crate::{
     cli::{CliRunResult, FormatCommand},
-    reporter,
+    reporter::DefaultReporter,
     service::FormatService,
     walk::Walk,
 };
@@ -62,7 +62,7 @@ impl FormatRunner {
             return CliRunResult::FormatNoFilesFound;
         }
 
-        let reporter = Box::new(reporter::DefaultReporter);
+        let reporter = Box::new(DefaultReporter::default());
         let (mut diagnostic_service, tx_error) = DiagnosticService::new(reporter);
 
         rayon::spawn(move || {

--- a/apps/oxfmt/src/reporter.rs
+++ b/apps/oxfmt/src/reporter.rs
@@ -1,28 +1,40 @@
 use oxc_diagnostics::{
-    Error, Severity,
+    Error, GraphicalReportHandler, Severity,
     reporter::{DiagnosticReporter, DiagnosticResult},
 };
 
 #[derive(Debug)]
-pub struct DefaultReporter;
+pub struct DefaultReporter {
+    handler: GraphicalReportHandler,
+}
+
+impl Default for DefaultReporter {
+    fn default() -> Self {
+        Self { handler: GraphicalReportHandler::new() }
+    }
+}
 
 impl DiagnosticReporter for DefaultReporter {
     fn render_error(&mut self, error: Error) -> Option<String> {
+        // If `.labels()` exists, it means this comes from `oxc_parser`, `oxc_formatter`, etc
         if error.labels().is_some() {
-            // TODO: GraphicalReporter should be used
-            return Some(format!("{error:?}\n"));
+            let mut output = String::new();
+            self.handler.render_report(&mut output, error.as_ref()).unwrap();
+            return Some(output);
         }
 
+        // Otherwise, this is a error without `labels`, originate from `oxfmt` itself
         let prefix = match error.severity().unwrap_or_default() {
             Severity::Warning => "[warn] ",
             _ => "",
         };
-        // NOTE: Formatted `path` should be inlined in `error`,
+        // NOTE: Formatted `path` should be inlined
         // there is no way to get here since we do not have `labels`
         Some(format!("{prefix}{error}\n"))
     }
 
     fn finish(&mut self, _result: &DiagnosticResult) -> Option<String> {
+        // Leave it to the caller with `diagnostic_service.run()`, to determine exit code
         None
     }
 }


### PR DESCRIPTION
Part of #10573

- Use `GraphicalReporter` to display diagnostics nicely
