### PR TITLE
refactor(allocator/pool): `AllocatorPool::new` always create standard pool

### DIFF
--- a/crates/oxc_allocator/src/pool/standard.rs
+++ b/crates/oxc_allocator/src/pool/standard.rs
@@ -12,7 +12,6 @@ pub struct StandardAllocatorPool {
 
 impl StandardAllocatorPool {
     /// Create a new [`StandardAllocatorPool`] for use across the specified number of threads.
-    #[cfg_attr(all(feature = "fixed_size", not(feature = "disable_fixed_size")), expect(dead_code))]
     pub fn new(thread_count: usize) -> StandardAllocatorPool {
         let allocators = iter::repeat_with(Allocator::new).take(thread_count).collect();
         StandardAllocatorPool { allocators: Mutex::new(allocators) }


### PR DESCRIPTION
#13622 added `AllocatorPool::new_fixed_size` method to create a fixed-size allocator pool. #13623 switched the linter over to using this method when a fixed-size allocator is required. So now we can make `AllocatorPool::new` do what it's intended to do, and create a standard allocator pool.

Strictly speaking this is a breaking change, but I don't think anyone is using the `fixed_size` feature, except for the linter. Without that, this change makes no difference to behavior.
