### PR TITLE
fix(language_server): don't resend diagnostic on save, when `typeAware` is disabled and run is onType

### DIFF
--- a/crates/oxc_language_server/fixtures/linter/lint_on_run/on_type/on-save-no-type-aware.ts
+++ b/crates/oxc_language_server/fixtures/linter/lint_on_run/on_type/on-save-no-type-aware.ts
@@ -1,0 +1,7 @@
+debugger;
+
+async function returnsPromise() {
+  return "value";
+}
+
+returnsPromise().then(() => {});

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_lint_on_run_on_type@on-save-no-type-aware.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_lint_on_run_on_type@on-save-no-type-aware.ts.snap
@@ -1,0 +1,5 @@
+---
+source: crates/oxc_language_server/src/tester.rs
+input_file: crates/oxc_language_server/fixtures/linter/lint_on_run/on_type/on-save-no-type-aware.ts
+---
+File is ignored


### PR DESCRIPTION
Fixes an edge case introduced in #13332 where diagnostics disappear when saving a file with `oxc.lint.run: "onType"` and `oxc.typeAware: false`.

## Problem

The logic from #13332 assumes `tsgolint` always exists when `Run::OnType`:
```rust
(ServerLinterRun::OnSave, Run::OnType) => (false, true)  // always run tsgolint
```

But when `type_aware: false`, there is no `tsgo_linter`, causing the server to return empty diagnostics instead of None, which clears all error highlights in VSCode.


![clear-diagnostics](https://github.com/user-attachments/assets/3f7a530e-5319-4fa5-8668-7a34a3742e82)

## Solution

Check if `tsgo_linter` actually exists:
```rust
(ServerLinterRun::OnSave, Run::OnType) => {
    let should_run_tsgo = self.tsgo_linter.as_ref().is_some();
    (false, should_run_tsgo)
}
```

Now returns None when no linters should run, preserving existing diagnostics.

**Test:** Added `test_lint_on_run_on_type_on_save_without_type_aware` with fixture
