### PR TITLE
fix(oxfmt): Sort matched paths

### DIFF
--- a/apps/oxfmt/src/walk.rs
+++ b/apps/oxfmt/src/walk.rs
@@ -139,6 +139,9 @@ impl Walk {
         let mut builder = WalkBuilder { sender };
         self.inner.visit(&mut builder);
         drop(builder);
-        receiver.into_iter().flatten().collect()
+
+        let mut entries: Vec<WalkEntry> = receiver.into_iter().flatten().collect();
+        entries.sort_unstable_by(|a, b| a.path.cmp(&b.path));
+        entries
     }
 }


### PR DESCRIPTION
Sort matched paths to be formatted.

This will be needed for tests as well.
