### PR TITLE
fix(transformer/styled-components): remove unnecessary whitespace when removing block comments in CSS minification

### DIFF
--- a/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/input.js
+++ b/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/input.js
@@ -15,9 +15,11 @@ const Bar = styled.div`
 const Qux = styled.div`
   color: /* blah */ red;
   .a /* blah */ { color: blue; }
+  .b {/* blah */color: green; }
 `;
 
 const Bing = styled.div`
   color: /* ${123} */ red;
   .a /* ${123} */ { color: blue; }
+  .b {/* ${123} */color: green; }
 `;

--- a/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/output.js
+++ b/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/output.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
-const Button = styled.div`${x}${z}`;
+const Button = styled.div`${x} ${z}`;
 const Foo = styled.div`.a{color:red;}`;
 const Bar = styled.div`.a{color:red;}`;
-const Qux = styled.div`color:red;.a{color:blue;}`;
-const Bing = styled.div`color:red;.a{color:blue;}`;
+const Qux = styled.div`color:red;.a{color:blue;}.b{color:green;}`;
+const Bing = styled.div`color:red;.a{color:blue;}.b{color:green;}`;


### PR DESCRIPTION
Remove special logic for inserting spaces when removing comments. Instead, treat comments as equivalent to whitespace, and apply the same rules.

This fixes 2 problems:

1. Don't add unnecessary space when a block comment appears after a character like `{`.
2. *Do* add a space when a block comment is the whole quasi between 2 interpolations, to prevent them being merged.

Simplifying this logic also gives 1%-2% speed-up on transformer benchmarks.

Input:

```js
styled.div`.a {/* blah */color: green; }`;
styled.div`${x}/* blah */${y}`;
```

Previous output post-minification:

```js
styled.div`.a{ color:green;}`;
styled.div`${x}${y}`;
```

After this PR:

```js
styled.div`.a{color:green;}`;
styled.div`${x} ${y}`;
```
