### PR TITLE
fix(editor): run `oxc_language_server` in shell

### DIFF
--- a/editors/vscode/client/ConfigService.ts
+++ b/editors/vscode/client/ConfigService.ts
@@ -73,6 +73,10 @@ export class ConfigService implements IDisposable {
         return;
       }
       bin = path.normalize(path.join(cwd, bin));
+      // on Windows we will get a path like `\C:\path\to\bin`, remove the leading \
+      if (process.platform === 'win32' && bin.startsWith('\\')) {
+        bin = bin.slice(1);
+      }
     }
 
     return bin;

--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -159,6 +159,9 @@ export async function activate(context: ExtensionContext) {
   const run: Executable = {
     command: command!,
     options: {
+      // Execute with shell, because user can define custom `oxc.path.server`.
+      // This allows for more flexibility in the server path configuration with cross-platform support.
+      shell: true,
       env: {
         ...process.env,
         RUST_LOG: process.env.RUST_LOG || 'info',


### PR DESCRIPTION
See https://github.com/oxc-project/oxc/issues/12849#issuecomment-3278213562

Executing on Windows these paths will not work:
- `node_modules/.bin/oxc_language_server`
- `node_modules/.bin/oxc_language_server.CMD`
- `node_modules/.bin/oxc_language_server.ps1`

VSCode wants under windows the real `.exe` file. 
Searching for it with the different package manager folder structures is a bit of pain.

Execute the server with `shell`, then  `node_modules/bin/oxc_language_server` will work for Linux and windows the same way.

Tested it in windows10 and Ubuntu (Windows WSL2 env)
- with `oxc.path.server` to  `node_modules/.bin/oxc_language_server`
- without `oxc.path.server`