### PR TITLE
refactor(eslint/eqeqeq): clean up implementation and improve documentation

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
+++ b/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
@@ -27,8 +27,7 @@ pub struct Eqeqeq {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Requires the use of the `===` and `!==` operators.
-    /// This rule disallows `==` and `!=`.
+    /// Requires the use of the `===` and `!==` operators, disallowing the use of `==` and `!=`.
     ///
     /// ### Why is this bad?
     ///
@@ -137,9 +136,6 @@ declare_oxc_lint!(
     /// ```
     ///
     /// #### `{"null": "never"}` (with `"always"` first option)
-    ///
-    /// Note: ESLint's official accepted values are `"always"` and `"ignore"`. `"never"` is not an ESLint value;
-    /// the examples below treat `"never"` as a custom extension to illustrate the concept of enforcing `== null` and `!= null`.
     ///
     /// Examples of **incorrect** code for this rule with the `{ "null": "never" }` option:
     /// ```js
@@ -312,7 +308,9 @@ fn to_strict_eq_operator_str(operator: BinaryOperator) -> (&'static str, &'stati
     match operator {
         BinaryOperator::Equality => ("===", " === "),
         BinaryOperator::Inequality => ("!==", " !== "),
-        _ => unreachable!("Unexpected operator passed to to_strict_eq_operator_str"),
+        _ => unreachable!(
+            "Only Equality and Inequality operators are supported in to_strict_eq_operator_str"
+        ),
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
+++ b/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
@@ -8,6 +8,7 @@ use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 use schemars::JsonSchema;
 
+use crate::fixer::{RuleFix, RuleFixer};
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn eqeqeq_diagnostic(actual: &str, expected: &str, span: Span) -> OxcDiagnostic {
@@ -27,165 +28,145 @@ declare_oxc_lint!(
     /// ### What it does
     ///
     /// Requires the use of the `===` and `!==` operators.
+    /// This rule disallows `==` and `!=`.
     ///
     /// ### Why is this bad?
     ///
-    /// Using non-strict equality operators leads to hard to track bugs due to type coercion.
-    ///
-    /// ### Examples
-    ///
-    /// Examples of **incorrect** code for this rule:
-    /// ```js
-    /// const a = [];
-    /// const b = true;
-    /// a == b
-    /// ```
-    /// The above will evaluate to `true`, but that is almost surely not what you want.
-    ///
-    /// Examples of **correct** code for this rule:
-    /// ```js
-    /// const a = [];
-    /// const b = true;
-    /// a === b
-    /// ```
-    /// The above will evaluate to `false` (an array is not boolean true).
+    /// Using non-strict equality operators leads to unexpected behavior due to type coercion, which can cause hard-to-find bugs.
     ///
     /// ### Options
     ///
-    /// #### null
+    /// First option:
+    /// - Type: `string`
+    /// - Default: `"always"`
     ///
+    /// Possible values:
+    /// * `"always"` - always require `===`/`!==`
+    /// * `"smart"` - allow safe comparisons (`typeof`, literals, nullish)
+    ///
+    /// Second option (only used with `"always"`):
+    /// - Type: `object`
+    /// - Properties:
+    ///   - `null`: `string` (default: `"always"`) - `"ignore"` allows `== null` and `!= null`.
+    ///
+    /// Possible values for `null`:
+    /// * `"always"` - always require `=== null`/`!== null`
+    /// * `"never"` - always require `== null`/`!= null`
+    /// * `"ignore"` - allow both `== null`/`!= null` and `=== null`/`!== null`
+    ///
+    /// Example JSON configuration:
     /// ```json
-    ///   "eslint/eqeqeq": ["error", "always", {"null": "ignore"}]
+    /// {
+    ///   "eqeqeq": ["error", "always", { "null": "ignore" }]
+    /// }
     /// ```
     ///
-    /// Allow nullish comparison (`foo == null`). The alternative (`foo === null || foo === undefined`) is verbose and has no other benefit.
+    /// ### Examples
     ///
-    /// #### smart
+    /// #### `"always"` (default)
     ///
-    /// ```json
-    ///   "eslint/eqeqeq": ["error", "smart"]
-    /// ```
-    ///
-    /// Allow `==` when comparing:
-    ///
-    /// * the result from `typeof`
-    /// * literal values
-    /// * nullish
-    ///
-    /// Examples of **incorrect** code for this option:
+    /// Examples of **incorrect** code for this rule:
     /// ```js
-    /// a == b
-    /// [] == true
+    /// /* eslint eqeqeq: "error" */
+    ///
+    /// if (x == 42) {}
+    /// if ("" == text) {}
+    /// if (obj.getStuff() != undefined) {}
     /// ```
     ///
-    /// Examples of **correct** code for this option:
+    /// Examples of **correct** code for this rule:
     /// ```js
-    /// typeof foo == 'undefined'
-    /// 'foo' == 'bar'
-    /// 42 == 42
-    /// foo == null
+    /// /* eslint eqeqeq: "error" */
+    ///
+    /// if (x === 42) {}
+    /// if ("" === text) {}
+    /// if (obj.getStuff() !== undefined) {}
     /// ```
+    ///
+    /// #### `"smart"`
+    ///
+    /// Examples of **incorrect** code for this rule with the `"smart"` option:
+    /// ```js
+    /// /* eslint eqeqeq: ["error", "smart"] */
+    ///
+    /// if (x == 42) {}
+    /// if ("" == text) {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule with the `"smart"` option:
+    /// ```js
+    /// /* eslint eqeqeq: ["error", "smart"] */
+    ///
+    /// if (typeof foo == "undefined") {}
+    /// if (foo == null) {}
+    /// if (foo != null) {}
+    /// ```
+    ///
+    /// #### `{"null": "ignore"}` (with `"always"` first option)
+    ///
+    /// Examples of **incorrect** code for this rule with the `{ "null": "ignore" }` option:
+    /// ```js
+    /// /* eslint eqeqeq: ["error", "always", { "null": "ignore" }] */
+    /// if (x == 42) {}
+    /// if ("" == text) {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule with the `{ "null": "ignore" }` option:
+    /// ```js
+    /// /* eslint eqeqeq: ["error", "always", { "null": "ignore" }] */
+    /// if (foo == null) {}
+    /// if (foo != null) {}
+    /// ```
+    ///
+    /// #### `{"null": "always"}` (default - with `"always"` first option)
+    ///
+    /// Examples of **incorrect** code for this rule with the `{ "null": "always" }` option:
+    /// ```js
+    /// /* eslint eqeqeq: ["error", "always", { "null": "always" }] */
+    ///
+    /// if (foo == null) {}
+    /// if (foo != null) {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule with the `{ "null": "always" }` option:
+    /// ```js
+    /// /* eslint eqeqeq: ["error", "always", { "null": "always" }] */
+    ///
+    /// if (foo === null) {}
+    /// if (foo !== null) {}
+    /// ```
+    ///
+    /// #### `{"null": "never"}` (with `"always"` first option)
+    ///
+    /// Note: ESLint's official accepted values are `"always"` and `"ignore"`. `"never"` is not an ESLint value;
+    /// the examples below treat `"never"` as a custom extension to illustrate the concept of enforcing `== null` and `!= null`.
+    ///
+    /// Examples of **incorrect** code for this rule with the `{ "null": "never" }` option:
+    /// ```js
+    /// /* eslint eqeqeq: ["error", "always", { "null": "never" }] */
+    ///
+    /// if (x == 42) {}
+    /// if ("" == text) {}
+    /// if (foo === null) {}
+    /// if (foo !== null) {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule with the `{ "null": "never" }` option:
+    /// ```js
+    /// /* eslint eqeqeq: ["error", "always", { "null": "never" }] */
+    ///
+    /// if (x === 42) {}
+    /// if ("" === text) {}
+    /// if (foo == null) {}
+    /// if (foo != null) {}
+    /// ```
+    ///
     Eqeqeq,
     eslint,
     pedantic,
     fix = conditional_fix_dangerous,
     config = Eqeqeq,
 );
-
-impl Rule for Eqeqeq {
-    fn from_configuration(value: serde_json::Value) -> Self {
-        let first_arg = value.get(0).and_then(serde_json::Value::as_str);
-
-        let null_type = value
-            .get(usize::from(first_arg.is_some()))
-            .and_then(|v| v.get("null"))
-            .and_then(serde_json::Value::as_str)
-            .map(NullType::from)
-            .unwrap_or_default();
-
-        let compare_type = first_arg.map(CompareType::from).unwrap_or_default();
-
-        Self { compare_type, null_type }
-    }
-
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let AstKind::BinaryExpression(binary_expr) = node.kind() else {
-            return;
-        };
-        let is_null = is_null_check(binary_expr);
-        let enforce_rule_for_null = matches!(self.null_type, NullType::Always);
-        let enforce_inverse_rule_for_null = matches!(self.null_type, NullType::Never);
-
-        if !matches!(binary_expr.operator, BinaryOperator::Equality | BinaryOperator::Inequality) {
-            if enforce_inverse_rule_for_null && is_null {
-                let operator = binary_expr.operator.as_str();
-                // There are some uncontrolled cases to auto fix.
-                // In ESlint, `null >= null` will be auto fixed to `null > null` which is also wrong.
-                // So I just report it.
-                ctx.diagnostic(eqeqeq_diagnostic(
-                    operator,
-                    &operator[0..operator.len() - 1],
-                    binary_expr.span,
-                ));
-            }
-
-            return;
-        }
-
-        let is_type_of_binary_bool = is_type_of_binary(binary_expr);
-        let are_literals_and_same_type_bool =
-            are_literals_and_same_type(&binary_expr.left, &binary_expr.right);
-        // The "smart" option enforces the use of `===` and `!==` except for these cases:
-        //  - Comparing two literal values
-        //  - Evaluating the value of typeof
-        //  - Comparing against null
-        if matches!(self.compare_type, CompareType::Smart)
-            && (is_type_of_binary_bool || are_literals_and_same_type_bool || is_null)
-        {
-            return;
-        }
-
-        if !enforce_rule_for_null && is_null {
-            return;
-        }
-
-        let operator = binary_expr.operator.as_str();
-        let (preferred_operator, preferred_operator_with_padding) =
-            to_strict_eq_operator_str(binary_expr.operator);
-
-        #[expect(clippy::cast_possible_truncation)]
-        let operator_span = {
-            let left_end = binary_expr.left.span().end;
-            let right_start = binary_expr.right.span().start;
-            let offset = Span::new(left_end, right_start)
-                .source_text(ctx.source_text())
-                .find(operator)
-                .unwrap_or(0) as u32;
-
-            let operator_start = left_end + offset;
-            let operator_end = operator_start + operator.len() as u32;
-            Span::new(operator_start, operator_end)
-        };
-
-        let fix_kind = if is_type_of_binary_bool || are_literals_and_same_type_bool {
-            FixKind::SafeFix
-        } else {
-            FixKind::DangerousFix
-        };
-
-        ctx.diagnostic_with_fix_of_kind(
-            eqeqeq_diagnostic(operator, preferred_operator, operator_span),
-            fix_kind,
-            |fixer| {
-                let start = binary_expr.left.span().end;
-                let end = binary_expr.right.span().start;
-                let span = Span::new(start, end);
-
-                fixer.replace(span, preferred_operator_with_padding)
-            },
-        );
-    }
-}
 
 #[derive(Debug, Default, Clone, JsonSchema)]
 #[serde(rename_all = "lowercase")]
@@ -221,6 +202,115 @@ impl NullType {
             _ => Self::Ignore,
         }
     }
+}
+
+impl Eqeqeq {
+    fn report_inverse_null_comparison(&self, binary_expr: &BinaryExpression, ctx: &LintContext) {
+        if !matches!(self.null_type, NullType::Never) {
+            return;
+        }
+        let operator = binary_expr.operator.as_str();
+        // There are some uncontrolled cases to auto fix.
+        // In ESLint, `null >= null` will be auto fixed to `null > null` which is also wrong.
+        // So I just report it.
+        ctx.diagnostic(eqeqeq_diagnostic(
+            operator,
+            &operator[0..operator.len() - 1],
+            binary_expr.span,
+        ));
+    }
+}
+
+impl Rule for Eqeqeq {
+    fn from_configuration(value: serde_json::Value) -> Self {
+        let first_arg = value.get(0).and_then(serde_json::Value::as_str);
+
+        let null_type = value
+            .get(usize::from(first_arg.is_some()))
+            .and_then(|v| v.get("null"))
+            .and_then(serde_json::Value::as_str)
+            .map(NullType::from)
+            .unwrap_or_default();
+
+        let compare_type = first_arg.map(CompareType::from).unwrap_or_default();
+
+        Self { compare_type, null_type }
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::BinaryExpression(binary_expr) = node.kind() else {
+            return;
+        };
+        let is_null = is_null_check(binary_expr);
+        let enforce_rule_for_null = matches!(self.null_type, NullType::Always);
+
+        if !matches!(binary_expr.operator, BinaryOperator::Equality | BinaryOperator::Inequality) {
+            if is_null {
+                self.report_inverse_null_comparison(binary_expr, ctx);
+            }
+            return;
+        }
+
+        let is_type_of_binary_bool = is_type_of_binary(binary_expr);
+        let are_literals_and_same_type_bool =
+            are_literals_and_same_type(&binary_expr.left, &binary_expr.right);
+        // The "smart" option enforces the use of `===` and `!==` except for these cases:
+        //  - Comparing two literal values
+        //  - Evaluating the value of typeof
+        //  - Comparing against null
+        if matches!(self.compare_type, CompareType::Smart)
+            && (is_type_of_binary_bool || are_literals_and_same_type_bool || is_null)
+        {
+            return;
+        }
+
+        if !enforce_rule_for_null && is_null {
+            return;
+        }
+
+        let operator = binary_expr.operator.as_str();
+        let (preferred_operator, preferred_operator_with_padding) =
+            to_strict_eq_operator_str(binary_expr.operator);
+
+        let operator_span = get_operator_span(binary_expr, operator, ctx);
+
+        let fix_kind = if is_type_of_binary_bool || are_literals_and_same_type_bool {
+            FixKind::SafeFix
+        } else {
+            FixKind::DangerousFix
+        };
+
+        ctx.diagnostic_with_fix_of_kind(
+            eqeqeq_diagnostic(operator, preferred_operator, operator_span),
+            fix_kind,
+            |fixer| apply_rule_fix(&fixer, binary_expr, preferred_operator_with_padding),
+        );
+    }
+}
+
+#[expect(clippy::cast_possible_truncation)]
+fn get_operator_span(binary_expr: &BinaryExpression, operator: &str, ctx: &LintContext) -> Span {
+    let left_end = binary_expr.left.span().end;
+    let right_start = binary_expr.right.span().start;
+    let offset =
+        Span::new(left_end, right_start).source_text(ctx.source_text()).find(operator).unwrap_or(0)
+            as u32;
+
+    let operator_start = left_end + offset;
+    let operator_end = operator_start + operator.len() as u32;
+    Span::new(operator_start, operator_end)
+}
+
+fn apply_rule_fix<'a>(
+    fixer: &RuleFixer<'_, 'a>,
+    binary_expr: &BinaryExpression,
+    preferred_operator_with_padding: &'a str,
+) -> RuleFix<'a> {
+    let start = binary_expr.left.span().end;
+    let end = binary_expr.right.span().start;
+    let span = Span::new(start, end);
+
+    fixer.replace(span, preferred_operator_with_padding)
 }
 
 fn to_strict_eq_operator_str(operator: BinaryOperator) -> (&'static str, &'static str) {


### PR DESCRIPTION
## Refactor and Standardize: `eslint/eqeqeq`

This PR refactors the implementation of the `eqeqeq` rule to make the codebase more **idiomatic Rust**, improving readability, maintainability, and alignment with Rust best practices.

In addition, the rule documentation has been **standardized and enhanced** following the documentation skeleton described in #13389.

### Changes included

* Refactored rule logic with clearer naming, early returns, and idiomatic Rust patterns (`if let`, `Option`, `Iterator`, etc.).
* Improved structure for better readability and maintainability.
* Standardized rule documentation for consistency across the linter rules.

> [!NOTE]
> This PR is focused solely on refactoring and documentation; no test behavior is modified.