### PR TITLE
fix(editor): strip leading slash for bin path on windows

### DIFF
--- a/editors/vscode/client/ConfigService.ts
+++ b/editors/vscode/client/ConfigService.ts
@@ -73,6 +73,10 @@ export class ConfigService implements IDisposable {
         return;
       }
       bin = path.normalize(path.join(cwd, bin));
+      // strip the leading slash on Windows
+      if (process.platform === 'win32' && bin.startsWith('\\')) {
+        bin = bin.slice(1);
+      }
     }
 
     return bin;


### PR DESCRIPTION
The `bin` variable is under windows `\C:\Users\..`, using this path style to check accessibility,
will check a file like: `C:\C:\Users\...` which is of course invalid.