### PR TITLE
chore(diagnostics): fix `cargo doc` warning

### DIFF
--- a/crates/oxc_diagnostics/src/service.rs
+++ b/crates/oxc_diagnostics/src/service.rs
@@ -296,7 +296,7 @@ fn from_file_path<A: AsRef<Path>>(path: A) -> Option<String> {
 }
 
 /// On Windows, rewrites the wide path prefix `\\?\C:` to `C:`
-/// Source: https://stackoverflow.com/a/70970317
+/// Source: <https://stackoverflow.com/a/70970317>
 #[inline]
 #[cfg(windows)]
 fn strict_canonicalize<P: AsRef<Path>>(path: P) -> std::io::Result<PathBuf> {


### PR DESCRIPTION
This PR fixes this warning that was shown when running `just doc`:
```
error: this URL is not a hyperlink                                                                                                     
   --> crates\oxc_diagnostics\src\service.rs:299:13
    |
299 | /// Source: https://stackoverflow.com/a/70970317
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
    = note: `-D rustdoc::bare-urls` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(rustdoc::bare_urls)]`
help: use an automatic link instead
    |
299 | /// Source: <https://stackoverflow.com/a/70970317>
    |             +                                    +
```