### PR TITLE
feat(oxfmt): Fix up result and exit code

### DIFF
--- a/apps/oxfmt/src/format.rs
+++ b/apps/oxfmt/src/format.rs
@@ -6,6 +6,7 @@ use oxc_diagnostics::DiagnosticService;
 
 use crate::{
     cli::{CliRunResult, FormatCommand},
+    command::OutputOptions,
     reporter::DefaultReporter,
     service::FormatService,
     walk::Walk,
@@ -28,15 +29,12 @@ impl FormatRunner {
         let cwd = self.cwd;
         let FormatCommand { paths, output_options, .. } = self.options;
 
-        let (exclude_patterns, regular_paths): (Vec<_>, Vec<_>) =
+        // Instead of `--ignore-pattern=PAT`, we support `!` prefix in paths
+        let (exclude_patterns, target_paths): (Vec<_>, Vec<_>) =
             paths.into_iter().partition(|p| p.to_string_lossy().starts_with('!'));
 
-        // Need at least one regular path
-        if regular_paths.is_empty() {
-            print_and_flush_stdout(
-                stdout,
-                "Expected at least one target file/dir/glob(non-override pattern)\n",
-            );
+        if target_paths.is_empty() {
+            print_and_flush_stdout(stdout, "Expected at least one target file/dir/glob\n");
             return CliRunResult::FormatNoFilesFound;
         }
 
@@ -51,43 +49,92 @@ impl FormatRunner {
             })
             .flatten();
 
-        let walker = Walk::new(&regular_paths, override_builder);
-        let entries = walker.entries();
+        let walker = Walk::new(&target_paths, override_builder);
+        let entries = walker.collect_entries();
 
         let files_to_format = entries
             .into_iter()
+            // TODO: Support .pretttierignore
+            // TODO: Support default ignores like node_modules, .git, etc.
             // .filter(|entry| !config_store.should_ignore(Path::new(&entry.path)))
             .collect::<Vec<_>>();
 
+        // It may be empty after filtering ignored files
         if files_to_format.is_empty() {
             print_and_flush_stdout(stdout, "Expected at least one target file\n");
             return CliRunResult::FormatNoFilesFound;
         }
 
-        let reporter = Box::new(DefaultReporter::default());
-        let (mut diagnostic_service, tx_error) = DiagnosticService::new(reporter);
+        let (mut diagnostic_service, tx_error) =
+            DiagnosticService::new(Box::new(DefaultReporter::default()));
 
-        // TODO: if -c, print "Checking formatting..."
+        if matches!(output_options, OutputOptions::Check) {
+            print_and_flush_stdout(stdout, "Checking formatting...\n");
+        }
 
+        let target_files_count = files_to_format.len();
+        let output_options_clone = output_options.clone();
+
+        // Spawn a thread to run formatting service and wait diagnostics
         rayon::spawn(move || {
-            let mut format_service = FormatService::new(cwd, &output_options);
+            let mut format_service = FormatService::new(cwd, &output_options_clone);
             format_service.with_entries(files_to_format);
             format_service.run(&tx_error);
         });
         // NOTE: This is a blocking
         let res = diagnostic_service.run(stdout);
 
-        let elapsed = start_time.elapsed();
-        // TODO: if -c && all unchanged, print "All matched files use the correct format"
-        // TODO: if -c && changed, print "Format issue found in above files. Run with `-w` to fix."
-        print_and_flush_stdout(stdout, &format!("{res:?} in {elapsed:.2?}\n"));
+        if 0 < res.errors_count() {
+            // Each error is already printed in reporter
+            print_and_flush_stdout(
+                stdout,
+                "Error occurred when checking code style in the above files.\n",
+            );
+            return CliRunResult::FormatFailed;
+        }
 
-        // TODO: return different exit codes based on warnings_count, errors_count
-        CliRunResult::FormatSucceeded
+        let print_stats = |stdout| {
+            print_and_flush_stdout(
+                stdout,
+                &format!(
+                    "Finished in {}ms on {target_files_count} files using {} threads.\n",
+                    start_time.elapsed().as_millis(),
+                    rayon::current_num_threads()
+                ),
+            );
+        };
+
+        match (&output_options, res.warnings_count()) {
+            // `-l` outputs nothing here, mismatched paths are already printed in reporter
+            (OutputOptions::ListDifferent, 0) => CliRunResult::FormatSucceeded,
+            (OutputOptions::ListDifferent, _) => CliRunResult::FormatMismatch,
+            // `-c` outputs friendly summary
+            (OutputOptions::Check | OutputOptions::Default, 0) => {
+                print_and_flush_stdout(stdout, "All matched files use the correct format.\n");
+                print_stats(stdout);
+                CliRunResult::FormatSucceeded
+            }
+            (OutputOptions::Check | OutputOptions::Default, mismatched_count) => {
+                print_and_flush_stdout(
+                    stdout,
+                    &format!(
+                        "Format issues found in above {mismatched_count} files. Run with `-w` or `--write` to fix.\n",
+                    ),
+                );
+                print_stats(stdout);
+                CliRunResult::FormatMismatch
+            }
+            // `-w` also outputs friendly summary
+            (OutputOptions::Write, formatted_count) => {
+                print_and_flush_stdout(stdout, &format!("Formatted {formatted_count} files.\n"));
+                print_stats(stdout);
+                CliRunResult::FormatSucceeded
+            }
+        }
     }
 }
 
-pub fn print_and_flush_stdout(stdout: &mut dyn Write, message: &str) {
+fn print_and_flush_stdout(stdout: &mut dyn Write, message: &str) {
     use std::io::{Error, ErrorKind};
     fn check_for_writer_error(error: Error) -> Result<(), Error> {
         // Do not panic when the process is killed (e.g. piping into `less`).

--- a/apps/oxfmt/src/lib.rs
+++ b/apps/oxfmt/src/lib.rs
@@ -33,13 +33,16 @@ pub fn format() -> CliRunResult {
     }
     let args = args.collect::<Vec<_>>();
 
+    // Parse command line arguments
     let command = match format_command().run_inner(&*args) {
         Ok(cmd) => cmd,
         Err(e) => {
             e.print_message(100);
             return if e.exit_code() == 0 {
-                CliRunResult::FormatSucceeded
+                // e.g. `-V` and `--help`
+                CliRunResult::None
             } else {
+                // e.g. Unknown options
                 CliRunResult::InvalidOptionConfig
             };
         }

--- a/apps/oxfmt/src/result.rs
+++ b/apps/oxfmt/src/result.rs
@@ -8,13 +8,18 @@ pub enum CliRunResult {
     // Failure
     FormatNoFilesFound,
     InvalidOptionConfig,
+    FormatMismatch,
+    FormatFailed,
 }
 
 impl Termination for CliRunResult {
     fn report(self) -> ExitCode {
         match self {
             Self::None | Self::FormatSucceeded => ExitCode::SUCCESS,
-            Self::FormatNoFilesFound | Self::InvalidOptionConfig => ExitCode::FAILURE,
+            Self::FormatNoFilesFound
+            | Self::InvalidOptionConfig
+            | Self::FormatMismatch
+            | Self::FormatFailed => ExitCode::FAILURE,
         }
     }
 }

--- a/apps/oxfmt/src/service.rs
+++ b/apps/oxfmt/src/service.rs
@@ -3,7 +3,7 @@ use std::{fs, path::Path, time::Instant};
 use rayon::prelude::*;
 
 use oxc_allocator::Allocator;
-use oxc_diagnostics::{DiagnosticSender, DiagnosticService, OxcDiagnostic, Severity};
+use oxc_diagnostics::{DiagnosticSender, DiagnosticService, OxcDiagnostic};
 use oxc_formatter::{FormatOptions, Formatter};
 use oxc_parser::{ParseOptions, Parser};
 
@@ -85,16 +85,12 @@ impl FormatService {
                 (OutputOptions::ListDifferent, true) => {
                     Some(OxcDiagnostic::warn(format!("{}", path.to_string_lossy())))
                 }
-                (OutputOptions::Write, _) => Some(
-                    OxcDiagnostic::warn(format!(
-                        "{} {}ms{}",
-                        path.to_string_lossy(),
-                        elapsed.as_millis(),
-                        if is_changed { "" } else { " (unchanged)" }
-                    ))
-                    // This cannot be `Warning`, otherwise CLI exit code will be 1
-                    .with_severity(Severity::Advice),
-                ),
+                (OutputOptions::Write, _) => Some(OxcDiagnostic::warn(format!(
+                    "{} {}ms{}",
+                    path.to_string_lossy(),
+                    elapsed.as_millis(),
+                    if is_changed { "" } else { " (unchanged)" }
+                ))),
                 _ => None,
             } {
                 tx_error.send((path.to_path_buf(), vec![diagnostic.into()])).unwrap();

--- a/apps/oxfmt/src/walk.rs
+++ b/apps/oxfmt/src/walk.rs
@@ -134,7 +134,7 @@ impl Walk {
         Self { inner }
     }
 
-    pub fn entries(self) -> Vec<WalkEntry> {
+    pub fn collect_entries(self) -> Vec<WalkEntry> {
         let (sender, receiver) = mpsc::channel::<Vec<WalkEntry>>();
         let mut builder = WalkBuilder { sender };
         self.inner.visit(&mut builder);


### PR DESCRIPTION
Improved the CLI execution results, which were previously just placeholders.

Also, the exit code is now correctly reflected.


```sh
❯ cargo run -- ./fixtures/ '!broken.js' -c
Checking formatting...
./fixtures/bar.ts (2ms)
Format issues found in above 1 files. Run with `-w` or `--write` to fix.
Finished in 9ms on 2 files using 8 threads.

❯ cargo run -- ./fixtures/ '!broken.js' -l
./fixtures/bar.ts

❯ cargo run -- ./fixtures/ '!broken.js' -w
./fixtures/foo.js 2ms (unchanged)
./fixtures/bar.ts 2ms
Formatted 2 files.
Finished in 11ms on 2 files using 8 threads.
```