### PR TITLE
perf(linter): detect node types from `let..else` statements

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -13,11 +13,13 @@ impl RuleRunner for crate::rules::eslint::array_callback_return::ArrayCallbackRe
 }
 
 impl RuleRunner for crate::rules::eslint::arrow_body_style::ArrowBodyStyle {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ArrowFunctionExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::block_scoped_var::BlockScopedVar {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::VariableDeclaration]));
 }
 
 impl RuleRunner for crate::rules::eslint::curly::Curly {
@@ -25,11 +27,13 @@ impl RuleRunner for crate::rules::eslint::curly::Curly {
 }
 
 impl RuleRunner for crate::rules::eslint::default_case::DefaultCase {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::SwitchStatement]));
 }
 
 impl RuleRunner for crate::rules::eslint::default_case_last::DefaultCaseLast {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::SwitchStatement]));
 }
 
 impl RuleRunner for crate::rules::eslint::default_param_last::DefaultParamLast {
@@ -37,11 +41,13 @@ impl RuleRunner for crate::rules::eslint::default_param_last::DefaultParamLast {
 }
 
 impl RuleRunner for crate::rules::eslint::eqeqeq::Eqeqeq {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::for_direction::ForDirection {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ForStatement]));
 }
 
 impl RuleRunner for crate::rules::eslint::func_names::FuncNames {
@@ -103,7 +109,8 @@ impl RuleRunner for crate::rules::eslint::new_cap::NewCap {
 }
 
 impl RuleRunner for crate::rules::eslint::no_alert::NoAlert {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_array_constructor::NoArrayConstructor {
@@ -111,7 +118,8 @@ impl RuleRunner for crate::rules::eslint::no_array_constructor::NoArrayConstruct
 }
 
 impl RuleRunner for crate::rules::eslint::no_async_promise_executor::NoAsyncPromiseExecutor {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::NewExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_await_in_loop::NoAwaitInLoop {
@@ -137,7 +145,8 @@ impl RuleRunner for crate::rules::eslint::no_class_assign::NoClassAssign {
 }
 
 impl RuleRunner for crate::rules::eslint::no_compare_neg_zero::NoCompareNegZero {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_cond_assign::NoCondAssign {
@@ -163,7 +172,8 @@ impl RuleRunner for crate::rules::eslint::no_constant_condition::NoConstantCondi
 }
 
 impl RuleRunner for crate::rules::eslint::no_constructor_return::NoConstructorReturn {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ReturnStatement]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_continue::NoContinue {
@@ -181,7 +191,8 @@ impl RuleRunner for crate::rules::eslint::no_debugger::NoDebugger {
 }
 
 impl RuleRunner for crate::rules::eslint::no_delete_var::NoDeleteVar {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::UnaryExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_div_regex::NoDivRegex {
@@ -194,11 +205,13 @@ impl RuleRunner for crate::rules::eslint::no_dupe_class_members::NoDupeClassMemb
 }
 
 impl RuleRunner for crate::rules::eslint::no_dupe_else_if::NoDupeElseIf {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::IfStatement]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_dupe_keys::NoDupeKeys {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ObjectExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_duplicate_case::NoDuplicateCase {
@@ -210,7 +223,8 @@ impl RuleRunner for crate::rules::eslint::no_duplicate_imports::NoDuplicateImpor
 }
 
 impl RuleRunner for crate::rules::eslint::no_else_return::NoElseReturn {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::IfStatement]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_empty::NoEmpty {
@@ -223,7 +237,8 @@ impl RuleRunner for crate::rules::eslint::no_empty_character_class::NoEmptyChara
 }
 
 impl RuleRunner for crate::rules::eslint::no_empty_function::NoEmptyFunction {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::FunctionBody]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_empty_pattern::NoEmptyPattern {
@@ -253,7 +268,8 @@ impl RuleRunner for crate::rules::eslint::no_extend_native::NoExtendNative {
 }
 
 impl RuleRunner for crate::rules::eslint::no_extra_bind::NoExtraBind {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_extra_boolean_cast::NoExtraBooleanCast {
@@ -265,7 +281,8 @@ impl RuleRunner for crate::rules::eslint::no_extra_label::NoExtraLabel {
 }
 
 impl RuleRunner for crate::rules::eslint::no_fallthrough::NoFallthrough {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::SwitchStatement]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_func_assign::NoFuncAssign {
@@ -297,7 +314,8 @@ impl RuleRunner for crate::rules::eslint::no_iterator::NoIterator {
 }
 
 impl RuleRunner for crate::rules::eslint::no_label_var::NoLabelVar {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::LabeledStatement]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_labels::NoLabels {
@@ -305,11 +323,13 @@ impl RuleRunner for crate::rules::eslint::no_labels::NoLabels {
 }
 
 impl RuleRunner for crate::rules::eslint::no_lone_blocks::NoLoneBlocks {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BlockStatement]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_lonely_if::NoLonelyIf {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::IfStatement]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_loss_of_precision::NoLossOfPrecision {
@@ -339,7 +359,8 @@ impl RuleRunner for crate::rules::eslint::no_nested_ternary::NoNestedTernary {
 }
 
 impl RuleRunner for crate::rules::eslint::no_new::NoNew {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::NewExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_new_func::NoNewFunc {
@@ -347,11 +368,13 @@ impl RuleRunner for crate::rules::eslint::no_new_func::NoNewFunc {
 }
 
 impl RuleRunner for crate::rules::eslint::no_new_native_nonconstructor::NoNewNativeNonconstructor {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::NewExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_new_wrappers::NoNewWrappers {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::NewExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_nonoctal_decimal_escape::NoNonoctalDecimalEscape {
@@ -368,7 +391,8 @@ impl RuleRunner for crate::rules::eslint::no_object_constructor::NoObjectConstru
 }
 
 impl RuleRunner for crate::rules::eslint::no_plusplus::NoPlusplus {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::UpdateExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_proto::NoProto {
@@ -376,7 +400,8 @@ impl RuleRunner for crate::rules::eslint::no_proto::NoProto {
 }
 
 impl RuleRunner for crate::rules::eslint::no_prototype_builtins::NoPrototypeBuiltins {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_redeclare::NoRedeclare {
@@ -393,11 +418,13 @@ impl RuleRunner for crate::rules::eslint::no_restricted_globals::NoRestrictedGlo
 }
 
 impl RuleRunner for crate::rules::eslint::no_restricted_imports::NoRestrictedImports {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TSImportEqualsDeclaration]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_return_assign::NoReturnAssign {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::AssignmentExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_script_url::NoScriptUrl {
@@ -405,15 +432,18 @@ impl RuleRunner for crate::rules::eslint::no_script_url::NoScriptUrl {
 }
 
 impl RuleRunner for crate::rules::eslint::no_self_assign::NoSelfAssign {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::AssignmentExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_self_compare::NoSelfCompare {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_setter_return::NoSetterReturn {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ReturnStatement]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_shadow_restricted_names::NoShadowRestrictedNames {
@@ -426,7 +456,8 @@ impl RuleRunner for crate::rules::eslint::no_sparse_arrays::NoSparseArrays {
 }
 
 impl RuleRunner for crate::rules::eslint::no_template_curly_in_string::NoTemplateCurlyInString {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::StringLiteral]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_ternary::NoTernary {
@@ -439,11 +470,13 @@ impl RuleRunner for crate::rules::eslint::no_this_before_super::NoThisBeforeSupe
 }
 
 impl RuleRunner for crate::rules::eslint::no_throw_literal::NoThrowLiteral {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ThrowStatement]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_unassigned_vars::NoUnassignedVars {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::VariableDeclarator]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_undef::NoUndef {
@@ -459,7 +492,8 @@ impl RuleRunner for crate::rules::eslint::no_unexpected_multiline::NoUnexpectedM
 }
 
 impl RuleRunner for crate::rules::eslint::no_unneeded_ternary::NoUnneededTernary {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ConditionalExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_unreachable::NoUnreachable {
@@ -471,7 +505,8 @@ impl RuleRunner for crate::rules::eslint::no_unsafe_finally::NoUnsafeFinally {
 }
 
 impl RuleRunner for crate::rules::eslint::no_unsafe_negation::NoUnsafeNegation {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_unsafe_optional_chaining::NoUnsafeOptionalChaining {
@@ -479,7 +514,8 @@ impl RuleRunner for crate::rules::eslint::no_unsafe_optional_chaining::NoUnsafeO
 }
 
 impl RuleRunner for crate::rules::eslint::no_unused_expressions::NoUnusedExpressions {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ExpressionStatement]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_unused_labels::NoUnusedLabels {
@@ -501,19 +537,23 @@ impl RuleRunner for crate::rules::eslint::no_useless_backreference::NoUselessBac
 }
 
 impl RuleRunner for crate::rules::eslint::no_useless_call::NoUselessCall {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_useless_catch::NoUselessCatch {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TryStatement]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_useless_concat::NoUselessConcat {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_useless_constructor::NoUselessConstructor {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::MethodDefinition]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_useless_escape::NoUselessEscape {
@@ -530,7 +570,8 @@ impl RuleRunner for crate::rules::eslint::no_var::NoVar {
 }
 
 impl RuleRunner for crate::rules::eslint::no_void::NoVoid {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::UnaryExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_with::NoWith {
@@ -539,7 +580,8 @@ impl RuleRunner for crate::rules::eslint::no_with::NoWith {
 }
 
 impl RuleRunner for crate::rules::eslint::operator_assignment::OperatorAssignment {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::AssignmentExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::prefer_destructuring::PreferDestructuring {
@@ -549,19 +591,23 @@ impl RuleRunner for crate::rules::eslint::prefer_destructuring::PreferDestructur
 impl RuleRunner
     for crate::rules::eslint::prefer_exponentiation_operator::PreferExponentiationOperator
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::prefer_numeric_literals::PreferNumericLiterals {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::prefer_object_has_own::PreferObjectHasOwn {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::prefer_object_spread::PreferObjectSpread {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::prefer_promise_reject_errors::PreferPromiseRejectErrors {
@@ -574,19 +620,23 @@ impl RuleRunner for crate::rules::eslint::prefer_rest_params::PreferRestParams {
 }
 
 impl RuleRunner for crate::rules::eslint::prefer_spread::PreferSpread {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::prefer_template::PreferTemplate {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::radix::Radix {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::require_await::RequireAwait {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::FunctionBody]));
 }
 
 impl RuleRunner for crate::rules::eslint::require_yield::RequireYield {
@@ -604,11 +654,13 @@ impl RuleRunner for crate::rules::eslint::sort_keys::SortKeys {
 }
 
 impl RuleRunner for crate::rules::eslint::sort_vars::SortVars {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::VariableDeclaration]));
 }
 
 impl RuleRunner for crate::rules::eslint::symbol_description::SymbolDescription {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::unicode_bom::UnicodeBom {
@@ -624,17 +676,20 @@ impl RuleRunner for crate::rules::eslint::valid_typeof::ValidTypeof {
 }
 
 impl RuleRunner for crate::rules::eslint::vars_on_top::VarsOnTop {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::VariableDeclaration]));
 }
 
 impl RuleRunner for crate::rules::eslint::yoda::Yoda {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression]));
 }
 
 impl RuleRunner
     for crate::rules::import::consistent_type_specifier_style::ConsistentTypeSpecifierStyle
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ImportDeclaration]));
 }
 
 impl RuleRunner for crate::rules::import::default::Default {
@@ -682,7 +737,8 @@ impl RuleRunner for crate::rules::import::no_amd::NoAmd {
 }
 
 impl RuleRunner for crate::rules::import::no_anonymous_default_export::NoAnonymousDefaultExport {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ExportDefaultDeclaration]));
 }
 
 impl RuleRunner for crate::rules::import::no_commonjs::NoCommonjs {
@@ -706,7 +762,8 @@ impl RuleRunner for crate::rules::import::no_dynamic_require::NoDynamicRequire {
 }
 
 impl RuleRunner for crate::rules::import::no_empty_named_blocks::NoEmptyNamedBlocks {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ImportDeclaration]));
 }
 
 impl RuleRunner for crate::rules::import::no_mutable_exports::NoMutableExports {
@@ -902,11 +959,13 @@ impl RuleRunner for crate::rules::jest::prefer_lowercase_title::PreferLowercaseT
 }
 
 impl RuleRunner for crate::rules::jest::prefer_mock_promise_shorthand::PreferMockPromiseShorthand {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::jest::prefer_spy_on::PreferSpyOn {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::AssignmentExpression]));
 }
 
 impl RuleRunner for crate::rules::jest::prefer_strict_equal::PreferStrictEqual {
@@ -1026,11 +1085,13 @@ impl RuleRunner for crate::rules::jsdoc::require_yields::RequireYields {
 }
 
 impl RuleRunner for crate::rules::jsx_a11y::alt_text::AltText {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::jsx_a11y::anchor_ambiguous_text::AnchorAmbiguousText {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXElement]));
 }
 
 impl RuleRunner for crate::rules::jsx_a11y::anchor_has_content::AnchorHasContent {
@@ -1046,7 +1107,8 @@ impl RuleRunner for crate::rules::jsx_a11y::anchor_is_valid::AnchorIsValid {
 impl RuleRunner
     for crate::rules::jsx_a11y::aria_activedescendant_has_tabindex::AriaActivedescendantHasTabindex
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::jsx_a11y::aria_props::AriaProps {
@@ -1070,65 +1132,80 @@ impl RuleRunner for crate::rules::jsx_a11y::autocomplete_valid::AutocompleteVali
 }
 
 impl RuleRunner for crate::rules::jsx_a11y::click_events_have_key_events::ClickEventsHaveKeyEvents {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::jsx_a11y::heading_has_content::HeadingHasContent {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::jsx_a11y::html_has_lang::HtmlHasLang {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::jsx_a11y::iframe_has_title::IframeHasTitle {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::jsx_a11y::img_redundant_alt::ImgRedundantAlt {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner
     for crate::rules::jsx_a11y::label_has_associated_control::LabelHasAssociatedControl
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXElement]));
 }
 
 impl RuleRunner for crate::rules::jsx_a11y::lang::Lang {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::jsx_a11y::media_has_caption::MediaHasCaption {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::jsx_a11y::mouse_events_have_key_events::MouseEventsHaveKeyEvents {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::jsx_a11y::no_access_key::NoAccessKey {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::jsx_a11y::no_aria_hidden_on_focusable::NoAriaHiddenOnFocusable {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::jsx_a11y::no_autofocus::NoAutofocus {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXElement]));
 }
 
 impl RuleRunner for crate::rules::jsx_a11y::no_distracting_elements::NoDistractingElements {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::jsx_a11y::no_noninteractive_tabindex::NoNoninteractiveTabindex {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::jsx_a11y::no_redundant_roles::NoRedundantRoles {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::jsx_a11y::prefer_tag_over_role::PreferTagOverRole {
@@ -1142,35 +1219,43 @@ impl RuleRunner for crate::rules::jsx_a11y::role_has_required_aria_props::RoleHa
 }
 
 impl RuleRunner for crate::rules::jsx_a11y::role_supports_aria_props::RoleSupportsAriaProps {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::jsx_a11y::scope::Scope {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::jsx_a11y::tabindex_no_positive::TabindexNoPositive {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::nextjs::google_font_display::GoogleFontDisplay {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::nextjs::google_font_preconnect::GoogleFontPreconnect {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::nextjs::inline_script_id::InlineScriptId {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ImportDefaultSpecifier]));
 }
 
 impl RuleRunner for crate::rules::nextjs::next_script_for_ga::NextScriptForGa {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::nextjs::no_assign_module_variable::NoAssignModuleVariable {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::VariableDeclaration]));
 }
 
 impl RuleRunner for crate::rules::nextjs::no_async_client_component::NoAsyncClientComponent {
@@ -1182,11 +1267,13 @@ impl RuleRunner for crate::rules::nextjs::no_before_interactive_script_outside_d
 }
 
 impl RuleRunner for crate::rules::nextjs::no_css_tags::NoCssTags {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::nextjs::no_document_import_in_page::NoDocumentImportInPage {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ImportDeclaration]));
 }
 
 impl RuleRunner for crate::rules::nextjs::no_duplicate_head::NoDuplicateHead {
@@ -1199,35 +1286,43 @@ impl RuleRunner for crate::rules::nextjs::no_head_element::NoHeadElement {
 }
 
 impl RuleRunner for crate::rules::nextjs::no_head_import_in_document::NoHeadImportInDocument {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ImportDeclaration]));
 }
 
 impl RuleRunner for crate::rules::nextjs::no_html_link_for_pages::NoHtmlLinkForPages {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::nextjs::no_img_element::NoImgElement {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::nextjs::no_page_custom_font::NoPageCustomFont {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::nextjs::no_script_component_in_head::NoScriptComponentInHead {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ImportDeclaration]));
 }
 
 impl RuleRunner for crate::rules::nextjs::no_styled_jsx_in_document::NoStyledJsxInDocument {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::nextjs::no_sync_scripts::NoSyncScripts {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::nextjs::no_title_in_document_head::NoTitleInDocumentHead {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ImportDeclaration]));
 }
 
 impl RuleRunner for crate::rules::nextjs::no_typos::NoTypos {
@@ -1236,19 +1331,23 @@ impl RuleRunner for crate::rules::nextjs::no_typos::NoTypos {
 }
 
 impl RuleRunner for crate::rules::nextjs::no_unwanted_polyfillio::NoUnwantedPolyfillio {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::node::no_exports_assign::NoExportsAssign {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::AssignmentExpression]));
 }
 
 impl RuleRunner for crate::rules::node::no_new_require::NoNewRequire {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::NewExpression]));
 }
 
 impl RuleRunner for crate::rules::oxc::approx_constant::ApproxConstant {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::NumericLiteral]));
 }
 
 impl RuleRunner for crate::rules::oxc::bad_array_method_on_arguments::BadArrayMethodOnArguments {
@@ -1260,23 +1359,28 @@ impl RuleRunner for crate::rules::oxc::bad_bitwise_operator::BadBitwiseOperator 
 }
 
 impl RuleRunner for crate::rules::oxc::bad_char_at_comparison::BadCharAtComparison {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::oxc::bad_comparison_sequence::BadComparisonSequence {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression]));
 }
 
 impl RuleRunner for crate::rules::oxc::bad_min_max_func::BadMinMaxFunc {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::oxc::bad_object_literal_comparison::BadObjectLiteralComparison {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression]));
 }
 
 impl RuleRunner for crate::rules::oxc::bad_replace_all_arg::BadReplaceAllArg {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::oxc::const_comparisons::ConstComparisons {
@@ -1284,23 +1388,28 @@ impl RuleRunner for crate::rules::oxc::const_comparisons::ConstComparisons {
 }
 
 impl RuleRunner for crate::rules::oxc::double_comparisons::DoubleComparisons {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::LogicalExpression]));
 }
 
 impl RuleRunner for crate::rules::oxc::erasing_op::ErasingOp {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression]));
 }
 
 impl RuleRunner for crate::rules::oxc::misrefactored_assign_op::MisrefactoredAssignOp {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::AssignmentExpression]));
 }
 
 impl RuleRunner for crate::rules::oxc::missing_throw::MissingThrow {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::NewExpression]));
 }
 
 impl RuleRunner for crate::rules::oxc::no_accumulating_spread::NoAccumulatingSpread {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::SpreadElement]));
 }
 
 impl RuleRunner for crate::rules::oxc::no_async_await::NoAsyncAwait {
@@ -1321,7 +1430,8 @@ impl RuleRunner for crate::rules::oxc::no_const_enum::NoConstEnum {
 }
 
 impl RuleRunner for crate::rules::oxc::no_map_spread::NoMapSpread {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::oxc::no_optional_chaining::NoOptionalChaining {
@@ -1334,7 +1444,8 @@ impl RuleRunner for crate::rules::oxc::no_rest_spread_properties::NoRestSpreadPr
 }
 
 impl RuleRunner for crate::rules::oxc::number_arg_out_of_range::NumberArgOutOfRange {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::oxc::only_used_in_recursion::OnlyUsedInRecursion {
@@ -1342,7 +1453,8 @@ impl RuleRunner for crate::rules::oxc::only_used_in_recursion::OnlyUsedInRecursi
 }
 
 impl RuleRunner for crate::rules::oxc::uninvoked_array_callback::UninvokedArrayCallback {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::NewExpression]));
 }
 
 impl RuleRunner for crate::rules::promise::always_return::AlwaysReturn {
@@ -1350,11 +1462,13 @@ impl RuleRunner for crate::rules::promise::always_return::AlwaysReturn {
 }
 
 impl RuleRunner for crate::rules::promise::avoid_new::AvoidNew {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::NewExpression]));
 }
 
 impl RuleRunner for crate::rules::promise::catch_or_return::CatchOrReturn {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ExpressionStatement]));
 }
 
 impl RuleRunner for crate::rules::promise::no_callback_in_promise::NoCallbackInPromise {
@@ -1362,27 +1476,33 @@ impl RuleRunner for crate::rules::promise::no_callback_in_promise::NoCallbackInP
 }
 
 impl RuleRunner for crate::rules::promise::no_nesting::NoNesting {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::promise::no_new_statics::NoNewStatics {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::NewExpression]));
 }
 
 impl RuleRunner for crate::rules::promise::no_promise_in_callback::NoPromiseInCallback {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::promise::no_return_in_finally::NoReturnInFinally {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::promise::no_return_wrap::NoReturnWrap {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::promise::param_names::ParamNames {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::NewExpression]));
 }
 
 impl RuleRunner for crate::rules::promise::prefer_await_to_callbacks::PreferAwaitToCallbacks {
@@ -1390,11 +1510,13 @@ impl RuleRunner for crate::rules::promise::prefer_await_to_callbacks::PreferAwai
 }
 
 impl RuleRunner for crate::rules::promise::prefer_await_to_then::PreferAwaitToThen {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::promise::prefer_catch::PreferCatch {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ExpressionStatement]));
 }
 
 impl RuleRunner for crate::rules::promise::spec_only::SpecOnly {
@@ -1402,7 +1524,8 @@ impl RuleRunner for crate::rules::promise::spec_only::SpecOnly {
 }
 
 impl RuleRunner for crate::rules::promise::valid_params::ValidParams {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::react::button_has_type::ButtonHasType {
@@ -1414,7 +1537,8 @@ impl RuleRunner for crate::rules::react::checked_requires_onchange_or_readonly::
 }
 
 impl RuleRunner for crate::rules::react::exhaustive_deps::ExhaustiveDeps {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::react::forbid_elements::ForbidElements {
@@ -1422,7 +1546,8 @@ impl RuleRunner for crate::rules::react::forbid_elements::ForbidElements {
 }
 
 impl RuleRunner for crate::rules::react::forward_ref_uses_ref::ForwardRefUsesRef {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::react::iframe_missing_sandbox::IframeMissingSandbox {
@@ -1430,7 +1555,8 @@ impl RuleRunner for crate::rules::react::iframe_missing_sandbox::IframeMissingSa
 }
 
 impl RuleRunner for crate::rules::react::jsx_boolean_value::JsxBooleanValue {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::react::jsx_curly_brace_presence::JsxCurlyBracePresence {
@@ -1446,7 +1572,8 @@ impl RuleRunner for crate::rules::react::jsx_fragments::JsxFragments {
 }
 
 impl RuleRunner for crate::rules::react::jsx_handler_names::JsxHandlerNames {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXAttribute]));
 }
 
 impl RuleRunner for crate::rules::react::jsx_key::JsxKey {
@@ -1454,11 +1581,13 @@ impl RuleRunner for crate::rules::react::jsx_key::JsxKey {
 }
 
 impl RuleRunner for crate::rules::react::jsx_no_comment_textnodes::JsxNoCommentTextnodes {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXText]));
 }
 
 impl RuleRunner for crate::rules::react::jsx_no_duplicate_props::JsxNoDuplicateProps {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::react::jsx_no_script_url::JsxNoScriptUrl {
@@ -1505,11 +1634,13 @@ impl RuleRunner for crate::rules::react::no_direct_mutation_state::NoDirectMutat
 }
 
 impl RuleRunner for crate::rules::react::no_find_dom_node::NoFindDomNode {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::react::no_is_mounted::NoIsMounted {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::react::no_namespace::NoNamespace {
@@ -1517,11 +1648,13 @@ impl RuleRunner for crate::rules::react::no_namespace::NoNamespace {
 }
 
 impl RuleRunner for crate::rules::react::no_render_return_value::NoRenderReturnValue {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::react::no_set_state::NoSetState {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::react::no_string_refs::NoStringRefs {
@@ -1534,7 +1667,8 @@ impl RuleRunner for crate::rules::react::no_unescaped_entities::NoUnescapedEntit
 }
 
 impl RuleRunner for crate::rules::react::no_unknown_property::NoUnknownProperty {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::react::prefer_es6_class::PreferEs6Class {
@@ -1550,11 +1684,13 @@ impl RuleRunner for crate::rules::react::require_render_return::RequireRenderRet
 }
 
 impl RuleRunner for crate::rules::react::rules_of_hooks::RulesOfHooks {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::react::self_closing_comp::SelfClosingComp {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXElement]));
 }
 
 impl RuleRunner for crate::rules::react::style_prop_object::StylePropObject {
@@ -1662,7 +1798,8 @@ impl RuleRunner
 }
 
 impl RuleRunner for crate::rules::typescript::no_duplicate_enum_values::NoDuplicateEnumValues {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TSEnumBody]));
 }
 
 impl RuleRunner
@@ -1672,7 +1809,8 @@ impl RuleRunner
 }
 
 impl RuleRunner for crate::rules::typescript::no_dynamic_delete::NoDynamicDelete {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::UnaryExpression]));
 }
 
 impl RuleRunner for crate::rules::typescript::no_empty_interface::NoEmptyInterface {
@@ -1685,7 +1823,8 @@ impl RuleRunner for crate::rules::typescript::no_empty_object_type::NoEmptyObjec
 }
 
 impl RuleRunner for crate::rules::typescript::no_explicit_any::NoExplicitAny {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TSAnyKeyword]));
 }
 
 impl RuleRunner for crate::rules::typescript::no_extra_non_null_assertion::NoExtraNonNullAssertion {
@@ -1693,7 +1832,8 @@ impl RuleRunner for crate::rules::typescript::no_extra_non_null_assertion::NoExt
 }
 
 impl RuleRunner for crate::rules::typescript::no_extraneous_class::NoExtraneousClass {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Class]));
 }
 
 impl RuleRunner for crate::rules::typescript::no_floating_promises::NoFloatingPromises {
@@ -1709,7 +1849,8 @@ impl RuleRunner for crate::rules::typescript::no_implied_eval::NoImpliedEval {
 }
 
 impl RuleRunner for crate::rules::typescript::no_import_type_side_effects::NoImportTypeSideEffects {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ImportDeclaration]));
 }
 
 impl RuleRunner for crate::rules::typescript::no_inferrable_types::NoInferrableTypes {
@@ -1739,19 +1880,21 @@ impl RuleRunner for crate::rules::typescript::no_mixed_enums::NoMixedEnums {
 }
 
 impl RuleRunner for crate::rules::typescript::no_namespace::NoNamespace {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TSModuleDeclaration]));
 }
 
 impl RuleRunner for crate::rules::typescript::no_non_null_asserted_nullish_coalescing::NoNonNullAssertedNullishCoalescing {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[AstType::LogicalExpression]));
 }
 
 impl RuleRunner for crate::rules::typescript::no_non_null_asserted_optional_chain::NoNonNullAssertedOptionalChain {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[AstType::TSNonNullExpression]));
 }
 
 impl RuleRunner for crate::rules::typescript::no_non_null_assertion::NoNonNullAssertion {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TSNonNullExpression]));
 }
 
 impl RuleRunner
@@ -1773,7 +1916,7 @@ impl RuleRunner for crate::rules::typescript::no_unnecessary_boolean_literal_com
 }
 
 impl RuleRunner for crate::rules::typescript::no_unnecessary_parameter_property_assignment::NoUnnecessaryParameterPropertyAssignment {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[AstType::MethodDefinition]));
 }
 
 impl RuleRunner for crate::rules::typescript::no_unnecessary_template_expression::NoUnnecessaryTemplateExpression {
@@ -1795,7 +1938,8 @@ impl RuleRunner
 impl RuleRunner
     for crate::rules::typescript::no_unnecessary_type_constraint::NoUnnecessaryTypeConstraint
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TSTypeParameterDeclaration]));
 }
 
 impl RuleRunner for crate::rules::typescript::no_unsafe_argument::NoUnsafeArgument {
@@ -1841,11 +1985,13 @@ impl RuleRunner for crate::rules::typescript::no_unsafe_unary_minus::NoUnsafeUna
 }
 
 impl RuleRunner for crate::rules::typescript::no_useless_empty_export::NoUselessEmptyExport {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ExportNamedDeclaration]));
 }
 
 impl RuleRunner for crate::rules::typescript::no_var_requires::NoVarRequires {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::typescript::no_wrapper_object_types::NoWrapperObjectTypes {
@@ -1867,11 +2013,13 @@ impl RuleRunner for crate::rules::typescript::prefer_as_const::PreferAsConst {
 }
 
 impl RuleRunner for crate::rules::typescript::prefer_enum_initializers::PreferEnumInitializers {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TSEnumBody]));
 }
 
 impl RuleRunner for crate::rules::typescript::prefer_for_of::PreferForOf {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ForStatement]));
 }
 
 impl RuleRunner for crate::rules::typescript::prefer_function_type::PreferFunctionType {
@@ -1879,11 +2027,13 @@ impl RuleRunner for crate::rules::typescript::prefer_function_type::PreferFuncti
 }
 
 impl RuleRunner for crate::rules::typescript::prefer_literal_enum_member::PreferLiteralEnumMember {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TSEnumMember]));
 }
 
 impl RuleRunner for crate::rules::typescript::prefer_namespace_keyword::PreferNamespaceKeyword {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TSModuleDeclaration]));
 }
 
 impl RuleRunner
@@ -1961,23 +2111,27 @@ impl RuleRunner for crate::rules::unicorn::catch_error_name::CatchErrorName {
 }
 
 impl RuleRunner for crate::rules::unicorn::consistent_assert::ConsistentAssert {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ImportDeclaration]));
 }
 
 impl RuleRunner for crate::rules::unicorn::consistent_date_clone::ConsistentDateClone {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::NewExpression]));
 }
 
 impl RuleRunner
     for crate::rules::unicorn::consistent_empty_array_spread::ConsistentEmptyArraySpread
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ConditionalExpression]));
 }
 
 impl RuleRunner
     for crate::rules::unicorn::consistent_existence_index_check::ConsistentExistenceIndexCheck
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::consistent_function_scoping::ConsistentFunctionScoping {
@@ -2014,7 +2168,8 @@ impl RuleRunner for crate::rules::unicorn::no_abusive_eslint_disable::NoAbusiveE
 }
 
 impl RuleRunner for crate::rules::unicorn::no_accessor_recursion::NoAccessorRecursion {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ThisExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_anonymous_default_export::NoAnonymousDefaultExport {
@@ -2022,7 +2177,8 @@ impl RuleRunner for crate::rules::unicorn::no_anonymous_default_export::NoAnonym
 }
 
 impl RuleRunner for crate::rules::unicorn::no_array_for_each::NoArrayForEach {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner
@@ -2032,11 +2188,13 @@ impl RuleRunner
 }
 
 impl RuleRunner for crate::rules::unicorn::no_array_reduce::NoArrayReduce {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_array_reverse::NoArrayReverse {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_await_expression_member::NoAwaitExpressionMember {
@@ -2044,15 +2202,18 @@ impl RuleRunner for crate::rules::unicorn::no_await_expression_member::NoAwaitEx
 }
 
 impl RuleRunner for crate::rules::unicorn::no_await_in_promise_methods::NoAwaitInPromiseMethods {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_console_spaces::NoConsoleSpaces {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_document_cookie::NoDocumentCookie {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::AssignmentExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_empty_file::NoEmptyFile {
@@ -2064,11 +2225,13 @@ impl RuleRunner for crate::rules::unicorn::no_hex_escape::NoHexEscape {
 }
 
 impl RuleRunner for crate::rules::unicorn::no_instanceof_array::NoInstanceofArray {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_instanceof_builtins::NoInstanceofBuiltins {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_invalid_fetch_options::NoInvalidFetchOptions {
@@ -2078,19 +2241,23 @@ impl RuleRunner for crate::rules::unicorn::no_invalid_fetch_options::NoInvalidFe
 impl RuleRunner
     for crate::rules::unicorn::no_invalid_remove_event_listener::NoInvalidRemoveEventListener
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_length_as_slice_end::NoLengthAsSliceEnd {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_lonely_if::NoLonelyIf {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::IfStatement]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_magic_array_flat_depth::NoMagicArrayFlatDepth {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner
@@ -2101,25 +2268,30 @@ impl RuleRunner
 }
 
 impl RuleRunner for crate::rules::unicorn::no_nested_ternary::NoNestedTernary {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ConditionalExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_new_array::NoNewArray {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::NewExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_new_buffer::NoNewBuffer {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::NewExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_null::NoNull {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::NullLiteral]));
 }
 
 impl RuleRunner
     for crate::rules::unicorn::no_object_as_default_parameter::NoObjectAsDefaultParameter
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::AssignmentPattern]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_process_exit::NoProcessExit {
@@ -2130,11 +2302,13 @@ impl RuleRunner for crate::rules::unicorn::no_process_exit::NoProcessExit {
 impl RuleRunner
     for crate::rules::unicorn::no_single_promise_in_promise_methods::NoSinglePromiseInPromiseMethods
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_static_only_class::NoStaticOnlyClass {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Class]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_thenable::NoThenable {
@@ -2146,13 +2320,15 @@ impl RuleRunner for crate::rules::unicorn::no_this_assignment::NoThisAssignment 
 }
 
 impl RuleRunner for crate::rules::unicorn::no_typeof_undefined::NoTypeofUndefined {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression]));
 }
 
 impl RuleRunner
     for crate::rules::unicorn::no_unnecessary_array_flat_depth::NoUnnecessaryArrayFlatDepth
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_unnecessary_await::NoUnnecessaryAwait {
@@ -2161,7 +2337,8 @@ impl RuleRunner for crate::rules::unicorn::no_unnecessary_await::NoUnnecessaryAw
 }
 
 impl RuleRunner for crate::rules::unicorn::no_unnecessary_slice_end::NoUnnecessarySliceEnd {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner
@@ -2171,13 +2348,15 @@ impl RuleRunner
 }
 
 impl RuleRunner for crate::rules::unicorn::no_unreadable_iife::NoUnreadableIife {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner
     for crate::rules::unicorn::no_useless_fallback_in_spread::NoUselessFallbackInSpread
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::LogicalExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_useless_length_check::NoUselessLengthCheck {
@@ -2188,7 +2367,8 @@ impl RuleRunner for crate::rules::unicorn::no_useless_length_check::NoUselessLen
 impl RuleRunner
     for crate::rules::unicorn::no_useless_promise_resolve_reject::NoUselessPromiseResolveReject
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_useless_spread::NoUselessSpread {
@@ -2196,7 +2376,8 @@ impl RuleRunner for crate::rules::unicorn::no_useless_spread::NoUselessSpread {
 }
 
 impl RuleRunner for crate::rules::unicorn::no_useless_switch_case::NoUselessSwitchCase {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::SwitchStatement]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_useless_undefined::NoUselessUndefined {
@@ -2204,7 +2385,8 @@ impl RuleRunner for crate::rules::unicorn::no_useless_undefined::NoUselessUndefi
 }
 
 impl RuleRunner for crate::rules::unicorn::no_zero_fractions::NoZeroFractions {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::NumericLiteral]));
 }
 
 impl RuleRunner for crate::rules::unicorn::number_literal_case::NumberLiteralCase {
@@ -2216,7 +2398,8 @@ impl RuleRunner for crate::rules::unicorn::numeric_separators_style::NumericSepa
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_add_event_listener::PreferAddEventListener {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::AssignmentExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_array_find::PreferArrayFind {
@@ -2224,15 +2407,18 @@ impl RuleRunner for crate::rules::unicorn::prefer_array_find::PreferArrayFind {
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_array_flat::PreferArrayFlat {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_array_flat_map::PreferArrayFlatMap {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_array_index_of::PreferArrayIndexOf {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_array_some::PreferArraySome {
@@ -2240,11 +2426,13 @@ impl RuleRunner for crate::rules::unicorn::prefer_array_some::PreferArraySome {
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_blob_reading_methods::PreferBlobReadingMethods {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_code_point::PreferCodePoint {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_date_now::PreferDateNow {
@@ -2252,15 +2440,18 @@ impl RuleRunner for crate::rules::unicorn::prefer_date_now::PreferDateNow {
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_dom_node_append::PreferDomNodeAppend {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_dom_node_dataset::PreferDomNodeDataset {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_dom_node_remove::PreferDomNodeRemove {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_dom_node_text_content::PreferDomNodeTextContent {
@@ -2268,23 +2459,27 @@ impl RuleRunner for crate::rules::unicorn::prefer_dom_node_text_content::PreferD
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_event_target::PreferEventTarget {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::IdentifierReference]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_global_this::PreferGlobalThis {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::IdentifierReference]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_includes::PreferIncludes {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_logical_operator_over_ternary::PreferLogicalOperatorOverTernary {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[AstType::ConditionalExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_math_min_max::PreferMathMinMax {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ConditionalExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_math_trunc::PreferMathTrunc {
@@ -2292,7 +2487,8 @@ impl RuleRunner for crate::rules::unicorn::prefer_math_trunc::PreferMathTrunc {
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_modern_dom_apis::PreferModernDomApis {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_modern_math_apis::PreferModernMathApis {
@@ -2306,7 +2502,8 @@ impl RuleRunner
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_negative_index::PreferNegativeIndex {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_node_protocol::PreferNodeProtocol {
@@ -2318,89 +2515,108 @@ impl RuleRunner for crate::rules::unicorn::prefer_number_properties::PreferNumbe
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_object_from_entries::PreferObjectFromEntries {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner
     for crate::rules::unicorn::prefer_optional_catch_binding::PreferOptionalCatchBinding
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CatchParameter]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_prototype_methods::PreferPrototypeMethods {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_query_selector::PreferQuerySelector {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_reflect_apply::PreferReflectApply {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_regexp_test::PreferRegexpTest {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_set_has::PreferSetHas {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::VariableDeclarator]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_set_size::PreferSetSize {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::StaticMemberExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_spread::PreferSpread {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_string_raw::PreferStringRaw {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::StringLiteral]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_string_replace_all::PreferStringReplaceAll {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_string_slice::PreferStringSlice {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner
     for crate::rules::unicorn::prefer_string_starts_ends_with::PreferStringStartsEndsWith
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_string_trim_start_end::PreferStringTrimStartEnd {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_structured_clone::PreferStructuredClone {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_type_error::PreferTypeError {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ThrowStatement]));
 }
 
 impl RuleRunner for crate::rules::unicorn::require_array_join_separator::RequireArrayJoinSeparator {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::require_number_to_fixed_digits_argument::RequireNumberToFixedDigitsArgument {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner
     for crate::rules::unicorn::require_post_message_target_origin::RequirePostMessageTargetOrigin
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::switch_case_braces::SwitchCaseBraces {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::SwitchStatement]));
 }
 
 impl RuleRunner
@@ -2410,7 +2626,8 @@ impl RuleRunner
 }
 
 impl RuleRunner for crate::rules::unicorn::throw_new_error::ThrowNewError {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::vitest::no_conditional_tests::NoConditionalTests {
@@ -2438,15 +2655,18 @@ impl RuleRunner for crate::rules::vitest::require_local_test_context_for_concurr
 }
 
 impl RuleRunner for crate::rules::vue::define_emits_declaration::DefineEmitsDeclaration {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::vue::define_props_declaration::DefinePropsDeclaration {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::vue::no_multiple_slot_args::NoMultipleSlotArgs {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::vue::valid_define_emits::ValidDefineEmits {

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -346,20 +346,37 @@ mod test {
         assert_rule_runs_on_node_types(&eslint::no_debugger::NoDebugger, &[DebuggerStatement]);
         assert_rule_runs_on_node_types(&eslint::no_with::NoWith, &[WithStatement]);
         assert_rule_runs_on_node_types(
+            &eslint::arrow_body_style::ArrowBodyStyle::default(),
+            &[ArrowFunctionExpression],
+        );
+        assert_rule_runs_on_node_types(
+            &eslint::no_else_return::NoElseReturn::default(),
+            &[IfStatement],
+        );
+        assert_rule_runs_on_node_types(
             &jest::prefer_jest_mocked::PreferJestMocked,
             &[TSAsExpression, TSTypeAssertion],
         );
+        assert_rule_runs_on_node_types(&jest::prefer_spy_on::PreferSpyOn, &[AssignmentExpression]);
         assert_rule_runs_on_node_types(
             &jsx_a11y::anchor_is_valid::AnchorIsValid::default(),
             &[JSXElement],
+        );
+        assert_rule_runs_on_node_types(
+            &jsx_a11y::aria_activedescendant_has_tabindex::AriaActivedescendantHasTabindex,
+            &[JSXOpeningElement],
         );
         assert_rule_runs_on_node_types(
             &nextjs::no_head_element::NoHeadElement,
             &[JSXOpeningElement],
         );
         assert_rule_runs_on_node_types(
-            &unicorn::explicit_length_check::ExplicitLengthCheck::default(),
-            &[StaticMemberExpression],
+            &nextjs::google_font_display::GoogleFontDisplay,
+            &[JSXOpeningElement],
+        );
+        assert_rule_runs_on_node_types(
+            &unicorn::consistent_assert::ConsistentAssert,
+            &[ImportDeclaration],
         );
     }
 

--- a/crates/oxc_linter/src/rules/react/no_unknown_property.rs
+++ b/crates/oxc_linter/src/rules/react/no_unknown_property.rs
@@ -480,7 +480,7 @@ impl Rule for NoUnknownProperty {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let AstKind::JSXOpeningElement(el) = &node.kind() else {
+        let AstKind::JSXOpeningElement(el) = node.kind() else {
             return;
         };
         let JSXElementName::Identifier(ident) = &el.name else {

--- a/crates/oxc_linter/src/rules/unicorn/consistent_date_clone.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_date_clone.rs
@@ -46,7 +46,7 @@ declare_oxc_lint!(
 
 impl Rule for ConsistentDateClone {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let AstKind::NewExpression(expr) = &node.kind() else {
+        let AstKind::NewExpression(expr) = node.kind() else {
             return;
         };
 

--- a/tasks/linter_codegen/src/let_else_detector.rs
+++ b/tasks/linter_codegen/src/let_else_detector.rs
@@ -1,0 +1,62 @@
+use syn::{Expr, Pat, Stmt};
+
+use crate::{
+    CollectionResult,
+    node_type_set::NodeTypeSet,
+    utils::{astkind_variant_from_path, is_node_kind_call},
+};
+
+/// Detects top-level `let AstKind::... = node.kind() else { return; }` patterns in the `run` method.
+pub struct LetElseDetector {
+    node_types: NodeTypeSet,
+}
+
+impl LetElseDetector {
+    pub fn from_run_func(run_func: &syn::ImplItemFn) -> Option<NodeTypeSet> {
+        // Only consider when the body's first statement is `let AstKind::... = node.kind() else { ... }`,
+        // and the body of the `else` is just `return`.
+        let block = &run_func.block;
+        let first_stmt = block.stmts.first()?;
+        // Must be a local `let` statement
+        let Stmt::Local(local) = first_stmt else { return None };
+        // Must have an initializer that is a `node.kind()` call
+        let Some(init) = &local.init else { return None };
+        if !is_node_kind_call(&init.expr) {
+            return None;
+        }
+        // Must have a diverging `else` block
+        let Some(diverge) = &init.diverge else { return None };
+        let diverge_expr = &*diverge.1;
+        let Expr::Block(else_block) = diverge_expr else { return None };
+        // The else block must have exactly one statement and it must be a `return`
+        if else_block.block.stmts.len() != 1 {
+            return None;
+        }
+        let Stmt::Expr(expr, _) = &else_block.block.stmts[0] else { return None };
+        if !matches!(expr, Expr::Return(_)) {
+            return None;
+        }
+
+        let mut detector = Self { node_types: NodeTypeSet::new() };
+        let result = detector.extract_variants_from_pat(&local.pat);
+        if detector.node_types.is_empty() || result == CollectionResult::Incomplete {
+            return None;
+        }
+
+        Some(detector.node_types)
+    }
+
+    fn extract_variants_from_pat(&mut self, pat: &Pat) -> CollectionResult {
+        match pat {
+            Pat::TupleStruct(ts) => {
+                if let Some(variant) = astkind_variant_from_path(&ts.path) {
+                    self.node_types.insert(variant);
+                    CollectionResult::Complete
+                } else {
+                    CollectionResult::Incomplete
+                }
+            }
+            _ => CollectionResult::Incomplete,
+        }
+    }
+}


### PR DESCRIPTION
- part of https://github.com/oxc-project/oxc/issues/12223

Adds basic detection for syntax like `let AstKind::Something(...) = node.kind() else { return };` in lint rules for generating rule runner trait impls.

## Correctness

Spot checking it on my laptop shows same number of diagnostics for `kibana` and `vscode`:

<img width="640" height="180" alt="Screenshot 2025-09-11 at 5 35 47 PM" src="https://github.com/user-attachments/assets/43eb90a7-c3a9-46ed-8b73-e077a1d8d7f3" />

<img width="632" height="179" alt="Screenshot 2025-09-11 at 5 36 08 PM" src="https://github.com/user-attachments/assets/93652148-e27a-4d8c-9121-307624f2ee27" />


## Benchmarks

~15% faster on `oven-sh/bun`:

<img width="880" height="369" alt="Screenshot 2025-09-11 at 5 26 49 PM" src="https://github.com/user-attachments/assets/69a4c806-003e-4ff0-a679-ab9c6616dfc4" />

~9% faster on `microsoft/vscode`:

<img width="833" height="331" alt="Screenshot 2025-09-11 at 5 27 50 PM" src="https://github.com/user-attachments/assets/a6a42f96-ecab-448e-919c-550e6b4bdc26" />

~11% faster on `posthog/posthog`:

<img width="814" height="323" alt="Screenshot 2025-09-11 at 5 28 23 PM" src="https://github.com/user-attachments/assets/64daac0d-5bff-40df-aee7-ee843ba84351" />

~8% faster on `elastic/kibana`:

<img width="797" height="324" alt="Screenshot 2025-09-11 at 5 31 00 PM" src="https://github.com/user-attachments/assets/3ca57a2b-0e69-4460-903f-baa36de69123" />
