### PR TITLE
fix(oxfmt): Do not follow symlinks like prettier

### DIFF
--- a/apps/oxfmt/src/walk.rs
+++ b/apps/oxfmt/src/walk.rs
@@ -84,8 +84,9 @@ impl Walk {
             inner.overrides(override_builder);
         }
 
-        let inner =
-            inner.ignore(false).git_global(false).follow_links(true).hidden(false).build_parallel();
+        // Do not follow symlinks like Prettier does.
+        // See https://github.com/prettier/prettier/pull/14627
+        let inner = inner.hidden(false).ignore(false).git_global(false).build_parallel();
         Self { inner, extensions: Extensions::default() }
     }
 


### PR DESCRIPTION
Part of #10573

> Prettier no longer follows symbolic links while expanding command line arguments. This avoids problems in many scenarios such as symlinks outside the source tree, symlinks to ignored files, and cycles of symlinks.
> https://prettier.io/blog/2023/07/05/3.0.0.html#dont-expand-globs-via-symbolic-links-14627-by-andersk

Follows this behavior.
