### PR TITLE
refactor(linter/plugins): use fixed-size allocators when `ExternalLinter` exists

### DIFF
--- a/apps/oxlint/src/raw_fs.rs
+++ b/apps/oxlint/src/raw_fs.rs
@@ -14,7 +14,7 @@ use oxc_linter::RuntimeFileSystem;
 /// Identical to `OsFileSystem`, except that `read_to_arena_str` reads the file's contents into
 /// start of the allocator, instead of the end. This conforms to what raw transfer needs.
 ///
-/// Must only be used in conjunction with `AllocatorPool` with `fixed_size` feature enabled,
+/// Must only be used in conjunction with `AllocatorPool` created with `new_fixed_size`,
 /// which wraps `Allocator`s with a custom `Drop` impl, which makes `read_to_arena_str` safe.
 ///
 /// This is a temporary solution. When we replace `bumpalo` with our own allocator, all strings

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -17,7 +17,7 @@ description.workspace = true
 default = []
 ruledocs = ["oxc_macros/ruledocs"] # Enables the `ruledocs` feature for conditional compilation
 language_server = ["oxc_data_structures/rope"] # For the Runtime to support needed information for the language server
-oxlint2 = ["dep:oxc_ast_macros", "oxc_ast_visit/serialize", "tokio/rt-multi-thread"]
+oxlint2 = ["dep:oxc_ast_macros", "oxc_allocator/fixed_size", "oxc_ast_visit/serialize", "tokio/rt-multi-thread"]
 disable_oxlint2 = []
 force_test_reporter = []
 


### PR DESCRIPTION
We're trying to move the linter away from relying on Cargo features to enable/disable support for JS plugins, and over to runtime options.

The signal that JS plugins are in use is the existence of an `ExternalLinter`.

Select what kind of `AllocatorPool` to use based on this criteria - fixed-size allocators if JS plugins are in use, or standard allocators otherwise. Utilize the `AllocatorPool::new_fixed_size` method added in #13622 to do this.