### PR TITLE
refactor(language_server): introduce `LSPFileSystem`

### DIFF
--- a/crates/oxc_language_server/src/capabilities.rs
+++ b/crates/oxc_language_server/src/capabilities.rs
@@ -14,6 +14,7 @@ pub struct Capabilities {
     pub workspace_execute_command: bool,
     pub workspace_configuration: bool,
     pub dynamic_watchers: bool,
+    pub dynamic_formatting: bool,
 }
 
 impl From<ClientCapabilities> for Capabilities {
@@ -39,6 +40,12 @@ impl From<ClientCapabilities> for Capabilities {
                 watched_files.dynamic_registration.is_some_and(|dynamic| dynamic)
             })
         });
+        // TODO: enable it when we support formatting
+        // let formatting = value.text_document.as_ref().is_some_and(|text_document| {
+        //     text_document.formatting.is_some_and(|formatting| {
+        //         formatting.dynamic_registration.is_some_and(|dynamic| dynamic)
+        //     })
+        // });
 
         Self {
             code_action_provider,
@@ -46,6 +53,7 @@ impl From<ClientCapabilities> for Capabilities {
             workspace_execute_command,
             workspace_configuration,
             dynamic_watchers,
+            dynamic_formatting: false,
         }
     }
 }

--- a/crates/oxc_language_server/src/file_system.rs
+++ b/crates/oxc_language_server/src/file_system.rs
@@ -1,0 +1,27 @@
+use tower_lsp_server::lsp_types::Uri;
+
+use crate::ConcurrentHashMap;
+
+#[derive(Debug, Default)]
+pub struct LSPFileSystem {
+    files: ConcurrentHashMap<Uri, String>,
+}
+
+impl LSPFileSystem {
+    pub fn clear(&self) {
+        self.files.pin().clear();
+    }
+
+    pub fn set(&self, uri: &Uri, content: String) {
+        self.files.pin().insert(uri.clone(), content);
+    }
+
+    #[expect(dead_code)] // used for the oxc_formatter in the future
+    pub fn get(&self, uri: &Uri) -> Option<String> {
+        self.files.pin().get(uri).cloned()
+    }
+
+    pub fn remove(&self, uri: &Uri) {
+        self.files.pin().remove(uri);
+    }
+}


### PR DESCRIPTION
Formatting requests has no source text included:
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentFormattingParams

Because users can format in memory files, the server needs to keep track of the changes.
Created in `Backend` struct, so when we later support `textDocument/diagnostic` (we support currently only `textDocument/publishDiagnostic)`, we can use the same File System for it too :) 

Putting the struct into a Workspace Worker is an option too, but there can be multiple of it. 
With this solution, there is only one instance of it :) 