### PR TITLE
refactor(linter/plugins): import named in tests

### DIFF
--- a/apps/oxlint/test/e2e.test.ts
+++ b/apps/oxlint/test/e2e.test.ts
@@ -1,15 +1,15 @@
-import path from 'node:path';
+import { dirname, join as pathJoin } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
 import { execa } from 'execa';
 
-const PACKAGE_ROOT_PATH = path.dirname(import.meta.dirname);
-const CLI_PATH = path.join(PACKAGE_ROOT_PATH, 'dist/cli.js');
+const PACKAGE_ROOT_PATH = dirname(import.meta.dirname);
+const CLI_PATH = pathJoin(PACKAGE_ROOT_PATH, 'dist/cli.js');
 
 async function runOxlintWithoutPlugins(cwd: string, args: string[] = []) {
   return await execa('node', [CLI_PATH, ...args], {
-    cwd: path.join(PACKAGE_ROOT_PATH, cwd),
+    cwd: pathJoin(PACKAGE_ROOT_PATH, cwd),
     reject: false,
   });
 }


### PR DESCRIPTION
Pure refactor of tests. Import `dirname` and `join` from `node:path` module as named imports, instead of using `path.dirname`.