### PR TITLE
fix(oxlint): resolve false positives for non-PascalCase JSX components in no-unused-vars

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -1361,6 +1361,22 @@ import Layout from '../layouts/Layout.astro';
         .test();
 }
 
+#[test]
+fn test_jsx_plain_identifier_fallback() {
+    let pass = vec![
+        ("const 테스트 = () => null; <테스트 />;", None),
+        ("const fooBar = () => null; <fooBar/>", None),
+    ];
+    let fail = vec![
+        ("const foo = () => null; <foo />;", None),
+        ("const value = 1; <div />;", None),
+    ];
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
+        .change_rule_path_extension("tsx")
+        .intentionally_allow_no_fix_tests()
+        .test();
+}
+
 // #[test]
 // fn test_template() {
 //     let pass = vec![];


### PR DESCRIPTION
Fixes false positives in `no-unused-vars` for non-PascalCase JSX components like CJK and camelCase identifiers.

**Problem**
The `no-unused-vars` rule incorrectly marks JSX components as "unused" when they use non-PascalCase naming, even when actually rendered in JSX. While variables and constants with multilingual characters or mixed casing are correctly recognized, component names like `fooBar` and `테스트` (CJK) trigger false positives.

This occurs because the parser only promotes JSX tags starting with uppercase letters, `_`, or `$` to `IdentifierReference`, leaving others as plain `Identifier` nodes without generating semantic references. If this is intended to enforce the convention that "JSX components should start with uppercase letters," this should be handled by separate naming/JSX rules rather than having `no-unused-vars`, which is responsible for determining usage, issue warnings inappropriately.

**Solution**  
Added a local fallback within the rule logic that checks for JSX usage when no semantic references exist
This maintains the existing heuristic for HTML intrinsics (pure lowercase ASCII) while correctly detecting usage for multilingual and mixed-case components.

**Test:** 
Added `test_jsx_plain_identifier_fallback` covering CJK (`테스트`) and camelCase (`fooBar`) components, ensuring HTML intrinsics like `<foo />` still trigger unused warnings.

|oxlint|eslint|
|---|---|
|<img width="858" height="417" alt="스크린샷 2025-09-16 오후 1 51 51" src="https://github.com/user-attachments/assets/e30beac9-79cc-4c76-ad63-3d65bd842ff3" />|<img width="602" height="310" alt="스크린샷 2025-09-16 오후 1 51 20" src="https://github.com/user-attachments/assets/5be8cac3-5f37-4b63-9a8e-a40fd51f87b0" />|

Note: ESLint currently exhibits the same false positive behavior that this PR addresses for oxlint.
