### PR TITLE
feat(oxfmt): Support more extensions from linguist-languages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2516,7 +2516,6 @@ version = "0.1.0"
 dependencies = [
  "bpaf",
  "ignore",
- "indexmap",
  "mimalloc-safe",
  "oxc-miette",
  "oxc_allocator",
@@ -2525,7 +2524,6 @@ dependencies = [
  "oxc_parser",
  "oxc_span",
  "rayon",
- "rustc-hash",
  "tracing-subscriber",
 ]
 

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -35,10 +35,8 @@ oxc_span = { workspace = true }
 
 bpaf = { workspace = true, features = ["autocomplete", "bright-color", "derive"] }
 ignore = { workspace = true, features = ["simd-accel"] }
-indexmap = { workspace = true }
 miette = { workspace = true }
 rayon = { workspace = true }
-rustc-hash = { workspace = true }
 tracing-subscriber = { workspace = true, features = [] } # Omit the `regex` feature
 
 [target.'cfg(not(any(target_os = "linux", target_os = "freebsd", target_arch = "arm", target_family = "wasm")))'.dependencies]

--- a/apps/oxfmt/src/format.rs
+++ b/apps/oxfmt/src/format.rs
@@ -1,4 +1,4 @@
-use std::{env, ffi::OsStr, io::Write, path::PathBuf, sync::Arc};
+use std::{env, io::Write, path::PathBuf};
 
 use ignore::overrides::OverrideBuilder;
 
@@ -50,12 +50,12 @@ impl FormatRunner {
             .flatten();
 
         let walker = Walk::new(&regular_paths, override_builder);
-        let paths = walker.paths();
+        let entries = walker.entries();
 
-        let files_to_format = paths
+        let files_to_format = entries
             .into_iter()
-            // .filter(|path| !config_store.should_ignore(Path::new(path)))
-            .collect::<Vec<Arc<OsStr>>>();
+            // .filter(|entry| !config_store.should_ignore(Path::new(&entry.path)))
+            .collect::<Vec<_>>();
 
         if files_to_format.is_empty() {
             print_and_flush_stdout(stdout, "Expected at least one target file\n");
@@ -67,7 +67,7 @@ impl FormatRunner {
 
         rayon::spawn(move || {
             let mut format_service = FormatService::new(cwd, &output_options);
-            format_service.with_paths(files_to_format);
+            format_service.with_entries(files_to_format);
             format_service.run(&tx_error);
         });
         // NOTE: This is a blocking

--- a/apps/oxfmt/src/service.rs
+++ b/apps/oxfmt/src/service.rs
@@ -1,22 +1,18 @@
-use std::{ffi::OsStr, fs, path::Path, sync::Arc, time::Instant};
+use std::{fs, path::Path, time::Instant};
 
-use indexmap::IndexSet;
 use rayon::prelude::*;
-use rustc_hash::FxBuildHasher;
 
 use oxc_allocator::Allocator;
 use oxc_diagnostics::{DiagnosticSender, DiagnosticService, OxcDiagnostic, Severity};
 use oxc_formatter::{FormatOptions, Formatter};
 use oxc_parser::{ParseOptions, Parser};
-use oxc_span::SourceType;
 
-use crate::command::OutputOptions;
+use crate::{command::OutputOptions, walk::WalkEntry};
 
 pub struct FormatService {
     cwd: Box<Path>,
     output_options: OutputOptions,
-    // TODO: Just use `Vec`?
-    paths: IndexSet<Arc<OsStr>, FxBuildHasher>,
+    entries: Vec<WalkEntry>,
 }
 
 impl FormatService {
@@ -24,25 +20,20 @@ impl FormatService {
     where
         T: Into<Box<Path>>,
     {
-        Self {
-            cwd: cwd.into(),
-            output_options: output_options.clone(),
-            paths: IndexSet::with_capacity_and_hasher(0, FxBuildHasher),
-        }
+        Self { cwd: cwd.into(), output_options: output_options.clone(), entries: Vec::new() }
     }
 
-    pub fn with_paths(&mut self, paths: Vec<Arc<OsStr>>) -> &mut Self {
-        self.paths = paths.into_iter().collect();
+    pub fn with_entries(&mut self, entries: Vec<WalkEntry>) -> &mut Self {
+        self.entries = entries;
         self
     }
 
     pub fn run(&self, tx_error: &DiagnosticSender) {
-        self.paths.iter().par_bridge().for_each(|path| {
+        self.entries.iter().par_bridge().for_each(|entry| {
             let start_time = Instant::now();
 
-            let path = Path::new(path);
-            let source_type =
-                SourceType::from_path(path).expect("`path` should be valid SourceType");
+            let path = Path::new(&entry.path);
+            let source_type = entry.source_type;
             // TODO: read_to_arena_str()?
             let source_text = fs::read_to_string(path).expect("Failed to read file");
 

--- a/apps/oxfmt/src/walk.rs
+++ b/apps/oxfmt/src/walk.rs
@@ -1,50 +1,86 @@
 use std::{ffi::OsStr, path::PathBuf, sync::Arc, sync::mpsc};
 
-use ignore::{DirEntry, overrides::Override};
-use oxc_span::VALID_EXTENSIONS;
+use ignore::overrides::Override;
 
-// use crate::cli::IgnoreOptions;
+use oxc_span::SourceType;
 
-#[derive(Debug, Clone)]
-pub struct Extensions(pub Vec<&'static str>);
+// Additional extensions from linguist-languages, which Prettier also supports
+// - https://github.com/ikatyang-collab/linguist-languages/blob/d1dc347c7ced0f5b42dd66c7d1c4274f64a3eb6b/data/JavaScript.js
+// No special extensions for TypeScript
+// - https://github.com/ikatyang-collab/linguist-languages/blob/d1dc347c7ced0f5b42dd66c7d1c4274f64a3eb6b/data/TypeScript.js
+const ADDITIONAL_JS_EXTENSIONS: &[&str] = &[
+    "_js",
+    "bones",
+    "es",
+    "es6",
+    "frag",
+    "gs",
+    "jake",
+    "javascript",
+    "jsb",
+    "jscad",
+    "jsfl",
+    "jslib",
+    "jsm",
+    "jspre",
+    "jss",
+    "njs",
+    "pac",
+    "sjs",
+    "ssjs",
+    "xsjs",
+    "xsjslib",
+];
 
-impl Default for Extensions {
-    fn default() -> Self {
-        Self(VALID_EXTENSIONS.to_vec())
+fn is_supported_source_type(path: &std::path::Path) -> Option<SourceType> {
+    let extension = path.extension()?.to_string_lossy();
+
+    // Standard extensions, also supported by `oxc_span::VALID_EXTENSIONS`
+    if let Ok(source_type) = SourceType::from_extension(&extension) {
+        return Some(source_type);
     }
+    // Additional extensions from linguist-languages, which Prettier also supports
+    if ADDITIONAL_JS_EXTENSIONS.contains(&extension.as_ref()) {
+        return Some(SourceType::default());
+    }
+    // `Jakefile` has no extension but is a valid JS file defined by linguist-languages
+    if path.file_name() == Some(OsStr::new("Jakefile")) {
+        return Some(SourceType::default());
+    }
+
+    None
 }
+
+// ---
 
 pub struct Walk {
     inner: ignore::WalkParallel,
-    /// The file extensions to include during the traversal.
-    extensions: Extensions,
+}
+
+pub struct WalkEntry {
+    pub path: Arc<OsStr>,
+    pub source_type: SourceType,
 }
 
 struct WalkBuilder {
-    sender: mpsc::Sender<Vec<Arc<OsStr>>>,
-    extensions: Extensions,
+    sender: mpsc::Sender<Vec<WalkEntry>>,
 }
 
 impl<'s> ignore::ParallelVisitorBuilder<'s> for WalkBuilder {
     fn build(&mut self) -> Box<dyn ignore::ParallelVisitor + 's> {
-        Box::new(WalkCollector {
-            paths: vec![],
-            sender: self.sender.clone(),
-            extensions: self.extensions.clone(),
-        })
+        Box::new(WalkCollector { entries: vec![], sender: self.sender.clone() })
     }
 }
 
 struct WalkCollector {
-    paths: Vec<Arc<OsStr>>,
-    sender: mpsc::Sender<Vec<Arc<OsStr>>>,
-    extensions: Extensions,
+    entries: Vec<WalkEntry>,
+    sender: mpsc::Sender<Vec<WalkEntry>>,
 }
 
 impl Drop for WalkCollector {
     fn drop(&mut self) {
-        let paths = std::mem::take(&mut self.paths);
-        self.sender.send(paths).unwrap();
+        let entries = std::mem::take(&mut self.entries);
+        self.sender.send(entries).unwrap();
     }
 }
 
@@ -52,8 +88,16 @@ impl ignore::ParallelVisitor for WalkCollector {
     fn visit(&mut self, entry: Result<ignore::DirEntry, ignore::Error>) -> ignore::WalkState {
         match entry {
             Ok(entry) => {
-                if Walk::is_wanted_entry(&entry, &self.extensions) {
-                    self.paths.push(entry.path().as_os_str().into());
+                // Skip if we can't get file type or if it's a directory
+                if let Some(file_type) = entry.file_type() {
+                    if !file_type.is_dir() {
+                        if let Some(source_type) = is_supported_source_type(entry.path()) {
+                            self.entries.push(WalkEntry {
+                                path: entry.path().as_os_str().into(),
+                                source_type,
+                            });
+                        }
+                    }
                 }
                 ignore::WalkState::Continue
             }
@@ -87,24 +131,14 @@ impl Walk {
         // Do not follow symlinks like Prettier does.
         // See https://github.com/prettier/prettier/pull/14627
         let inner = inner.hidden(false).ignore(false).git_global(false).build_parallel();
-        Self { inner, extensions: Extensions::default() }
+        Self { inner }
     }
 
-    pub fn paths(self) -> Vec<Arc<OsStr>> {
-        let (sender, receiver) = mpsc::channel::<Vec<Arc<OsStr>>>();
-        let mut builder = WalkBuilder { sender, extensions: self.extensions };
+    pub fn entries(self) -> Vec<WalkEntry> {
+        let (sender, receiver) = mpsc::channel::<Vec<WalkEntry>>();
+        let mut builder = WalkBuilder { sender };
         self.inner.visit(&mut builder);
         drop(builder);
         receiver.into_iter().flatten().collect()
-    }
-
-    fn is_wanted_entry(dir_entry: &DirEntry, extensions: &Extensions) -> bool {
-        let Some(file_type) = dir_entry.file_type() else { return false };
-        if file_type.is_dir() {
-            return false;
-        }
-        let Some(extension) = dir_entry.path().extension() else { return false };
-        let extension = extension.to_string_lossy();
-        extensions.0.contains(&extension.as_ref())
     }
 }


### PR DESCRIPTION
Part of #10573

Prettier supports many more file extensions than those listed in `oxc_span::VALID_EXTENSIONS`.

Refs:

- https://github.com/ikatyang-collab/linguist-languages/blob/main/data/JavaScript.js
- https://github.com/ikatyang-collab/linguist-languages/blob/main/data/TypeScript.js

At the same time, I simplified the file extension check to a simple function.