### PR TITLE
perf(mangler): replace `FixedBitSet` with `Vec<bool>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2065,7 +2065,6 @@ dependencies = [
 name = "oxc_mangler"
 version = "0.84.0"
 dependencies = [
- "fixedbitset",
  "itertools",
  "oxc_allocator",
  "oxc_ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,6 @@ encoding_rs = "0.8.35"
 encoding_rs_io = "0.1.7"
 env_logger = { version = "0.11.8", default-features = false }
 fast-glob = "1.0.0"
-fixedbitset = "0.5.7"
 flate2 = "1.1.2"
 futures = "0.3.31"
 handlebars = "6.3.2"

--- a/crates/oxc_mangler/Cargo.toml
+++ b/crates/oxc_mangler/Cargo.toml
@@ -21,13 +21,13 @@ test = true
 doctest = false
 
 [dependencies]
+itertools = { workspace = true }
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_data_structures = { workspace = true, features = ["inline_string"] }
 oxc_index = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
-itertools = { workspace = true }
 rustc-hash = { workspace = true }
 
 [dev-dependencies]

--- a/crates/oxc_mangler/Cargo.toml
+++ b/crates/oxc_mangler/Cargo.toml
@@ -27,8 +27,6 @@ oxc_data_structures = { workspace = true, features = ["inline_string"] }
 oxc_index = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
-
-fixedbitset = { workspace = true }
 itertools = { workspace = true }
 rustc-hash = { workspace = true }
 


### PR DESCRIPTION
closes #11347

Although `FixedBitSet` is faster in CPU cycles, it performs worse when allocated inside `std::vec::Vec`. Each `FixedBitSet` requires allocation and dropping.