### PR TITLE
feat(minifier): remove unused variable declarations in dead code

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -59,7 +59,9 @@ impl<'a> PeepholeOptimizations {
                 break;
             }
         }
-        if let Some(stmt) = keep_var.get_variable_declaration_statement() {
+        if let Some(stmt) = keep_var.get_variable_declaration_statement()
+            && let Some(stmt) = Self::remove_unused_variable_declaration(stmt, ctx)
+        {
             stmts.push(stmt);
         }
 


### PR DESCRIPTION
Unused variable declarations in dead code was not removed. For example, the following cases was not removed:
```js
if (false) { var a; console.log(a) }
```
```js
(function () { return; var a })()
```
