### PR TITLE
refactor(linter/plugins): remove `oxlint2` Cargo feature

### DIFF
--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -27,7 +27,7 @@ test = false
 doctest = false
 
 [dependencies]
-oxc_allocator = { workspace = true }
+oxc_allocator = { workspace = true, features = ["fixed_size"] }
 oxc_diagnostics = { workspace = true }
 oxc_linter = { workspace = true }
 oxc_span = { workspace = true }
@@ -41,7 +41,7 @@ rayon = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-simdutf8 = { workspace = true, optional = true }
+simdutf8 = { workspace = true }
 tempfile = { workspace = true }
 tracing-subscriber = { workspace = true, features = [] } # Omit the `regex` feature
 
@@ -61,5 +61,4 @@ lazy-regex = { workspace = true }
 [features]
 default = []
 allocator = ["dep:mimalloc-safe"]
-oxlint2 = ["oxc_linter/oxlint2", "oxc_allocator/fixed_size", "dep:simdutf8"]
 force_test_reporter = ["oxc_linter/force_test_reporter"]

--- a/apps/oxlint/src/lib.rs
+++ b/apps/oxlint/src/lib.rs
@@ -8,6 +8,7 @@ pub use oxc_linter::{
 mod command;
 mod lint;
 mod output_formatter;
+mod raw_fs;
 mod result;
 mod tester;
 mod walk;
@@ -17,9 +18,6 @@ pub mod cli {
 }
 
 use cli::{CliRunResult, LintRunner};
-
-#[cfg(feature = "oxlint2")]
-mod raw_fs;
 
 #[cfg(all(feature = "allocator", not(miri), not(target_family = "wasm")))]
 #[global_allocator]

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -359,15 +359,13 @@ impl LintRunner {
 
         // Spawn linting in another thread so diagnostics can be printed immediately from diagnostic_service.run.
         rayon::spawn(move || {
-            #[cfg(feature = "oxlint2")]
             let has_external_linter = linter.has_external_linter();
 
             let mut lint_service = LintService::new(linter, options);
             lint_service.with_paths(files_to_lint);
 
-            // Use `RawTransferFileSystem` if `oxlint2` feature is enabled and `ExternalLinter` exists.
+            // Use `RawTransferFileSystem` if `ExternalLinter` exists.
             // This reads the source text into start of allocator, instead of the end.
-            #[cfg(feature = "oxlint2")]
             if has_external_linter {
                 use crate::raw_fs::RawTransferFileSystem;
                 lint_service.with_file_system(Box::new(RawTransferFileSystem));

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -17,7 +17,6 @@ description.workspace = true
 default = []
 ruledocs = ["oxc_macros/ruledocs"] # Enables the `ruledocs` feature for conditional compilation
 language_server = ["oxc_data_structures/rope"] # For the Runtime to support needed information for the language server
-oxlint2 = ["dep:oxc_ast_macros", "oxc_allocator/fixed_size", "oxc_ast_visit/serialize"]
 force_test_reporter = []
 
 [lints]
@@ -27,10 +26,10 @@ workspace = true
 doctest = true
 
 [dependencies]
-oxc_allocator = { workspace = true, features = ["pool"] }
+oxc_allocator = { workspace = true, features = ["fixed_size"] }
 oxc_ast = { workspace = true }
-oxc_ast_macros = { workspace = true, optional = true }
-oxc_ast_visit = { workspace = true }
+oxc_ast_macros = { workspace = true }
+oxc_ast_visit = { workspace = true, features = ["serialize"] }
 oxc_cfg = { workspace = true }
 oxc_codegen = { workspace = true }
 oxc_data_structures = { workspace = true, features = ["box_macros"] }

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -494,19 +494,6 @@ impl ConfigStoreBuilder {
         serde_json::to_string_pretty(&oxlintrc).unwrap()
     }
 
-    #[cfg(not(feature = "oxlint2"))]
-    #[expect(unused_variables, clippy::needless_pass_by_ref_mut)]
-    fn load_external_plugin(
-        oxlintrc_dir_path: &Path,
-        plugin_specifier: &str,
-        external_linter: &ExternalLinter,
-        resolver: &Resolver,
-        external_plugin_store: &mut ExternalPluginStore,
-    ) -> Result<(), ConfigBuilderError> {
-        unreachable!()
-    }
-
-    #[cfg(feature = "oxlint2")]
     fn load_external_plugin(
         oxlintrc_dir_path: &Path,
         plugin_specifier: &str,

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -343,7 +343,6 @@ impl ConfigStore {
         None
     }
 
-    #[cfg_attr(not(feature = "oxlint2"), expect(dead_code))]
     pub(crate) fn resolve_plugin_rule_names(
         &self,
         external_rule_id: ExternalRuleId,

--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -39,7 +39,6 @@ pub struct Loc {
 }
 
 #[derive(Clone)]
-#[cfg_attr(not(feature = "oxlint2"), expect(dead_code))]
 pub struct ExternalLinter {
     pub(crate) load_plugin: ExternalLinterLoadPluginCb,
     pub(crate) lint_file: ExternalLinterLintFileCb,

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -269,14 +269,7 @@ impl Runtime {
         // If an external linter is used (JS plugins), we must use fixed-size allocators,
         // for compatibility with raw transfer
         let allocator_pool = if linter.has_external_linter() {
-            #[cfg(feature = "oxlint2")]
-            {
-                AllocatorPool::new_fixed_size(thread_count)
-            }
-            #[cfg(not(feature = "oxlint2"))]
-            {
-                panic!("`oxlint2` feature must be enabled when using external linters");
-            }
+            AllocatorPool::new_fixed_size(thread_count)
         } else {
             AllocatorPool::new(thread_count)
         };

--- a/napi/oxlint2/Cargo.toml
+++ b/napi/oxlint2/Cargo.toml
@@ -23,7 +23,7 @@ doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true, features = ["fixed_size"] }
-oxlint = { workspace = true, features = ["oxlint2", "allocator"] }
+oxlint = { workspace = true, features = ["allocator"] }
 
 napi = { workspace = true, features = ["async"] }
 napi-derive = { workspace = true }


### PR DESCRIPTION
Remove `oxlint2` Cargo feature from `oxlint` and `oxc_linter` crates.

Now that enabling `fixed_size` Cargo feature of `oxc_allocator` doesn't change behavior, we don't need the feature gate. The incompatibility of `tokio` with WASM has been resolved by #13647.