### PR TITLE
chore(pnpm): apply minimumReleaseAge: 1 day to reduce risk

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,3 +14,16 @@ catalog:
   '@napi-rs/wasm-runtime': 1.0.5
 
 verifyDepsBeforeRun: install
+
+# To reduce the risk of installing compromised packages.
+minimumReleaseAge: 1440 # 1 day
+minimumReleaseAgeExclude:
+  - oxfmt
+  - oxlint
+  - oxlint-tsgolint
+  - rolldown
+  - rolldown-vite
+  - tsdown
+  - vite
+  - vitepress
+  - vitest


### PR DESCRIPTION
To reduce the risk of installing compromised packages.