### PR TITLE
release(crates): v0.89.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,7 +1654,7 @@ checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
 name = "oxc"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "bitflags 2.9.4",
  "oxc_allocator",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1793,7 +1793,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_cfg"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "bitflags 2.9.4",
  "itertools",
@@ -1840,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_codegen"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "bitflags 2.9.4",
  "cow-utils",
@@ -1904,14 +1904,14 @@ dependencies = [
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "ropey",
 ]
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1933,7 +1933,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_estree"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_isolated_declarations"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "bitflags 2.9.4",
  "insta",
@@ -2090,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_mangler"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "itertools",
  "oxc_allocator",
@@ -2105,7 +2105,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_minifier"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "cow-utils",
  "insta",
@@ -2129,7 +2129,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_minify_napi"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "mimalloc-safe",
  "napi",
@@ -2168,7 +2168,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_napi"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "bitflags 2.9.4",
  "cow-utils",
@@ -2205,7 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser_napi"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "mimalloc-safe",
  "napi",
@@ -2255,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "bitflags 2.9.4",
  "oxc_allocator",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_semantic"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "insta",
  "itertools",
@@ -2340,7 +2340,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -2353,7 +2353,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "bitflags 2.9.4",
  "cow-utils",
@@ -2427,7 +2427,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_transform_napi"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "mimalloc-safe",
  "napi",
@@ -2441,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "base64",
  "compact_str",
@@ -2473,7 +2473,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer_plugins"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "cow-utils",
  "insta",
@@ -2500,7 +2500,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_traverse"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "itoa",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,32 +103,32 @@ multiple_crate_versions = "allow"
 
 [workspace.dependencies]
 # publish = true
-oxc = { version = "0.88.0", path = "crates/oxc" }
-oxc_allocator = { version = "0.88.0", path = "crates/oxc_allocator" }
-oxc_ast = { version = "0.88.0", path = "crates/oxc_ast" }
-oxc_ast_macros = { version = "0.88.0", path = "crates/oxc_ast_macros" }
-oxc_ast_visit = { version = "0.88.0", path = "crates/oxc_ast_visit" }
-oxc_cfg = { version = "0.88.0", path = "crates/oxc_cfg" }
-oxc_codegen = { version = "0.88.0", path = "crates/oxc_codegen" }
-oxc_data_structures = { version = "0.88.0", path = "crates/oxc_data_structures" }
-oxc_diagnostics = { version = "0.88.0", path = "crates/oxc_diagnostics" }
-oxc_ecmascript = { version = "0.88.0", path = "crates/oxc_ecmascript" }
-oxc_estree = { version = "0.88.0", path = "crates/oxc_estree" }
-oxc_isolated_declarations = { version = "0.88.0", path = "crates/oxc_isolated_declarations" }
-oxc_mangler = { version = "0.88.0", path = "crates/oxc_mangler" }
-oxc_minifier = { version = "0.88.0", path = "crates/oxc_minifier" }
-oxc_minify_napi = { version = "0.88.0", path = "napi/minify" }
-oxc_napi = { version = "0.88.0", path = "crates/oxc_napi" }
-oxc_parser = { version = "0.88.0", path = "crates/oxc_parser", features = ["regular_expression"] }
-oxc_parser_napi = { version = "0.88.0", path = "napi/parser" }
-oxc_regular_expression = { version = "0.88.0", path = "crates/oxc_regular_expression" }
-oxc_semantic = { version = "0.88.0", path = "crates/oxc_semantic" }
-oxc_span = { version = "0.88.0", path = "crates/oxc_span" }
-oxc_syntax = { version = "0.88.0", path = "crates/oxc_syntax" }
-oxc_transform_napi = { version = "0.88.0", path = "napi/transform" }
-oxc_transformer = { version = "0.88.0", path = "crates/oxc_transformer" }
-oxc_transformer_plugins = { version = "0.88.0", path = "crates/oxc_transformer_plugins" }
-oxc_traverse = { version = "0.88.0", path = "crates/oxc_traverse" }
+oxc = { version = "0.89.0", path = "crates/oxc" }
+oxc_allocator = { version = "0.89.0", path = "crates/oxc_allocator" }
+oxc_ast = { version = "0.89.0", path = "crates/oxc_ast" }
+oxc_ast_macros = { version = "0.89.0", path = "crates/oxc_ast_macros" }
+oxc_ast_visit = { version = "0.89.0", path = "crates/oxc_ast_visit" }
+oxc_cfg = { version = "0.89.0", path = "crates/oxc_cfg" }
+oxc_codegen = { version = "0.89.0", path = "crates/oxc_codegen" }
+oxc_data_structures = { version = "0.89.0", path = "crates/oxc_data_structures" }
+oxc_diagnostics = { version = "0.89.0", path = "crates/oxc_diagnostics" }
+oxc_ecmascript = { version = "0.89.0", path = "crates/oxc_ecmascript" }
+oxc_estree = { version = "0.89.0", path = "crates/oxc_estree" }
+oxc_isolated_declarations = { version = "0.89.0", path = "crates/oxc_isolated_declarations" }
+oxc_mangler = { version = "0.89.0", path = "crates/oxc_mangler" }
+oxc_minifier = { version = "0.89.0", path = "crates/oxc_minifier" }
+oxc_minify_napi = { version = "0.89.0", path = "napi/minify" }
+oxc_napi = { version = "0.89.0", path = "crates/oxc_napi" }
+oxc_parser = { version = "0.89.0", path = "crates/oxc_parser", features = ["regular_expression"] }
+oxc_parser_napi = { version = "0.89.0", path = "napi/parser" }
+oxc_regular_expression = { version = "0.89.0", path = "crates/oxc_regular_expression" }
+oxc_semantic = { version = "0.89.0", path = "crates/oxc_semantic" }
+oxc_span = { version = "0.89.0", path = "crates/oxc_span" }
+oxc_syntax = { version = "0.89.0", path = "crates/oxc_syntax" }
+oxc_transform_napi = { version = "0.89.0", path = "napi/transform" }
+oxc_transformer = { version = "0.89.0", path = "crates/oxc_transformer" }
+oxc_transformer_plugins = { version = "0.89.0", path = "crates/oxc_transformer_plugins" }
+oxc_traverse = { version = "0.89.0", path = "crates/oxc_traverse" }
 
 # publish = false
 oxc_formatter = { path = "crates/oxc_formatter" }

--- a/crates/oxc/CHANGELOG.md
+++ b/crates/oxc/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.88.0] - 2025-09-15
 
 ### ⚡ Performance

--- a/crates/oxc/Cargo.toml
+++ b/crates/oxc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_allocator/CHANGELOG.md
+++ b/crates/oxc_allocator/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.88.0] - 2025-09-15
 
 ### 💥 BREAKING CHANGES

--- a/crates/oxc_allocator/Cargo.toml
+++ b/crates/oxc_allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_allocator"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ast/CHANGELOG.md
+++ b/crates/oxc_ast/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.88.0] - 2025-09-15
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_ast/Cargo.toml
+++ b/crates/oxc_ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ast"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ast_macros/CHANGELOG.md
+++ b/crates/oxc_ast_macros/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.82.3] - 2025-08-20
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_ast_macros/Cargo.toml
+++ b/crates/oxc_ast_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ast_macros"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ast_visit/CHANGELOG.md
+++ b/crates/oxc_ast_visit/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.83.0] - 2025-08-29
 
 ### 🚀 Features

--- a/crates/oxc_ast_visit/Cargo.toml
+++ b/crates/oxc_ast_visit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ast_visit"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_cfg/CHANGELOG.md
+++ b/crates/oxc_cfg/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.82.0] - 2025-08-12
 
 ### 🚜 Refactor

--- a/crates/oxc_cfg/Cargo.toml
+++ b/crates/oxc_cfg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_cfg"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_codegen/CHANGELOG.md
+++ b/crates/oxc_codegen/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.88.0] - 2025-09-15
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_codegen"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_data_structures/CHANGELOG.md
+++ b/crates/oxc_data_structures/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.88.0] - 2025-09-15
 
 ### 💥 BREAKING CHANGES

--- a/crates/oxc_data_structures/Cargo.toml
+++ b/crates/oxc_data_structures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_data_structures"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_diagnostics/CHANGELOG.md
+++ b/crates/oxc_diagnostics/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.80.0] - 2025-08-03
 
 ### 🚜 Refactor

--- a/crates/oxc_diagnostics/Cargo.toml
+++ b/crates/oxc_diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_diagnostics"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ecmascript/CHANGELOG.md
+++ b/crates/oxc_ecmascript/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.86.0] - 2025-08-31
 
 ### 🚀 Features

--- a/crates/oxc_ecmascript/Cargo.toml
+++ b/crates/oxc_ecmascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ecmascript"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_estree/CHANGELOG.md
+++ b/crates/oxc_estree/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.88.0] - 2025-09-15
 
 ### 🚜 Refactor

--- a/crates/oxc_estree/Cargo.toml
+++ b/crates/oxc_estree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_estree"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_isolated_declarations/CHANGELOG.md
+++ b/crates/oxc_isolated_declarations/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.83.0] - 2025-08-29
 
 ### 🚜 Refactor

--- a/crates/oxc_isolated_declarations/Cargo.toml
+++ b/crates/oxc_isolated_declarations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_isolated_declarations"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_mangler/CHANGELOG.md
+++ b/crates/oxc_mangler/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.86.0] - 2025-08-31
 
 ### 🚀 Features

--- a/crates/oxc_mangler/Cargo.toml
+++ b/crates/oxc_mangler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_mangler"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_minifier/CHANGELOG.md
+++ b/crates/oxc_minifier/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.88.0] - 2025-09-15
 
 ### 🚀 Features

--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_minifier"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_napi/CHANGELOG.md
+++ b/crates/oxc_napi/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.80.0] - 2025-08-03
 
 ### 📚 Documentation

--- a/crates/oxc_napi/Cargo.toml
+++ b/crates/oxc_napi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_napi"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_parser/CHANGELOG.md
+++ b/crates/oxc_parser/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.88.0] - 2025-09-15
 
 ### 🚀 Features

--- a/crates/oxc_parser/Cargo.toml
+++ b/crates/oxc_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_parser"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_regular_expression/CHANGELOG.md
+++ b/crates/oxc_regular_expression/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.88.0] - 2025-09-15
 
 ### 🚀 Features

--- a/crates/oxc_regular_expression/Cargo.toml
+++ b/crates/oxc_regular_expression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_regular_expression"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_semantic/CHANGELOG.md
+++ b/crates/oxc_semantic/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.88.0] - 2025-09-15
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_semantic"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_span/CHANGELOG.md
+++ b/crates/oxc_span/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.88.0] - 2025-09-15
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_span/Cargo.toml
+++ b/crates/oxc_span/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_span"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_syntax/CHANGELOG.md
+++ b/crates/oxc_syntax/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.88.0] - 2025-09-15
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_syntax/Cargo.toml
+++ b/crates/oxc_syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_syntax"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_transformer/CHANGELOG.md
+++ b/crates/oxc_transformer/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.88.0] - 2025-09-15
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_transformer/Cargo.toml
+++ b/crates/oxc_transformer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_transformer"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_transformer_plugins/CHANGELOG.md
+++ b/crates/oxc_transformer_plugins/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
+
 ## [0.87.0] - 2025-09-08
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_transformer_plugins/Cargo.toml
+++ b/crates/oxc_transformer_plugins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_transformer_plugins"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_traverse/CHANGELOG.md
+++ b/crates/oxc_traverse/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
+
 ## [0.87.0] - 2025-09-08
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_traverse/Cargo.toml
+++ b/crates/oxc_traverse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_traverse"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/minify/CHANGELOG.md
+++ b/napi/minify/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
+
 ## [0.83.0] - 2025-08-29
 
 ### 💥 BREAKING CHANGES

--- a/napi/minify/Cargo.toml
+++ b/napi/minify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_minify_napi"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/minify/package.json
+++ b/napi/minify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-minify",
-  "version": "0.88.0",
+  "version": "0.89.0",
   "type": "module",
   "main": "index.js",
   "browser": "browser.js",

--- a/napi/parser/CHANGELOG.md
+++ b/napi/parser/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.89.0] - 2025-09-15
+
+### 🐛 Bug Fixes
+
+- 341791e parser: Invalid `main` entrypoint in `package.json` (#13767) (Ari Perkkiö)
+
+
+## [0.89.0] - 2025-09-15
+
+### 🐛 Bug Fixes
+
+- 341791e parser: Invalid `main` entrypoint in `package.json` (#13767) (Ari Perkkiö)
+
+
 ## [0.88.0] - 2025-09-15
 
 ### 💥 BREAKING CHANGES

--- a/napi/parser/Cargo.toml
+++ b/napi/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_parser_napi"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-parser",
-  "version": "0.88.0",
+  "version": "0.89.0",
   "type": "commonjs",
   "main": "index.mjs",
   "browser": "wasm.mjs",

--- a/napi/transform/CHANGELOG.md
+++ b/napi/transform/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
+
 ## [0.83.0] - 2025-08-29
 
 ### 💥 BREAKING CHANGES

--- a/napi/transform/Cargo.toml
+++ b/napi/transform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_transform_napi"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/transform/package.json
+++ b/napi/transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-transform",
-  "version": "0.88.0",
+  "version": "0.89.0",
   "type": "module",
   "main": "index.js",
   "browser": "browser.js",

--- a/npm/oxc-types/CHANGELOG.md
+++ b/npm/oxc-types/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.82.0] - 2025-08-12
 
 ### 🚜 Refactor

--- a/npm/oxc-types/package.json
+++ b/npm/oxc-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxc-project/types",
-  "version": "0.88.0",
+  "version": "0.89.0",
   "description": "Types for Oxc AST nodes",
   "type": "commonjs",
   "keywords": [

--- a/npm/runtime/CHANGELOG.md
+++ b/npm/runtime/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 # Changelog
 
 All notable changes to this package will be documented in this file.

--- a/npm/runtime/package.json
+++ b/npm/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxc-project/runtime",
-  "version": "0.88.0",
+  "version": "0.89.0",
   "description": "Oxc's modular runtime helpers",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## [0.89.0] - 2025-09-15

### 🐛 Bug Fixes

- 341791e parser: Invalid `main` entrypoint in `package.json` (#13767) (Ari Perkkiö)