### PR TITLE
fix(mangler): keep names for parenthesized functions and classes

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -315,7 +315,7 @@ impl<'a> Expression<'a> {
     /// Note that this includes [`Class`]s.
     /// <https://262.ecma-international.org/15.0/#sec-isanonymousfunctiondefinition>
     pub fn is_anonymous_function_definition(&self) -> bool {
-        match self {
+        match self.without_parentheses() {
             Self::ArrowFunctionExpression(_) => true,
             Self::FunctionExpression(func) => func.name().is_none(),
             Self::ClassExpression(class) => class.name().is_none(),

--- a/crates/oxc_mangler/src/keep_names.rs
+++ b/crates/oxc_mangler/src/keep_names.rs
@@ -240,7 +240,7 @@ impl<'a, 'b: 'a> NameSymbolCollector<'a, 'b> {
             return true;
         }
 
-        let is_class = matches!(expr, Expression::ClassExpression(_));
+        let is_class = matches!(expr.without_parentheses(), Expression::ClassExpression(_));
         (self.options.class && is_class) || (self.options.function && !is_class)
     }
 }
@@ -291,8 +291,11 @@ mod test {
     #[test]
     fn test_simple_declare_init() {
         assert_eq!(collect(function_only(), "var foo = function() {}"), data("foo"));
+        assert_eq!(collect(function_only(), "var foo = (function() {})"), data("foo"));
         assert_eq!(collect(function_only(), "var foo = () => {}"), data("foo"));
+        assert_eq!(collect(function_only(), "var foo = (() => {})"), data("foo"));
         assert_eq!(collect(class_only(), "var Foo = class {}"), data("Foo"));
+        assert_eq!(collect(class_only(), "var Foo = (class {})"), data("Foo"));
     }
 
     #[test]


### PR DESCRIPTION
`var a = (function () {})` sets the function name, so these have to be kept as well.

https://tc39.es/ecma262/multipage/syntax-directed-operations.html#sec-static-semantics-isfunctiondefinition