### PR TITLE
refactor(allocator/pool): move `AllocatorPool` into own directory

### DIFF
--- a/.github/generated/ast_changes_watch_list.yml
+++ b/.github/generated/ast_changes_watch_list.yml
@@ -5,7 +5,7 @@ src:
   - '.github/generated/ast_changes_watch_list.yml'
   - 'crates/oxc_allocator/src/generated/assert_layouts.rs'
   - 'crates/oxc_allocator/src/generated/fixed_size_constants.rs'
-  - 'crates/oxc_allocator/src/pool_fixed_size.rs'
+  - 'crates/oxc_allocator/src/pool/fixed_size.rs'
   - 'crates/oxc_ast/src/ast/comment.rs'
   - 'crates/oxc_ast/src/ast/js.rs'
   - 'crates/oxc_ast/src/ast/jsx.rs'

--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -53,6 +53,8 @@ mod convert;
 #[cfg(feature = "from_raw_parts")]
 mod from_raw_parts;
 pub mod hash_map;
+#[cfg(feature = "pool")]
+mod pool;
 mod string_builder;
 mod take_in;
 #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
@@ -69,113 +71,16 @@ pub use boxed::Box;
 pub use clone_in::CloneIn;
 pub use convert::{FromIn, IntoIn};
 pub use hash_map::HashMap;
+#[cfg(feature = "pool")]
+pub use pool::*;
 pub use string_builder::StringBuilder;
 pub use take_in::{Dummy, TakeIn};
 pub use vec::Vec;
 
-// Fixed size allocators are only supported on 64-bit little-endian platforms at present
-
+// Fixed size allocators are only supported on 64-bit little-endian platforms at present.
+//
+// Note: Importing the `fixed_size_constants` module would cause a compilation error on 32-bit systems.
 #[cfg(all(
-    feature = "pool",
-    not(all(
-        feature = "fixed_size",
-        not(feature = "disable_fixed_size"),
-        target_pointer_width = "64",
-        target_endian = "little"
-    ))
-))]
-mod pool;
-
-#[cfg(all(
-    feature = "pool",
-    feature = "fixed_size",
-    not(feature = "disable_fixed_size"),
-    target_pointer_width = "64",
-    target_endian = "little"
-))]
-mod pool_fixed_size;
-#[cfg(all(
-    feature = "pool",
-    feature = "fixed_size",
-    not(feature = "disable_fixed_size"),
-    target_pointer_width = "64",
-    target_endian = "little"
-))]
-use pool_fixed_size as pool;
-// Import here so `generated/assert_layouts.rs` can access it.
-// Add `debug_assertions` here because `assert_layouts` is only loaded in debug mode,
-// so this is required to avoid unused vars lint warning in release mode.
-#[cfg(all(
-    debug_assertions,
-    feature = "pool",
-    feature = "fixed_size",
-    not(feature = "disable_fixed_size"),
-    target_pointer_width = "64",
-    target_endian = "little"
-))]
-use pool_fixed_size::FixedSizeAllocatorMetadata;
-// Export so can be used in `napi/oxlint2`
-#[cfg(all(
-    feature = "pool",
-    feature = "fixed_size",
-    not(feature = "disable_fixed_size"),
-    target_pointer_width = "64",
-    target_endian = "little"
-))]
-pub use pool_fixed_size::free_fixed_size_allocator;
-
-#[cfg(feature = "pool")]
-pub use pool::{AllocatorGuard, AllocatorPool};
-
-// Dummy implementations of interfaces from `pool_fixed_size`, just to stop clippy complaining.
-// Seems to be necessary due to feature unification.
-#[cfg(all(
-    feature = "pool",
-    not(all(
-        feature = "fixed_size",
-        not(feature = "disable_fixed_size"),
-        target_pointer_width = "64",
-        target_endian = "little"
-    ))
-))]
-#[allow(missing_docs, clippy::missing_safety_doc, clippy::unused_self, clippy::allow_attributes)]
-mod dummies {
-    use std::{ptr::NonNull, sync::atomic::AtomicBool};
-
-    use super::Allocator;
-
-    #[doc(hidden)]
-    pub struct FixedSizeAllocatorMetadata {
-        pub id: u32,
-        pub alloc_ptr: NonNull<u8>,
-        pub is_double_owned: AtomicBool,
-    }
-
-    #[doc(hidden)]
-    pub unsafe fn free_fixed_size_allocator(_metadata_ptr: NonNull<FixedSizeAllocatorMetadata>) {
-        unreachable!();
-    }
-
-    #[doc(hidden)]
-    impl Allocator {
-        pub unsafe fn fixed_size_metadata_ptr(&self) -> NonNull<FixedSizeAllocatorMetadata> {
-            unreachable!();
-        }
-    }
-}
-#[cfg(all(
-    feature = "pool",
-    not(all(
-        feature = "fixed_size",
-        not(feature = "disable_fixed_size"),
-        target_pointer_width = "64",
-        target_endian = "little"
-    ))
-))]
-pub use dummies::*;
-
-#[cfg(all(
-    feature = "pool",
     feature = "fixed_size",
     not(feature = "disable_fixed_size"),
     target_pointer_width = "64",
@@ -186,11 +91,3 @@ mod generated {
     mod assert_layouts;
     pub mod fixed_size_constants;
 }
-#[cfg(all(
-    feature = "pool",
-    feature = "fixed_size",
-    not(feature = "disable_fixed_size"),
-    target_pointer_width = "64",
-    target_endian = "little"
-))]
-use generated::fixed_size_constants;

--- a/crates/oxc_allocator/src/pool/mod.rs
+++ b/crates/oxc_allocator/src/pool/mod.rs
@@ -1,0 +1,33 @@
+// Fixed size allocators are only supported on 64-bit little-endian platforms at present.
+// They are only enabled if `fixed_size` feature enabled, and `disable_fixed_size` feature is not enabled.
+//
+// Note: Importing the `fixed_size` module would cause a compilation error on 32-bit systems.
+#[cfg(all(
+    feature = "fixed_size",
+    not(feature = "disable_fixed_size"),
+    target_pointer_width = "64",
+    target_endian = "little"
+))]
+mod fixed_size;
+#[cfg(all(
+    feature = "fixed_size",
+    not(feature = "disable_fixed_size"),
+    target_pointer_width = "64",
+    target_endian = "little"
+))]
+pub use fixed_size::*;
+
+#[cfg(not(all(
+    feature = "fixed_size",
+    not(feature = "disable_fixed_size"),
+    target_pointer_width = "64",
+    target_endian = "little"
+)))]
+mod standard;
+#[cfg(not(all(
+    feature = "fixed_size",
+    not(feature = "disable_fixed_size"),
+    target_pointer_width = "64",
+    target_endian = "little"
+)))]
+pub use standard::*;

--- a/crates/oxc_allocator/src/pool/standard.rs
+++ b/crates/oxc_allocator/src/pool/standard.rs
@@ -71,3 +71,38 @@ impl Drop for AllocatorGuard<'_> {
         self.pool.add(allocator);
     }
 }
+
+// Dummy implementations of interfaces from `fixed_size`, just to stop clippy complaining.
+// Seems to be necessary due to feature unification.
+#[allow(
+    dead_code,
+    missing_docs,
+    clippy::missing_safety_doc,
+    clippy::unused_self,
+    clippy::allow_attributes
+)]
+mod dummies {
+    use std::{ptr::NonNull, sync::atomic::AtomicBool};
+
+    use crate::Allocator;
+
+    #[doc(hidden)]
+    pub struct FixedSizeAllocatorMetadata {
+        pub id: u32,
+        pub(crate) alloc_ptr: NonNull<u8>,
+        pub is_double_owned: AtomicBool,
+    }
+
+    #[doc(hidden)]
+    pub unsafe fn free_fixed_size_allocator(_metadata_ptr: NonNull<FixedSizeAllocatorMetadata>) {
+        unreachable!();
+    }
+
+    #[doc(hidden)]
+    impl Allocator {
+        pub unsafe fn fixed_size_metadata_ptr(&self) -> NonNull<FixedSizeAllocatorMetadata> {
+            unreachable!();
+        }
+    }
+}
+pub use dummies::*;

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -207,7 +207,7 @@ use utils::create_ident;
 
 /// Paths to source files containing AST types
 static SOURCE_PATHS: &[&str] = &[
-    "crates/oxc_allocator/src/pool_fixed_size.rs",
+    "crates/oxc_allocator/src/pool/fixed_size.rs",
     "crates/oxc_ast/src/ast/js.rs",
     "crates/oxc_ast/src/ast/literal.rs",
     "crates/oxc_ast/src/ast/jsx.rs",


### PR DESCRIPTION
Pure refactor. Move all code related to `AllocatorPool` into a directory together, in preparation for further changes.