### PR TITLE
feat(formatter): support `TSTypePredicate`

### DIFF
--- a/crates/oxc_formatter/src/write/mod.rs
+++ b/crates/oxc_formatter/src/write/mod.rs
@@ -1176,7 +1176,11 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSEnumMember<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeAnnotation<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [":", space(), self.type_annotation()])
+        if matches!(self.parent, AstNodes::TSTypePredicate(_)) {
+            write!(f, [self.type_annotation()])
+        } else {
+            write!(f, [":", space(), self.type_annotation()])
+        }
     }
 }
 
@@ -1687,6 +1691,13 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSInterfaceHeritage<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSTypePredicate<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        if self.asserts() {
+            write!(f, ["asserts", space()])?;
+        }
+        write!(f, [self.parameter_name()])?;
+        if let Some(type_annotation) = self.type_annotation() {
+            write!(f, [space(), "is", space(), type_annotation])?;
+        }
         Ok(())
     }
 }

--- a/tasks/coverage/snapshots/formatter_babel.snap
+++ b/tasks/coverage/snapshots/formatter_babel.snap
@@ -2,7 +2,7 @@ commit: 41d96516
 
 formatter_babel Summary:
 AST Parsed     : 2423/2423 (100.00%)
-Positive Passed: 2403/2423 (99.17%)
+Positive Passed: 2414/2423 (99.63%)
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/basic/try-statement/input.js
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/regression/13750/input.js
@@ -10,28 +10,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/commen
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/class/division/input.js
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/private-in/private-in-class-heritage/input.js
-
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/loc-index-property/input.js
-
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/loc-index-property-babel-7/input.js
-
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/predicate-types/input.ts
-
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/assert-predicate/arrow-function/input.ts
-
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-this/input.ts
-
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-this-with-predicate/input.ts
-
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-var/input.ts
-
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-var-with-predicate/input.ts
-
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/assert-predicate/declare-asserts-var-with-predicate/input.ts
-
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/predicate-types/input.ts
-
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/function/predicate-types/input.ts
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/conditional-infer/input.ts
 

--- a/tasks/coverage/snapshots/formatter_typescript.snap
+++ b/tasks/coverage/snapshots/formatter_typescript.snap
@@ -2,28 +2,14 @@ commit: 261630d6
 
 formatter_typescript Summary:
 AST Parsed     : 8816/8816 (100.00%)
-Positive Passed: 8585/8816 (97.38%)
+Positive Passed: 8695/8816 (98.63%)
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/APISample_jsdoc.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/aliasInstantiationExpressionGenericIntersectionNoCrash1.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/amdLikeInputDeclarationEmit.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/arrayEvery.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/arrayFind.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/assertionFunctionWildcardImport1.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/assertionFunctionWildcardImport2.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/assertionFunctionsCanNarrowByDiscriminant.ts
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/betterErrorForUnionCall.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/booleanFilterAnyArray.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/builtinIterator.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/callOfConditionalTypeWithConcreteBranches.ts
 
@@ -37,11 +23,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/circularReferenc
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/classNonUniqueSymbolMethodHasSymbolIndexer.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences2.ts
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences3.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences4.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences6.ts
 
@@ -49,39 +31,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/coAndContraVaria
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/complexNarrowingWithAny.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/complexRecursiveCollections.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesNarrowed.ts
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/conditionalEqualityTestingNullability.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeBasedContextualTypeReturnTypeWidening.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeDoesntSpinForever.ts
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/contextualTypeBasedOnIntersectionWithAnyInTheMix3.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/contextualTypeFunctionObjectPropertyIntersection.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/contextualTypingReturnStatementWithReturnTypeAnnotation.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/contravariantInferenceAndTypeGuard.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/controlFlowAnalysisOnBareThisKeyword.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/controlFlowCommaExpressionAssertionWithinTernary.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/controlFlowCommaExpressionFunctionCall.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/controlFlowDestructuringLoop.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/controlFlowFavorAssertedTypeThroughTypePredicate.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/controlFlowInstanceofWithSymbolHasInstance.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/controlFlowUnionContainingTypeParameter1.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/declFileFunctions.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationUnionType.ts
 
@@ -103,33 +59,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/declarationEmitU
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/deferredConditionalTypes2.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/discriminantNarrowingCouldBeCircular.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/discriminantPropertyCheck.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/discriminantsAndTypePredicates.ts
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes7.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/divideAndConquerIntersections.ts
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/exportDefaultParenthesizeES6.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/flowControlTypeGuardThenSwitch.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/genericCapturingFunctionNarrowing.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/genericConditionalConstrainedToUnknownNotAssignableToConcreteObject.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/genericRestTypes.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/identityRelationNeverTypes.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/inKeywordNarrowingWithNoUncheckedIndexedAccess.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/inKeywordTypeguard.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/indexedAccessAndNullableNarrowing.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/inferTypesWithFixedTupleExtendsAtVariadicPosition.ts
 
@@ -138,16 +74,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/infiniteConstrai
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/intersectionConstraintReduction.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/intersectionWithConstructSignaturePrototypeResult.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/intersectionsOfLargeUnions.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/jsxEmitWithAttributes.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryAndReactNamespace.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryIdentifier.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryQualifiedName.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceGlobalReexport.tsx
 
@@ -161,35 +87,15 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/largeTupleTypes.
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/multiSignatureTypeInference.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/narrowByBooleanComparison.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue1.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/narrowCommaOperatorNestedWithinLHS.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/narrowUnknownByTypePredicate.ts
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/narrowingByTypeofInSwitch.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/narrowingConstrainedTypeParameter.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/narrowingMutualSubtypes.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/narrowingUnionToUnion.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/nestedGenericConditionalTypeWithGenericImportType.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/noInferUnionExcessPropertyCheck1.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/nonInferrableTypePropagation2.ts
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/nonNullableReduction.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/nonNullableReductionNonStrict.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/partialTypeNarrowedToByTypeGuard.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/partiallyDiscriminantedUnions.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/propertyAccessExpressionInnerComments.ts
 
@@ -205,11 +111,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/reducibleIndexed
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/referenceSatisfiesExpression.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/returnTypePredicateIsInstantiateInContextOfTarget.tsx
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeInferenceSameSource1.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/reverseMappedUnionInference.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/signatureCombiningRestParameters1.ts
 
@@ -219,87 +121,27 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidat
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/specedNoStackBlown.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/strictSubtypeAndNarrowing.ts
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/styledComponentsInstantiaionLimitNotReached.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/substitutionTypeForIndexedAccessType2.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/subtypeReductionUnionConstraints.ts
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/superAccessCastedCall.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/thisInTypeQuery.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/trackedSymbolsNoCrash.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/tryStatementInternalComments.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowByMutableUntypedField.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowByUntypedField.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typeGuardOnContainerTypeNoHang.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typeInferenceTypePredicate.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typeInferenceTypePredicate2.ts
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typeName1.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typePredicateAcceptingPartialOfRefinedType.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typePredicateFreshLiteralWidening.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typePredicateInherit.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typePredicateStructuralMatch.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typePredicateTopLevelTypeParameter.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typePredicateWithThisParameter.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typePredicatesCanNarrowByDiscriminant.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion2.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion3.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion_noMatch.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining1.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining2.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining3.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typeVariableConstraintIntersections.ts
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typeVariableTypeGuards.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/unionOfArraysFilterCall.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/unionOfFunctionAndSignatureIsCallable.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/unionSignaturesWithThisParameter.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/unionWithIndexSignature.ts
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParametersTypeAliases.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/varianceProblingAndZeroOrderIndexSignatureRelationsAlign.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/varianceProblingAndZeroOrderIndexSignatureRelationsAlign2.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/voidUndefinedReduction.ts
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/vueLikeDataAndPropsInference2.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameInInExpressionUnused.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesAssertion.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAbstractClasses.ts
 
@@ -308,22 +150,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/prope
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticAutoAccessorsWithDecorators.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowAssignmentPatternOrder.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowBinaryOrExpression.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/controlFlow/typeGuardsAsAssertions.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitIdentifierPredicates01.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitIdentifierPredicatesWithPrivateName01.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicates01.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicates02.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicatesWithPrivateName01.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicatesWithPrivateName02.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratorChecksFunctionBodies.ts
 
@@ -363,26 +189,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/o
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/optionalChainingInTypeAssertions.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunction.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunctionGenerics.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunctionOfFormThis.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardIntersectionTypes.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardNarrowsPrimitiveIntersection.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardNarrowsToLiteralType.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardNarrowsToLiteralTypeUnion.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormFunctionEquality.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormIsType.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormIsTypeOnInterfaces.ts
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfFunction.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfIsOrderIndependent.ts
@@ -393,8 +199,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/t
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelAwait.1.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/generators/generatorYieldContextualType.ts
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/generators/yieldStatementNoAsiAfterTransform.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithPrivates2.ts
@@ -403,19 +207,11 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/interfaces/in
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/pedantic/noUncheckedIndexedAccess.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/inferingFromAny.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/requireAssertsFromTypescript.ts
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/returnStatements/returnStatementNoAsiAfterTransform.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/conditional/conditionalTypes2.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypesWithExtends1.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypeWidening.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypes2.ts
 
@@ -433,33 +229,17 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/specify
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/unionTypeLiterals.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralCheckedInIf02.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTags01.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTags02.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTags03.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesTypePredicates01.ts
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInClasses.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions2.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions4.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInInterfaces.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInObjectLiterals2.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInTypePredicate.ts
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/namedTupleMembers.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/genericTypeAliases.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference1.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbols.ts
 

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 341/573 (59.51%)
+ts compatibility: 346/573 (60.38%)
 
 # Failed
 
@@ -26,8 +26,6 @@ ts compatibility: 341/573 (59.51%)
 | typescript/as/long-identifiers.ts | 💥 | 92.86% |
 | typescript/as/nested-await-and-as.ts | 💥 | 42.86% |
 | typescript/as/ternary.ts | 💥 | 82.00% |
-| typescript/assert/comment.ts | 💥 | 0.00% |
-| typescript/assert/index.ts | 💥 | 75.00% |
 | typescript/assignment/issue-10846.ts | 💥 | 38.60% |
 | typescript/assignment/issue-10848.tsx | 💥 | 48.48% |
 | typescript/assignment/issue-10850.ts | 💥 | 50.00% |
@@ -71,14 +69,13 @@ ts compatibility: 341/573 (59.51%)
 | typescript/conditional-types/infer-type.ts | 💥💥 | 47.07% |
 | typescript/conditional-types/nested-in-condition.ts | 💥💥 | 58.46% |
 | typescript/conditional-types/new-ternary-spec.ts | 💥💥 | 48.48% |
-| typescript/conditional-types/parentheses.ts | 💥💥 | 19.38% |
+| typescript/conditional-types/parentheses.ts | 💥💥 | 42.21% |
 | typescript/conformance/ambient/ambientDeclarations.ts | 💥 | 53.85% |
 | typescript/conformance/classes/mixinAccessModifiers.ts | 💥 | 99.07% |
 | typescript/conformance/classes/mixinClassesAnnotated.ts | 💥 | 98.57% |
 | typescript/conformance/classes/mixinClassesMembers.ts | 💥 | 95.05% |
 | typescript/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMixedWithModifiers.ts | 💥 | 86.67% |
 | typescript/conformance/classes/classDeclarations/classHeritageSpecification/classExtendingClass.ts | 💥 | 96.77% |
-| typescript/conformance/declarationEmit/typePredicates/declarationEmitThisPredicatesWithPrivateName01.ts | 💥 | 90.00% |
 | typescript/conformance/es6/Symbols/symbolProperty15.ts | 💥 | 66.67% |
 | typescript/conformance/expressions/functionCalls/callWithSpreadES6.ts | 💥 | 97.96% |
 | typescript/conformance/interfaces/interfaceDeclarations/interfaceWithMultipleBaseTypes2.ts | 💥 | 64.00% |
@@ -87,7 +84,6 @@ ts compatibility: 341/573 (59.51%)
 | typescript/conformance/internalModules/importDeclarations/invalidImportAliasIdentifiers.ts | 💥 | 95.83% |
 | typescript/conformance/internalModules/importDeclarations/shadowedInternalModule.ts | 💥 | 87.88% |
 | typescript/conformance/types/ambient/ambientDeclarations.ts | 💥 | 70.00% |
-| typescript/conformance/types/firstTypeNode/firstTypeNode.ts | 💥 | 51.61% |
 | typescript/conformance/types/functions/functionImplementations.ts | 💥 | 99.44% |
 | typescript/conformance/types/functions/functionOverloadCompatibilityWithVoid01.ts | 💥 | 75.00% |
 | typescript/conformance/types/functions/functionOverloadCompatibilityWithVoid02.ts | 💥 | 75.00% |
@@ -180,7 +176,6 @@ ts compatibility: 341/573 (59.51%)
 | typescript/optional-variance/basic.ts | 💥 | 59.02% |
 | typescript/optional-variance/with-jsx.tsx | 💥 | 59.02% |
 | typescript/override-modifiers/override-modifier.ts | 💥 | 25.00% |
-| typescript/predicate-types/predicate-types.ts | 💥 | 50.00% |
 | typescript/prettier-ignore/mapped-types.ts | 💥 | 54.72% |
 | typescript/prettier-ignore/prettier-ignore-nested-unions.ts | 💥 | 15.79% |
 | typescript/prettier-ignore/prettier-ignore-parenthesized-type.ts | 💥 | 0.00% |


### PR DESCRIPTION

Do not know if the parser is wrong, or the description of `TSTypeAnnotation`:

```
pub struct TSTypeAnnotation<'a> {
    /// starts at the `:` token and ends at the end of the type annotation
    pub span: Span,
    /// The actual type in the annotation
    pub type_annotation: TSType<'a>,
}
```

having this code:
`tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/assert-predicate/function-declaration/input.ts`
```
function asserts1 (value: unknown): asserts value is string {} 
function asserts2 (value: unknown): asserts value {}
function asserts3 (value: unknown): asserts {}
```

there are 2 `TSTypeAnnotation`s here:

<img width="928" height="912" alt="grafik" src="https://github.com/user-attachments/assets/b0d12446-7e6b-4e59-a426-8eee9d7f2bb0" />
