### PR TITLE
refactor(linter/plugins): remove `disable_oxlint2` Cargo feature

### DIFF
--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -62,5 +62,4 @@ lazy-regex = { workspace = true }
 default = []
 allocator = ["dep:mimalloc-safe"]
 oxlint2 = ["oxc_linter/oxlint2", "oxc_allocator/fixed_size", "dep:simdutf8"]
-disable_oxlint2 = ["oxc_linter/disable_oxlint2"]
 force_test_reporter = ["oxc_linter/force_test_reporter"]

--- a/apps/oxlint/src/lib.rs
+++ b/apps/oxlint/src/lib.rs
@@ -18,7 +18,7 @@ pub mod cli {
 
 use cli::{CliRunResult, LintRunner};
 
-#[cfg(all(feature = "oxlint2", not(feature = "disable_oxlint2")))]
+#[cfg(feature = "oxlint2")]
 mod raw_fs;
 
 #[cfg(all(feature = "allocator", not(miri), not(target_family = "wasm")))]

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -359,7 +359,7 @@ impl LintRunner {
 
         // Spawn linting in another thread so diagnostics can be printed immediately from diagnostic_service.run.
         rayon::spawn(move || {
-            #[cfg(all(feature = "oxlint2", not(feature = "disable_oxlint2")))]
+            #[cfg(feature = "oxlint2")]
             let has_external_linter = linter.has_external_linter();
 
             let mut lint_service = LintService::new(linter, options);
@@ -367,7 +367,7 @@ impl LintRunner {
 
             // Use `RawTransferFileSystem` if `oxlint2` feature is enabled and `ExternalLinter` exists.
             // This reads the source text into start of allocator, instead of the end.
-            #[cfg(all(feature = "oxlint2", not(feature = "disable_oxlint2")))]
+            #[cfg(feature = "oxlint2")]
             if has_external_linter {
                 use crate::raw_fs::RawTransferFileSystem;
                 lint_service.with_file_system(Box::new(RawTransferFileSystem));

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -18,7 +18,6 @@ default = []
 ruledocs = ["oxc_macros/ruledocs"] # Enables the `ruledocs` feature for conditional compilation
 language_server = ["oxc_data_structures/rope"] # For the Runtime to support needed information for the language server
 oxlint2 = ["dep:oxc_ast_macros", "oxc_allocator/fixed_size", "oxc_ast_visit/serialize", "tokio/rt-multi-thread"]
-disable_oxlint2 = []
 force_test_reporter = []
 
 [lints]

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -494,7 +494,7 @@ impl ConfigStoreBuilder {
         serde_json::to_string_pretty(&oxlintrc).unwrap()
     }
 
-    #[cfg(not(all(feature = "oxlint2", not(feature = "disable_oxlint2"))))]
+    #[cfg(not(feature = "oxlint2"))]
     #[expect(unused_variables, clippy::needless_pass_by_ref_mut)]
     fn load_external_plugin(
         oxlintrc_dir_path: &Path,
@@ -506,7 +506,7 @@ impl ConfigStoreBuilder {
         unreachable!()
     }
 
-    #[cfg(all(feature = "oxlint2", not(feature = "disable_oxlint2")))]
+    #[cfg(feature = "oxlint2")]
     fn load_external_plugin(
         oxlintrc_dir_path: &Path,
         plugin_specifier: &str,

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -343,7 +343,7 @@ impl ConfigStore {
         None
     }
 
-    #[cfg_attr(not(all(feature = "oxlint2", not(feature = "disable_oxlint2"))), expect(dead_code))]
+    #[cfg_attr(not(feature = "oxlint2"), expect(dead_code))]
     pub(crate) fn resolve_plugin_rule_names(
         &self,
         external_rule_id: ExternalRuleId,

--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -47,7 +47,7 @@ pub struct Loc {
 }
 
 #[derive(Clone)]
-#[cfg_attr(not(all(feature = "oxlint2", not(feature = "disable_oxlint2"))), expect(dead_code))]
+#[cfg_attr(not(feature = "oxlint2"), expect(dead_code))]
 pub struct ExternalLinter {
     pub(crate) load_plugin: ExternalLinterLoadPluginCb,
     pub(crate) lint_file: ExternalLinterLintFileCb,

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -8,9 +8,9 @@ use oxc_ast::ast_kind::AST_TYPE_MAX;
 use oxc_data_structures::box_macros::boxed_array;
 use oxc_semantic::AstNode;
 
-#[cfg(all(feature = "oxlint2", not(feature = "disable_oxlint2")))]
+#[cfg(feature = "oxlint2")]
 use oxc_ast_macros::ast;
-#[cfg(all(feature = "oxlint2", not(feature = "disable_oxlint2")))]
+#[cfg(feature = "oxlint2")]
 use oxc_ast_visit::utf8_to_utf16::Utf8ToUtf16;
 
 #[cfg(test)]
@@ -40,8 +40,7 @@ pub mod rules;
 pub mod table;
 
 mod generated {
-    #[cfg(all(feature = "oxlint2", not(feature = "disable_oxlint2")))]
-    #[cfg(debug_assertions)]
+    #[cfg(all(feature = "oxlint2", debug_assertions))]
     mod assert_layouts;
     mod rule_runner_impls;
 }
@@ -260,11 +259,11 @@ impl Linter {
                 }
             }
 
-            #[cfg(all(feature = "oxlint2", not(feature = "disable_oxlint2")))]
+            #[cfg(feature = "oxlint2")]
             self.run_external_rules(&external_rules, path, &mut ctx_host, allocator);
 
             // Stop clippy complaining about unused vars
-            #[cfg(not(all(feature = "oxlint2", not(feature = "disable_oxlint2"))))]
+            #[cfg(not(feature = "oxlint2"))]
             let (_, _, _) = (&external_rules, &mut ctx_host, allocator);
 
             if let Some(severity) = self.options.report_unused_directive {
@@ -282,7 +281,7 @@ impl Linter {
         ctx_host.take_diagnostics()
     }
 
-    #[cfg(all(feature = "oxlint2", not(feature = "disable_oxlint2")))]
+    #[cfg(feature = "oxlint2")]
     fn run_external_rules<'a>(
         &self,
         external_rules: &[(ExternalRuleId, AllowWarnDeny)],
@@ -400,7 +399,7 @@ impl Linter {
     }
 }
 
-#[cfg(all(feature = "oxlint2", not(feature = "disable_oxlint2")))]
+#[cfg(feature = "oxlint2")]
 /// Metadata written to end of buffer.
 ///
 /// Duplicate of `RawTransferMetadata` in `napi/parser/src/raw_transfer_types.rs`.
@@ -418,10 +417,10 @@ struct RawTransferMetadata2 {
     pub(crate) _padding: u64,
 }
 
-#[cfg(all(feature = "oxlint2", not(feature = "disable_oxlint2")))]
+#[cfg(feature = "oxlint2")]
 use RawTransferMetadata2 as RawTransferMetadata;
 
-#[cfg(all(feature = "oxlint2", not(feature = "disable_oxlint2")))]
+#[cfg(feature = "oxlint2")]
 impl RawTransferMetadata {
     pub fn new(data_offset: u32) -> Self {
         Self { data_offset, is_ts: false, _padding: 0 }

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -269,11 +269,11 @@ impl Runtime {
         // If an external linter is used (JS plugins), we must use fixed-size allocators,
         // for compatibility with raw transfer
         let allocator_pool = if linter.has_external_linter() {
-            #[cfg(all(feature = "oxlint2", not(feature = "disable_oxlint2")))]
+            #[cfg(feature = "oxlint2")]
             {
                 AllocatorPool::new_fixed_size(thread_count)
             }
-            #[cfg(not(all(feature = "oxlint2", not(feature = "disable_oxlint2"))))]
+            #[cfg(not(feature = "oxlint2"))]
             {
                 panic!("`oxlint2` feature must be enabled when using external linters");
             }


### PR DESCRIPTION
Similar to #13625. Remove the `disable_oxlint2` Cargo feature in `oxlint` and `oxc_linter` crates. It's no longer required.