### PR TITLE
release(crates): v0.88.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,7 +1654,7 @@ checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
 name = "oxc"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "bitflags 2.9.4",
  "oxc_allocator",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1793,7 +1793,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_cfg"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "bitflags 2.9.4",
  "itertools",
@@ -1840,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_codegen"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "bitflags 2.9.4",
  "cow-utils",
@@ -1904,14 +1904,14 @@ dependencies = [
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "ropey",
 ]
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1933,7 +1933,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_estree"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_isolated_declarations"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "bitflags 2.9.4",
  "insta",
@@ -2090,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_mangler"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "itertools",
  "oxc_allocator",
@@ -2105,7 +2105,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_minifier"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "cow-utils",
  "insta",
@@ -2129,7 +2129,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_minify_napi"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "mimalloc-safe",
  "napi",
@@ -2168,7 +2168,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_napi"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "bitflags 2.9.4",
  "cow-utils",
@@ -2205,7 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser_napi"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "mimalloc-safe",
  "napi",
@@ -2255,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "bitflags 2.9.4",
  "oxc_allocator",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_semantic"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "insta",
  "itertools",
@@ -2340,7 +2340,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -2353,7 +2353,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "bitflags 2.9.4",
  "cow-utils",
@@ -2427,7 +2427,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_transform_napi"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "mimalloc-safe",
  "napi",
@@ -2441,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "base64",
  "compact_str",
@@ -2473,7 +2473,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer_plugins"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "cow-utils",
  "insta",
@@ -2500,7 +2500,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_traverse"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "itoa",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,32 +103,32 @@ multiple_crate_versions = "allow"
 
 [workspace.dependencies]
 # publish = true
-oxc = { version = "0.87.0", path = "crates/oxc" }
-oxc_allocator = { version = "0.87.0", path = "crates/oxc_allocator" }
-oxc_ast = { version = "0.87.0", path = "crates/oxc_ast" }
-oxc_ast_macros = { version = "0.87.0", path = "crates/oxc_ast_macros" }
-oxc_ast_visit = { version = "0.87.0", path = "crates/oxc_ast_visit" }
-oxc_cfg = { version = "0.87.0", path = "crates/oxc_cfg" }
-oxc_codegen = { version = "0.87.0", path = "crates/oxc_codegen" }
-oxc_data_structures = { version = "0.87.0", path = "crates/oxc_data_structures" }
-oxc_diagnostics = { version = "0.87.0", path = "crates/oxc_diagnostics" }
-oxc_ecmascript = { version = "0.87.0", path = "crates/oxc_ecmascript" }
-oxc_estree = { version = "0.87.0", path = "crates/oxc_estree" }
-oxc_isolated_declarations = { version = "0.87.0", path = "crates/oxc_isolated_declarations" }
-oxc_mangler = { version = "0.87.0", path = "crates/oxc_mangler" }
-oxc_minifier = { version = "0.87.0", path = "crates/oxc_minifier" }
-oxc_minify_napi = { version = "0.87.0", path = "napi/minify" }
-oxc_napi = { version = "0.87.0", path = "crates/oxc_napi" }
-oxc_parser = { version = "0.87.0", path = "crates/oxc_parser", features = ["regular_expression"] }
-oxc_parser_napi = { version = "0.87.0", path = "napi/parser" }
-oxc_regular_expression = { version = "0.87.0", path = "crates/oxc_regular_expression" }
-oxc_semantic = { version = "0.87.0", path = "crates/oxc_semantic" }
-oxc_span = { version = "0.87.0", path = "crates/oxc_span" }
-oxc_syntax = { version = "0.87.0", path = "crates/oxc_syntax" }
-oxc_transform_napi = { version = "0.87.0", path = "napi/transform" }
-oxc_transformer = { version = "0.87.0", path = "crates/oxc_transformer" }
-oxc_transformer_plugins = { version = "0.87.0", path = "crates/oxc_transformer_plugins" }
-oxc_traverse = { version = "0.87.0", path = "crates/oxc_traverse" }
+oxc = { version = "0.88.0", path = "crates/oxc" }
+oxc_allocator = { version = "0.88.0", path = "crates/oxc_allocator" }
+oxc_ast = { version = "0.88.0", path = "crates/oxc_ast" }
+oxc_ast_macros = { version = "0.88.0", path = "crates/oxc_ast_macros" }
+oxc_ast_visit = { version = "0.88.0", path = "crates/oxc_ast_visit" }
+oxc_cfg = { version = "0.88.0", path = "crates/oxc_cfg" }
+oxc_codegen = { version = "0.88.0", path = "crates/oxc_codegen" }
+oxc_data_structures = { version = "0.88.0", path = "crates/oxc_data_structures" }
+oxc_diagnostics = { version = "0.88.0", path = "crates/oxc_diagnostics" }
+oxc_ecmascript = { version = "0.88.0", path = "crates/oxc_ecmascript" }
+oxc_estree = { version = "0.88.0", path = "crates/oxc_estree" }
+oxc_isolated_declarations = { version = "0.88.0", path = "crates/oxc_isolated_declarations" }
+oxc_mangler = { version = "0.88.0", path = "crates/oxc_mangler" }
+oxc_minifier = { version = "0.88.0", path = "crates/oxc_minifier" }
+oxc_minify_napi = { version = "0.88.0", path = "napi/minify" }
+oxc_napi = { version = "0.88.0", path = "crates/oxc_napi" }
+oxc_parser = { version = "0.88.0", path = "crates/oxc_parser", features = ["regular_expression"] }
+oxc_parser_napi = { version = "0.88.0", path = "napi/parser" }
+oxc_regular_expression = { version = "0.88.0", path = "crates/oxc_regular_expression" }
+oxc_semantic = { version = "0.88.0", path = "crates/oxc_semantic" }
+oxc_span = { version = "0.88.0", path = "crates/oxc_span" }
+oxc_syntax = { version = "0.88.0", path = "crates/oxc_syntax" }
+oxc_transform_napi = { version = "0.88.0", path = "napi/transform" }
+oxc_transformer = { version = "0.88.0", path = "crates/oxc_transformer" }
+oxc_transformer_plugins = { version = "0.88.0", path = "crates/oxc_transformer_plugins" }
+oxc_traverse = { version = "0.88.0", path = "crates/oxc_traverse" }
 
 # publish = false
 oxc_formatter = { path = "crates/oxc_formatter" }

--- a/crates/oxc/CHANGELOG.md
+++ b/crates/oxc/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.88.0] - 2025-09-15
+
+### ⚡ Performance
+
+- 08c05df semantic: Make CFG construction a compile-time feature (#13678) (Boshen)
+
+
 
 
 

--- a/crates/oxc/Cargo.toml
+++ b/crates/oxc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_allocator/CHANGELOG.md
+++ b/crates/oxc_allocator/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.88.0] - 2025-09-15
+
+### 💥 BREAKING CHANGES
+
+- edc70ea allocator/pool: [**BREAKING**] Remove `disable_fixed_size` Cargo feature (#13625) (overlookmotel)
+
+### 🐛 Bug Fixes
+
+- ab51394 raw_transfer: Disable layout assertions on some 32-bit platforms (#13716) (overlookmotel)
+
+### 🚜 Refactor
+
+- b9bef25 allocator/pool: `AllocatorPool::new` always create standard pool (#13624) (overlookmotel)
+- a306c6f allocator/pool: Single `AllocatorPool` implementation (#13622) (overlookmotel)
+- 99dd1a7 allocator/pool: Share `AllocatorGuard` between pool impls (#13621) (overlookmotel)
+- 0dde7f0 allocator/pool: Move resetting into `AllocatorPool::add` (#13620) (overlookmotel)
+- a0d7389 allocator/pool: Move `AllocatorPool` into own directory (#13619) (overlookmotel)
+- babbaca all: Remove `pub` from modules with no exports (#13618) (overlookmotel)
+
+
 ## [0.87.0] - 2025-09-08
 
 ### 🚀 Features

--- a/crates/oxc_allocator/Cargo.toml
+++ b/crates/oxc_allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_allocator"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ast/CHANGELOG.md
+++ b/crates/oxc_ast/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.88.0] - 2025-09-15
+
+### 🐛 Bug Fixes
+
+- ab51394 raw_transfer: Disable layout assertions on some 32-bit platforms (#13716) (overlookmotel)
+
+### 🚜 Refactor
+
+- babbaca all: Remove `pub` from modules with no exports (#13618) (overlookmotel)
+
+
 ## [0.87.0] - 2025-09-08
 
 ### 🚀 Features

--- a/crates/oxc_ast/Cargo.toml
+++ b/crates/oxc_ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ast"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ast_macros/CHANGELOG.md
+++ b/crates/oxc_ast_macros/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.82.3] - 2025-08-20
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_ast_macros/Cargo.toml
+++ b/crates/oxc_ast_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ast_macros"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ast_visit/CHANGELOG.md
+++ b/crates/oxc_ast_visit/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.83.0] - 2025-08-29
 
 ### 🚀 Features

--- a/crates/oxc_ast_visit/Cargo.toml
+++ b/crates/oxc_ast_visit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ast_visit"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_cfg/CHANGELOG.md
+++ b/crates/oxc_cfg/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.82.0] - 2025-08-12
 
 ### 🚜 Refactor

--- a/crates/oxc_cfg/Cargo.toml
+++ b/crates/oxc_cfg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_cfg"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_codegen/CHANGELOG.md
+++ b/crates/oxc_codegen/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.88.0] - 2025-09-15
+
+### 🐛 Bug Fixes
+
+- bf50a02 codegen: Avoid backticks for object property keys in destructuring assignments (#13631) (copilot-swe-agent)
+
+### ⚡ Performance
+
+- d4608f1 codegen: Reduce memory usage in `SourcemapBuilder` (#13679) (overlookmotel)
+- 4ded22b codegen: Reduce allocations in `SourcemapBuilder` (#13677) (overlookmotel)
+- b35bf30 codegen: Optimize sourcemap builder to reduce allocations (#13670) (Boshen)
+- 641b252 codegen: Reduce branches when printing `ObjectProperty` and `BindingProperty` (#13659) (overlookmotel)
+
+
 ## [0.87.0] - 2025-09-08
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_codegen"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_data_structures/CHANGELOG.md
+++ b/crates/oxc_data_structures/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.88.0] - 2025-09-15
+
+### 💥 BREAKING CHANGES
+
+- e433633 data_structures: [**BREAKING**] Make `NonEmptyStack::is_empty` a compile-time error (#13673) (overlookmotel)
+
+### 🚀 Features
+
+- 1a58e99 data_structures: Add `is_exhausted` method to `NonEmptyStack` and `SparseStack` (#13672) (overlookmotel)
+- 2db32eb data_structures: Add `boxed_slice!` and `boxed_array!` macros (#13596) (overlookmotel)
+
+
 ## [0.87.0] - 2025-09-08
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_data_structures/Cargo.toml
+++ b/crates/oxc_data_structures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_data_structures"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_diagnostics/CHANGELOG.md
+++ b/crates/oxc_diagnostics/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.80.0] - 2025-08-03
 
 ### 🚜 Refactor

--- a/crates/oxc_diagnostics/Cargo.toml
+++ b/crates/oxc_diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_diagnostics"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ecmascript/CHANGELOG.md
+++ b/crates/oxc_ecmascript/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
+
 ## [0.86.0] - 2025-08-31
 
 ### 🚀 Features

--- a/crates/oxc_ecmascript/Cargo.toml
+++ b/crates/oxc_ecmascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ecmascript"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_estree/CHANGELOG.md
+++ b/crates/oxc_estree/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.88.0] - 2025-09-15
+
+### 🚜 Refactor
+
+- 08cbd39 transformer, estree: Clarify code using `is_exhausted` stack methods (#13674) (overlookmotel)
+
+
 
 ## [0.86.0] - 2025-08-31
 

--- a/crates/oxc_estree/Cargo.toml
+++ b/crates/oxc_estree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_estree"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_isolated_declarations/CHANGELOG.md
+++ b/crates/oxc_isolated_declarations/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.83.0] - 2025-08-29
 
 ### 🚜 Refactor

--- a/crates/oxc_isolated_declarations/Cargo.toml
+++ b/crates/oxc_isolated_declarations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_isolated_declarations"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_mangler/CHANGELOG.md
+++ b/crates/oxc_mangler/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
+
 ## [0.86.0] - 2025-08-31
 
 ### 🚀 Features

--- a/crates/oxc_mangler/Cargo.toml
+++ b/crates/oxc_mangler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_mangler"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_minifier/CHANGELOG.md
+++ b/crates/oxc_minifier/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.88.0] - 2025-09-15
+
+### 🚀 Features
+
+- a49d7cf minifier: Remove `typeof` guarded global access expressions (#13751) (sapphi-red)
+- c364ad1 minifier: Support ForStatements for single use variable inlining (#13755) (sapphi-red)
+- c868796 minifier: Remove unused variable declarations in dead code (#13754) (sapphi-red)
+
+### 🐛 Bug Fixes
+
+- 3d895cf minifier: Remove unused long array expressions (#13752) (sapphi-red)
+- f9fd65b minifier: Disallow merging assignments to let declarations when TDZ error would be introduced (#13635) (sapphi-red)
+
+
 ## [0.87.0] - 2025-09-08
 
 ### 🚀 Features

--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_minifier"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_napi/CHANGELOG.md
+++ b/crates/oxc_napi/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.80.0] - 2025-08-03
 
 ### 📚 Documentation

--- a/crates/oxc_napi/Cargo.toml
+++ b/crates/oxc_napi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_napi"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_parser/CHANGELOG.md
+++ b/crates/oxc_parser/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.88.0] - 2025-09-15
+
+### 🚀 Features
+
+- db33196 parser: Adds typescript rule for empty argument list (#13730) (Karan Kiri)
+
+### 🐛 Bug Fixes
+
+- f795d69 parser: Improve diagnostics around modifier checks (#13526) (Ulrich Stark)
+
+
 ## [0.87.0] - 2025-09-08
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_parser/Cargo.toml
+++ b/crates/oxc_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_parser"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_regular_expression/CHANGELOG.md
+++ b/crates/oxc_regular_expression/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.88.0] - 2025-09-15
+
+### 🚀 Features
+
+- 9a205d1 regex-parser: Parse simple `TemplateLiterals` (#13265) (Sysix)
+
+### 🐛 Bug Fixes
+
+- ab51394 raw_transfer: Disable layout assertions on some 32-bit platforms (#13716) (overlookmotel)
+
+### 🚜 Refactor
+
+- babbaca all: Remove `pub` from modules with no exports (#13618) (overlookmotel)
+
+
 ## [0.87.0] - 2025-09-08
 
 ### 🚀 Features

--- a/crates/oxc_regular_expression/Cargo.toml
+++ b/crates/oxc_regular_expression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_regular_expression"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_semantic/CHANGELOG.md
+++ b/crates/oxc_semantic/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.88.0] - 2025-09-15
+
+### 🐛 Bug Fixes
+
+- 9fa551a semantic: Handle edge cases checking `super` (#13499) (overlookmotel)
+- 198243b semantic: Dont parse `@` as jsdoc tags inside quotes (#13571) (Gwenn Le Bihan)
+
+### 📚 Documentation
+
+- 5dc82ff semantic: Make doc tests for `AstNode::contains_any` etc runnable (#13595) (overlookmotel)
+
+### ⚡ Performance
+
+- 08c05df semantic: Make CFG construction a compile-time feature (#13678) (Boshen)
+
+
 ## [0.87.0] - 2025-09-08
 
 ### 🚀 Features

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_semantic"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_span/CHANGELOG.md
+++ b/crates/oxc_span/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.88.0] - 2025-09-15
+
+### 🐛 Bug Fixes
+
+- ab51394 raw_transfer: Disable layout assertions on some 32-bit platforms (#13716) (overlookmotel)
+
+### 🚜 Refactor
+
+- babbaca all: Remove `pub` from modules with no exports (#13618) (overlookmotel)
+
+
 
 
 

--- a/crates/oxc_span/Cargo.toml
+++ b/crates/oxc_span/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_span"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_syntax/CHANGELOG.md
+++ b/crates/oxc_syntax/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.88.0] - 2025-09-15
+
+### 🐛 Bug Fixes
+
+- ab51394 raw_transfer: Disable layout assertions on some 32-bit platforms (#13716) (overlookmotel)
+
+### 🚜 Refactor
+
+- babbaca all: Remove `pub` from modules with no exports (#13618) (overlookmotel)
+
+
 
 
 

--- a/crates/oxc_syntax/Cargo.toml
+++ b/crates/oxc_syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_syntax"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_transformer/CHANGELOG.md
+++ b/crates/oxc_transformer/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.88.0] - 2025-09-15
+
+### 🐛 Bug Fixes
+
+- bb2bcf0 transformer: Improve legacy decorator handling and fix constructor parameter decorators (#13632) (Dunqing)
+
+### 🚜 Refactor
+
+- 08cbd39 transformer, estree: Clarify code using `is_exhausted` stack methods (#13674) (overlookmotel)
+
+
 ## [0.87.0] - 2025-09-08
 
 ### 🚀 Features

--- a/crates/oxc_transformer/Cargo.toml
+++ b/crates/oxc_transformer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_transformer"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_transformer_plugins/CHANGELOG.md
+++ b/crates/oxc_transformer_plugins/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.87.0] - 2025-09-08
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_transformer_plugins/Cargo.toml
+++ b/crates/oxc_transformer_plugins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_transformer_plugins"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_traverse/CHANGELOG.md
+++ b/crates/oxc_traverse/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.87.0] - 2025-09-08
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_traverse/Cargo.toml
+++ b/crates/oxc_traverse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_traverse"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/minify/CHANGELOG.md
+++ b/napi/minify/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
+
 ## [0.83.0] - 2025-08-29
 
 ### 💥 BREAKING CHANGES

--- a/napi/minify/Cargo.toml
+++ b/napi/minify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_minify_napi"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/minify/package.json
+++ b/napi/minify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-minify",
-  "version": "0.87.0",
+  "version": "0.88.0",
   "type": "module",
   "main": "index.js",
   "browser": "browser.js",

--- a/napi/parser/CHANGELOG.md
+++ b/napi/parser/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.88.0] - 2025-09-15
+
+### 💥 BREAKING CHANGES
+
+- 4577b71 napi/parser: [**BREAKING**] Change `oxc-parser` to ESM (#13432) (Boshen)
+
+### 🐛 Bug Fixes
+
+- ab51394 raw_transfer: Disable layout assertions on some 32-bit platforms (#13716) (overlookmotel)
+
+### 🚜 Refactor
+
+- babbaca all: Remove `pub` from modules with no exports (#13618) (overlookmotel)
+
+
+## [0.88.0] - 2025-09-15
+
+### 💥 BREAKING CHANGES
+
+- 4577b71 napi/parser: [**BREAKING**] Change `oxc-parser` to ESM (#13432) (Boshen)
+
+### 🐛 Bug Fixes
+
+- ab51394 raw_transfer: Disable layout assertions on some 32-bit platforms (#13716) (overlookmotel)
+
+### 🚜 Refactor
+
+- babbaca all: Remove `pub` from modules with no exports (#13618) (overlookmotel)
+
+
 
 
 

--- a/napi/parser/Cargo.toml
+++ b/napi/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_parser_napi"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-parser",
-  "version": "0.87.0",
+  "version": "0.88.0",
   "type": "commonjs",
   "main": "index.js",
   "browser": "wasm.mjs",

--- a/napi/transform/CHANGELOG.md
+++ b/napi/transform/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
+
 ## [0.83.0] - 2025-08-29
 
 ### 💥 BREAKING CHANGES

--- a/napi/transform/Cargo.toml
+++ b/napi/transform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_transform_napi"
-version = "0.87.0"
+version = "0.88.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/transform/package.json
+++ b/napi/transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-transform",
-  "version": "0.87.0",
+  "version": "0.88.0",
   "type": "module",
   "main": "index.js",
   "browser": "browser.js",

--- a/npm/oxc-types/CHANGELOG.md
+++ b/npm/oxc-types/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.82.0] - 2025-08-12
 
 ### 🚜 Refactor

--- a/npm/oxc-types/package.json
+++ b/npm/oxc-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxc-project/types",
-  "version": "0.87.0",
+  "version": "0.88.0",
   "description": "Types for Oxc AST nodes",
   "type": "commonjs",
   "keywords": [

--- a/npm/runtime/CHANGELOG.md
+++ b/npm/runtime/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 # Changelog
 
 All notable changes to this package will be documented in this file.

--- a/npm/runtime/package.json
+++ b/npm/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxc-project/runtime",
-  "version": "0.87.0",
+  "version": "0.88.0",
   "description": "Oxc's modular runtime helpers",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## [0.88.0] - 2025-09-15

### 💥 BREAKING CHANGES

- e433633 data_structures: [**BREAKING**] Make `NonEmptyStack::is_empty` a compile-time error (#13673) (overlookmotel)
- edc70ea allocator/pool: [**BREAKING**] Remove `disable_fixed_size` Cargo feature (#13625) (overlookmotel)
- 4577b71 napi/parser: [**BREAKING**] Change `oxc-parser` to ESM (#13432) (Boshen)

### 🚀 Features

- a49d7cf minifier: Remove `typeof` guarded global access expressions (#13751) (sapphi-red)
- c364ad1 minifier: Support ForStatements for single use variable inlining (#13755) (sapphi-red)
- c868796 minifier: Remove unused variable declarations in dead code (#13754) (sapphi-red)
- db33196 parser: Adds typescript rule for empty argument list (#13730) (Karan Kiri)
- 9a205d1 regex-parser: Parse simple `TemplateLiterals` (#13265) (Sysix)
- 1a58e99 data_structures: Add `is_exhausted` method to `NonEmptyStack` and `SparseStack` (#13672) (overlookmotel)
- 2db32eb data_structures: Add `boxed_slice!` and `boxed_array!` macros (#13596) (overlookmotel)

### 🐛 Bug Fixes

- 3d895cf minifier: Remove unused long array expressions (#13752) (sapphi-red)
- ab51394 raw_transfer: Disable layout assertions on some 32-bit platforms (#13716) (overlookmotel)
- bb2bcf0 transformer: Improve legacy decorator handling and fix constructor parameter decorators (#13632) (Dunqing)
- f9fd65b minifier: Disallow merging assignments to let declarations when TDZ error would be introduced (#13635) (sapphi-red)
- 9fa551a semantic: Handle edge cases checking `super` (#13499) (overlookmotel)
- bf50a02 codegen: Avoid backticks for object property keys in destructuring assignments (#13631) (copilot-swe-agent)
- f795d69 parser: Improve diagnostics around modifier checks (#13526) (Ulrich Stark)
- 198243b semantic: Dont parse `@` as jsdoc tags inside quotes (#13571) (Gwenn Le Bihan)

### 🚜 Refactor

- 08cbd39 transformer, estree: Clarify code using `is_exhausted` stack methods (#13674) (overlookmotel)
- b9bef25 allocator/pool: `AllocatorPool::new` always create standard pool (#13624) (overlookmotel)
- a306c6f allocator/pool: Single `AllocatorPool` implementation (#13622) (overlookmotel)
- 99dd1a7 allocator/pool: Share `AllocatorGuard` between pool impls (#13621) (overlookmotel)
- 0dde7f0 allocator/pool: Move resetting into `AllocatorPool::add` (#13620) (overlookmotel)
- a0d7389 allocator/pool: Move `AllocatorPool` into own directory (#13619) (overlookmotel)
- babbaca all: Remove `pub` from modules with no exports (#13618) (overlookmotel)

### 📚 Documentation

- 5dc82ff semantic: Make doc tests for `AstNode::contains_any` etc runnable (#13595) (overlookmotel)

### ⚡ Performance

- 08c05df semantic: Make CFG construction a compile-time feature (#13678) (Boshen)
- d4608f1 codegen: Reduce memory usage in `SourcemapBuilder` (#13679) (overlookmotel)
- 4ded22b codegen: Reduce allocations in `SourcemapBuilder` (#13677) (overlookmotel)
- b35bf30 codegen: Optimize sourcemap builder to reduce allocations (#13670) (Boshen)
- 641b252 codegen: Reduce branches when printing `ObjectProperty` and `BindingProperty` (#13659) (overlookmotel)