### PR TITLE
refactor(allocator/pool): move resetting into `AllocatorPool::add`

### DIFF
--- a/crates/oxc_allocator/src/pool/fixed_size.rs
+++ b/crates/oxc_allocator/src/pool/fixed_size.rs
@@ -66,12 +66,13 @@ impl AllocatorPool {
 
     /// Add a [`FixedSizeAllocator`] to the pool.
     ///
-    /// The `Allocator` should be empty, ready to be re-used.
+    /// The `Allocator` is reset by this method, so it's ready to be re-used.
     ///
     /// # Panics
     ///
     /// Panics if the underlying mutex is poisoned.
-    fn add(&self, allocator: FixedSizeAllocator) {
+    fn add(&self, mut allocator: FixedSizeAllocator) {
+        allocator.reset();
         let mut allocators = self.allocators.lock().unwrap();
         allocators.push(allocator);
     }
@@ -97,8 +98,7 @@ impl Drop for AllocatorGuard<'_> {
     /// Return [`Allocator`] back to the pool.
     fn drop(&mut self) {
         // SAFETY: After taking ownership of the `FixedSizeAllocator`, we do not touch the `ManuallyDrop` again
-        let mut allocator = unsafe { ManuallyDrop::take(&mut self.allocator) };
-        allocator.reset();
+        let allocator = unsafe { ManuallyDrop::take(&mut self.allocator) };
         self.pool.add(allocator);
     }
 }


### PR DESCRIPTION
Pure refactor. Previously `Allocator`s were reset in `AllocatorGuard`'s `Drop` impl. Instead move the `reset()` call into `AllocatorPool::add`, which `AllocatorGuard::drop` calls.