### PR TITLE
perf(linter): reduce indirection

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -181,6 +181,7 @@ impl Linter {
                 let mut rules_any_ast_type = Vec::with_capacity(rules.len());
 
                 for (rule, ctx) in &rules {
+                    let rule = *rule;
                     // Collect node type information for rules. In large files, benchmarking showed it was worth
                     // collecting rules into buckets by AST node type to avoid iterating over all rules for each node.
                     if rule.should_run(&ctx_host) {


### PR DESCRIPTION
Follow-on after #13138, as per [this comment](https://github.com/oxc-project/oxc/pull/13138#discussion_r2328531176).

Previously `rules_by_ast_type` and `rules_any_ast_type` contained `&&RuleEnum`, which is unnecessary indirection. Store `&RuleEnum` instead.