### PR TITLE
refactor(formatter): move `is_supported_source_type` to `oxc_formatter` crate

### DIFF
--- a/apps/oxfmt/src/walk.rs
+++ b/apps/oxfmt/src/walk.rs
@@ -2,56 +2,8 @@ use std::{ffi::OsStr, path::PathBuf, sync::Arc, sync::mpsc};
 
 use ignore::overrides::Override;
 
+use oxc_formatter::get_supported_source_type;
 use oxc_span::SourceType;
-
-// Additional extensions from linguist-languages, which Prettier also supports
-// - https://github.com/ikatyang-collab/linguist-languages/blob/d1dc347c7ced0f5b42dd66c7d1c4274f64a3eb6b/data/JavaScript.js
-// No special extensions for TypeScript
-// - https://github.com/ikatyang-collab/linguist-languages/blob/d1dc347c7ced0f5b42dd66c7d1c4274f64a3eb6b/data/TypeScript.js
-const ADDITIONAL_JS_EXTENSIONS: &[&str] = &[
-    "_js",
-    "bones",
-    "es",
-    "es6",
-    "frag",
-    "gs",
-    "jake",
-    "javascript",
-    "jsb",
-    "jscad",
-    "jsfl",
-    "jslib",
-    "jsm",
-    "jspre",
-    "jss",
-    "njs",
-    "pac",
-    "sjs",
-    "ssjs",
-    "xsjs",
-    "xsjslib",
-];
-
-fn is_supported_source_type(path: &std::path::Path) -> Option<SourceType> {
-    let extension = path.extension()?.to_string_lossy();
-
-    // Standard extensions, also supported by `oxc_span::VALID_EXTENSIONS`
-    if let Ok(source_type) = SourceType::from_extension(&extension) {
-        return Some(source_type);
-    }
-    // Additional extensions from linguist-languages, which Prettier also supports
-    if ADDITIONAL_JS_EXTENSIONS.contains(&extension.as_ref()) {
-        return Some(SourceType::default());
-    }
-    // `Jakefile` has no extension but is a valid JS file defined by linguist-languages
-    if path.file_name() == Some(OsStr::new("Jakefile")) {
-        return Some(SourceType::default());
-    }
-
-    None
-}
-
-// ---
 
 pub struct Walk {
     inner: ignore::WalkParallel,
@@ -91,7 +43,7 @@ impl ignore::ParallelVisitor for WalkCollector {
                 // Skip if we can't get file type or if it's a directory
                 if let Some(file_type) = entry.file_type() {
                     if !file_type.is_dir() {
-                        if let Some(source_type) = is_supported_source_type(entry.path()) {
+                        if let Some(source_type) = get_supported_source_type(entry.path()) {
                             self.entries.push(WalkEntry {
                                 path: entry.path().as_os_str().into(),
                                 source_type,

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -16,6 +16,7 @@ mod generated {
 mod formatter;
 mod options;
 mod parentheses;
+mod service;
 mod utils;
 mod write;
 
@@ -33,6 +34,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use write::FormatWrite;
 
 pub use crate::options::*;
+pub use crate::service::source_type::get_supported_source_type;
 use crate::{
     formatter::FormatContext,
     generated::ast_nodes::{AstNode, AstNodes},

--- a/crates/oxc_formatter/src/service/mod.rs
+++ b/crates/oxc_formatter/src/service/mod.rs
@@ -1,0 +1,1 @@
+pub mod source_type;

--- a/crates/oxc_formatter/src/service/source_type.rs
+++ b/crates/oxc_formatter/src/service/source_type.rs
@@ -1,0 +1,50 @@
+use std::ffi::OsStr;
+
+use oxc_span::SourceType;
+
+// Additional extensions from linguist-languages, which Prettier also supports
+// - https://github.com/ikatyang-collab/linguist-languages/blob/d1dc347c7ced0f5b42dd66c7d1c4274f64a3eb6b/data/JavaScript.js
+// No special extensions for TypeScript
+// - https://github.com/ikatyang-collab/linguist-languages/blob/d1dc347c7ced0f5b42dd66c7d1c4274f64a3eb6b/data/TypeScript.js
+const ADDITIONAL_JS_EXTENSIONS: &[&str] = &[
+    "_js",
+    "bones",
+    "es",
+    "es6",
+    "frag",
+    "gs",
+    "jake",
+    "javascript",
+    "jsb",
+    "jscad",
+    "jsfl",
+    "jslib",
+    "jsm",
+    "jspre",
+    "jss",
+    "njs",
+    "pac",
+    "sjs",
+    "ssjs",
+    "xsjs",
+    "xsjslib",
+];
+
+pub fn get_supported_source_type(path: &std::path::Path) -> Option<SourceType> {
+    let extension = path.extension()?.to_string_lossy();
+
+    // Standard extensions, also supported by `oxc_span::VALID_EXTENSIONS`
+    if let Ok(source_type) = SourceType::from_extension(&extension) {
+        return Some(source_type);
+    }
+    // Additional extensions from linguist-languages, which Prettier also supports
+    if ADDITIONAL_JS_EXTENSIONS.contains(&extension.as_ref()) {
+        return Some(SourceType::default());
+    }
+    // `Jakefile` has no extension but is a valid JS file defined by linguist-languages
+    if path.file_name() == Some(OsStr::new("Jakefile")) {
+        return Some(SourceType::default());
+    }
+
+    None
+}


### PR DESCRIPTION
- Renamed `is_supported_source_type` to `get_supported_source_type`
- Moved the function to `oxc_formatter`, because the language server wants to use the function too