### PR TITLE
perf(linter): add node type codegen support for `match node.kind()`

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -27,7 +27,14 @@ impl RuleRunner for crate::rules::eslint::class_methods_use_this::ClassMethodsUs
 }
 
 impl RuleRunner for crate::rules::eslint::curly::Curly {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::DoWhileStatement,
+        AstType::ForInStatement,
+        AstType::ForOfStatement,
+        AstType::ForStatement,
+        AstType::IfStatement,
+        AstType::WhileStatement,
+    ]));
 }
 
 impl RuleRunner for crate::rules::eslint::default_case::DefaultCase {
@@ -77,7 +84,11 @@ impl RuleRunner for crate::rules::eslint::guard_for_in::GuardForIn {
 }
 
 impl RuleRunner for crate::rules::eslint::id_length::IdLength {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::BindingIdentifier,
+        AstType::IdentifierName,
+        AstType::PrivateIdentifier,
+    ]));
 }
 
 impl RuleRunner for crate::rules::eslint::init_declarations::InitDeclarations {
@@ -106,7 +117,8 @@ impl RuleRunner for crate::rules::eslint::max_nested_callbacks::MaxNestedCallbac
 }
 
 impl RuleRunner for crate::rules::eslint::max_params::MaxParams {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ArrowFunctionExpression, AstType::Function]));
 }
 
 impl RuleRunner for crate::rules::eslint::new_cap::NewCap {
@@ -132,7 +144,11 @@ impl RuleRunner for crate::rules::eslint::no_await_in_loop::NoAwaitInLoop {
 }
 
 impl RuleRunner for crate::rules::eslint::no_bitwise::NoBitwise {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::AssignmentExpression,
+        AstType::BinaryExpression,
+        AstType::UnaryExpression,
+    ]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_caller::NoCaller {
@@ -168,11 +184,18 @@ impl RuleRunner for crate::rules::eslint::no_const_assign::NoConstAssign {
 impl RuleRunner
     for crate::rules::eslint::no_constant_binary_expression::NoConstantBinaryExpression
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression, AstType::LogicalExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_constant_condition::NoConstantCondition {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::ConditionalExpression,
+        AstType::DoWhileStatement,
+        AstType::ForStatement,
+        AstType::IfStatement,
+        AstType::WhileStatement,
+    ]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_constructor_return::NoConstructorReturn {
@@ -492,11 +515,19 @@ impl RuleRunner for crate::rules::eslint::no_undef::NoUndef {
 }
 
 impl RuleRunner for crate::rules::eslint::no_undefined::NoUndefined {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::BindingIdentifier,
+        AstType::IdentifierReference,
+    ]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_unexpected_multiline::NoUnexpectedMultiline {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::BinaryExpression,
+        AstType::CallExpression,
+        AstType::ComputedMemberExpression,
+        AstType::TaggedTemplateExpression,
+    ]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_unneeded_ternary::NoUnneededTernary {
@@ -573,7 +604,12 @@ impl RuleRunner for crate::rules::eslint::no_useless_escape::NoUselessEscape {
 }
 
 impl RuleRunner for crate::rules::eslint::no_useless_rename::NoUselessRename {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::ExportNamedDeclaration,
+        AstType::ImportSpecifier,
+        AstType::ObjectAssignmentTarget,
+        AstType::ObjectPattern,
+    ]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_var::NoVar {
@@ -622,7 +658,8 @@ impl RuleRunner for crate::rules::eslint::prefer_object_spread::PreferObjectSpre
 }
 
 impl RuleRunner for crate::rules::eslint::prefer_promise_reject_errors::PreferPromiseRejectErrors {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::NewExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::prefer_rest_params::PreferRestParams {
@@ -773,7 +810,8 @@ impl RuleRunner for crate::rules::import::no_duplicates::NoDuplicates {
 }
 
 impl RuleRunner for crate::rules::import::no_dynamic_require::NoDynamicRequire {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::ImportExpression]));
 }
 
 impl RuleRunner for crate::rules::import::no_empty_named_blocks::NoEmptyNamedBlocks {
@@ -782,7 +820,10 @@ impl RuleRunner for crate::rules::import::no_empty_named_blocks::NoEmptyNamedBlo
 }
 
 impl RuleRunner for crate::rules::import::no_mutable_exports::NoMutableExports {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::ExportDefaultDeclaration,
+        AstType::ExportNamedDeclaration,
+    ]));
 }
 
 impl RuleRunner for crate::rules::import::no_named_as_default::NoNamedAsDefault {
@@ -806,7 +847,10 @@ impl RuleRunner for crate::rules::import::no_self_import::NoSelfImport {
 }
 
 impl RuleRunner for crate::rules::import::no_unassigned_import::NoUnassignedImport {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::ExpressionStatement,
+        AstType::ImportDeclaration,
+    ]));
 }
 
 impl RuleRunner for crate::rules::import::no_webpack_loader_syntax::NoWebpackLoaderSyntax {
@@ -1368,7 +1412,10 @@ impl RuleRunner for crate::rules::oxc::bad_array_method_on_arguments::BadArrayMe
 }
 
 impl RuleRunner for crate::rules::oxc::bad_bitwise_operator::BadBitwiseOperator {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::AssignmentExpression,
+        AstType::BinaryExpression,
+    ]));
 }
 
 impl RuleRunner for crate::rules::oxc::bad_char_at_comparison::BadCharAtComparison {
@@ -1426,7 +1473,8 @@ impl RuleRunner for crate::rules::oxc::no_accumulating_spread::NoAccumulatingSpr
 }
 
 impl RuleRunner for crate::rules::oxc::no_async_await::NoAsyncAwait {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ArrowFunctionExpression, AstType::Function]));
 }
 
 impl RuleRunner for crate::rules::oxc::no_async_endpoint_handlers::NoAsyncEndpointHandlers {
@@ -1453,7 +1501,11 @@ impl RuleRunner for crate::rules::oxc::no_optional_chaining::NoOptionalChaining 
 }
 
 impl RuleRunner for crate::rules::oxc::no_rest_spread_properties::NoRestSpreadProperties {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::BindingRestElement,
+        AstType::ObjectAssignmentTarget,
+        AstType::SpreadElement,
+    ]));
 }
 
 impl RuleRunner for crate::rules::oxc::number_arg_out_of_range::NumberArgOutOfRange {
@@ -1519,7 +1571,11 @@ impl RuleRunner for crate::rules::promise::param_names::ParamNames {
 }
 
 impl RuleRunner for crate::rules::promise::prefer_await_to_callbacks::PreferAwaitToCallbacks {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::ArrowFunctionExpression,
+        AstType::CallExpression,
+        AstType::Function,
+    ]));
 }
 
 impl RuleRunner for crate::rules::promise::prefer_await_to_then::PreferAwaitToThen {
@@ -1542,11 +1598,12 @@ impl RuleRunner for crate::rules::promise::valid_params::ValidParams {
 }
 
 impl RuleRunner for crate::rules::react::button_has_type::ButtonHasType {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::react::checked_requires_onchange_or_readonly::CheckedRequiresOnchangeOrReadonly {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::react::exhaustive_deps::ExhaustiveDeps {
@@ -1564,7 +1621,8 @@ impl RuleRunner for crate::rules::react::forward_ref_uses_ref::ForwardRefUsesRef
 }
 
 impl RuleRunner for crate::rules::react::iframe_missing_sandbox::IframeMissingSandbox {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::react::jsx_boolean_value::JsxBooleanValue {
@@ -1573,7 +1631,8 @@ impl RuleRunner for crate::rules::react::jsx_boolean_value::JsxBooleanValue {
 }
 
 impl RuleRunner for crate::rules::react::jsx_curly_brace_presence::JsxCurlyBracePresence {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXElement, AstType::JSXFragment]));
 }
 
 impl RuleRunner for crate::rules::react::jsx_filename_extension::JsxFilenameExtension {
@@ -1590,7 +1649,8 @@ impl RuleRunner for crate::rules::react::jsx_handler_names::JsxHandlerNames {
 }
 
 impl RuleRunner for crate::rules::react::jsx_key::JsxKey {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXElement, AstType::JSXFragment]));
 }
 
 impl RuleRunner for crate::rules::react::jsx_no_comment_textnodes::JsxNoCommentTextnodes {
@@ -1619,7 +1679,8 @@ impl RuleRunner for crate::rules::react::jsx_no_undef::JsxNoUndef {
 }
 
 impl RuleRunner for crate::rules::react::jsx_no_useless_fragment::JsxNoUselessFragment {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXElement, AstType::JSXFragment]));
 }
 
 impl RuleRunner for crate::rules::react::jsx_props_no_spread_multi::JsxPropsNoSpreadMulti {
@@ -1632,11 +1693,13 @@ impl RuleRunner for crate::rules::react::no_array_index_key::NoArrayIndexKey {
 }
 
 impl RuleRunner for crate::rules::react::no_children_prop::NoChildrenProp {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::JSXAttribute]));
 }
 
 impl RuleRunner for crate::rules::react::no_danger::NoDanger {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::JSXElement]));
 }
 
 impl RuleRunner for crate::rules::react::no_danger_with_children::NoDangerWithChildren {
@@ -1644,7 +1707,10 @@ impl RuleRunner for crate::rules::react::no_danger_with_children::NoDangerWithCh
 }
 
 impl RuleRunner for crate::rules::react::no_direct_mutation_state::NoDirectMutationState {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::AssignmentExpression,
+        AstType::UpdateExpression,
+    ]));
 }
 
 impl RuleRunner for crate::rules::react::no_find_dom_node::NoFindDomNode {
@@ -1658,7 +1724,8 @@ impl RuleRunner for crate::rules::react::no_is_mounted::NoIsMounted {
 }
 
 impl RuleRunner for crate::rules::react::no_namespace::NoNamespace {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::JSXOpeningElement]));
 }
 
 impl RuleRunner for crate::rules::react::no_render_return_value::NoRenderReturnValue {
@@ -1708,11 +1775,13 @@ impl RuleRunner for crate::rules::react::self_closing_comp::SelfClosingComp {
 }
 
 impl RuleRunner for crate::rules::react::style_prop_object::StylePropObject {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::JSXElement]));
 }
 
 impl RuleRunner for crate::rules::react::void_dom_elements_no_children::VoidDomElementsNoChildren {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::JSXElement]));
 }
 
 impl RuleRunner for crate::rules::react_perf::jsx_no_jsx_as_prop::JsxNoJsxAsProp {
@@ -1734,7 +1803,15 @@ impl RuleRunner for crate::rules::react_perf::jsx_no_new_object_as_prop::JsxNoNe
 impl RuleRunner
     for crate::rules::typescript::adjacent_overload_signatures::AdjacentOverloadSignatures
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::BlockStatement,
+        AstType::Class,
+        AstType::FunctionBody,
+        AstType::Program,
+        AstType::TSInterfaceDeclaration,
+        AstType::TSModuleBlock,
+        AstType::TSTypeLiteral,
+    ]));
 }
 
 impl RuleRunner for crate::rules::typescript::array_type::ArrayType {
@@ -1754,13 +1831,18 @@ impl RuleRunner for crate::rules::typescript::ban_tslint_comment::BanTslintComme
 }
 
 impl RuleRunner for crate::rules::typescript::ban_types::BanTypes {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TSTypeLiteral, AstType::TSTypeReference]));
 }
 
 impl RuleRunner
     for crate::rules::typescript::consistent_generic_constructors::ConsistentGenericConstructors
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::AssignmentPattern,
+        AstType::PropertyDefinition,
+        AstType::VariableDeclarator,
+    ]));
 }
 
 impl RuleRunner
@@ -1782,13 +1864,18 @@ impl RuleRunner for crate::rules::typescript::consistent_type_imports::Consisten
 impl RuleRunner
     for crate::rules::typescript::explicit_function_return_type::ExplicitFunctionReturnType
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ArrowFunctionExpression, AstType::Function]));
 }
 
 impl RuleRunner
     for crate::rules::typescript::explicit_module_boundary_types::ExplicitModuleBoundaryTypes
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::ExportDefaultDeclaration,
+        AstType::ExportNamedDeclaration,
+        AstType::TSExportAssignment,
+    ]));
 }
 
 impl RuleRunner for crate::rules::typescript::no_array_delete::NoArrayDelete {
@@ -1867,7 +1954,12 @@ impl RuleRunner for crate::rules::typescript::no_import_type_side_effects::NoImp
 }
 
 impl RuleRunner for crate::rules::typescript::no_inferrable_types::NoInferrableTypes {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::ArrowFunctionExpression,
+        AstType::Function,
+        AstType::PropertyDefinition,
+        AstType::VariableDeclarator,
+    ]));
 }
 
 impl RuleRunner
@@ -1877,7 +1969,11 @@ impl RuleRunner
 }
 
 impl RuleRunner for crate::rules::typescript::no_misused_new::NoMisusedNew {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::Class,
+        AstType::TSInterfaceDeclaration,
+        AstType::TSMethodSignature,
+    ]));
 }
 
 impl RuleRunner for crate::rules::typescript::no_misused_promises::NoMisusedPromises {
@@ -1917,11 +2013,17 @@ impl RuleRunner
 }
 
 impl RuleRunner for crate::rules::typescript::no_require_imports::NoRequireImports {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::CallExpression,
+        AstType::TSImportEqualsDeclaration,
+    ]));
 }
 
 impl RuleRunner for crate::rules::typescript::no_this_alias::NoThisAlias {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::AssignmentExpression,
+        AstType::VariableDeclarator,
+    ]));
 }
 
 impl RuleRunner for crate::rules::typescript::no_unnecessary_boolean_literal_compare::NoUnnecessaryBooleanLiteralCompare {
@@ -1970,7 +2072,8 @@ impl RuleRunner for crate::rules::typescript::no_unsafe_call::NoUnsafeCall {
 impl RuleRunner
     for crate::rules::typescript::no_unsafe_declaration_merging::NoUnsafeDeclarationMerging
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Class, AstType::TSInterfaceDeclaration]));
 }
 
 impl RuleRunner for crate::rules::typescript::no_unsafe_enum_comparison::NoUnsafeEnumComparison {
@@ -1978,7 +2081,11 @@ impl RuleRunner for crate::rules::typescript::no_unsafe_enum_comparison::NoUnsaf
 }
 
 impl RuleRunner for crate::rules::typescript::no_unsafe_function_type::NoUnsafeFunctionType {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::TSClassImplements,
+        AstType::TSInterfaceHeritage,
+        AstType::TSTypeReference,
+    ]));
 }
 
 impl RuleRunner for crate::rules::typescript::no_unsafe_member_access::NoUnsafeMemberAccess {
@@ -2022,7 +2129,11 @@ impl RuleRunner for crate::rules::typescript::only_throw_error::OnlyThrowError {
 }
 
 impl RuleRunner for crate::rules::typescript::prefer_as_const::PreferAsConst {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::PropertyDefinition,
+        AstType::TSAsExpression,
+        AstType::VariableDeclarator,
+    ]));
 }
 
 impl RuleRunner for crate::rules::typescript::prefer_enum_initializers::PreferEnumInitializers {
@@ -2036,7 +2147,12 @@ impl RuleRunner for crate::rules::typescript::prefer_for_of::PreferForOf {
 }
 
 impl RuleRunner for crate::rules::typescript::prefer_function_type::PreferFunctionType {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::ExportDefaultDeclaration,
+        AstType::TSInterfaceDeclaration,
+        AstType::TSTypeAliasDeclaration,
+        AstType::TSTypeAnnotation,
+    ]));
 }
 
 impl RuleRunner for crate::rules::typescript::prefer_literal_enum_member::PreferLiteralEnumMember {
@@ -2160,7 +2276,11 @@ impl RuleRunner for crate::rules::unicorn::error_message::ErrorMessage {
 }
 
 impl RuleRunner for crate::rules::unicorn::escape_case::EscapeCase {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::RegExpLiteral,
+        AstType::StringLiteral,
+        AstType::TemplateLiteral,
+    ]));
 }
 
 impl RuleRunner for crate::rules::unicorn::explicit_length_check::ExplicitLengthCheck {
@@ -2173,7 +2293,8 @@ impl RuleRunner for crate::rules::unicorn::filename_case::FilenameCase {
 }
 
 impl RuleRunner for crate::rules::unicorn::new_for_builtins::NewForBuiltins {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::NewExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_abusive_eslint_disable::NoAbusiveEslintDisable {
@@ -2234,7 +2355,11 @@ impl RuleRunner for crate::rules::unicorn::no_empty_file::NoEmptyFile {
 }
 
 impl RuleRunner for crate::rules::unicorn::no_hex_escape::NoHexEscape {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::RegExpLiteral,
+        AstType::StringLiteral,
+        AstType::TemplateLiteral,
+    ]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_instanceof_array::NoInstanceofArray {
@@ -2324,11 +2449,21 @@ impl RuleRunner for crate::rules::unicorn::no_static_only_class::NoStaticOnlyCla
 }
 
 impl RuleRunner for crate::rules::unicorn::no_thenable::NoThenable {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::AssignmentExpression,
+        AstType::CallExpression,
+        AstType::ExportNamedDeclaration,
+        AstType::MethodDefinition,
+        AstType::ObjectExpression,
+        AstType::PropertyDefinition,
+    ]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_this_assignment::NoThisAssignment {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::AssignmentExpression,
+        AstType::VariableDeclarator,
+    ]));
 }
 
 impl RuleRunner for crate::rules::unicorn::no_typeof_undefined::NoTypeofUndefined {
@@ -2406,7 +2541,8 @@ impl RuleRunner for crate::rules::unicorn::number_literal_case::NumberLiteralCas
 }
 
 impl RuleRunner for crate::rules::unicorn::numeric_separators_style::NumericSeparatorsStyle {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BigIntLiteral, AstType::NumericLiteral]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_add_event_listener::PreferAddEventListener {
@@ -2434,7 +2570,8 @@ impl RuleRunner for crate::rules::unicorn::prefer_array_index_of::PreferArrayInd
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_array_some::PreferArraySome {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression, AstType::CallExpression]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_blob_reading_methods::PreferBlobReadingMethods {
@@ -2448,7 +2585,12 @@ impl RuleRunner for crate::rules::unicorn::prefer_code_point::PreferCodePoint {
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_date_now::PreferDateNow {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::AssignmentExpression,
+        AstType::BinaryExpression,
+        AstType::CallExpression,
+        AstType::UnaryExpression,
+    ]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_dom_node_append::PreferDomNodeAppend {
@@ -2467,7 +2609,11 @@ impl RuleRunner for crate::rules::unicorn::prefer_dom_node_remove::PreferDomNode
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_dom_node_text_content::PreferDomNodeTextContent {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::IdentifierName,
+        AstType::IdentifierReference,
+        AstType::StaticMemberExpression,
+    ]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_event_target::PreferEventTarget {
@@ -2504,13 +2650,15 @@ impl RuleRunner for crate::rules::unicorn::prefer_modern_dom_apis::PreferModernD
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_modern_math_apis::PreferModernMathApis {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression, AstType::CallExpression]));
 }
 
 impl RuleRunner
     for crate::rules::unicorn::prefer_native_coercion_functions::PreferNativeCoercionFunctions
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ArrowFunctionExpression, AstType::Function]));
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_negative_index::PreferNegativeIndex {

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -354,6 +354,14 @@ mod test {
             &[IfStatement],
         );
         assert_rule_runs_on_node_types(
+            &eslint::max_params::MaxParams::default(),
+            &[Function, ArrowFunctionExpression],
+        );
+        assert_rule_runs_on_node_types(
+            &import::no_dynamic_require::NoDynamicRequire::default(),
+            &[ImportExpression, CallExpression],
+        );
+        assert_rule_runs_on_node_types(
             &jest::prefer_jest_mocked::PreferJestMocked,
             &[TSAsExpression, TSTypeAssertion],
         );

--- a/tasks/linter_codegen/src/main.rs
+++ b/tasks/linter_codegen/src/main.rs
@@ -3,6 +3,7 @@
 use crate::{
     if_else_detector::IfElseKindDetector,
     let_else_detector::LetElseDetector,
+    match_detector::MatchDetector,
     node_type_set::NodeTypeSet,
     rules::{RuleEntry, find_rule_source_file, get_all_rules},
     utils::{find_impl_function, find_rule_impl_block},
@@ -17,6 +18,7 @@ use syn::File;
 
 mod if_else_detector;
 mod let_else_detector;
+mod match_detector;
 mod node_type_set;
 mod rules;
 mod utils;
@@ -89,6 +91,13 @@ fn detect_top_level_node_types(file: &File, rule: &RuleEntry) -> Option<NodeType
     let run_func = find_impl_function(rule_impl, "run")?;
 
     let node_types = LetElseDetector::from_run_func(run_func);
+    if let Some(node_types) = node_types
+        && !node_types.is_empty()
+    {
+        return Some(node_types);
+    }
+
+    let node_types = MatchDetector::from_run_func(run_func);
     if let Some(node_types) = node_types
         && !node_types.is_empty()
     {

--- a/tasks/linter_codegen/src/match_detector.rs
+++ b/tasks/linter_codegen/src/match_detector.rs
@@ -1,0 +1,85 @@
+use syn::{Arm, Expr, Pat, Stmt};
+
+use crate::{
+    CollectionResult,
+    node_type_set::NodeTypeSet,
+    utils::{astkind_variant_from_path, is_node_kind_call},
+};
+
+/// Detects top-level `match node.kind() { ... }` patterns in the `run` method.
+pub struct MatchDetector {
+    node_types: NodeTypeSet,
+}
+
+impl MatchDetector {
+    pub fn from_run_func(run_func: &syn::ImplItemFn) -> Option<NodeTypeSet> {
+        // Only consider when the body's only statement is `match node.kind() { ... }`
+        let block = &run_func.block;
+        if block.stmts.len() != 1 {
+            return None;
+        }
+        let first_stmt = &block.stmts[0];
+        // Must be an expression statement
+        let Stmt::Expr(expr, _) = first_stmt else { return None };
+        // Must be a match expression
+        let Expr::Match(match_expr) = expr else { return None };
+        // The match expression's must be matching on a `node.kind()` call
+        if !is_node_kind_call(&match_expr.expr) {
+            return None;
+        }
+
+        let mut detector = Self { node_types: NodeTypeSet::new() };
+        let result = detector.extract_variants_from_match_expr(match_expr);
+        if detector.node_types.is_empty() || result == CollectionResult::Incomplete {
+            return None;
+        }
+
+        Some(detector.node_types)
+    }
+
+    fn extract_variants_from_match_expr(
+        &mut self,
+        match_expr: &syn::ExprMatch,
+    ) -> CollectionResult {
+        let mut overall_result = CollectionResult::Complete;
+        for arm in &match_expr.arms {
+            let result = self.extract_variants_from_match_arm(arm);
+            if result == CollectionResult::Incomplete {
+                overall_result = CollectionResult::Incomplete;
+            }
+        }
+        overall_result
+    }
+
+    fn extract_variants_from_match_arm(&mut self, arm: &Arm) -> CollectionResult {
+        // If there are any guards, we can't be 100% sure which variants this runs on, as it may
+        // run on any node type depending on the guard condition.
+        if arm.guard.is_some() {
+            return CollectionResult::Incomplete;
+        }
+        let pat = &arm.pat;
+        match pat {
+            Pat::TupleStruct(ts) => {
+                if let Some(variant) = astkind_variant_from_path(&ts.path) {
+                    self.node_types.insert(variant);
+                    CollectionResult::Complete
+                } else {
+                    CollectionResult::Incomplete
+                }
+            }
+            Pat::Wild(_) => {
+                // Body must be completely empty.
+                if let Expr::Block(block) = &*arm.body {
+                    if block.block.stmts.is_empty() {
+                        CollectionResult::Complete
+                    } else {
+                        CollectionResult::Incomplete
+                    }
+                } else {
+                    CollectionResult::Incomplete
+                }
+            }
+            _ => CollectionResult::Incomplete,
+        }
+    }
+}


### PR DESCRIPTION
- part of github.com/oxc-project/oxc/issues/12223

Continuation of PRs that generate node types for lint rules. This implements the last main syntax pattern in lint rules which looks like this:

```rust
match node.kind() {
  AstKind::Function(_) => ...,
  AstKind::ArrowFunctionExpression(_) => ...,
  _ => {},
}
```

For this example, we would generate `[Function, ArrowFunctionExpression]`. We do not support guards at the moment, or any non tuple-struct patterns. The wildcard block must be empty, and the match statement must be the only one in the `run` function. This is so that we can be absolutely sure the list of node types is correct, so we tend to be more conservative in what we allow.