### PR TITLE
perf(mangler): replace `FixedBitSet` with `BitSet` based on Rolldown's implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2065,7 +2065,6 @@ dependencies = [
 name = "oxc_mangler"
 version = "0.85.0"
 dependencies = [
- "fixedbitset",
  "itertools",
  "oxc_allocator",
  "oxc_ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,6 @@ encoding_rs = "0.8.35"
 encoding_rs_io = "0.1.7"
 env_logger = { version = "0.11.8", default-features = false }
 fast-glob = "1.0.0"
-fixedbitset = "0.5.7"
 flate2 = "1.1.2"
 futures = "0.3.31"
 handlebars = "6.3.2"

--- a/crates/oxc_mangler/Cargo.toml
+++ b/crates/oxc_mangler/Cargo.toml
@@ -28,7 +28,6 @@ oxc_index = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
 
-fixedbitset = { workspace = true }
 itertools = { workspace = true }
 rustc-hash = { workspace = true }
 

--- a/crates/oxc_mangler/src/bitset.rs
+++ b/crates/oxc_mangler/src/bitset.rs
@@ -1,0 +1,101 @@
+use std::fmt::{Debug, Display};
+
+use oxc_allocator::{Allocator, CloneIn, Vec};
+
+#[derive(PartialEq, Eq, Hash)]
+pub struct BitSet<'alloc> {
+    entries: Vec<'alloc, u8>,
+}
+
+impl<'alloc> BitSet<'alloc> {
+    pub fn new_in(max_bit_count: usize, allocator: &'alloc Allocator) -> Self {
+        Self {
+            entries: Vec::from_iter_in(
+                std::iter::repeat_n(0, max_bit_count.div_ceil(8)),
+                allocator,
+            ),
+        }
+    }
+
+    pub fn has_bit(&self, bit: usize) -> bool {
+        (self.entries[bit / 8] & (1 << (bit & 7))) != 0
+    }
+
+    pub fn set_bit(&mut self, bit: usize) {
+        self.entries[bit / 8] |= 1 << (bit & 7);
+    }
+}
+
+impl Display for BitSet<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // using little endian representation
+        // e.g. 256
+        // 00000001_00000000
+        // ^               ^
+        // msb             lsb
+        let mut iter = self.entries.iter().rev();
+        if let Some(first) = iter.next() {
+            f.write_str(&format!("{first:08b}"))?;
+        }
+        for e in iter {
+            f.write_str(&format!("_{e:08b}"))?;
+        }
+        Ok(())
+    }
+}
+
+impl Debug for BitSet<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("BitSet").field(&self.to_string()).finish()
+    }
+}
+
+impl<'allocator> CloneIn<'allocator> for BitSet<'allocator> {
+    type Cloned = Self;
+
+    fn clone_in(&self, allocator: &'allocator Allocator) -> Self {
+        Self { entries: self.entries.clone_in(allocator) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic() {
+        let allocator = Allocator::default();
+        let mut bs = BitSet::new_in(1, &allocator);
+        assert_eq!(bs.to_string(), "00000000");
+        bs.set_bit(0);
+        bs.set_bit(1);
+        bs.set_bit(7);
+        assert_eq!(bs.to_string(), "10000011");
+
+        let mut bs = BitSet::new_in(9, &allocator);
+        assert_eq!(bs.to_string(), "00000000_00000000");
+        bs.set_bit(0);
+        bs.set_bit(1);
+        bs.set_bit(7);
+        assert_eq!(bs.to_string(), "00000000_10000011");
+        bs.set_bit(8);
+        assert_eq!(bs.to_string(), "00000001_10000011");
+        bs.set_bit(15);
+        assert_eq!(bs.to_string(), "10000001_10000011");
+    }
+
+    #[test]
+    fn union() {
+        let allocator = Allocator::default();
+        let mut bs = BitSet::new_in(9, &allocator);
+        assert_eq!(bs.to_string(), "00000000_00000000");
+        let mut bs2 = bs.clone_in(&allocator);
+        bs.set_bit(0);
+        bs.set_bit(1);
+        bs.set_bit(7);
+        assert_eq!(bs.to_string(), "00000000_10000011");
+        bs2.set_bit(8);
+        bs2.set_bit(15);
+        assert_eq!(bs2.to_string(), "10000001_00000000");
+    }
+}


### PR DESCRIPTION
Just recalled that there's a bitset implementation in rolldown that is not complicated. I've copied that and change it to use the allocator. This might work?

refs #11347
