### PR TITLE
fix(minifier): set reference_id when removing `window.` from `window?.Object`

### DIFF
--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -4,6 +4,7 @@ use oxc_allocator::{CloneIn, TakeIn, Vec};
 use oxc_ast::{NONE, ast::*};
 use oxc_ecmascript::constant_evaluation::{ConstantEvaluation, ConstantValue, DetermineValueType};
 use oxc_ecmascript::{ToJsString, ToNumber, side_effects::MayHaveSideEffects};
+use oxc_semantic::ReferenceFlags;
 use oxc_span::GetSpan;
 use oxc_span::SPAN;
 use oxc_syntax::{
@@ -1088,7 +1089,12 @@ impl<'a> PeepholeOptimizations {
                     .as_member_expression()
                     .is_some_and(|mem_expr| mem_expr.is_specific_member_access("window", "Object"))
             {
-                call_expr.callee = ctx.ast.expression_identifier(call_expr.callee.span(), "Object");
+                let reference_id = ctx.create_unbound_reference("Object", ReferenceFlags::Read);
+                call_expr.callee = ctx.ast.expression_identifier_with_reference_id(
+                    call_expr.callee.span(),
+                    "Object",
+                    reference_id,
+                );
                 ctx.state.changed = true;
             }
         }


### PR DESCRIPTION
This caused errors when changing the code in #13443.