### PR TITLE
feat(oxfmt): Support --no-error-on-unmatched-pattern

### DIFF
--- a/apps/oxfmt/src/command.rs
+++ b/apps/oxfmt/src/command.rs
@@ -35,12 +35,12 @@ pub struct FormatCommand {
 /// Output Options
 #[derive(Debug, Clone, Bpaf)]
 pub enum OutputOptions {
+    /// Default - when no output option is specified, behaves like `--check`
     #[bpaf(hide)]
     Default,
     /// Check mode - check if files are formatted
     #[bpaf(long, short)]
     Check,
-    // -l, --list-different
     /// List mode - list files that would be changed
     #[bpaf(long, short)]
     ListDifferent,
@@ -52,6 +52,9 @@ pub enum OutputOptions {
 /// Miscellaneous
 #[derive(Debug, Clone, Bpaf)]
 pub struct MiscOptions {
+    /// Do not exit with error when pattern is unmatched
+    #[bpaf(switch, hide_usage)]
+    pub no_error_on_unmatched_pattern: bool,
     /// Number of threads to use. Set to 1 for using only 1 CPU core
     #[bpaf(argument("INT"), hide_usage)]
     pub threads: Option<usize>,

--- a/apps/oxfmt/src/result.rs
+++ b/apps/oxfmt/src/result.rs
@@ -5,21 +5,20 @@ pub enum CliRunResult {
     // Success
     None,
     FormatSucceeded,
-    // Failure
-    FormatNoFilesFound,
+    // Warning error
     InvalidOptionConfig,
     FormatMismatch,
+    // Fatal error
+    NoFilesFound,
     FormatFailed,
 }
 
 impl Termination for CliRunResult {
     fn report(self) -> ExitCode {
         match self {
-            Self::None | Self::FormatSucceeded => ExitCode::SUCCESS,
-            Self::FormatNoFilesFound
-            | Self::InvalidOptionConfig
-            | Self::FormatMismatch
-            | Self::FormatFailed => ExitCode::FAILURE,
+            Self::None | Self::FormatSucceeded => ExitCode::from(0),
+            Self::InvalidOptionConfig | Self::FormatMismatch => ExitCode::from(1),
+            Self::NoFilesFound | Self::FormatFailed => ExitCode::from(2),
         }
     }
 }


### PR DESCRIPTION
Implement `--no-error-on-unmatched-pattern` w/ small refactoring.
