### PR TITLE
refactor(linter_codegen): improve code style for collecting nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,6 +2061,7 @@ version = "0.0.0"
 dependencies = [
  "convert_case",
  "project-root",
+ "rustc-hash",
  "syn",
 ]
 

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -1437,7 +1437,6 @@ impl RuleRunner for crate::rules::nextjs::no_async_client_component::NoAsyncClie
 impl RuleRunner for crate::rules::nextjs::no_before_interactive_script_outside_document::NoBeforeInteractiveScriptOutsideDocument {
     const NODE_TYPES: &AstTypesBitset = &AstTypesBitset::from_types(&[AstType::JSXOpeningElement]);
     const ANY_NODE_TYPE: bool = false;
-
 }
 
 impl RuleRunner for crate::rules::nextjs::no_css_tags::NoCssTags {
@@ -1724,7 +1723,6 @@ impl RuleRunner for crate::rules::react::button_has_type::ButtonHasType {
 impl RuleRunner for crate::rules::react::checked_requires_onchange_or_readonly::CheckedRequiresOnchangeOrReadonly {
     const NODE_TYPES: &AstTypesBitset = &AstTypesBitset::new();
     const ANY_NODE_TYPE: bool = true;
-
 }
 
 impl RuleRunner for crate::rules::react::exhaustive_deps::ExhaustiveDeps {
@@ -2131,13 +2129,11 @@ impl RuleRunner for crate::rules::typescript::no_namespace::NoNamespace {
 impl RuleRunner for crate::rules::typescript::no_non_null_asserted_nullish_coalescing::NoNonNullAssertedNullishCoalescing {
     const NODE_TYPES: &AstTypesBitset = &AstTypesBitset::new();
     const ANY_NODE_TYPE: bool = true;
-
 }
 
 impl RuleRunner for crate::rules::typescript::no_non_null_asserted_optional_chain::NoNonNullAssertedOptionalChain {
     const NODE_TYPES: &AstTypesBitset = &AstTypesBitset::new();
     const ANY_NODE_TYPE: bool = true;
-
 }
 
 impl RuleRunner for crate::rules::typescript::no_non_null_assertion::NoNonNullAssertion {
@@ -2165,19 +2161,16 @@ impl RuleRunner for crate::rules::typescript::no_this_alias::NoThisAlias {
 impl RuleRunner for crate::rules::typescript::no_unnecessary_boolean_literal_compare::NoUnnecessaryBooleanLiteralCompare {
     const NODE_TYPES: &AstTypesBitset = &AstTypesBitset::new();
     const ANY_NODE_TYPE: bool = true;
-
 }
 
 impl RuleRunner for crate::rules::typescript::no_unnecessary_parameter_property_assignment::NoUnnecessaryParameterPropertyAssignment {
     const NODE_TYPES: &AstTypesBitset = &AstTypesBitset::new();
     const ANY_NODE_TYPE: bool = true;
-
 }
 
 impl RuleRunner for crate::rules::typescript::no_unnecessary_template_expression::NoUnnecessaryTemplateExpression {
     const NODE_TYPES: &AstTypesBitset = &AstTypesBitset::new();
     const ANY_NODE_TYPE: bool = true;
-
 }
 
 impl RuleRunner
@@ -2393,7 +2386,6 @@ impl RuleRunner for crate::rules::typescript::unbound_method::UnboundMethod {
 impl RuleRunner for crate::rules::typescript::use_unknown_in_catch_callback_variable::UseUnknownInCatchCallbackVariable {
     const NODE_TYPES: &AstTypesBitset = &AstTypesBitset::new();
     const ANY_NODE_TYPE: bool = true;
-
 }
 
 impl RuleRunner for crate::rules::unicorn::catch_error_name::CatchErrorName {
@@ -2787,7 +2779,6 @@ impl RuleRunner for crate::rules::unicorn::prefer_includes::PreferIncludes {
 impl RuleRunner for crate::rules::unicorn::prefer_logical_operator_over_ternary::PreferLogicalOperatorOverTernary {
     const NODE_TYPES: &AstTypesBitset = &AstTypesBitset::new();
     const ANY_NODE_TYPE: bool = true;
-
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_math_min_max::PreferMathMinMax {
@@ -2924,7 +2915,6 @@ impl RuleRunner for crate::rules::unicorn::require_array_join_separator::Require
 impl RuleRunner for crate::rules::unicorn::require_number_to_fixed_digits_argument::RequireNumberToFixedDigitsArgument {
     const NODE_TYPES: &AstTypesBitset = &AstTypesBitset::new();
     const ANY_NODE_TYPE: bool = true;
-
 }
 
 impl RuleRunner
@@ -2979,7 +2969,6 @@ impl RuleRunner for crate::rules::vitest::prefer_to_be_truthy::PreferToBeTruthy 
 impl RuleRunner for crate::rules::vitest::require_local_test_context_for_concurrent_snapshots::RequireLocalTestContextForConcurrentSnapshots {
     const NODE_TYPES: &AstTypesBitset = &AstTypesBitset::new();
     const ANY_NODE_TYPE: bool = true;
-
 }
 
 impl RuleRunner for crate::rules::vue::valid_define_emits::ValidDefineEmits {

--- a/tasks/linter_codegen/Cargo.toml
+++ b/tasks/linter_codegen/Cargo.toml
@@ -16,4 +16,5 @@ doctest = false
 [dependencies]
 convert_case = { workspace = true }
 project-root = { workspace = true }
+rustc-hash = { workspace = true }
 syn = { workspace = true, features = ["full", "visit", "parsing"] }


### PR DESCRIPTION
Almost pure refactor. There are some slight styling changes in the rule runner impls file, but other than that, this is just some clean up.

- Make the rule runner template string a multiline string, so it is easier to read and edit
- Move functions into the if-else detector so we don't need to pass around mutable sets of strings
- Replaced BTreeSet with a `NodeTypeSet` that abstracts over the set manipulation somewhat and offers more utilities specific to the linter codegen