### PR TITLE
refactor(data_structures)!: rename `SliceIterExt` to `SliceIter`

### DIFF
--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -22,7 +22,7 @@ doctest = true
 [dependencies]
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
-oxc_data_structures = { workspace = true, features = ["code_buffer", "slice_iter_ext", "stack"] }
+oxc_data_structures = { workspace = true, features = ["code_buffer", "slice_iter", "stack"] }
 oxc_index = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_sourcemap = { workspace = true }

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use nonmax::NonMaxU32;
 
-use oxc_data_structures::slice_iter_ext::SliceIterExt;
+use oxc_data_structures::slice_iter::SliceIter;
 use oxc_index::{Idx, IndexVec};
 use oxc_span::Span;
 use oxc_syntax::identifier::{LS, PS};

--- a/crates/oxc_codegen/src/str.rs
+++ b/crates/oxc_codegen/src/str.rs
@@ -1,7 +1,7 @@
 use std::slice;
 
 use oxc_ast::ast::StringLiteral;
-use oxc_data_structures::{assert_unchecked, slice_iter_ext::SliceIterExt};
+use oxc_data_structures::{assert_unchecked, slice_iter::SliceIter};
 use oxc_syntax::identifier::{LS, NBSP, PS};
 
 use crate::Codegen;

--- a/crates/oxc_data_structures/Cargo.toml
+++ b/crates/oxc_data_structures/Cargo.toml
@@ -26,10 +26,10 @@ ropey = { workspace = true, optional = true }
 
 [features]
 default = []
-all = ["assert_unchecked", "code_buffer", "inline_string", "rope", "slice_iter_ext", "stack"]
+all = ["assert_unchecked", "code_buffer", "inline_string", "rope", "slice_iter", "stack"]
 assert_unchecked = []
 code_buffer = ["assert_unchecked"]
 inline_string = ["assert_unchecked"]
 rope = ["dep:ropey"]
-slice_iter_ext = ["assert_unchecked"]
+slice_iter = ["assert_unchecked"]
 stack = []

--- a/crates/oxc_data_structures/src/lib.rs
+++ b/crates/oxc_data_structures/src/lib.rs
@@ -11,11 +11,11 @@ pub mod code_buffer;
 #[cfg(feature = "inline_string")]
 pub mod inline_string;
 
-#[cfg(feature = "slice_iter_ext")]
-pub mod slice_iter_ext;
-
 #[cfg(feature = "rope")]
 pub mod rope;
+
+#[cfg(feature = "slice_iter")]
+pub mod slice_iter;
 
 #[cfg(feature = "stack")]
 pub mod stack;

--- a/crates/oxc_data_structures/src/slice_iter.rs
+++ b/crates/oxc_data_structures/src/slice_iter.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides additional methods to inspect and advance iterators.
 //!
-//! See [`SliceIterExt`] and [`SliceIterMutExt`].
+//! See [`SliceIter`] and [`SliceIterMut`].
 
 // All methods boil down to just a few instructions.
 // https://godbolt.org/z/KrsTz9478
@@ -17,7 +17,7 @@ use crate::assert_unchecked;
 
 /// Extension trait for slice iterators.
 #[expect(private_bounds)]
-pub trait SliceIterExt<'slice, T>: ExactSizeIterator + AsRef<[T]> + Sealed {
+pub trait SliceIter<'slice, T>: ExactSizeIterator + AsRef<[T]> + Sealed {
     /// The type returned by `peek` method.
     type Peeked<'iter>
     where
@@ -83,7 +83,7 @@ pub trait SliceIterExt<'slice, T>: ExactSizeIterator + AsRef<[T]> + Sealed {
     }
 }
 
-impl<'slice, T: 'slice> SliceIterExt<'slice, T> for Iter<'slice, T> {
+impl<'slice, T: 'slice> SliceIter<'slice, T> for Iter<'slice, T> {
     // `peek` method returns a reference which borrows the slice, not the iterator
     type Peeked<'iter>
         = &'slice T
@@ -141,7 +141,7 @@ impl<'slice, T: 'slice> SliceIterExt<'slice, T> for Iter<'slice, T> {
     }
 }
 
-impl<'slice, T: 'slice> SliceIterExt<'slice, T> for IterMut<'slice, T> {
+impl<'slice, T: 'slice> SliceIter<'slice, T> for IterMut<'slice, T> {
     // `peek` method returns a reference which borrows the iterator
     type Peeked<'iter>
         = &'iter T
@@ -207,12 +207,12 @@ impl<'slice, T: 'slice> SliceIterExt<'slice, T> for IterMut<'slice, T> {
 }
 
 /// Extension trait for [`IterMut`] slice iterator.
-pub trait SliceIterMutExt<'slice, T>: SliceIterExt<'slice, T> {
+pub trait SliceIterMut<'slice, T>: SliceIter<'slice, T> {
     /// Get the remaining items in the iterator as a mutable slice.
     fn as_mut_slice(&mut self) -> &mut [T];
 }
 
-impl<'slice, T: 'slice> SliceIterMutExt<'slice, T> for IterMut<'slice, T> {
+impl<'slice, T: 'slice> SliceIterMut<'slice, T> for IterMut<'slice, T> {
     /// Get the remaining items in the iterator as a mutable slice.
     ///
     /// This method is present in standard library, but requires nightly Rust.
@@ -234,8 +234,8 @@ impl<'slice, T: 'slice> SliceIterMutExt<'slice, T> for IterMut<'slice, T> {
 }
 
 /// Private trait.
-/// [`SliceIterExt`] extends `Sealed`, which prevents code outside this file implementing
-/// `SliceIterExt` on other types.
+/// [`SliceIter`] extends `Sealed`, which prevents code outside this file implementing
+/// `SliceIter` on other types.
 trait Sealed {}
 
 impl<'slice, T: 'slice> Sealed for Iter<'slice, T> {}

--- a/crates/oxc_estree/Cargo.toml
+++ b/crates/oxc_estree/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 doctest = false
 
 [dependencies]
-oxc_data_structures = { workspace = true, features = ["code_buffer", "slice_iter_ext", "stack"], optional = true }
+oxc_data_structures = { workspace = true, features = ["code_buffer", "slice_iter", "stack"], optional = true }
 
 dragonbox_ecma = { workspace = true, optional = true }
 itoa = { workspace = true, optional = true }

--- a/crates/oxc_estree/src/serialize/strings.rs
+++ b/crates/oxc_estree/src/serialize/strings.rs
@@ -1,6 +1,6 @@
 use std::{num::NonZeroU64, slice};
 
-use oxc_data_structures::{code_buffer::CodeBuffer, slice_iter_ext::SliceIterExt};
+use oxc_data_structures::{code_buffer::CodeBuffer, slice_iter::SliceIter};
 
 use super::{ESTree, Serializer};
 

--- a/crates/oxc_transformer/Cargo.toml
+++ b/crates/oxc_transformer/Cargo.toml
@@ -25,7 +25,7 @@ oxc-browserslist = { workspace = true }
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
-oxc_data_structures = { workspace = true, features = ["assert_unchecked", "inline_string", "rope", "slice_iter_ext", "stack"] }
+oxc_data_structures = { workspace = true, features = ["assert_unchecked", "inline_string", "rope", "slice_iter", "stack"] }
 oxc_diagnostics = { workspace = true }
 oxc_ecmascript = { workspace = true }
 oxc_parser = { workspace = true }

--- a/crates/oxc_transformer/src/plugins/styled_components.rs
+++ b/crates/oxc_transformer/src/plugins/styled_components.rs
@@ -65,7 +65,7 @@ use serde::Deserialize;
 
 use oxc_allocator::{TakeIn, Vec as ArenaVec};
 use oxc_ast::{AstBuilder, NONE, ast::*};
-use oxc_data_structures::{inline_string::InlineString, slice_iter_ext::SliceIterExt};
+use oxc_data_structures::{inline_string::InlineString, slice_iter::SliceIter};
 use oxc_semantic::SymbolId;
 use oxc_span::SPAN;
 use oxc_traverse::{Ancestor, Traverse};


### PR DESCRIPTION
Pure refactor. Rename:

* `SliceIterExt` -> `SliceIter`
* `SliceIterMutExt` -> `SliceIterMut`
* `slice_iter_ext` module -> `slice_iter`
* `slice_iter_ext` Cargo feature -> `slice_iter`

I don't think "ext" added any value. There is no `SliceIter` trait in std library, so no naming clash.
