### PR TITLE
fix(linter/react-perf/jsx-no-new-object-as-prop): skip as/satisfies exprs

### DIFF
--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_object_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_object_as_prop.rs
@@ -77,7 +77,7 @@ impl ReactPerfRule for JsxNoNewObjectAsProp {
 }
 
 fn check_expression(expr: &Expression) -> Option<Span> {
-    match expr.without_parentheses() {
+    match expr.get_inner_expression() {
         Expression::ObjectExpression(expr) => Some(expr.span),
         Expression::CallExpression(expr) => {
             if is_constructor_matching_name(&expr.callee, "Object")
@@ -158,6 +158,10 @@ fn test() {
         r"const Foo = () => (<Item config={this.props.config || (this.props.default ? this.props.default : {})} />)",
         r"const Foo = () => { const x = {}; return <Bar x={x} /> }",
         r"const Foo = ({ x = {} }) => <Item x={x} />",
+        r"const Foo = () => { const x: Foo = {}; return <Bar x={x} /> }",
+        r"const Foo = () => { const x: Foo = {} as Foo; return <Bar x={x} /> }",
+        r"const Foo = () => { const x: Foo = {} satisfies Foo; return <Bar x={x} /> }",
+        r"const Foo = () => { const x: Foo = {} as const; return <Bar x={x} /> }",
     ];
 
     Tester::new(JsxNoNewObjectAsProp::NAME, JsxNoNewObjectAsProp::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/react_perf_jsx_no_new_object_as_prop.snap
+++ b/crates/oxc_linter/src/snapshots/react_perf_jsx_no_new_object_as_prop.snap
@@ -83,3 +83,43 @@ source: crates/oxc_linter/src/tester.rs
    ·                ╰── The prop was declared here
    ╰────
   help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).
+
+  ⚠ eslint-plugin-react-perf(jsx-no-new-object-as-prop): JSX attribute values should not contain objects created in the same scope.
+   ╭─[jsx_no_new_object_as_prop.tsx:1:27]
+ 1 │ const Foo = () => { const x: Foo = {}; return <Bar x={x} /> }
+   ·                           ───┬──   ─┬                 ┬
+   ·                              │      │                 ╰── And used here
+   ·                              │      ╰── And assigned a new value here
+   ·                              ╰── The prop was declared here
+   ╰────
+  help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).
+
+  ⚠ eslint-plugin-react-perf(jsx-no-new-object-as-prop): JSX attribute values should not contain objects created in the same scope.
+   ╭─[jsx_no_new_object_as_prop.tsx:1:27]
+ 1 │ const Foo = () => { const x: Foo = {} as Foo; return <Bar x={x} /> }
+   ·                           ───┬──   ─┬                        ┬
+   ·                              │      │                        ╰── And used here
+   ·                              │      ╰── And assigned a new value here
+   ·                              ╰── The prop was declared here
+   ╰────
+  help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).
+
+  ⚠ eslint-plugin-react-perf(jsx-no-new-object-as-prop): JSX attribute values should not contain objects created in the same scope.
+   ╭─[jsx_no_new_object_as_prop.tsx:1:27]
+ 1 │ const Foo = () => { const x: Foo = {} satisfies Foo; return <Bar x={x} /> }
+   ·                           ───┬──   ─┬                               ┬
+   ·                              │      │                               ╰── And used here
+   ·                              │      ╰── And assigned a new value here
+   ·                              ╰── The prop was declared here
+   ╰────
+  help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).
+
+  ⚠ eslint-plugin-react-perf(jsx-no-new-object-as-prop): JSX attribute values should not contain objects created in the same scope.
+   ╭─[jsx_no_new_object_as_prop.tsx:1:27]
+ 1 │ const Foo = () => { const x: Foo = {} as const; return <Bar x={x} /> }
+   ·                           ───┬──   ─┬                          ┬
+   ·                              │      │                          ╰── And used here
+   ·                              │      ╰── And assigned a new value here
+   ·                              ╰── The prop was declared here
+   ╰────
+  help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).


### PR DESCRIPTION
fixes #13717