### PR TITLE
fix(editor): don't allow `oxc.path.server` for untrusted workspaces

### DIFF
--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -139,7 +139,7 @@ export async function activate(context: ExtensionContext) {
 
   async function findBinary(): Promise<string> {
     let bin = configService.getUserServerBinPath();
-    if (bin) {
+    if (workspace.isTrusted && bin) {
       try {
         await fsPromises.access(bin);
         return bin;

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -178,6 +178,15 @@
       }
     ]
   },
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": "limited",
+      "description": "The Extension will always use the Language Server shipped with the Extension.",
+      "restrictedConfigurations": [
+        "oxc.path.server"
+      ]
+    }
+  },
   "scripts": {
     "preinstall": "[ -f icon.png ] || curl https://cdn.jsdelivr.net/gh/oxc-project/oxc-assets/square.png --output icon.png",
     "build": "pnpm run server:build:release && pnpm run compile && pnpm run package",


### PR DESCRIPTION
Opening a project with a custom `oxc.path.server` could run another executable then the extensions wants.  
Will work on further optimization.

https://code.visualstudio.com/docs/editing/workspaces/workspace-trust
