### PR TITLE
fix(oxfmt): Set preserve_parens: false to prevent panic

### DIFF
--- a/apps/oxfmt/src/service.rs
+++ b/apps/oxfmt/src/service.rs
@@ -43,10 +43,12 @@ impl FormatService {
 
             let ret = Parser::new(&allocator, &source_text, source_type)
                 .with_options(ParseOptions {
+                    parse_regular_expression: false,
                     // Enable all syntax features
                     allow_v8_intrinsics: true,
                     allow_return_outside_function: true,
-                    ..ParseOptions::default()
+                    // `oxc_formatter` expects this to be false
+                    preserve_parens: false,
                 })
                 .parse();
             if !ret.errors.is_empty() {


### PR DESCRIPTION
I tried `oxfmt` on Prettier repo and found this error.

```
❯ npx oxfmt@latest src/**/*.js -c
Checking formatting...

thread '<unnamed>' panicked at crates/oxc_formatter/src/parentheses/expression.rs:523:9:
internal error: entered unreachable code: Already disabled `preserveParens` option in the parser
```
