### PR TITLE
feat(oxfmt): Implement -l, -c output options

### DIFF
--- a/apps/oxfmt/src/command.rs
+++ b/apps/oxfmt/src/command.rs
@@ -37,6 +37,13 @@ pub struct FormatCommand {
 pub enum OutputOptions {
     #[bpaf(hide)]
     Default,
+    /// Check mode - check if files are formatted
+    #[bpaf(long, short)]
+    Check,
+    // -l, --list-different
+    /// List mode - list files that would be changed
+    #[bpaf(long, short)]
+    ListDifferent,
     /// Write mode - write formatted code back
     #[bpaf(long, short)]
     Write,

--- a/apps/oxfmt/src/reporter.rs
+++ b/apps/oxfmt/src/reporter.rs
@@ -1,5 +1,5 @@
 use oxc_diagnostics::{
-    Error, GraphicalReportHandler, Severity,
+    Error, GraphicalReportHandler,
     reporter::{DiagnosticReporter, DiagnosticResult},
 };
 
@@ -24,13 +24,10 @@ impl DiagnosticReporter for DefaultReporter {
         }
 
         // Otherwise, this is a error without `labels`, originate from `oxfmt` itself
-        let prefix = match error.severity().unwrap_or_default() {
-            Severity::Warning => "[warn] ",
-            _ => "",
-        };
+
         // NOTE: Formatted `path` should be inlined
         // there is no way to get here since we do not have `labels`
-        Some(format!("{prefix}{error}\n"))
+        Some(format!("{error}\n"))
     }
 
     fn finish(&mut self, _result: &DiagnosticResult) -> Option<String> {


### PR DESCRIPTION
Similar to the Prettier CLI, I've implemented the `-l, --list-different` and `-c, --check` flags.

In Prettier, you can choose not to give any flags, but for now, we fallback it to `-c`.