### PR TITLE
fix(oxfmt): Print sorted output

### DIFF
--- a/apps/oxfmt/src/reporter.rs
+++ b/apps/oxfmt/src/reporter.rs
@@ -6,32 +6,45 @@ use oxc_diagnostics::{
 #[derive(Debug)]
 pub struct DefaultReporter {
     handler: GraphicalReportHandler,
+    diagnostics: Vec<Error>,
 }
 
 impl Default for DefaultReporter {
     fn default() -> Self {
-        Self { handler: GraphicalReportHandler::new() }
+        Self { handler: GraphicalReportHandler::new(), diagnostics: Vec::new() }
     }
 }
 
 impl DiagnosticReporter for DefaultReporter {
     fn render_error(&mut self, error: Error) -> Option<String> {
-        // If `.labels()` exists, it means this comes from `oxc_parser`, `oxc_formatter`, etc
-        if error.labels().is_some() {
-            let mut output = String::new();
-            self.handler.render_report(&mut output, error.as_ref()).unwrap();
-            return Some(output);
-        }
-
-        // Otherwise, this is a error without `labels`, originate from `oxfmt` itself
-
-        // NOTE: Formatted `path` should be inlined
-        // there is no way to get here since we do not have `labels`
-        Some(format!("{error}\n"))
+        // Collect diagnostics for sorting instead of immediate rendering
+        self.diagnostics.push(error);
+        None
     }
 
     fn finish(&mut self, _result: &DiagnosticResult) -> Option<String> {
-        // Leave it to the caller with `diagnostic_service.run()`, to determine exit code
-        None
+        let mut output = String::new();
+
+        // Sort diagnostics: labels-less warnings first, then errors with labels last
+        self.diagnostics.sort_by_cached_key(|diagnostic| {
+            if diagnostic.labels().is_none() {
+                (0, diagnostic.to_string())
+            } else {
+                (1, diagnostic.to_string())
+            }
+        });
+
+        // Render all sorted diagnostics
+        for diagnostic in &self.diagnostics {
+            // If `.labels()` exists, it means this comes from `oxc_parser`, `oxc_formatter`, etc
+            // Otherwise, this is a warnings just contains formatted path from `oxfmt` itself
+            if diagnostic.labels().is_none() {
+                output.push_str(format!("{diagnostic}\n").as_str());
+            } else {
+                self.handler.render_report(&mut output, diagnostic.as_ref()).unwrap();
+            }
+        }
+
+        Some(output)
     }
 }


### PR DESCRIPTION
CLI now displays the sorted execution result paths.

Ref: https://github.com/oxc-project/oxc/pull/13681#issuecomment-3283594227
(Thanks Cameron!)

