### PR TITLE
feat(minifier): inline single use functions past sideeffectful expressions

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -1620,8 +1620,8 @@ impl<'a> PeepholeOptimizations {
             return None;
         }
 
-        // We can always reorder past primitive values
-        if replacement.is_literal_value(false, ctx) || target_expr.is_literal_value(false, ctx) {
+        // We can always reorder past literal values
+        if replacement.is_literal_value(true, ctx) || target_expr.is_literal_value(true, ctx) {
             return None;
         }
 

--- a/crates/oxc_minifier/tests/peephole/inline_single_use_variable.rs
+++ b/crates/oxc_minifier/tests/peephole/inline_single_use_variable.rs
@@ -146,6 +146,14 @@ fn test_inline_single_use_variable() {
         "function wrapper() { let x = [0, 1, 2]; return foo.bar(x);}",
         "function wrapper() { return foo.bar([0, 1, 2]);}",
     );
+    test(
+        "function wrapper() { let x = () => { console.log() }; foo(x) }",
+        "function wrapper() { foo(() => { console.log() }) }",
+    );
+    test(
+        "function wrapper() { let x = function () { console.log() }; foo(x) }",
+        "function wrapper() { foo(function() { console.log() }) }",
+    );
 }
 
 #[test]
@@ -160,7 +168,7 @@ fn keep_exposed_variables() {
 fn keep_names() {
     test(
         "var x = function() {}; var y = x; console.log(y.name)",
-        "var y = function() {}; console.log(y.name)",
+        "console.log(function() {}.name)",
     );
     test_keep_names(
         "var x = function() {}; var y = x; console.log(y.name)",
@@ -172,7 +180,7 @@ fn keep_names() {
     );
     test_keep_names(
         "var x = function foo() {}; var y = x; console.log(y.name)",
-        "var y = function foo() {}; console.log(y.name)",
+        "console.log(function foo() {}.name)",
     );
 
     test(

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -17,11 +17,11 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 1.25 MB    | 645.65 kB  | 646.76 kB  | 159.55 kB  | 163.73 kB  |          2 | three.js   
 
-2.14 MB    | 713.64 kB  | 724.14 kB  | 161.04 kB  | 181.07 kB  |          2 | victory.js 
+2.14 MB    | 713.54 kB  | 724.14 kB  | 161.00 kB  | 181.07 kB  |          2 | victory.js 
 
-3.20 MB    | 1.00 MB    | 1.01 MB    | 323.13 kB  | 331.56 kB  |          3 | echarts.js 
+3.20 MB    | 1.00 MB    | 1.01 MB    | 323.12 kB  | 331.56 kB  |          3 | echarts.js 
 
-6.69 MB    | 2.22 MB    | 2.31 MB    | 459.59 kB  | 488.28 kB  |          4 | antd.js    
+6.69 MB    | 2.22 MB    | 2.31 MB    | 459.29 kB  | 488.28 kB  |          4 | antd.js    
 
-10.95 MB   | 3.34 MB    | 3.49 MB    | 855.39 kB  | 915.50 kB  |          4 | typescript.js 
+10.95 MB   | 3.34 MB    | 3.49 MB    | 855.41 kB  | 915.50 kB  |          4 | typescript.js 
 


### PR DESCRIPTION
Allowed literal functions to be inlined past sideeffectful expressions as it's in the same scope.
https://github.com/oxc-project/oxc/blob/b30bff56717c54028833a4a3cba0336be50ab60b/crates/oxc_ecmascript/src/constant_evaluation/is_literal_value.rs#L5-L18

close #13109
