### PR TITLE
chore(linter/no-non-null-asserted-optional-chain): make fixer a suggestion not a fix

### DIFF
--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_issue_9958@issue.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_issue_9958@issue.ts.snap
@@ -28,7 +28,7 @@ related_information[1].location.range: Range { start: Position { line: 11, chara
 severity: Some(Error)
 source: Some("oxc")
 tags: None
-fixed: Single(FixedContent { message: Some("Delete this code."), code: "", range: Range { start: Position { line: 11, character: 21 }, end: Position { line: 11, character: 22 } } })
+fixed: None
 
 
 code: "None"

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
@@ -57,7 +57,7 @@ declare_oxc_lint!(
     NoNonNullAssertedOptionalChain,
     typescript,
     correctness,
-    fix
+    suggestion
 );
 
 impl Rule for NoNonNullAssertedOptionalChain {
@@ -111,8 +111,7 @@ impl Rule for NoNonNullAssertedOptionalChain {
                 Span::sized(chain_span_end, 1),
                 Span::sized(non_null_end, 1),
             );
-            // ctx.diagnostic(diagnostic);
-            ctx.diagnostic_with_fix(diagnostic, |fixer| {
+            ctx.diagnostic_with_suggestion(diagnostic, |fixer| {
                 fixer.delete_range(Span::sized(non_null_end, 1))
             });
         }


### PR DESCRIPTION
while this wouldn't change the runtime behaviour, it would cause user's typecheck workflows to fail hence it's unsafe to unconditionally apply.