### PR TITLE
feat(napi/oxlint2): lazy-load code for handling JS plugins

### DIFF
--- a/napi/oxlint2/src-js/index.ts
+++ b/napi/oxlint2/src-js/index.ts
@@ -1,8 +1,26 @@
+import { createRequire } from 'node:module';
 import { lint } from './bindings.js';
-import { lintFile, loadPlugin } from './plugins/index.js';
+
+// Lazy-load `loadPlugin` and `lintFile` functions, on first call to `loadPlugin`.
+// This avoids loading this code if user doesn't utilize JS plugins.
+let loadPlugin: typeof loadPluginWrapper | null = null;
+let lintFile: typeof lintFileWrapper | null = null;
+
+function loadPluginWrapper(path: string): Promise<string> {
+  if (loadPlugin === null) {
+    const require = createRequire(import.meta.url);
+    ({ loadPlugin, lintFile } = require('./plugins/index.js'));
+  }
+  return loadPlugin(path);
+}
+
+function lintFileWrapper(filePath: string, bufferId: number, buffer: Uint8Array | null, ruleIds: number[]): string {
+  // `lintFile` is never called without `loadPlugin` being called first, so `lintFile` must be defined here
+  return lintFile(filePath, bufferId, buffer, ruleIds);
+}
 
 // Call Rust, passing `loadPlugin` and `lintFile` as callbacks
-const success = await lint(loadPlugin, lintFile);
+const success = await lint(loadPluginWrapper, lintFileWrapper);
 
 // Note: It's recommended to set `process.exitCode` instead of calling `process.exit()`.
 // `process.exit()` kills the process immediately and `stdout` may not be flushed before process dies.

--- a/napi/oxlint2/tsdown.config.ts
+++ b/napi/oxlint2/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  entry: ['src-js/index.ts'],
+  entry: ['src-js/index.ts', 'src-js/plugins/index.ts'],
   format: ['esm'],
   platform: 'node',
   target: 'node20',


### PR DESCRIPTION
`napi/oxlint2` will soon become the default version of `oxlint`. It will support JS plugins, but only behind an `--experimental-js-plugins` option. Most users will not be using JS plugins.

Therefore, don't load the code for loading/running JS plugins upfront. Instead, lazy-load the code when Rust first calls into JS asking it to load a JS plugin. This means the addition of JS plugin support should not affect perf for users who aren't using JS plugins.