### PR TITLE
refactor(linter): add `--experimental-js-plugins` CLI arg

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -50,6 +50,10 @@ pub struct LintCommand {
     #[bpaf(switch, hide_usage)]
     pub type_aware: bool,
 
+    /// Enables JS plugins.
+    #[bpaf(switch, hide)]
+    pub experimental_js_plugins: bool,
+
     #[bpaf(external)]
     pub inline_config_options: InlineConfigOptions,
 

--- a/napi/oxlint2/test/e2e.test.ts
+++ b/napi/oxlint2/test/e2e.test.ts
@@ -8,7 +8,7 @@ const PACKAGE_ROOT_PATH = path.dirname(import.meta.dirname);
 const ENTRY_POINT_PATH = path.join(PACKAGE_ROOT_PATH, 'dist/index.js');
 
 async function runOxlint(cwd: string, args: string[] = []) {
-  return await execa('node', [ENTRY_POINT_PATH, ...args], {
+  return await execa('node', [ENTRY_POINT_PATH, '--experimental-js-plugins', ...args], {
     cwd: path.join(PACKAGE_ROOT_PATH, cwd),
     reject: false,
   });


### PR DESCRIPTION
Add `--experimental-js-plugins` CLI option to `oxlint`.

At present this option is hidden in the CLI's `--help` output.

If this option is not present, `ExternalLinter` is dropped, which disables JS plugins.

Therefore, JS plugins are only enabled, and code related to them (e.g. fixed size allocators) runs only if both:

1. `oxlint` is run via `napi/oxlint2`.
2. `--experimental-js-plugins` CLI option is present.

This prepares the way for switching `oxlint` over to `napi/oxlint2`.
