### PR TITLE
fix(tasks): use same version of `antd.js` for all tasks

### DIFF
--- a/tasks/common/src/test_file.rs
+++ b/tasks/common/src/test_file.rs
@@ -68,8 +68,8 @@ impl TestFiles {
             "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@main/RadixUIAdoptionSection.jsx",
             // Heavy with classes (554K)
             "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.0.269/build/pdf.mjs",
-            // ES5 (3.9M)
-            "https://cdn.jsdelivr.net/npm/antd@5.12.5/dist/antd.js",
+            // ES5 (6.7M)
+            "https://cdn.jsdelivr.net/npm/antd@4.16.1/dist/antd.js",
             // TypeScript syntax (189K)
             "https://cdn.jsdelivr.net/gh/microsoft/TypeScript@v5.3.3/src/compiler/binder.ts",
         ]


### PR DESCRIPTION
`minifier()` and `complicated()` were using different versions of `antd.js` as fixtures.

This was problematic as the tasks using these fixtures all download the file to same location (`target` dir) and don't re-download if the file is already present. This lead to unpredictable results depending on which task you ran first, and so which version was downloaded.

Use v4.16.1 for both. I chose v4.16.1 rather than v5.12.5, because there's a comment above `minifier` function saying the versions there (v4.16.1) are kept in sync with `privatenumber/minification-benchmarks`.
