### PR TITLE
feat(formatter): print type cast comments

### DIFF
--- a/crates/oxc_formatter/src/generated/format.rs
+++ b/crates/oxc_formatter/src/generated/format.rs
@@ -9,7 +9,7 @@ use crate::{
     formatter::{Buffer, Format, FormatResult, Formatter, trivia::FormatTrailingComments},
     generated::ast_nodes::{AstNode, AstNodes, transmute_self},
     parentheses::NeedsParentheses,
-    utils::suppressed::FormatSuppressedNode,
+    utils::{suppressed::FormatSuppressedNode, typecast::format_type_cast_comment_node},
     write::{FormatFunctionOptions, FormatJsArrowFunctionExpressionOptions, FormatWrite},
 };
 
@@ -374,6 +374,9 @@ impl<'a> Format<'a> for AstNode<'a, IdentifierName<'a>> {
 impl<'a> Format<'a> for AstNode<'a, IdentifierReference<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -414,6 +417,9 @@ impl<'a> Format<'a> for AstNode<'a, LabelIdentifier<'a>> {
 impl<'a> Format<'a> for AstNode<'a, ThisExpression> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -432,6 +438,9 @@ impl<'a> Format<'a> for AstNode<'a, ThisExpression> {
 impl<'a> Format<'a> for AstNode<'a, ArrayExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, true, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -498,6 +507,9 @@ impl<'a> Format<'a> for AstNode<'a, Elision> {
 impl<'a> Format<'a> for AstNode<'a, ObjectExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, true, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -590,6 +602,9 @@ impl<'a> Format<'a> for AstNode<'a, PropertyKey<'a>> {
 impl<'a> Format<'a> for AstNode<'a, TemplateLiteral<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -608,6 +623,9 @@ impl<'a> Format<'a> for AstNode<'a, TemplateLiteral<'a>> {
 impl<'a> Format<'a> for AstNode<'a, TaggedTemplateExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -673,6 +691,9 @@ impl<'a> Format<'a> for AstNode<'a, MemberExpression<'a>> {
 impl<'a> Format<'a> for AstNode<'a, ComputedMemberExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -691,6 +712,9 @@ impl<'a> Format<'a> for AstNode<'a, ComputedMemberExpression<'a>> {
 impl<'a> Format<'a> for AstNode<'a, StaticMemberExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -709,6 +733,9 @@ impl<'a> Format<'a> for AstNode<'a, StaticMemberExpression<'a>> {
 impl<'a> Format<'a> for AstNode<'a, PrivateFieldExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -727,6 +754,9 @@ impl<'a> Format<'a> for AstNode<'a, PrivateFieldExpression<'a>> {
 impl<'a> Format<'a> for AstNode<'a, CallExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -745,6 +775,9 @@ impl<'a> Format<'a> for AstNode<'a, CallExpression<'a>> {
 impl<'a> Format<'a> for AstNode<'a, NewExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -763,6 +796,9 @@ impl<'a> Format<'a> for AstNode<'a, NewExpression<'a>> {
 impl<'a> Format<'a> for AstNode<'a, MetaProperty<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -821,6 +857,9 @@ impl<'a> Format<'a> for AstNode<'a, Argument<'a>> {
 impl<'a> Format<'a> for AstNode<'a, UpdateExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -839,6 +878,9 @@ impl<'a> Format<'a> for AstNode<'a, UpdateExpression<'a>> {
 impl<'a> Format<'a> for AstNode<'a, UnaryExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -857,6 +899,9 @@ impl<'a> Format<'a> for AstNode<'a, UnaryExpression<'a>> {
 impl<'a> Format<'a> for AstNode<'a, BinaryExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -875,6 +920,9 @@ impl<'a> Format<'a> for AstNode<'a, BinaryExpression<'a>> {
 impl<'a> Format<'a> for AstNode<'a, PrivateInExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -893,6 +941,9 @@ impl<'a> Format<'a> for AstNode<'a, PrivateInExpression<'a>> {
 impl<'a> Format<'a> for AstNode<'a, LogicalExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -911,6 +962,9 @@ impl<'a> Format<'a> for AstNode<'a, LogicalExpression<'a>> {
 impl<'a> Format<'a> for AstNode<'a, ConditionalExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -929,6 +983,9 @@ impl<'a> Format<'a> for AstNode<'a, ConditionalExpression<'a>> {
 impl<'a> Format<'a> for AstNode<'a, AssignmentExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -1187,6 +1244,9 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTargetPropertyProperty<'a>> {
 impl<'a> Format<'a> for AstNode<'a, SequenceExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -1205,6 +1265,9 @@ impl<'a> Format<'a> for AstNode<'a, SequenceExpression<'a>> {
 impl<'a> Format<'a> for AstNode<'a, Super> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -1223,6 +1286,9 @@ impl<'a> Format<'a> for AstNode<'a, Super> {
 impl<'a> Format<'a> for AstNode<'a, AwaitExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -1241,6 +1307,9 @@ impl<'a> Format<'a> for AstNode<'a, AwaitExpression<'a>> {
 impl<'a> Format<'a> for AstNode<'a, ChainExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -1296,6 +1365,9 @@ impl<'a> Format<'a> for AstNode<'a, ChainElement<'a>> {
 impl<'a> Format<'a> for AstNode<'a, ParenthesizedExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -1629,12 +1701,7 @@ impl<'a> Format<'a> for AstNode<'a, EmptyStatement> {
 
 impl<'a> Format<'a> for AstNode<'a, ExpressionStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.write(f)
     }
 }
 
@@ -2009,6 +2076,9 @@ impl<'a> Format<'a> for AstNode<'a, BindingRestElement<'a>> {
 impl<'a> Format<'a, FormatFunctionOptions> for AstNode<'a, Function<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -2029,6 +2099,9 @@ impl<'a> Format<'a, FormatFunctionOptions> for AstNode<'a, Function<'a>> {
         f: &mut Formatter<'_, 'a>,
     ) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -2089,6 +2162,9 @@ impl<'a> Format<'a, FormatJsArrowFunctionExpressionOptions>
 {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -2109,6 +2185,9 @@ impl<'a> Format<'a, FormatJsArrowFunctionExpressionOptions>
         f: &mut Formatter<'_, 'a>,
     ) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -2130,6 +2209,9 @@ impl<'a> Format<'a, FormatJsArrowFunctionExpressionOptions>
 impl<'a> Format<'a> for AstNode<'a, YieldExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -2148,6 +2230,9 @@ impl<'a> Format<'a> for AstNode<'a, YieldExpression<'a>> {
 impl<'a> Format<'a> for AstNode<'a, Class<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -2342,6 +2427,9 @@ impl<'a> Format<'a> for AstNode<'a, AccessorProperty<'a>> {
 impl<'a> Format<'a> for AstNode<'a, ImportExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -2613,6 +2701,9 @@ impl<'a> Format<'a> for AstNode<'a, ModuleExportName<'a>> {
 impl<'a> Format<'a> for AstNode<'a, V8IntrinsicExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -2631,6 +2722,9 @@ impl<'a> Format<'a> for AstNode<'a, V8IntrinsicExpression<'a>> {
 impl<'a> Format<'a> for AstNode<'a, BooleanLiteral> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -2649,6 +2743,9 @@ impl<'a> Format<'a> for AstNode<'a, BooleanLiteral> {
 impl<'a> Format<'a> for AstNode<'a, NullLiteral> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -2667,6 +2764,9 @@ impl<'a> Format<'a> for AstNode<'a, NullLiteral> {
 impl<'a> Format<'a> for AstNode<'a, NumericLiteral<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -2685,6 +2785,9 @@ impl<'a> Format<'a> for AstNode<'a, NumericLiteral<'a>> {
 impl<'a> Format<'a> for AstNode<'a, StringLiteral<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -2703,6 +2806,9 @@ impl<'a> Format<'a> for AstNode<'a, StringLiteral<'a>> {
 impl<'a> Format<'a> for AstNode<'a, BigIntLiteral<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -2721,6 +2827,9 @@ impl<'a> Format<'a> for AstNode<'a, BigIntLiteral<'a>> {
 impl<'a> Format<'a> for AstNode<'a, RegExpLiteral<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -2738,6 +2847,9 @@ impl<'a> Format<'a> for AstNode<'a, RegExpLiteral<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, JSXElement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        if format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
@@ -2774,6 +2886,9 @@ impl<'a> Format<'a> for AstNode<'a, JSXClosingElement<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, JSXFragment<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        if format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
             "(".fmt(f)?;
@@ -4478,6 +4593,9 @@ impl<'a> Format<'a> for AstNode<'a, TSTemplateLiteralType<'a>> {
 impl<'a> Format<'a> for AstNode<'a, TSAsExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -4496,6 +4614,9 @@ impl<'a> Format<'a> for AstNode<'a, TSAsExpression<'a>> {
 impl<'a> Format<'a> for AstNode<'a, TSSatisfiesExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -4514,6 +4635,9 @@ impl<'a> Format<'a> for AstNode<'a, TSSatisfiesExpression<'a>> {
 impl<'a> Format<'a> for AstNode<'a, TSTypeAssertion<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -4583,6 +4707,9 @@ impl<'a> Format<'a> for AstNode<'a, TSExternalModuleReference<'a>> {
 impl<'a> Format<'a> for AstNode<'a, TSNonNullExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
@@ -4636,6 +4763,9 @@ impl<'a> Format<'a> for AstNode<'a, TSNamespaceExportDeclaration<'a>> {
 impl<'a> Format<'a> for AstNode<'a, TSInstantiationExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
+            return Ok(());
+        }
         self.format_leading_comments(f)?;
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {

--- a/crates/oxc_formatter/src/utils/mod.rs
+++ b/crates/oxc_formatter/src/utils/mod.rs
@@ -7,6 +7,7 @@ pub mod member_chain;
 pub mod object;
 pub mod string_utils;
 pub mod suppressed;
+pub mod typecast;
 
 use oxc_allocator::Address;
 use oxc_ast::{AstKind, ast::CallExpression};

--- a/crates/oxc_formatter/src/utils/typecast.rs
+++ b/crates/oxc_formatter/src/utils/typecast.rs
@@ -1,0 +1,157 @@
+use oxc_ast::{
+    Comment,
+    ast::{ArrowFunctionExpression, Function},
+};
+use oxc_span::GetSpan;
+
+use crate::{
+    Buffer, Format, FormatResult, format_args,
+    formatter::{Formatter, prelude::*, trivia::FormatLeadingComments},
+    generated::ast_nodes::AstNode,
+    write,
+    write::{
+        FormatFunctionOptions, FormatJsArrowFunctionExpression,
+        FormatJsArrowFunctionExpressionOptions,
+    },
+};
+
+/// Check if the first non-whitespace byte at the given position matches the expected byte
+fn next_byte_is(source_text: &str, position: usize, expected_byte: u8) -> bool {
+    source_text.as_bytes()[position..]
+        .trim_ascii_start()
+        .first()
+        .is_some_and(|&b| b == expected_byte)
+}
+
+/// Formats a node with TypeScript type cast comments if present.
+///
+/// This function handles the formatting of JSDoc type cast comments that appear
+/// immediately before parenthesized expressions, creating patterns like:
+/// `(/** @type {string} */ value)` or `(/** @type {number} */ (expression))`
+///
+/// The function:
+/// 1. Checks if there's a closing parenthesis after the node (indicating a type cast)
+/// 2. Looks for associated type cast comments that precede the node
+/// 3. Wraps the node in parentheses with proper formatting and indentation
+/// 4. Handles both object/array expressions and other expression types differently
+///
+/// Returns `Ok(true)` if the node was formatted as a type cast, `Ok(false)` otherwise.
+/// This allows callers to know whether they need to apply their own formatting.
+pub fn format_type_cast_comment_node<'a, T>(
+    node: &(impl Format<'a, T> + GetSpan),
+    is_object_or_array_expression: bool,
+    f: &mut Formatter<'_, 'a>,
+) -> FormatResult<bool> {
+    let comments = f.context().comments();
+    let span = node.span();
+
+    if !next_byte_is(f.source_text(), span.end as usize, b')') {
+        return Ok(false);
+    }
+
+    if let Some(type_cast_comment_index) = comments.get_type_cast_comment_index(span) {
+        let comments = f.context().comments().unprinted_comments();
+        let type_cast_comment = &comments[type_cast_comment_index];
+
+        // Get the source text from the end of type cast comment to the node span
+        let node_source_text =
+            &f.source_text()[type_cast_comment.span.end as usize..span.end as usize];
+
+        // `(/** @type {Number} */ (bar).zoo)`
+        //                         ^^^^
+        // Should wrap for `baz` rather than `baz.zoo`
+        if has_closed_parentheses(node_source_text) {
+            return Ok(false);
+        }
+
+        let type_cast_comments = &comments[..=type_cast_comment_index];
+
+        write!(f, [FormatLeadingComments::Comments(type_cast_comments)])?;
+        f.context_mut().comments_mut().mark_as_handled_type_cast_comment();
+    } else {
+        let elements = f.elements().iter().rev();
+
+        // If the printed cast comment is already handled, return early to avoid infinite recursion.
+        if !comments.is_already_handled_type_cast_comment()
+            && comments.printed_comments().last().is_some_and(|c| {
+                next_byte_is(f.source_text(), c.span.end as usize, b'(')
+                    && f.comments().is_type_cast_comment(c)
+            })
+        {
+            f.context_mut().comments_mut().mark_as_handled_type_cast_comment();
+        } else {
+            // No typecast comment
+            return Ok(false);
+        }
+    }
+
+    // https://github.com/prettier/prettier/blob/7584432401a47a26943dd7a9ca9a8e032ead7285/src/language-js/print/estree.js#L117-L120
+    if is_object_or_array_expression && !f.comments().has_comments_before(span.start) {
+        write!(f, group(&format_args!("(", &format_once(|f| node.fmt(f)), ")")))?;
+    } else {
+        write!(
+            f,
+            group(&format_args!("(", soft_block_indent(&format_once(|f| node.fmt(f))), ")"))
+        )?;
+    }
+
+    Ok(true)
+}
+
+/// Check if the source text has properly closed parentheses starting with '('.
+/// Returns true if the text starts with '(' and all parentheses are balanced.
+fn has_closed_parentheses(source: &str) -> bool {
+    let bytes = source.as_bytes();
+
+    let mut paren_count = 0i32;
+    let mut i = 0;
+
+    while i < bytes.len() {
+        match bytes[i] {
+            b'(' => paren_count += 1,
+            b')' => paren_count -= 1,
+            b'/' if i + 1 < bytes.len() => {
+                match bytes[i + 1] {
+                    b'/' => {
+                        // Skip to end of line comment
+                        i += 2;
+                        while i < bytes.len() && bytes[i] != b'\n' {
+                            i += 1;
+                        }
+                        continue;
+                    }
+                    b'*' => {
+                        // Skip to end of block comment
+                        i += 2;
+                        while i + 1 < bytes.len() {
+                            if bytes[i] == b'*' && bytes[i + 1] == b'/' {
+                                i += 2;
+                                break;
+                            }
+                            i += 1;
+                        }
+                        continue;
+                    }
+                    _ => {}
+                }
+            }
+            quote @ (b'"' | b'\'' | b'`') => {
+                // Skip string literal (double-quoted, single-quoted, or template)
+                i += 1;
+                while i < bytes.len() {
+                    match bytes[i] {
+                        b if b == quote => break,
+                        b'\\' if i + 1 < bytes.len() => i += 1, // Skip escaped character
+                        _ => {}
+                    }
+                    i += 1;
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    // Return true only if parentheses are properly balanced
+    paren_count == 0
+}

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -22,7 +22,9 @@ const AST_NODE_WITHOUT_PRINTING_COMMENTS_LIST: &[&str] = &[
     "CatchParameter",
     "CatchClause",
     "Decorator",
-    // Manually prints it, because class's decorators can be appears before `export class Cls {}`.
+    // Manually prints it because it needs to specially handle leading comments.
+    "ExpressionStatement",
+    // Manually prints it because class's decorators can be appears before `export class Cls {}`.
     "ExportNamedDeclaration",
     "ExportDefaultDeclaration",
     "TSClassImplements",
@@ -82,7 +84,7 @@ impl Generator for FormatterFormatGenerator {
                 },
                 parentheses::NeedsParentheses,
                 generated::ast_nodes::{AstNode, AstNodes, transmute_self},
-                utils::suppressed::FormatSuppressedNode,
+                utils::{suppressed::FormatSuppressedNode, typecast::format_type_cast_comment_node},
                 write::{FormatWrite #(#options)*},
             };
 
@@ -158,15 +160,17 @@ fn generate_struct_implementation(
 
         // `Program` can't be suppressed.
         // `JSXElement` and `JSXFragment` implement suppression formatting in their formatting logic
-        let suppressed_check = if matches!(struct_name, "Program" | "JSXElement" | "JSXFragment") {
-            quote! {}
-        } else {
+        let suppressed_check = (!matches!(
+            struct_name,
+            "Program" | "JSXElement" | "JSXFragment" | "ExpressionStatement"
+        ))
+        .then(|| {
             quote! {
                 let is_suppressed = f.comments().is_suppressed(self.span().start);
             }
-        };
+        });
 
-        let write_implementation = if suppressed_check.is_empty() {
+        let write_implementation = if suppressed_check.is_none() {
             write_call
         } else if trailing_comments.is_empty() {
             quote! {
@@ -188,14 +192,39 @@ fn generate_struct_implementation(
             }
         };
 
+        let type_cast_comment_formatting = parenthesis_type_ids.contains(&struct_def.id).then(|| {
+            let is_object_or_array_argument =
+                if matches!(struct_def.name.as_str(), "ObjectExpression" | "ArrayExpression") {
+                    quote! {
+                        true
+                    }
+                } else {
+                    quote! { false }
+                };
+
+            let suppressed_check_for_typecast = suppressed_check.is_some().then(|| {
+                quote! {
+                    !is_suppressed &&
+                }
+            });
+
+            quote! {
+                if #suppressed_check_for_typecast format_type_cast_comment_node(self, #is_object_or_array_argument, f)? {
+                    return Ok(());
+                }
+            }
+        });
+
         if needs_parentheses_before.is_empty() && trailing_comments.is_empty() {
             quote! {
                 #suppressed_check
+                #type_cast_comment_formatting
                 #write_implementation
             }
         } else {
             quote! {
                 #suppressed_check
+                #type_cast_comment_formatting
                 #leading_comments
                 #needs_parentheses_before
                 let result = #write_implementation;

--- a/tasks/coverage/snapshots/formatter_typescript.snap
+++ b/tasks/coverage/snapshots/formatter_typescript.snap
@@ -2,7 +2,7 @@ commit: 261630d6
 
 formatter_typescript Summary:
 AST Parsed     : 8816/8816 (100.00%)
-Positive Passed: 7923/8816 (89.87%)
+Positive Passed: 7922/8816 (89.86%)
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/APISample_jsdoc.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/addMoreCallSignaturesToBaseSignature.ts
@@ -268,6 +268,8 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofEn
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofInAnonymousType.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/declarationEmitArrayTypesFromGenericArrayUsage.ts
+
+Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/declarationEmitCastReusesTypeNode4.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassMemberNameConflict2.ts
 

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 645/699 (92.27%)
+js compatibility: 658/699 (94.13%)
 
 # Failed
 
@@ -8,23 +8,10 @@ js compatibility: 645/699 (92.27%)
 | js/comments/empty-statements.js | 💥💥 | 90.91% |
 | js/comments/export.js | 💥💥 | 97.37% |
 | js/comments/function-declaration.js | 💥💥 | 92.80% |
+| js/comments/jsdoc.js | 💥💥 | 81.48% |
 | js/comments/return-statement.js | 💥💥 | 98.85% |
 | js/comments/html-like/comment.js | 💥 | 0.00% |
-| js/comments-closure-typecast/binary-expr.js | 💥 | 0.00% |
-| js/comments-closure-typecast/closure-compiler-type-cast.js | 💥 | 66.13% |
 | js/comments-closure-typecast/comment-in-the-middle.js | 💥 | 90.91% |
-| js/comments-closure-typecast/comment-placement.js | 💥 | 61.54% |
-| js/comments-closure-typecast/extra-spaces-and-asterisks.js | 💥 | 0.00% |
-| js/comments-closure-typecast/iife.js | 💥 | 27.27% |
-| js/comments-closure-typecast/issue-4124.js | 💥 | 47.37% |
-| js/comments-closure-typecast/issue-8045.js | 💥 | 75.86% |
-| js/comments-closure-typecast/issue-9358.js | 💥 | 16.00% |
-| js/comments-closure-typecast/member.js | 💥 | 0.00% |
-| js/comments-closure-typecast/nested.js | 💥 | 23.53% |
-| js/comments-closure-typecast/object-with-comment.js | 💥 | 38.10% |
-| js/comments-closure-typecast/satisfies.js | 💥 | 33.33% |
-| js/comments-closure-typecast/superclass.js | 💥 | 0.00% |
-| js/comments-closure-typecast/ways-to-specify-type.js | 💥 | 15.38% |
 | js/conditional/comments.js | 💥✨ | 23.69% |
 | js/conditional/new-ternary-examples.js | 💥✨ | 20.14% |
 | js/conditional/new-ternary-spec.js | 💥✨ | 24.35% |


### PR DESCRIPTION
Add support for type casting comment, see https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#casts