### PR TITLE
fix(linter): fix false positive detection in `no-unused-private-class-members`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
@@ -214,6 +214,7 @@ fn is_value_context(kind: &AstNode, semantic: &Semantic<'_>) -> bool {
         | AstKind::TemplateLiteral(_)
         | AstKind::UnaryExpression(_)
         | AstKind::IfStatement(_)
+        | AstKind::SpreadElement(_)
         | AstKind::LogicalExpression(_) => true,
         AstKind::ExpressionStatement(_) => {
             let parent_node = semantic.nodes().parent_node(kind.id());
@@ -256,6 +257,9 @@ fn test() {
     use crate::tester::Tester;
 
     let pass = vec![
+        r"
+            class Foo { #privateMember = {}; a() { return { ...this.#privateMember }; } }
+        ",
         r"
             class Test {
                 #prop = undefined


### PR DESCRIPTION
Fixes #13628 