### PR TITLE
refactor(linter/plugins): discard `ExternalLinter` if no JS plugins registered

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -234,6 +234,12 @@ impl LintRunner {
         }
         .with_filters(&filters);
 
+        // If no external rules, discard `ExternalLinter`
+        let mut external_linter = self.external_linter;
+        if external_plugin_store.is_empty() {
+            external_linter = None;
+        }
+
         if let Some(basic_config_file) = oxlintrc_for_print {
             let config_file = config_builder.resolve_final_config_file(basic_config_file);
             if misc_options.print_config {
@@ -324,7 +330,7 @@ impl LintRunner {
             }
         }
 
-        let linter = Linter::new(LintOptions::default(), config_store, self.external_linter)
+        let linter = Linter::new(LintOptions::default(), config_store, external_linter)
             .with_fix(fix_options.fix_kind())
             .with_report_unused_directives(report_unused_directives);
 

--- a/crates/oxc_linter/src/external_plugin_store.rs
+++ b/crates/oxc_linter/src/external_plugin_store.rs
@@ -22,6 +22,11 @@ pub struct ExternalPluginStore {
 }
 
 impl ExternalPluginStore {
+    /// Returns `true` if no external plugins have been loaded.
+    pub fn is_empty(&self) -> bool {
+        self.plugins.is_empty()
+    }
+
     pub fn is_plugin_registered(&self, plugin_path: &str) -> bool {
         self.registered_plugin_paths.contains(plugin_path)
     }


### PR DESCRIPTION
If no JS plugins are registered, the `ExternalLinter` can be discarded. This is a step towards removing Cargo features for controlling whether JS plugins are supported or not - they will be if `ExternalLinter` exists.