### PR TITLE
feat(linter): add `vue/valid-define-props` rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2440,3 +2440,7 @@ impl RuleRunner for crate::rules::vitest::require_local_test_context_for_concurr
 impl RuleRunner for crate::rules::vue::valid_define_emits::ValidDefineEmits {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
 }
+
+impl RuleRunner for crate::rules::vue::valid_define_props::ValidDefineProps {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+}

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -625,6 +625,7 @@ pub(crate) mod node {
 
 pub(crate) mod vue {
     pub mod valid_define_emits;
+    pub mod valid_define_props;
 }
 
 oxc_macros::declare_all_lint_rules! {
@@ -1203,4 +1204,5 @@ oxc_macros::declare_all_lint_rules! {
     vitest::prefer_to_be_truthy,
     vitest::require_local_test_context_for_concurrent_snapshots,
     vue::valid_define_emits,
+    vue::valid_define_props,
 }

--- a/crates/oxc_linter/src/snapshots/vue_valid_define_props.snap
+++ b/crates/oxc_linter/src/snapshots/vue_valid_define_props.snap
@@ -1,0 +1,51 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint-plugin-vue(valid-define-props): `defineProps` is referencing locally declared variables.
+   ╭─[valid_define_props.tsx:5:12]
+ 4 │                     const def = { msg: String }
+ 5 │                     defineProps(def)
+   ·                     ────────────────
+ 6 │                   </script>
+   ╰────
+  help: inline the variable or import it from another module.
+
+  ⚠ eslint-plugin-vue(valid-define-props): `defineProps` has both a type-only emit and an argument.
+   ╭─[valid_define_props.tsx:4:12]
+ 3 │                     /* ✗ BAD */
+ 4 │                     defineProps<{ msg?:string }>({ msg: String })
+   ·                     ─────────────────────────────────────────────
+ 5 │                   </script>
+   ╰────
+  help: remove the argument for better type inference.
+
+  ⚠ eslint-plugin-vue(valid-define-props): `defineProps` has been called multiple times.
+   ╭─[valid_define_props.tsx:4:12]
+ 3 │                     /* ✗ BAD */
+ 4 │                     defineProps({ msg: String })
+   ·                     ──────────────┬─────────────
+   ·                                   ╰── `defineProps` is called here too
+ 5 │                     defineProps({ count: Number })
+   ·                     ───────────────┬──────────────
+   ·                                    ╰── `defineProps` is called here
+ 6 │                   </script>
+   ╰────
+  help: combine all `defineProps` calls into a single `defineProps` call.
+
+  ⚠ eslint-plugin-vue(valid-define-props): Props are defined in both `defineProps` and `export default {}`.
+    ╭─[valid_define_props.tsx:9:12]
+  8 │                     /* ✗ BAD */
+  9 │                     defineProps({ count: Number })
+    ·                     ──────────────────────────────
+ 10 │                   </script>
+    ╰────
+  help: Remove `export default`.
+
+  ⚠ eslint-plugin-vue(valid-define-props): Props are not defined.
+   ╭─[valid_define_props.tsx:4:12]
+ 3 │                     /* ✗ BAD */
+ 4 │                     defineProps()
+   ·                     ─────────────
+ 5 │                   </script>
+   ╰────
+  help: Define at least one prop in `defineProps`.

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -22,10 +22,11 @@ mod regex;
 mod unicorn;
 mod url;
 mod vitest;
+mod vue;
 
 pub use self::{
     comment::*, config::*, express::*, jest::*, jsdoc::*, nextjs::*, promise::*, react::*,
-    react_perf::*, regex::*, unicorn::*, url::*, vitest::*,
+    react_perf::*, regex::*, unicorn::*, url::*, vitest::*, vue::*,
 };
 
 /// List of Jest rules that have Vitest equivalents.

--- a/crates/oxc_linter/src/utils/vue.rs
+++ b/crates/oxc_linter/src/utils/vue.rs
@@ -1,0 +1,117 @@
+use oxc_ast::{
+    AstKind,
+    ast::{
+        CallExpression, ExportDefaultDeclarationKind, Expression, IdentifierReference,
+        ObjectPropertyKind,
+    },
+};
+
+use crate::{ContextSubHost, LintContext};
+
+/// Check if any of the other contexts has a default export with the `name` property.
+///
+/// # Example
+///
+/// ```vue
+/// <script>
+/// export default {
+///  emits: []
+/// }
+/// </script>
+/// ```
+///
+/// Check if it has `emits` property with `has_default_exports_property(others, "emits")`
+pub fn has_default_exports_property(others: &Vec<&ContextSubHost<'_>>, check_name: &str) -> bool {
+    for host in others {
+        for other_node in host.semantic().nodes() {
+            let AstKind::ExportDefaultDeclaration(export) = other_node.kind() else {
+                continue;
+            };
+
+            let ExportDefaultDeclarationKind::ObjectExpression(export_obj) = &export.declaration
+            else {
+                continue;
+            };
+
+            let has_emits_exports = export_obj.properties.iter().any(|property| {
+                let ObjectPropertyKind::ObjectProperty(property) = property else {
+                    return false;
+                };
+
+                property.key.name().is_some_and(|name| name == check_name)
+            });
+
+            if has_emits_exports {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+pub enum DefineMacroProblem {
+    DefineInBoth,
+    HasTypeAndArguments,
+    EventsNotDefined,
+    ReferencingLocally,
+}
+
+pub fn check_define_macro_call_expression(
+    call_expr: &CallExpression,
+    ctx: &LintContext,
+    has_export_default_equivalent: bool,
+) -> Option<DefineMacroProblem> {
+    let has_type_args = call_expr.type_arguments.is_some();
+
+    if has_type_args && has_export_default_equivalent {
+        return Some(DefineMacroProblem::DefineInBoth);
+    }
+
+    // `defineEmits` has type arguments and js arguments. Vue Compiler allows only one of them.
+    if has_type_args && !call_expr.arguments.is_empty() {
+        return Some(DefineMacroProblem::HasTypeAndArguments);
+    }
+
+    if has_type_args {
+        // If there are type arguments, we don't need to check the arguments.
+        return None;
+    }
+
+    let Some(expression) = call_expr.arguments.first().and_then(|first| first.as_expression())
+    else {
+        // `defineEmits();` is valid when `export default { emits: [] }` is defined
+        if !has_export_default_equivalent {
+            return Some(DefineMacroProblem::EventsNotDefined);
+        }
+        return None;
+    };
+
+    if has_export_default_equivalent {
+        return Some(DefineMacroProblem::DefineInBoth);
+    }
+
+    match expression {
+        Expression::ArrayExpression(_) | Expression::ObjectExpression(_) => None,
+        Expression::Identifier(identifier) => {
+            if !is_non_local_reference(identifier, ctx) {
+                return Some(DefineMacroProblem::ReferencingLocally);
+            }
+            None
+        }
+        _ => Some(DefineMacroProblem::EventsNotDefined),
+    }
+}
+
+fn is_non_local_reference(identifier: &IdentifierReference, ctx: &LintContext<'_>) -> bool {
+    if let Some(symbol_id) = ctx.semantic().scoping().get_root_binding(&identifier.name) {
+        return matches!(
+            ctx.semantic().symbol_declaration(symbol_id).kind(),
+            AstKind::ImportSpecifier(_)
+        );
+    }
+
+    // variables outside the current `<script>` block are valid.
+    // This is the same for unresolved variables.
+    true
+}


### PR DESCRIPTION
related https://github.com/oxc-project/oxc/issues/11440

https://eslint.vuejs.org/rules/valid-define-props.html

`defineEmits` and `defineProps` behave the same, refactored code to some utils, so both rules reuses the logic.