### PR TITLE
refactor(regular_expression): extract `has_unsupported_regular_expression_pattern`

### DIFF
--- a/crates/oxc_regular_expression/src/ast_impl/mod.rs
+++ b/crates/oxc_regular_expression/src/ast_impl/mod.rs
@@ -1,4 +1,5 @@
 mod allocator;
 mod display;
 mod span;
+pub mod support;
 pub mod visit;

--- a/crates/oxc_regular_expression/src/ast_impl/support.rs
+++ b/crates/oxc_regular_expression/src/ast_impl/support.rs
@@ -1,0 +1,53 @@
+use crate::ast::{CharacterClass, CharacterClassContents, LookAroundAssertionKind, Pattern, Term};
+
+pub struct RegexUnsupportedPatterns {
+    pub named_capture_groups: bool,
+    pub unicode_property_escapes: bool,
+    pub look_behind_assertions: bool,
+}
+
+/// Check if the regular expression contains any unsupported syntax.
+///
+/// Based on parsed regular expression pattern.
+pub fn has_unsupported_regular_expression_pattern(
+    pattern: &Pattern,
+    unsupported: &RegexUnsupportedPatterns,
+) -> bool {
+    pattern.body.body.iter().any(|alternative| {
+        alternative.body.iter().any(|term| term_contains_unsupported(term, unsupported))
+    })
+}
+
+fn term_contains_unsupported(mut term: &Term, unsupported: &RegexUnsupportedPatterns) -> bool {
+    // Loop because `Term::Quantifier` contains a nested `Term`
+    loop {
+        match term {
+            Term::CapturingGroup(_) => return unsupported.named_capture_groups,
+            Term::UnicodePropertyEscape(_) => return unsupported.unicode_property_escapes,
+            Term::CharacterClass(character_class) => {
+                return unsupported.unicode_property_escapes
+                    && character_class_has_unicode_property_escape(character_class);
+            }
+            Term::LookAroundAssertion(assertion) => {
+                return unsupported.look_behind_assertions
+                    && matches!(
+                        assertion.kind,
+                        LookAroundAssertionKind::Lookbehind
+                            | LookAroundAssertionKind::NegativeLookbehind
+                    );
+            }
+            Term::Quantifier(quantifier) => term = &quantifier.body,
+            _ => return false,
+        }
+    }
+}
+
+fn character_class_has_unicode_property_escape(character_class: &CharacterClass) -> bool {
+    character_class.body.iter().any(|element| match element {
+        CharacterClassContents::UnicodePropertyEscape(_) => true,
+        CharacterClassContents::NestedCharacterClass(character_class) => {
+            character_class_has_unicode_property_escape(character_class)
+        }
+        _ => false,
+    })
+}

--- a/crates/oxc_regular_expression/src/lib.rs
+++ b/crates/oxc_regular_expression/src/lib.rs
@@ -15,6 +15,7 @@ mod generated {
 
 pub mod ast;
 pub use crate::{
+    ast_impl::support::{RegexUnsupportedPatterns, has_unsupported_regular_expression_pattern},
     ast_impl::visit,
     options::Options,
     parser::{ConstructorParser, LiteralParser},


### PR DESCRIPTION
Extracted the unsupported regex syntax code from the transformer to oxc_regular_expression to use it from the minifier.