### PR TITLE
fix(formatter): add space after `readonly` in `TSPropertySignature`

### DIFF
--- a/crates/oxc_formatter/src/write/mod.rs
+++ b/crates/oxc_formatter/src/write/mod.rs
@@ -1550,10 +1550,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSInterfaceBody<'a>> {
 impl<'a> FormatWrite<'a> for AstNode<'a, TSPropertySignature<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         if self.readonly() {
-            write!(f, "readonly")?;
+            write!(f, ["readonly", space()])?;
         }
         if self.computed() {
-            write!(f, [space(), "[", self.key(), "]"])?;
+            write!(f, ["[", self.key(), "]"])?;
         } else {
             write!(f, self.key())?;
         }


### PR DESCRIPTION
`tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbols.ts`

line 95:

```
interface I {
  readonly readonlyType: unique symbol;
}
```

would be formatted to:

```
interface I {
  readonlyreadonlyType: unique symbol
}
```