### PR TITLE
build(napi/oxlint): flatten `dist` directory structure

### DIFF
--- a/napi/oxlint/scripts/build.js
+++ b/napi/oxlint/scripts/build.js
@@ -10,7 +10,7 @@ const oxlintDirPath = join(import.meta.dirname, '..'),
 console.log('Building with tsdown...');
 execSync('pnpm tsdown', { stdio: 'inherit', cwd: oxlintDirPath });
 
-// Copy files from `napi/parser` to `napi/oxlint/dist/parser`
+// Copy files from `napi/parser` to `napi/oxlint/dist`
 console.log('Copying files from parser...');
 
 const parserFilePaths = [
@@ -22,7 +22,7 @@ const parserFilePaths = [
 ];
 
 for (const parserFilePath of parserFilePaths) {
-  copyFile(join(parserDirPath, parserFilePath), join(distDirPath, 'parser', parserFilePath));
+  copyFile(join(parserDirPath, parserFilePath), join(distDirPath, parserFilePath));
 }
 
 // Copy native `.node` files from `src-js`

--- a/napi/oxlint/src-js/plugins/lint.ts
+++ b/napi/oxlint/src-js/plugins/lint.ts
@@ -10,9 +10,9 @@ import { assertIs } from './utils.js';
 import { addVisitorToCompiled, compiledVisitor, finalizeCompiledVisitor, initCompiledVisitor } from './visitor.js';
 
 // @ts-expect-error we need to generate `.d.ts` file for this module.
-import { TOKEN } from '../../dist/parser/raw-transfer/lazy-common.mjs';
+import { TOKEN } from '../../dist/raw-transfer/lazy-common.mjs';
 // @ts-expect-error we need to generate `.d.ts` file for this module.
-import { walkProgram } from '../../dist/parser/generated/lazy/walk.mjs';
+import { walkProgram } from '../../dist/generated/lazy/walk.mjs';
 
 // Buffer with typed array views of itself stored as properties
 interface BufferWithArrays extends Uint8Array {

--- a/napi/oxlint/src-js/plugins/visitor.ts
+++ b/napi/oxlint/src-js/plugins/visitor.ts
@@ -74,7 +74,7 @@
 
 // TODO(camc314): we need to generate `.d.ts` file for this module.
 // @ts-expect-error
-import { LEAF_NODE_TYPES_COUNT, NODE_TYPE_IDS_MAP, NODE_TYPES_COUNT } from '../../dist/parser/generated/lazy/types.mjs';
+import { LEAF_NODE_TYPES_COUNT, NODE_TYPE_IDS_MAP, NODE_TYPES_COUNT } from '../../dist/generated/lazy/types.mjs';
 import { assertIs } from './utils.js';
 
 import type { CompiledVisitorEntry, EnterExit, Node, VisitFn, Visitor } from './types.ts';

--- a/napi/oxlint/test/compile-visitor.test.ts
+++ b/napi/oxlint/test/compile-visitor.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // TODO(camc314): we need to generate `.d.ts` file for this module.
 // @ts-expect-error
-import { NODE_TYPE_IDS_MAP } from '../../parser/generated/lazy/types.mjs';
+import { NODE_TYPE_IDS_MAP } from '../dist/generated/lazy/types.mjs';
 import {
   addVisitorToCompiled,
   compiledVisitor,

--- a/napi/oxlint/tsdown.config.ts
+++ b/napi/oxlint/tsdown.config.ts
@@ -12,8 +12,9 @@ export default defineConfig({
     // External native bindings
     './oxlint.*.node',
     'oxlint-*',
-    // These are generated (also used by oxc-parser, so we'll copy them separately)
-    /..\/parser\/.*/,
+    // Files copied from `oxc-parser`.
+    // Not bundled, to avoid needing sourcemaps when debugging.
+    /\/dist\//,
   ],
   // At present only compress syntax.
   // Don't mangle identifiers or remove whitespace, so `dist` code remains somewhat readable.


### PR DESCRIPTION
Pure refactor. Flatten directory structure of `dist` dir a little, by removing `parser` dir.