### PR TITLE
refactor(data_structures)!: make `NonEmptyStack::is_empty` a compile-time error

### DIFF
--- a/crates/oxc_data_structures/src/stack/non_empty.rs
+++ b/crates/oxc_data_structures/src/stack/non_empty.rs
@@ -353,17 +353,22 @@ impl<T> NonEmptyStack<T> {
         <Self as StackCommon<T>>::len(self)
     }
 
-    /// Get if stack is empty. Always returns `false`.
+    /// Get if stack is empty.
     ///
-    /// Probably you want [`is_exhausted`] instead.
+    /// This method is pointless, as the stack is never empty.
+    /// Only present to override the default method from `[T]::is_empty` which is inherited via `Deref`.
+    ///
+    /// Using this method is a compile-time error, because using it is certainly a logic error.
+    ///
+    /// Use [`is_exhausted`] instead.
     ///
     /// [`is_exhausted`]: Self::is_exhausted
     #[expect(clippy::unused_self)]
     #[inline]
     pub fn is_empty(&self) -> bool {
-        // This method is pointless, as the stack is never empty. But provide it to override
-        // the default method from `slice::is_empty` which is inherited via `Deref`
-        false
+        const {
+            panic!("`NonEmptyStack` is never empty. Use `is_exhausted` instead.");
+        }
     }
 
     /// Get if stack is back in its initial state.


### PR DESCRIPTION
Continuation from #13672.

Calling `NonEmptyStack::is_empty` is always a logic error. `NonEmptyStack` can never be empty, and `NonEmptyStack::is_exhausted` is very likely what was intended.

Make calling `NonEmptyStack::is_empty` a compile-time error, to prevent this erroneous usage.

Ideally, we'd remove the method entirely, but `&NonEmptyStack<T>` derefs to `&[T]`, so without defining `is_empty` method on `NonEmptyStack`, `stack.is_empty()` falls through to `[T]::is_empty`, which is not what we want.
