### PR TITLE
fix(linter): don't panic when parsing regex with multiple parentheses

### DIFF
--- a/crates/oxc_linter/src/utils/regex.rs
+++ b/crates/oxc_linter/src/utils/regex.rs
@@ -35,8 +35,8 @@ fn run_on_arguments<M>(arg1: Option<&Argument>, arg2: Option<&Argument>, ctx: &L
 where
     M: FnOnce(&Pattern<'_>, Span),
 {
-    let arg1 = arg1.map(|arg| arg.to_expression().get_inner_expression());
-    let arg2 = arg2.map(|arg| arg.to_expression().get_inner_expression());
+    let arg1 = arg1.and_then(Argument::as_expression).map(Expression::get_inner_expression);
+    let arg2 = arg2.and_then(Argument::as_expression).map(Expression::get_inner_expression);
     // note: improvements required for strings used via identifier references
     // Missing or non-string arguments will be runtime errors, but are not covered by this rule.
     match (&arg1, &arg2) {


### PR DESCRIPTION
`to_expression` does some `unwrap` which will panic when multiple parentheses are present.
Use `as_expression` to get an `Option<Expression>` instead.