### PR TITLE
fix(codegen): use backticks for computed object property keys in destructuring assignments

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1996,14 +1996,8 @@ impl Gen for AssignmentTargetPropertyProperty<'_> {
                 PropertyKey::PrivateIdentifier(ident) => {
                     ident.print(p, ctx);
                 }
-                PropertyKey::StringLiteral(s) => {
-                    if self.computed {
-                        p.print_ascii_byte(b'[');
-                    }
+                PropertyKey::StringLiteral(s) if !self.computed => {
                     p.print_string_literal(s, /* allow_backtick */ false);
-                    if self.computed {
-                        p.print_ascii_byte(b']');
-                    }
                 }
                 key => {
                     if self.computed {

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -229,7 +229,7 @@ fn assignment() {
     test_minify(r#"({"my-key": value} = obj);"#, r#"({"my-key":value}=obj);"#);
     test_minify(
         r#"({["computed"]: a, "literal": b} = obj);"#,
-        r#"({["computed"]:a,"literal":b}=obj);"#,
+        r#"({[`computed`]:a,"literal":b}=obj);"#,
     );
     test_minify(r#"let {"test-key": testKey} = obj;"#, r#"let{"test-key":testKey}=obj;"#);
 


### PR DESCRIPTION
Follow-on after #13631.

That PR fixed a bug where codegen generated invalid code like ``({`my-key`: value} = obj)``, by using normal quotes instead of backticks (`{"my-key": value}`).

However, it went too far. Backticks are fine when the key is computed e.g. ``({[`my-key`]: value} = obj)``. This PR reverts to original behavior of allowing backticks in computed keys.
