### PR TITLE
feat(data_structures): add `boxed_slice!` and `boxed_array!` macros

### DIFF
--- a/crates/oxc_data_structures/Cargo.toml
+++ b/crates/oxc_data_structures/Cargo.toml
@@ -26,8 +26,9 @@ ropey = { workspace = true, optional = true }
 
 [features]
 default = []
-all = ["assert_unchecked", "code_buffer", "inline_string", "rope", "slice_iter", "stack"]
+all = ["assert_unchecked", "box_macros", "code_buffer", "inline_string", "rope", "slice_iter", "stack"]
 assert_unchecked = []
+box_macros = []
 code_buffer = ["assert_unchecked"]
 inline_string = ["assert_unchecked"]
 rope = ["dep:ropey"]

--- a/crates/oxc_data_structures/README.md
+++ b/crates/oxc_data_structures/README.md
@@ -13,6 +13,7 @@ This crate provides specialized data structures and utilities that are used thro
 - **Inline strings**: Memory-efficient string storage for short strings
 - **Slice iterators**: Enhanced iteration capabilities for slices
 - **Rope data structure**: Efficient text manipulation for large documents
+- **Box macros**: Macros for creating boxed arrays / slices (similar to `vec!` macro)
 
 ## Architecture
 

--- a/crates/oxc_data_structures/src/box_macros.rs
+++ b/crates/oxc_data_structures/src/box_macros.rs
@@ -1,0 +1,58 @@
+//! Macros for creating boxed slices and arrays.
+
+// TODO: We might be able to make these more performant by using `MaybeUninit`.
+
+/// Macro to create a boxed slice (`Box<[T]>`).
+///
+/// Similar to standard library's `vec!` macro.
+///
+/// If length is a const (known at compile time), you would likely be better off using a boxed array instead
+/// (`boxed_array!` macro).
+///
+/// # Example
+/// ```
+/// # fn get_length_somehow() -> usize { 5 }
+///
+/// use oxc_data_structures::box_macros::boxed_slice;
+///
+/// let len = get_length_somehow();
+/// // Creates a `Box<[u64]>`
+/// let boxed = boxed_slice![0u64; len];
+/// ```
+#[macro_export]
+macro_rules! boxed_slice {
+    ($value:expr; $len:expr) => {
+        ::std::vec![$value; $len].into_boxed_slice()
+    };
+}
+
+pub use boxed_slice;
+
+/// Macro to create a boxed array (`Box<[T; N]>`).
+///
+/// Similar to standard library's `vec!` macro.
+///
+/// `$len` must be a const expression.
+///
+/// # Example
+/// ```
+/// use oxc_data_structures::box_macros::boxed_array;
+///
+/// const LENGTH: usize = 5;
+/// // Creates a `Box<[u64; LENGTH]>`
+/// let boxed = boxed_array![0u64; LENGTH];
+/// ```
+#[macro_export]
+macro_rules! boxed_array {
+    ($value:expr; $len:expr) => {{
+        // Make sure `$len` is const
+        const LEN: usize = $len;
+        let boxed_slice = ::std::vec![$value; LEN].into_boxed_slice();
+        // `.ok()` is to support types which are not `Debug`
+        #[allow(clippy::allow_attributes)]
+        #[allow(clippy::missing_panics_doc, reason = "infallible")]
+        ::std::boxed::Box::<[_; LEN]>::try_from(boxed_slice).ok().unwrap()
+    }};
+}
+
+pub use boxed_array;

--- a/crates/oxc_data_structures/src/lib.rs
+++ b/crates/oxc_data_structures/src/lib.rs
@@ -5,6 +5,9 @@
 #[cfg(feature = "assert_unchecked")]
 mod assert_unchecked;
 
+#[cfg(feature = "box_macros")]
+pub mod box_macros;
+
 #[cfg(feature = "code_buffer")]
 pub mod code_buffer;
 

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -34,7 +34,7 @@ oxc_ast_macros = { workspace = true, optional = true }
 oxc_ast_visit = { workspace = true }
 oxc_cfg = { workspace = true }
 oxc_codegen = { workspace = true }
-oxc_data_structures = { workspace = true, optional = true }
+oxc_data_structures = { workspace = true, features = ["box_macros"] }
 oxc_diagnostics = { workspace = true }
 oxc_ecmascript = { workspace = true }
 oxc_index = { workspace = true, features = ["serde"] }


### PR DESCRIPTION
Add `boxed_slice!` and `boxed_array!` macros, similar to std lib's `vec!` macro.

```rs
// Box<[u64]>
let box_slice = boxed_slice![0u64; 10];
// Box<[u64; 10]>
let box_array = boxed_array![0u64; 10];
```

Use `boxed_array!` in linter to shorten code.

These macros could probably be made more efficient by using `MaybeUninit` and emplacement, but can leave that until later.
