### PR TITLE
refactor(linter/plugins): only use `RawTransferFileSystem` if JS plugins registered

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -359,13 +359,16 @@ impl LintRunner {
 
         // Spawn linting in another thread so diagnostics can be printed immediately from diagnostic_service.run.
         rayon::spawn(move || {
+            #[cfg(all(feature = "oxlint2", not(feature = "disable_oxlint2")))]
+            let has_external_linter = linter.has_external_linter();
+
             let mut lint_service = LintService::new(linter, options);
             lint_service.with_paths(files_to_lint);
 
-            // Use `RawTransferFileSystem` if `oxlint2` feature is enabled.
+            // Use `RawTransferFileSystem` if `oxlint2` feature is enabled and `ExternalLinter` exists.
             // This reads the source text into start of allocator, instead of the end.
             #[cfg(all(feature = "oxlint2", not(feature = "disable_oxlint2")))]
-            {
+            if has_external_linter {
                 use crate::raw_fs::RawTransferFileSystem;
                 lint_service.with_file_system(Box::new(RawTransferFileSystem));
             }

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -92,7 +92,6 @@ fn size_asserts() {
 pub struct Linter {
     options: LintOptions,
     config: ConfigStore,
-    #[cfg_attr(not(all(feature = "oxlint2", not(feature = "disable_oxlint2"))), expect(dead_code))]
     external_linter: Option<ExternalLinter>,
 }
 
@@ -127,6 +126,11 @@ impl Linter {
     /// number of rules depends on which file is being linted.
     pub fn number_of_rules(&self, type_aware: bool) -> Option<usize> {
         self.config.number_of_rules(type_aware)
+    }
+
+    /// Return `true` if `Linter` has an external linter (JS plugins).
+    pub fn has_external_linter(&self) -> bool {
+        self.external_linter.is_some()
     }
 
     pub fn run<'a>(


### PR DESCRIPTION
Another step towards getting rid of the Cargo feature for enabling JS plugins. The signal for whether JS plugins are enabled is whether `ExternalLinter` exists. If it doesn't, don't use `RawTransferFileSystem`, which is only required for JS plugins.