### PR TITLE
refactor(minifier): use `.reference_id()` instead of `.reference_id`

### DIFF
--- a/crates/oxc_minifier/src/peephole/inline.rs
+++ b/crates/oxc_minifier/src/peephole/inline.rs
@@ -21,7 +21,7 @@ impl<'a> PeepholeOptimizations {
 
     pub fn inline_identifier_reference(expr: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) {
         let Expression::Identifier(ident) = expr else { return };
-        let Some(reference_id) = ident.reference_id.get() else { return };
+        let reference_id = ident.reference_id();
         let Some(symbol_id) = ctx.scoping().get_reference(reference_id).symbol_id() else { return };
         let Some(symbol_value) = ctx.state.symbol_values.get_symbol_value(symbol_id) else {
             return;

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -512,8 +512,7 @@ struct ReferencesCounter {
 
 impl<'a> Visit<'a> for ReferencesCounter {
     fn visit_identifier_reference(&mut self, it: &IdentifierReference<'a>) {
-        if let Some(reference_id) = it.reference_id.get() {
-            self.refs.insert(reference_id);
-        }
+        let reference_id = it.reference_id();
+        self.refs.insert(reference_id);
     }
 }

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -624,7 +624,7 @@ impl<'a> PeepholeOptimizations {
         if Self::keep_top_level_var_in_script_mode(ctx) {
             return false;
         }
-        let Some(reference_id) = ident.reference_id.get() else { return false };
+        let reference_id = ident.reference_id();
         let Some(symbol_id) = ctx.scoping().get_reference(reference_id).symbol_id() else {
             return false;
         };


### PR DESCRIPTION
The `.reference_id()` should exist. If it doesn't exist, it's a bug and we might be generating an invalid code. To avoid that we should panic.