### PR TITLE
perf(linter): use unstable sort where possible

### DIFF
--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -482,7 +482,7 @@ impl ConfigStoreBuilder {
         let new_rules = self
             .rules
             .iter()
-            .sorted_by_key(|(r, _)| (r.plugin_name(), r.name()))
+            .sorted_unstable_by_key(|(r, _)| (r.plugin_name(), r.name()))
             .map(|(r, severity)| ESLintRule {
                 plugin_name: r.plugin_name().to_string(),
                 rule_name: r.name().to_string(),

--- a/crates/oxc_linter/src/config/ignore_matcher.rs
+++ b/crates/oxc_linter/src/config/ignore_matcher.rs
@@ -27,7 +27,7 @@ impl LintIgnoreMatcher {
         };
 
         // Sort nested configs deepest-to-shallowest for correct precedence
-        nested.sort_by(|a, b| {
+        nested.sort_unstable_by(|a, b| {
             let a_len = a.1.components().count();
             let b_len = b.1.components().count();
             b_len.cmp(&a_len)

--- a/crates/oxc_linter/src/rules/eslint/sort_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_keys.rs
@@ -202,7 +202,7 @@ fn alphanumeric_sort(arr: &mut [String]) {
 }
 
 fn natural_sort(arr: &mut [String]) {
-    arr.sort_by(|a, b| {
+    arr.sort_unstable_by(|a, b| {
         let mut a_chars = a.chars();
         let mut b_chars = b.chars();
 

--- a/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
+++ b/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
@@ -206,7 +206,7 @@ impl Rule for ConsistentTestIt {
     fn run_once(&self, ctx: &LintContext) {
         let mut describe_nesting_hash: FxHashMap<ScopeId, i32> = FxHashMap::default();
         let mut possible_jest_nodes = collect_possible_jest_call_node(ctx);
-        possible_jest_nodes.sort_by_key(|n| n.node.id());
+        possible_jest_nodes.sort_unstable_by_key(|n| n.node.id());
 
         for possible_jest_node in &possible_jest_nodes {
             self.run(&mut describe_nesting_hash, possible_jest_node, ctx);

--- a/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
@@ -135,7 +135,7 @@ impl Rule for MaxNestedDescribe {
     fn run_once(&self, ctx: &LintContext) {
         let mut describes_hooks_depth: Vec<ScopeId> = vec![];
         let mut possibles_jest_nodes = collect_possible_jest_call_node(ctx);
-        possibles_jest_nodes.sort_by_key(|n| n.node.id());
+        possibles_jest_nodes.sort_unstable_by_key(|n| n.node.id());
 
         for possible_jest_node in &possibles_jest_nodes {
             self.run(possible_jest_node, &mut describes_hooks_depth, ctx);
@@ -421,7 +421,7 @@ fn test() {
                     describe('another suite', () => {
                         describe('another suite', () => {
                             describe('another suite', () => {
-                            
+
                             })
                         })
                     })
@@ -440,7 +440,7 @@ fn test() {
                             describe('another suite', () => {
                                 describe('another suite', () => {
                                     describe('another suite', () => {
-                                
+
                                     })
                                 })
                             })

--- a/crates/oxc_linter/src/rules/jest/no_duplicate_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_duplicate_hooks.rs
@@ -112,7 +112,7 @@ impl Rule for NoDuplicateHooks {
         hook_contexts.insert(NodeId::ROOT, Vec::new());
 
         let mut possibles_jest_nodes = collect_possible_jest_call_node(ctx);
-        possibles_jest_nodes.sort_by_key(|n| n.node.id());
+        possibles_jest_nodes.sort_unstable_by_key(|n| n.node.id());
 
         for possible_jest_node in possibles_jest_nodes {
             Self::run(&possible_jest_node, NodeId::ROOT, &mut hook_contexts, ctx);
@@ -580,7 +580,7 @@ fn test() {
                     beforeEach(() => {})
                     afterEach(() => {})
                     afterAll(() => {})
-                
+
                     test("bar", () => {
                         someFn();
                     })
@@ -705,7 +705,7 @@ fn test() {
                 describe.each(['hello'])('%s', () => {
                     beforeEach(() => {});
                     beforeEach(() => {});
-                    
+
                     it('is not fine', () => {});
                 });
             ",
@@ -716,14 +716,14 @@ fn test() {
                 describe('something', () => {
                     describe.each(['hello'])('%s', () => {
                         beforeEach(() => {});
-                    
+
                         it('is fine', () => {});
                     });
-			    
+
                     describe.each(['world'])('%s', () => {
                         beforeEach(() => {});
                         beforeEach(() => {});
-                    
+
                         it('is not fine', () => {});
                     });
                 });

--- a/crates/oxc_linter/src/rules/jest/no_identical_title.rs
+++ b/crates/oxc_linter/src/rules/jest/no_identical_title.rs
@@ -104,7 +104,7 @@ impl Rule for NoIdenticalTitle {
                 })
                 .collect::<Vec<(Span, JestFnKind, NodeId)>>();
             // After being sorted by parent_id, the span with the same parent will be placed nearby.
-            kind_and_spans.sort_by(|a, b| a.2.cmp(&b.2));
+            kind_and_spans.sort_unstable_by(|a, b| a.2.cmp(&b.2));
 
             // Skip the first element, for `describe('foo'); describe('foo');`, we only need to check the second one.
             for i in 1..kind_and_spans.len() {

--- a/crates/oxc_linter/src/rules/jest/prefer_hooks_on_top.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_hooks_on_top.rs
@@ -153,7 +153,7 @@ impl Rule for PreferHooksOnTop {
     fn run_once(&self, ctx: &LintContext) {
         let mut hooks_contexts: FxHashMap<ScopeId, bool> = FxHashMap::default();
         let mut possibles_jest_nodes = collect_possible_jest_call_node(ctx);
-        possibles_jest_nodes.sort_by_key(|n| n.node.id());
+        possibles_jest_nodes.sort_unstable_by_key(|n| n.node.id());
 
         for possible_jest_node in &possibles_jest_nodes {
             Self::run(possible_jest_node, &mut hooks_contexts, ctx);

--- a/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
@@ -132,7 +132,7 @@ impl Rule for RequireTopLevelDescribe {
     fn run_once(&self, ctx: &LintContext) {
         let mut describe_contexts: FxHashMap<ScopeId, usize> = FxHashMap::default();
         let mut possibles_jest_nodes = collect_possible_jest_call_node(ctx);
-        possibles_jest_nodes.sort_by_key(|n| n.node.id());
+        possibles_jest_nodes.sort_unstable_by_key(|n| n.node.id());
 
         for possible_jest_node in &possibles_jest_nodes {
             self.run(possible_jest_node, &mut describe_contexts, ctx);

--- a/crates/oxc_linter/src/rules/react/style_prop_object.rs
+++ b/crates/oxc_linter/src/rules/react/style_prop_object.rs
@@ -153,7 +153,7 @@ impl Rule for StylePropObject {
             })
             .unwrap_or_default();
 
-        allow.sort();
+        allow.sort_unstable();
 
         Self(Box::new(StylePropObjectConfig { allow }))
     }

--- a/crates/oxc_linter/src/snapshots/jest_max_nested_describe.snap
+++ b/crates/oxc_linter/src/snapshots/jest_max_nested_describe.snap
@@ -121,7 +121,7 @@ source: crates/oxc_linter/src/tester.rs
     ╭─[max_nested_describe.tsx:7:37]
   6 │                                     describe('another suite', () => {
   7 │ ╭─▶                                     describe('another suite', () => {
-  8 │ │                                   
+  8 │ │   
   9 │ ╰─▶                                     })
  10 │                                     })
     ╰────

--- a/crates/oxc_linter/src/snapshots/jest_no_duplicate_hooks.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_duplicate_hooks.snap
@@ -204,7 +204,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │                     beforeEach(() => {});
  4 │                     beforeEach(() => {});
    ·                     ────────────────────
- 5 │                     
+ 5 │ 
    ╰────
   help: Describe blocks can only have one of each hook. Consider consolidating the duplicate hooks into a single call.
 
@@ -213,6 +213,6 @@ source: crates/oxc_linter/src/tester.rs
  10 │                         beforeEach(() => {});
  11 │                         beforeEach(() => {});
     ·                         ────────────────────
- 12 │                     
+ 12 │ 
     ╰────
   help: Describe blocks can only have one of each hook. Consider consolidating the duplicate hooks into a single call.


### PR DESCRIPTION
Noticed that some places can use unstable sort but was using stable sort.