### PR TITLE
fix(formatter): correct comments printing for import and export

### DIFF
--- a/crates/oxc_formatter/src/formatter/comments.rs
+++ b/crates/oxc_formatter/src/formatter/comments.rs
@@ -305,12 +305,6 @@ impl<'a> Comments<'a> {
         );
 
         let Some(following_node) = following_node else {
-            if let SiblingNode::ImportDeclaration(import) = enclosing_node
-                && import.source.span.start > preceding_span.end
-            {
-                return self.comments_before(import.source.span.start);
-            }
-
             let enclosing_span = enclosing_node.span();
             return self.comments_before(enclosing_span.end);
         };

--- a/crates/oxc_formatter/src/generated/format.rs
+++ b/crates/oxc_formatter/src/generated/format.rs
@@ -2496,33 +2496,39 @@ impl<'a> Format<'a> for AstNode<'a, ImportDeclarationSpecifier<'a>> {
 impl<'a> Format<'a> for AstNode<'a, ImportSpecifier<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        if is_suppressed {
+            self.format_leading_comments(f)?;
+            FormatSuppressedNode(self.span()).fmt(f)?;
+            self.format_trailing_comments(f)
+        } else {
+            self.write(f)
+        }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ImportDefaultSpecifier<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        if is_suppressed {
+            self.format_leading_comments(f)?;
+            FormatSuppressedNode(self.span()).fmt(f)?;
+            self.format_trailing_comments(f)
+        } else {
+            self.write(f)
+        }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ImportNamespaceSpecifier<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        if is_suppressed {
+            self.format_leading_comments(f)?;
+            FormatSuppressedNode(self.span()).fmt(f)?;
+            self.format_trailing_comments(f)
+        } else {
+            self.write(f)
+        }
     }
 }
 
@@ -2614,11 +2620,13 @@ impl<'a> Format<'a> for AstNode<'a, ExportAllDeclaration<'a>> {
 impl<'a> Format<'a> for AstNode<'a, ExportSpecifier<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        if is_suppressed {
+            self.format_leading_comments(f)?;
+            FormatSuppressedNode(self.span()).fmt(f)?;
+            self.format_trailing_comments(f)
+        } else {
+            self.write(f)
+        }
     }
 }
 

--- a/crates/oxc_formatter/src/write/import_declaration.rs
+++ b/crates/oxc_formatter/src/write/import_declaration.rs
@@ -7,7 +7,10 @@ use crate::{
     Format, FormatResult, FormatTrailingCommas, QuoteProperties, TrailingSeparator, best_fitting,
     format_args,
     formatter::{
-        Formatter, prelude::*, separated::FormatSeparatedIter, trivia::FormatLeadingComments,
+        Formatter,
+        prelude::*,
+        separated::FormatSeparatedIter,
+        trivia::{FormatLeadingComments, FormatTrailingComments},
     },
     generated::ast_nodes::{AstNode, AstNodes},
     write,
@@ -61,7 +64,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, ImportDeclarationSpecifier<'a>>> {
         let should_insert_space_around_brackets = f.options().bracket_spacing.value();
 
         if self.is_empty() {
-            write!(f, ["{", "}"])?;
+            write!(f, ["{}"])?;
         } else if self.len() == 1
             && let Some(ImportDeclarationSpecifier::ImportSpecifier(specifier)) =
                 specifiers_iter.peek().map(AsRef::as_ref)
@@ -137,7 +140,13 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ImportSpecifier<'a>> {
         } else {
             write!(f, [self.imported(), space(), "as", space(), self.local()])?;
         }
-        Ok(())
+
+        if f.source_text().next_non_whitespace_byte_is(self.span.end, b'}') {
+            let comments = f.context().comments().comments_before_character(self.span.end, b'}');
+            write!(f, [FormatTrailingComments::Comments(comments)])
+        } else {
+            self.format_trailing_comments(f)
+        }
     }
 }
 
@@ -149,7 +158,15 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ImportDefaultSpecifier<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ImportNamespaceSpecifier<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, ["*", space(), "as", space(), self.local()])
+        write!(f, ["*", space(), "as", space()])?;
+        let local = self.local();
+        local.format_leading_comments(f)?;
+        local.write(f)?;
+        // `import * as all /* comment */ from 'mod'`
+        //                  ^^^^^^^^^^^^ get comments that before `from` keyword to print
+        // `f` is the first character of `from`
+        let comments = f.context().comments().comments_before_character(local.span().start, b'f');
+        write!(f, [space(), FormatTrailingComments::Comments(comments)])
     }
 }
 

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -31,6 +31,10 @@ const AST_NODE_WITHOUT_PRINTING_COMMENTS_LIST: &[&str] = &[
     "JSXFragment",
     //
     "TemplateElement",
+    "ImportSpecifier",
+    "ImportDefaultSpecifier",
+    "ImportNamespaceSpecifier",
+    "ExportSpecifier",
 ];
 
 const AST_NODE_NEEDS_PARENTHESES: &[&str] = &["TSTypeAssertion"];

--- a/tasks/coverage/snapshots/formatter_babel.snap
+++ b/tasks/coverage/snapshots/formatter_babel.snap
@@ -2,12 +2,10 @@ commit: 41d96516
 
 formatter_babel Summary:
 AST Parsed     : 2423/2423 (100.00%)
-Positive Passed: 2379/2423 (98.18%)
+Positive Passed: 2383/2423 (98.35%)
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/basic/try-statement/input.js
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/regression/13750/input.js
-
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-type-only/input.ts
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/class/division/input.js
 
@@ -61,10 +59,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/members-trailing-comma-with-initializer-babel-7/input.ts
 
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/export/export-type/input.ts
-
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/export/export-type-from/input.ts
-
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/function/predicate-types/input.ts
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/extends/input.ts
@@ -78,8 +72,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type-2-babel-7/input.ts
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type-babel-7/input.ts
-
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-in-different-module-and-top-level/input.ts
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/conditional-infer/input.ts
 

--- a/tasks/coverage/snapshots/formatter_typescript.snap
+++ b/tasks/coverage/snapshots/formatter_typescript.snap
@@ -2,7 +2,7 @@ commit: 261630d6
 
 formatter_typescript Summary:
 AST Parsed     : 8816/8816 (100.00%)
-Positive Passed: 7922/8816 (89.86%)
+Positive Passed: 7935/8816 (90.01%)
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/APISample_jsdoc.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/addMoreCallSignaturesToBaseSignature.ts
@@ -316,8 +316,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/declarationEmitU
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules2.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/declarationsForIndirectTypeAliasReference.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataTypeOnlyExport.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/deepKeysIndexing.ts
 
@@ -1095,8 +1093,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/declarationEm
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicatesWithPrivateName02.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typeofImportTypeOnlyExport.ts
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/decorators/1.0lib-noErrors.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratorChecksFunctionBodies.ts
@@ -1317,33 +1313,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/externalModul
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelAwait.1.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/circular1.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/circular3.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportDeclaration.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportDeclaration_moduleSpecifier-isolatedModules.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportDeclaration_value.ts
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importsNotUsedAsValues_error.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceImportTypeQuery.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceImportTypeQuery2.ts
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/nestedNamespace.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/preserveValueImports_errors.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnlyMerge1.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxConstEnum.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxConstEnumUsage.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxRestrictionsESM.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeIndirectReferenceToGlobalType.ts
 
@@ -1446,8 +1422,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttrib
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload6.tsx
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/allowImportingTypesDtsExtension.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit1.ts
 

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 659/699 (94.28%)
+js compatibility: 662/699 (94.71%)
 
 # Failed
 
@@ -6,7 +6,6 @@ js compatibility: 659/699 (94.28%)
 | :-------- | :--------------: | :---------: |
 | js/comments/15661.js | 💥💥 | 55.81% |
 | js/comments/empty-statements.js | 💥💥 | 90.91% |
-| js/comments/export.js | 💥💥 | 97.37% |
 | js/comments/function-declaration.js | 💥💥 | 92.80% |
 | js/comments/return-statement.js | 💥💥 | 98.85% |
 | js/comments/html-like/comment.js | 💥 | 0.00% |
@@ -20,8 +19,6 @@ js compatibility: 659/699 (94.28%)
 | js/for/parentheses.js | 💥 | 96.00% |
 | js/identifier/for-of/let.js | 💥 | 92.31% |
 | js/identifier/parentheses/let.js | 💥💥 | 82.27% |
-| js/import-assertions/keyword-detect.js | 💥 | 71.43% |
-| js/import-attributes/keyword-detect.js | 💥 | 71.43% |
 | js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 22.22% |
 | js/logical_expressions/issue-7024.js | 💥 | 66.67% |
 | js/object-multiline/multiline.js | 💥✨ | 22.22% |

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 331/573 (57.77%)
+ts compatibility: 332/573 (57.94%)
 
 # Failed
 
@@ -145,7 +145,6 @@ ts compatibility: 331/573 (57.77%)
 | typescript/generic/issue-6899.ts | 💥 | 21.05% |
 | typescript/generic/object-method.ts | 💥 | 72.73% |
 | typescript/generic/ungrouped-parameters.ts | 💥 | 74.07% |
-| typescript/import-export/type-modifier.ts | 💥 | 66.67% |
 | typescript/import-type/import-type.ts | 💥💥 | 93.33% |
 | typescript/index-signature/static.ts | 💥 | 66.67% |
 | typescript/infer-extends/basic.ts | 💥 | 66.67% |


### PR DESCRIPTION
This PR aims to remove the special logic for import and export declarations from `get_trailing_comments` and move the special logic to the printing site. The benefits of this are to make `get_trailing_comments` cleaner so that we can entirely remove `SiblingNode`, which may lead to significant performance improvements.