### PR TITLE
fix(semantic): handle edge cases checking `super`

### DIFF
--- a/tasks/coverage/misc/fail/oxc-13284-1.js
+++ b/tasks/coverage/misc/fail/oxc-13284-1.js
@@ -1,0 +1,305 @@
+// `super()` not in a class or object method
+super();
+() => () => 123 + super();
+if (true) { while (false) { { super(); } } }
+() => (arg = super()) => {
+  super();
+  () => () => 123 + super();
+  if (true) { while (false) { { super(); } } }
+};
+
+// `super()` in a function
+function f(arg = super()) {
+  super();
+  () => () => 123 + super();
+  if (true) { while (false) { { super(); } } }
+}
+f = function(arg = super()) {
+  super();
+  () => () => 123 + super();
+  if (true) { while (false) { { super(); } } }
+};
+
+// `super()` in class constructor of class without super class
+class A {
+  constructor(arg = super()) {
+    super();
+    () => (arg = super()) => 123 + super();
+    if (true) { while (false) { { super(); } } }
+  }
+}
+
+// `super()` in class properties
+class B extends Super {
+  prop = super();
+  static prop = () => (arg = super()) => 123 + super();
+
+  accessor access = super();
+  static accessor access = () => () => 123 + super();
+}
+
+// `super()` in class methods / getters / setters
+class C extends Super {
+  method(arg = super()) {
+    super();
+    () => (arg = super()) => 123 + super();
+    if (true) { while (false) { { super(); } } }
+  }
+
+  static method(arg = super()) {
+    super();
+    () => (arg = super()) => 123 + super();
+    if (true) { while (false) { { super(); } } }
+  }
+
+  ['x'](arg = super()) {
+    super();
+    () => (arg = super()) => 123 + super();
+    if (true) { while (false) { { super(); } } }
+  }
+
+  static ['x'](arg = super()) {
+    super();
+    () => (arg = super()) => 123 + super();
+    if (true) { while (false) { { super(); } } }
+  }
+
+  get y() {
+    super();
+    () => (arg = super()) => 123 + super();
+    if (true) { while (false) { { super(); } } }
+  }
+
+  set y(arg = super()) {
+    super();
+    () => (arg = super()) => 123 + super();
+    if (true) { while (false) { { super(); } } }
+  }
+
+  static get y() {
+    super();
+    () => (arg = super()) => 123 + super();
+    if (true) { while (false) { { super(); } } }
+  }
+
+  static set y(arg = super()) {
+    super();
+    () => (arg = super()) => 123 + super();
+    if (true) { while (false) { { super(); } } }
+  }
+}
+
+// `super()` in class static block
+class D extends Super {
+  static {
+    super();
+    () => (arg = super()) => 123 + super();
+    if (true) { while (false) { { super(); } } }
+  }
+}
+
+// `super()` in function or object method inside class constructor
+class E extends Super {
+  constructor() {
+    function inner(arg = super()) {
+      super();
+      () => (arg = super()) => 123 + super();
+      if (true) { while (false) { { super(); } } }
+    }
+    f = () => function(arg = super()) {
+      super();
+      () => (arg = super()) => 123 + super();
+      if (true) { while (false) { { super(); } } }
+    };
+    obj = {
+      method(arg = super()) {
+        super();
+        () => (arg = super()) => 123 + super();
+        if (true) { while (false) { { super(); } } }
+      },
+      set x(arg = super()) {
+        super();
+        () => (arg = super()) => 123 + super();
+        if (true) { while (false) { { super(); } } }
+      },
+    };
+  }
+}
+
+// `super()` in class computed keys
+class F extends Super {
+  [super()] = 1;
+  static [(arg = super()) => super()] = 2;
+  accessor [123 + super()] = 3;
+  static accessor [() => (arg = super()) => 123 + super()] = 4;
+  [super()]() {};
+  static [() => super()]() {};
+  get [super()]() {};
+  static get [() => super()]() {};
+  set [super()](v) {};
+  static set [() => () => 123 + super()](v) {};
+}
+
+// `super()` in class extends
+class G extends super() {}
+class H extends (() => () => 123 + super()) {}
+
+// `super()` in class decorators
+@super()
+class I extends Super {
+  @super() prop = 1;
+  @super() static prop = 2;
+  @super() accessor access = 3;
+  @super() static accessor access = 4;
+  @super() method() {}
+}
+
+// `super()` in properties / methods of class inside class constructor
+class J extends Super {
+  constructor() {
+    class Inner {
+      prop = super();
+      static prop = (arg = super()) => 123 + super();
+      accessor access = super();
+      static accessor access = (arg = super()) => 123 + super();
+      method() { super(); }
+      static method() { (arg = super()) => 123 + super(); }
+      get x() { super(); }
+      static get y() { (arg = super()) => 123 + super(); }
+      set x(v) { super(); }
+      static set y(v) { (arg = super()) => 123 + super(); }
+      static { super(); }
+    }
+  }
+}
+
+// `super()` in computed keys of class inside class property
+class K extends Super {
+  prop = class Inner {
+    [super()] = 1;
+    static [(arg = super()) => super()] = 2;
+    accessor [123 + super()] = 3;
+    static accessor [() => (arg = super()) => 123 + super()] = 4;
+    [super()]() {};
+    static [() => super()]() {};
+    get [super()]() {};
+    static get [() => super()]() {};
+    set [super()](v) {};
+    static set [() => () => 123 + super()](v) {};
+  };
+}
+
+// `super()` in computed keys of class inside class method
+class L extends Super {
+  method() {
+    class Inner {
+      [super()] = 1;
+      static [(arg = super()) => super()] = 2;
+      accessor [123 + super()] = 3;
+      static accessor [() => (arg = super()) => 123 + super()] = 4;
+      [super()]() {};
+      static [() => super()]() {};
+      get [super()]() {};
+      static get [() => super()]() {};
+      set [super()](v) {};
+      static set [() => () => 123 + super()](v) {};
+    }
+  }
+}
+
+// `super()` in extends clause of class inside class property
+class M extends Super {
+  prop1 = class Inner extends super() {};
+  prop2 = class Inner extends (() => (arg = super()) => 123 + super()) {};
+}
+
+// `super()` in extends clause of class inside class method
+class N extends Super {
+  method() {
+    class Inner1 extends super() {};
+    class Inner2 extends (() => (arg = super()) => 123 + super()) {};
+  }
+}
+
+// `super()` in decorators of class inside class property
+class O extends Super {
+  prop = @super() class Inner extends Super {
+    @super() prop = 1;
+    @super() static prop = 2;
+    @super() accessor access = 3;
+    @super() static accessor access = 4;
+    @super() method() {}
+  };
+}
+
+// `super()` in decorators of class inside class method
+class P extends Super {
+  method() {
+    @super()
+    class Inner extends Super {
+      @super() prop = 1;
+      @super() static prop = 2;
+      @super() accessor access = 3;
+      @super() static accessor access = 4;
+      @super() method() {}
+    }
+  }
+}
+
+// `super()` in deeply nested classes inside class method
+class Q extends Super {
+  method() {
+    class A {
+      [
+        class B {
+          [
+            class C {
+              [super()]() {}
+            }
+          ]() {}
+        }
+      ]() {}
+    }
+
+    class D extends class E extends class F extends super() {} {} {}
+
+    class G {
+      @(
+        class H {
+          @(
+            class I {
+              @super()
+              method() {}
+            }
+          )
+          method() {}
+        }
+      )
+      method() {}
+    }
+  }
+}
+
+// `super()` in object methods
+obj = {
+  method() {
+    super();
+    () => (arg = super()) => 123 + super();
+    if (true) { while (false) { { super(); } } }
+  },
+  ['x']() {
+    super();
+    () => (arg = super()) => 123 + super();
+    if (true) { while (false) { { super(); } } }
+  },
+  get x() {
+    super();
+    () => (arg = super()) => 123 + super();
+    if (true) { while (false) { { super(); } } }
+  },
+  set x(v) {
+    super();
+    () => (arg = super()) => 123 + super();
+    if (true) { while (false) { { super(); } } }
+  },
+};

--- a/tasks/coverage/misc/fail/oxc-13284-2.js
+++ b/tasks/coverage/misc/fail/oxc-13284-2.js
@@ -1,0 +1,145 @@
+// `super.foo` not in a class or object method
+super.foo;
+() => (arg = super.foo) => 123 + super.foo;
+if (true) { while (false) { { super.foo; } } }
+() => () => {
+  super.foo;
+  () => (arg = super.foo) => 123 + super.foo;
+  if (true) { while (false) { { super.foo; } } }
+};
+
+// `super.foo` in a function
+function f(arg = super.foo) {
+  super.foo;
+  () => (arg = super.foo) => 123 + super.foo;
+  if (true) { while (false) { { super.foo; } } }
+}
+f = function(arg = super.foo) {
+  super.foo;
+  () => (arg = super.foo) => 123 + super.foo;
+  if (true) { while (false) { { super.foo; } } }
+};
+
+// `super.foo` in function inside class constructor
+class A extends Super {
+  constructor() {
+    function inner(arg = super.foo) {
+      super.foo;
+      () => (arg = super.foo) => 123 + super.foo;
+      if (true) { while (false) { { super.foo; } } }
+    }
+    f = () => function(arg = super.foo) {
+      super.foo;
+      () => (arg = super.foo) => 123 + super.foo;
+      if (true) { while (false) { { super.foo; } } }
+    };
+  }
+}
+
+// `super.foo` in function inside class method
+class B extends Super {
+  method() {
+    function inner(arg = super.foo) {
+      super.foo;
+      () => (arg = super.foo) => 123 + super.foo;
+      if (true) { while (false) { { super.foo; } } }
+    }
+    f = () => function(arg = super.foo) {
+      super.foo;
+      () => (arg = super.foo) => 123 + super.foo;
+      if (true) { while (false) { { super.foo; } } }
+    };
+  }
+}
+
+// `super.foo` in function inside class property
+class C extends Super {
+  prop = () => {
+    function inner(arg = super.foo) {
+      super.foo;
+      () => (arg = super.foo) => 123 + super.foo;
+      if (true) { while (false) { { super.foo; } } }
+    }
+    f = () => function(arg = super.foo) {
+      super.foo;
+      () => (arg = super.foo) => 123 + super.foo;
+      if (true) { while (false) { { super.foo; } } }
+    };
+  };
+}
+
+// `super.foo` in class computed keys
+class D {
+  [super.foo] = 1;
+  static [() => super.foo] = 2;
+  accessor [123 + super.foo] = 3;
+  static accessor [() => () => 123 + super.foo] = 4;
+  [super.foo]() {};
+  static [() => super.foo]() {};
+  get [super.foo]() {};
+  static get [() => super.foo]() {};
+  set [super.foo](v) {};
+  static set [() => () => 123 + super.foo](v) {};
+}
+
+// `super.foo` in class extends
+class E extends super.foo {}
+class F extends (() => (arg = super.foo) => 123 + super.foo) {}
+
+// `super.foo` in class decorators
+@super.foo
+class G extends Super {
+  @super.foo prop = 1;
+  @super.foo static prop = 2;
+  @super.foo accessor access = 3;
+  @super.foo static accessor access = 4;
+  @super.foo method() {}
+}
+
+// `super.foo` in computed keys in class inside function
+function g() {
+  class Inner {
+    [super.foo] = 1;
+    static [(arg = super.foo) => super.foo] = 2;
+    accessor [123 + super.foo] = 3;
+    static accessor [() => (arg = super.foo) => 123 + super.foo] = 4;
+    [super.foo]() {};
+    static [() => super.foo]() {};
+    get [super.foo]() {};
+    static get [() => super.foo]() {};
+    set [super.foo](v) {};
+    static set [() => () => 123 + super.foo](v) {};
+  }
+}
+
+// `super.foo` in extends clause of class inside function
+function h() {
+  class E extends super.foo {}
+  class F extends (() => (arg = super.foo) => 123 + super.foo) {}
+}
+
+// `super.foo` in decorators in class inside function
+function i() {
+  @super.foo
+  class Inner {
+    @super.foo prop = 1;
+    @super.foo static prop = 2;
+    @super.foo accessor access = 3;
+    @super.foo static accessor access = 4;
+    @super.foo method() {}
+  }
+}
+
+// `super.foo` in object properties
+obj = {
+  prop: (arg = super.foo) => {
+    super.foo;
+    () => (arg = super.foo) => 123 + super.foo;
+    if (true) { while (false) { { super.foo; } } }
+  },
+  ['x']: (arg = super.foo) => {
+    super.foo;
+    () => (arg = super.foo) => 123 + super.foo;
+    if (true) { while (false) { { super.foo; } } }
+  },
+};

--- a/tasks/coverage/misc/fail/oxc-13284.ts
+++ b/tasks/coverage/misc/fail/oxc-13284.ts
@@ -1,0 +1,36 @@
+// Not sure this is correct, but adding this test to make sure it doesn't panic at least.
+// See comment in `check_super` in `oxc_semantic`.
+
+// `super()`
+class C extends Super {
+  [keys: string]: typeof import('x', { with: super() }).y;
+}
+
+class D extends Super {
+  [keys: typeof import('x', { with: super() }).y]: string;
+}
+
+class Outer extends Super {
+  constructor() {
+    class Inner {
+      [keys: string]: typeof import('x', { with: super() }).y;
+    }
+  }
+}
+
+class Outer2 {
+  constructor() {
+    class Inner extends Super {
+      [keys: typeof import('x', { with: super() }).y]: string;
+    }
+  }
+}
+
+// `super.foo`
+class E {
+  [keys: typeof super.foo]: string;
+}
+
+class F {
+  [keys: typeof import('x', { with: super.foo }).y]: string;
+}

--- a/tasks/coverage/misc/pass/oxc-13284.js
+++ b/tasks/coverage/misc/pass/oxc-13284.js
@@ -1,9 +1,587 @@
-class C {
-  foo() {
-    return {
-      bar() {
-        super.bar();
-      },
+// `super()` / `super.prop` / `super.method()` in class constructor
+class C extends S {
+  constructor(arg = super(), arg2 = super.foo, arg3 = () => super.bar()) {
+    super();
+    super.foo;
+    super.bar();
+
+    () => (arg = super(), arg2 = super.foo, arg3 = () => super.bar()) => {
+      if (true) {
+        while (false) {
+          (arg = super(), arg2 = super.foo, arg3 = () => super.bar()) => {
+            super();
+            super.foo;
+            super.bar();
+          };
+        }
+      }
+    }
+  }
+}
+
+// `super.prop` / `super.method()` in class
+class D {
+  prop1 = super.foo;
+  prop2 = () => super.bar();
+  prop3 = () => (arg = super.qux) => {
+    if (true) { while (false) { { super.bing; } } }
+  };
+  prop4 = {
+    objMethod(arg = super.foo, arg2 = () => super.bar()) {
+      super.foo;
+      () => super.bar();
+      (arg = super.qux) => {};
+      if (true) { while (false) { { super.bing; } } }
+    }
+  };
+
+  accessor access1 = super.foo;
+  accessor access2 = () => super.bar();
+  accessor access3 = () => (arg = super.qux) => {
+    if (true) { while (false) { { super.bing; } } }
+  };
+  accessor access4 = {
+    objMethod(arg = super.foo, arg2 = () => super.bar()) {
+      super.foo;
+      () => super.bar();
+      (arg = super.qux) => {};
+      if (true) { while (false) { { super.bing; } } }
+    }
+  };
+
+  static prop1 = super.foo;
+  static prop2 = () => super.bar();
+  static prop3 = () => (arg = super.qux) => {
+    if (true) { while (false) { { super.bing; } } }
+  };
+  static prop4 = {
+    objMethod(arg = super.foo, arg2 = () => super.bar()) {
+      super.foo;
+      () => super.bar();
+      (arg = super.qux) => {};
+      if (true) { while (false) { { super.bing; } } }
+    }
+  };
+
+  static accessor access1 = super.foo;
+  static accessor access2 = () => super.bar();
+  static accessor access3 = () => () => {
+    if (true) { while (false) { { super.qux; } } }
+  };
+  static accessor access4 = {
+    objMethod(arg = super.foo, arg2 = () => super.bar()) {
+      super.foo;
+      () => super.bar();
+      (arg = super.qux) => {};
+      if (true) { while (false) { { super.bing; } } }
+    }
+  };
+
+  method(arg = super.foo, arg2 = () => super.bar()) {
+    super.foo;
+    () => super.bar();
+    (arg = super.qux) => {};
+    if (true) { while (false) { { super.bing; } } }
+
+    obj = {
+      objMethod(arg = super.foo, arg2 = () => super.bar()) {
+        super.foo;
+        () => super.bar();
+        (arg = super.qux) => {};
+        if (true) { while (false) { { super.bing; } } }
+      }
+    };
+  }
+
+  static method(arg = super.foo, arg2 = () => super.bar()) {
+    super.foo;
+    () => super.bar();
+    (arg = super.qux) => {};
+    if (true) { while (false) { { super.bing; } } }
+
+    obj = {
+      objMethod(arg = super.foo, arg2 = () => super.bar()) {
+        super.foo;
+        () => super.bar();
+        (arg = super.qux) => {};
+        if (true) { while (false) { { super.bing; } } }
+      }
+    };
+  }
+
+  get x() {
+    super.foo;
+    () => super.bar();
+    (arg = super.qux) => {};
+    if (true) { while (false) { { super.bing; } } }
+
+    obj = {
+      objMethod(arg = super.foo, arg2 = () => super.bar()) {
+        super.foo;
+        () => super.bar();
+        (arg = super.qux) => {};
+        if (true) { while (false) { { super.bing; } } }
+      }
+    };
+  }
+
+  set x(arg = (super.foo, () => super.bar())) {
+    super.foo;
+    () => super.bar();
+    (arg = super.qux) => {};
+    if (true) { while (false) { { super.bing; } } }
+
+    obj = {
+      objMethod(arg = super.foo, arg2 = () => super.bar()) {
+        super.foo;
+        () => super.bar();
+        (arg = super.qux) => {};
+        if (true) { while (false) { { super.bing; } } }
+      }
+    };
+  }
+
+  static {
+    super.foo;
+    () => super.bar();
+    (arg = super.qux) => {};
+    if (true) { while (false) { { super.bing; } } }
+
+    obj = {
+      objMethod(arg = super.foo, arg2 = () => super.bar()) {
+        super.foo;
+        () => super.bar();
+        (arg = super.qux) => {};
+        if (true) { while (false) { { super.bing; } } }
+      }
     };
   }
 }
+
+// `super()` in nested class
+class Outer extends S {
+  constructor() {
+    class Inner extends S {
+      constructor(arg = super()) {
+        super();
+      }
+    }
+
+    // `super` refers to `Outer`'s `super`
+
+    class Inner2 {
+      [super()] = 1;
+      [super.foo] = 2;
+      accessor [super()] = 3;
+      accessor [super.foo] = 4;
+      [() => 123 + super()]() {}
+      [() => 123 + super.bar()]() {}
+    }
+
+    class Inner3 extends super() {}
+    class Inner4 extends super.foo {}
+
+    @super()
+    @super.foo
+    class Inner5 {}
+
+    class Inner6 {
+      @super()
+      @super.foo
+      prop = 1;
+
+      @super()
+      @super.foo
+      static prop = 2;
+
+      @super()
+      @super.foo
+      accessor access = 3;
+
+      @super()
+      @super.foo
+      static accessor access = 4;
+
+      @super()
+      @super.foo
+      method() {}
+
+      @super()
+      @super.foo
+      static method() {}
+    }
+  }
+}
+
+// `super.prop` / `super.method()` in nested class
+class Outer2 {
+  // `super` refers to `Outer2`'s `super`
+
+  prop1 = class Inner {
+    [super.foo] = 1;
+    accessor [super.foo] = 2;
+    [(arg = super.foo) => 123 + super.bar()]() {};
+    @super.qux prop = 3;
+    @super.bing accessor access = 4;
+    @super.doom method() {}
+  };
+  prop2 = class Inner2 extends super.foo {};
+  prop3 = 123 + (() => () => 456 + class Inner3 {
+    [super.foo] = 1;
+    accessor [super.foo] = 2;
+    [(arg = super.foo) => 123 + super.bar()]() {};
+    @super.qux prop = 3;
+    @super.bing accessor access = 4;
+    @super.doom method() {}
+  });
+  prop4 = 123 + (() => () => 456 + class Inner4 extends super.foo {});
+
+  static prop1 = class Inner {
+    [super.foo] = 1;
+    accessor [super.foo] = 2;
+    [(arg = super.foo) => 123 + super.bar()]() {};
+    @super.qux prop = 3;
+    @super.bing accessor access = 4;
+    @super.doom method() {}
+  };
+  static prop2 = class Inner2 extends super.foo {};
+  static prop3 = 123 + (() => () => 456 + class Inner3 {
+    [super.foo] = 1;
+    accessor [super.foo] = 2;
+    [(arg = super.foo) => 123 + super.bar()]() {};
+    @super.qux prop = 3;
+    @super.bing accessor access = 4;
+    @super.doom method() {}
+  });
+  static prop4 = 123 + (() => () => 456 + class Inner4 extends super.foo {});
+
+  method() {
+    class Inner {
+      [super.foo] = 1;
+      accessor [super.foo] = 2;
+      [(arg = super.foo) => 123 + super.bar()]() {};
+      @super.qux prop = 3;
+      @super.bing accessor access = 4;
+      @super.doom method() {}
+    }
+    class Inner2 extends super.foo {}
+    123 + (() => () => 456 + class Inner3 {
+      [super.foo] = 1;
+      accessor [super.foo] = 2;
+      [super.bar()]() {};
+      @super.qux prop = 3;
+      @super.bing accessor access = 4;
+      @super.doom method() {}
+    });
+    123 + (() => () => 456 + class Inner4 extends super.foo {});
+  }
+
+  static method() {
+    class Inner {
+      [super.foo] = 1;
+      accessor [super.foo] = 2;
+      [(arg = super.foo) => 123 + super.bar()]() {};
+      @super.qux prop = 3;
+      @super.bing accessor access = 4;
+      @super.doom method() {}
+    }
+    class Inner2 extends super.foo {}
+    123 + (() => () => 456 + class Inner3 {
+      [super.foo] = 1;
+      accessor [super.foo] = 2;
+      [(arg = super.foo) => 123 + super.bar()]() {};
+      @super.qux prop = 3;
+      @super.bing accessor access = 4;
+      @super.doom method() {}
+    });
+    123 + (() => () => 456 + class Inner4 extends super.foo {});
+  }
+
+  get x() {
+    class Inner {
+      [super.foo] = 1;
+      accessor [super.foo] = 2;
+      [(arg = super.foo) => 123 + super.bar()]() {};
+      @super.qux prop = 3;
+      @super.bing accessor access = 4;
+      @super.doom method() {}
+    }
+    class Inner2 extends super.foo {}
+    123 + (() => () => 456 + class Inner3 {
+      [super.foo] = 1;
+      accessor [super.foo] = 2;
+      [super.bar()]() {};
+      @super.qux prop = 3;
+      @super.bing accessor access = 4;
+      @super.doom method() {}
+    });
+    123 + (() => () => 456 + class Inner4 extends super.foo {});
+  }
+
+  static {
+    class Inner {
+      [super.foo] = 1;
+      accessor [super.foo] = 2;
+      [(arg = super.foo) => 123 + super.bar()]() {};
+      @super.qux prop = 3;
+      @super.bing accessor access = 4;
+      @super.doom method() {}
+    }
+    class Inner2 extends super.foo {}
+    123 + (() => () => 456 + class Inner3 {
+      [super.foo] = 1;
+      accessor [super.foo] = 2;
+      [(arg = super.foo) => 123 + super.bar()]() {};
+      @super.qux prop = 3;
+      @super.bing accessor access = 4;
+      @super.doom method() {}
+    });
+    123 + (() => () => 456 + class Inner4 extends super.foo {});
+  }
+}
+
+// `super.prop` / `super.method()` in object method
+obj = {
+  method(arg = super.foo, arg2 = () => super.bar()) {
+    super.foo;
+    () => super.bar();
+    123 + (() => (arg = super.foo) => 456 + super.qux);
+    if (true) { while (false) { { super.bing; } } }
+  },
+  get x() {
+    super.foo;
+    () => super.bar();
+    123 + (() => (arg = super.foo) => 456 + super.qux);
+    if (true) { while (false) { { super.bing; } } }
+  },
+  set x(arg = (super.foo, () => super.bar())) {
+    super.foo;
+    () => super.bar();
+    123 + (() => (arg = super.foo) => 456 + super.qux);
+    if (true) { while (false) { { super.bing; } } }
+  },
+  outer() {
+    return {
+      inner(arg = super.foo, arg2 = () => super.bar()) {
+        super.foo;
+        () => super.bar();
+        123 + (() => (arg = super.foo) => 456 + super.qux);
+        if (true) { while (false) { { super.bing; } } }
+      }
+    };
+  },
+};
+
+// Class nested in object method
+obj = {
+  method() {
+    class Inner {
+      prop1 = super.foo;
+      prop2 = () => super.bar();
+      prop3 = () => (arg = super.qux) => {
+        if (true) { while (false) { { super.bing; } } }
+      };
+      prop4 = {
+        objMethod(arg = super.foo, arg2 = () => super.bar()) {
+          super.foo;
+          () => super.bar();
+          (arg = super.qux) => {};
+          if (true) { while (false) { { super.bing; } } }
+        }
+      };
+
+      accessor access1 = super.foo;
+      accessor access2 = () => super.bar();
+      accessor access3 = () => () => {
+        if (true) { while (false) { { super.qux; } } }
+      };
+      accessor access4 = {
+        objMethod(arg = super.foo, arg2 = () => super.bar()) {
+          super.foo;
+          () => super.bar();
+          (arg = super.qux) => {};
+          if (true) { while (false) { { super.bing; } } }
+        }
+      };
+
+      method(arg = super.foo, arg2 = () => super.bar()) {
+        super.foo;
+        () => super.bar();
+        if (true) { while (false) { { super.qux; } } }
+
+        obj = {
+          objMethod(arg = super.foo, arg2 = () => super.bar()) {
+            super.foo;
+            () => super.bar();
+            (arg = super.qux) => {};
+            if (true) { while (false) { { super.bing; } } }
+          }
+        };
+      }
+
+      get x() {
+        super.foo;
+        () => super.bar();
+        if (true) { while (false) { { super.qux; } } }
+
+        obj = {
+          objMethod(arg = super.foo, arg2 = () => super.bar()) {
+            super.foo;
+            () => super.bar();
+            (arg = super.qux) => {};
+            if (true) { while (false) { { super.bing; } } }
+          }
+        };
+      }
+
+      set x(arg = (super.foo, () => super.bar())) {
+        super.foo;
+        () => super.bar();
+        if (true) { while (false) { { super.qux; } } }
+
+        obj = {
+          objMethod(arg = super.foo, arg2 = () => super.bar()) {
+            super.foo;
+            () => super.bar();
+            (arg = super.qux) => {};
+            if (true) { while (false) { { super.bing; } } }
+          }
+        };
+      }
+
+      static {
+        super.foo;
+        () => super.bar();
+        (arg = super.qux) => {};
+        if (true) { while (false) { { super.bing; } } }
+      }
+    }
+
+    // `super` refers to object method's `super`
+
+    class Inner2 {
+      [super.foo] = 1;
+      accessor [super.foo] = 2;
+      [() => 123 + super.bar()]() {}
+      @super.qux prop5 = 3;
+      @super.bing accessor access = 4;
+      @super.doom method() {}
+    }
+
+    class Inner3 extends super.foo {}
+
+    @super.foo
+    class Inner4 {}
+
+    class Inner5 {
+      @super.foo prop = 1;
+      @super.foo accessor access = 1;
+      @super.foo static prop = 2;
+      @super.foo static accessor access = 1;
+      @super.foo method() {}
+      @super.foo static method() {}
+    }
+  }
+};
+
+// `super()` in deeply nested classes inside class constructor
+class Outer3 extends Super {
+  constructor() {
+    class A {
+      [
+        class B {
+          [
+            class C {
+              [super()]() {}
+            }
+          ]() {}
+        }
+      ]() {}
+    }
+
+    class D extends class E extends class F extends super() {} {} {}
+
+    class G {
+      @(
+        class H {
+          @(
+            class I {
+              @super()
+              method() {}
+            }
+          )
+          method() {}
+        }
+      )
+      method() {}
+    }
+  }
+}
+
+// `super.foo` in deeply nested classes inside class method
+class Outer4 {
+  method() {
+    class A {
+      [
+        class B {
+          [
+            class C {
+              [super.foo]() {}
+            }
+          ]() {}
+        }
+      ]() {}
+    }
+
+    class D extends class E extends class F extends super.foo {} {} {}
+
+    class G {
+      @(
+        class H {
+          @(
+            class I {
+              @super.foo
+              method() {}
+            }
+          )
+          method() {}
+        }
+      )
+      method() {}
+    }
+  }
+}
+
+// `super.foo` in deeply nested classes inside object method
+obj = {
+  method() {
+    class A {
+      [
+        class B {
+          [
+            class C {
+              [super.foo]() {}
+            }
+          ]() {}
+        }
+      ]() {}
+    }
+
+    class D extends class E extends class F extends super.foo {} {} {}
+
+    class G {
+      @(
+        class H {
+          @(
+            class I {
+              @super.foo
+              method() {}
+            }
+          )
+          method() {}
+        }
+      )
+      method() {}
+    }
+  }
+};

--- a/tasks/coverage/misc/pass/oxc-13284.ts
+++ b/tasks/coverage/misc/pass/oxc-13284.ts
@@ -1,9 +1,47 @@
+// Not sure this is correct, but adding this test to make sure it doesn't panic at least.
+// See comment in `check_super` in `oxc_semantic`.
+
 class C {
-  foo() {
-    return {
-      bar() {
-        super.bar();
-      },
-    };
+  [keys: string]: typeof super.foo;
+}
+
+class D {
+  [keys: string]: typeof import('x', { with: super.foo }).y;
+}
+
+class Outer extends Super {
+  constructor() {
+    class Inner {
+      [keys: typeof super.foo]: string;
+    }
+    class Inner2 {
+      [keys: typeof import('x', { with: super.foo }).y]: string;
+    }
+    class Inner3 {
+      [keys: typeof import('x', { with: super() }).y]: string;
+    }
+  }
+
+  prop1 = class Inner {
+    [keys: typeof super.foo]: string;
+  };
+  prop2 = class Inner {
+    [keys: typeof import('x', { with: super.foo }).y]: string;
+  };
+
+  accessor access1 = class Inner {
+    [keys: typeof super.foo]: string;
+  };
+  accessor access2 = class Inner {
+    [keys: typeof import('x', { with: super.foo }).y]: string;
+  };
+
+  method() {
+    class Inner {
+      [keys: typeof super.foo]: string;
+    }
+    class Inner2 {
+      [keys: typeof import('x', { with: super.foo }).y]: string;
+    }
   }
 }

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 49/49 (100.00%)
 Positive Passed: 49/49 (100.00%)
-Negative Passed: 83/83 (100.00%)
+Negative Passed: 86/86 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -448,6 +448,2350 @@ Negative Passed: 83/83 (100.00%)
  1 │ {if(\ ()<1){}}
    ·      ─
    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+   ╭─[misc/fail/oxc-13284-1.js:2:1]
+ 1 │ // `super()` not in a class or object method
+ 2 │ super();
+   · ───────
+ 3 │ () => () => 123 + super();
+   ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+   ╭─[misc/fail/oxc-13284-1.js:3:19]
+ 2 │ super();
+ 3 │ () => () => 123 + super();
+   ·                   ───────
+ 4 │ if (true) { while (false) { { super(); } } }
+   ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+   ╭─[misc/fail/oxc-13284-1.js:4:31]
+ 3 │ () => () => 123 + super();
+ 4 │ if (true) { while (false) { { super(); } } }
+   ·                               ───────
+ 5 │ () => (arg = super()) => {
+   ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+   ╭─[misc/fail/oxc-13284-1.js:5:14]
+ 4 │ if (true) { while (false) { { super(); } } }
+ 5 │ () => (arg = super()) => {
+   ·              ───────
+ 6 │   super();
+   ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+   ╭─[misc/fail/oxc-13284-1.js:6:3]
+ 5 │ () => (arg = super()) => {
+ 6 │   super();
+   ·   ───────
+ 7 │   () => () => 123 + super();
+   ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+   ╭─[misc/fail/oxc-13284-1.js:7:21]
+ 6 │   super();
+ 7 │   () => () => 123 + super();
+   ·                     ───────
+ 8 │   if (true) { while (false) { { super(); } } }
+   ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+   ╭─[misc/fail/oxc-13284-1.js:8:33]
+ 7 │   () => () => 123 + super();
+ 8 │   if (true) { while (false) { { super(); } } }
+   ·                                 ───────
+ 9 │ };
+   ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:12:18]
+ 11 │ // `super()` in a function
+ 12 │ function f(arg = super()) {
+    ·                  ───────
+ 13 │   super();
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:13:3]
+ 12 │ function f(arg = super()) {
+ 13 │   super();
+    ·   ───────
+ 14 │   () => () => 123 + super();
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:14:21]
+ 13 │   super();
+ 14 │   () => () => 123 + super();
+    ·                     ───────
+ 15 │   if (true) { while (false) { { super(); } } }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:15:33]
+ 14 │   () => () => 123 + super();
+ 15 │   if (true) { while (false) { { super(); } } }
+    ·                                 ───────
+ 16 │ }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:17:20]
+ 16 │ }
+ 17 │ f = function(arg = super()) {
+    ·                    ───────
+ 18 │   super();
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:18:3]
+ 17 │ f = function(arg = super()) {
+ 18 │   super();
+    ·   ───────
+ 19 │   () => () => 123 + super();
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:19:21]
+ 18 │   super();
+ 19 │   () => () => 123 + super();
+    ·                     ───────
+ 20 │   if (true) { while (false) { { super(); } } }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:20:33]
+ 19 │   () => () => 123 + super();
+ 20 │   if (true) { while (false) { { super(); } } }
+    ·                                 ───────
+ 21 │ };
+    ╰────
+
+  × 'super' can only be referenced in a derived class.
+    ╭─[misc/fail/oxc-13284-1.js:24:1]
+ 23 │     // `super()` in class constructor of class without super class
+ 24 │ ╭─▶ class A {
+ 25 │ │     constructor(arg = super()) {
+    · │                       ─────
+ 26 │ │       super();
+ 27 │ │       () => (arg = super()) => 123 + super();
+ 28 │ │       if (true) { while (false) { { super(); } } }
+ 29 │ │     }
+ 30 │ ├─▶ }
+    · ╰──── class does not have `extends`
+ 31 │     
+    ╰────
+  help: either remove this super, or extend the class
+
+  × 'super' can only be referenced in a derived class.
+    ╭─[misc/fail/oxc-13284-1.js:24:1]
+ 23 │     // `super()` in class constructor of class without super class
+ 24 │ ╭─▶ class A {
+ 25 │ │     constructor(arg = super()) {
+ 26 │ │       super();
+    · │       ─────
+ 27 │ │       () => (arg = super()) => 123 + super();
+ 28 │ │       if (true) { while (false) { { super(); } } }
+ 29 │ │     }
+ 30 │ ├─▶ }
+    · ╰──── class does not have `extends`
+ 31 │     
+    ╰────
+  help: either remove this super, or extend the class
+
+  × 'super' can only be referenced in a derived class.
+    ╭─[misc/fail/oxc-13284-1.js:24:1]
+ 23 │     // `super()` in class constructor of class without super class
+ 24 │ ╭─▶ class A {
+ 25 │ │     constructor(arg = super()) {
+ 26 │ │       super();
+ 27 │ │       () => (arg = super()) => 123 + super();
+    · │                    ─────
+ 28 │ │       if (true) { while (false) { { super(); } } }
+ 29 │ │     }
+ 30 │ ├─▶ }
+    · ╰──── class does not have `extends`
+ 31 │     
+    ╰────
+  help: either remove this super, or extend the class
+
+  × 'super' can only be referenced in a derived class.
+    ╭─[misc/fail/oxc-13284-1.js:24:1]
+ 23 │     // `super()` in class constructor of class without super class
+ 24 │ ╭─▶ class A {
+ 25 │ │     constructor(arg = super()) {
+ 26 │ │       super();
+ 27 │ │       () => (arg = super()) => 123 + super();
+    · │                                      ─────
+ 28 │ │       if (true) { while (false) { { super(); } } }
+ 29 │ │     }
+ 30 │ ├─▶ }
+    · ╰──── class does not have `extends`
+ 31 │     
+    ╰────
+  help: either remove this super, or extend the class
+
+  × 'super' can only be referenced in a derived class.
+    ╭─[misc/fail/oxc-13284-1.js:24:1]
+ 23 │     // `super()` in class constructor of class without super class
+ 24 │ ╭─▶ class A {
+ 25 │ │     constructor(arg = super()) {
+ 26 │ │       super();
+ 27 │ │       () => (arg = super()) => 123 + super();
+ 28 │ │       if (true) { while (false) { { super(); } } }
+    · │                                     ─────
+ 29 │ │     }
+ 30 │ ├─▶ }
+    · ╰──── class does not have `extends`
+ 31 │     
+    ╰────
+  help: either remove this super, or extend the class
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:34:10]
+ 33 │ class B extends Super {
+ 34 │   prop = super();
+    ·          ───────
+ 35 │   static prop = () => (arg = super()) => 123 + super();
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:35:30]
+ 34 │   prop = super();
+ 35 │   static prop = () => (arg = super()) => 123 + super();
+    ·                              ───────
+ 36 │ 
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:35:48]
+ 34 │   prop = super();
+ 35 │   static prop = () => (arg = super()) => 123 + super();
+    ·                                                ───────
+ 36 │ 
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:37:21]
+ 36 │ 
+ 37 │   accessor access = super();
+    ·                     ───────
+ 38 │   static accessor access = () => () => 123 + super();
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:38:46]
+ 37 │   accessor access = super();
+ 38 │   static accessor access = () => () => 123 + super();
+    ·                                              ───────
+ 39 │ }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:43:16]
+ 42 │ class C extends Super {
+ 43 │   method(arg = super()) {
+    ·                ───────
+ 44 │     super();
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:44:5]
+ 43 │   method(arg = super()) {
+ 44 │     super();
+    ·     ───────
+ 45 │     () => (arg = super()) => 123 + super();
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:45:18]
+ 44 │     super();
+ 45 │     () => (arg = super()) => 123 + super();
+    ·                  ───────
+ 46 │     if (true) { while (false) { { super(); } } }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:45:36]
+ 44 │     super();
+ 45 │     () => (arg = super()) => 123 + super();
+    ·                                    ───────
+ 46 │     if (true) { while (false) { { super(); } } }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:46:35]
+ 45 │     () => (arg = super()) => 123 + super();
+ 46 │     if (true) { while (false) { { super(); } } }
+    ·                                   ───────
+ 47 │   }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:49:23]
+ 48 │ 
+ 49 │   static method(arg = super()) {
+    ·                       ───────
+ 50 │     super();
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:50:5]
+ 49 │   static method(arg = super()) {
+ 50 │     super();
+    ·     ───────
+ 51 │     () => (arg = super()) => 123 + super();
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:51:18]
+ 50 │     super();
+ 51 │     () => (arg = super()) => 123 + super();
+    ·                  ───────
+ 52 │     if (true) { while (false) { { super(); } } }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:51:36]
+ 50 │     super();
+ 51 │     () => (arg = super()) => 123 + super();
+    ·                                    ───────
+ 52 │     if (true) { while (false) { { super(); } } }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:52:35]
+ 51 │     () => (arg = super()) => 123 + super();
+ 52 │     if (true) { while (false) { { super(); } } }
+    ·                                   ───────
+ 53 │   }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:55:15]
+ 54 │ 
+ 55 │   ['x'](arg = super()) {
+    ·               ───────
+ 56 │     super();
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:56:5]
+ 55 │   ['x'](arg = super()) {
+ 56 │     super();
+    ·     ───────
+ 57 │     () => (arg = super()) => 123 + super();
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:57:18]
+ 56 │     super();
+ 57 │     () => (arg = super()) => 123 + super();
+    ·                  ───────
+ 58 │     if (true) { while (false) { { super(); } } }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:57:36]
+ 56 │     super();
+ 57 │     () => (arg = super()) => 123 + super();
+    ·                                    ───────
+ 58 │     if (true) { while (false) { { super(); } } }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:58:35]
+ 57 │     () => (arg = super()) => 123 + super();
+ 58 │     if (true) { while (false) { { super(); } } }
+    ·                                   ───────
+ 59 │   }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:61:22]
+ 60 │ 
+ 61 │   static ['x'](arg = super()) {
+    ·                      ───────
+ 62 │     super();
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:62:5]
+ 61 │   static ['x'](arg = super()) {
+ 62 │     super();
+    ·     ───────
+ 63 │     () => (arg = super()) => 123 + super();
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:63:18]
+ 62 │     super();
+ 63 │     () => (arg = super()) => 123 + super();
+    ·                  ───────
+ 64 │     if (true) { while (false) { { super(); } } }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:63:36]
+ 62 │     super();
+ 63 │     () => (arg = super()) => 123 + super();
+    ·                                    ───────
+ 64 │     if (true) { while (false) { { super(); } } }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:64:35]
+ 63 │     () => (arg = super()) => 123 + super();
+ 64 │     if (true) { while (false) { { super(); } } }
+    ·                                   ───────
+ 65 │   }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:68:5]
+ 67 │   get y() {
+ 68 │     super();
+    ·     ───────
+ 69 │     () => (arg = super()) => 123 + super();
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:69:18]
+ 68 │     super();
+ 69 │     () => (arg = super()) => 123 + super();
+    ·                  ───────
+ 70 │     if (true) { while (false) { { super(); } } }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:69:36]
+ 68 │     super();
+ 69 │     () => (arg = super()) => 123 + super();
+    ·                                    ───────
+ 70 │     if (true) { while (false) { { super(); } } }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:70:35]
+ 69 │     () => (arg = super()) => 123 + super();
+ 70 │     if (true) { while (false) { { super(); } } }
+    ·                                   ───────
+ 71 │   }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:73:15]
+ 72 │ 
+ 73 │   set y(arg = super()) {
+    ·               ───────
+ 74 │     super();
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:74:5]
+ 73 │   set y(arg = super()) {
+ 74 │     super();
+    ·     ───────
+ 75 │     () => (arg = super()) => 123 + super();
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:75:18]
+ 74 │     super();
+ 75 │     () => (arg = super()) => 123 + super();
+    ·                  ───────
+ 76 │     if (true) { while (false) { { super(); } } }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:75:36]
+ 74 │     super();
+ 75 │     () => (arg = super()) => 123 + super();
+    ·                                    ───────
+ 76 │     if (true) { while (false) { { super(); } } }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:76:35]
+ 75 │     () => (arg = super()) => 123 + super();
+ 76 │     if (true) { while (false) { { super(); } } }
+    ·                                   ───────
+ 77 │   }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:80:5]
+ 79 │   static get y() {
+ 80 │     super();
+    ·     ───────
+ 81 │     () => (arg = super()) => 123 + super();
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:81:18]
+ 80 │     super();
+ 81 │     () => (arg = super()) => 123 + super();
+    ·                  ───────
+ 82 │     if (true) { while (false) { { super(); } } }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:81:36]
+ 80 │     super();
+ 81 │     () => (arg = super()) => 123 + super();
+    ·                                    ───────
+ 82 │     if (true) { while (false) { { super(); } } }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:82:35]
+ 81 │     () => (arg = super()) => 123 + super();
+ 82 │     if (true) { while (false) { { super(); } } }
+    ·                                   ───────
+ 83 │   }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:85:22]
+ 84 │ 
+ 85 │   static set y(arg = super()) {
+    ·                      ───────
+ 86 │     super();
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:86:5]
+ 85 │   static set y(arg = super()) {
+ 86 │     super();
+    ·     ───────
+ 87 │     () => (arg = super()) => 123 + super();
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:87:18]
+ 86 │     super();
+ 87 │     () => (arg = super()) => 123 + super();
+    ·                  ───────
+ 88 │     if (true) { while (false) { { super(); } } }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:87:36]
+ 86 │     super();
+ 87 │     () => (arg = super()) => 123 + super();
+    ·                                    ───────
+ 88 │     if (true) { while (false) { { super(); } } }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:88:35]
+ 87 │     () => (arg = super()) => 123 + super();
+ 88 │     if (true) { while (false) { { super(); } } }
+    ·                                   ───────
+ 89 │   }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:95:5]
+ 94 │   static {
+ 95 │     super();
+    ·     ───────
+ 96 │     () => (arg = super()) => 123 + super();
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:96:18]
+ 95 │     super();
+ 96 │     () => (arg = super()) => 123 + super();
+    ·                  ───────
+ 97 │     if (true) { while (false) { { super(); } } }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:96:36]
+ 95 │     super();
+ 96 │     () => (arg = super()) => 123 + super();
+    ·                                    ───────
+ 97 │     if (true) { while (false) { { super(); } } }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284-1.js:97:35]
+ 96 │     () => (arg = super()) => 123 + super();
+ 97 │     if (true) { while (false) { { super(); } } }
+    ·                                   ───────
+ 98 │   }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:104:26]
+ 103 │   constructor() {
+ 104 │     function inner(arg = super()) {
+     ·                          ───────
+ 105 │       super();
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:105:7]
+ 104 │     function inner(arg = super()) {
+ 105 │       super();
+     ·       ───────
+ 106 │       () => (arg = super()) => 123 + super();
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:106:20]
+ 105 │       super();
+ 106 │       () => (arg = super()) => 123 + super();
+     ·                    ───────
+ 107 │       if (true) { while (false) { { super(); } } }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:106:38]
+ 105 │       super();
+ 106 │       () => (arg = super()) => 123 + super();
+     ·                                      ───────
+ 107 │       if (true) { while (false) { { super(); } } }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:107:37]
+ 106 │       () => (arg = super()) => 123 + super();
+ 107 │       if (true) { while (false) { { super(); } } }
+     ·                                     ───────
+ 108 │     }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:109:30]
+ 108 │     }
+ 109 │     f = () => function(arg = super()) {
+     ·                              ───────
+ 110 │       super();
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:110:7]
+ 109 │     f = () => function(arg = super()) {
+ 110 │       super();
+     ·       ───────
+ 111 │       () => (arg = super()) => 123 + super();
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:111:20]
+ 110 │       super();
+ 111 │       () => (arg = super()) => 123 + super();
+     ·                    ───────
+ 112 │       if (true) { while (false) { { super(); } } }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:111:38]
+ 110 │       super();
+ 111 │       () => (arg = super()) => 123 + super();
+     ·                                      ───────
+ 112 │       if (true) { while (false) { { super(); } } }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:112:37]
+ 111 │       () => (arg = super()) => 123 + super();
+ 112 │       if (true) { while (false) { { super(); } } }
+     ·                                     ───────
+ 113 │     };
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:115:20]
+ 114 │     obj = {
+ 115 │       method(arg = super()) {
+     ·                    ───────
+ 116 │         super();
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:116:9]
+ 115 │       method(arg = super()) {
+ 116 │         super();
+     ·         ───────
+ 117 │         () => (arg = super()) => 123 + super();
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:117:22]
+ 116 │         super();
+ 117 │         () => (arg = super()) => 123 + super();
+     ·                      ───────
+ 118 │         if (true) { while (false) { { super(); } } }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:117:40]
+ 116 │         super();
+ 117 │         () => (arg = super()) => 123 + super();
+     ·                                        ───────
+ 118 │         if (true) { while (false) { { super(); } } }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:118:39]
+ 117 │         () => (arg = super()) => 123 + super();
+ 118 │         if (true) { while (false) { { super(); } } }
+     ·                                       ───────
+ 119 │       },
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:120:19]
+ 119 │       },
+ 120 │       set x(arg = super()) {
+     ·                   ───────
+ 121 │         super();
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:121:9]
+ 120 │       set x(arg = super()) {
+ 121 │         super();
+     ·         ───────
+ 122 │         () => (arg = super()) => 123 + super();
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:122:22]
+ 121 │         super();
+ 122 │         () => (arg = super()) => 123 + super();
+     ·                      ───────
+ 123 │         if (true) { while (false) { { super(); } } }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:122:40]
+ 121 │         super();
+ 122 │         () => (arg = super()) => 123 + super();
+     ·                                        ───────
+ 123 │         if (true) { while (false) { { super(); } } }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:123:39]
+ 122 │         () => (arg = super()) => 123 + super();
+ 123 │         if (true) { while (false) { { super(); } } }
+     ·                                       ───────
+ 124 │       },
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:131:4]
+ 130 │ class F extends Super {
+ 131 │   [super()] = 1;
+     ·    ───────
+ 132 │   static [(arg = super()) => super()] = 2;
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:132:18]
+ 131 │   [super()] = 1;
+ 132 │   static [(arg = super()) => super()] = 2;
+     ·                  ───────
+ 133 │   accessor [123 + super()] = 3;
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:132:30]
+ 131 │   [super()] = 1;
+ 132 │   static [(arg = super()) => super()] = 2;
+     ·                              ───────
+ 133 │   accessor [123 + super()] = 3;
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:133:19]
+ 132 │   static [(arg = super()) => super()] = 2;
+ 133 │   accessor [123 + super()] = 3;
+     ·                   ───────
+ 134 │   static accessor [() => (arg = super()) => 123 + super()] = 4;
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:134:33]
+ 133 │   accessor [123 + super()] = 3;
+ 134 │   static accessor [() => (arg = super()) => 123 + super()] = 4;
+     ·                                 ───────
+ 135 │   [super()]() {};
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:134:51]
+ 133 │   accessor [123 + super()] = 3;
+ 134 │   static accessor [() => (arg = super()) => 123 + super()] = 4;
+     ·                                                   ───────
+ 135 │   [super()]() {};
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:135:4]
+ 134 │   static accessor [() => (arg = super()) => 123 + super()] = 4;
+ 135 │   [super()]() {};
+     ·    ───────
+ 136 │   static [() => super()]() {};
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:136:17]
+ 135 │   [super()]() {};
+ 136 │   static [() => super()]() {};
+     ·                 ───────
+ 137 │   get [super()]() {};
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:137:8]
+ 136 │   static [() => super()]() {};
+ 137 │   get [super()]() {};
+     ·        ───────
+ 138 │   static get [() => super()]() {};
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:138:21]
+ 137 │   get [super()]() {};
+ 138 │   static get [() => super()]() {};
+     ·                     ───────
+ 139 │   set [super()](v) {};
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:139:8]
+ 138 │   static get [() => super()]() {};
+ 139 │   set [super()](v) {};
+     ·        ───────
+ 140 │   static set [() => () => 123 + super()](v) {};
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:140:33]
+ 139 │   set [super()](v) {};
+ 140 │   static set [() => () => 123 + super()](v) {};
+     ·                                 ───────
+ 141 │ }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:144:17]
+ 143 │ // `super()` in class extends
+ 144 │ class G extends super() {}
+     ·                 ───────
+ 145 │ class H extends (() => () => 123 + super()) {}
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:145:36]
+ 144 │ class G extends super() {}
+ 145 │ class H extends (() => () => 123 + super()) {}
+     ·                                    ───────
+ 146 │ 
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:148:2]
+ 147 │ // `super()` in class decorators
+ 148 │ @super()
+     ·  ───────
+ 149 │ class I extends Super {
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:150:4]
+ 149 │ class I extends Super {
+ 150 │   @super() prop = 1;
+     ·    ───────
+ 151 │   @super() static prop = 2;
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:151:4]
+ 150 │   @super() prop = 1;
+ 151 │   @super() static prop = 2;
+     ·    ───────
+ 152 │   @super() accessor access = 3;
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:152:4]
+ 151 │   @super() static prop = 2;
+ 152 │   @super() accessor access = 3;
+     ·    ───────
+ 153 │   @super() static accessor access = 4;
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:153:4]
+ 152 │   @super() accessor access = 3;
+ 153 │   @super() static accessor access = 4;
+     ·    ───────
+ 154 │   @super() method() {}
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:154:4]
+ 153 │   @super() static accessor access = 4;
+ 154 │   @super() method() {}
+     ·    ───────
+ 155 │ }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:161:14]
+ 160 │     class Inner {
+ 161 │       prop = super();
+     ·              ───────
+ 162 │       static prop = (arg = super()) => 123 + super();
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:162:28]
+ 161 │       prop = super();
+ 162 │       static prop = (arg = super()) => 123 + super();
+     ·                            ───────
+ 163 │       accessor access = super();
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:162:46]
+ 161 │       prop = super();
+ 162 │       static prop = (arg = super()) => 123 + super();
+     ·                                              ───────
+ 163 │       accessor access = super();
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:163:25]
+ 162 │       static prop = (arg = super()) => 123 + super();
+ 163 │       accessor access = super();
+     ·                         ───────
+ 164 │       static accessor access = (arg = super()) => 123 + super();
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:164:39]
+ 163 │       accessor access = super();
+ 164 │       static accessor access = (arg = super()) => 123 + super();
+     ·                                       ───────
+ 165 │       method() { super(); }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:164:57]
+ 163 │       accessor access = super();
+ 164 │       static accessor access = (arg = super()) => 123 + super();
+     ·                                                         ───────
+ 165 │       method() { super(); }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:165:18]
+ 164 │       static accessor access = (arg = super()) => 123 + super();
+ 165 │       method() { super(); }
+     ·                  ───────
+ 166 │       static method() { (arg = super()) => 123 + super(); }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:166:32]
+ 165 │       method() { super(); }
+ 166 │       static method() { (arg = super()) => 123 + super(); }
+     ·                                ───────
+ 167 │       get x() { super(); }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:166:50]
+ 165 │       method() { super(); }
+ 166 │       static method() { (arg = super()) => 123 + super(); }
+     ·                                                  ───────
+ 167 │       get x() { super(); }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:167:17]
+ 166 │       static method() { (arg = super()) => 123 + super(); }
+ 167 │       get x() { super(); }
+     ·                 ───────
+ 168 │       static get y() { (arg = super()) => 123 + super(); }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:168:31]
+ 167 │       get x() { super(); }
+ 168 │       static get y() { (arg = super()) => 123 + super(); }
+     ·                               ───────
+ 169 │       set x(v) { super(); }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:168:49]
+ 167 │       get x() { super(); }
+ 168 │       static get y() { (arg = super()) => 123 + super(); }
+     ·                                                 ───────
+ 169 │       set x(v) { super(); }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:169:18]
+ 168 │       static get y() { (arg = super()) => 123 + super(); }
+ 169 │       set x(v) { super(); }
+     ·                  ───────
+ 170 │       static set y(v) { (arg = super()) => 123 + super(); }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:170:32]
+ 169 │       set x(v) { super(); }
+ 170 │       static set y(v) { (arg = super()) => 123 + super(); }
+     ·                                ───────
+ 171 │       static { super(); }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:170:50]
+ 169 │       set x(v) { super(); }
+ 170 │       static set y(v) { (arg = super()) => 123 + super(); }
+     ·                                                  ───────
+ 171 │       static { super(); }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:171:16]
+ 170 │       static set y(v) { (arg = super()) => 123 + super(); }
+ 171 │       static { super(); }
+     ·                ───────
+ 172 │     }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:179:6]
+ 178 │   prop = class Inner {
+ 179 │     [super()] = 1;
+     ·      ───────
+ 180 │     static [(arg = super()) => super()] = 2;
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:180:20]
+ 179 │     [super()] = 1;
+ 180 │     static [(arg = super()) => super()] = 2;
+     ·                    ───────
+ 181 │     accessor [123 + super()] = 3;
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:180:32]
+ 179 │     [super()] = 1;
+ 180 │     static [(arg = super()) => super()] = 2;
+     ·                                ───────
+ 181 │     accessor [123 + super()] = 3;
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:181:21]
+ 180 │     static [(arg = super()) => super()] = 2;
+ 181 │     accessor [123 + super()] = 3;
+     ·                     ───────
+ 182 │     static accessor [() => (arg = super()) => 123 + super()] = 4;
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:182:35]
+ 181 │     accessor [123 + super()] = 3;
+ 182 │     static accessor [() => (arg = super()) => 123 + super()] = 4;
+     ·                                   ───────
+ 183 │     [super()]() {};
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:182:53]
+ 181 │     accessor [123 + super()] = 3;
+ 182 │     static accessor [() => (arg = super()) => 123 + super()] = 4;
+     ·                                                     ───────
+ 183 │     [super()]() {};
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:183:6]
+ 182 │     static accessor [() => (arg = super()) => 123 + super()] = 4;
+ 183 │     [super()]() {};
+     ·      ───────
+ 184 │     static [() => super()]() {};
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:184:19]
+ 183 │     [super()]() {};
+ 184 │     static [() => super()]() {};
+     ·                   ───────
+ 185 │     get [super()]() {};
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:185:10]
+ 184 │     static [() => super()]() {};
+ 185 │     get [super()]() {};
+     ·          ───────
+ 186 │     static get [() => super()]() {};
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:186:23]
+ 185 │     get [super()]() {};
+ 186 │     static get [() => super()]() {};
+     ·                       ───────
+ 187 │     set [super()](v) {};
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:187:10]
+ 186 │     static get [() => super()]() {};
+ 187 │     set [super()](v) {};
+     ·          ───────
+ 188 │     static set [() => () => 123 + super()](v) {};
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:188:35]
+ 187 │     set [super()](v) {};
+ 188 │     static set [() => () => 123 + super()](v) {};
+     ·                                   ───────
+ 189 │   };
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:196:8]
+ 195 │     class Inner {
+ 196 │       [super()] = 1;
+     ·        ───────
+ 197 │       static [(arg = super()) => super()] = 2;
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:197:22]
+ 196 │       [super()] = 1;
+ 197 │       static [(arg = super()) => super()] = 2;
+     ·                      ───────
+ 198 │       accessor [123 + super()] = 3;
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:197:34]
+ 196 │       [super()] = 1;
+ 197 │       static [(arg = super()) => super()] = 2;
+     ·                                  ───────
+ 198 │       accessor [123 + super()] = 3;
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:198:23]
+ 197 │       static [(arg = super()) => super()] = 2;
+ 198 │       accessor [123 + super()] = 3;
+     ·                       ───────
+ 199 │       static accessor [() => (arg = super()) => 123 + super()] = 4;
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:199:37]
+ 198 │       accessor [123 + super()] = 3;
+ 199 │       static accessor [() => (arg = super()) => 123 + super()] = 4;
+     ·                                     ───────
+ 200 │       [super()]() {};
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:199:55]
+ 198 │       accessor [123 + super()] = 3;
+ 199 │       static accessor [() => (arg = super()) => 123 + super()] = 4;
+     ·                                                       ───────
+ 200 │       [super()]() {};
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:200:8]
+ 199 │       static accessor [() => (arg = super()) => 123 + super()] = 4;
+ 200 │       [super()]() {};
+     ·        ───────
+ 201 │       static [() => super()]() {};
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:201:21]
+ 200 │       [super()]() {};
+ 201 │       static [() => super()]() {};
+     ·                     ───────
+ 202 │       get [super()]() {};
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:202:12]
+ 201 │       static [() => super()]() {};
+ 202 │       get [super()]() {};
+     ·            ───────
+ 203 │       static get [() => super()]() {};
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:203:25]
+ 202 │       get [super()]() {};
+ 203 │       static get [() => super()]() {};
+     ·                         ───────
+ 204 │       set [super()](v) {};
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:204:12]
+ 203 │       static get [() => super()]() {};
+ 204 │       set [super()](v) {};
+     ·            ───────
+ 205 │       static set [() => () => 123 + super()](v) {};
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:205:37]
+ 204 │       set [super()](v) {};
+ 205 │       static set [() => () => 123 + super()](v) {};
+     ·                                     ───────
+ 206 │     }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:212:31]
+ 211 │ class M extends Super {
+ 212 │   prop1 = class Inner extends super() {};
+     ·                               ───────
+ 213 │   prop2 = class Inner extends (() => (arg = super()) => 123 + super()) {};
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:213:45]
+ 212 │   prop1 = class Inner extends super() {};
+ 213 │   prop2 = class Inner extends (() => (arg = super()) => 123 + super()) {};
+     ·                                             ───────
+ 214 │ }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:213:63]
+ 212 │   prop1 = class Inner extends super() {};
+ 213 │   prop2 = class Inner extends (() => (arg = super()) => 123 + super()) {};
+     ·                                                               ───────
+ 214 │ }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:219:26]
+ 218 │   method() {
+ 219 │     class Inner1 extends super() {};
+     ·                          ───────
+ 220 │     class Inner2 extends (() => (arg = super()) => 123 + super()) {};
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:220:40]
+ 219 │     class Inner1 extends super() {};
+ 220 │     class Inner2 extends (() => (arg = super()) => 123 + super()) {};
+     ·                                        ───────
+ 221 │   }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:220:58]
+ 219 │     class Inner1 extends super() {};
+ 220 │     class Inner2 extends (() => (arg = super()) => 123 + super()) {};
+     ·                                                          ───────
+ 221 │   }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:226:11]
+ 225 │ class O extends Super {
+ 226 │   prop = @super() class Inner extends Super {
+     ·           ───────
+ 227 │     @super() prop = 1;
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:227:6]
+ 226 │   prop = @super() class Inner extends Super {
+ 227 │     @super() prop = 1;
+     ·      ───────
+ 228 │     @super() static prop = 2;
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:228:6]
+ 227 │     @super() prop = 1;
+ 228 │     @super() static prop = 2;
+     ·      ───────
+ 229 │     @super() accessor access = 3;
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:229:6]
+ 228 │     @super() static prop = 2;
+ 229 │     @super() accessor access = 3;
+     ·      ───────
+ 230 │     @super() static accessor access = 4;
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:230:6]
+ 229 │     @super() accessor access = 3;
+ 230 │     @super() static accessor access = 4;
+     ·      ───────
+ 231 │     @super() method() {}
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:231:6]
+ 230 │     @super() static accessor access = 4;
+ 231 │     @super() method() {}
+     ·      ───────
+ 232 │   };
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:238:6]
+ 237 │   method() {
+ 238 │     @super()
+     ·      ───────
+ 239 │     class Inner extends Super {
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:240:8]
+ 239 │     class Inner extends Super {
+ 240 │       @super() prop = 1;
+     ·        ───────
+ 241 │       @super() static prop = 2;
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:241:8]
+ 240 │       @super() prop = 1;
+ 241 │       @super() static prop = 2;
+     ·        ───────
+ 242 │       @super() accessor access = 3;
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:242:8]
+ 241 │       @super() static prop = 2;
+ 242 │       @super() accessor access = 3;
+     ·        ───────
+ 243 │       @super() static accessor access = 4;
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:243:8]
+ 242 │       @super() accessor access = 3;
+ 243 │       @super() static accessor access = 4;
+     ·        ───────
+ 244 │       @super() method() {}
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:244:8]
+ 243 │       @super() static accessor access = 4;
+ 244 │       @super() method() {}
+     ·        ───────
+ 245 │     }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:257:16]
+ 256 │             class C {
+ 257 │               [super()]() {}
+     ·                ───────
+ 258 │             }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:264:53]
+ 263 │ 
+ 264 │     class D extends class E extends class F extends super() {} {} {}
+     ·                                                     ───────
+ 265 │ 
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:271:16]
+ 270 │             class I {
+ 271 │               @super()
+     ·                ───────
+ 272 │               method() {}
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:286:5]
+ 285 │   method() {
+ 286 │     super();
+     ·     ───────
+ 287 │     () => (arg = super()) => 123 + super();
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:287:18]
+ 286 │     super();
+ 287 │     () => (arg = super()) => 123 + super();
+     ·                  ───────
+ 288 │     if (true) { while (false) { { super(); } } }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:287:36]
+ 286 │     super();
+ 287 │     () => (arg = super()) => 123 + super();
+     ·                                    ───────
+ 288 │     if (true) { while (false) { { super(); } } }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:288:35]
+ 287 │     () => (arg = super()) => 123 + super();
+ 288 │     if (true) { while (false) { { super(); } } }
+     ·                                   ───────
+ 289 │   },
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:291:5]
+ 290 │   ['x']() {
+ 291 │     super();
+     ·     ───────
+ 292 │     () => (arg = super()) => 123 + super();
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:292:18]
+ 291 │     super();
+ 292 │     () => (arg = super()) => 123 + super();
+     ·                  ───────
+ 293 │     if (true) { while (false) { { super(); } } }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:292:36]
+ 291 │     super();
+ 292 │     () => (arg = super()) => 123 + super();
+     ·                                    ───────
+ 293 │     if (true) { while (false) { { super(); } } }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:293:35]
+ 292 │     () => (arg = super()) => 123 + super();
+ 293 │     if (true) { while (false) { { super(); } } }
+     ·                                   ───────
+ 294 │   },
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:296:5]
+ 295 │   get x() {
+ 296 │     super();
+     ·     ───────
+ 297 │     () => (arg = super()) => 123 + super();
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:297:18]
+ 296 │     super();
+ 297 │     () => (arg = super()) => 123 + super();
+     ·                  ───────
+ 298 │     if (true) { while (false) { { super(); } } }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:297:36]
+ 296 │     super();
+ 297 │     () => (arg = super()) => 123 + super();
+     ·                                    ───────
+ 298 │     if (true) { while (false) { { super(); } } }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:298:35]
+ 297 │     () => (arg = super()) => 123 + super();
+ 298 │     if (true) { while (false) { { super(); } } }
+     ·                                   ───────
+ 299 │   },
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:301:5]
+ 300 │   set x(v) {
+ 301 │     super();
+     ·     ───────
+ 302 │     () => (arg = super()) => 123 + super();
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:302:18]
+ 301 │     super();
+ 302 │     () => (arg = super()) => 123 + super();
+     ·                  ───────
+ 303 │     if (true) { while (false) { { super(); } } }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:302:36]
+ 301 │     super();
+ 302 │     () => (arg = super()) => 123 + super();
+     ·                                    ───────
+ 303 │     if (true) { while (false) { { super(); } } }
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+     ╭─[misc/fail/oxc-13284-1.js:303:35]
+ 302 │     () => (arg = super()) => 123 + super();
+ 303 │     if (true) { while (false) { { super(); } } }
+     ·                                   ───────
+ 304 │   },
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+   ╭─[misc/fail/oxc-13284-2.js:2:1]
+ 1 │ // `super.foo` not in a class or object method
+ 2 │ super.foo;
+   · ─────
+ 3 │ () => (arg = super.foo) => 123 + super.foo;
+   ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+   ╭─[misc/fail/oxc-13284-2.js:3:14]
+ 2 │ super.foo;
+ 3 │ () => (arg = super.foo) => 123 + super.foo;
+   ·              ─────
+ 4 │ if (true) { while (false) { { super.foo; } } }
+   ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+   ╭─[misc/fail/oxc-13284-2.js:3:34]
+ 2 │ super.foo;
+ 3 │ () => (arg = super.foo) => 123 + super.foo;
+   ·                                  ─────
+ 4 │ if (true) { while (false) { { super.foo; } } }
+   ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+   ╭─[misc/fail/oxc-13284-2.js:4:31]
+ 3 │ () => (arg = super.foo) => 123 + super.foo;
+ 4 │ if (true) { while (false) { { super.foo; } } }
+   ·                               ─────
+ 5 │ () => () => {
+   ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+   ╭─[misc/fail/oxc-13284-2.js:6:3]
+ 5 │ () => () => {
+ 6 │   super.foo;
+   ·   ─────
+ 7 │   () => (arg = super.foo) => 123 + super.foo;
+   ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+   ╭─[misc/fail/oxc-13284-2.js:7:16]
+ 6 │   super.foo;
+ 7 │   () => (arg = super.foo) => 123 + super.foo;
+   ·                ─────
+ 8 │   if (true) { while (false) { { super.foo; } } }
+   ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+   ╭─[misc/fail/oxc-13284-2.js:7:36]
+ 6 │   super.foo;
+ 7 │   () => (arg = super.foo) => 123 + super.foo;
+   ·                                    ─────
+ 8 │   if (true) { while (false) { { super.foo; } } }
+   ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+   ╭─[misc/fail/oxc-13284-2.js:8:33]
+ 7 │   () => (arg = super.foo) => 123 + super.foo;
+ 8 │   if (true) { while (false) { { super.foo; } } }
+   ·                                 ─────
+ 9 │ };
+   ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:12:18]
+ 11 │ // `super.foo` in a function
+ 12 │ function f(arg = super.foo) {
+    ·                  ─────
+ 13 │   super.foo;
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:13:3]
+ 12 │ function f(arg = super.foo) {
+ 13 │   super.foo;
+    ·   ─────
+ 14 │   () => (arg = super.foo) => 123 + super.foo;
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:14:16]
+ 13 │   super.foo;
+ 14 │   () => (arg = super.foo) => 123 + super.foo;
+    ·                ─────
+ 15 │   if (true) { while (false) { { super.foo; } } }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:14:36]
+ 13 │   super.foo;
+ 14 │   () => (arg = super.foo) => 123 + super.foo;
+    ·                                    ─────
+ 15 │   if (true) { while (false) { { super.foo; } } }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:15:33]
+ 14 │   () => (arg = super.foo) => 123 + super.foo;
+ 15 │   if (true) { while (false) { { super.foo; } } }
+    ·                                 ─────
+ 16 │ }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:17:20]
+ 16 │ }
+ 17 │ f = function(arg = super.foo) {
+    ·                    ─────
+ 18 │   super.foo;
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:18:3]
+ 17 │ f = function(arg = super.foo) {
+ 18 │   super.foo;
+    ·   ─────
+ 19 │   () => (arg = super.foo) => 123 + super.foo;
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:19:16]
+ 18 │   super.foo;
+ 19 │   () => (arg = super.foo) => 123 + super.foo;
+    ·                ─────
+ 20 │   if (true) { while (false) { { super.foo; } } }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:19:36]
+ 18 │   super.foo;
+ 19 │   () => (arg = super.foo) => 123 + super.foo;
+    ·                                    ─────
+ 20 │   if (true) { while (false) { { super.foo; } } }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:20:33]
+ 19 │   () => (arg = super.foo) => 123 + super.foo;
+ 20 │   if (true) { while (false) { { super.foo; } } }
+    ·                                 ─────
+ 21 │ };
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:26:26]
+ 25 │   constructor() {
+ 26 │     function inner(arg = super.foo) {
+    ·                          ─────
+ 27 │       super.foo;
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:27:7]
+ 26 │     function inner(arg = super.foo) {
+ 27 │       super.foo;
+    ·       ─────
+ 28 │       () => (arg = super.foo) => 123 + super.foo;
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:28:20]
+ 27 │       super.foo;
+ 28 │       () => (arg = super.foo) => 123 + super.foo;
+    ·                    ─────
+ 29 │       if (true) { while (false) { { super.foo; } } }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:28:40]
+ 27 │       super.foo;
+ 28 │       () => (arg = super.foo) => 123 + super.foo;
+    ·                                        ─────
+ 29 │       if (true) { while (false) { { super.foo; } } }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:29:37]
+ 28 │       () => (arg = super.foo) => 123 + super.foo;
+ 29 │       if (true) { while (false) { { super.foo; } } }
+    ·                                     ─────
+ 30 │     }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:31:30]
+ 30 │     }
+ 31 │     f = () => function(arg = super.foo) {
+    ·                              ─────
+ 32 │       super.foo;
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:32:7]
+ 31 │     f = () => function(arg = super.foo) {
+ 32 │       super.foo;
+    ·       ─────
+ 33 │       () => (arg = super.foo) => 123 + super.foo;
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:33:20]
+ 32 │       super.foo;
+ 33 │       () => (arg = super.foo) => 123 + super.foo;
+    ·                    ─────
+ 34 │       if (true) { while (false) { { super.foo; } } }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:33:40]
+ 32 │       super.foo;
+ 33 │       () => (arg = super.foo) => 123 + super.foo;
+    ·                                        ─────
+ 34 │       if (true) { while (false) { { super.foo; } } }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:34:37]
+ 33 │       () => (arg = super.foo) => 123 + super.foo;
+ 34 │       if (true) { while (false) { { super.foo; } } }
+    ·                                     ─────
+ 35 │     };
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:42:26]
+ 41 │   method() {
+ 42 │     function inner(arg = super.foo) {
+    ·                          ─────
+ 43 │       super.foo;
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:43:7]
+ 42 │     function inner(arg = super.foo) {
+ 43 │       super.foo;
+    ·       ─────
+ 44 │       () => (arg = super.foo) => 123 + super.foo;
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:44:20]
+ 43 │       super.foo;
+ 44 │       () => (arg = super.foo) => 123 + super.foo;
+    ·                    ─────
+ 45 │       if (true) { while (false) { { super.foo; } } }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:44:40]
+ 43 │       super.foo;
+ 44 │       () => (arg = super.foo) => 123 + super.foo;
+    ·                                        ─────
+ 45 │       if (true) { while (false) { { super.foo; } } }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:45:37]
+ 44 │       () => (arg = super.foo) => 123 + super.foo;
+ 45 │       if (true) { while (false) { { super.foo; } } }
+    ·                                     ─────
+ 46 │     }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:47:30]
+ 46 │     }
+ 47 │     f = () => function(arg = super.foo) {
+    ·                              ─────
+ 48 │       super.foo;
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:48:7]
+ 47 │     f = () => function(arg = super.foo) {
+ 48 │       super.foo;
+    ·       ─────
+ 49 │       () => (arg = super.foo) => 123 + super.foo;
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:49:20]
+ 48 │       super.foo;
+ 49 │       () => (arg = super.foo) => 123 + super.foo;
+    ·                    ─────
+ 50 │       if (true) { while (false) { { super.foo; } } }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:49:40]
+ 48 │       super.foo;
+ 49 │       () => (arg = super.foo) => 123 + super.foo;
+    ·                                        ─────
+ 50 │       if (true) { while (false) { { super.foo; } } }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:50:37]
+ 49 │       () => (arg = super.foo) => 123 + super.foo;
+ 50 │       if (true) { while (false) { { super.foo; } } }
+    ·                                     ─────
+ 51 │     };
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:58:26]
+ 57 │   prop = () => {
+ 58 │     function inner(arg = super.foo) {
+    ·                          ─────
+ 59 │       super.foo;
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:59:7]
+ 58 │     function inner(arg = super.foo) {
+ 59 │       super.foo;
+    ·       ─────
+ 60 │       () => (arg = super.foo) => 123 + super.foo;
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:60:20]
+ 59 │       super.foo;
+ 60 │       () => (arg = super.foo) => 123 + super.foo;
+    ·                    ─────
+ 61 │       if (true) { while (false) { { super.foo; } } }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:60:40]
+ 59 │       super.foo;
+ 60 │       () => (arg = super.foo) => 123 + super.foo;
+    ·                                        ─────
+ 61 │       if (true) { while (false) { { super.foo; } } }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:61:37]
+ 60 │       () => (arg = super.foo) => 123 + super.foo;
+ 61 │       if (true) { while (false) { { super.foo; } } }
+    ·                                     ─────
+ 62 │     }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:63:30]
+ 62 │     }
+ 63 │     f = () => function(arg = super.foo) {
+    ·                              ─────
+ 64 │       super.foo;
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:64:7]
+ 63 │     f = () => function(arg = super.foo) {
+ 64 │       super.foo;
+    ·       ─────
+ 65 │       () => (arg = super.foo) => 123 + super.foo;
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:65:20]
+ 64 │       super.foo;
+ 65 │       () => (arg = super.foo) => 123 + super.foo;
+    ·                    ─────
+ 66 │       if (true) { while (false) { { super.foo; } } }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:65:40]
+ 64 │       super.foo;
+ 65 │       () => (arg = super.foo) => 123 + super.foo;
+    ·                                        ─────
+ 66 │       if (true) { while (false) { { super.foo; } } }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:66:37]
+ 65 │       () => (arg = super.foo) => 123 + super.foo;
+ 66 │       if (true) { while (false) { { super.foo; } } }
+    ·                                     ─────
+ 67 │     };
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:73:4]
+ 72 │ class D {
+ 73 │   [super.foo] = 1;
+    ·    ─────
+ 74 │   static [() => super.foo] = 2;
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:74:17]
+ 73 │   [super.foo] = 1;
+ 74 │   static [() => super.foo] = 2;
+    ·                 ─────
+ 75 │   accessor [123 + super.foo] = 3;
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:75:19]
+ 74 │   static [() => super.foo] = 2;
+ 75 │   accessor [123 + super.foo] = 3;
+    ·                   ─────
+ 76 │   static accessor [() => () => 123 + super.foo] = 4;
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:76:38]
+ 75 │   accessor [123 + super.foo] = 3;
+ 76 │   static accessor [() => () => 123 + super.foo] = 4;
+    ·                                      ─────
+ 77 │   [super.foo]() {};
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:77:4]
+ 76 │   static accessor [() => () => 123 + super.foo] = 4;
+ 77 │   [super.foo]() {};
+    ·    ─────
+ 78 │   static [() => super.foo]() {};
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:78:17]
+ 77 │   [super.foo]() {};
+ 78 │   static [() => super.foo]() {};
+    ·                 ─────
+ 79 │   get [super.foo]() {};
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:79:8]
+ 78 │   static [() => super.foo]() {};
+ 79 │   get [super.foo]() {};
+    ·        ─────
+ 80 │   static get [() => super.foo]() {};
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:80:21]
+ 79 │   get [super.foo]() {};
+ 80 │   static get [() => super.foo]() {};
+    ·                     ─────
+ 81 │   set [super.foo](v) {};
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:81:8]
+ 80 │   static get [() => super.foo]() {};
+ 81 │   set [super.foo](v) {};
+    ·        ─────
+ 82 │   static set [() => () => 123 + super.foo](v) {};
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:82:33]
+ 81 │   set [super.foo](v) {};
+ 82 │   static set [() => () => 123 + super.foo](v) {};
+    ·                                 ─────
+ 83 │ }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:86:17]
+ 85 │ // `super.foo` in class extends
+ 86 │ class E extends super.foo {}
+    ·                 ─────
+ 87 │ class F extends (() => (arg = super.foo) => 123 + super.foo) {}
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:87:31]
+ 86 │ class E extends super.foo {}
+ 87 │ class F extends (() => (arg = super.foo) => 123 + super.foo) {}
+    ·                               ─────
+ 88 │ 
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:87:51]
+ 86 │ class E extends super.foo {}
+ 87 │ class F extends (() => (arg = super.foo) => 123 + super.foo) {}
+    ·                                                   ─────
+ 88 │ 
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:90:2]
+ 89 │ // `super.foo` in class decorators
+ 90 │ @super.foo
+    ·  ─────
+ 91 │ class G extends Super {
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:92:4]
+ 91 │ class G extends Super {
+ 92 │   @super.foo prop = 1;
+    ·    ─────
+ 93 │   @super.foo static prop = 2;
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:93:4]
+ 92 │   @super.foo prop = 1;
+ 93 │   @super.foo static prop = 2;
+    ·    ─────
+ 94 │   @super.foo accessor access = 3;
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:94:4]
+ 93 │   @super.foo static prop = 2;
+ 94 │   @super.foo accessor access = 3;
+    ·    ─────
+ 95 │   @super.foo static accessor access = 4;
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:95:4]
+ 94 │   @super.foo accessor access = 3;
+ 95 │   @super.foo static accessor access = 4;
+    ·    ─────
+ 96 │   @super.foo method() {}
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284-2.js:96:4]
+ 95 │   @super.foo static accessor access = 4;
+ 96 │   @super.foo method() {}
+    ·    ─────
+ 97 │ }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:102:6]
+ 101 │   class Inner {
+ 102 │     [super.foo] = 1;
+     ·      ─────
+ 103 │     static [(arg = super.foo) => super.foo] = 2;
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:103:20]
+ 102 │     [super.foo] = 1;
+ 103 │     static [(arg = super.foo) => super.foo] = 2;
+     ·                    ─────
+ 104 │     accessor [123 + super.foo] = 3;
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:103:34]
+ 102 │     [super.foo] = 1;
+ 103 │     static [(arg = super.foo) => super.foo] = 2;
+     ·                                  ─────
+ 104 │     accessor [123 + super.foo] = 3;
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:104:21]
+ 103 │     static [(arg = super.foo) => super.foo] = 2;
+ 104 │     accessor [123 + super.foo] = 3;
+     ·                     ─────
+ 105 │     static accessor [() => (arg = super.foo) => 123 + super.foo] = 4;
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:105:35]
+ 104 │     accessor [123 + super.foo] = 3;
+ 105 │     static accessor [() => (arg = super.foo) => 123 + super.foo] = 4;
+     ·                                   ─────
+ 106 │     [super.foo]() {};
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:105:55]
+ 104 │     accessor [123 + super.foo] = 3;
+ 105 │     static accessor [() => (arg = super.foo) => 123 + super.foo] = 4;
+     ·                                                       ─────
+ 106 │     [super.foo]() {};
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:106:6]
+ 105 │     static accessor [() => (arg = super.foo) => 123 + super.foo] = 4;
+ 106 │     [super.foo]() {};
+     ·      ─────
+ 107 │     static [() => super.foo]() {};
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:107:19]
+ 106 │     [super.foo]() {};
+ 107 │     static [() => super.foo]() {};
+     ·                   ─────
+ 108 │     get [super.foo]() {};
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:108:10]
+ 107 │     static [() => super.foo]() {};
+ 108 │     get [super.foo]() {};
+     ·          ─────
+ 109 │     static get [() => super.foo]() {};
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:109:23]
+ 108 │     get [super.foo]() {};
+ 109 │     static get [() => super.foo]() {};
+     ·                       ─────
+ 110 │     set [super.foo](v) {};
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:110:10]
+ 109 │     static get [() => super.foo]() {};
+ 110 │     set [super.foo](v) {};
+     ·          ─────
+ 111 │     static set [() => () => 123 + super.foo](v) {};
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:111:35]
+ 110 │     set [super.foo](v) {};
+ 111 │     static set [() => () => 123 + super.foo](v) {};
+     ·                                   ─────
+ 112 │   }
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:117:19]
+ 116 │ function h() {
+ 117 │   class E extends super.foo {}
+     ·                   ─────
+ 118 │   class F extends (() => (arg = super.foo) => 123 + super.foo) {}
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:118:33]
+ 117 │   class E extends super.foo {}
+ 118 │   class F extends (() => (arg = super.foo) => 123 + super.foo) {}
+     ·                                 ─────
+ 119 │ }
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:118:53]
+ 117 │   class E extends super.foo {}
+ 118 │   class F extends (() => (arg = super.foo) => 123 + super.foo) {}
+     ·                                                     ─────
+ 119 │ }
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:123:4]
+ 122 │ function i() {
+ 123 │   @super.foo
+     ·    ─────
+ 124 │   class Inner {
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:125:6]
+ 124 │   class Inner {
+ 125 │     @super.foo prop = 1;
+     ·      ─────
+ 126 │     @super.foo static prop = 2;
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:126:6]
+ 125 │     @super.foo prop = 1;
+ 126 │     @super.foo static prop = 2;
+     ·      ─────
+ 127 │     @super.foo accessor access = 3;
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:127:6]
+ 126 │     @super.foo static prop = 2;
+ 127 │     @super.foo accessor access = 3;
+     ·      ─────
+ 128 │     @super.foo static accessor access = 4;
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:128:6]
+ 127 │     @super.foo accessor access = 3;
+ 128 │     @super.foo static accessor access = 4;
+     ·      ─────
+ 129 │     @super.foo method() {}
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:129:6]
+ 128 │     @super.foo static accessor access = 4;
+ 129 │     @super.foo method() {}
+     ·      ─────
+ 130 │   }
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:135:16]
+ 134 │ obj = {
+ 135 │   prop: (arg = super.foo) => {
+     ·                ─────
+ 136 │     super.foo;
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:136:5]
+ 135 │   prop: (arg = super.foo) => {
+ 136 │     super.foo;
+     ·     ─────
+ 137 │     () => (arg = super.foo) => 123 + super.foo;
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:137:18]
+ 136 │     super.foo;
+ 137 │     () => (arg = super.foo) => 123 + super.foo;
+     ·                  ─────
+ 138 │     if (true) { while (false) { { super.foo; } } }
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:137:38]
+ 136 │     super.foo;
+ 137 │     () => (arg = super.foo) => 123 + super.foo;
+     ·                                      ─────
+ 138 │     if (true) { while (false) { { super.foo; } } }
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:138:35]
+ 137 │     () => (arg = super.foo) => 123 + super.foo;
+ 138 │     if (true) { while (false) { { super.foo; } } }
+     ·                                   ─────
+ 139 │   },
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:140:17]
+ 139 │   },
+ 140 │   ['x']: (arg = super.foo) => {
+     ·                 ─────
+ 141 │     super.foo;
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:141:5]
+ 140 │   ['x']: (arg = super.foo) => {
+ 141 │     super.foo;
+     ·     ─────
+ 142 │     () => (arg = super.foo) => 123 + super.foo;
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:142:18]
+ 141 │     super.foo;
+ 142 │     () => (arg = super.foo) => 123 + super.foo;
+     ·                  ─────
+ 143 │     if (true) { while (false) { { super.foo; } } }
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:142:38]
+ 141 │     super.foo;
+ 142 │     () => (arg = super.foo) => 123 + super.foo;
+     ·                                      ─────
+ 143 │     if (true) { while (false) { { super.foo; } } }
+     ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+     ╭─[misc/fail/oxc-13284-2.js:143:35]
+ 142 │     () => (arg = super.foo) => 123 + super.foo;
+ 143 │     if (true) { while (false) { { super.foo; } } }
+     ·                                   ─────
+ 144 │   },
+     ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+   ╭─[misc/fail/oxc-13284.ts:6:46]
+ 5 │ class C extends Super {
+ 6 │   [keys: string]: typeof import('x', { with: super() }).y;
+   ·                                              ───────
+ 7 │ }
+   ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284.ts:10:37]
+  9 │ class D extends Super {
+ 10 │   [keys: typeof import('x', { with: super() }).y]: string;
+    ·                                     ───────
+ 11 │ }
+    ╰────
+
+  × Super calls are not permitted outside constructors or in nested functions inside constructors.
+    ╭─[misc/fail/oxc-13284.ts:16:50]
+ 15 │     class Inner {
+ 16 │       [keys: string]: typeof import('x', { with: super() }).y;
+    ·                                                  ───────
+ 17 │     }
+    ╰────
+
+  × 'super' can only be referenced in a derived class.
+    ╭─[misc/fail/oxc-13284.ts:21:1]
+ 20 │     
+ 21 │ ╭─▶ class Outer2 {
+ 22 │ │     constructor() {
+ 23 │ │       class Inner extends Super {
+ 24 │ │         [keys: typeof import('x', { with: super() }).y]: string;
+    · │                                           ─────
+ 25 │ │       }
+ 26 │ │     }
+ 27 │ ├─▶ }
+    · ╰──── class does not have `extends`
+ 28 │     
+    ╰────
+  help: either remove this super, or extend the class
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[misc/fail/oxc-13284.ts:35:37]
+ 34 │ class F {
+ 35 │   [keys: typeof import('x', { with: super.foo }).y]: string;
+    ·                                     ─────
+ 36 │ }
+    ╰────
 
   × 'super' can only be referenced in members of derived classes or object literal expressions.
    ╭─[misc/fail/oxc-13323.js:3:5]

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: 261630d6
 parser_typescript Summary:
 AST Parsed     : 8814/8816 (99.98%)
 Positive Passed: 8803/8816 (99.85%)
-Negative Passed: 1437/3535 (40.65%)
+Negative Passed: 1442/3535 (40.79%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment8.ts
@@ -2336,8 +2336,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/decorator
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod11.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod12.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod6.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod8.ts
@@ -2505,14 +2503,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/compu
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames23_ES5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames23_ES6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames24_ES5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames24_ES6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames26_ES5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames26_ES6.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames2_ES5.ts
 
@@ -13214,6 +13204,22 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ╰────
 
   × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[typescript/tests/cases/compiler/superInObjectLiterals_ES5.ts:49:17]
+ 48 │             p1: function () {
+ 49 │                 super.method();
+    ·                 ─────
+ 50 │             },
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[typescript/tests/cases/compiler/superInObjectLiterals_ES5.ts:52:17]
+ 51 │             p2: function f() {
+ 52 │                 super.method();
+    ·                 ─────
+ 53 │             },
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
     ╭─[typescript/tests/cases/compiler/superInObjectLiterals_ES6.ts:17:9]
  16 │     p1: function () {
  17 │         super.method();
@@ -13235,6 +13241,22 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  23 │         super.method();
     ·         ─────
  24 │     }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[typescript/tests/cases/compiler/superInObjectLiterals_ES6.ts:49:17]
+ 48 │             p1: function () {
+ 49 │                 super.method();
+    ·                 ─────
+ 50 │             },
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[typescript/tests/cases/compiler/superInObjectLiterals_ES6.ts:52:17]
+ 51 │             p2: function f() {
+ 52 │                 super.method();
+    ·                 ─────
+ 53 │             },
     ╰────
 
   × 'super' can only be used with function calls or in property accesses
@@ -16697,6 +16719,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  5 │ }
    ╰────
 
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+   ╭─[typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod12.ts:6:11]
+ 5 │     class C extends S {
+ 6 │         @(super.decorator)
+   ·           ─────
+ 7 │         method() { }
+   ╰────
+
   × Expected `;` but found `@`
    ╭─[typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod17.ts:4:18]
  3 │ class Foo {
@@ -17185,6 +17215,38 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·      ─
  6 │     static [{}]() { }
    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+   ╭─[typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames24_ES5.ts:7:6]
+ 6 │ class C extends Base {
+ 7 │     [super.bar()]() { }
+   ·      ─────
+ 8 │ }
+   ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames24_ES6.ts:9:6]
+  8 │     // use of super in static properties initializers.
+  9 │     [super.bar()]() { }
+    ·      ─────
+ 10 │ }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+   ╭─[typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames26_ES5.ts:8:12]
+ 7 │     [
+ 8 │         { [super.bar()]: 1 }[0]
+   ·            ─────
+ 9 │     ]() { }
+   ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames26_ES6.ts:10:12]
+  9 │     [
+ 10 │         { [super.bar()]: 1 }[0]
+    ·            ─────
+ 11 │     ]() { }
+    ╰────
 
   × Super calls are not permitted outside constructors or in nested functions inside constructors.
    ╭─[typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames27_ES5.ts:4:7]
@@ -20519,6 +20581,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  73 │             super.publicFunc();
     ·             ─────
  74 │         }
+    ╰────
+
+  × 'super' can only be referenced in members of derived classes or object literal expressions.
+    ╭─[typescript/tests/cases/conformance/expressions/superPropertyAccess/errorSuperPropertyAccess.ts:76:40]
+ 75 │         var x = {
+ 76 │             test: function () { return super.publicFunc(); }
+    ·                                        ─────
+ 77 │         }
     ╰────
 
   × 'super' can only be referenced in members of derived classes or object literal expressions.

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
 AST Parsed     : 49/49 (100.00%)
-Positive Passed: 33/49 (67.35%)
+Positive Passed: 31/49 (63.27%)
 semantic Error: tasks/coverage/misc/pass/oxc-11593.ts
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
@@ -27,6 +27,181 @@ semantic Error: tasks/coverage/misc/pass/oxc-1289.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["infer", "target", "type"]
 rebuilt        : ScopeId(0): []
+
+semantic Error: tasks/coverage/misc/pass/oxc-13284.js
+Scope children mismatch:
+after transform: ScopeId(133): [ScopeId(134), ScopeId(136), ScopeId(141), ScopeId(142), ScopeId(143), ScopeId(144)]
+rebuilt        : ScopeId(134): [ScopeId(135), ScopeId(137), ScopeId(138), ScopeId(139), ScopeId(143), ScopeId(144), ScopeId(145), ScopeId(146)]
+Scope parent mismatch:
+after transform: ScopeId(137): Some(ScopeId(136))
+rebuilt        : ScopeId(137): Some(ScopeId(134))
+Scope parent mismatch:
+after transform: ScopeId(139): Some(ScopeId(136))
+rebuilt        : ScopeId(138): Some(ScopeId(134))
+Scope children mismatch:
+after transform: ScopeId(136): [ScopeId(137), ScopeId(138), ScopeId(139), ScopeId(140), ScopeId(398)]
+rebuilt        : ScopeId(139): [ScopeId(140), ScopeId(141), ScopeId(142)]
+Scope children mismatch:
+after transform: ScopeId(400): [ScopeId(148), ScopeId(152), ScopeId(153), ScopeId(159)]
+rebuilt        : ScopeId(151): [ScopeId(152), ScopeId(153), ScopeId(157), ScopeId(158), ScopeId(165)]
+Scope parent mismatch:
+after transform: ScopeId(149): Some(ScopeId(148))
+rebuilt        : ScopeId(152): Some(ScopeId(151))
+Scope children mismatch:
+after transform: ScopeId(148): [ScopeId(149), ScopeId(150), ScopeId(151), ScopeId(401)]
+rebuilt        : ScopeId(153): [ScopeId(154), ScopeId(155), ScopeId(156)]
+Scope children mismatch:
+after transform: ScopeId(154): [ScopeId(155)]
+rebuilt        : ScopeId(159): [ScopeId(160), ScopeId(161)]
+Scope parent mismatch:
+after transform: ScopeId(156): Some(ScopeId(155))
+rebuilt        : ScopeId(160): Some(ScopeId(159))
+Scope children mismatch:
+after transform: ScopeId(155): [ScopeId(156), ScopeId(157), ScopeId(158), ScopeId(402)]
+rebuilt        : ScopeId(161): [ScopeId(162), ScopeId(163), ScopeId(164)]
+Scope children mismatch:
+after transform: ScopeId(176): [ScopeId(177), ScopeId(181), ScopeId(182), ScopeId(187)]
+rebuilt        : ScopeId(168): [ScopeId(169), ScopeId(170), ScopeId(174), ScopeId(175), ScopeId(181)]
+Scope parent mismatch:
+after transform: ScopeId(178): Some(ScopeId(177))
+rebuilt        : ScopeId(169): Some(ScopeId(168))
+Scope children mismatch:
+after transform: ScopeId(177): [ScopeId(178), ScopeId(179), ScopeId(180), ScopeId(405)]
+rebuilt        : ScopeId(170): [ScopeId(171), ScopeId(172), ScopeId(173)]
+Scope children mismatch:
+after transform: ScopeId(190): [ScopeId(191), ScopeId(195), ScopeId(196), ScopeId(202)]
+rebuilt        : ScopeId(184): [ScopeId(185), ScopeId(186), ScopeId(190), ScopeId(191), ScopeId(198)]
+Scope parent mismatch:
+after transform: ScopeId(192): Some(ScopeId(191))
+rebuilt        : ScopeId(185): Some(ScopeId(184))
+Scope children mismatch:
+after transform: ScopeId(191): [ScopeId(192), ScopeId(193), ScopeId(194), ScopeId(407)]
+rebuilt        : ScopeId(186): [ScopeId(187), ScopeId(188), ScopeId(189)]
+Scope children mismatch:
+after transform: ScopeId(197): [ScopeId(198)]
+rebuilt        : ScopeId(192): [ScopeId(193), ScopeId(194)]
+Scope parent mismatch:
+after transform: ScopeId(199): Some(ScopeId(198))
+rebuilt        : ScopeId(193): Some(ScopeId(192))
+Scope children mismatch:
+after transform: ScopeId(198): [ScopeId(199), ScopeId(200), ScopeId(201), ScopeId(408)]
+rebuilt        : ScopeId(194): [ScopeId(195), ScopeId(196), ScopeId(197)]
+Scope children mismatch:
+after transform: ScopeId(205): [ScopeId(206), ScopeId(210), ScopeId(211), ScopeId(216)]
+rebuilt        : ScopeId(201): [ScopeId(202), ScopeId(203), ScopeId(207), ScopeId(208), ScopeId(214)]
+Scope parent mismatch:
+after transform: ScopeId(207): Some(ScopeId(206))
+rebuilt        : ScopeId(202): Some(ScopeId(201))
+Scope children mismatch:
+after transform: ScopeId(206): [ScopeId(207), ScopeId(208), ScopeId(209), ScopeId(409)]
+rebuilt        : ScopeId(203): [ScopeId(204), ScopeId(205), ScopeId(206)]
+Scope children mismatch:
+after transform: ScopeId(168): [ScopeId(169)]
+rebuilt        : ScopeId(224): [ScopeId(225), ScopeId(226)]
+Scope parent mismatch:
+after transform: ScopeId(170): Some(ScopeId(169))
+rebuilt        : ScopeId(225): Some(ScopeId(224))
+Scope children mismatch:
+after transform: ScopeId(169): [ScopeId(170), ScopeId(171), ScopeId(172), ScopeId(404)]
+rebuilt        : ScopeId(226): [ScopeId(227), ScopeId(228), ScopeId(229)]
+Scope children mismatch:
+after transform: ScopeId(219): [ScopeId(220), ScopeId(224), ScopeId(225), ScopeId(231)]
+rebuilt        : ScopeId(233): [ScopeId(234), ScopeId(235), ScopeId(239), ScopeId(240), ScopeId(247)]
+Scope parent mismatch:
+after transform: ScopeId(221): Some(ScopeId(220))
+rebuilt        : ScopeId(234): Some(ScopeId(233))
+Scope children mismatch:
+after transform: ScopeId(220): [ScopeId(221), ScopeId(222), ScopeId(223), ScopeId(411)]
+rebuilt        : ScopeId(235): [ScopeId(236), ScopeId(237), ScopeId(238)]
+Scope children mismatch:
+after transform: ScopeId(226): [ScopeId(227)]
+rebuilt        : ScopeId(241): [ScopeId(242), ScopeId(243)]
+Scope parent mismatch:
+after transform: ScopeId(228): Some(ScopeId(227))
+rebuilt        : ScopeId(242): Some(ScopeId(241))
+Scope children mismatch:
+after transform: ScopeId(227): [ScopeId(228), ScopeId(229), ScopeId(230), ScopeId(412)]
+rebuilt        : ScopeId(243): [ScopeId(244), ScopeId(245), ScopeId(246)]
+Scope children mismatch:
+after transform: ScopeId(266): [ScopeId(267), ScopeId(338), ScopeId(342), ScopeId(343), ScopeId(344), ScopeId(332)]
+rebuilt        : ScopeId(282): [ScopeId(283), ScopeId(349), ScopeId(355), ScopeId(356), ScopeId(360), ScopeId(361), ScopeId(362)]
+Scope parent mismatch:
+after transform: ScopeId(339): Some(ScopeId(338))
+rebuilt        : ScopeId(355): Some(ScopeId(282))
+Scope children mismatch:
+after transform: ScopeId(338): [ScopeId(339), ScopeId(340), ScopeId(341), ScopeId(414)]
+rebuilt        : ScopeId(356): [ScopeId(357), ScopeId(358), ScopeId(359)]
+Scope children mismatch:
+after transform: ScopeId(348): [ScopeId(349), ScopeId(355), ScopeId(358)]
+rebuilt        : ScopeId(367): [ScopeId(368), ScopeId(374), ScopeId(377), ScopeId(379)]
+Scope children mismatch:
+after transform: ScopeId(358): [ScopeId(359), ScopeId(363)]
+rebuilt        : ScopeId(377): [ScopeId(378)]
+Scope parent mismatch:
+after transform: ScopeId(359): Some(ScopeId(358))
+rebuilt        : ScopeId(379): Some(ScopeId(367))
+Scope children mismatch:
+after transform: ScopeId(365): [ScopeId(366), ScopeId(372), ScopeId(375)]
+rebuilt        : ScopeId(384): [ScopeId(385), ScopeId(391), ScopeId(394), ScopeId(396)]
+Scope children mismatch:
+after transform: ScopeId(375): [ScopeId(376), ScopeId(380)]
+rebuilt        : ScopeId(394): [ScopeId(395)]
+Scope parent mismatch:
+after transform: ScopeId(376): Some(ScopeId(375))
+rebuilt        : ScopeId(396): Some(ScopeId(384))
+Scope children mismatch:
+after transform: ScopeId(381): [ScopeId(382), ScopeId(388), ScopeId(391)]
+rebuilt        : ScopeId(400): [ScopeId(401), ScopeId(407), ScopeId(410), ScopeId(412)]
+Scope children mismatch:
+after transform: ScopeId(391): [ScopeId(392), ScopeId(396)]
+rebuilt        : ScopeId(410): [ScopeId(411)]
+Scope parent mismatch:
+after transform: ScopeId(392): Some(ScopeId(391))
+rebuilt        : ScopeId(412): Some(ScopeId(400))
+Symbol reference IDs mismatch for "_decorateMetadata":
+after transform: SymbolId(166): [ReferenceId(68), ReferenceId(70), ReferenceId(72), ReferenceId(74), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(80), ReferenceId(81), ReferenceId(82), ReferenceId(106), ReferenceId(108), ReferenceId(110), ReferenceId(111), ReferenceId(112), ReferenceId(120), ReferenceId(122), ReferenceId(124), ReferenceId(125), ReferenceId(126), ReferenceId(134), ReferenceId(136), ReferenceId(138), ReferenceId(139), ReferenceId(140), ReferenceId(148), ReferenceId(150), ReferenceId(152), ReferenceId(153), ReferenceId(154), ReferenceId(162), ReferenceId(164), ReferenceId(166), ReferenceId(167), ReferenceId(168), ReferenceId(186), ReferenceId(188), ReferenceId(190), ReferenceId(191), ReferenceId(192), ReferenceId(200), ReferenceId(202), ReferenceId(204), ReferenceId(205), ReferenceId(206), ReferenceId(224), ReferenceId(226), ReferenceId(228), ReferenceId(229), ReferenceId(230), ReferenceId(238), ReferenceId(240), ReferenceId(242), ReferenceId(243), ReferenceId(244), ReferenceId(262), ReferenceId(264), ReferenceId(266), ReferenceId(267), ReferenceId(268), ReferenceId(276), ReferenceId(278), ReferenceId(280), ReferenceId(281), ReferenceId(282), ReferenceId(300), ReferenceId(302), ReferenceId(304), ReferenceId(305), ReferenceId(306), ReferenceId(429), ReferenceId(431), ReferenceId(433), ReferenceId(434), ReferenceId(435), ReferenceId(453), ReferenceId(455), ReferenceId(457), ReferenceId(459), ReferenceId(461), ReferenceId(462), ReferenceId(463), ReferenceId(465), ReferenceId(466), ReferenceId(467), ReferenceId(483), ReferenceId(484), ReferenceId(485), ReferenceId(487), ReferenceId(488), ReferenceId(489), ReferenceId(491), ReferenceId(492), ReferenceId(493), ReferenceId(497), ReferenceId(498), ReferenceId(499), ReferenceId(501), ReferenceId(502), ReferenceId(503), ReferenceId(505), ReferenceId(506), ReferenceId(507), ReferenceId(511), ReferenceId(512), ReferenceId(513), ReferenceId(515), ReferenceId(516), ReferenceId(517), ReferenceId(519), ReferenceId(520), ReferenceId(521)]
+rebuilt        : SymbolId(3): [ReferenceId(63), ReferenceId(67), ReferenceId(71), ReferenceId(75), ReferenceId(79), ReferenceId(81), ReferenceId(82), ReferenceId(85), ReferenceId(87), ReferenceId(88), ReferenceId(97), ReferenceId(107), ReferenceId(121), ReferenceId(125), ReferenceId(129), ReferenceId(131), ReferenceId(132), ReferenceId(140), ReferenceId(153), ReferenceId(157), ReferenceId(161), ReferenceId(163), ReferenceId(164), ReferenceId(172), ReferenceId(185), ReferenceId(189), ReferenceId(193), ReferenceId(195), ReferenceId(196), ReferenceId(204), ReferenceId(231), ReferenceId(264), ReferenceId(300), ReferenceId(307), ReferenceId(314), ReferenceId(316), ReferenceId(317), ReferenceId(343), ReferenceId(385), ReferenceId(389), ReferenceId(393), ReferenceId(395), ReferenceId(396), ReferenceId(405), ReferenceId(409), ReferenceId(413), ReferenceId(417), ReferenceId(421), ReferenceId(423), ReferenceId(424), ReferenceId(427), ReferenceId(429), ReferenceId(430), ReferenceId(434), ReferenceId(436), ReferenceId(437), ReferenceId(440), ReferenceId(442), ReferenceId(443), ReferenceId(447), ReferenceId(449), ReferenceId(450)]
+Symbol span mismatch for "Inner5":
+after transform: SymbolId(57): Span { start: 4573, end: 4579 }
+rebuilt        : SymbolId(69): Span { start: 0, end: 0 }
+Symbol span mismatch for "Inner5":
+after transform: SymbolId(164): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(70): Span { start: 4573, end: 4579 }
+Symbol span mismatch for "Inner4":
+after transform: SymbolId(126): Span { start: 12166, end: 12172 }
+rebuilt        : SymbolId(169): Span { start: 0, end: 0 }
+Symbol span mismatch for "Inner4":
+after transform: SymbolId(200): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(170): Span { start: 12166, end: 12172 }
+Reference flags mismatch for "_super$foo7":
+after transform: ReferenceId(170): ReferenceFlags(Read | Write)
+rebuilt        : ReferenceId(115): ReferenceFlags(Write)
+Reference flags mismatch for "_super$foo10":
+after transform: ReferenceId(208): ReferenceFlags(Read | Write)
+rebuilt        : ReferenceId(147): ReferenceFlags(Write)
+Reference flags mismatch for "_super$foo13":
+after transform: ReferenceId(246): ReferenceFlags(Read | Write)
+rebuilt        : ReferenceId(179): ReferenceFlags(Write)
+Reference flags mismatch for "_super$foo16":
+after transform: ReferenceId(284): ReferenceFlags(Read | Write)
+rebuilt        : ReferenceId(288): ReferenceFlags(Write)
+Reference flags mismatch for "_super$foo19":
+after transform: ReferenceId(437): ReferenceFlags(Read | Write)
+rebuilt        : ReferenceId(379): ReferenceFlags(Write)
+Unresolved reference IDs mismatch for "Object":
+after transform: [ReferenceId(67), ReferenceId(69), ReferenceId(71), ReferenceId(73), ReferenceId(105), ReferenceId(107), ReferenceId(119), ReferenceId(121), ReferenceId(133), ReferenceId(135), ReferenceId(147), ReferenceId(149), ReferenceId(161), ReferenceId(163), ReferenceId(185), ReferenceId(187), ReferenceId(199), ReferenceId(201), ReferenceId(223), ReferenceId(225), ReferenceId(237), ReferenceId(239), ReferenceId(261), ReferenceId(263), ReferenceId(275), ReferenceId(277), ReferenceId(299), ReferenceId(301), ReferenceId(428), ReferenceId(430), ReferenceId(452), ReferenceId(454), ReferenceId(456), ReferenceId(458)]
+rebuilt        : [ReferenceId(64), ReferenceId(68), ReferenceId(72), ReferenceId(76), ReferenceId(98), ReferenceId(108), ReferenceId(122), ReferenceId(126), ReferenceId(141), ReferenceId(154), ReferenceId(158), ReferenceId(173), ReferenceId(186), ReferenceId(190), ReferenceId(205), ReferenceId(232), ReferenceId(265), ReferenceId(301), ReferenceId(308), ReferenceId(344), ReferenceId(386), ReferenceId(390), ReferenceId(406), ReferenceId(410), ReferenceId(414), ReferenceId(418)]
+Unresolved reference IDs mismatch for "Function":
+after transform: [ReferenceId(75), ReferenceId(79), ReferenceId(109), ReferenceId(123), ReferenceId(137), ReferenceId(151), ReferenceId(165), ReferenceId(189), ReferenceId(203), ReferenceId(227), ReferenceId(241), ReferenceId(265), ReferenceId(279), ReferenceId(303), ReferenceId(432), ReferenceId(460), ReferenceId(464), ReferenceId(482), ReferenceId(486), ReferenceId(490), ReferenceId(496), ReferenceId(500), ReferenceId(504), ReferenceId(510), ReferenceId(514), ReferenceId(518)]
+rebuilt        : [ReferenceId(80), ReferenceId(86), ReferenceId(130), ReferenceId(162), ReferenceId(194), ReferenceId(315), ReferenceId(394), ReferenceId(422), ReferenceId(428), ReferenceId(435), ReferenceId(441), ReferenceId(448)]
+
+semantic Error: tasks/coverage/misc/pass/oxc-13284.ts
+Symbol reference IDs mismatch for "_super":
+after transform: SymbolId(13): [ReferenceId(8)]
+rebuilt        : SymbolId(4): []
+Unresolved references mismatch:
+after transform: ["Super", "super"]
+rebuilt        : ["Super"]
 
 semantic Error: tasks/coverage/misc/pass/oxc-2087.ts
 Scope children mismatch:

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,5 @@
 transformer_misc Summary:
 AST Parsed     : 49/49 (100.00%)
-Positive Passed: 49/49 (100.00%)
+Positive Passed: 48/49 (97.96%)
+Mismatch: tasks/coverage/misc/pass/oxc-13284.js
+


### PR DESCRIPTION
Fixes #13284.

Fix semantic's checking of `super()` and `super.prop`.

This fixes various TS test cases, notably correctly identifying that these are all illegal:

```js
class C {
  prop = function() { super.foo };
  [super.foo]() {}
  @super.foo method() {}
};
```

It also fixes various edge cases related to classes nested within other classes that aren't covered by existing conformance tests.

It's pretty much a complete re-write. I've combined the 2 paths for in a class and not in a class into one, to avoid repeated code.

This PR includes pass + fail test fixtures which include `super` in every conceivable position I could think of. There are so many errors in the fail test fixtures, that I had to write a script to check the snapshot includes them all!

Hopefully this solves this issue for once and for all!

Note: The large pass fixture seems to be revealing bugs somewhere in transformer - there's a mismatch, as well as lots of wrong scopes. But that's incidental to this PR, and can be addressed separately.