### PR TITLE
fix(ci/lint-rules): fix(workflow): update setup-node action to use oxc-project version

### DIFF
--- a/.github/workflows/lint_rules.yml
+++ b/.github/workflows/lint_rules.yml
@@ -22,9 +22,7 @@ jobs:
       - name: Checkout Branch
         uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
 
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
-        with:
-          node-version-file: .node-version
+      - uses: oxc-project/setup-node@f42e3bda950c7454575e78ee4eaac880a077700c # v1.0.0
 
       - name: Install latest plugins
         working-directory: tasks/lint_rules


### PR DESCRIPTION
to fix [this](https://github.com/oxc-project/oxc/actions/runs/17604014167/job/50011184946) failure