### PR TITLE
build(napi/oxlint): do not fully minify JS code

### DIFF
--- a/napi/oxlint2/tsdown.config.ts
+++ b/napi/oxlint2/tsdown.config.ts
@@ -19,5 +19,5 @@ export default defineConfig({
   ],
   // At present only compress syntax.
   // Don't mangle identifiers or remove whitespace, so `dist` code remains somewhat readable.
-  minify: { compress: true },
+  minify: { compress: true, mangle: false, codegen: { removeWhitespace: false } },
 });


### PR DESCRIPTION
Alter TSDown settings for `napi/oxlint2`.

We intended the code to be minified, but not to have symbols mangled, or whitespace removed, so it remains somewhat readable. It seems that TSDown may have changed how it handles these options, as `minify: { compress: true }` now turns on mangling and whitespace removal.

Alter the TSDown options to get the intended output.
