### PR TITLE
fix(formatter): incorrectly wrap a parenthesis for `ArrowFunctionExpression` when it has a leading type cast comment

### DIFF
--- a/crates/oxc_formatter/src/generated/format.rs
+++ b/crates/oxc_formatter/src/generated/format.rs
@@ -1701,7 +1701,10 @@ impl<'a> Format<'a> for AstNode<'a, EmptyStatement> {
 
 impl<'a> Format<'a> for AstNode<'a, ExpressionStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        self.write(f)
+        self.format_leading_comments(f)?;
+        let result = self.write(f);
+        self.format_trailing_comments(f)?;
+        result
     }
 }
 

--- a/crates/oxc_formatter/src/utils/typecast.rs
+++ b/crates/oxc_formatter/src/utils/typecast.rs
@@ -66,7 +66,10 @@ pub fn format_type_cast_comment_node<'a, T>(
         // If the printed cast comment is already handled, return early to avoid infinite recursion.
         if !comments.is_already_handled_type_cast_comment()
             && comments.printed_comments().last().is_some_and(|c| {
-                source.next_non_whitespace_byte_is(c.span.end, b'(')
+                c.span.end <= span.start
+                    && source.all_bytes_match(c.span.end, span.start, |c| {
+                        c.is_ascii_whitespace() || c == b'('
+                    })
                     && f.comments().is_type_cast_comment(c)
             })
         {

--- a/crates/oxc_formatter/src/write/mod.rs
+++ b/crates/oxc_formatter/src/write/mod.rs
@@ -544,22 +544,6 @@ fn expression_statement_needs_semicolon<'a>(
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ExpressionStatement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed
-            && let Some(last_comment_index) =
-                f.context().comments().get_type_cast_comment_index(self.span)
-        {
-            let comments = &f.context().comments().unprinted_comments()[..last_comment_index];
-            write!(f, [FormatLeadingComments::Comments(comments)])?;
-        } else {
-            self.format_leading_comments(f)?;
-        }
-
-        if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f)?;
-            return self.format_trailing_comments(f);
-        }
-
         // Check if we need a leading semicolon to prevent ASI issues
         if f.options().semicolons == Semicolons::AsNeeded
             && expression_statement_needs_semicolon(self, f)
@@ -567,9 +551,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ExpressionStatement<'a>> {
             write!(f, ";")?;
         }
 
-        write!(f, [self.expression(), OptionalSemicolon])?;
-
-        self.format_trailing_comments(f)
+        write!(f, [self.expression(), OptionalSemicolon])
     }
 }
 

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -22,8 +22,6 @@ const AST_NODE_WITHOUT_PRINTING_COMMENTS_LIST: &[&str] = &[
     "CatchParameter",
     "CatchClause",
     "Decorator",
-    // Manually prints it because it needs to specially handle leading comments.
-    "ExpressionStatement",
     // Manually prints it because class's decorators can be appears before `export class Cls {}`.
     "ExportNamedDeclaration",
     "ExportDefaultDeclaration",

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 658/699 (94.13%)
+js compatibility: 659/699 (94.28%)
 
 # Failed
 
@@ -8,7 +8,6 @@ js compatibility: 658/699 (94.13%)
 | js/comments/empty-statements.js | 💥💥 | 90.91% |
 | js/comments/export.js | 💥💥 | 97.37% |
 | js/comments/function-declaration.js | 💥💥 | 92.80% |
-| js/comments/jsdoc.js | 💥💥 | 81.48% |
 | js/comments/return-statement.js | 💥💥 | 98.85% |
 | js/comments/html-like/comment.js | 💥 | 0.00% |
 | js/comments-closure-typecast/comment-in-the-middle.js | 💥 | 90.91% |


### PR DESCRIPTION
Previously, wrongly wrapped a parenthesis for `FunctionBody` because it has a leading type cast comment. The problem we only check whether there is a `(` between the type cast comment and the node, but it actually contains `\n() => (\n`.
 
In this fix, I added an extra check to ensure only `(` and whitespace can be inside it.
```js
/**
 * @type {object}
 */
() => (
    <div>
        sajdfpoiasdjfpoiasdjfpoiasdjfpoiadsjfpaoisdjfapsdiofjapioisadfaskfaspiofjp
    </div>
);
```