### PR TITLE
fix(semantic): dont parse `@` as jsdoc tags inside quotes

### DIFF
--- a/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
@@ -607,6 +607,17 @@ fn test() {
           Some(serde_json::json!([ { "definedTags": [] } ])),
           None,
       ),
+       // https://github.com/oxc-project/oxc/issues/13570
+        (
+          "
+          /**
+           * @import { Page } from '@playwright/test';
+           */
+          function quux (foo) { }
+      ",
+          Some(serde_json::json!([ { "definedTags": [] } ])),
+          None,
+      ),
         (
           "
           /**


### PR DESCRIPTION
Fixes #13570

