### PR TITLE
test(oxfmt): Use normalized path separator

### DIFF
--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -34,6 +34,7 @@ oxc_parser = { workspace = true }
 oxc_span = { workspace = true }
 
 bpaf = { workspace = true, features = ["autocomplete", "bright-color", "derive"] }
+cow-utils = { workspace = true }
 ignore = { workspace = true, features = ["simd-accel"] }
 miette = { workspace = true }
 rayon = { workspace = true }
@@ -49,7 +50,6 @@ mimalloc-safe = { workspace = true, optional = true, features = ["skip_collect_o
 mimalloc-safe = { workspace = true, optional = true, features = ["skip_collect_on_exit", "local_dynamic_tls", "no_opt_arch"] }
 
 [dev-dependencies]
-cow-utils = { workspace = true }
 insta = { workspace = true }
 lazy-regex = { workspace = true }
 


### PR DESCRIPTION
Try to fix https://github.com/oxc-project/oxc/actions/runs/17669363561/job/50217437836#step:7:2170

```
───────────────────────────────────────────────────────────────────────────────
-old snapshot
+new results
────────────┬──────────────────────────────────────────────────────────────────
   16    16 │ arguments: tests/fixtures/multiple_files
   17    17 │ working directory: 
   18    18 │ ----------
   19    19 │ Checking formatting...
   20       │-tests/fixtures/multiple_files/arrow.js (<variable>ms)
   21       │-tests/fixtures/multiple_files/simple.js (<variable>ms)
         20 │+tests/fixtures/multiple_files\arrow.js (<variable>ms)
         21 │+tests/fixtures/multiple_files\simple.js (<variable>ms)
   22    22 │ 
   23    23 │ Format issues found in above 2 files. Run with `-w` or `--write` to fix.
   24    24 │ Finished in <variable>ms on 2 files using 1 threads.
   25    25 │ ----------
────────────┴──────────────────────────────────────────────────────────────────
Stopped on the first failure. Run `cargo insta test` to run all snapshots.
```

This PR unifies `\` and `/` to `/`.
