### PR TITLE
refactor(language_server): split options for linting and formatting

### DIFF
--- a/crates/oxc_language_server/src/formatter/mod.rs
+++ b/crates/oxc_language_server/src/formatter/mod.rs
@@ -1,0 +1,1 @@
+pub mod options;

--- a/crates/oxc_language_server/src/formatter/options.rs
+++ b/crates/oxc_language_server/src/formatter/options.rs
@@ -1,0 +1,5 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct FormatOptions;

--- a/crates/oxc_language_server/src/linter/mod.rs
+++ b/crates/oxc_language_server/src/linter/mod.rs
@@ -1,5 +1,6 @@
 pub mod config_walker;
 pub mod error_with_position;
 pub mod isolated_lint_handler;
+pub mod options;
 pub mod server_linter;
 pub mod tsgo_linter;

--- a/crates/oxc_language_server/src/linter/options.rs
+++ b/crates/oxc_language_server/src/linter/options.rs
@@ -1,0 +1,201 @@
+use log::info;
+use rustc_hash::{FxBuildHasher, FxHashMap};
+use serde::{Deserialize, Deserializer, Serialize, de::Error};
+use serde_json::Value;
+
+use oxc_linter::FixKind;
+
+#[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq, Clone, Copy)]
+#[serde(rename_all = "camelCase")]
+pub enum UnusedDisableDirectives {
+    #[default]
+    Allow,
+    Warn,
+    Deny,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq, Clone, Copy)]
+#[serde(rename_all = "camelCase")]
+pub enum Run {
+    OnSave,
+    #[default]
+    OnType,
+}
+
+#[derive(Debug, Default, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct LintOptions {
+    pub run: Run, // TODO: the client wants maybe only the formatter, make it optional
+    pub config_path: Option<String>,
+    pub ts_config_path: Option<String>,
+    pub unused_disable_directives: UnusedDisableDirectives,
+    pub type_aware: bool,
+    pub flags: FxHashMap<String, String>,
+}
+
+impl LintOptions {
+    pub fn use_nested_configs(&self) -> bool {
+        !self.flags.contains_key("disable_nested_config") && self.config_path.is_none()
+    }
+
+    pub fn fix_kind(&self) -> FixKind {
+        self.flags.get("fix_kind").map_or(FixKind::SafeFix, |kind| match kind.as_str() {
+            "safe_fix" => FixKind::SafeFix,
+            "safe_fix_or_suggestion" => FixKind::SafeFixOrSuggestion,
+            "dangerous_fix" => FixKind::DangerousFix,
+            "dangerous_fix_or_suggestion" => FixKind::DangerousFixOrSuggestion,
+            "none" => FixKind::None,
+            "all" => FixKind::All,
+            _ => {
+                info!("invalid fix_kind flag `{kind}`, fallback to `safe_fix`");
+                FixKind::SafeFix
+            }
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for LintOptions {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        LintOptions::try_from(value).map_err(Error::custom)
+    }
+}
+
+impl TryFrom<Value> for LintOptions {
+    type Error = String;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        let Some(object) = value.as_object() else {
+            return Err("no object passed".to_string());
+        };
+
+        let mut flags = FxHashMap::with_capacity_and_hasher(2, FxBuildHasher);
+        if let Some(json_flags) = object.get("flags").and_then(|value| value.as_object()) {
+            if let Some(disable_nested_config) =
+                json_flags.get("disable_nested_config").and_then(|value| value.as_str())
+            {
+                flags
+                    .insert("disable_nested_config".to_string(), disable_nested_config.to_string());
+            }
+
+            if let Some(fix_kind) = json_flags.get("fix_kind").and_then(|value| value.as_str()) {
+                flags.insert("fix_kind".to_string(), fix_kind.to_string());
+            }
+        }
+
+        Ok(Self {
+            run: object
+                .get("run")
+                .map(|run| serde_json::from_value::<Run>(run.clone()).unwrap_or_default())
+                .unwrap_or_default(),
+            unused_disable_directives: object
+                .get("unusedDisableDirectives")
+                .map(|key| {
+                    serde_json::from_value::<UnusedDisableDirectives>(key.clone())
+                        .unwrap_or_default()
+                })
+                .unwrap_or_default(),
+            config_path: object
+                .get("configPath")
+                .and_then(|config_path| serde_json::from_value::<String>(config_path.clone()).ok()),
+            ts_config_path: object
+                .get("tsConfigPath")
+                .and_then(|config_path| serde_json::from_value::<String>(config_path.clone()).ok()),
+            type_aware: object
+                .get("typeAware")
+                .is_some_and(|key| serde_json::from_value::<bool>(key.clone()).unwrap_or_default()),
+            flags,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use rustc_hash::FxHashMap;
+    use serde_json::json;
+
+    use super::{LintOptions, Run, UnusedDisableDirectives};
+
+    #[test]
+    fn test_valid_options_json() {
+        let json = json!({
+            "run": "onSave",
+            "configPath": "./custom.json",
+            "unusedDisableDirectives": "warn",
+            "typeAware": true,
+            "flags": {
+                "disable_nested_config": "true",
+                "fix_kind": "dangerous_fix"
+            }
+        });
+
+        let options = LintOptions::try_from(json).unwrap();
+        assert_eq!(options.run, Run::OnSave);
+        assert_eq!(options.config_path, Some("./custom.json".into()));
+        assert_eq!(options.unused_disable_directives, UnusedDisableDirectives::Warn);
+        assert!(options.type_aware);
+        assert_eq!(options.flags.get("disable_nested_config"), Some(&"true".to_string()));
+        assert_eq!(options.flags.get("fix_kind"), Some(&"dangerous_fix".to_string()));
+    }
+
+    #[test]
+    fn test_empty_options_json() {
+        let json = json!({});
+
+        let options = LintOptions::try_from(json).unwrap();
+        assert_eq!(options.run, Run::OnType);
+        assert_eq!(options.config_path, None);
+        assert_eq!(options.unused_disable_directives, UnusedDisableDirectives::Allow);
+        assert!(!options.type_aware);
+        assert!(options.flags.is_empty());
+    }
+
+    #[test]
+    fn test_invalid_options_json() {
+        let json = json!({
+            "run": true,
+            "configPath": "./custom.json"
+        });
+
+        let options = LintOptions::try_from(json).unwrap();
+        assert_eq!(options.run, Run::OnType); // fallback
+        assert_eq!(options.config_path, Some("./custom.json".into()));
+        assert!(options.flags.is_empty());
+    }
+
+    #[test]
+    fn test_invalid_flags_options_json() {
+        let json = json!({
+            "configPath": "./custom.json",
+            "flags": {
+                "disable_nested_config": true, // should be string
+                "fix_kind": "dangerous_fix"
+            }
+        });
+
+        let options = LintOptions::try_from(json).unwrap();
+        assert_eq!(options.run, Run::OnType); // fallback
+        assert_eq!(options.config_path, Some("./custom.json".into()));
+        assert_eq!(options.flags.get("disable_nested_config"), None);
+        assert_eq!(options.flags.get("fix_kind"), Some(&"dangerous_fix".to_string()));
+    }
+
+    #[test]
+    fn test_use_nested_configs() {
+        let options = LintOptions::default();
+        assert!(options.use_nested_configs());
+
+        let options =
+            LintOptions { config_path: Some("config.json".to_string()), ..Default::default() };
+        assert!(!options.use_nested_configs());
+
+        let mut flags = FxHashMap::default();
+        flags.insert("disable_nested_config".to_string(), "true".to_string());
+
+        let options = LintOptions { flags, ..Default::default() };
+        assert!(!options.use_nested_configs());
+    }
+}

--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -3,6 +3,7 @@ use std::{str::FromStr, sync::Arc};
 use futures::future::join_all;
 use log::{debug, info, warn};
 use rustc_hash::FxBuildHasher;
+use serde::Deserialize;
 use serde_json::json;
 use tokio::sync::{OnceCell, RwLock, SetError};
 use tower_lsp_server::{
@@ -21,6 +22,7 @@ use tower_lsp_server::{
 mod capabilities;
 mod code_actions;
 mod commands;
+mod formatter;
 mod linter;
 mod options;
 #[cfg(test)]
@@ -64,7 +66,7 @@ impl LanguageServer for Backend {
                 return Some(new_settings);
             }
 
-            let deprecated_settings = Options::try_from(value.get_mut("settings")?.take()).ok();
+            let deprecated_settings = Options::deserialize(value.get_mut("settings")?.take()).ok();
 
             // the client has deprecated settings and has a deprecated root uri.
             // handle all things like the old way

--- a/crates/oxc_language_server/src/options.rs
+++ b/crates/oxc_language_server/src/options.rs
@@ -1,115 +1,15 @@
-use log::info;
-use oxc_linter::FixKind;
-use rustc_hash::{FxBuildHasher, FxHashMap};
-use serde::{Deserialize, Deserializer, Serialize, de::Error};
-use serde_json::Value;
+use serde::{Deserialize, Serialize};
 use tower_lsp_server::lsp_types::Uri;
 
-#[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq, Clone, Copy)]
-#[serde(rename_all = "camelCase")]
-pub enum Run {
-    OnSave,
-    #[default]
-    OnType,
-}
+use crate::{formatter::options::FormatOptions, linter::options::LintOptions};
 
-#[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq, Clone, Copy)]
-#[serde(rename_all = "camelCase")]
-pub enum UnusedDisableDirectives {
-    #[default]
-    Allow,
-    Warn,
-    Deny,
-}
-
-#[derive(Debug, Default, Serialize, Clone)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Options {
-    pub run: Run,
-    pub config_path: Option<String>,
-    pub ts_config_path: Option<String>,
-    pub unused_disable_directives: UnusedDisableDirectives,
-    pub type_aware: bool,
-    pub flags: FxHashMap<String, String>,
-}
-
-impl Options {
-    pub fn use_nested_configs(&self) -> bool {
-        !self.flags.contains_key("disable_nested_config") && self.config_path.is_none()
-    }
-
-    pub fn fix_kind(&self) -> FixKind {
-        self.flags.get("fix_kind").map_or(FixKind::SafeFix, |kind| match kind.as_str() {
-            "safe_fix" => FixKind::SafeFix,
-            "safe_fix_or_suggestion" => FixKind::SafeFixOrSuggestion,
-            "dangerous_fix" => FixKind::DangerousFix,
-            "dangerous_fix_or_suggestion" => FixKind::DangerousFixOrSuggestion,
-            "none" => FixKind::None,
-            "all" => FixKind::All,
-            _ => {
-                info!("invalid fix_kind flag `{kind}`, fallback to `safe_fix`");
-                FixKind::SafeFix
-            }
-        })
-    }
-}
-
-impl<'de> Deserialize<'de> for Options {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let value = Value::deserialize(deserializer)?;
-        Options::try_from(value).map_err(Error::custom)
-    }
-}
-
-impl TryFrom<Value> for Options {
-    type Error = String;
-
-    fn try_from(value: Value) -> Result<Self, Self::Error> {
-        let Some(object) = value.as_object() else {
-            return Err("no object passed".to_string());
-        };
-
-        let mut flags = FxHashMap::with_capacity_and_hasher(2, FxBuildHasher);
-        if let Some(json_flags) = object.get("flags").and_then(|value| value.as_object()) {
-            if let Some(disable_nested_config) =
-                json_flags.get("disable_nested_config").and_then(|value| value.as_str())
-            {
-                flags
-                    .insert("disable_nested_config".to_string(), disable_nested_config.to_string());
-            }
-
-            if let Some(fix_kind) = json_flags.get("fix_kind").and_then(|value| value.as_str()) {
-                flags.insert("fix_kind".to_string(), fix_kind.to_string());
-            }
-        }
-
-        Ok(Self {
-            run: object
-                .get("run")
-                .map(|run| serde_json::from_value::<Run>(run.clone()).unwrap_or_default())
-                .unwrap_or_default(),
-            unused_disable_directives: object
-                .get("unusedDisableDirectives")
-                .map(|key| {
-                    serde_json::from_value::<UnusedDisableDirectives>(key.clone())
-                        .unwrap_or_default()
-                })
-                .unwrap_or_default(),
-            config_path: object
-                .get("configPath")
-                .and_then(|config_path| serde_json::from_value::<String>(config_path.clone()).ok()),
-            ts_config_path: object
-                .get("tsConfigPath")
-                .and_then(|config_path| serde_json::from_value::<String>(config_path.clone()).ok()),
-            type_aware: object
-                .get("typeAware")
-                .is_some_and(|key| serde_json::from_value::<bool>(key.clone()).unwrap_or_default()),
-            flags,
-        })
-    }
+    #[serde(flatten)]
+    pub lint: LintOptions,
+    #[serde(flatten)]
+    pub format: FormatOptions,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -121,74 +21,11 @@ pub struct WorkspaceOption {
 
 #[cfg(test)]
 mod test {
-    use rustc_hash::FxHashMap;
     use serde_json::json;
 
-    use super::{Options, Run, UnusedDisableDirectives, WorkspaceOption};
+    use crate::linter::options::Run;
 
-    #[test]
-    fn test_valid_options_json() {
-        let json = json!({
-            "run": "onSave",
-            "configPath": "./custom.json",
-            "unusedDisableDirectives": "warn",
-            "typeAware": true,
-            "flags": {
-                "disable_nested_config": "true",
-                "fix_kind": "dangerous_fix"
-            }
-        });
-
-        let options = Options::try_from(json).unwrap();
-        assert_eq!(options.run, Run::OnSave);
-        assert_eq!(options.config_path, Some("./custom.json".into()));
-        assert_eq!(options.unused_disable_directives, UnusedDisableDirectives::Warn);
-        assert!(options.type_aware);
-        assert_eq!(options.flags.get("disable_nested_config"), Some(&"true".to_string()));
-        assert_eq!(options.flags.get("fix_kind"), Some(&"dangerous_fix".to_string()));
-    }
-
-    #[test]
-    fn test_empty_options_json() {
-        let json = json!({});
-
-        let options = Options::try_from(json).unwrap();
-        assert_eq!(options.run, Run::OnType);
-        assert_eq!(options.config_path, None);
-        assert_eq!(options.unused_disable_directives, UnusedDisableDirectives::Allow);
-        assert!(!options.type_aware);
-        assert!(options.flags.is_empty());
-    }
-
-    #[test]
-    fn test_invalid_options_json() {
-        let json = json!({
-            "run": true,
-            "configPath": "./custom.json"
-        });
-
-        let options = Options::try_from(json).unwrap();
-        assert_eq!(options.run, Run::OnType); // fallback
-        assert_eq!(options.config_path, Some("./custom.json".into()));
-        assert!(options.flags.is_empty());
-    }
-
-    #[test]
-    fn test_invalid_flags_options_json() {
-        let json = json!({
-            "configPath": "./custom.json",
-            "flags": {
-                "disable_nested_config": true, // should be string
-                "fix_kind": "dangerous_fix"
-            }
-        });
-
-        let options = Options::try_from(json).unwrap();
-        assert_eq!(options.run, Run::OnType); // fallback
-        assert_eq!(options.config_path, Some("./custom.json".into()));
-        assert_eq!(options.flags.get("disable_nested_config"), None);
-        assert_eq!(options.flags.get("fix_kind"), Some(&"dangerous_fix".to_string()));
-    }
+    use super::WorkspaceOption;
 
     #[test]
     fn test_invalid_workspace_options_json() {
@@ -196,7 +33,7 @@ mod test {
             "workspaceUri": "file:///root/",
             "options": {
                 "run": true,
-                "configPath": "./custom.json"
+                "configPath": "./custom.json",
             }
         }]);
 
@@ -206,24 +43,8 @@ mod test {
         assert_eq!(workspace[0].workspace_uri.path().as_str(), "/root/");
 
         let options = &workspace[0].options;
-        assert_eq!(options.run, Run::OnType); // fallback
-        assert_eq!(options.config_path, Some("./custom.json".into()));
-        assert!(options.flags.is_empty());
-    }
-
-    #[test]
-    fn test_use_nested_configs() {
-        let options = Options::default();
-        assert!(options.use_nested_configs());
-
-        let options =
-            Options { config_path: Some("config.json".to_string()), ..Default::default() };
-        assert!(!options.use_nested_configs());
-
-        let mut flags = FxHashMap::default();
-        flags.insert("disable_nested_config".to_string(), "true".to_string());
-
-        let options = Options { flags, ..Default::default() };
-        assert!(!options.use_nested_configs());
+        assert_eq!(options.lint.run, Run::OnType); // fallback
+        assert_eq!(options.lint.config_path, Some("./custom.json".into()));
+        assert!(options.lint.flags.is_empty());
     }
 }

--- a/crates/oxc_language_server/src/tester.rs
+++ b/crates/oxc_language_server/src/tester.rs
@@ -6,7 +6,12 @@ use tower_lsp_server::{
 };
 
 use crate::{
-    Options, linter::server_linter::ServerLinterRun, options::Run, worker::WorkspaceWorker,
+    Options,
+    linter::{
+        options::{LintOptions, Run},
+        server_linter::ServerLinterRun,
+    },
+    worker::WorkspaceWorker,
 };
 
 use super::linter::error_with_position::DiagnosticReport;
@@ -94,11 +99,11 @@ fixed: {fixed:?}
 /// Testing struct for the [linter server][crate::linter::server_linter::ServerLinter].
 pub struct Tester<'t> {
     relative_root_dir: &'t str,
-    options: Option<Options>,
+    options: Option<LintOptions>,
 }
 
 impl Tester<'_> {
-    pub fn new(relative_root_dir: &'static str, options: Option<Options>) -> Self {
+    pub fn new(relative_root_dir: &'static str, options: Option<LintOptions>) -> Self {
         Self { relative_root_dir, options }
     }
 
@@ -108,7 +113,12 @@ impl Tester<'_> {
             .join(self.relative_root_dir);
         let uri = Uri::from_file_path(absolute_path).expect("could not convert current dir to uri");
         let worker = WorkspaceWorker::new(uri);
-        worker.init_linter(&self.options.clone().unwrap_or_default()).await;
+        worker
+            .init_linter(&Options {
+                lint: self.options.clone().unwrap_or_default(),
+                ..Default::default()
+            })
+            .await;
 
         worker
     }


### PR DESCRIPTION
Splits the options intern, so we can define options for `ServerLinter` and `ServerFormatter`.
There is no option added. This comes later (maybe `experimental: bool`?)