### PR TITLE
fix(transformer/styled-components): remove leading whitespace when literal starts with block comment containing interpolation in CSS minification

### DIFF
--- a/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/input.js
+++ b/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/input.js
@@ -23,3 +23,7 @@ const Bing = styled.div`
   .a /* ${123} */ { color: blue; }
   .b {/* ${123} */color: green; }
 `;
+
+const Bong = styled.div`/* ${123} */color: red;`;
+
+const Doom = styled.div` /* ${123} */ color: red; `;

--- a/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/output.js
+++ b/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/minify-comments/output.js
@@ -4,3 +4,5 @@ const Foo = styled.div`.a{color:red;}`;
 const Bar = styled.div`.a{color:red;}`;
 const Qux = styled.div`color:red;.a{color:blue;}.b{color:green;}`;
 const Bing = styled.div`color:red;.a{color:blue;}.b{color:green;}`;
+const Bong = styled.div`color:red;`;
+const Doom = styled.div`color:red;`;


### PR DESCRIPTION
Remove leading whitespace when template literal starts with a block comment which contains interpolations.

Previously we didn't remove it because we checked if we're at start of the template literal with `quasi_index == 0`, but that wasn't right because the 1st quasi gets merged into the 2nd. So the 2nd quasi is the 1st *output* quasi. Introduce `is_first_output` var to track this state.

Input:

```js
styled.div` /* ${x} */ color: red; `;
```

Previous output post-minification:

```js
styled.div` color:red;`;
```

After this PR:

```js
styled.div`color:red;`;
```
