### PR TITLE
refactor(all): remove `pub` from modules with no exports

### DIFF
--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -183,7 +183,7 @@ pub use dummies::*;
 ))]
 mod generated {
     #[cfg(debug_assertions)]
-    pub mod assert_layouts;
+    mod assert_layouts;
     pub mod fixed_size_constants;
 }
 #[cfg(all(

--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -54,23 +54,24 @@ pub mod precedence;
 mod trivia;
 
 mod generated {
-    #[cfg(debug_assertions)]
-    pub mod assert_layouts;
-    pub mod ast_builder;
     pub mod ast_kind;
-    pub mod derive_clone_in;
-    pub mod derive_content_eq;
-    pub mod derive_dummy;
+
+    #[cfg(debug_assertions)]
+    mod assert_layouts;
+    mod ast_builder;
+    mod derive_clone_in;
+    mod derive_content_eq;
+    mod derive_dummy;
     #[cfg(feature = "serialize")]
-    pub mod derive_estree;
-    pub mod derive_get_address;
-    pub mod derive_get_span;
-    pub mod derive_get_span_mut;
-    pub mod derive_take_in;
-    pub mod get_id;
+    mod derive_estree;
+    mod derive_get_address;
+    mod derive_get_span;
+    mod derive_get_span_mut;
+    mod derive_take_in;
+    mod get_id;
 }
 
-pub use generated::{ast_builder, ast_kind};
+pub use generated::ast_kind;
 
 pub use crate::{
     ast::comment::{Comment, CommentContent, CommentKind, CommentPosition},

--- a/crates/oxc_formatter/src/formatter/trivia.rs
+++ b/crates/oxc_formatter/src/formatter/trivia.rs
@@ -9,7 +9,7 @@ use oxc_syntax::comment_node;
 
 use crate::{
     formatter::comments::{is_alignable_comment, is_end_of_line_comment, is_own_line_comment},
-    generated::{ast_nodes::SiblingNode, format},
+    generated::ast_nodes::SiblingNode,
     write,
 };
 

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -11,7 +11,7 @@
 
 mod generated {
     pub mod ast_nodes;
-    pub mod format;
+    mod format;
 }
 mod formatter;
 mod options;

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -42,7 +42,7 @@ pub mod table;
 mod generated {
     #[cfg(all(feature = "oxlint2", not(feature = "disable_oxlint2")))]
     #[cfg(debug_assertions)]
-    pub mod assert_layouts;
+    mod assert_layouts;
     mod rule_runner_impls;
 }
 

--- a/crates/oxc_regular_expression/src/lib.rs
+++ b/crates/oxc_regular_expression/src/lib.rs
@@ -8,7 +8,7 @@ mod surrogate_pair;
 
 mod generated {
     #[cfg(debug_assertions)]
-    pub mod assert_layouts;
+    mod assert_layouts;
     mod derive_clone_in;
     mod derive_content_eq;
 }

--- a/crates/oxc_span/src/lib.rs
+++ b/crates/oxc_span/src/lib.rs
@@ -20,10 +20,10 @@ pub use span::{GetSpan, GetSpanMut, SPAN, Span};
 
 mod generated {
     #[cfg(debug_assertions)]
-    pub mod assert_layouts;
+    mod assert_layouts;
     mod derive_dummy;
     #[cfg(feature = "serialize")]
-    pub mod derive_estree;
+    mod derive_estree;
 }
 
 #[doc(hidden)]

--- a/crates/oxc_syntax/src/lib.rs
+++ b/crates/oxc_syntax/src/lib.rs
@@ -24,7 +24,7 @@ pub mod xml_entities;
 
 mod generated {
     #[cfg(debug_assertions)]
-    pub mod assert_layouts;
+    mod assert_layouts;
     mod derive_clone_in;
     mod derive_content_eq;
     mod derive_dummy;

--- a/napi/parser/src/lib.rs
+++ b/napi/parser/src/lib.rs
@@ -48,7 +48,7 @@ pub fn raw_transfer_supported() -> bool {
 mod generated {
     // Note: We intentionally don't import `generated/derive_estree.rs`. It's not needed.
     #[cfg(debug_assertions)]
-    pub mod assert_layouts;
+    mod assert_layouts;
     #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
     pub mod raw_transfer_constants;
 }


### PR DESCRIPTION
Pure refactor. All these generated modules have no exports, so importing them with `pub mod` is misleading - there is nothing to make public. Import them with plain `mod` instead.

```diff
mod generated {
- pub mod assert_layouts;
+ mod assert_layouts;
}
```