### PR TITLE
build(napi/oxlint): do not extern `constants.mjs`

### DIFF
--- a/napi/oxlint/scripts/build.js
+++ b/napi/oxlint/scripts/build.js
@@ -10,10 +10,6 @@ const oxlintDirPath = join(import.meta.dirname, '..'),
 console.log('Building with tsdown...');
 execSync('pnpm tsdown', { stdio: 'inherit', cwd: oxlintDirPath });
 
-// Copy generated constants file
-console.log('Copying generated files...');
-copyFile(join(oxlintDirPath, 'src-js/generated/constants.mjs'), join(distDirPath, 'generated/constants.mjs'));
-
 // Copy files from `napi/parser` to `napi/oxlint/dist/parser`
 console.log('Copying files from parser...');
 

--- a/napi/oxlint/tsdown.config.ts
+++ b/napi/oxlint/tsdown.config.ts
@@ -12,8 +12,6 @@ export default defineConfig({
     // External native bindings
     './oxlint.*.node',
     'oxlint-*',
-    // External the generated constants file - we'll copy it separately
-    './generated/constants.mjs',
     // These are generated (also used by oxc-parser, so we'll copy them separately)
     /..\/parser\/.*/,
   ],


### PR DESCRIPTION
Surprisingly, TSDown inlines the constants from `constants.mjs` into the bundled code, regardless of whether the file is listed as `external` in TSDown config. So remove it from `external` list and don't copy the file into `dist`.