### PR TITLE
feat(linter/exhaustive-deps): implement fixer for dep in global scope

### DIFF
--- a/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
@@ -556,11 +556,14 @@ impl Rule for ExhaustiveDeps {
                 }
             }
 
-            ctx.diagnostic(unnecessary_outer_scope_dependency_diagnostic(
-                hook_name,
-                &dependency.name,
-                dependency.span,
-            ));
+            ctx.diagnostic_with_fix(
+                unnecessary_outer_scope_dependency_diagnostic(
+                    hook_name,
+                    &dependency.name,
+                    dependency.span,
+                ),
+                |fixer| fix::remove_dependency(fixer, dependency, dependencies_node),
+            );
         }
 
         let undeclared_deps = found_dependencies.difference(&declared_dependencies).filter(|dep| {
@@ -4196,6 +4199,10 @@ fn test() {
         (
             "function MyComponent() { const local = {}; useEffect(() => { console.log(local); }, [local, local]); }",
             "function MyComponent() { const local = {}; useEffect(() => { console.log(local); }, [local]); }",
+        ),
+        (
+            "const x = {}; function Comp() { useEffect(() => {}, [x]) }",
+            "const x = {}; function Comp() { useEffect(() => {}, []) }",
         ),
     ];
 


### PR DESCRIPTION
In the below example, `x` is a useless dependency, as changes to `x`
will not trigger a re-rended as it is not in the component scope.

This commit implements a fixer that removes the dependency from the
dependency array.

```
const x = {}
function MyComponent() {
    useEffect(() => {}, [x])
}
```