### PR TITLE
feat(allocator): introduce `BitSet` type

### DIFF
--- a/crates/oxc_allocator/Cargo.toml
+++ b/crates/oxc_allocator/Cargo.toml
@@ -36,6 +36,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 [features]
+bitset = []
 fixed_size = ["from_raw_parts", "pool", "dep:oxc_ast_macros"]
 disable_fixed_size = []
 from_raw_parts = []

--- a/crates/oxc_allocator/README.md
+++ b/crates/oxc_allocator/README.md
@@ -27,6 +27,7 @@ This approach is significantly faster than using the system allocator for AST op
 
 - `serialize` - Enables serialization support for `Box` and `Vec` with `serde` and `oxc_estree`.
 - `pool` - Enables `AllocatorPool`.
+- `bitset` - Enables `BitSet`.
 - `from_raw_parts` - Adds unsafe `from_raw_parts` method (not recommended for general use).
 - `fixed_size` - Makes `AllocatorPool` create large fixed-size allocators, instead of flexibly-sized ones.
   Only supported on 64-bit little-endian platforms at present.

--- a/crates/oxc_allocator/src/bitset.rs
+++ b/crates/oxc_allocator/src/bitset.rs
@@ -1,13 +1,15 @@
 use std::fmt::{Debug, Display};
 
-use oxc_allocator::{Allocator, CloneIn, Vec};
+use crate::{Allocator, CloneIn, Vec};
 
+/// A bitset allocated in an arena.
 #[derive(PartialEq, Eq, Hash)]
 pub struct BitSet<'alloc> {
     entries: Vec<'alloc, u8>,
 }
 
 impl<'alloc> BitSet<'alloc> {
+    /// Create new [`BitSet`] with size `max_bit_count`, in the specified allocator.
     pub fn new_in(max_bit_count: usize, allocator: &'alloc Allocator) -> Self {
         Self {
             entries: Vec::from_iter_in(
@@ -17,10 +19,12 @@ impl<'alloc> BitSet<'alloc> {
         }
     }
 
+    /// Returns `true` if the bit at the given position is set.
     pub fn has_bit(&self, bit: usize) -> bool {
         (self.entries[bit / 8] & (1 << (bit & 7))) != 0
     }
 
+    /// Set the bit at the given position.
     pub fn set_bit(&mut self, bit: usize) {
         self.entries[bit / 8] |= 1 << (bit & 7);
     }

--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -18,6 +18,8 @@
 //!
 //! * `pool` - Enables [`AllocatorPool`].
 //!
+//! * `bitset` - Enables [`BitSet`].
+//!
 //! * `from_raw_parts` - Adds [`Allocator::from_raw_parts`] method.
 //!   Usage of this feature is not advisable, and it will be removed as soon as we're able to.
 //!
@@ -43,6 +45,8 @@ mod address;
 mod alloc;
 mod allocator;
 mod allocator_api2;
+#[cfg(feature = "bitset")]
+mod bitset;
 mod boxed;
 mod clone_in;
 mod convert;
@@ -59,6 +63,8 @@ mod vec2;
 pub use accessor::AllocatorAccessor;
 pub use address::{Address, GetAddress};
 pub use allocator::Allocator;
+#[cfg(feature = "bitset")]
+pub use bitset::BitSet;
 pub use boxed::Box;
 pub use clone_in::CloneIn;
 pub use convert::{FromIn, IntoIn};

--- a/crates/oxc_mangler/Cargo.toml
+++ b/crates/oxc_mangler/Cargo.toml
@@ -21,7 +21,7 @@ test = true
 doctest = false
 
 [dependencies]
-oxc_allocator = { workspace = true }
+oxc_allocator = { workspace = true, features = ["bitset"] }
 oxc_ast = { workspace = true }
 oxc_data_structures = { workspace = true, features = ["inline_string"] }
 oxc_index = { workspace = true }

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -5,7 +5,7 @@ use keep_names::collect_name_symbols;
 use rustc_hash::FxHashSet;
 
 use base54::base54;
-use oxc_allocator::{Allocator, Vec};
+use oxc_allocator::{Allocator, BitSet, Vec};
 use oxc_ast::ast::{Declaration, Program, Statement};
 use oxc_data_structures::inline_string::InlineString;
 use oxc_index::Idx;
@@ -13,12 +13,9 @@ use oxc_semantic::{AstNodes, Scoping, Semantic, SemanticBuilder, SymbolId};
 use oxc_span::Atom;
 
 pub(crate) mod base54;
-mod bitset;
 mod keep_names;
 
 pub use keep_names::MangleOptionsKeepNames;
-
-use crate::bitset::BitSet;
 
 #[derive(Default, Debug, Clone, Copy)]
 pub struct MangleOptions {


### PR DESCRIPTION
#13419 introduced a `BitSet` type which stores its data in the arena, in the mangler.

This type may be useful in other contexts, so move it from `oxc_mangler` into `oxc_allocator`. But put it behind a `bitset` feature, so only crates which use it pay for it.
