### PR TITLE
ai: add rust-analyzer in copilot setup for serena

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -33,7 +33,7 @@ jobs:
           cache-key: warm
           save-cache: false
           tools: just,cargo-insta,typos-cli,cargo-shear,dprint,ast-grep
-          components: clippy rust-docs rustfmt
+          components: clippy rust-docs rustfmt rust-analyzer
 
       - uses: oxc-project/setup-node@f42e3bda950c7454575e78ee4eaac880a077700c # v1.0.0
 


### PR DESCRIPTION
https://github.com/oxc-project/oxc/actions/runs/17393892766/job/49372287672#step:19:357
serena is failing because rust-analyzer is not installed.
