### PR TITLE
fix(linter/react/jsx-handler-names): do not detect the function name within the inline-function's body block

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
@@ -389,6 +389,9 @@ fn extract_callee_name_from_arrow_function<'a>(
     arrow_function: &'a ArrowFunctionExpression<'a>,
 ) -> Option<&'a str> {
     if !arrow_function.expression {
+        // Ignore arrow functions with block bodies like `() => { this.handleChange() }`.
+        // The event handler name can only be extracted from arrow functions
+        // with a single expression body, such as `() => this.handleChange()`.
         return None;
     }
     let Some(Statement::ExpressionStatement(stmt)) = arrow_function.body.statements.first() else {

--- a/crates/oxc_linter/src/snapshots/react_jsx_handler_names.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_handler_names.snap
@@ -1,91 +1,91 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler name
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: doSomethingOnChange
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={this.doSomethingOnChange} />
    ·                         ──────────────────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler name
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handlerChange
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={this.handlerChange} />
    ·                         ────────────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler name
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={this.handle} />
    ·                         ─────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler name
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle2
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={this.handle2} />
    ·                         ──────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler name
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handl3Change
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={this.handl3Change} />
    ·                         ───────────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler name
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle4change
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={this.handle4change} />
    ·                         ────────────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler name
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: takeCareOfChange
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={takeCareOfChange} />
    ·                         ──────────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler name
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: takeCareOfChange
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={() => this.takeCareOfChange()} />
    ·                         ───────────────────────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler prop name
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: only
    ╭─[jsx_handler_names.tsx:1:16]
  1 │ <TestComponent only={this.handleChange} />
    ·                ────
    ╰────
   help: Prop key for handleChange must begin with 'on'
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler prop name
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: only
    ╭─[jsx_handler_names.tsx:1:17]
  1 │ <TestComponent2 only={this.handleChange} />
    ·                 ────
    ╰────
   help: Prop key for handleChange must begin with 'on'
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler prop name
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: handleChange
    ╭─[jsx_handler_names.tsx:1:16]
  1 │ <TestComponent handleChange={this.handleChange} />
    ·                ────────────
    ╰────
   help: Prop key for handleChange must begin with 'on'
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler prop name
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: whenChange
    ╭─[jsx_handler_names.tsx:1:16]
  1 │ <TestComponent whenChange={handleChange} />
    ·                ──────────
    ╰────
   help: Prop key for handleChange must begin with 'on'
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler prop name
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: whenChange
    ╭─[jsx_handler_names.tsx:1:16]
  1 │ <TestComponent whenChange={() => handleChange()} />
    ·                ──────────
@@ -99,42 +99,42 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler prop name
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: onChange
    ╭─[jsx_handler_names.tsx:1:16]
  1 │ <TestComponent onChange={handleChange} />
    ·                ────────
    ╰────
   help: Prop key for handleChange must begin with 'when'
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler prop name
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: onChange
    ╭─[jsx_handler_names.tsx:1:16]
  1 │ <TestComponent onChange={() => handleChange()} />
    ·                ────────
    ╰────
   help: Prop key for handleChange must begin with 'when'
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler name
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handleChange
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={handleChange} />
    ·                         ──────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'when|on' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler prop name
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: somePrefixChange
    ╭─[jsx_handler_names.tsx:1:16]
  1 │ <TestComponent somePrefixChange={handleChange} />
    ·                ────────────────
    ╰────
   help: Prop key for handleChange must begin with 'when|on'
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler name
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: onChange
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={this.onChange} />
    ·                         ───────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler prop name
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: customPropNameBar
    ╭─[jsx_handler_names.tsx:5:31]
  4 │                 <div>
  5 │                   <MyLibInput customPropNameBar={handleInput} />;
@@ -143,7 +143,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Prop key for handleInput must begin with 'on'
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler prop name
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: customPropNameBar
    ╭─[jsx_handler_names.tsx:6:34]
  5 │                   <MyLibInput customPropNameBar={handleInput} />;
  6 │                   <MyLibCheckbox customPropNameBar={handleCheckbox} />;
@@ -152,7 +152,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Prop key for handleCheckbox must begin with 'on'
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler prop name
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: customPropNameBar
    ╭─[jsx_handler_names.tsx:7:32]
  6 │                   <MyLibCheckbox customPropNameBar={handleCheckbox} />;
  7 │                   <MyLibButton customPropNameBar={handleButton} />;

--- a/crates/oxc_linter/src/snapshots/react_jsx_handler_names.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_handler_names.snap
@@ -1,133 +1,140 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: doSomethingOnChange
+  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler name
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={this.doSomethingOnChange} />
    ·                         ──────────────────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handlerChange
+  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler name
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={this.handlerChange} />
    ·                         ────────────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle
+  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler name
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={this.handle} />
    ·                         ─────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle2
+  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler name
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={this.handle2} />
    ·                         ──────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handl3Change
+  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler name
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={this.handl3Change} />
    ·                         ───────────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle4change
+  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler name
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={this.handle4change} />
    ·                         ────────────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: takeCareOfChange
+  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler name
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={takeCareOfChange} />
    ·                         ──────────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: takeCareOfChange
+  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler name
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={() => this.takeCareOfChange()} />
    ·                         ───────────────────────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: only
+  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler prop name
    ╭─[jsx_handler_names.tsx:1:16]
  1 │ <TestComponent only={this.handleChange} />
    ·                ────
    ╰────
   help: Prop key for handleChange must begin with 'on'
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: only
+  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler prop name
    ╭─[jsx_handler_names.tsx:1:17]
  1 │ <TestComponent2 only={this.handleChange} />
    ·                 ────
    ╰────
   help: Prop key for handleChange must begin with 'on'
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: handleChange
+  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler prop name
    ╭─[jsx_handler_names.tsx:1:16]
  1 │ <TestComponent handleChange={this.handleChange} />
    ·                ────────────
    ╰────
   help: Prop key for handleChange must begin with 'on'
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: whenChange
+  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler prop name
    ╭─[jsx_handler_names.tsx:1:16]
  1 │ <TestComponent whenChange={handleChange} />
    ·                ──────────
    ╰────
   help: Prop key for handleChange must begin with 'on'
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: whenChange
+  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler prop name
    ╭─[jsx_handler_names.tsx:1:16]
  1 │ <TestComponent whenChange={() => handleChange()} />
    ·                ──────────
    ╰────
   help: Prop key for handleChange must begin with 'on'
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: onChange
+  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler name
+   ╭─[jsx_handler_names.tsx:1:25]
+ 1 │ <TestComponent onChange={() => { handleChange() }} />
+   ·                         ──────────────────────────
+   ╰────
+  help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
+
+  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler prop name
    ╭─[jsx_handler_names.tsx:1:16]
  1 │ <TestComponent onChange={handleChange} />
    ·                ────────
    ╰────
   help: Prop key for handleChange must begin with 'when'
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: onChange
+  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler prop name
    ╭─[jsx_handler_names.tsx:1:16]
  1 │ <TestComponent onChange={() => handleChange()} />
    ·                ────────
    ╰────
   help: Prop key for handleChange must begin with 'when'
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handleChange
+  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler name
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={handleChange} />
    ·                         ──────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'when|on' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: somePrefixChange
+  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler prop name
    ╭─[jsx_handler_names.tsx:1:16]
  1 │ <TestComponent somePrefixChange={handleChange} />
    ·                ────────────────
    ╰────
   help: Prop key for handleChange must begin with 'when|on'
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: onChange
+  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler name
    ╭─[jsx_handler_names.tsx:1:25]
  1 │ <TestComponent onChange={this.onChange} />
    ·                         ───────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: customPropNameBar
+  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler prop name
    ╭─[jsx_handler_names.tsx:5:31]
  4 │                 <div>
  5 │                   <MyLibInput customPropNameBar={handleInput} />;
@@ -136,7 +143,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Prop key for handleInput must begin with 'on'
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: customPropNameBar
+  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler prop name
    ╭─[jsx_handler_names.tsx:6:34]
  5 │                   <MyLibInput customPropNameBar={handleInput} />;
  6 │                   <MyLibCheckbox customPropNameBar={handleCheckbox} />;
@@ -145,7 +152,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Prop key for handleCheckbox must begin with 'on'
 
-  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler prop name: customPropNameBar
+  ⚠ eslint-plugin-react(jsx-handler-names): Bad handler prop name
    ╭─[jsx_handler_names.tsx:7:32]
  6 │                   <MyLibCheckbox customPropNameBar={handleCheckbox} />;
  7 │                   <MyLibButton customPropNameBar={handleButton} />;


### PR DESCRIPTION
This PR fixes a behavior of `react/jsx-handler-names` rule incompatible with that of the eslint-version.
## Fixed difference with the eslint version
With the configuration below:
```json
{ "checkInlineFunction": true, "checkLocalVariables": true }
```
the eslint version of `react/jsx-handler-names` rule treats the following code as invalid.
```tsx
<TestComponent onChange={() => { handleChange() }} />
```
But the current oxc version finds `handleChange` to be an event handler name and considers this code to be correct.

Along with this change, the diagnostic messages are also modified because the event handler name is not always available, and replaced "invalid" with "bad" to be in accordance with the eslint-version's message ID`badHandlerName` and `badPropKey`.
