### PR TITLE
refactor(linter/plugins): improve error messages for JS plugins

### DIFF
--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -594,11 +594,13 @@ impl Display for ConfigBuilderError {
                 write!(f, "invalid config file {file}: {reason}")
             }
             ConfigBuilderError::PluginLoadFailed { plugin_specifier, error } => {
-                write!(f, "Failed to load external plugin: {plugin_specifier}\n  {error}")?;
+                write!(f, "Failed to load JS plugin: {plugin_specifier}\n  {error}")?;
                 Ok(())
             }
             ConfigBuilderError::NoExternalLinterConfigured => {
-                f.write_str("Failed to load external plugin because no external linter was configured. This means the Oxlint binary was executed directly rather than via napi bindings.")?;
+                f.write_str(
+                    "JS plugins are not supported without `--experimental-js-plugins` CLI option",
+                )?;
                 Ok(())
             }
             ConfigBuilderError::ExternalRuleLookupError(e) => std::fmt::Display::fmt(&e, f),

--- a/napi/oxlint/test/__snapshots__/e2e.test.ts.snap
+++ b/napi/oxlint/test/__snapshots__/e2e.test.ts.snap
@@ -447,8 +447,15 @@ exports[`oxlint CLI > should report an error if a a rule is not found within a c
 exports[`oxlint CLI > should report an error if a custom plugin cannot be loaded 1`] = `
 "Failed to parse configuration file.
 
-  x Failed to load external plugin: ./test_plugin
+  x Failed to load JS plugin: ./test_plugin
   |   Cannot find module './test_plugin'
+"
+`;
+
+exports[`oxlint CLI > should report an error if a custom plugin in config but JS plugins are not enabled 1`] = `
+"Failed to parse configuration file.
+
+  x JS plugins are not supported without \`--experimental-js-plugins\` CLI option
 "
 `;
 

--- a/napi/oxlint/test/e2e.test.ts
+++ b/napi/oxlint/test/e2e.test.ts
@@ -67,6 +67,12 @@ describe('oxlint CLI', () => {
     expect(normalizeOutput(stdout)).toMatchSnapshot();
   });
 
+  it('should report an error if a custom plugin in config but JS plugins are not enabled', async () => {
+    const { stdout, exitCode } = await runOxlintWithoutPlugins('test/fixtures/basic_custom_plugin');
+    expect(exitCode).toBe(1);
+    expect(normalizeOutput(stdout)).toMatchSnapshot();
+  });
+
   it('should report an error if a custom plugin cannot be loaded', async () => {
     const { stdout, exitCode } = await runOxlint('test/fixtures/missing_custom_plugin');
     expect(exitCode).toBe(1);


### PR DESCRIPTION
Amend error messages related to JS plugins. "external" is the term we use in the codebase, but it probably wouldn't make much sense to end users. Use the term "JS plugin" instead.