### PR TITLE
test(linter): set CWD for tests

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -903,10 +903,12 @@ mod test {
     #[test]
     fn test_tsconfig_option() {
         // passed
-        Tester::new().test(&["--tsconfig", "fixtures/tsconfig/tsconfig.json"]);
+        Tester::new().with_cwd("fixtures".into()).test(&["--tsconfig", "tsconfig/tsconfig.json"]);
 
         // failed
-        Tester::new().test_and_snapshot(&["--tsconfig", "oxc/tsconfig.json"]);
+        Tester::new()
+            .with_cwd("fixtures".into())
+            .test_and_snapshot(&["--tsconfig", "oxc/tsconfig.json"]);
     }
 
     #[test]
@@ -953,7 +955,7 @@ mod test {
     #[test]
     fn test_print_config_ban_all_rules() {
         let args = &["-A", "all", "--print-config"];
-        Tester::new().test_and_snapshot(args);
+        Tester::new().with_cwd("fixtures".into()).test_and_snapshot(args);
     }
 
     #[test]
@@ -975,7 +977,7 @@ mod test {
         assert!(!fs::exists(LintRunner::DEFAULT_OXLINTRC).unwrap());
 
         let args = &["--init"];
-        Tester::new().test(args);
+        Tester::new().with_cwd("fixtures".into()).test(args);
 
         assert!(fs::exists(LintRunner::DEFAULT_OXLINTRC).unwrap());
 

--- a/apps/oxlint/src/snapshots/fixtures_--tsconfig oxc__tsconfig.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures_--tsconfig oxc__tsconfig.json@oxlint.snap
@@ -3,9 +3,9 @@ source: apps/oxlint/src/tester.rs
 ---
 ########## 
 arguments: --tsconfig oxc/tsconfig.json
-working directory: 
+working directory: fixtures
 ----------
-The tsconfig file "<cwd>/oxc/tsconfig.json" does not exist, Please provide a valid tsconfig file.
+The tsconfig file "<cwd>/fixtures/oxc/tsconfig.json" does not exist, Please provide a valid tsconfig file.
 ----------
 CLI result: InvalidOptionTsConfig
 ----------

--- a/apps/oxlint/src/snapshots/fixtures_-A all --print-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures_-A all --print-config@oxlint.snap
@@ -3,7 +3,7 @@ source: apps/oxlint/src/tester.rs
 ---
 ########## 
 arguments: -A all --print-config
-working directory: 
+working directory: fixtures
 ----------
 {
   "plugins": [


### PR DESCRIPTION
#13723 turns `apps/oxlint` into a NAPI package, and moves all the files from `napi/oxlint` into `apps/oxlint`.

These files include the `test` directory, which includes tests for JS plugins. This causes problems with 3 of the existing `oxlint` Rust tests, which run with `cwd` as `apps/oxlint` and no config file specified, because they pick up config files in the JS test fixtures. These config files include JS plugins, which `oxlint`'s Rust tests can't handle because they're run without an `ExternalLinter`.

This PR works around this problem by setting `cwd` to `apps/oxlint/fixtures` for these 3 tests.

I'm not sure if this is a reasonable way to solve the problem.
