### PR TITLE
perf(mangler): do not sort `Vec` if empty

### DIFF
--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -321,10 +321,10 @@ impl<'t> Mangler<'t> {
             tmp_bindings.extend(
                 bindings.values().copied().filter(|binding| !keep_name_symbols.contains(binding)),
             );
-            tmp_bindings.sort_unstable();
             if tmp_bindings.is_empty() {
                 continue;
             }
+            tmp_bindings.sort_unstable();
 
             let mut slot = slot_liveness.len();
 


### PR DESCRIPTION
Tiny optimization to mangler. We sort a `Vec` and then check if it's empty. Move the empty check to be first, so can skip sorting in that case.