### PR TITLE
test(linter/plugins): include stack trace in plugin loading errors

### DIFF
--- a/apps/oxlint/src-js/plugins/utils.ts
+++ b/apps/oxlint/src-js/plugins/utils.ts
@@ -3,18 +3,28 @@
  *
  * `err` is expected to be an `Error` object, but can be anything.
  *
- * This function will never throw, and always returns a string, even if:
+ * * If it's an `Error`, the error message and stack trace is returned.
+ * * If it's another object with a string `message` property, `message` is returned.
+ * * Otherwise, a generic "Unknown error" message is returned.
+ *
+ * This function will never throw, and always returns a non-empty string, even if:
  *
  * * `err` is `null` or `undefined`.
  * * `err` is an object with a getter for `message` property which throws.
- * * `err` has a getter for `message` property which returns a different value each time it's accessed.
+ * * `err` has a getter for `stack` or `message` property which returns a different value each time it's accessed.
  *
  * @param err - Error
  * @returns Error message
  */
 export function getErrorMessage(err: unknown): string {
   try {
-    const { message } = err as undefined | { message: string };
+    if (err instanceof Error) {
+      // Note: `stack` includes the error message
+      const { stack } = err;
+      if (typeof stack === 'string' && stack !== '') return stack;
+    }
+
+    const { message } = err as { message?: unknown };
     if (typeof message === 'string' && message !== '') return message;
   } catch {}
 

--- a/apps/oxlint/test/__snapshots__/e2e.test.ts.snap
+++ b/apps/oxlint/test/__snapshots__/e2e.test.ts.snap
@@ -444,7 +444,14 @@ exports[`oxlint CLI > should report an error if a a rule is not found within a c
 "
 `;
 
-exports[`oxlint CLI > should report an error if a custom plugin cannot be loaded 1`] = `
+exports[`oxlint CLI > should report an error if a custom plugin in config but JS plugins are not enabled 1`] = `
+"Failed to parse configuration file.
+
+  x JS plugins are not supported without \`--experimental-js-plugins\` CLI option
+"
+`;
+
+exports[`oxlint CLI > should report an error if a custom plugin is missing 1`] = `
 "Failed to parse configuration file.
 
   x Failed to load JS plugin: ./test_plugin
@@ -452,10 +459,12 @@ exports[`oxlint CLI > should report an error if a custom plugin cannot be loaded
 "
 `;
 
-exports[`oxlint CLI > should report an error if a custom plugin in config but JS plugins are not enabled 1`] = `
+exports[`oxlint CLI > should report an error if a custom plugin throws an error during import 1`] = `
 "Failed to parse configuration file.
 
-  x JS plugins are not supported without \`--experimental-js-plugins\` CLI option
+  x Failed to load JS plugin: ./test_plugin
+  |   Error: whoops!
+  |     at <root>/apps/oxlint/test/fixtures/custom_plugin_import_error/test_plugin/index.js:1:7
 "
 `;
 

--- a/apps/oxlint/test/fixtures/custom_plugin_import_error/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_import_error/.oxlintrc.json
@@ -1,0 +1,7 @@
+{
+  "plugins": ["./test_plugin"],
+  "categories": { "correctness": "off" },
+  "rules": {
+    "basic-custom-plugin/unknown-rule": "error"
+  }
+}

--- a/apps/oxlint/test/fixtures/custom_plugin_import_error/test_plugin/index.js
+++ b/apps/oxlint/test/fixtures/custom_plugin_import_error/test_plugin/index.js
@@ -1,0 +1,1 @@
+throw new Error("whoops!");


### PR DESCRIPTION
Improve error output when there's an error loading a JS plugin. Previously only the error message was output, but no indication of where the error came from. Now we output stack trace for the error.

In tests, adapt output normalizer to remove extraneous lines from stack traces and normalize file paths, so snapshots do not change when there are irrelevant changes to internal code.