### PR TITLE
refactor(linter_codegen): simplify matching "or" patterns

### DIFF
--- a/tasks/linter_codegen/src/main.rs
+++ b/tasks/linter_codegen/src/main.rs
@@ -269,13 +269,12 @@ fn is_node_kind_call(expr: &Expr) -> bool {
 fn extract_variants_from_pat(pat: &Pat, out: &mut BTreeSet<String>) -> CollectionResult {
     match pat {
         Pat::Or(orpat) => {
-            let mut result = CollectionResult::Complete;
             for p in &orpat.cases {
                 if extract_variants_from_pat(p, out) == CollectionResult::Incomplete {
-                    result = CollectionResult::Incomplete;
+                    return CollectionResult::Incomplete;
                 }
             }
-            result
+            CollectionResult::Complete
         }
         Pat::TupleStruct(ts) => {
             if let Some(variant) = astkind_variant_from_path(&ts.path) {


### PR DESCRIPTION
Follow-on after #13138, as per [this comment](https://github.com/oxc-project/oxc/pull/13138#discussion_r2328545173).

Pure refactor. Break out of loop early on first failure, as following iterations have no effect.