### PR TITLE
refactor(linter/plugins): move `tokio` usage from `oxc_linter` to `napi/oxlint2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2052,7 +2052,6 @@ dependencies = [
  "serde_json",
  "simdutf8",
  "smallvec",
- "tokio",
 ]
 
 [[package]]
@@ -2075,6 +2074,7 @@ dependencies = [
  "oxc_allocator",
  "oxlint",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -17,7 +17,7 @@ description.workspace = true
 default = []
 ruledocs = ["oxc_macros/ruledocs"] # Enables the `ruledocs` feature for conditional compilation
 language_server = ["oxc_data_structures/rope"] # For the Runtime to support needed information for the language server
-oxlint2 = ["dep:oxc_ast_macros", "oxc_allocator/fixed_size", "oxc_ast_visit/serialize", "tokio/rt-multi-thread"]
+oxlint2 = ["dep:oxc_ast_macros", "oxc_allocator/fixed_size", "oxc_ast_visit/serialize"]
 force_test_reporter = []
 
 [lints]
@@ -71,7 +71,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] } # preserve_order: print config with ordered keys.
 simdutf8 = { workspace = true }
 smallvec = { workspace = true }
-tokio = { workspace = true, optional = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -531,13 +531,11 @@ impl ConfigStoreBuilder {
 
         let result = {
             let plugin_path = plugin_path.clone();
-            tokio::task::block_in_place(move || {
-                tokio::runtime::Handle::current()
-                    .block_on((external_linter.load_plugin)(plugin_path))
-            })
-            .map_err(|e| ConfigBuilderError::PluginLoadFailed {
-                plugin_specifier: plugin_specifier.to_string(),
-                error: e.to_string(),
+            (external_linter.load_plugin)(plugin_path).map_err(|e| {
+                ConfigBuilderError::PluginLoadFailed {
+                    plugin_specifier: plugin_specifier.to_string(),
+                    error: e.to_string(),
+                }
             })
         }?;
 

--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -1,21 +1,13 @@
-use std::{fmt::Debug, pin::Pin, sync::Arc};
+use std::{fmt::Debug, sync::Arc};
 
 use serde::{Deserialize, Serialize};
 
 use oxc_allocator::Allocator;
 
 pub type ExternalLinterLoadPluginCb = Arc<
-    dyn Fn(
-            String,
-        ) -> Pin<
-            Box<
-                dyn Future<
-                        Output = Result<PluginLoadResult, Box<dyn std::error::Error + Send + Sync>>,
-                    > + Send,
-            >,
-        > + Send
-        + Sync
-        + 'static,
+    dyn Fn(String) -> Result<PluginLoadResult, Box<dyn std::error::Error + Send + Sync>>
+        + Send
+        + Sync,
 >;
 
 pub type ExternalLinterLintFileCb =

--- a/napi/oxlint2/Cargo.toml
+++ b/napi/oxlint2/Cargo.toml
@@ -28,6 +28,7 @@ oxlint = { workspace = true, features = ["oxlint2", "allocator"] }
 napi = { workspace = true, features = ["async"] }
 napi-derive = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [build-dependencies]
 napi-build = { workspace = true }


### PR DESCRIPTION
`tokio` is required to run `load_plugin` JS callback, to load a JS plugin.

Move this code into `napi/oxlint2`, so can remove the `tokio` dependency from `oxc_linter` crate.