### PR TITLE
fix(linter/exhaustive-deps): remove impossible comparison with parent kind

### DIFF
--- a/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
@@ -1076,7 +1076,7 @@ fn is_stable_value<'a, 'b>(
                     .any(|reference| {
                         matches!(
                             ctx.nodes().parent_kind(reference.node_id()),
-                            AstKind::IdentifierReference(_) | AstKind::AssignmentExpression(_)
+                            AstKind::AssignmentExpression(_)
                         )
                     })
             {


### PR DESCRIPTION
`IdentifierReference`​ can never be the parent of a reference