### PR TITLE
fix(minifier): avoid inlining single use variables when the name needs to be preserved

### DIFF
--- a/crates/oxc_minifier/src/ctx.rs
+++ b/crates/oxc_minifier/src/ctx.rs
@@ -265,4 +265,17 @@ impl<'a> Ctx<'a, '_> {
             })
             .unwrap_or_default()
     }
+
+    /// Whether the assignment expression needs to be kept to preserve the name
+    pub fn is_expression_whose_name_needs_to_be_kept(&self, expr: &Expression) -> bool {
+        let options = &self.options().keep_names;
+        if !options.class && !options.function {
+            return false;
+        }
+        if !expr.is_anonymous_function_definition() {
+            return false;
+        }
+        let is_class = matches!(expr.without_parentheses(), Expression::ClassExpression(_));
+        (options.class && is_class) || (options.function && !is_class)
+    }
 }

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -1053,6 +1053,9 @@ impl<'a> PeepholeOptimizations {
             let BindingPatternKind::BindingIdentifier(prev_decl_id) = &prev_decl.id.kind else {
                 return true;
             };
+            if ctx.is_expression_whose_name_needs_to_be_kept(prev_decl_init) {
+                return true;
+            }
             let Some(symbol_value) =
                 ctx.state.symbol_values.get_symbol_value(prev_decl_id.symbol_id())
             else {


### PR DESCRIPTION
Made the single use variable inlining to respect `keep_names` option.

refs https://github.com/rolldown/rolldown/pull/5975#discussion_r2311840923
