### PR TITLE
fix(transformer/class-properties): don't transform properties that have `declare` modifier

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/mod.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/mod.rs
@@ -404,7 +404,9 @@ impl<'a> Traverse<'a, TransformState<'a>> for ClassProperties<'a, '_> {
         prop: &mut PropertyDefinition<'a>,
         _ctx: &mut TraverseCtx<'a>,
     ) {
-        if prop.r#static {
+        // Ignore `declare` properties as they don't have any runtime effect,
+        // and will be removed in the TypeScript transform later
+        if prop.r#static && !prop.declare {
             self.flag_entering_static_property_or_block();
         }
     }
@@ -414,7 +416,9 @@ impl<'a> Traverse<'a, TransformState<'a>> for ClassProperties<'a, '_> {
         prop: &mut PropertyDefinition<'a>,
         _ctx: &mut TraverseCtx<'a>,
     ) {
-        if prop.r#static {
+        // Ignore `declare` properties as they don't have any runtime effect,
+        // and will be removed in the TypeScript transform later
+        if prop.r#static && !prop.declare {
             self.flag_exiting_static_property_or_block();
         }
     }

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -2,7 +2,7 @@ commit: 41d96516
 
 semantic_babel Summary:
 AST Parsed     : 2423/2423 (100.00%)
-Positive Passed: 2007/2423 (82.83%)
+Positive Passed: 2006/2423 (82.79%)
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/decorators/decorators-after-export/input.js
 Symbol span mismatch for "C":
 after transform: SymbolId(0): Span { start: 65, end: 66 }
@@ -462,6 +462,11 @@ Multiple constructor implementations are not allowed.
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/declare/input.ts
 Identifier `x` has already been declared
+
+semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/declare-readonly-field-initializer/input.ts
+Unresolved references mismatch:
+after transform: ["a"]
+rebuilt        : []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/expression-extends/input.ts
 Unresolved references mismatch:

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -8625,8 +8625,8 @@ rebuilt        : SymbolId(0): [ReferenceId(12), ReferenceId(13)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataElidedImportOnDeclare.ts
 Symbol reference IDs mismatch for "Observable":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(0): [ReferenceId(5), ReferenceId(6)]
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
+rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(5)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataForMethodWithNoReturnTypeAnnotation01.ts
 Bindings mismatch:
@@ -12989,27 +12989,21 @@ after transform: ["DecoratorContext", "require"]
 rebuilt        : ["require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/esNextWeakRefs_IterableWeakMap.ts
-Symbol reference IDs mismatch for "_Symbol$toStringTag":
-after transform: SymbolId(26): [ReferenceId(73), ReferenceId(74)]
-rebuilt        : SymbolId(3): [ReferenceId(6)]
-Symbol reference IDs mismatch for "_Symbol$iterator":
-after transform: SymbolId(29): [ReferenceId(82), ReferenceId(83)]
-rebuilt        : SymbolId(4): [ReferenceId(18)]
 Unresolved references mismatch:
 after transform: ["FinalizationRegistry", "Generator", "Iterable", "Object", "Set", "Symbol", "WeakMap", "WeakRef", "undefined"]
 rebuilt        : ["FinalizationRegistry", "Object", "Set", "Symbol", "WeakMap", "WeakRef", "undefined"]
 Unresolved reference IDs mismatch for "WeakRef":
 after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(11), ReferenceId(15), ReferenceId(33)]
-rebuilt        : [ReferenceId(30)]
+rebuilt        : [ReferenceId(26)]
 Unresolved reference IDs mismatch for "Set":
 after transform: [ReferenceId(1), ReferenceId(14)]
-rebuilt        : [ReferenceId(12)]
+rebuilt        : [ReferenceId(10)]
 Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(8), ReferenceId(55), ReferenceId(69), ReferenceId(72)]
-rebuilt        : [ReferenceId(85), ReferenceId(88)]
+rebuilt        : [ReferenceId(81), ReferenceId(84)]
 Unresolved reference IDs mismatch for "WeakMap":
-after transform: [ReferenceId(5), ReferenceId(9), ReferenceId(114), ReferenceId(115), ReferenceId(116)]
-rebuilt        : [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(9)]
+after transform: [ReferenceId(5), ReferenceId(9), ReferenceId(108), ReferenceId(109), ReferenceId(110)]
+rebuilt        : [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(7)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/escapedIdentifiers.ts
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -18909,17 +18903,14 @@ rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/iterableTReturnTNext.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["MyMap", "_Symbol$iterator", "_Symbol$toStringTag", "_defineProperty", "_source", "_wrapAsyncGenerator", "doubles", "map", "r1", "r2", "r3", "set", "source"]
-rebuilt        : ScopeId(0): ["MyMap", "_Symbol$iterator", "_Symbol$toStringTag", "_defineProperty", "_source", "_wrapAsyncGenerator", "doubles", "r1", "r2", "r3", "source"]
+after transform: ScopeId(0): ["MyMap", "_source", "_wrapAsyncGenerator", "doubles", "map", "r1", "r2", "r3", "set", "source"]
+rebuilt        : ScopeId(0): ["MyMap", "_source", "_wrapAsyncGenerator", "doubles", "r1", "r2", "r3", "source"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(15), ScopeId(16)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
 Scope children mismatch:
 after transform: ScopeId(6): [ScopeId(7)]
-rebuilt        : ScopeId(8): []
-Symbol reference IDs mismatch for "_Symbol$toStringTag":
-after transform: SymbolId(20): [ReferenceId(29), ReferenceId(30)]
-rebuilt        : SymbolId(2): [ReferenceId(19)]
+rebuilt        : ScopeId(7): []
 Reference symbol mismatch for "map":
 after transform: SymbolId(0) "map"
 rebuilt        : <None>
@@ -18934,7 +18925,7 @@ after transform: ["Error", "Map", "MapIterator", "Set", "Symbol", "arguments", "
 rebuilt        : ["Error", "Symbol", "arguments", "map", "require", "set", "undefined"]
 Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(10), ReferenceId(17)]
-rebuilt        : [ReferenceId(14)]
+rebuilt        : [ReferenceId(15)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jqueryInference.ts
 Bindings mismatch:
@@ -19965,13 +19956,13 @@ rebuilt        : []
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mergedInstantiationAssignment.ts
 Symbol reference IDs mismatch for "GenericObject":
 after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(1): [ReferenceId(1)]
+rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch for "GenericObjectWithoutSetter":
 after transform: SymbolId(4): [ReferenceId(5), ReferenceId(6)]
-rebuilt        : SymbolId(4): [ReferenceId(4)]
+rebuilt        : SymbolId(3): [ReferenceId(2)]
 Symbol reference IDs mismatch for "NormalObject":
 after transform: SymbolId(7): [ReferenceId(8), ReferenceId(9)]
-rebuilt        : SymbolId(6): [ReferenceId(6)]
+rebuilt        : SymbolId(5): [ReferenceId(4)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mergedInterfaceFromMultipleFiles1.ts
 Scope children mismatch:
@@ -36542,11 +36533,17 @@ rebuilt        : ["Object", "dec", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorInAmbientContext.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "_decorate", "_decorateMetadata", "_defineProperty", "b", "decorator"]
-rebuilt        : ScopeId(0): ["Foo", "_decorate", "_decorateMetadata", "_defineProperty", "b"]
+after transform: ScopeId(0): ["Foo", "_b", "_decorate", "_decorateMetadata", "b", "decorator"]
+rebuilt        : ScopeId(0): ["Foo", "_b", "_decorate", "_decorateMetadata", "b"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
+Symbol reference IDs mismatch for "_b":
+after transform: SymbolId(7): [ReferenceId(11), ReferenceId(12)]
+rebuilt        : SymbolId(2): [ReferenceId(13)]
+Symbol reference IDs mismatch for "b":
+after transform: SymbolId(3): [ReferenceId(3)]
+rebuilt        : SymbolId(3): []
 Reference symbol mismatch for "decorator":
 after transform: SymbolId(0) "decorator"
 rebuilt        : <None>

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 41d96516
 
-Passed: 187/314
+Passed: 188/316
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -39,7 +39,7 @@ after transform: SymbolId(4): ScopeId(1)
 rebuilt        : SymbolId(5): ScopeId(4)
 
 
-# babel-plugin-transform-class-properties (23/29)
+# babel-plugin-transform-class-properties (24/31)
 * private-field-resolve-to-method/input.js
 x Output mismatch
 
@@ -51,6 +51,11 @@ x Output mismatch
 
 * static-super-tagged-template/input.js
 x Output mismatch
+
+* typescript/declare-computed-keys/input.ts
+Symbol reference IDs mismatch for "KEY1":
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
+rebuilt        : SymbolId(1): []
 
 * typescript/optional-call/input.ts
 Symbol reference IDs mismatch for "X":

--- a/tasks/transform_conformance/snapshots/oxc_exec.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc_exec.snap.md
@@ -2,7 +2,7 @@ commit: 41d96516
 
 node: v22.14.0
 
-Passed: 8 of 10 (80.00%)
+Passed: 9 of 11 (81.82%)
 
 Failures:
 

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/declare-computed-keys/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/declare-computed-keys/input.ts
@@ -1,0 +1,17 @@
+// Test declare fields with computed keys
+const KEY1 = "dynamicKey1";
+const KEY2 = "dynamicKey2";
+
+class TestClass {
+  // declare field with computed key should be removed
+  declare [KEY1]: string;
+  
+  // regular field with computed key should be transformed
+  [KEY2]: number = 42;
+  
+  // static declare field with computed key should be removed
+  declare static [KEY1 + "Static"]: boolean;
+  
+  // regular static field with computed key should be transformed
+  static [KEY2 + "Static"]: string = "static";
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/declare-computed-keys/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/declare-computed-keys/output.js
@@ -1,0 +1,16 @@
+let _ref;
+// Test declare fields with computed keys
+const KEY1 = "dynamicKey1";
+const KEY2 = "dynamicKey2";
+_ref = KEY2 + "Static";
+
+class TestClass {
+  // regular field with computed key should be transformed
+  constructor() {
+    babelHelpers.defineProperty(this, KEY2, 42);
+  }
+  
+  // regular static field with computed key should be transformed
+}
+
+babelHelpers.defineProperty(TestClass, _ref, "static");

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/declare-fields/exec.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/declare-fields/exec.ts
@@ -1,0 +1,21 @@
+// Test case for declare fields issue #13733
+class B {
+  public value: number = 3;
+  
+  constructor(value?: number) {
+    if (value !== undefined) {
+      this.value = value;
+    }
+  }
+}
+
+class C extends B {
+  declare public value: number;
+
+  log() {
+    return "C " + this.value
+  }
+}
+
+// This should log "C 6", not "C undefined"
+expect(new C(6).log()).toBe("C 6");

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/declare-fields/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/declare-fields/input.ts
@@ -1,0 +1,21 @@
+// Test case for declare fields issue #13733
+class B {
+	public value: number = 3;
+
+	constructor(value?: number) {
+		if (value !== undefined) {
+			this.value = value;
+		}
+	}
+}
+
+class C extends B {
+	public declare value: number;
+
+	log() {
+		return "C " + this.value;
+	}
+}
+
+// This should log "C 6", not "C undefined"
+expect(new C(6).log()).toBe("C 6");

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/declare-fields/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/declare-fields/output.js
@@ -1,0 +1,15 @@
+
+class B {
+  constructor(value) {
+    babelHelpers.defineProperty(this, "value", 3);
+    if (value !== undefined) {
+      this.value = value;
+    }
+  }
+}
+class C extends B {
+  log() {
+    return "C " + this.value;
+  }
+}
+expect(new C(6).log()).toBe("C 6");


### PR DESCRIPTION
* Fixes #13733

Fixes the issue where `declare` fields were incorrectly transformed instead of being removed, causing inheritance issues where child `declare` fields would interfere with parent class property initialization.

Only in the `enter_*` phase do we have to skip the `declare` field; in the exit phase, the `declare` fields have already been removed in the `TypeScript` plugin.