### PR TITLE
test(linter/plugins): check `this` is undefined in visit functions

### DIFF
--- a/apps/oxlint/test/fixtures/context_properties/test_plugin/index.js
+++ b/apps/oxlint/test/fixtures/context_properties/test_plugin/index.js
@@ -27,7 +27,11 @@ const rule = {
 
     if (this !== rule) context.report({ message: 'this !== rule', node: SPAN });
 
-    return {};
+    return {
+      VariableDeclaration(node) {
+        if (this !== undefined) context.report({ message: 'this !== undefined', node });
+      }
+    };
   },
 };
 


### PR DESCRIPTION
Add test coverage for the value of `this` within visit functions. It should be `undefined`, to match ESLint.