### PR TITLE
fix(transformer/typescript): panic occurs when `declare` property and `definite` property that has initializer

### DIFF
--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -343,16 +343,6 @@ impl<'a> Traverse<'a, TransformState<'a>> for TypeScriptAnnotations<'a, '_> {
         def: &mut PropertyDefinition<'a>,
         _ctx: &mut TraverseCtx<'a>,
     ) {
-        assert!(
-            !(def.declare && def.value.is_some()),
-            "Fields with the 'declare' modifier cannot be initialized here, but only in the constructor"
-        );
-
-        assert!(
-            !(def.definite && def.value.is_some()),
-            "Definitely assigned fields cannot be initialized here, but only in the constructor"
-        );
-
         def.accessibility = None;
         def.definite = false;
         def.r#override = false;

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 41d96516
 
-Passed: 186/313
+Passed: 187/314
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -63,7 +63,7 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), R
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(10)]
 
 
-# babel-plugin-transform-typescript (5/27)
+# babel-plugin-transform-typescript (6/28)
 * allow-declare-fields-false/input.ts
 Unresolved references mismatch:
 after transform: ["dce"]

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/declare-and-definite-with-initializer/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/declare-and-definite-with-initializer/input.ts
@@ -1,0 +1,10 @@
+// Test declare fields with initializers vs definite assignment assertions
+class DeclareExample {
+  declare readonly bar = "test";
+  declare readonly foo = 1;
+}
+
+class DefiniteExample {
+   readonly bar! = "test";
+   readonly foo! = 1;
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/declare-and-definite-with-initializer/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/declare-and-definite-with-initializer/output.js
@@ -1,0 +1,5 @@
+class DeclareExample {}
+class DefiniteExample {
+  bar = "test";
+  foo = 1;
+}


### PR DESCRIPTION
Remove two incorrect assertions, which cause panic in the https://github.com/oxc-project/oxc/pull/13766.

The `declare` property with an initializer is allowed in [TypeScript](https://www.typescriptlang.org/play/?useDefineForClassFields=true&target=7&noCheck=false&stripInternal=true&ts=5.9.2#code/MYGwhgzhAEAiCmowCd4FEAeYC2AHE80A3gFDTQAmi4q0qYFA9gHYgCe0ARitALzQAiAC7wIQgQG4ylaikL0mrDgDNGjPtACMUgL4kSSKHHjKAls1MjMOfIVLk68Bi3ZcUAQg3DR4qQ4UuKmqe-NokekA)
```ts
class DeclareExample {
  declare readonly bar = "test";
  declare readonly foo = 1;
}
```

The `!` (definite) with an initializer isn't allowed in [TypeScript](https://www.typescriptlang.org/play/?useDefineForClassFields=true&target=7&noCheck=false&stripInternal=true&ts=5.9.2#code/MYGwhgzhAEAiCmowCd4FEAeYC2AHE80A3gFDTQAmi4q0qYFA9gHYgCe0ARitALzQAiAC7wIQgQG4ylaikL0mrDgDNGjPtACMUgL5A), but this is a recoverable error, so the AST can have such.

```ts
class DefiniteExample {
   readonly bar! = "test";
   readonly foo! = 1;
}
```