### PR TITLE
feat(ecmascript): check side effects inside static blocks

### DIFF
--- a/crates/oxc_ecmascript/src/side_effects/expressions.rs
+++ b/crates/oxc_ecmascript/src/side_effects/expressions.rs
@@ -412,8 +412,9 @@ impl<'a> MayHaveSideEffects<'a> for Class<'a> {
 impl<'a> MayHaveSideEffects<'a> for ClassElement<'a> {
     fn may_have_side_effects(&self, ctx: &impl MayHaveSideEffectsContext<'a>) -> bool {
         match self {
-            // TODO: check side effects inside the block
-            ClassElement::StaticBlock(block) => !block.body.is_empty(),
+            ClassElement::StaticBlock(block) => {
+                block.body.iter().any(|stmt| stmt.may_have_side_effects(ctx))
+            }
             ClassElement::MethodDefinition(e) => {
                 !e.decorators.is_empty() || e.key.may_have_side_effects(ctx)
             }

--- a/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
+++ b/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
@@ -387,14 +387,14 @@ fn closure_compiler_tests() {
 
     // CLASS_STATIC_BLOCK
     test("(class C { static {} })", false);
-    // test("(class C { static { [1]; } })", false);
-    test("(class C { static { let x; } })", true);
-    test("(class C { static { const x =1 ; } })", true);
-    test("(class C { static { var x; } })", true);
+    test("(class C { static { [1]; } })", false);
+    test("(class C { static { let x; } })", false);
+    test("(class C { static { const x =1 ; } })", false);
+    test("(class C { static { var x; } })", false);
     test("(class C { static { this.x = 1; } })", true);
-    test("(class C { static { function f() { } } })", true);
-    // test("(class C { static { (function () {} )} })", false);
-    // test("(class C { static { ()=>{} } })", false);
+    test("(class C { static { function f() { } } })", false);
+    test("(class C { static { (function () {} )} })", false);
+    test("(class C { static { ()=>{} } })", false);
 
     // SUPER calls
     test("super()", true);
@@ -715,6 +715,7 @@ fn test_class_expression() {
     test("(class extends foo() {})", true);
     test("(class extends (() => {}) {})", true);
     test("(class { static {} })", false);
+    test("(class { static { 1; } })", false);
     test("(class { static { foo(); } })", true);
     test("(class { a() {} })", false);
     test("(class { [1]() {} })", false);


### PR DESCRIPTION
Now that we have `MayHaveSideEffects` for Statements, we can check the static block.