### PR TITLE
fix(raw_transfer): disable layout assertions on some 32-bit platforms

### DIFF
--- a/crates/oxc_allocator/src/generated/assert_layouts.rs
+++ b/crates/oxc_allocator/src/generated/assert_layouts.rs
@@ -18,7 +18,7 @@ const _: () = {
 };
 
 #[cfg(target_pointer_width = "32")]
-const _: () = {
+const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     // Padding: 3 bytes
     assert!(size_of::<FixedSizeAllocatorMetadata>() == 12);
     assert!(align_of::<FixedSizeAllocatorMetadata>() == 4);

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -1612,7 +1612,7 @@ const _: () = {
 };
 
 #[cfg(target_pointer_width = "32")]
-const _: () = {
+const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     // Padding: 1 bytes
     assert!(size_of::<Program>() == 88);
     assert!(align_of::<Program>() == 4);

--- a/crates/oxc_linter/src/generated/assert_layouts.rs
+++ b/crates/oxc_linter/src/generated/assert_layouts.rs
@@ -18,7 +18,7 @@ const _: () = {
 };
 
 #[cfg(target_pointer_width = "32")]
-const _: () = {
+const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     // Padding: 3 bytes
     assert!(size_of::<RawTransferMetadata2>() == 16);
     assert!(align_of::<RawTransferMetadata2>() == 8);

--- a/crates/oxc_regular_expression/src/generated/assert_layouts.rs
+++ b/crates/oxc_regular_expression/src/generated/assert_layouts.rs
@@ -166,7 +166,7 @@ const _: () = {
 };
 
 #[cfg(target_pointer_width = "32")]
-const _: () = {
+const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     // Padding: 0 bytes
     assert!(size_of::<Pattern>() == 32);
     assert!(align_of::<Pattern>() == 4);

--- a/crates/oxc_span/src/generated/assert_layouts.rs
+++ b/crates/oxc_span/src/generated/assert_layouts.rs
@@ -33,7 +33,7 @@ const _: () = {
 };
 
 #[cfg(target_pointer_width = "32")]
-const _: () = {
+const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     // Padding: 0 bytes
     assert!(size_of::<Span>() == 8);
     assert!(align_of::<Span>() == 4);

--- a/crates/oxc_syntax/src/generated/assert_layouts.rs
+++ b/crates/oxc_syntax/src/generated/assert_layouts.rs
@@ -100,7 +100,7 @@ const _: () = {
 };
 
 #[cfg(target_pointer_width = "32")]
-const _: () = {
+const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     // Padding: 0 bytes
     assert!(size_of::<NonMaxU32>() == 4);
     assert!(align_of::<NonMaxU32>() == 4);

--- a/napi/parser/src/generated/assert_layouts.rs
+++ b/napi/parser/src/generated/assert_layouts.rs
@@ -66,7 +66,7 @@ const _: () = {
 };
 
 #[cfg(target_pointer_width = "32")]
-const _: () = {
+const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     // Padding: 0 bytes
     assert!(size_of::<RawTransferData>() == 188);
     assert!(align_of::<RawTransferData>() == 4);

--- a/tasks/ast_tools/src/generators/assert_layouts.rs
+++ b/tasks/ast_tools/src/generators/assert_layouts.rs
@@ -684,9 +684,20 @@ fn template(krate: &str, assertions_64: &TokenStream, assertions_32: &TokenStrea
         #[cfg(target_pointer_width = "64")]
         const _: () = { #assertions_64 };
 
+        // Some 32-bit platforms have 8-byte alignment for `u64` and `f64`, while others have 4-byte alignment.
+        //
+        // Skip these assertions on 32-bit platforms where `u64` / `f64` have 4-byte alignment, because
+        // some layout calculations may be incorrect. https://github.com/oxc-project/oxc/issues/13694
+        //
+        // At present 32-bit layouts aren't relied on by any code, so it's fine if they're incorrect for now.
+        // However, raw transfer will be supported on WASM32 in future, and layout calculations are correct
+        // for WASM32 at present. So keep these assertions for WASM, to ensure changes to AST or this codegen
+        // don't break anything.
         ///@@line_break
         #[cfg(target_pointer_width = "32")]
-        const _: () = { #assertions_32 };
+        const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
+            #assertions_32
+        };
 
         ///@@line_break
         #[cfg(not(any(target_pointer_width = "64", target_pointer_width = "32")))]


### PR DESCRIPTION
Fixes #13694.

Some 32-bit platforms give `u64` and `f64` alignment of 8, and others alignment of 4. WASM32 uses alignment 8, and layout calculator assumes that.

Skip layout assertions for platforms where alignment is 4, because we know some layouts are wrong for those platforms, and it causes compilation failure in debug builds. But retain the assertions for other 32-bit platforms (notably WASM), to make sure they remain correct. This will make it easier to extend raw transfer support to WASM later on.