### PR TITLE
fix(linter/plugins): exit early if JS plugins enabled on unsupported platforms

### DIFF
--- a/apps/oxlint/src/lib.rs
+++ b/apps/oxlint/src/lib.rs
@@ -62,6 +62,15 @@ pub fn lint(mut external_linter: Option<ExternalLinter>) -> CliRunResult {
             eprintln!("ERROR: JS plugins are not supported at present");
             return CliRunResult::InvalidOptionConfig;
         }
+
+        // Exit early if not 64-bit little-endian, to avoid a panic later on when trying to create
+        // a fixed-size allocator for raw transfer
+        if cfg!(not(all(target_pointer_width = "64", target_endian = "little"))) {
+            eprintln!(
+                "ERROR: JS plugins are only supported on 64-bit little-endian platforms at present"
+            );
+            return CliRunResult::InvalidOptionConfig;
+        }
     } else {
         external_linter = None;
     }


### PR DESCRIPTION
JS plugins use raw transfer. Raw transfer does not currently support 32-bit or big-endian platforms.

Exit early with a descriptive error message if `--experimental-js-plugins` option is used on an unsupported platform. This avoids a panic with a weird error later on when first try to create a raw transfer-compatible allocator.
