### PR TITLE
refactor(formatter): introduce `SourceText` with utility methods

### DIFF
--- a/crates/oxc_formatter/src/formatter/comments/mod.rs
+++ b/crates/oxc_formatter/src/formatter/comments/mod.rs
@@ -14,16 +14,13 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{
     Format, FormatResult, SyntaxTriviaPieceComments,
-    formatter::{
-        Formatter,
-        prelude::{get_lines_after, get_lines_before},
-    },
+    formatter::{Formatter, SourceText},
     generated::ast_nodes::SiblingNode,
 };
 
 #[derive(Debug, Clone)]
 pub struct Comments<'a> {
-    source_text: &'a str,
+    source_text: SourceText<'a>,
     comments: &'a Vec<'a, Comment>,
     printed_count: usize,
     // The index of the type cast comment that has been printed already.
@@ -31,7 +28,7 @@ pub struct Comments<'a> {
 }
 
 impl<'a> Comments<'a> {
-    pub fn new(source_text: &'a str, comments: &'a Vec<'a, Comment>) -> Self {
+    pub fn new(source_text: SourceText<'a>, comments: &'a Vec<'a, Comment>) -> Self {
         Comments { source_text, comments, printed_count: 0, handled_type_cast_comment: 0 }
     }
 
@@ -82,7 +79,7 @@ impl<'a> Comments<'a> {
 
         let comments = self.unprinted_comments();
         for comment in comments {
-            if !is_own_line_comment(comment, self.source_text) {
+            if !is_own_line_comment(comment, &self.source_text) {
                 break;
             }
 
@@ -100,9 +97,7 @@ impl<'a> Comments<'a> {
         let comments = self.comments_after(start);
         while index < comments.len() {
             let comment = &comments[index];
-            if self.source_text[start as usize..comment.span.start as usize]
-                .contains(character as char)
-            {
+            if self.source_text.bytes_range(start, comment.span.start).contains(&character) {
                 return &comments[..index];
             }
 
@@ -213,9 +208,9 @@ impl<'a> Comments<'a> {
                 break;
             }
 
-            if is_own_line_comment(comment, self.source_text) {
+            if is_own_line_comment(comment, &self.source_text) {
                 return true;
-            } else if is_end_of_line_comment(comment, self.source_text) {
+            } else if is_end_of_line_comment(comment, &self.source_text) {
                 return false;
             }
 
@@ -227,10 +222,9 @@ impl<'a> Comments<'a> {
         }
 
         let last_remaining_comment = &comments[comment_index - 1];
-        let gap_str =
-            Span::new(last_remaining_comment.span.end, current_start).source_text(self.source_text);
-
-        gap_str.as_bytes().iter().all(|&b| matches!(b, b' ' | b'('))
+        self.source_text.all_bytes_match(last_remaining_comment.span.end, current_start, |b| {
+            b.is_ascii_whitespace() || b == b'('
+        })
     }
 
     pub fn has_leading_own_line_comments(&self, start: u32) -> bool {
@@ -240,8 +234,8 @@ impl<'a> Comments<'a> {
                 return false;
             }
 
-            if is_own_line_comment(comment, self.source_text)
-                || get_lines_after(comment.span.end, self.source_text) > 0
+            if is_own_line_comment(comment, &self.source_text)
+                || self.source_text.lines_after(comment.span.end) > 0
             {
                 return true;
             }
@@ -260,9 +254,9 @@ impl<'a> Comments<'a> {
                 break;
             }
 
-            if is_own_line_comment(comment, self.source_text) {
+            if is_own_line_comment(comment, &self.source_text) {
                 return false;
-            } else if is_end_of_line_comment(comment, self.source_text) {
+            } else if is_end_of_line_comment(comment, &self.source_text) {
                 return true;
             }
 
@@ -276,8 +270,9 @@ impl<'a> Comments<'a> {
         let mut gap_end = following_start;
         for cur_index in (0..comment_index).rev() {
             let comment = &comments[cur_index];
-            let gap_str = Span::new(comment.span.end, gap_end).source_text(self.source_text);
-            if gap_str.as_bytes().iter().all(|&b| matches!(b, b' ' | b'(')) {
+            if self.source_text.all_bytes_match(comment.span.end, gap_end, |b| {
+                b.is_ascii_whitespace() || b == b'('
+            }) {
                 gap_end = comment.span.start;
             } else {
                 return true;
@@ -293,9 +288,9 @@ impl<'a> Comments<'a> {
                 return false;
             }
 
-            if is_own_line_comment(comment, self.source_text) {
+            if is_own_line_comment(comment, &self.source_text) {
                 return false;
-            } else if is_end_of_line_comment(comment, self.source_text) {
+            } else if is_end_of_line_comment(comment, &self.source_text) {
                 return true;
             }
         }
@@ -319,8 +314,8 @@ impl<'a> Comments<'a> {
     #[inline]
     pub fn is_trailing_line_comment(&self, comment: &Comment) -> bool {
         comment.is_line()
-            && !is_own_line_comment(comment, self.source_text)
-            && is_end_of_line_comment(comment, self.source_text)
+            && !is_own_line_comment(comment, &self.source_text)
+            && is_end_of_line_comment(comment, &self.source_text)
     }
 
     #[inline]
@@ -400,7 +395,7 @@ impl<'a> Comments<'a> {
                 break;
             }
 
-            if is_own_line_comment(comment, source_text) {
+            if is_own_line_comment(comment, &source_text) {
                 // TODO: describe the logic here
                 // Reached an own line comment, which means it is the leading comment for the next node.
 
@@ -411,12 +406,12 @@ impl<'a> Comments<'a> {
                         following_span.start,
                         comment_index,
                         comments,
-                        source_text,
+                        &source_text,
                     );
                 }
 
                 break;
-            } else if is_end_of_line_comment(comment, source_text) {
+            } else if is_end_of_line_comment(comment, &source_text) {
                 if let SiblingNode::IfStatement(if_stmt) = enclosing_node {
                     if if_stmt.consequent.span() == preceding_span {
                         // If comment is after the `else` keyword, it is not a trailing comment of consequent.
@@ -435,7 +430,7 @@ impl<'a> Comments<'a> {
                         following_span.start,
                         comment_index,
                         comments,
-                        source_text,
+                        &source_text,
                     );
                 }
 
@@ -479,8 +474,9 @@ impl<'a> Comments<'a> {
         let mut gap_end = following_span.start;
         for cur_index in (0..comment_index).rev() {
             let comment = &comments[cur_index];
-            let gap_str = Span::new(comment.span.end, gap_end).source_text(source_text);
-            if gap_str.as_bytes().iter().all(|&s| s.is_ascii_whitespace() || s == b'(') {
+            if source_text.all_bytes_match(comment.span.end, gap_end, |b| {
+                b.is_ascii_whitespace() || b == b'('
+            }) {
                 gap_end = comment.span.start;
             } else {
                 // If there is a non-whitespace character, we stop here
@@ -498,7 +494,7 @@ impl<'a> Comments<'a> {
 
     fn is_suppressed_comment(&self, comment: &Comment) -> bool {
         // TODO: should replace `prettier-ignore` with `oxc-formatter-ignore` or something else later.
-        comment.content_span().source_text(self.source_text).trim() == "prettier-ignore"
+        self.source_text.text_for(&comment.content_span()).trim() == "prettier-ignore"
     }
 
     pub fn is_type_cast_comment(&self, comment: &Comment) -> bool {
@@ -509,19 +505,16 @@ impl<'a> Comments<'a> {
             return false;
         }
 
-        let start = comment.span.start as usize;
-        let end = comment.span.end as usize;
-        let bytes = self.source_text.as_bytes();
-
-        for i in start..end {
-            if bytes[i] == b'@'
+        let bytes = self.source_text.text_for(&comment.span).as_bytes();
+        let mut bytes_iter = bytes.iter().enumerate();
+        for (i, &byte) in bytes_iter {
+            if byte == b'@'
                 && (matches_pattern_at(bytes, i, TYPE_PATTERN)
                     || matches_pattern_at(bytes, i, SATISFIES_PATTERN))
             {
                 return true;
             }
         }
-
         false
     }
 
@@ -538,26 +531,17 @@ impl<'a> Comments<'a> {
     pub fn get_type_cast_comment_index(&self, span: Span) -> Option<usize> {
         let start = span.start;
 
-        let mut index = 0;
-        let mut comments =
-            self.unprinted_comments().iter().take_while(|c| c.span.end <= start).peekable();
-
-        while let Some(comment) = comments.next() {
+        let comments = self.unprinted_comments().iter().take_while(|c| c.span.end <= start);
+        for (index, comment) in comments.enumerate() {
             if comment.span.end > start {
                 return None;
             }
 
-            if self.source_text.as_bytes()[comment.span.end as usize
-                ..=comments.peek().map_or(start as usize, |c| c.span.start as usize)]
-                .trim_ascii_start()
-                .first()
-                .is_some_and(|&b| b == b'(')
+            if self.source_text.next_non_whitespace_byte_is(comment.span.end, b'(')
                 && self.is_type_cast_comment(comment)
             {
                 return Some(index);
             }
-
-            index += 1;
         }
 
         None
@@ -579,21 +563,19 @@ fn is_word_boundary_byte(byte: Option<&u8>) -> bool {
 }
 
 fn matches_pattern_at(bytes: &[u8], pos: usize, pattern: &[u8]) -> bool {
-    pos + pattern.len() <= bytes.len()
-        && &bytes[pos..pos + pattern.len()] == pattern
-        && is_word_boundary_byte(bytes.get(pos + pattern.len()))
+    bytes[pos..].starts_with(pattern) && is_word_boundary_byte(bytes.get(pos + pattern.len()))
 }
 
 fn handle_if_and_while_statement_comments<'a>(
     mut end: u32,
     mut comment_index: usize,
     comments: &'a [Comment],
-    source_text: &'a str,
+    source_text: &SourceText,
 ) -> &'a [Comment] {
     // `if (a /* comment before paren */) // comment after paren`
     loop {
         let cur_comment_span = comments[comment_index].span;
-        if source_text.as_bytes()[cur_comment_span.end as usize..end as usize].contains(&b')') {
+        if source_text.bytes_contain(cur_comment_span.end, end, b')') {
             return &comments[..=comment_index];
         }
 
@@ -609,68 +591,12 @@ fn handle_if_and_while_statement_comments<'a>(
     unreachable!()
 }
 
-#[inline]
-pub fn is_new_line(char: char) -> ControlFlow<bool> {
-    if char == ' ' || char == '\t' {
-        ControlFlow::Continue(())
-    } else if char == '\n' || char == '\r' || char == '\u{2028}' || char == '\u{2029}' {
-        ControlFlow::Break(true)
-    } else {
-        ControlFlow::Break(false)
-    }
+pub fn is_own_line_comment(comment: &Comment, source_text: &SourceText) -> bool {
+    source_text.has_newline_before(comment.span.start)
 }
 
-pub fn has_new_line_backward(text: &str) -> bool {
-    let mut chars = text.chars().rev();
-
-    for char in chars {
-        match is_new_line(char) {
-            ControlFlow::Continue(()) => {}
-            ControlFlow::Break(true) => return true,
-            ControlFlow::Break(false) => return false,
-        }
-    }
-
-    false
-}
-
-pub fn has_new_line_forward(text: &str) -> bool {
-    let mut chars = text.chars();
-
-    for char in chars {
-        match is_new_line(char) {
-            ControlFlow::Continue(()) => {}
-            ControlFlow::Break(true) => return true,
-            ControlFlow::Break(false) => return false,
-        }
-    }
-
-    false
-}
-
-pub fn is_own_line_comment(comment: &Comment, source_text: &str) -> bool {
-    let start = comment.span.start;
-    if start == 0 {
-        return false;
-    }
-
-    has_new_line_backward(Span::sized(0, comment.span.start).source_text(source_text))
-}
-
-pub fn is_end_of_line_comment(comment: &Comment, source_text: &str) -> bool {
-    let end = comment.span.end;
-    has_new_line_forward(&source_text[(end as usize)..])
-}
-
-/// Formats a comment as it was in the source document
-pub struct FormatPlainComment<C> {
-    context: PhantomData<C>,
-}
-
-impl<C> Default for FormatPlainComment<C> {
-    fn default() -> Self {
-        FormatPlainComment { context: PhantomData }
-    }
+pub fn is_end_of_line_comment(comment: &Comment, source_text: &SourceText) -> bool {
+    source_text.has_newline_after(comment.span.end)
 }
 
 /// Returns `true` if `comment` is a multi line block comment where each line

--- a/crates/oxc_formatter/src/formatter/context.rs
+++ b/crates/oxc_formatter/src/formatter/context.rs
@@ -10,14 +10,14 @@ use rustc_hash::FxHashMap;
 
 use crate::{formatter::FormatElement, generated::ast_nodes::AstNode, options::FormatOptions};
 
-use super::Comments;
+use super::{Comments, SourceText};
 
 /// Context object storing data relevant when formatting an object.
 #[derive(Clone)]
 pub struct FormatContext<'ast> {
     options: FormatOptions,
 
-    source_text: &'ast str,
+    source_text: SourceText<'ast>,
 
     source_type: SourceType,
 
@@ -46,11 +46,12 @@ impl<'ast> FormatContext<'ast> {
         allocator: &'ast Allocator,
         options: FormatOptions,
     ) -> Self {
+        let source_text = SourceText::new(program.source_text);
         Self {
             options,
-            source_text: program.source_text,
+            source_text,
             source_type: program.source_type,
-            comments: Comments::new(program.source_text, &program.comments),
+            comments: Comments::new(source_text, &program.comments),
             allocator,
             cached_elements: FxHashMap::default(),
         }
@@ -71,8 +72,8 @@ impl<'ast> FormatContext<'ast> {
         &mut self.comments
     }
 
-    /// Returns the formatting options
-    pub fn source_text(&self) -> &'ast str {
+    /// Returns the source text wrapper
+    pub fn source_text(&self) -> SourceText<'ast> {
         self.source_text
     }
 

--- a/crates/oxc_formatter/src/formatter/formatter.rs
+++ b/crates/oxc_formatter/src/formatter/formatter.rs
@@ -7,7 +7,7 @@ use crate::options::FormatOptions;
 
 use super::{
     Arguments, Buffer, Comments, FormatContext, FormatState, FormatStateSnapshot, GroupId,
-    VecBuffer,
+    SourceText, VecBuffer,
     buffer::BufferSnapshot,
     builders::{FillBuilder, JoinBuilder, JoinNodesBuilder, Line},
     prelude::*,
@@ -49,9 +49,9 @@ impl<'buf, 'ast> Formatter<'buf, 'ast> {
         self.state_mut().context_mut()
     }
 
-    /// Returns the source text.
+    /// Returns the source text wrapper.
     #[inline]
-    pub fn source_text(&self) -> &'ast str {
+    pub fn source_text(&self) -> SourceText<'ast> {
         self.context().source_text()
     }
 

--- a/crates/oxc_formatter/src/formatter/mod.rs
+++ b/crates/oxc_formatter/src/formatter/mod.rs
@@ -33,6 +33,7 @@ pub mod prelude;
 pub mod printed_tokens;
 pub mod printer;
 pub mod separated;
+mod source_text;
 mod state;
 mod syntax_element_key;
 mod syntax_node;
@@ -65,6 +66,7 @@ pub use self::{
     context::FormatContext,
     diagnostics::{ActualStart, FormatError, InvalidDocumentError, PrintError},
     formatter::Formatter,
+    source_text::SourceText,
     state::{FormatState, FormatStateSnapshot},
     syntax_node::SyntaxNode,
     syntax_token::SyntaxToken,

--- a/crates/oxc_formatter/src/formatter/source_text.rs
+++ b/crates/oxc_formatter/src/formatter/source_text.rs
@@ -1,0 +1,193 @@
+use std::ops::Deref;
+
+use oxc_ast::Comment;
+use oxc_span::{GetSpan, Span};
+use oxc_syntax::identifier::{is_line_terminator, is_white_space_single_line};
+
+use super::Comments;
+
+/// Source text wrapper providing utilities for text analysis in the formatter.
+#[derive(Debug, Clone, Copy)]
+pub struct SourceText<'a> {
+    text: &'a str,
+}
+
+impl Deref for SourceText<'_> {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.text
+    }
+}
+
+impl<'a> SourceText<'a> {
+    /// Create a new SourceText wrapper
+    pub fn new(text: &'a str) -> Self {
+        Self { text }
+    }
+
+    /// Extract text for an object that has a span
+    pub fn text_for<T: GetSpan>(&self, obj: &T) -> &'a str {
+        obj.span().source_text(self.text)
+    }
+
+    // Text slicing
+    /// Get text from position to end
+    pub fn slice_from(&self, position: u32) -> &'a str {
+        &self.text[position as usize..]
+    }
+
+    /// Get text from start to position
+    pub fn slice_to(&self, position: u32) -> &'a str {
+        &self.text[..position as usize]
+    }
+
+    /// Get text between two positions
+    pub fn slice_range(&self, start: u32, end: u32) -> &'a str {
+        &self.text[start as usize..end as usize]
+    }
+
+    // Byte slicing
+    /// Get bytes from position to end
+    pub fn bytes_from(&self, position: u32) -> &'a [u8] {
+        &self.text.as_bytes()[position as usize..]
+    }
+
+    /// Get bytes from start to position
+    pub fn bytes_to(&self, position: u32) -> &'a [u8] {
+        &self.text.as_bytes()[..position as usize]
+    }
+
+    /// Get bytes between two positions
+    pub fn bytes_range(&self, start: u32, end: u32) -> &'a [u8] {
+        &self.text.as_bytes()[start as usize..end as usize]
+    }
+
+    // Byte checking
+    /// Check if first non-whitespace byte at position matches expected
+    pub fn next_non_whitespace_byte_is(&self, position: u32, expected_byte: u8) -> bool {
+        self.bytes_from(position).trim_ascii_start().first().is_some_and(|&b| b == expected_byte)
+    }
+
+    /// Get first byte at position
+    pub fn byte_at(&self, position: u32) -> Option<u8> {
+        self.bytes_from(position).first().copied()
+    }
+
+    // Newline detection
+    /// Check if span contains line terminators
+    pub fn contains_newline(&self, span: Span) -> bool {
+        self.contains_newline_between(span.start, span.end)
+    }
+
+    /// Check if range contains line terminators
+    pub fn contains_newline_between(&self, start: u32, end: u32) -> bool {
+        self.slice_range(start, end).chars().any(is_line_terminator)
+    }
+
+    /// Check for newlines before position, stopping at first non-whitespace
+    pub fn has_newline_before(&self, position: u32) -> bool {
+        for &byte in self.bytes_to(position).iter().rev() {
+            match byte {
+                b'\n' | b'\r' => return true,
+                b' ' | b'\t' => {}
+                _ => return false,
+            }
+        }
+        false
+    }
+
+    /// Check for newlines after position, stopping at first non-whitespace
+    pub fn has_newline_after(&self, position: u32) -> bool {
+        for &byte in self.bytes_from(position) {
+            match byte {
+                b'\n' | b'\r' => return true,
+                b' ' | b'\t' => {}
+                _ => return false,
+            }
+        }
+        false
+    }
+
+    // Byte range operations
+    /// Check if byte range contains specific byte
+    pub fn bytes_contain(&self, start: u32, end: u32, byte: u8) -> bool {
+        self.bytes_range(start, end).contains(&byte)
+    }
+
+    /// Check if all bytes in range match predicate
+    pub fn all_bytes_match<F>(&self, start: u32, end: u32, predicate: F) -> bool
+    where
+        F: Fn(u8) -> bool,
+    {
+        self.bytes_range(start, end).iter().all(|&b| predicate(b))
+    }
+
+    // Utility methods
+    /// Get character count of span
+    pub fn span_width(&self, span: Span) -> usize {
+        self.text_for(&span).chars().count()
+    }
+
+    /// Count consecutive line breaks after position
+    pub fn lines_after(&self, end: u32) -> usize {
+        self.slice_from(end)
+            .chars()
+            .filter(|&c| !is_white_space_single_line(c))
+            .take_while(|&c| is_line_terminator(c))
+            .count()
+    }
+
+    /// Count line breaks between syntax nodes, considering comments and parentheses
+    pub fn get_lines_before(&self, span: Span, comments: &Comments) -> usize {
+        let mut start = span.start;
+
+        let comments = comments.unprinted_comments();
+
+        // Should skip the leading comments of the node.
+        if let Some(comment) = comments.first() {
+            if comment.span.end < start {
+                start = comment.span.start;
+            }
+        }
+
+        // Count the newlines in the leading trivia of the next node
+        let mut count = 0;
+        let mut following_source = self.bytes_from(span.end).iter();
+        for c in self.slice_to(start).chars().rev() {
+            if is_white_space_single_line(c) {
+                continue;
+            }
+
+            if c == '(' {
+                // We don't have a parenthesis node when `preserveParens` is turned off,
+                // but we will find the `(` and `)` around the node if it exists.
+                // If we find a `(`, we try to find the matching `)` and reset the count.
+                // This is necessary to avoid counting the newlines inside the parenthesis.
+
+                for c in following_source.by_ref() {
+                    if c.is_ascii_whitespace() {
+                        continue;
+                    }
+
+                    if c == &b')' {
+                        break;
+                    }
+
+                    return count;
+                }
+
+                count = 0;
+                continue;
+            }
+
+            if !is_line_terminator(c) {
+                return count;
+            }
+
+            count += 1;
+        }
+
+        count
+    }
+}

--- a/crates/oxc_formatter/src/formatter/trivia.rs
+++ b/crates/oxc_formatter/src/formatter/trivia.rs
@@ -13,7 +13,7 @@ use crate::{
     write,
 };
 
-use super::{Argument, Arguments, GroupId, SyntaxToken, prelude::*};
+use super::{Argument, Arguments, GroupId, SourceText, SyntaxToken, prelude::*};
 
 /// Returns true if:
 /// - `next_comment` is Some, and
@@ -33,13 +33,13 @@ use super::{Argument, Arguments, GroupId, SyntaxToken, prelude::*};
 fn should_nestle_adjacent_doc_comments(
     current: &Comment,
     next: &Comment,
-    source_text: &str,
+    source_text: &SourceText,
 ) -> bool {
     matches!(current.content, CommentContent::Jsdoc)
         && matches!(next.content, CommentContent::Jsdoc)
         && current.span.end == next.span.start
-        && current.span.source_text(source_text).contains('\n')
-        && next.span.source_text(source_text).contains('\n')
+        && source_text.contains_newline(current.span)
+        && source_text.contains_newline(next.span)
 }
 
 /// Formats the leading comments of `node`
@@ -66,31 +66,29 @@ impl<'a> Format<'a> for FormatLeadingComments<'a> {
                 write!(f, comment)?;
 
                 match comment.kind {
-                    CommentKind::Block => {
-                        match get_lines_after(comment.span.end, f.source_text()) {
-                            0 => {
-                                let should_nestle =
-                                    leading_comments_iter.peek().is_some_and(|next_comment| {
-                                        should_nestle_adjacent_doc_comments(
-                                            comment,
-                                            next_comment,
-                                            f.source_text(),
-                                        )
-                                    });
+                    CommentKind::Block => match f.source_text().lines_after(comment.span.end) {
+                        0 => {
+                            let should_nestle =
+                                leading_comments_iter.peek().is_some_and(|next_comment| {
+                                    should_nestle_adjacent_doc_comments(
+                                        comment,
+                                        next_comment,
+                                        &f.source_text(),
+                                    )
+                                });
 
-                                write!(f, [maybe_space(!should_nestle)])?;
-                            }
-                            1 => {
-                                if get_lines_before(comment.span, f) == 0 {
-                                    write!(f, [soft_line_break_or_space()])?;
-                                } else {
-                                    write!(f, [hard_line_break()])?;
-                                }
-                            }
-                            _ => write!(f, [empty_line()])?,
+                            write!(f, [maybe_space(!should_nestle)])?;
                         }
-                    }
-                    CommentKind::Line => match get_lines_after(comment.span.end, f.source_text()) {
+                        1 => {
+                            if f.source_text().get_lines_before(comment.span, f.comments()) == 0 {
+                                write!(f, [soft_line_break_or_space()])?;
+                            } else {
+                                write!(f, [hard_line_break()])?;
+                            }
+                        }
+                        _ => write!(f, [empty_line()])?,
+                    },
+                    CommentKind::Line => match f.source_text().lines_after(comment.span.end) {
                         0 | 1 => write!(f, [hard_line_break()])?,
                         _ => write!(f, [empty_line()])?,
                     },
@@ -139,11 +137,11 @@ impl<'a> Format<'a> for FormatTrailingComments<'a, '_> {
             for comment in comments {
                 f.context_mut().comments_mut().increment_printed_count();
 
-                let lines_before = get_lines_before(comment.span, f);
+                let lines_before = f.source_text().get_lines_before(comment.span, f.comments());
                 total_lines_before += lines_before;
 
                 let should_nestle = previous_comment.is_some_and(|previous_comment| {
-                    should_nestle_adjacent_doc_comments(previous_comment, comment, f.source_text())
+                    should_nestle_adjacent_doc_comments(previous_comment, comment, &f.source_text())
                 });
 
                 // This allows comments at the end of nested structures:
@@ -316,7 +314,7 @@ impl<'a> Format<'a> for FormatDanglingComments<'a> {
                         should_nestle_adjacent_doc_comments(
                             previous_comment,
                             comment,
-                            f.source_text(),
+                            &f.source_text(),
                         )
                     });
 
@@ -627,7 +625,7 @@ impl Format<'_> for FormatSkippedTokenTrivia {
 impl<'a> Format<'a> for Comment {
     #[expect(clippy::cast_possible_truncation)]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        let source_text = self.span.source_text(f.source_text()).trim_end();
+        let source_text = f.source_text().text_for(&self.span).trim_end();
         if is_alignable_comment(source_text) {
             let mut source_offset = self.span.start;
 

--- a/crates/oxc_formatter/src/utils/assignment_like.rs
+++ b/crates/oxc_formatter/src/utils/assignment_like.rs
@@ -172,7 +172,7 @@ impl<'a> AssignmentLike<'a, '_> {
                     if property.shorthand {
                         Ok(false)
                     } else {
-                        Ok(property.key.span().source_text(f.source_text()).width() + 2
+                        Ok(f.source_text().span_width(property.key.span()) + 2
                             < text_width_for_break)
                     }
                 } else if property.shorthand {
@@ -534,8 +534,8 @@ fn should_break_after_operator<'a>(
 
     for comment in f.comments().comments_before(right.span().start) {
         if !is_jsx
-            && (get_lines_after(comment.span.end, f.source_text()) > 0
-                || is_own_line_comment(comment, f.source_text()))
+            && (f.source_text().lines_after(comment.span.end) > 0
+                || is_own_line_comment(comment, &f.source_text()))
         {
             return true;
         }
@@ -837,7 +837,7 @@ fn is_short_argument(argument: &Argument, threshold: u16, f: &Formatter) -> bool
         Argument::RegExpLiteral(regex) => regex.regex.pattern.text.len() <= threshold as usize,
         Argument::StringLiteral(literal) => {
             let formatter = FormatLiteralStringToken::new(
-                literal.span.source_text(f.source_text()),
+                f.source_text().text_for(literal.as_ref()),
                 literal.span,
                 false,
                 StringLiteralParentKind::Expression,

--- a/crates/oxc_formatter/src/utils/conditional.rs
+++ b/crates/oxc_formatter/src/utils/conditional.rs
@@ -140,10 +140,8 @@ fn format_trailing_comments<'a>(
             //   |        |        |
             //   |        |        |
             //  these are the gaps between comments
-            let gap_str = &source_text.as_bytes()[start as usize..comment.span.start as usize];
-
             // If this comment is in a new line, we stop here and return the comments before this comment
-            if gap_str.contains(&b'\n') {
+            if source_text.contains_newline_between(start, comment.span.start) {
                 return &comments[..index];
             }
             // If this comment is a line comment, then it is a end of line comment, so we stop here and return the comments with this comment
@@ -151,7 +149,7 @@ fn format_trailing_comments<'a>(
                 return &comments[..=index];
             }
             // Store the index of the comment before the operator, if no line comment or no new line is found, then return all comments before operator
-            else if gap_str.contains(&operator) {
+            else if source_text.bytes_contain(start, comment.span.start, operator) {
                 index_before_operator = Some(index + 1);
             }
 

--- a/crates/oxc_formatter/src/utils/member_chain/groups.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/groups.rs
@@ -4,7 +4,7 @@ use oxc_span::{GetSpan, Span};
 
 use super::chain_member::ChainMember;
 use crate::{
-    formatter::{Format, FormatResult, Formatter, prelude::*},
+    formatter::{Format, FormatResult, Formatter, SourceText, prelude::*},
     generated::ast_nodes::AstNode,
     parentheses::NeedsParentheses,
     write,
@@ -192,7 +192,7 @@ impl<'a, 'b> MemberChainGroup<'a, 'b> {
             return false;
         };
 
-        let source_text = f.source_text().as_bytes();
+        let source = f.source_text();
 
         // `A \n\n/* comment . */ . / comment . */ B`
         //    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -210,7 +210,7 @@ impl<'a, 'b> MemberChainGroup<'a, 'b> {
                 end = last_comment.span.start - 1;
                 last_comment_span = comments.next_back();
                 continue;
-            } else if matches!(source_text[end as usize], b'.') {
+            } else if matches!(source.byte_at(end), Some(b'.')) {
                 // Found the operator, stop the loop
                 break;
             }
@@ -225,7 +225,7 @@ impl<'a, 'b> MemberChainGroup<'a, 'b> {
 
         // Count the number of continuous new lines
         let mut new_lines_count = 0;
-        for &b in &source_text[start as usize..end as usize] {
+        for &b in source.bytes_range(start, end) {
             if matches!(b, b'\n' | b'\r') {
                 new_lines_count += 1;
                 // If there are more than 1 continuous new lines, return true

--- a/crates/oxc_formatter/src/utils/member_chain/mod.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/mod.rs
@@ -6,7 +6,7 @@ use std::iter;
 
 use crate::{
     JsLabels, best_fitting,
-    formatter::{Buffer, Format, FormatResult, Formatter, prelude::*},
+    formatter::{Buffer, Format, FormatResult, Formatter, SourceText, prelude::*},
     generated::ast_nodes::{AstNode, AstNodes},
     utils::{
         call_expression::is_test_call_expression,
@@ -416,10 +416,7 @@ fn chain_members_iter<'a, 'b>(
                 .printed_comments()
                 .last()
                 .is_some_and(|c| f.comments().is_type_cast_comment(c))
-                && f.source_text().as_bytes()[expression.span().end as usize..]
-                    .trim_ascii_start()
-                    .first()
-                    .is_some_and(|&b| b == b')')
+                && f.source_text().next_non_whitespace_byte_is(expression.span().end, b')')
         {
             return ChainMember::Node(expression).into();
         }

--- a/crates/oxc_formatter/src/utils/object.rs
+++ b/crates/oxc_formatter/src/utils/object.rs
@@ -16,7 +16,7 @@ pub fn format_property_key<'a>(
 ) -> FormatResult<()> {
     if let PropertyKey::StringLiteral(s) = key.as_ref() {
         FormatLiteralStringToken::new(
-            s.span.source_text(f.source_text()),
+            f.source_text().text_for(s.as_ref()),
             s.span,
             /* jsx */
             false,
@@ -34,7 +34,7 @@ pub fn write_member_name<'a>(
 ) -> FormatResult<usize> {
     if let AstNodes::StringLiteral(string) = key.as_ast_nodes() {
         let format = FormatLiteralStringToken::new(
-            string.span.source_text(f.source_text()),
+            f.source_text().text_for(string),
             string.span,
             false,
             StringLiteralParentKind::Member,
@@ -49,6 +49,6 @@ pub fn write_member_name<'a>(
     } else {
         write!(f, key)?;
 
-        Ok(key.span().source_text(f.source_text()).width())
+        Ok(f.source_text().span_width(key.span()))
     }
 }

--- a/crates/oxc_formatter/src/utils/suppressed.rs
+++ b/crates/oxc_formatter/src/utils/suppressed.rs
@@ -16,7 +16,7 @@ impl FormatSuppressedNode {
 
 impl<'a> Format<'a> for FormatSuppressedNode {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [dynamic_text(self.0.span().source_text(f.source_text()))]);
+        write!(f, [dynamic_text(f.source_text().text_for(&self.0))]);
 
         // The suppressed node contains comments that should be marked as printed.
         mark_comments_as_printed_before(self.0.end, f);

--- a/crates/oxc_formatter/src/write/array_element_list.rs
+++ b/crates/oxc_formatter/src/write/array_element_list.rs
@@ -52,7 +52,7 @@ impl<'a> Format<'a> for ArrayElementList<'a, '_> {
                 {
                     filler.entry(
                         &format_once(|f| {
-                            if get_lines_before(element.span(), f) > 1 {
+                            if f.source_text().get_lines_before(element.span(), f.comments()) > 1 {
                                 write!(f, empty_line())
                             } else if f
                                 .comments()

--- a/crates/oxc_formatter/src/write/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/write/arrow_function_expression.rs
@@ -6,12 +6,10 @@ use oxc_span::GetSpan;
 use crate::{
     format_args,
     formatter::{
-        Buffer, Comments, Format, FormatError, FormatResult, Formatter,
+        Buffer, Comments, Format, FormatError, FormatResult, Formatter, SourceText,
         buffer::RemoveSoftLinesBuffer,
-        comments::has_new_line_backward,
         prelude::*,
         trivia::{FormatLeadingComments, format_trailing_comments},
-        write,
     },
     generated::ast_nodes::{AstNode, AstNodes},
     options::FormatTrailingCommas,
@@ -174,14 +172,14 @@ impl<'a> Format<'a> for FormatJsArrowFunctionExpression<'a, '_> {
                             is_multiline_template_starting_on_same_line(
                                 template.span.start,
                                 template,
-                                f.source_text(),
+                                &f.source_text(),
                             )
                         }
                         Expression::TaggedTemplateExpression(template) => {
                             is_multiline_template_starting_on_same_line(
                                 template.span.start,
                                 &template.quasi,
-                                f.source_text(),
+                                &f.source_text(),
                             )
                         }
                         _ => false,
@@ -398,10 +396,10 @@ impl<'a, 'b> ArrowFunctionLayout<'a, 'b> {
 pub fn is_multiline_template_starting_on_same_line(
     start: u32,
     template: &TemplateLiteral,
-    source_text: &str,
+    source_text: &SourceText,
 ) -> bool {
-    template.quasis.iter().any(|quasi| quasi.value.raw.contains('\n'))
-        && !has_new_line_backward(&source_text[..start as usize])
+    template.quasis.iter().any(|quasi| source_text.contains_newline(quasi.span))
+        && !source_text.has_newline_before(start)
 }
 
 struct ArrowChain<'a, 'b> {

--- a/crates/oxc_formatter/src/write/decorators.rs
+++ b/crates/oxc_formatter/src/write/decorators.rs
@@ -63,5 +63,5 @@ fn should_expand_decorators<'a>(
     decorators: &AstNode<'a, Vec<'a, Decorator<'a>>>,
     f: &Formatter<'_, 'a>,
 ) -> bool {
-    decorators.iter().any(|decorator| get_lines_after(decorator.span().end, f.source_text()) > 0)
+    decorators.iter().any(|decorator| f.source_text().lines_after(decorator.span().end) > 0)
 }

--- a/crates/oxc_formatter/src/write/export_declarations.rs
+++ b/crates/oxc_formatter/src/write/export_declarations.rs
@@ -149,7 +149,9 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, ExportSpecifier<'a>>> {
                             let comments =
                                 f.context().comments().comments_before(specifier.span().start);
                             if !comments.is_empty() {
-                                if get_lines_before(comments[0].span, f) > 1 {
+                                if f.source_text().get_lines_before(comments[0].span, f.comments())
+                                    > 1
+                                {
                                     write!(f, [empty_line()])?;
                                 }
                                 write!(f, [FormatLeadingComments::Comments(comments)])?;

--- a/crates/oxc_formatter/src/write/import_declaration.rs
+++ b/crates/oxc_formatter/src/write/import_declaration.rs
@@ -96,7 +96,10 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, ImportDeclarationSpecifier<'a>>> {
                                             .comments()
                                             .comments_before(specifier.span().start);
                                         if !comments.is_empty() {
-                                            if f.source_text().get_lines_before(comments[0].span, f.comments()) > 1 {
+                                            if f.source_text()
+                                                .get_lines_before(comments[0].span, f.comments())
+                                                > 1
+                                            {
                                                 write!(f, [empty_line()])?;
                                             }
                                             write!(f, [FormatLeadingComments::Comments(comments)])?;

--- a/crates/oxc_formatter/src/write/import_declaration.rs
+++ b/crates/oxc_formatter/src/write/import_declaration.rs
@@ -96,7 +96,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, ImportDeclarationSpecifier<'a>>> {
                                             .comments()
                                             .comments_before(specifier.span().start);
                                         if !comments.is_empty() {
-                                            if get_lines_before(comments[0].span, f) > 1 {
+                                            if f.source_text().get_lines_before(comments[0].span, f.comments()) > 1 {
                                                 write!(f, [empty_line()])?;
                                             }
                                             write!(f, [FormatLeadingComments::Comments(comments)])?;

--- a/crates/oxc_formatter/src/write/mod.rs
+++ b/crates/oxc_formatter/src/write/mod.rs
@@ -743,8 +743,8 @@ impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
                 || comments.last().is_some_and(|last_comment| {
                     // Ensure the comments are placed before the else keyword or on a new line
                     let gap_str =
-                        &f.source_text()[last_comment.span.end as usize..alternate_start as usize];
-                    gap_str.contains("else") || gap_str.contains('\n')
+                        f.source_text().slice_range(last_comment.span.end, alternate_start);
+                    gap_str.contains("else") || f.source_text().contains_newline_between(last_comment.span.end, alternate_start)
                 });
 
             let else_on_same_line =
@@ -1091,7 +1091,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, NullLiteral> {
 impl<'a> FormatWrite<'a> for AstNode<'a, NumericLiteral<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         format_number_token(
-            self.span().source_text(f.source_text()),
+            f.source_text().text_for(self),
             self.span(),
             NumberFormatOptions::default().keep_one_trailing_decimal_zero(),
         )
@@ -1103,7 +1103,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, StringLiteral<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_jsx = matches!(self.parent, AstNodes::JSXAttribute(_));
         FormatLiteralStringToken::new(
-            self.span().source_text(f.source_text()),
+            f.source_text().text_for(self),
             self.span(),
             /* jsx */
             is_jsx,

--- a/crates/oxc_formatter/src/write/mod.rs
+++ b/crates/oxc_formatter/src/write/mod.rs
@@ -744,7 +744,9 @@ impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
                     // Ensure the comments are placed before the else keyword or on a new line
                     let gap_str =
                         f.source_text().slice_range(last_comment.span.end, alternate_start);
-                    gap_str.contains("else") || f.source_text().contains_newline_between(last_comment.span.end, alternate_start)
+                    gap_str.contains("else")
+                        || f.source_text()
+                            .contains_newline_between(last_comment.span.end, alternate_start)
                 });
 
             let else_on_same_line =

--- a/crates/oxc_formatter/src/write/object_like.rs
+++ b/crates/oxc_formatter/src/write/object_like.rs
@@ -48,17 +48,12 @@ impl<'a> ObjectLike<'a, '_> {
     }
 
     fn members_have_leading_newline(&self, f: &Formatter<'_, 'a>) -> bool {
-        // TODO: Polish the code
         match self {
             Self::ObjectExpression(o) => o.as_ref().properties.first().is_some_and(|p| {
-                Span::new(o.span().start, p.span().start)
-                    .source_text(f.source_text())
-                    .contains('\n')
+                f.source_text().contains_newline_between(o.span.start, p.span().start)
             }),
             Self::TSTypeLiteral(o) => o.as_ref().members.first().is_some_and(|p| {
-                Span::new(o.span().start, p.span().start)
-                    .source_text(f.source_text())
-                    .contains('\n')
+                f.source_text().contains_newline_between(o.span().start, p.span().start)
             }),
         }
     }

--- a/crates/oxc_formatter/src/write/program.rs
+++ b/crates/oxc_formatter/src/write/program.rs
@@ -114,7 +114,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, Directive<'a>>> {
         // so we should keep an extra empty line after JsDirectiveList
         let source_text = f.context().source_text();
         let mut count = 0;
-        let mut source_text_chars = source_text[last_directive.span.end as usize..].chars();
+        let mut source_text_chars = source_text.slice_from(last_directive.span.end).chars();
         for char in source_text_chars.by_ref() {
             if is_line_terminator(char) {
                 count += 1;
@@ -135,7 +135,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, Directive<'a>> {
             f,
             [
                 FormatLiteralStringToken::new(
-                    self.expression().span().source_text(f.source_text()),
+                    f.source_text().text_for(self.expression()),
                     self.expression().span(),
                     /* jsx */
                     false,
@@ -151,7 +151,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, Hashbang<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         write!(f, ["#!", dynamic_text(self.value().as_str().trim_end())])?;
 
-        if get_lines_after(self.span.end, f.source_text()) > 1 {
+        if f.source_text().lines_after(self.span.end) > 1 {
             write!(f, [empty_line()])
         } else {
             write!(f, [hard_line_break()])

--- a/crates/oxc_formatter/src/write/return_or_throw_statement.rs
+++ b/crates/oxc_formatter/src/write/return_or_throw_statement.rs
@@ -6,10 +6,7 @@ use crate::{
     Format, FormatResult, format_args,
     formatter::{
         Formatter,
-        comments::{
-            Comments, has_new_line_forward, is_end_of_line_comment, is_new_line,
-            is_own_line_comment,
-        },
+        comments::{Comments, is_end_of_line_comment, is_own_line_comment},
         prelude::*,
     },
     generated::ast_nodes::AstNode,
@@ -132,12 +129,12 @@ fn has_argument_leading_comments(argument: &AstNode<Expression>, f: &Formatter<'
         let comments = f.comments().comments_before(start);
 
         let is_line_comment_or_multi_line_comment = |comments: &[Comment]| {
-            comments.iter().any(|comment| {
-                comment.is_line()
-                    || comment.span.source_text(source_text).chars().any(is_line_terminator)
-            }) || comments
-                .last()
-                .is_some_and(|comment| is_end_of_line_comment(comment, source_text))
+            comments
+                .iter()
+                .any(|comment| comment.is_line() || source_text.contains_newline(comment.span))
+                || comments
+                    .last()
+                    .is_some_and(|comment| is_end_of_line_comment(comment, &source_text))
         };
 
         if is_line_comment_or_multi_line_comment(comments) {

--- a/crates/oxc_formatter/src/write/template.rs
+++ b/crates/oxc_formatter/src/write/template.rs
@@ -339,18 +339,9 @@ impl<'a> TemplateExpression<'a, '_> {
                     Expression::ConditionalExpression(_)
                         | Expression::ArrowFunctionExpression(_)
                         | Expression::FunctionExpression(_)
-                )
-                // TODO: improve this
-                || f.source_text()[..e.span().start as usize]
-                    .chars()
-                    .rev()
-                    .take_while(|c| *c != '{')
-                    .any(is_line_terminator)
-                    || f.source_text()[e.span().end as usize..]
-                        .chars()
-                        .take_while(|c| *c != '}')
-                        .any(is_line_terminator)
-                    || e.span().source_text(f.source_text()).chars().any(is_line_terminator)
+                ) || f.source_text().has_newline_before(e.span().start)
+                    || f.source_text().has_newline_after(e.span().end)
+                    || f.source_text().contains_newline(e.span())
             }
             TemplateExpression::TSType(t) => {
                 matches!(

--- a/crates/oxc_formatter/src/write/try_statement.rs
+++ b/crates/oxc_formatter/src/write/try_statement.rs
@@ -65,15 +65,15 @@ impl<'a> FormatWrite<'a> for AstNode<'a, CatchParameter<'a>> {
         let span = self.pattern.span();
 
         let leading_comments = f.context().comments().comments_before(span.start);
-        let leading_comment_with_break = leading_comments.iter().any(|comment| {
-            comment.is_line() || get_lines_after(comment.span.end, f.source_text()) > 0
-        });
+        let leading_comment_with_break = leading_comments
+            .iter()
+            .any(|comment| comment.is_line() || f.source_text().lines_after(comment.span.end) > 0);
 
         let trailing_comments =
             f.context().comments().comments_before_character(self.span().end, b')');
-        let trailing_comment_with_break = trailing_comments
-            .iter()
-            .any(|comment| comment.is_line() || get_lines_before(comment.span, f) > 0);
+        let trailing_comment_with_break = trailing_comments.iter().any(|comment| {
+            comment.is_line() || f.source_text().get_lines_before(comment.span, f.comments()) > 0
+        });
 
         if leading_comment_with_break || trailing_comment_with_break {
             write!(

--- a/crates/oxc_formatter/src/write/utils/array.rs
+++ b/crates/oxc_formatter/src/write/utils/array.rs
@@ -54,7 +54,8 @@ where
                         let next_span =
                             array_iter.peek().map_or(SPAN, |e| e.1.map_or(SPAN, GetSpan::span));
 
-                        let comma_position = source_text.as_bytes()[..next_span.start as usize]
+                        let comma_position = source_text
+                            .bytes_to(next_span.start)
                             .iter()
                             .rev()
                             .position(|c| *c == b',');


### PR DESCRIPTION
This PR introduces a new `SourceText` wrapper to encapsulate string operations and centralize logic related to analyzing and manipulating source code. The changes simplify and improve the handling of comments, line breaks, and byte-level operations.

