### PR TITLE
feat(data_structures): add `SliceIterExt::peek` method

### DIFF
--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use nonmax::NonMaxU32;
 
+use oxc_data_structures::slice_iter_ext::SliceIterExt;
 use oxc_index::{Idx, IndexVec};
 use oxc_span::Span;
 use oxc_syntax::identifier::{LS, PS};
@@ -257,7 +258,7 @@ impl<'a> SourcemapBuilder<'a> {
                 b'\n' => {}
                 b'\r' => {
                     // Handle Windows-specific "\r\n" newlines
-                    if iter.clone().next() == Some(&b'\n') {
+                    if iter.peek() == Some(&b'\n') {
                         iter.next();
                     }
                 }

--- a/crates/oxc_codegen/src/str.rs
+++ b/crates/oxc_codegen/src/str.rs
@@ -104,7 +104,7 @@ impl PrintStringState<'_> {
     /// Peek next byte in `bytes` iterator.
     #[inline]
     fn peek(&self) -> Option<u8> {
-        self.bytes.clone().next().copied()
+        self.bytes.peek_copy()
     }
 
     /// Advance the `bytes` iterator by 1 byte.
@@ -235,7 +235,7 @@ impl PrintStringState<'_> {
                 b'"' => double_cost += 1,
                 b'`' => backtick_cost += 1,
                 b'$' => {
-                    if bytes.clone().next() == Some(&b'{') {
+                    if bytes.peek() == Some(&b'{') {
                         backtick_cost += 1;
                     }
                 }


### PR DESCRIPTION
Add `peek` and `peek_copy` methods to `SliceIterExt`.

This is just syntax sugar, but it makes code easier to understand - it's clear what `bytes.peek()` does, whereas `bytes.clone().next()` is a bit less obvious.

Use these methods in codegen.

Unclear to me why this has +4% perf impact on codegen. My best guess is it's pushing compiler to make better inlining decisions, as `peek` is marked `#[inline(always)]`.