### PR TITLE
fix(parser): invalid `main` entrypoint in `package.json`

### DIFF
--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -2,7 +2,7 @@
   "name": "oxc-parser",
   "version": "0.88.0",
   "type": "commonjs",
-  "main": "index.js",
+  "main": "index.mjs",
   "browser": "wasm.mjs",
   "scripts": {
     "build-dev": "napi build --esm --platform --js bindings.mjs",


### PR DESCRIPTION
In https://github.com/oxc-project/oxc/pull/13432 the filename was changed but `main` remained as is. I'm now seeing following error in Vitest:

```
⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯
Error: Failed to resolve entry for package "oxc-parser". The package may have incorrect main/module/exports specified in its package.json.
1  |  import { parse as BabelParser } from "@babel/parser";
2  |  import { parse as AcornParser } from "acorn";
3  |  import { parseSync as OxcParser } from "oxc-parser";
   |                                          ^
4  |  import { parseAst as ViteParser } from "vite";
5  |  import { expectTypeOf, test } from "vitest";
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
```

https://github.com/AriPerkkio/ast-v8-to-istanbul/actions/runs/17722503037/job/50357275013?pr=86

See errors from https://publint.dev/oxc-parser@0.88.0.