### PR TITLE
fix(linter): change `typescript/no-confusing-void-expression` to pedantic

### DIFF
--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_tsgolint@no-floating-promises_index.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_tsgolint@no-floating-promises_index.ts.snap
@@ -2,19 +2,6 @@
 source: crates/oxc_language_server/src/tester.rs
 input_file: crates/oxc_language_server/fixtures/linter/tsgolint/no-floating-promises/index.ts
 ---
-code: "typescript-eslint(no-confusing-void-expression)"
-code_description.href: "None"
-message: "Returning a void expression from an arrow function shorthand is forbidden. Please add braces to the arrow function."
-range: Range { start: Position { line: 0, character: 50 }, end: Position { line: 0, character: 66 } }
-related_information[0].message: ""
-related_information[0].location.uri: "file://<variable>/fixtures/linter/tsgolint/no-floating-promises/index.ts"
-related_information[0].location.range: Range { start: Position { line: 0, character: 50 }, end: Position { line: 0, character: 66 } }
-severity: Some(Warning)
-source: Some("oxc")
-tags: None
-fixed: Single(FixedContent { message: None, code: "{  resolve(\"value\"); }", range: Range { start: Position { line: 0, character: 49 }, end: Position { line: 0, character: 66 } } })
-
-
 code: "typescript-eslint(no-floating-promises)"
 code_description.href: "None"
 message: "Promises must be awaited.\nhelp: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator."

--- a/crates/oxc_linter/src/rules/typescript/no_confusing_void_expression.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_confusing_void_expression.rs
@@ -51,7 +51,7 @@ declare_oxc_lint!(
     /// ```
     NoConfusingVoidExpression(tsgolint),
     typescript,
-    correctness,
+    pedantic,
     pending,
 );
 


### PR DESCRIPTION
This rule falls under `plugin:@typescript-eslint/strict-type-checked`.

This rule does not flag any incorrect code.