### PR TITLE
experiment: remove repr(transparent) from Token

### DIFF
--- a/crates/oxc_parser/src/lexer/token.rs
+++ b/crates/oxc_parser/src/lexer/token.rs
@@ -42,7 +42,6 @@ const _: () = {
 };
 
 #[derive(Clone, Copy)]
-#[repr(transparent)]
 pub struct Token(u128);
 
 impl Default for Token {


### PR DESCRIPTION
Related to https://github.com/oxc-project/backlog/issues/178. Checking if simply removing `repr(transparent)` has a significant effect on performance.