### PR TITLE
refactor(allocator): add `#[repr(transparent)]` to `Vec` and `Box`

### DIFF
--- a/crates/oxc_allocator/src/boxed.rs
+++ b/crates/oxc_allocator/src/boxed.rs
@@ -30,6 +30,7 @@ use crate::Allocator;
 ///
 /// Static checks make this impossible to do. [`Box::new_in`] will refuse to compile if called
 /// with a [`Drop`] type.
+#[repr(transparent)]
 pub struct Box<'alloc, T: ?Sized>(NonNull<T>, PhantomData<(&'alloc (), T)>);
 
 impl<T: ?Sized> Box<'_, T> {

--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -37,6 +37,7 @@ type InnerVec<'a, T> = InnerVecGeneric<'a, T, Bump>;
 /// Static checks make this impossible to do. [`Vec::new_in`] and all other methods which create
 /// a [`Vec`] will refuse to compile if called with a [`Drop`] type.
 #[derive(PartialEq, Eq)]
+#[repr(transparent)]
 pub struct Vec<'alloc, T>(InnerVec<'alloc, T>);
 
 /// SAFETY: Even though `Bump` is not `Sync`, we can make `Vec<T>` `Sync` if `T` is `Sync` because:


### PR DESCRIPTION
Both these structs are just wrappers around another type. Best to put `#[repr(transparent)]` on them.