### PR TITLE
fix(language_server): include the diagnostic of the other linter

### DIFF
--- a/editors/vscode/fixtures/lint_on_run/.oxlintrc.json
+++ b/editors/vscode/fixtures/lint_on_run/.oxlintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "unicorn/no-empty-file": "off"
+  }
+}

--- a/editors/vscode/tests/test-helpers.ts
+++ b/editors/vscode/tests/test-helpers.ts
@@ -101,12 +101,27 @@ export async function loadFixture(fixture: string, workspaceDir: Uri = fixturesW
 }
 
 export async function getDiagnostics(file: string, workspaceDir: Uri = fixturesWorkspaceUri()): Promise<Diagnostic[]> {
+  const diagnostics = await getDiagnosticsWithoutClose(file, workspaceDir);
+  await commands.executeCommand('workbench.action.closeActiveEditor');
+  return diagnostics;
+}
+
+export async function getDiagnosticsWithoutClose(file: string, workspaceDir: Uri = fixturesWorkspaceUri()): Promise<Diagnostic[]> {
   const fileUri = Uri.joinPath(workspaceDir, 'fixtures', file);
   await window.showTextDocument(fileUri);
   await sleep(500);
   const diagnostics = languages.getDiagnostics(fileUri);
-  await commands.executeCommand('workbench.action.closeActiveEditor');
   return diagnostics;
+}
+
+export async function writeToFixtureFile(file: string, content: string, workspaceDir: Uri = fixturesWorkspaceUri()): Promise<void> {
+   const fileUri = Uri.joinPath(workspaceDir, 'fixtures', file);
+  await window.showTextDocument(fileUri);
+
+  for (const char of content) {
+      await commands.executeCommand('type', { text: char });
+      await sleep(50);
+  }
 }
 
 export async function waitForDiagnosticChange(): Promise<void> {


### PR DESCRIPTION
Not the `ServerLinter` and `WorkspaceWorker` are holding the diagnostics of a file.
The next PR will refactor it, so `WorkspaceWorker` will no longer hold a copy of it.

Wanted to be ready for a possible patch release

closes #13480