### PR TITLE
refactor(linter): remove `#[cfg(test)]` attributes from `tester` module

### DIFF
--- a/apps/oxlint/src/lib.rs
+++ b/apps/oxlint/src/lib.rs
@@ -10,8 +10,10 @@ mod js_plugins;
 mod lint;
 mod output_formatter;
 mod result;
-mod tester;
 mod walk;
+
+#[cfg(test)]
+mod tester;
 
 pub mod cli {
     pub use crate::{command::*, lint::LintRunner, result::CliRunResult};

--- a/apps/oxlint/src/tester.rs
+++ b/apps/oxlint/src/tester.rs
@@ -1,20 +1,14 @@
-#[cfg(test)]
 use std::{env, path::PathBuf};
 
-#[cfg(test)]
 use cow_utils::CowUtils;
-#[cfg(test)]
 use lazy_regex::Regex;
 
-#[cfg(test)]
 use crate::cli::{LintRunner, lint_command};
 
-#[cfg(test)]
 pub struct Tester {
     cwd: PathBuf,
 }
 
-#[cfg(test)]
 impl Tester {
     pub fn new() -> Self {
         let cwd = env::current_dir().unwrap();


### PR DESCRIPTION
Pure refactor. Add `#[cfg(test)]` to `tester` module, instead of to every item in the module, to simplify the code.