### PR TITLE
test(oxc_linter): run `from_tsgo_lint_diagnostic` tests only with lsp feature flag

### DIFF
--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -739,6 +739,7 @@ pub fn try_find_tsgolint_executable(cwd: &Path) -> Option<PathBuf> {
 }
 
 #[cfg(test)]
+#[cfg(feature = "language_server")]
 mod test {
     use oxc_diagnostics::{LabeledSpan, OxcCode, Severity};
     use oxc_span::{GetSpan, Span};


### PR DESCRIPTION
follow up from #13374