### PR TITLE
feat(minifier): remove pure function calls when the return value is not used

### DIFF
--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -132,7 +132,7 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
 
     fn enter_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
         let ctx = &mut Ctx::new(ctx);
-        Self::keep_track_of_empty_functions(stmt, ctx);
+        Self::keep_track_of_pure_functions(stmt, ctx);
     }
 
     fn exit_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -521,7 +521,19 @@ impl<'a> PeepholeOptimizations {
     fn remove_unused_call_expr(e: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) -> bool {
         let Expression::CallExpression(call_expr) = e else { return false };
 
-        if call_expr.pure && ctx.annotations() {
+        let is_pure = {
+            (call_expr.pure && ctx.annotations())
+                || (if let Expression::Identifier(id) = &call_expr.callee
+                    && let Some(symbol_id) =
+                        ctx.scoping().get_reference(id.reference_id()).symbol_id()
+                {
+                    ctx.state.pure_functions.contains_key(&symbol_id)
+                } else {
+                    false
+                })
+        };
+
+        if is_pure {
             let mut exprs =
                 Self::fold_arguments_into_needed_expressions(&mut call_expr.arguments, ctx);
             if exprs.is_empty() {
@@ -954,6 +966,9 @@ mod test {
         test("/* @__PURE__ */ new Foo(a)", "a");
         test("true && /* @__PURE__ */ noEffect()", "");
         test("false || /* @__PURE__ */ noEffect()", "");
+
+        test("var foo = () => 1; foo(), foo()", "var foo = () => 1");
+        test_same("var foo = () => { bar() }; foo(), foo()");
     }
 
     #[test]

--- a/crates/oxc_minifier/src/state.rs
+++ b/crates/oxc_minifier/src/state.rs
@@ -1,4 +1,5 @@
-use rustc_hash::FxHashSet;
+use oxc_ecmascript::constant_evaluation::ConstantValue;
+use rustc_hash::FxHashMap;
 
 use oxc_span::SourceType;
 use oxc_syntax::symbol::SymbolId;
@@ -10,8 +11,8 @@ pub struct MinifierState<'a> {
 
     pub options: CompressOptions,
 
-    /// Function declarations that are empty
-    pub empty_functions: FxHashSet<SymbolId>,
+    /// The return value of function declarations that are pure
+    pub pure_functions: FxHashMap<SymbolId, Option<ConstantValue<'a>>>,
 
     pub symbol_values: SymbolValues<'a>,
 
@@ -23,7 +24,7 @@ impl MinifierState<'_> {
         Self {
             source_type,
             options,
-            empty_functions: FxHashSet::default(),
+            pure_functions: FxHashMap::default(),
             symbol_values: SymbolValues::default(),
             changed: false,
         }


### PR DESCRIPTION
Remove pure function calls when the return value is not used.
```js
var foo = () => 1;
foo(), foo() // these can be removed
```

close #13027
