### PR TITLE
feat(editor): support relative path for `oxc.path.server`

### DIFF
--- a/editors/vscode/client/ConfigService.ts
+++ b/editors/vscode/client/ConfigService.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path';
 import { ConfigurationChangeEvent, Uri, workspace, WorkspaceFolder } from 'vscode';
 import { IDisposable } from './types';
 import { VSCodeConfig } from './VSCodeConfig';
@@ -57,6 +58,24 @@ export class ConfigService implements IDisposable {
       }
     }
     return false;
+  }
+
+  public getUserServerBinPath(): string | undefined {
+    let bin = this.vsCodeConfig.binPath;
+    if (!bin) {
+      return;
+    }
+
+    if (!path.isAbsolute(bin)) {
+      // if the path is not absolute, resolve it to the first workspace folder
+      let cwd = this.workspaceConfigs.keys().next().value;
+      if (!cwd) {
+        return;
+      }
+      bin = path.normalize(path.join(cwd, bin));
+    }
+
+    return bin;
   }
 
   private async onVscodeConfigChange(event: ConfigurationChangeEvent): Promise<void> {

--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -138,7 +138,7 @@ export async function activate(context: ExtensionContext) {
   );
 
   async function findBinary(): Promise<string> {
-    let bin = configService.vsCodeConfig.binPath;
+    let bin = configService.getUserServerBinPath();
     if (bin) {
       try {
         await fsPromises.access(bin);

--- a/editors/vscode/tests/ConfigService.spec.ts
+++ b/editors/vscode/tests/ConfigService.spec.ts
@@ -1,0 +1,37 @@
+import { strictEqual } from 'assert';
+import { workspace } from 'vscode';
+import { ConfigService } from '../client/ConfigService.js';
+import { testSingleFolderMode, WORKSPACE_FOLDER } from './test-helpers.js';
+
+const conf = workspace.getConfiguration('oxc');
+
+suite('ConfigService', () => {
+  setup(async () => {
+    const keys = ['path.server'];
+
+    await Promise.all(keys.map(key => conf.update(key, undefined)));
+  });
+
+  teardown(async () => {
+    const keys = ['path.server'];
+
+    await Promise.all(keys.map(key => conf.update(key, undefined)));
+  });
+
+  testSingleFolderMode('resolves relative server path with workspace folder', async () => {
+    const service = new ConfigService();
+    const nonDefinedServerPath = service.getUserServerBinPath();
+
+    strictEqual(nonDefinedServerPath, undefined);
+
+    await conf.update('path.server', '/absolute/binary');
+    const absoluteServerPath = service.getUserServerBinPath();
+
+    strictEqual(absoluteServerPath, '/absolute/binary');
+
+    await conf.update('path.server', './relative/binary');
+    const relativeServerPath = service.getUserServerBinPath();
+
+    strictEqual(relativeServerPath, WORKSPACE_FOLDER.uri.path + '/relative/binary');
+  });
+});


### PR DESCRIPTION
closes #12849