### PR TITLE
refactor(transformer, estree): clarify code using `is_exhausted` stack methods

### DIFF
--- a/crates/oxc_estree/src/serialize/mod.rs
+++ b/crates/oxc_estree/src/serialize/mod.rs
@@ -148,7 +148,7 @@ impl<C: Config, F: Formatter> ESTreeSerializer<C, F> {
 
         node.serialize(&mut self);
 
-        debug_assert_eq!(self.trace_path.len(), 1);
+        debug_assert!(self.trace_path.is_exhausted());
         debug_assert_eq!(self.trace_path[0], TracePathPart::DUMMY);
 
         self.buffer.print_str("\n,\"fixes\":[");

--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -195,18 +195,18 @@ impl<'a> Traverse<'a, TransformState<'a>> for ArrowFunctionConverter<'a> {
             ctx,
         );
 
-        debug_assert!(self.this_var_stack.len() == 1);
+        debug_assert!(self.this_var_stack.is_exhausted());
         debug_assert!(self.this_var_stack.first().is_none());
-        debug_assert!(self.arguments_var_stack.len() == 1);
+        debug_assert!(self.arguments_var_stack.is_exhausted());
         debug_assert!(self.arguments_var_stack.first().is_none());
-        debug_assert!(self.constructor_super_stack.len() == 1);
+        debug_assert!(self.constructor_super_stack.is_exhausted());
         // TODO: This assertion currently failing because we don't handle `super` in arrow functions
         // in class static properties correctly.
         // e.g. `class C { static f = () => super.prop; }`
         // debug_assert!(self.constructor_super_stack.first() == &false);
-        debug_assert!(self.super_methods_stack.len() == 1);
+        debug_assert!(self.super_methods_stack.is_exhausted());
         debug_assert!(self.super_methods_stack.first().is_empty());
-        debug_assert!(self.super_needs_transform_stack.len() == 1);
+        debug_assert!(self.super_needs_transform_stack.is_exhausted());
         debug_assert!(self.super_needs_transform_stack.first() == &false);
     }
 

--- a/crates/oxc_transformer/src/common/var_declarations.rs
+++ b/crates/oxc_transformer/src/common/var_declarations.rs
@@ -241,9 +241,9 @@ impl<'a> VarDeclarationsStore<'a> {
                 .insert_statements(var_statement.into_iter().chain(let_statement));
         }
 
-        // Check stack is emptied
+        // Check stack is exhausted
         let stack = self.stack.borrow();
-        debug_assert!(stack.len() == 1);
+        debug_assert!(stack.is_exhausted());
         debug_assert!(stack.last().is_none());
     }
 


### PR DESCRIPTION
Utilize `is_exhausted` methods of `NonEmptyStack` and `SparseStack` (added in #13672) in transformer and `oxc_estree` to clarify what these checks are doing.