### PR TITLE
fix(editor): add notice for a possible restart when fixing `filename-case`

### DIFF
--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -186,6 +186,15 @@ export async function activate(context: ExtensionContext) {
     outputChannel,
     traceOutputChannel: outputChannel,
     middleware: {
+      handleDiagnostics: (uri, diagnostics, next) => {
+        for (const diag of diagnostics) {
+          // https://github.com/oxc-project/oxc/issues/12404
+          if (typeof diag.code === 'object' && diag.code?.value === 'eslint-plugin-unicorn(filename-case)') {
+            diag.message += '\nYou may need to close the file and restart VSCode after renaming a file by only casing.';
+          }
+        }
+        next(uri, diagnostics);
+      },
       workspace: {
         configuration: (params: ConfigurationParams) => {
           return params.items.map(item => {


### PR DESCRIPTION
closes #12404

VSCode does not send the new filename case, when only renaming the file. 
So `oxc_language_server` receives the wrong URI and still reports for `filename-case` rule.

Other language server had the problems, and everybody fixed it in VSCode. Because other editors are doing this "correct".
See the linked issues in my replies:

https://github.com/oxc-project/oxc/issues/12404#issuecomment-3094684532

Comment highlight of go:  https://github.com/golang/go/issues/61293#issuecomment-1635991907