### PR TITLE
refactor(ast): implement `RegExpLiteral::parse_pattern`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,6 +1735,7 @@ dependencies = [
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_data_structures",
+ "oxc_diagnostics",
  "oxc_estree",
  "oxc_regular_expression",
  "oxc_span",

--- a/crates/oxc_ast/Cargo.toml
+++ b/crates/oxc_ast/Cargo.toml
@@ -22,6 +22,7 @@ doctest = true
 oxc_allocator = { workspace = true }
 oxc_ast_macros = { workspace = true }
 oxc_data_structures = { workspace = true, features = ["inline_string"] }
+oxc_diagnostics = { workspace = true }
 oxc_estree = { workspace = true }
 oxc_regular_expression = { workspace = true }
 oxc_span = { workspace = true }

--- a/crates/oxc_regular_expression/src/parser/parser_impl.rs
+++ b/crates/oxc_regular_expression/src/parser/parser_impl.rs
@@ -11,18 +11,18 @@ use crate::{
 /// Regular expression parser for `/literal/` usage.
 /// - `pattern_text`: the text between `/` and `/`
 /// - `flags_text`: the text after the second `/`
-pub struct LiteralParser<'a> {
+pub struct LiteralParser<'a, 'b> {
     allocator: &'a Allocator,
     pattern_text: &'a str,
-    flags_text: Option<&'a str>,
+    flags_text: Option<&'b str>,
     options: Options,
 }
 
-impl<'a> LiteralParser<'a> {
+impl<'a, 'b> LiteralParser<'a, 'b> {
     pub fn new(
         allocator: &'a Allocator,
         pattern_text: &'a str,
-        flags_text: Option<&'a str>,
+        flags_text: Option<&'b str>,
         options: Options,
     ) -> Self {
         Self { allocator, pattern_text, flags_text, options }


### PR DESCRIPTION
Moved the parse function to oxc_ast from oxc_transformer to use it from the minifier.