### PR TITLE
fix(transformer): improve legacy decorator handling and fix constructor parameter decorators

### DIFF
--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -50,6 +50,7 @@ use std::mem;
 use oxc_allocator::{Address, GetAddress, TakeIn, Vec as ArenaVec};
 use oxc_ast::{NONE, ast::*};
 use oxc_ast_visit::{Visit, VisitMut};
+use oxc_data_structures::stack::NonEmptyStack;
 use oxc_semantic::{ScopeFlags, SymbolFlags};
 use oxc_span::SPAN;
 use oxc_syntax::operator::AssignmentOperator;
@@ -62,23 +63,37 @@ use crate::{
     state::TransformState,
     utils::ast_builder::{create_assignment, create_prototype_member},
 };
-use metadata::{LegacyDecoratorMetadata, MethodMetadata};
-
-#[derive(Default)]
-struct ClassDecoratorInfo {
-    /// `@dec class C {}` or `class C { constructor(@dec p) {} }`
-    class_or_constructor_parameter_is_decorated: bool,
-    /// `class C { @dec m() {} }`
-    class_element_is_decorated: bool,
-    /// `class C { @(#a in C ? dec() : dec2()) prop = 0; }`
-    has_private_in_expression_in_decorator: bool,
-}
+use metadata::LegacyDecoratorMetadata;
 
 struct ClassDecoratedData<'a> {
     // Class binding. When a class is without binding, it will be `_default`,
     binding: BoundIdentifier<'a>,
     // Alias binding exist when the class body contains a reference that refers to class itself.
     alias_binding: Option<BoundIdentifier<'a>>,
+}
+
+/// Class decorations state for the current class being processed.
+#[derive(Default)]
+struct ClassDecorations<'a> {
+    /// Flag indicating whether the current class needs to transform or not,
+    /// `false` if the class is an expression or `declare`.
+    should_transform: bool,
+    /// Decoration statements accumulated for the current class.
+    /// These will be applied when the class processing is complete.
+    decoration_stmts: Vec<Statement<'a>>,
+    /// Binding for the current class being processed.
+    /// Generated on-demand when the first decorator needs it.
+    class_binding: Option<BoundIdentifier<'a>>,
+    /// Flag indicating whether the current class has a private `in` expression in any decorator.
+    /// This affects where decorations are placed (in static block vs after class).
+    class_has_private_in_expression_in_decorator: bool,
+}
+
+impl ClassDecorations<'_> {
+    fn with_should_transform(mut self, should_transform: bool) -> Self {
+        self.should_transform = should_transform;
+        self
+    }
 }
 
 pub struct LegacyDecorator<'a, 'ctx> {
@@ -95,6 +110,10 @@ pub struct LegacyDecorator<'a, 'ctx> {
     class_decorated_data: Option<ClassDecoratedData<'a>>,
     /// Transformed decorators, they will be inserted in the statements at [`Self::exit_class_at_end`].
     decorations: FxHashMap<Address, Vec<Statement<'a>>>,
+    /// Stack for managing nested class decoration state.
+    /// Each level represents the decoration state for a class in the hierarchy,
+    /// with the top being the currently processed class.
+    class_decorations_stack: NonEmptyStack<ClassDecorations<'a>>,
     ctx: &'ctx TransformCtx<'a>,
 }
 
@@ -104,13 +123,27 @@ impl<'a, 'ctx> LegacyDecorator<'a, 'ctx> {
             emit_decorator_metadata,
             metadata: LegacyDecoratorMetadata::new(ctx),
             class_decorated_data: None,
-            ctx,
             decorations: FxHashMap::default(),
+            class_decorations_stack: NonEmptyStack::new(ClassDecorations::default()),
+            ctx,
         }
     }
 }
 
 impl<'a> Traverse<'a, TransformState<'a>> for LegacyDecorator<'a, '_> {
+    #[inline]
+    fn exit_program(&mut self, node: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
+        if self.emit_decorator_metadata {
+            self.metadata.exit_program(node, ctx);
+        }
+
+        debug_assert!(
+            self.class_decorations_stack.is_exhausted(),
+            "All class decorations should have been popped."
+        );
+    }
+
+    #[inline]
     fn enter_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
         if self.emit_decorator_metadata {
             self.metadata.enter_statement(stmt, ctx);
@@ -119,6 +152,11 @@ impl<'a> Traverse<'a, TransformState<'a>> for LegacyDecorator<'a, '_> {
 
     #[inline]
     fn enter_class(&mut self, class: &mut Class<'a>, ctx: &mut TraverseCtx<'a>) {
+        self.class_decorations_stack.push(
+            ClassDecorations::default()
+                .with_should_transform(!(class.is_expression() || class.declare)),
+        );
+
         if self.emit_decorator_metadata {
             self.metadata.enter_class(class, ctx);
         }
@@ -176,9 +214,125 @@ impl<'a> Traverse<'a, TransformState<'a>> for LegacyDecorator<'a, '_> {
             self.metadata.enter_property_definition(node, ctx);
         }
     }
+
+    #[inline]
+    fn exit_method_definition(
+        &mut self,
+        method: &mut MethodDefinition<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        // `constructor` will handle in `transform_decorators_of_class_and_constructor`.
+        if method.kind.is_constructor() {
+            return;
+        }
+
+        if let Some(decorations) = self.get_all_decorators_of_class_method(method, ctx) {
+            // We emit `null` here to indicate to `_decorate` that it can invoke `Object.getOwnPropertyDescriptor` directly.
+            let descriptor = ctx.ast.expression_null_literal(SPAN);
+            self.handle_decorated_class_element(
+                method.r#static,
+                &mut method.key,
+                descriptor,
+                decorations,
+                ctx,
+            );
+        }
+    }
+
+    #[inline]
+    fn exit_property_definition(
+        &mut self,
+        prop: &mut PropertyDefinition<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        if prop.decorators.is_empty() {
+            return;
+        }
+
+        let decorations =
+            Self::convert_decorators_to_array_expression(prop.decorators.drain(..), ctx);
+
+        // We emit `void 0` here to indicate to `_decorate` that it can invoke `Object.defineProperty` directly.
+        let descriptor = ctx.ast.void_0(SPAN);
+        self.handle_decorated_class_element(
+            prop.r#static,
+            &mut prop.key,
+            descriptor,
+            decorations,
+            ctx,
+        );
+    }
+
+    #[inline]
+    fn exit_accessor_property(
+        &mut self,
+        accessor: &mut AccessorProperty<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        if accessor.decorators.is_empty() {
+            return;
+        }
+
+        let decorations =
+            Self::convert_decorators_to_array_expression(accessor.decorators.drain(..), ctx);
+        // We emit `null` here to indicate to `_decorate` that it can invoke `Object.getOwnPropertyDescriptor` directly.
+        let descriptor = ctx.ast.expression_null_literal(SPAN);
+        self.handle_decorated_class_element(
+            accessor.r#static,
+            &mut accessor.key,
+            descriptor,
+            decorations,
+            ctx,
+        );
+    }
+
+    fn enter_decorator(&mut self, node: &mut Decorator<'a>, _ctx: &mut TraverseCtx<'a>) {
+        let current_class = self.class_decorations_stack.last_mut();
+        if current_class.should_transform
+            && !current_class.class_has_private_in_expression_in_decorator
+        {
+            current_class.class_has_private_in_expression_in_decorator =
+                PrivateInExpressionDetector::has_private_in_expression(&node.expression);
+        }
+    }
 }
 
 impl<'a> LegacyDecorator<'a, '_> {
+    /// Helper method to handle a decorated class element (method, property, or accessor).
+    /// Accumulates decoration statements in the current decoration stack.
+    fn handle_decorated_class_element(
+        &mut self,
+        is_static: bool,
+        key: &mut PropertyKey<'a>,
+        descriptor: Expression<'a>,
+        decorations: Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        let current_class = self.class_decorations_stack.last_mut();
+
+        if !current_class.should_transform {
+            return;
+        }
+
+        // Get current class binding from stack
+        let class_binding = current_class.class_binding.get_or_insert_with(|| {
+            let Ancestor::ClassBody(class) = ctx.ancestor(1) else {
+                unreachable!("The grandparent of a class element is always a class.");
+            };
+            if let Some(ident) = class.id() {
+                BoundIdentifier::from_binding_ident(ident)
+            } else {
+                ctx.generate_uid_in_current_scope("default", SymbolFlags::Class)
+            }
+        });
+
+        let prefix = Self::get_class_member_prefix(class_binding, is_static, ctx);
+        let name = self.get_name_of_property_key(key, ctx);
+        let decorator_stmt = self.create_decorator(decorations, prefix, name, descriptor, ctx);
+
+        // Push to current decoration stack
+        self.class_decorations_stack.last_mut().decoration_stmts.push(decorator_stmt);
+    }
     /// Transforms a statement that is a class declaration
     ///
     ///
@@ -326,25 +480,38 @@ impl<'a> LegacyDecorator<'a, '_> {
     }
 
     fn transform_class(&mut self, class: &mut Class<'a>, ctx: &mut TraverseCtx<'a>) {
-        let ClassDecoratorInfo {
-            class_or_constructor_parameter_is_decorated,
-            class_element_is_decorated,
-            has_private_in_expression_in_decorator,
-        } = Self::check_class_has_decorated(class);
+        let current_class_decorations = self.class_decorations_stack.pop();
 
-        if class_or_constructor_parameter_is_decorated {
-            self.transform_class_declaration_with_class_decorators(
-                class,
-                has_private_in_expression_in_decorator,
-                ctx,
-            );
-        } else if class_element_is_decorated {
-            self.transform_class_declaration_without_class_decorators(
-                class,
-                has_private_in_expression_in_decorator,
-                ctx,
+        // Legacy decorator does not allow in class expression.
+        if current_class_decorations.should_transform {
+            let class_or_constructor_parameter_is_decorated =
+                Self::check_class_has_decorated(class);
+
+            if class_or_constructor_parameter_is_decorated {
+                self.transform_class_declaration_with_class_decorators(
+                    class,
+                    current_class_decorations,
+                    ctx,
+                );
+                return;
+            } else if !current_class_decorations.decoration_stmts.is_empty() {
+                self.transform_class_declaration_without_class_decorators(
+                    class,
+                    current_class_decorations,
+                    ctx,
+                );
+            }
+        } else {
+            debug_assert!(
+                current_class_decorations.class_binding.is_none(),
+                "Legacy decorator does not allow class expression, so that it should not have class binding."
             );
         }
+
+        debug_assert!(
+            !self.emit_decorator_metadata || self.metadata.pop_constructor_metadata().is_none(),
+            "`pop_constructor_metadata` should be `None` because there are no class decorators, so no metadata was generated."
+        );
     }
 
     /// Transforms a decorated class declaration and appends the resulting statements. If
@@ -352,7 +519,7 @@ impl<'a> LegacyDecorator<'a, '_> {
     fn transform_class_declaration_with_class_decorators(
         &mut self,
         class: &mut Class<'a>,
-        has_private_in_expression_in_decorator: bool,
+        current_class_decorations: ClassDecorations<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
         // When we emit an ES6 class that has a class decorator, we must tailor the
@@ -458,8 +625,19 @@ impl<'a> LegacyDecorator<'a, '_> {
             ClassReferenceChanger::new(id.clone(), ctx, self.ctx)
                 .get_class_alias_if_needed(&mut class.body)
         });
-        let class_binding = class_binding
-            .unwrap_or_else(|| ctx.generate_uid_in_current_scope("default", SymbolFlags::Class));
+
+        let ClassDecorations {
+            class_binding: class_binding_tmp,
+            mut decoration_stmts,
+            class_has_private_in_expression_in_decorator,
+            should_transform: _,
+        } = current_class_decorations;
+
+        let class_binding = class_binding.unwrap_or_else(|| {
+            // `class_binding_tmp` maybe already generated a default class binding for unnamed classes, so use it.
+            class_binding_tmp
+                .unwrap_or_else(|| ctx.generate_uid_in_current_scope("default", SymbolFlags::Class))
+        });
 
         let constructor_decoration = self.transform_decorators_of_class_and_constructor(
             class,
@@ -467,8 +645,6 @@ impl<'a> LegacyDecorator<'a, '_> {
             class_alias_binding.as_ref(),
             ctx,
         );
-        let mut decoration_stmts =
-            self.transform_decorators_of_class_elements(class, &class_binding, ctx);
 
         let class_alias_with_this_assignment = if self.ctx.is_class_properties_plugin_enabled {
             None
@@ -501,7 +677,7 @@ impl<'a> LegacyDecorator<'a, '_> {
             })
         };
 
-        if has_private_in_expression_in_decorator {
+        if class_has_private_in_expression_in_decorator {
             let decorations = mem::take(&mut decoration_stmts);
             Self::insert_decorations_into_class_static_block(class, decorations, ctx);
         } else {
@@ -573,22 +749,29 @@ impl<'a> LegacyDecorator<'a, '_> {
     fn transform_class_declaration_without_class_decorators(
         &mut self,
         class: &mut Class<'a>,
-        has_private_in_expression_in_decorator: bool,
+        current_class_decorations: ClassDecorations<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        // `export default class {}`
-        let class_binding = if let Some(ident) = &class.id {
-            BoundIdentifier::from_binding_ident(ident)
-        } else {
-            let class_binding = ctx.generate_uid_in_current_scope("default", SymbolFlags::Class);
-            class.id.replace(class_binding.create_binding_identifier(ctx));
-            class_binding
+        let ClassDecorations {
+            class_binding,
+            mut decoration_stmts,
+            class_has_private_in_expression_in_decorator,
+            should_transform: _,
+        } = current_class_decorations;
+
+        let Some(class_binding) = class_binding else {
+            unreachable!(
+                "Always has a class binding because there are decorators in class elements,
+                so that it has been added in `handle_decorated_class_element`"
+            );
         };
 
-        let mut decoration_stmts =
-            self.transform_decorators_of_class_elements(class, &class_binding, ctx);
+        // No class id, add one by using the class binding
+        if class.id.is_none() {
+            class.id = Some(class_binding.create_binding_identifier(ctx));
+        }
 
-        if has_private_in_expression_in_decorator {
+        if class_has_private_in_expression_in_decorator {
             Self::insert_decorations_into_class_static_block(class, decoration_stmts, ctx);
         } else {
             let stmt_address = match ctx.parent() {
@@ -599,70 +782,6 @@ impl<'a> LegacyDecorator<'a, '_> {
             };
             self.decorations.entry(stmt_address).or_default().append(&mut decoration_stmts);
         }
-    }
-
-    /// Transform decorators of [`ClassElement::MethodDefinition`],
-    /// [`ClassElement::PropertyDefinition`] and [`ClassElement::AccessorProperty`].
-    fn transform_decorators_of_class_elements(
-        &mut self,
-        class: &mut Class<'a>,
-        class_binding: &BoundIdentifier<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) -> Vec<Statement<'a>> {
-        let mut decoration_stmts = Vec::with_capacity(class.body.body.len());
-
-        for element in &mut class.body.body {
-            let (is_static, key, descriptor, decorations) = match element {
-                ClassElement::MethodDefinition(method) if !method.value.is_typescript_syntax() => {
-                    let Some(decorations) = self.get_all_decorators_of_class_method(method, ctx)
-                    else {
-                        continue;
-                    };
-
-                    // We emit `null` here to indicate to `_decorate` that it can invoke `Object.getOwnPropertyDescriptor` directly.
-                    // We have this extra argument here so that we can inject an explicit property descriptor at a later date.
-                    let descriptor = ctx.ast.expression_null_literal(SPAN);
-
-                    (method.r#static, &mut method.key, descriptor, decorations)
-                }
-                ClassElement::PropertyDefinition(prop) if !prop.decorators.is_empty() => {
-                    let decorations = Self::convert_decorators_to_array_expression(
-                        prop.decorators.drain(..),
-                        ctx,
-                    );
-
-                    // We emit `void 0` here to indicate to `_decorate` that it can invoke `Object.defineProperty` directly, but that it
-                    // should not invoke `Object.getOwnPropertyDescriptor`.
-                    let descriptor = ctx.ast.void_0(SPAN);
-
-                    (prop.r#static, &mut prop.key, descriptor, decorations)
-                }
-                ClassElement::AccessorProperty(accessor) => {
-                    let decorations = Self::convert_decorators_to_array_expression(
-                        accessor.decorators.drain(..),
-                        ctx,
-                    );
-
-                    // We emit `null` here to indicate to `_decorate` that it can invoke `Object.getOwnPropertyDescriptor` directly.
-                    // We have this extra argument here so that we can inject an explicit property descriptor at a later date.
-                    let descriptor = ctx.ast.expression_null_literal(SPAN);
-
-                    (accessor.r#static, &mut accessor.key, descriptor, decorations)
-                }
-                _ => {
-                    continue;
-                }
-            };
-
-            // `Class` or `Class.prototype`
-            let prefix = Self::get_class_member_prefix(class_binding, is_static, ctx);
-            let name = self.get_name_of_property_key(key, ctx);
-            // `_decorator([...decorators], Class, name, descriptor)`
-            let decorator_stmt = self.create_decorator(decorations, prefix, name, descriptor, ctx);
-            decoration_stmts.push(decorator_stmt);
-        }
-
-        decoration_stmts
     }
 
     /// Transform the decorators of class and constructor method.
@@ -706,6 +825,10 @@ impl<'a> LegacyDecorator<'a, '_> {
             self.get_all_decorators_of_class_method(constructor, ctx)
                 .expect("At least one decorator")
         } else {
+            debug_assert!(
+                !self.emit_decorator_metadata || self.metadata.pop_constructor_metadata().is_none(),
+                "`pop_constructor_metadata` should be `None` because there is no `constructor`, so no metadata was generated."
+            );
             Self::convert_decorators_to_array_expression(class.decorators.drain(..), ctx)
         };
 
@@ -837,6 +960,19 @@ impl<'a> LegacyDecorator<'a, '_> {
         let method_decoration_count = method.decorators.len() + param_decoration_count;
 
         if method_decoration_count == 0 {
+            if self.emit_decorator_metadata {
+                if method.kind.is_constructor() {
+                    debug_assert!(
+                        self.metadata.pop_constructor_metadata().is_none(),
+                        "No method decorators, so `pop_constructor_metadata` should be `None`"
+                    );
+                } else {
+                    debug_assert!(
+                        self.metadata.pop_method_metadata().is_none(),
+                        "No method decorators, so `pop_method_metadata` should be `None`"
+                    );
+                }
+            }
             return None;
         }
 
@@ -856,15 +992,14 @@ impl<'a> LegacyDecorator<'a, '_> {
             self.transform_decorators_of_parameters(&mut decorations, params, ctx);
         }
 
-        // `decorateMetadata` should always be injected after param decorators
-        if let Some(metadata) = self.metadata.pop_method_metadata() {
-            match metadata {
-                MethodMetadata::Constructor(meta) => {
-                    decorations.push(ArrayExpressionElement::from(meta));
+        if self.emit_decorator_metadata {
+            // `decorateMetadata` should always be injected after param decorators
+            if method.kind.is_constructor() {
+                if let Some(metadata) = self.metadata.pop_constructor_metadata() {
+                    decorations.push(ArrayExpressionElement::from(metadata));
                 }
-                MethodMetadata::Normal(meta) => {
-                    decorations.extend(meta.map(ArrayExpressionElement::from));
-                }
+            } else if let Some(metadata) = self.metadata.pop_method_metadata() {
+                decorations.extend(metadata.map(ArrayExpressionElement::from));
             }
         }
 
@@ -886,68 +1021,18 @@ impl<'a> LegacyDecorator<'a, '_> {
         }
     }
 
-    /// Check if a class or its elements have decorators.
-    fn check_class_has_decorated(class: &Class<'a>) -> ClassDecoratorInfo {
-        // Legacy decorator does not allow in class expression.
-        if class.is_expression() || class.declare {
-            return ClassDecoratorInfo::default();
+    /// Check if a class or its constructor parameters have decorators.
+    fn check_class_has_decorated(class: &Class<'a>) -> bool {
+        if !class.decorators.is_empty() {
+            return true;
         }
 
-        let mut class_or_constructor_parameter_is_decorated = !class.decorators.is_empty();
-        let mut class_element_is_decorated = false;
-        let mut has_private_in_expression_in_decorator = false;
-
-        for element in &class.body.body {
-            match element {
-                ClassElement::MethodDefinition(method) if method.kind.is_constructor() => {
-                    class_or_constructor_parameter_is_decorated |=
-                        Self::class_method_parameter_is_decorated(&method.value);
-
-                    if class_or_constructor_parameter_is_decorated
-                        && !has_private_in_expression_in_decorator
-                    {
-                        has_private_in_expression_in_decorator =
-                            PrivateInExpressionDetector::has_private_in_expression_in_method_decorator(method);
-                    }
-                }
-                ClassElement::MethodDefinition(method) if !method.value.is_typescript_syntax() => {
-                    class_element_is_decorated |= !method.decorators.is_empty()
-                        || Self::class_method_parameter_is_decorated(&method.value);
-
-                    if class_element_is_decorated && !has_private_in_expression_in_decorator {
-                        has_private_in_expression_in_decorator =
-                            PrivateInExpressionDetector::has_private_in_expression_in_method_decorator(method);
-                    }
-                }
-                ClassElement::PropertyDefinition(prop) if !prop.decorators.is_empty() => {
-                    class_element_is_decorated = true;
-
-                    if class_element_is_decorated && !has_private_in_expression_in_decorator {
-                        has_private_in_expression_in_decorator =
-                            PrivateInExpressionDetector::has_private_in_expression(
-                                &prop.decorators,
-                            );
-                    }
-                }
-                ClassElement::AccessorProperty(accessor) if !accessor.decorators.is_empty() => {
-                    class_element_is_decorated = true;
-
-                    if class_element_is_decorated && !has_private_in_expression_in_decorator {
-                        has_private_in_expression_in_decorator =
-                            PrivateInExpressionDetector::has_private_in_expression(
-                                &accessor.decorators,
-                            );
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        ClassDecoratorInfo {
-            class_or_constructor_parameter_is_decorated,
-            class_element_is_decorated,
-            has_private_in_expression_in_decorator,
-        }
+        class.body.body.iter().any(|element| {
+            matches!(element,
+                ClassElement::MethodDefinition(method) if method.kind.is_constructor() &&
+                    Self::class_method_parameter_is_decorated(&method.value)
+            )
+        })
     }
 
     /// Check if a class method parameter is decorated.
@@ -1099,22 +1184,10 @@ impl Visit<'_> for PrivateInExpressionDetector {
 }
 
 impl PrivateInExpressionDetector {
-    fn has_private_in_expression(decorators: &ArenaVec<'_, Decorator<'_>>) -> bool {
+    fn has_private_in_expression(expression: &Expression<'_>) -> bool {
         let mut detector = Self::default();
-        detector.visit_decorators(decorators);
+        detector.visit_expression(expression);
         detector.has_private_in_expression
-    }
-
-    fn has_private_in_expression_in_method_decorator(method: &MethodDefinition<'_>) -> bool {
-        let mut detector = Self::default();
-        detector.visit_decorators(&method.decorators);
-        if detector.has_private_in_expression {
-            return true;
-        }
-        method.value.params.items.iter().any(|param| {
-            detector.visit_decorators(&param.decorators);
-            detector.has_private_in_expression
-        })
     }
 }
 

--- a/crates/oxc_transformer/src/decorator/mod.rs
+++ b/crates/oxc_transformer/src/decorator/mod.rs
@@ -29,12 +29,25 @@ impl<'a, 'ctx> Decorator<'a, 'ctx> {
 }
 
 impl<'a> Traverse<'a, TransformState<'a>> for Decorator<'a, '_> {
+    #[inline]
+    fn exit_program(
+        &mut self,
+        node: &mut Program<'a>,
+        ctx: &mut oxc_traverse::TraverseCtx<'a, TransformState<'a>>,
+    ) {
+        if self.options.legacy {
+            self.legacy_decorator.exit_program(node, ctx);
+        }
+    }
+
+    #[inline]
     fn enter_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
         if self.options.legacy {
             self.legacy_decorator.enter_statement(stmt, ctx);
         }
     }
 
+    #[inline]
     fn exit_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
         if self.options.legacy {
             self.legacy_decorator.exit_statement(stmt, ctx);
@@ -67,6 +80,17 @@ impl<'a> Traverse<'a, TransformState<'a>> for Decorator<'a, '_> {
     }
 
     #[inline]
+    fn exit_method_definition(
+        &mut self,
+        node: &mut MethodDefinition<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        if self.options.legacy {
+            self.legacy_decorator.exit_method_definition(node, ctx);
+        }
+    }
+
+    #[inline]
     fn enter_accessor_property(
         &mut self,
         node: &mut AccessorProperty<'a>,
@@ -74,6 +98,17 @@ impl<'a> Traverse<'a, TransformState<'a>> for Decorator<'a, '_> {
     ) {
         if self.options.legacy {
             self.legacy_decorator.enter_accessor_property(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_accessor_property(
+        &mut self,
+        node: &mut AccessorProperty<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        if self.options.legacy {
+            self.legacy_decorator.exit_accessor_property(node, ctx);
         }
     }
 
@@ -87,9 +122,32 @@ impl<'a> Traverse<'a, TransformState<'a>> for Decorator<'a, '_> {
             self.legacy_decorator.enter_property_definition(node, ctx);
         }
     }
+
+    #[inline]
+    fn exit_property_definition(
+        &mut self,
+        node: &mut PropertyDefinition<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        if self.options.legacy {
+            self.legacy_decorator.exit_property_definition(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_decorator(
+        &mut self,
+        node: &mut oxc_ast::ast::Decorator<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        if self.options.legacy {
+            self.legacy_decorator.enter_decorator(node, ctx);
+        }
+    }
 }
 
 impl<'a> Decorator<'a, '_> {
+    #[inline]
     pub fn exit_class_at_end(&mut self, class: &mut Class<'a>, ctx: &mut TraverseCtx<'a>) {
         if self.options.legacy {
             self.legacy_decorator.exit_class_at_end(class, ctx);

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -206,6 +206,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for TransformerImpl<'a, '_> {
     }
 
     fn exit_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
+        self.decorator.exit_program(program, ctx);
         self.x1_jsx.exit_program(program, ctx);
         if let Some(typescript) = self.x0_typescript.as_mut() {
             typescript.exit_program(program, ctx);
@@ -463,6 +464,14 @@ impl<'a> Traverse<'a, TransformState<'a>> for TransformerImpl<'a, '_> {
         }
     }
 
+    fn exit_method_definition(
+        &mut self,
+        def: &mut MethodDefinition<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        self.decorator.exit_method_definition(def, ctx);
+    }
+
     fn enter_new_expression(&mut self, expr: &mut NewExpression<'a>, ctx: &mut TraverseCtx<'a>) {
         if let Some(typescript) = self.x0_typescript.as_mut() {
             typescript.enter_new_expression(expr, ctx);
@@ -486,6 +495,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for TransformerImpl<'a, '_> {
         def: &mut PropertyDefinition<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
+        self.decorator.exit_property_definition(def, ctx);
         self.x2_es2022.exit_property_definition(def, ctx);
     }
 
@@ -498,6 +508,14 @@ impl<'a> Traverse<'a, TransformState<'a>> for TransformerImpl<'a, '_> {
         if let Some(typescript) = self.x0_typescript.as_mut() {
             typescript.enter_accessor_property(node, ctx);
         }
+    }
+
+    fn exit_accessor_property(
+        &mut self,
+        node: &mut AccessorProperty<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        self.decorator.exit_accessor_property(node, ctx);
     }
 
     fn enter_statements(
@@ -690,5 +708,13 @@ impl<'a> Traverse<'a, TransformState<'a>> for TransformerImpl<'a, '_> {
         if let Some(typescript) = self.x0_typescript.as_mut() {
             typescript.enter_ts_export_assignment(export_assignment, ctx);
         }
+    }
+
+    fn enter_decorator(
+        &mut self,
+        node: &mut oxc_ast::ast::Decorator<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        self.decorator.enter_decorator(node, ctx);
     }
 }

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -141,26 +141,35 @@ Scope parent mismatch:
 after transform: ScopeId(359): Some(ScopeId(358))
 rebuilt        : ScopeId(379): Some(ScopeId(367))
 Scope children mismatch:
+after transform: ScopeId(359): [ScopeId(360), ScopeId(362)]
+rebuilt        : ScopeId(379): [ScopeId(380)]
+Scope children mismatch:
 after transform: ScopeId(365): [ScopeId(366), ScopeId(372), ScopeId(375)]
-rebuilt        : ScopeId(384): [ScopeId(385), ScopeId(391), ScopeId(394), ScopeId(396)]
+rebuilt        : ScopeId(382): [ScopeId(383), ScopeId(389), ScopeId(392), ScopeId(394)]
 Scope children mismatch:
 after transform: ScopeId(375): [ScopeId(376), ScopeId(380)]
-rebuilt        : ScopeId(394): [ScopeId(395)]
+rebuilt        : ScopeId(392): [ScopeId(393)]
 Scope parent mismatch:
 after transform: ScopeId(376): Some(ScopeId(375))
-rebuilt        : ScopeId(396): Some(ScopeId(384))
+rebuilt        : ScopeId(394): Some(ScopeId(382))
+Scope children mismatch:
+after transform: ScopeId(376): [ScopeId(377), ScopeId(379)]
+rebuilt        : ScopeId(394): [ScopeId(395)]
 Scope children mismatch:
 after transform: ScopeId(381): [ScopeId(382), ScopeId(388), ScopeId(391)]
-rebuilt        : ScopeId(400): [ScopeId(401), ScopeId(407), ScopeId(410), ScopeId(412)]
+rebuilt        : ScopeId(396): [ScopeId(397), ScopeId(403), ScopeId(406), ScopeId(408)]
 Scope children mismatch:
 after transform: ScopeId(391): [ScopeId(392), ScopeId(396)]
-rebuilt        : ScopeId(410): [ScopeId(411)]
+rebuilt        : ScopeId(406): [ScopeId(407)]
 Scope parent mismatch:
 after transform: ScopeId(392): Some(ScopeId(391))
-rebuilt        : ScopeId(412): Some(ScopeId(400))
+rebuilt        : ScopeId(408): Some(ScopeId(396))
+Scope children mismatch:
+after transform: ScopeId(392): [ScopeId(393), ScopeId(395)]
+rebuilt        : ScopeId(408): [ScopeId(409)]
 Symbol reference IDs mismatch for "_decorateMetadata":
-after transform: SymbolId(166): [ReferenceId(68), ReferenceId(70), ReferenceId(72), ReferenceId(74), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(80), ReferenceId(81), ReferenceId(82), ReferenceId(106), ReferenceId(108), ReferenceId(110), ReferenceId(111), ReferenceId(112), ReferenceId(120), ReferenceId(122), ReferenceId(124), ReferenceId(125), ReferenceId(126), ReferenceId(134), ReferenceId(136), ReferenceId(138), ReferenceId(139), ReferenceId(140), ReferenceId(148), ReferenceId(150), ReferenceId(152), ReferenceId(153), ReferenceId(154), ReferenceId(162), ReferenceId(164), ReferenceId(166), ReferenceId(167), ReferenceId(168), ReferenceId(186), ReferenceId(188), ReferenceId(190), ReferenceId(191), ReferenceId(192), ReferenceId(200), ReferenceId(202), ReferenceId(204), ReferenceId(205), ReferenceId(206), ReferenceId(224), ReferenceId(226), ReferenceId(228), ReferenceId(229), ReferenceId(230), ReferenceId(238), ReferenceId(240), ReferenceId(242), ReferenceId(243), ReferenceId(244), ReferenceId(262), ReferenceId(264), ReferenceId(266), ReferenceId(267), ReferenceId(268), ReferenceId(276), ReferenceId(278), ReferenceId(280), ReferenceId(281), ReferenceId(282), ReferenceId(300), ReferenceId(302), ReferenceId(304), ReferenceId(305), ReferenceId(306), ReferenceId(429), ReferenceId(431), ReferenceId(433), ReferenceId(434), ReferenceId(435), ReferenceId(453), ReferenceId(455), ReferenceId(457), ReferenceId(459), ReferenceId(461), ReferenceId(462), ReferenceId(463), ReferenceId(465), ReferenceId(466), ReferenceId(467), ReferenceId(483), ReferenceId(484), ReferenceId(485), ReferenceId(487), ReferenceId(488), ReferenceId(489), ReferenceId(491), ReferenceId(492), ReferenceId(493), ReferenceId(497), ReferenceId(498), ReferenceId(499), ReferenceId(501), ReferenceId(502), ReferenceId(503), ReferenceId(505), ReferenceId(506), ReferenceId(507), ReferenceId(511), ReferenceId(512), ReferenceId(513), ReferenceId(515), ReferenceId(516), ReferenceId(517), ReferenceId(519), ReferenceId(520), ReferenceId(521)]
-rebuilt        : SymbolId(3): [ReferenceId(63), ReferenceId(67), ReferenceId(71), ReferenceId(75), ReferenceId(79), ReferenceId(81), ReferenceId(82), ReferenceId(85), ReferenceId(87), ReferenceId(88), ReferenceId(97), ReferenceId(107), ReferenceId(121), ReferenceId(125), ReferenceId(129), ReferenceId(131), ReferenceId(132), ReferenceId(140), ReferenceId(153), ReferenceId(157), ReferenceId(161), ReferenceId(163), ReferenceId(164), ReferenceId(172), ReferenceId(185), ReferenceId(189), ReferenceId(193), ReferenceId(195), ReferenceId(196), ReferenceId(204), ReferenceId(231), ReferenceId(264), ReferenceId(300), ReferenceId(307), ReferenceId(314), ReferenceId(316), ReferenceId(317), ReferenceId(343), ReferenceId(385), ReferenceId(389), ReferenceId(393), ReferenceId(395), ReferenceId(396), ReferenceId(405), ReferenceId(409), ReferenceId(413), ReferenceId(417), ReferenceId(421), ReferenceId(423), ReferenceId(424), ReferenceId(427), ReferenceId(429), ReferenceId(430), ReferenceId(434), ReferenceId(436), ReferenceId(437), ReferenceId(440), ReferenceId(442), ReferenceId(443), ReferenceId(447), ReferenceId(449), ReferenceId(450)]
+after transform: SymbolId(166): [ReferenceId(68), ReferenceId(72), ReferenceId(76), ReferenceId(80), ReferenceId(84), ReferenceId(85), ReferenceId(86), ReferenceId(90), ReferenceId(91), ReferenceId(92), ReferenceId(106), ReferenceId(108), ReferenceId(110), ReferenceId(111), ReferenceId(112), ReferenceId(120), ReferenceId(122), ReferenceId(124), ReferenceId(125), ReferenceId(126), ReferenceId(134), ReferenceId(136), ReferenceId(138), ReferenceId(139), ReferenceId(140), ReferenceId(148), ReferenceId(150), ReferenceId(152), ReferenceId(153), ReferenceId(154), ReferenceId(162), ReferenceId(166), ReferenceId(170), ReferenceId(171), ReferenceId(172), ReferenceId(182), ReferenceId(184), ReferenceId(186), ReferenceId(187), ReferenceId(188), ReferenceId(196), ReferenceId(200), ReferenceId(204), ReferenceId(205), ReferenceId(206), ReferenceId(216), ReferenceId(218), ReferenceId(220), ReferenceId(221), ReferenceId(222), ReferenceId(230), ReferenceId(234), ReferenceId(238), ReferenceId(239), ReferenceId(240), ReferenceId(250), ReferenceId(252), ReferenceId(254), ReferenceId(255), ReferenceId(256), ReferenceId(264), ReferenceId(268), ReferenceId(272), ReferenceId(273), ReferenceId(274), ReferenceId(284), ReferenceId(286), ReferenceId(288), ReferenceId(289), ReferenceId(290), ReferenceId(395), ReferenceId(399), ReferenceId(403), ReferenceId(404), ReferenceId(405), ReferenceId(415), ReferenceId(419), ReferenceId(423), ReferenceId(427), ReferenceId(431), ReferenceId(432), ReferenceId(433), ReferenceId(437), ReferenceId(438), ReferenceId(439), ReferenceId(445), ReferenceId(446), ReferenceId(447), ReferenceId(449), ReferenceId(450), ReferenceId(451), ReferenceId(453), ReferenceId(454), ReferenceId(455), ReferenceId(459), ReferenceId(460), ReferenceId(461), ReferenceId(463), ReferenceId(464), ReferenceId(465), ReferenceId(467), ReferenceId(468), ReferenceId(469), ReferenceId(473), ReferenceId(474), ReferenceId(475), ReferenceId(477), ReferenceId(478), ReferenceId(479), ReferenceId(481), ReferenceId(482), ReferenceId(483)]
+rebuilt        : SymbolId(3): [ReferenceId(63), ReferenceId(67), ReferenceId(71), ReferenceId(75), ReferenceId(79), ReferenceId(81), ReferenceId(82), ReferenceId(85), ReferenceId(87), ReferenceId(88), ReferenceId(113), ReferenceId(117), ReferenceId(121), ReferenceId(123), ReferenceId(124), ReferenceId(139), ReferenceId(143), ReferenceId(147), ReferenceId(149), ReferenceId(150), ReferenceId(165), ReferenceId(169), ReferenceId(173), ReferenceId(175), ReferenceId(176), ReferenceId(258), ReferenceId(265), ReferenceId(272), ReferenceId(274), ReferenceId(275), ReferenceId(331), ReferenceId(335), ReferenceId(339), ReferenceId(341), ReferenceId(342), ReferenceId(351), ReferenceId(355), ReferenceId(359), ReferenceId(363), ReferenceId(367), ReferenceId(369), ReferenceId(370), ReferenceId(373), ReferenceId(375), ReferenceId(376), ReferenceId(380), ReferenceId(382), ReferenceId(383), ReferenceId(386), ReferenceId(388), ReferenceId(389), ReferenceId(393), ReferenceId(395), ReferenceId(396)]
 Symbol span mismatch for "Inner5":
 after transform: SymbolId(57): Span { start: 4573, end: 4579 }
 rebuilt        : SymbolId(69): Span { start: 0, end: 0 }
@@ -169,31 +178,16 @@ after transform: SymbolId(164): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(70): Span { start: 4573, end: 4579 }
 Symbol span mismatch for "Inner4":
 after transform: SymbolId(126): Span { start: 12166, end: 12172 }
-rebuilt        : SymbolId(169): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(164): Span { start: 0, end: 0 }
 Symbol span mismatch for "Inner4":
-after transform: SymbolId(200): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(170): Span { start: 12166, end: 12172 }
-Reference flags mismatch for "_super$foo7":
-after transform: ReferenceId(170): ReferenceFlags(Read | Write)
-rebuilt        : ReferenceId(115): ReferenceFlags(Write)
-Reference flags mismatch for "_super$foo10":
-after transform: ReferenceId(208): ReferenceFlags(Read | Write)
-rebuilt        : ReferenceId(147): ReferenceFlags(Write)
-Reference flags mismatch for "_super$foo13":
-after transform: ReferenceId(246): ReferenceFlags(Read | Write)
-rebuilt        : ReferenceId(179): ReferenceFlags(Write)
-Reference flags mismatch for "_super$foo16":
-after transform: ReferenceId(284): ReferenceFlags(Read | Write)
-rebuilt        : ReferenceId(288): ReferenceFlags(Write)
-Reference flags mismatch for "_super$foo19":
-after transform: ReferenceId(437): ReferenceFlags(Read | Write)
-rebuilt        : ReferenceId(379): ReferenceFlags(Write)
+after transform: SymbolId(195): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(165): Span { start: 12166, end: 12172 }
 Unresolved reference IDs mismatch for "Object":
-after transform: [ReferenceId(67), ReferenceId(69), ReferenceId(71), ReferenceId(73), ReferenceId(105), ReferenceId(107), ReferenceId(119), ReferenceId(121), ReferenceId(133), ReferenceId(135), ReferenceId(147), ReferenceId(149), ReferenceId(161), ReferenceId(163), ReferenceId(185), ReferenceId(187), ReferenceId(199), ReferenceId(201), ReferenceId(223), ReferenceId(225), ReferenceId(237), ReferenceId(239), ReferenceId(261), ReferenceId(263), ReferenceId(275), ReferenceId(277), ReferenceId(299), ReferenceId(301), ReferenceId(428), ReferenceId(430), ReferenceId(452), ReferenceId(454), ReferenceId(456), ReferenceId(458)]
-rebuilt        : [ReferenceId(64), ReferenceId(68), ReferenceId(72), ReferenceId(76), ReferenceId(98), ReferenceId(108), ReferenceId(122), ReferenceId(126), ReferenceId(141), ReferenceId(154), ReferenceId(158), ReferenceId(173), ReferenceId(186), ReferenceId(190), ReferenceId(205), ReferenceId(232), ReferenceId(265), ReferenceId(301), ReferenceId(308), ReferenceId(344), ReferenceId(386), ReferenceId(390), ReferenceId(406), ReferenceId(410), ReferenceId(414), ReferenceId(418)]
+after transform: [ReferenceId(67), ReferenceId(71), ReferenceId(75), ReferenceId(79), ReferenceId(105), ReferenceId(107), ReferenceId(119), ReferenceId(121), ReferenceId(133), ReferenceId(135), ReferenceId(147), ReferenceId(149), ReferenceId(161), ReferenceId(165), ReferenceId(181), ReferenceId(183), ReferenceId(195), ReferenceId(199), ReferenceId(215), ReferenceId(217), ReferenceId(229), ReferenceId(233), ReferenceId(249), ReferenceId(251), ReferenceId(263), ReferenceId(267), ReferenceId(283), ReferenceId(285), ReferenceId(394), ReferenceId(398), ReferenceId(414), ReferenceId(418), ReferenceId(422), ReferenceId(426)]
+rebuilt        : [ReferenceId(64), ReferenceId(68), ReferenceId(72), ReferenceId(76), ReferenceId(114), ReferenceId(118), ReferenceId(140), ReferenceId(144), ReferenceId(166), ReferenceId(170), ReferenceId(259), ReferenceId(266), ReferenceId(332), ReferenceId(336), ReferenceId(352), ReferenceId(356), ReferenceId(360), ReferenceId(364)]
 Unresolved reference IDs mismatch for "Function":
-after transform: [ReferenceId(75), ReferenceId(79), ReferenceId(109), ReferenceId(123), ReferenceId(137), ReferenceId(151), ReferenceId(165), ReferenceId(189), ReferenceId(203), ReferenceId(227), ReferenceId(241), ReferenceId(265), ReferenceId(279), ReferenceId(303), ReferenceId(432), ReferenceId(460), ReferenceId(464), ReferenceId(482), ReferenceId(486), ReferenceId(490), ReferenceId(496), ReferenceId(500), ReferenceId(504), ReferenceId(510), ReferenceId(514), ReferenceId(518)]
-rebuilt        : [ReferenceId(80), ReferenceId(86), ReferenceId(130), ReferenceId(162), ReferenceId(194), ReferenceId(315), ReferenceId(394), ReferenceId(422), ReferenceId(428), ReferenceId(435), ReferenceId(441), ReferenceId(448)]
+after transform: [ReferenceId(83), ReferenceId(89), ReferenceId(109), ReferenceId(123), ReferenceId(137), ReferenceId(151), ReferenceId(169), ReferenceId(185), ReferenceId(203), ReferenceId(219), ReferenceId(237), ReferenceId(253), ReferenceId(271), ReferenceId(287), ReferenceId(402), ReferenceId(430), ReferenceId(436), ReferenceId(444), ReferenceId(448), ReferenceId(452), ReferenceId(458), ReferenceId(462), ReferenceId(466), ReferenceId(472), ReferenceId(476), ReferenceId(480)]
+rebuilt        : [ReferenceId(80), ReferenceId(86), ReferenceId(122), ReferenceId(148), ReferenceId(174), ReferenceId(273), ReferenceId(340), ReferenceId(368), ReferenceId(374), ReferenceId(381), ReferenceId(387), ReferenceId(394)]
 
 semantic Error: tasks/coverage/misc/pass/oxc-13284.ts
 Symbol reference IDs mismatch for "_super":

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -8641,7 +8641,7 @@ rebuilt        : ["Function", "decorator", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataNoStrictNull.ts
 Unresolved reference IDs mismatch for "String":
-after transform: [ReferenceId(5), ReferenceId(8)]
+after transform: [ReferenceId(5), ReferenceId(10)]
 rebuilt        : [ReferenceId(14)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataOnInferredType.ts
@@ -8675,22 +8675,22 @@ Reference symbol mismatch for "decorator":
 after transform: SymbolId(0) "decorator"
 rebuilt        : <None>
 Reference flags mismatch for "Promise":
-after transform: ReferenceId(22): ReferenceFlags(Read | Type)
+after transform: ReferenceId(26): ReferenceFlags(Read | Type)
 rebuilt        : ReferenceId(28): ReferenceFlags(Read)
 Reference flags mismatch for "Promise":
-after transform: ReferenceId(23): ReferenceFlags(Read | Type)
+after transform: ReferenceId(27): ReferenceFlags(Read | Type)
 rebuilt        : ReferenceId(29): ReferenceFlags(Read)
 Reference flags mismatch for "Promise":
-after transform: ReferenceId(28): ReferenceFlags(Read | Type)
+after transform: ReferenceId(32): ReferenceFlags(Read | Type)
 rebuilt        : ReferenceId(34): ReferenceFlags(Read)
 Reference flags mismatch for "Promise":
-after transform: ReferenceId(29): ReferenceFlags(Read | Type)
+after transform: ReferenceId(33): ReferenceFlags(Read | Type)
 rebuilt        : ReferenceId(35): ReferenceFlags(Read)
 Unresolved references mismatch:
 after transform: ["Function", "MethodDecorator", "Object", "Promise", "require"]
 rebuilt        : ["Function", "Object", "Promise", "decorator", "require"]
 Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(11), ReferenceId(17), ReferenceId(22), ReferenceId(23), ReferenceId(28), ReferenceId(29)]
+after transform: [ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(11), ReferenceId(19), ReferenceId(26), ReferenceId(27), ReferenceId(32), ReferenceId(33)]
 rebuilt        : [ReferenceId(12), ReferenceId(20), ReferenceId(28), ReferenceId(29), ReferenceId(34), ReferenceId(35)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataRestParameterWithImportedType.ts
@@ -8701,7 +8701,7 @@ Symbol span mismatch for "ClassA":
 after transform: SymbolId(6): Span { start: 266, end: 272 }
 rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 Symbol span mismatch for "ClassA":
-after transform: SymbolId(11): Span { start: 0, end: 0 }
+after transform: SymbolId(12): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(8): Span { start: 266, end: 272 }
 Unresolved references mismatch:
 after transform: ["Array", "ClassDecorator", "Function", "MethodDecorator"]
@@ -8826,7 +8826,7 @@ Symbol span mismatch for "C":
 after transform: SymbolId(3): Span { start: 198, end: 199 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol span mismatch for "C":
-after transform: SymbolId(8): Span { start: 0, end: 0 }
+after transform: SymbolId(10): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(4): Span { start: 198, end: 199 }
 Symbol reference IDs mismatch for "y":
 after transform: SymbolId(6): [ReferenceId(5)]
@@ -10159,7 +10159,7 @@ Symbol span mismatch for "A":
 after transform: SymbolId(2): Span { start: 123, end: 124 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol span mismatch for "A":
-after transform: SymbolId(6): Span { start: 0, end: 0 }
+after transform: SymbolId(7): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(3): Span { start: 123, end: 124 }
 Reference symbol mismatch for "MyMethodDecorator":
 after transform: SymbolId(1) "MyMethodDecorator"
@@ -10179,7 +10179,7 @@ Symbol span mismatch for "A":
 after transform: SymbolId(2): Span { start: 123, end: 124 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol span mismatch for "A":
-after transform: SymbolId(9): Span { start: 0, end: 0 }
+after transform: SymbolId(10): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(3): Span { start: 123, end: 124 }
 Symbol span mismatch for "B":
 after transform: SymbolId(5): Span { start: 228, end: 229 }
@@ -12980,10 +12980,10 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/esDecoratorsClassFieldsCrash.ts
 Symbol reference IDs mismatch for "_decorateMetadata":
 after transform: SymbolId(10): [ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9)]
-rebuilt        : SymbolId(1): [ReferenceId(5), ReferenceId(7)]
+rebuilt        : SymbolId(1): []
 Symbol reference IDs mismatch for "dec":
 after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(6)]
+rebuilt        : SymbolId(3): []
 Unresolved references mismatch:
 after transform: ["DecoratorContext", "require"]
 rebuilt        : ["require"]
@@ -16123,7 +16123,7 @@ Symbol span mismatch for "C":
 after transform: SymbolId(3): Span { start: 83, end: 84 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol span mismatch for "C":
-after transform: SymbolId(10): Span { start: 0, end: 0 }
+after transform: SymbolId(12): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(6): Span { start: 83, end: 84 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(2) "dec"
@@ -16173,7 +16173,7 @@ Symbol span mismatch for "C":
 after transform: SymbolId(3): Span { start: 83, end: 84 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol span mismatch for "C":
-after transform: SymbolId(6): Span { start: 0, end: 0 }
+after transform: SymbolId(8): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(6): Span { start: 83, end: 84 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(2) "dec"
@@ -20232,10 +20232,10 @@ Unresolved references mismatch:
 after transform: ["Boolean", "Number", "Object", "String", "require"]
 rebuilt        : ["Boolean", "Number", "Object", "require"]
 Unresolved reference IDs mismatch for "Boolean":
-after transform: [ReferenceId(20), ReferenceId(21), ReferenceId(24)]
+after transform: [ReferenceId(22), ReferenceId(23), ReferenceId(28)]
 rebuilt        : [ReferenceId(14)]
 Unresolved reference IDs mismatch for "Object":
-after transform: [ReferenceId(0), ReferenceId(18), ReferenceId(25), ReferenceId(51), ReferenceId(53), ReferenceId(57)]
+after transform: [ReferenceId(0), ReferenceId(18), ReferenceId(29), ReferenceId(51), ReferenceId(55), ReferenceId(63)]
 rebuilt        : [ReferenceId(9), ReferenceId(19), ReferenceId(42), ReferenceId(47), ReferenceId(57)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/metadataOfUnionWithNull.ts
@@ -20243,13 +20243,13 @@ Symbol reference IDs mismatch for "A":
 after transform: SymbolId(3): [ReferenceId(10), ReferenceId(12)]
 rebuilt        : SymbolId(6): []
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(4): [ReferenceId(14), ReferenceId(53), ReferenceId(55), ReferenceId(57), ReferenceId(59), ReferenceId(61), ReferenceId(63), ReferenceId(65), ReferenceId(67), ReferenceId(69), ReferenceId(71), ReferenceId(73), ReferenceId(75)]
+after transform: SymbolId(4): [ReferenceId(14), ReferenceId(31), ReferenceId(35), ReferenceId(40), ReferenceId(43), ReferenceId(46), ReferenceId(49), ReferenceId(52), ReferenceId(57), ReferenceId(62), ReferenceId(66), ReferenceId(70), ReferenceId(75)]
 rebuilt        : SymbolId(7): [ReferenceId(19), ReferenceId(24), ReferenceId(29), ReferenceId(33), ReferenceId(37), ReferenceId(41), ReferenceId(45), ReferenceId(50), ReferenceId(55), ReferenceId(60), ReferenceId(65), ReferenceId(70)]
 Unresolved references mismatch:
 after transform: ["Boolean", "Object", "String", "Symbol", "require"]
 rebuilt        : ["Boolean", "Object", "require"]
 Unresolved reference IDs mismatch for "Object":
-after transform: [ReferenceId(0), ReferenceId(29), ReferenceId(34), ReferenceId(41), ReferenceId(44), ReferenceId(46), ReferenceId(48), ReferenceId(51)]
+after transform: [ReferenceId(0), ReferenceId(29), ReferenceId(38), ReferenceId(55), ReferenceId(60), ReferenceId(64), ReferenceId(68), ReferenceId(73)]
 rebuilt        : [ReferenceId(18), ReferenceId(28), ReferenceId(49), ReferenceId(54), ReferenceId(59), ReferenceId(64), ReferenceId(69)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/metadataReferencedWithinFilteredUnion.ts
@@ -36568,7 +36568,7 @@ Symbol span mismatch for "MyComponent":
 after transform: SymbolId(2): Span { start: 80, end: 91 }
 rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol span mismatch for "MyComponent":
-after transform: SymbolId(7): Span { start: 0, end: 0 }
+after transform: SymbolId(8): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(5): Span { start: 80, end: 91 }
 Reference symbol mismatch for "decorator":
 after transform: SymbolId(1) "decorator"
@@ -36588,7 +36588,7 @@ Symbol span mismatch for "MyComponent":
 after transform: SymbolId(2): Span { start: 89, end: 100 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol span mismatch for "MyComponent":
-after transform: SymbolId(6): Span { start: 0, end: 0 }
+after transform: SymbolId(7): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(3): Span { start: 89, end: 100 }
 Reference symbol mismatch for "decorator":
 after transform: SymbolId(1) "decorator"
@@ -36694,7 +36694,7 @@ Symbol span mismatch for "C":
 after transform: SymbolId(0): Span { start: 20, end: 21 }
 rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol span mismatch for "C":
-after transform: SymbolId(40): Span { start: 0, end: 0 }
+after transform: SymbolId(42): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(5): Span { start: 20, end: 21 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpression2ES2020.ts
@@ -38388,11 +38388,17 @@ rebuilt        : SymbolId(0): [ReferenceId(0)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/accessor/decoratorOnClassAccessor1.es6.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["_decorate", "_decorateMetadata", "_default", "dec"]
+after transform: ScopeId(0): ["_decorate", "_decorateMetadata", "dec"]
 rebuilt        : ScopeId(0): ["_decorate", "_decorateMetadata", "_default"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
+Bindings mismatch:
+after transform: ScopeId(2): ["_default"]
+rebuilt        : ScopeId(1): []
+Symbol scope ID mismatch for "_default":
+after transform: SymbolId(6): ScopeId(2)
+rebuilt        : SymbolId(2): ScopeId(0)
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -38577,11 +38583,17 @@ rebuilt        : ["_Class", "dec"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/method/decoratorOnClassMethod1.es6.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["_decorate", "_decorateMetadata", "_default", "dec"]
+after transform: ScopeId(0): ["_decorate", "_decorateMetadata", "dec"]
 rebuilt        : ScopeId(0): ["_decorate", "_decorateMetadata", "_default"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
+Bindings mismatch:
+after transform: ScopeId(2): ["_default"]
+rebuilt        : ScopeId(1): []
+Symbol scope ID mismatch for "_default":
+after transform: SymbolId(6): ScopeId(2)
+rebuilt        : SymbolId(2): ScopeId(0)
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -38591,11 +38603,17 @@ rebuilt        : ["Function", "dec"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/method/parameter/decoratorOnClassMethodParameter1.es6.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["_decorate", "_decorateMetadata", "_decorateParam", "_default", "dec"]
+after transform: ScopeId(0): ["_decorate", "_decorateMetadata", "_decorateParam", "dec"]
 rebuilt        : ScopeId(0): ["_decorate", "_decorateMetadata", "_decorateParam", "_default"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
+Bindings mismatch:
+after transform: ScopeId(2): ["_default"]
+rebuilt        : ScopeId(1): []
+Symbol scope ID mismatch for "_default":
+after transform: SymbolId(7): ScopeId(2)
+rebuilt        : SymbolId(3): ScopeId(0)
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -38605,11 +38623,17 @@ rebuilt        : ["Function", "Number", "dec"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/property/decoratorOnClassProperty1.es6.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["_decorate", "_decorateMetadata", "_default", "_defineProperty", "dec"]
+after transform: ScopeId(0): ["_decorate", "_decorateMetadata", "_defineProperty", "dec"]
 rebuilt        : ScopeId(0): ["_decorate", "_decorateMetadata", "_default", "_defineProperty"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
+Bindings mismatch:
+after transform: ScopeId(2): ["_default"]
+rebuilt        : ScopeId(1): []
+Symbol scope ID mismatch for "_default":
+after transform: SymbolId(5): ScopeId(2)
+rebuilt        : SymbolId(3): ScopeId(0)
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -39200,7 +39224,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["C", "_decorate", "_decorateMetadata", "_method", "_method2", "dec", "method3"]
 rebuilt        : ScopeId(0): ["C", "_decorate", "_decorateMetadata", "_method", "_method2", "method3"]
 Reference flags mismatch for "_method":
-after transform: ReferenceId(44): ReferenceFlags(Read | Write)
+after transform: ReferenceId(39): ReferenceFlags(Read | Write)
 rebuilt        : ReferenceId(2): ReferenceFlags(Write)
 Reference flags mismatch for "_method2":
 after transform: ReferenceId(48): ReferenceFlags(Read | Write)
@@ -39246,7 +39270,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["C", "_decorate", "_decorateMetadata", "_method", "_method2", "dec", "method3"]
 rebuilt        : ScopeId(0): ["C", "_decorate", "_decorateMetadata", "_method", "_method2", "method3"]
 Reference flags mismatch for "_method":
-after transform: ReferenceId(44): ReferenceFlags(Read | Write)
+after transform: ReferenceId(39): ReferenceFlags(Read | Write)
 rebuilt        : ReferenceId(2): ReferenceFlags(Write)
 Reference flags mismatch for "_method2":
 after transform: ReferenceId(48): ReferenceFlags(Read | Write)
@@ -39594,13 +39618,13 @@ Symbol span mismatch for "C":
 after transform: SymbolId(1): Span { start: 34, end: 35 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(8)]
-rebuilt        : SymbolId(3): [ReferenceId(3), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(13)]
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(3), ReferenceId(6)]
+rebuilt        : SymbolId(3): [ReferenceId(3), ReferenceId(6), ReferenceId(8), ReferenceId(11)]
 Symbol span mismatch for "C":
 after transform: SymbolId(2): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(4): Span { start: 34, end: 35 }
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(2): [ReferenceId(10)]
+after transform: SymbolId(2): [ReferenceId(8)]
 rebuilt        : SymbolId(4): []
 Reference symbol mismatch for "C":
 after transform: SymbolId(2) "C"
@@ -39620,7 +39644,7 @@ Symbol span mismatch for "C":
 after transform: SymbolId(1): Span { start: 57, end: 58 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol span mismatch for "C":
-after transform: SymbolId(10): Span { start: 0, end: 0 }
+after transform: SymbolId(11): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(4): Span { start: 57, end: 58 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
@@ -39769,7 +39793,7 @@ Symbol span mismatch for "A":
 after transform: SymbolId(2): Span { start: 119, end: 120 }
 rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 Symbol span mismatch for "A":
-after transform: SymbolId(8): Span { start: 0, end: 0 }
+after transform: SymbolId(9): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(8): Span { start: 119, end: 120 }
 Symbol span mismatch for "B":
 after transform: SymbolId(3): Span { start: 300, end: 301 }
@@ -39781,7 +39805,7 @@ Symbol span mismatch for "C":
 after transform: SymbolId(4): Span { start: 551, end: 552 }
 rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(4): [ReferenceId(8), ReferenceId(39), ReferenceId(41), ReferenceId(42)]
+after transform: SymbolId(4): [ReferenceId(8), ReferenceId(39), ReferenceId(41), ReferenceId(43)]
 rebuilt        : SymbolId(12): [ReferenceId(44), ReferenceId(45), ReferenceId(48)]
 Symbol span mismatch for "C":
 after transform: SymbolId(16): Span { start: 0, end: 0 }
@@ -39867,7 +39891,7 @@ Symbol span mismatch for "C":
 after transform: SymbolId(1): Span { start: 39, end: 40 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol span mismatch for "C":
-after transform: SymbolId(10): Span { start: 0, end: 0 }
+after transform: SymbolId(11): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(4): Span { start: 39, end: 40 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
@@ -40026,13 +40050,13 @@ Symbol span mismatch for "D":
 after transform: SymbolId(3): Span { start: 199, end: 200 }
 rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "D":
-after transform: SymbolId(3): [ReferenceId(19), ReferenceId(21), ReferenceId(22)]
-rebuilt        : SymbolId(6): [ReferenceId(21), ReferenceId(25), ReferenceId(26), ReferenceId(29)]
+after transform: SymbolId(3): [ReferenceId(19), ReferenceId(21)]
+rebuilt        : SymbolId(6): [ReferenceId(21), ReferenceId(24), ReferenceId(27)]
 Symbol span mismatch for "D":
 after transform: SymbolId(7): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(7): Span { start: 199, end: 200 }
 Symbol reference IDs mismatch for "D":
-after transform: SymbolId(7): [ReferenceId(26)]
+after transform: SymbolId(7): [ReferenceId(24)]
 rebuilt        : SymbolId(7): []
 Reference flags mismatch for "_field":
 after transform: ReferenceId(16): ReferenceFlags(Read | Write)
@@ -40093,13 +40117,13 @@ Symbol span mismatch for "D":
 after transform: SymbolId(2): Span { start: 85, end: 86 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "D":
-after transform: SymbolId(2): [ReferenceId(12), ReferenceId(14), ReferenceId(15)]
-rebuilt        : SymbolId(5): [ReferenceId(9), ReferenceId(19), ReferenceId(20), ReferenceId(23)]
+after transform: SymbolId(2): [ReferenceId(12), ReferenceId(14)]
+rebuilt        : SymbolId(5): [ReferenceId(9), ReferenceId(18), ReferenceId(21)]
 Symbol span mismatch for "D":
 after transform: SymbolId(7): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(6): Span { start: 85, end: 86 }
 Symbol reference IDs mismatch for "D":
-after transform: SymbolId(7): [ReferenceId(19)]
+after transform: SymbolId(7): [ReferenceId(17)]
 rebuilt        : SymbolId(6): []
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
@@ -40311,37 +40335,7 @@ after transform: ScopeId(0): ["_C", "_decorateMetadata", "_defineProperty", "_ge
 rebuilt        : ScopeId(0): ["_C", "_decorateMetadata", "_defineProperty", "_get_x", "_method", "_set_x", "_y"]
 Symbol reference IDs mismatch for "_decorateMetadata":
 after transform: SymbolId(10): [ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(32), ReferenceId(34), ReferenceId(35), ReferenceId(37), ReferenceId(39), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(49), ReferenceId(51), ReferenceId(52), ReferenceId(54), ReferenceId(56)]
-rebuilt        : SymbolId(1): [ReferenceId(14), ReferenceId(18)]
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
+rebuilt        : SymbolId(1): []
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -40350,10 +40344,7 @@ after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Function", "Number", "Object", "require"]
-rebuilt        : ["Object", "dec", "require"]
-Unresolved reference IDs mismatch for "Object":
-after transform: [ReferenceId(36), ReferenceId(38), ReferenceId(53), ReferenceId(55)]
-rebuilt        : [ReferenceId(15), ReferenceId(19)]
+rebuilt        : ["dec", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.1.ts
 Bindings mismatch:
@@ -40783,7 +40774,7 @@ Symbol span mismatch for "C":
 after transform: SymbolId(0): Span { start: 23, end: 24 }
 rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 Symbol span mismatch for "C":
-after transform: SymbolId(60): Span { start: 0, end: 0 }
+after transform: SymbolId(61): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(8): Span { start: 23, end: 24 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-decoratorExpression.2.ts
@@ -41005,7 +40996,7 @@ Symbol span mismatch for "C":
 after transform: SymbolId(5): Span { start: 144, end: 145 }
 rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 Symbol span mismatch for "C":
-after transform: SymbolId(7): Span { start: 0, end: 0 }
+after transform: SymbolId(8): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(8): Span { start: 144, end: 145 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/metadata/esDecoratorsMetadata2.ts
@@ -41013,7 +41004,7 @@ Symbol span mismatch for "C":
 after transform: SymbolId(5): Span { start: 144, end: 145 }
 rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 Symbol span mismatch for "C":
-after transform: SymbolId(8): Span { start: 0, end: 0 }
+after transform: SymbolId(9): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(8): Span { start: 144, end: 145 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/metadata/esDecoratorsMetadata3.ts
@@ -41035,7 +41026,7 @@ Symbol span mismatch for "C":
 after transform: SymbolId(7): Span { start: 366, end: 367 }
 rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
 Symbol span mismatch for "C":
-after transform: SymbolId(9): Span { start: 0, end: 0 }
+after transform: SymbolId(10): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(10): Span { start: 366, end: 367 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/metadata/esDecoratorsMetadata5.ts
@@ -52015,7 +52006,7 @@ Unresolved references mismatch:
 after transform: ["Array", "ReadonlyArray", "require"]
 rebuilt        : ["Array", "require", "someDec"]
 Unresolved reference IDs mismatch for "Array":
-after transform: [ReferenceId(0), ReferenceId(6), ReferenceId(8)]
+after transform: [ReferenceId(0), ReferenceId(6), ReferenceId(10)]
 rebuilt        : [ReferenceId(8), ReferenceId(13)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/typeInferenceWithTupleType.ts

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,5 +1,3 @@
 transformer_misc Summary:
 AST Parsed     : 49/49 (100.00%)
-Positive Passed: 48/49 (97.96%)
-Mismatch: tasks/coverage/misc/pass/oxc-13284.js
-
+Positive Passed: 49/49 (100.00%)

--- a/tasks/coverage/snapshots/transformer_typescript.snap
+++ b/tasks/coverage/snapshots/transformer_typescript.snap
@@ -2,12 +2,8 @@ commit: 261630d6
 
 transformer_typescript Summary:
 AST Parsed     : 8816/8816 (100.00%)
-Positive Passed: 8812/8816 (99.95%)
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/esDecoratorsClassFieldsCrash.ts
-
+Positive Passed: 8814/8816 (99.98%)
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor2.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-staticPrivateAccessor.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-commentPreservation.ts
 

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 41d96516
 
-Passed: 186/309
+Passed: 186/313
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -539,7 +539,32 @@ x Output mismatch
 x Output mismatch
 
 
-# legacy-decorators (6/81)
+# legacy-decorators (6/85)
+* oxc/class-without-name-with-decorated_class/input.ts
+Bindings mismatch:
+after transform: ScopeId(0): ["dec"]
+rebuilt        : ScopeId(0): ["_default", "dec"]
+Bindings mismatch:
+after transform: ScopeId(1): ["_default"]
+rebuilt        : ScopeId(1): []
+Symbol flags mismatch for "_default":
+after transform: SymbolId(1): SymbolFlags(Class)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol scope ID mismatch for "_default":
+after transform: SymbolId(1): ScopeId(1)
+rebuilt        : SymbolId(1): ScopeId(0)
+
+* oxc/class-without-name-with-decorated_element/input.ts
+Bindings mismatch:
+after transform: ScopeId(0): ["dec"]
+rebuilt        : ScopeId(0): ["_default", "dec"]
+Bindings mismatch:
+after transform: ScopeId(1): ["_default"]
+rebuilt        : ScopeId(1): []
+Symbol scope ID mismatch for "_default":
+after transform: SymbolId(1): ScopeId(1)
+rebuilt        : SymbolId(1): ScopeId(0)
+
 * oxc/metadata/abstract-class/input.ts
 Symbol reference IDs mismatch for "Dependency":
 after transform: SymbolId(1): [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
@@ -561,6 +586,14 @@ rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol span mismatch for "Example":
 after transform: SymbolId(4): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(3): Span { start: 87, end: 94 }
+
+* oxc/metadata/class-and-method-decorators/input.ts
+Symbol span mismatch for "Problem":
+after transform: SymbolId(4): Span { start: 90, end: 97 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
+Symbol span mismatch for "Problem":
+after transform: SymbolId(5): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(5): Span { start: 90, end: 97 }
 
 * oxc/metadata/enum-types/input.ts
 Bindings mismatch:
@@ -726,6 +759,53 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Boolean", "Function", "Number", "String", "babelHelpers"]
 rebuilt        : ["Boolean", "Function", "Number", "String", "babelHelpers", "methodDecorator", "paramDecorator"]
+
+* oxc/metadata/private-in-expression-in-decorator/input.ts
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
+Bindings mismatch:
+after transform: ScopeId(1): ["Cls"]
+rebuilt        : ScopeId(1): []
+Bindings mismatch:
+after transform: ScopeId(3): ["Cls2"]
+rebuilt        : ScopeId(4): []
+Symbol reference IDs mismatch for "dec":
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(4)]
+rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(10)]
+Symbol span mismatch for "Cls":
+after transform: SymbolId(4): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(1): Span { start: 46, end: 49 }
+Symbol scope ID mismatch for "Cls":
+after transform: SymbolId(4): ScopeId(1)
+rebuilt        : SymbolId(1): ScopeId(0)
+Symbol reference IDs mismatch for "Cls":
+after transform: SymbolId(4): []
+rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(7)]
+Symbol span mismatch for "Cls2":
+after transform: SymbolId(5): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(2): Span { start: 116, end: 120 }
+Symbol scope ID mismatch for "Cls2":
+after transform: SymbolId(5): ScopeId(3)
+rebuilt        : SymbolId(2): ScopeId(0)
+Symbol reference IDs mismatch for "Cls2":
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(2): [ReferenceId(11), ReferenceId(17)]
+Reference symbol mismatch for "Cls":
+after transform: SymbolId(1) "Cls"
+rebuilt        : SymbolId(1) "Cls"
+Reference symbol mismatch for "Cls":
+after transform: SymbolId(1) "Cls"
+rebuilt        : SymbolId(1) "Cls"
+Reference symbol mismatch for "Cls2":
+after transform: SymbolId(2) "Cls2"
+rebuilt        : SymbolId(2) "Cls2"
+Reference symbol mismatch for "Cls2":
+after transform: SymbolId(2) "Cls2"
+rebuilt        : SymbolId(2) "Cls2"
+Unresolved reference IDs mismatch for "babelHelpers":
+after transform: [ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(16), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(22), ReferenceId(24)]
+rebuilt        : [ReferenceId(0), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(9), ReferenceId(12), ReferenceId(14), ReferenceId(16)]
 
 * oxc/metadata/this/input.ts
 Symbol span mismatch for "Example":

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/class-without-name-with-decorated_class/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/class-without-name-with-decorated_class/input.ts
@@ -1,0 +1,7 @@
+import { dec } from "dec";
+
+@dec
+export default class {
+  @dec
+  foo = 0;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/class-without-name-with-decorated_class/options.json
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/class-without-name-with-decorated_class/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    [
+      "transform-legacy-decorator"
+    ]
+  ]
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/class-without-name-with-decorated_class/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/class-without-name-with-decorated_class/output.js
@@ -1,0 +1,7 @@
+import { dec } from "dec";
+let _default = class {
+  foo = 0;
+};
+babelHelpers.decorate([dec], _default.prototype, "foo", void 0);
+_default = babelHelpers.decorate([dec], _default);
+export default _default;

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/class-without-name-with-decorated_element/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/class-without-name-with-decorated_element/input.ts
@@ -1,0 +1,6 @@
+import { dec } from "dec";
+
+export default class {
+  @dec
+  foo = 0;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/class-without-name-with-decorated_element/options.json
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/class-without-name-with-decorated_element/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    [
+      "transform-legacy-decorator"
+    ]
+  ]
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/class-without-name-with-decorated_element/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/class-without-name-with-decorated_element/output.js
@@ -1,0 +1,5 @@
+import { dec } from "dec";
+export default class _default {
+  foo = 0;
+}
+babelHelpers.decorate([dec], _default.prototype, "foo", void 0);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/class-and-method-decorators/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/class-and-method-decorators/input.ts
@@ -1,0 +1,10 @@
+import { singleton, log, deco, C } from "dec";
+
+@log("Problem")
+@singleton()
+export class Problem extends C {
+  @deco()
+  run() {
+    return super.run();
+  }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/class-and-method-decorators/options.json
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/class-and-method-decorators/options.json
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    "transform-class-properties",
+    [
+      "transform-legacy-decorator",
+      {
+        "emitDecoratorMetadata": true
+      }
+    ]
+  ]
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/class-and-method-decorators/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/class-and-method-decorators/output.js
@@ -1,0 +1,21 @@
+import { singleton, log, deco, C } from "dec";
+let Problem = class Problem extends C {
+  run() {
+    return super.run();
+  }
+};
+
+babelHelpers.decorate(
+  [
+    deco(),
+    babelHelpers.decorateMetadata("design:type", Function),
+    babelHelpers.decorateMetadata("design:paramtypes", []),
+    babelHelpers.decorateMetadata("design:returntype", void 0),
+  ],
+  Problem.prototype,
+  "run",
+  null,
+);
+Problem = babelHelpers.decorate([log("Problem"), singleton()], Problem);
+
+export { Problem };

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/private-in-expression-in-decorator/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/private-in-expression-in-decorator/input.ts
@@ -1,0 +1,14 @@
+import { dec } from "dec";
+
+@dec
+export class Cls {
+  #zoo = 0;
+  @dec(#zoo in Cls)
+  foo() {}
+}
+
+@dec
+export class Cls2 {
+  #zoo = 0;
+  foo(@dec(#zoo in Cls2) param: number) {}
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/private-in-expression-in-decorator/options.json
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/private-in-expression-in-decorator/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    [
+      "transform-legacy-decorator",
+      {
+        "emitDecoratorMetadata": true
+      }
+    ]
+  ]
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/private-in-expression-in-decorator/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/private-in-expression-in-decorator/output.js
@@ -1,0 +1,26 @@
+
+import { dec } from "dec";
+export class Cls {
+  #zoo = 0;
+  foo() {}
+  static {
+    babelHelpers.decorate([
+      dec(#zoo in Cls),
+      babelHelpers.decorateMetadata("design:type", Function),
+      babelHelpers.decorateMetadata("design:paramtypes", []),
+      babelHelpers.decorateMetadata("design:returntype", void 0)
+    ], Cls.prototype, "foo", null);
+  }
+}
+export class Cls2 {
+  #zoo = 0;
+  foo(param) {}
+  static {
+    babelHelpers.decorate([
+      babelHelpers.decorateParam(0, dec(#zoo in Cls2)),
+      babelHelpers.decorateMetadata("design:type", Function),
+      babelHelpers.decorateMetadata("design:paramtypes", [Number]),
+      babelHelpers.decorateMetadata("design:returntype", void 0)
+    ], Cls2.prototype, "foo", null);
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/rolldown/rolldown/issues/6079. Regressed introduced by https://github.com/oxc-project/oxc/pull/13227.


The root cause is that the class plugin will insert a constructor method in some cases, but metadata handling is processed before the constructor is inserted, which causes the method count not to be exactly the same as the method metadata count. Thus, decorator metadata is inserted in the incorrect place.

This PR refactors the core transformation logic to ensure that the new methods and properties inserted by other plugins won't affect the decorator transformation.

### Transformation Flow Changes

  Before: Complex upfront analysis with separate processing paths
  - Used check_class_has_decorated() to analyze entire class tree
  - Separate handling for class vs element decorators
  - Multiple disconnected stacks for state tracking

  After: Unified incremental processing
  - Process decorators as we traverse (exit_method_definition,
  exit_property_definition, etc.)
  - Accumulate decoration statements in single stack during traversal
  - Unified processing in transform_class() using consolidated state
