### PR TITLE
feat(data_structures): add `ptr` and `end_ptr` methods to `SliceIterExt`

### DIFF
--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -282,7 +282,7 @@ impl<'a> SourcemapBuilder<'a> {
 
             // Line break found.
             // `iter` is now positioned after line break.
-            line_start_ptr = iter.as_slice().as_ptr();
+            line_start_ptr = iter.ptr();
             self.generated_line += 1;
             self.generated_column = 0;
             last_line_is_ascii = true;
@@ -290,8 +290,8 @@ impl<'a> SourcemapBuilder<'a> {
 
         // Calculate column
         self.generated_column += if last_line_is_ascii {
-            // `iter` is now exhausted, so `iter.as_slice().as_ptr()` is pointer to end of `output`
-            (iter.as_slice().as_ptr() as usize - line_start_ptr as usize) as u32
+            // `iter` is now exhausted, so `iter.ptr()` is pointer to end of `output`
+            (iter.ptr() as usize - line_start_ptr as usize) as u32
         } else {
             let line_byte_offset = line_start_ptr as usize - remaining.as_ptr() as usize;
             // TODO: It'd be better if could use `from_utf8_unchecked` here, but we'd need to make this

--- a/crates/oxc_codegen/src/str.rs
+++ b/crates/oxc_codegen/src/str.rs
@@ -46,7 +46,7 @@ impl Codegen<'_> {
         // String is written to buffer in chunks.
         let bytes = s.value.as_bytes().iter();
         let mut state = PrintStringState {
-            chunk_start: bytes.as_slice().as_ptr(),
+            chunk_start: bytes.ptr(),
             bytes,
             quote,
             lone_surrogates: s.lone_surrogates,
@@ -139,7 +139,7 @@ impl PrintStringState<'_> {
     /// Set the start of next chunk to be current position of `bytes` iterator.
     #[inline]
     fn start_chunk(&mut self) {
-        self.chunk_start = self.bytes.as_slice().as_ptr();
+        self.chunk_start = self.bytes.ptr();
     }
 
     /// Flush current chunk to buffer, consume 1 byte, and start next chunk after that byte.
@@ -183,7 +183,7 @@ impl PrintStringState<'_> {
         // SAFETY: `chunk_start` is pointer to current position of `bytes` iterator at some point,
         // and the iterator only advances, so current position of `bytes` must be on or after `chunk_start`
         let len = unsafe {
-            let bytes_ptr = self.bytes.as_slice().as_ptr();
+            let bytes_ptr = self.bytes.ptr();
             bytes_ptr.offset_from_unsigned(self.chunk_start)
         };
 


### PR DESCRIPTION
Add `ptr` and `end_ptr` methods to `SliceIterExt`. These methods get pointers to the start and end of slice iterators, using the minimum possible number of instructions (1).

`end_ptr` also avoids unsafe code, unlike `iter.as_slice().as_ptr().add(iter.as_slice().len())`, which we used previously.

Use these methods in codegen.
