### PR TITLE
fix(linter/switch-case-braces): add support for string including colon on case expression

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -96,6 +96,9 @@ impl Rule for SwitchCaseBraces {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let switch_clause_regex =
+            Regex::new(r#"(case|default)\s*(`.+`|'.+'|".+"|[^:]*):"#).unwrap();
+
         let AstKind::SwitchStatement(switch) = node.kind() else {
             return;
         };
@@ -143,9 +146,10 @@ impl Rule for SwitchCaseBraces {
             };
 
             if self.always_braces && missing_braces {
-                let regex = Regex::new(r#"(case|default)\s*(`.+`|'.+'|".+"|[^:]*):"#).unwrap();
-                let colon_end =
-                    u32::try_from(regex.find(ctx.source_range(case.span)).unwrap().end()).unwrap();
+                let colon_end = u32::try_from(
+                    switch_clause_regex.find(ctx.source_range(case.span)).unwrap().end(),
+                )
+                .unwrap();
                 let span = Span::sized(case.span.start, colon_end);
                 ctx.diagnostic_with_fix(
                     switch_case_braces_diagnostic_missing_braces(span),

--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -96,9 +96,6 @@ impl Rule for SwitchCaseBraces {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let switch_clause_regex =
-            Regex::new(r#"(case|default)\s*(`.+`|'.+'|".+"|[^:]*):"#).unwrap();
-
         let AstKind::SwitchStatement(switch) = node.kind() else {
             return;
         };
@@ -106,6 +103,9 @@ impl Rule for SwitchCaseBraces {
         if switch.cases.is_empty() {
             return;
         }
+
+        let switch_clause_regex =
+            Regex::new(r#"(case|default)\s*(`[^`]+`|'[^']+'|"[^"]+"|[^:]*):"#).unwrap();
 
         for case in &switch.cases {
             if case.consequent.is_empty() {

--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -105,7 +105,7 @@ impl Rule for SwitchCaseBraces {
         }
 
         let switch_clause_regex =
-            Regex::new(r#"(case|default)\s*(`[^`]+`|'[^']+'|"[^"]+"|[^:]*):"#).unwrap();
+            Regex::new(r#"(?:case|default)\s*(?:`[^`]+`|'[^']+'|"[^"]+"|[^:]*):"#).unwrap();
 
         for case in &switch.cases {
             if case.consequent.is_empty() {


### PR DESCRIPTION
### What version of Oxlint are you using?

1.14.0

### What command did you run?

`oxlint --type-aware --fix`

### What does your `.oxlintrc.json` config file look like?

```jsonc
{
  "plugins": ["unicorn"],
  "rules": {
    "unicorn/switch-case-braces": "error"
  }
}
```


### What happened?

The rule `unicorn/switch-case-braces` does not behave as expected.
The following case was wrongly formatted.

```typescript
// Input
case "scope:type":
  // ...
  break;
```

```typescript
// Observed
case "scope: {type":
  // ...
  break;
}
```

```typescript
// Expected
case "scope:type": {
  // ...
  break;
}
```

### How was it fixed?

I used a regex to determine where is the colon instead of relying on the first colon found.

Disclaimer: I have really low experience with Rust, maybe there was a smarter way of doing it I missed.
