### PR TITLE
test(oxfmt): Fix failing tests on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+apps/oxfmt/tests/fixtures/** text=auto eol=lf

--- a/apps/oxfmt/tests/mod.rs
+++ b/apps/oxfmt/tests/mod.rs
@@ -36,12 +36,12 @@ fn no_error_on_unmatched_pattern() {
     ]);
 }
 
-// TODO: Fix this test fails on Windows
-// #[test]
-// fn supported_extensions() {
-//     let args = &["tests/fixtures/extensions"];
-//     Tester::new().test_and_snapshot(args);
-// }
+#[test]
+fn supported_extensions() {
+    Tester::new()
+        .with_cwd(PathBuf::from("tests/fixtures/extensions"))
+        .test_and_snapshot_multiple(&[&["--check"]]);
+}
 
 #[test]
 fn write_mode() {

--- a/apps/oxfmt/tests/snapshots/tests__fixtures__extensions_--check@oxfmt.snap
+++ b/apps/oxfmt/tests/snapshots/tests__fixtures__extensions_--check@oxfmt.snap
@@ -1,0 +1,14 @@
+---
+source: apps/oxfmt/tests/tester.rs
+---
+########## 
+arguments: --check
+working directory: tests/fixtures/extensions
+----------
+Checking formatting...
+
+All matched files use the correct format.
+Finished in <variable>ms on 11 files using 1 threads.
+----------
+CLI result: FormatSucceeded
+----------

--- a/apps/oxfmt/tests/tester.rs
+++ b/apps/oxfmt/tests/tester.rs
@@ -42,11 +42,6 @@ impl Tester {
         FormatRunner::new(command).with_cwd(self.cwd.clone()).run(&mut output);
     }
 
-    // ///Runs a single test case and creates a snapshot.
-    // pub fn test_and_snapshot(&self, args: &[&str]) {
-    //     self.test_and_snapshot_multiple(&[args]);
-    // }
-
     /// Runs multiple test cases and creates snapshots.
     ///
     /// # Panics


### PR DESCRIPTION
Introduce https://docs.github.com/en/get-started/git-basics/configuring-git-to-handle-line-endings

Without this, the `oxfmt` tests will fail because:

- The committed test fixtures use `<LF>` as the EOL character on MacOS
  - There are no formatting diffs
- On Windows CI, these EOL characters are automatically converted to `<CRLF>`
- The formatter then changes these back to `<LF>`
- This difference causes the CI to fail

Initially, I tried to set it globally, but since CI failed, limited it to the minimum scope... 🫤 

> https://github.com/oxc-project/oxc/pull/13803