### PR TITLE
release(oxlint): v1.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_language_server"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "env_logger",
  "futures",
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_linter"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "bitflags 2.9.4",
  "constcat",
@@ -2537,7 +2537,7 @@ dependencies = [
 
 [[package]]
 name = "oxlint"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "bpaf",
  "cow-utils",

--- a/apps/oxlint/CHANGELOG.md
+++ b/apps/oxlint/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.16.0] - 2025-09-16
+
+### 🐛 Bug Fixes
+
+- 3af1e5d linter/no-unsafe-declaration-merging: Always mark first span as primary (#13830) (camc314)
+- 12baf5e linter/exhaustive-deps: Respect primary span when identifying disable directive location (#13781) (camc314)
+- 09428f6 linter/plugins: Remove outdated comment (#13691) (overlookmotel)
+- a294721 linter/plugins: Exit early if JS plugins enabled on unsupported platforms (#13689) (overlookmotel)
+- 68a2280 linter/plugins: More graceful exit for `--experimental-js-plugins` CLI option (#13688) (overlookmotel)
+
+### 🚜 Refactor
+
+- 7346099 linter: Move `oxlint` application code into separate module (#13745) (overlookmotel)
+- 6dd4107 linter: Remove `#[cfg(test)]` attributes from `tester` module (#13714) (overlookmotel)
+- c40c6ef linter/plugins: Directory for JS plugins-related code (#13701) (overlookmotel)
+- 1fd993f napi/oxlint: Rename `napi/oxlint2` to `napi/oxlint` (#13682) (overlookmotel)
+
+### 🎨 Styling
+
+- 99a7638 linter: Add comments + re-organise imports (#13715) (overlookmotel)
+
+### 🧪 Testing
+
+- fb2d087 linter: Set CWD for tests (#13722) (overlookmotel)
+
+
 ## [1.15.0] - 2025-09-11
 
 ### 💥 BREAKING CHANGES

--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxlint"
-version = "1.15.0"
+version = "1.16.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_language_server/CHANGELOG.md
+++ b/crates/oxc_language_server/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.16.0] - 2025-09-16
+
+### 🚜 Refactor
+
+- 137896a language_server: Split options for linting and formatting (#13627) (Sysix)
+
+
 ## [1.15.0] - 2025-09-11
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_language_server"
-version = "1.15.0"
+version = "1.16.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_linter/CHANGELOG.md
+++ b/crates/oxc_linter/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.16.0] - 2025-09-16
+
+### 🚀 Features
+
+- 97c8d06 linter: Add `preserve-caught-error` rule (#13748) (孔辉)
+- 8c19b18 linter/exhaustive-deps: Implement fixer for dep in global scope (#13783) (camc314)
+- 06bce8f linter/exhaustive-deps: Implement fixer for missing dep (#13782) (camc314)
+- a8675f4 linter: Add eslint/class-methods-use-this rule (#12977) (Peter Cardenas)
+- db33196 parser: Adds typescript rule for empty argument list (#13730) (Karan Kiri)
+- 2751193 linter: Add `eslint/no-useless-computed-key` rule (#13428) (yefan)
+- 9a205d1 regex-parser: Parse simple `TemplateLiterals` (#13265) (Sysix)
+
+### 🐛 Bug Fixes
+
+- 3af1e5d linter/no-unsafe-declaration-merging: Always mark first span as primary (#13830) (camc314)
+- 1c43c7c linter: Keep message when merging composite fixes (#13827) (camc314)
+- 26af302 linter/exhaustive-deps: Check stable value is on lhs of assignment expr (#13815) (camc314)
+- 4bc12d0 linter/exhaustive-deps: Remove impossible comparison with parent kind (#13814) (camc314)
+- 12baf5e linter/exhaustive-deps: Respect primary span when identifying disable directive location (#13781) (camc314)
+- fa7400a linter/no-undef: False positive with `arguments` in functions (#13763) (camc314)
+- 56da114 linter/react/jsx-handler-names: Do not detect the function name within the inline-function's body block (#13456) (Takuji Shimokawa)
+- b2bc5b4 linter/react-perf/jsx-no-new-object-as-prop: Skip as/satisfies exprs (#13718) (camc314)
+- ab51394 raw_transfer: Disable layout assertions on some 32-bit platforms (#13716) (overlookmotel)
+
+### 🚜 Refactor
+
+- 395d40d linter: Derive inmpls for `PartialEq`, `Eq` over manual ones (#13828) (camc314)
+- 8e4cd8f linter/func-names: Use `run_once` over looping over all nodes (#13798) (camc314)
+- 7f4e2fe eslint/func-names: Clean up implementation and improve documentation (#13601) (Antoine Zanardi)
+- a0022c1 linter/plugins: Improve error messages for JS plugins (#13699) (overlookmotel)
+
+### ⚡ Performance
+
+- 90c8286 linter: Detect node types from `let..else` statements (#13690) (camchenry)
+- 08c05df semantic: Make CFG construction a compile-time feature (#13678) (Boshen)
+
+### 🧪 Testing
+
+- 18a1145 linter: Add debug assertions for skipping rules (#13724) (camc314)
+- cb080de linter/no-unused-vars: Add test for non ASCII chars in JSX components (#13820) (camc314)
+- b6eba27 linter/no-undef: Add more test cases for `arguments` (#13764) (camc314)
+
+
 ## [1.15.0] - 2025-09-11
 
 ### 🚀 Features

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_linter"
-version = "1.15.0"
+version = "1.16.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.16.0] - 2025-09-16
+
+### 🐛 Bug Fixes
+
+- 50e6e3c editor: Restrict servers paths for  `oxc.path.server` (#13740) (Sysix)
+- b45077d editor: Strip leading slash for bin path on windows (#13738) (Sysix)
+- 8fa6227 editor: Don't allow `oxc.path.server` for untrusted workspaces (#13734) (Sysix)
+
+
 ## [1.15.0] - 2025-09-11
 
 ### 🚀 Features

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "oxc-vscode",
   "description": "oxc vscode extension",
   "license": "MIT",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "icon": "icon.png",
   "publisher": "oxc",
   "displayName": "Oxc",

--- a/npm/oxlint/CHANGELOG.md
+++ b/npm/oxlint/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
+
 ## [1.14.0] - 2025-08-30
 
 ### 🚀 Features

--- a/npm/oxlint/package.json
+++ b/npm/oxlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "type": "commonjs",
   "description": "Linter for the JavaScript Oxidation Compiler",
   "keywords": [],


### PR DESCRIPTION
## [1.16.0] - 2025-09-16

### 🚀 Features

- 97c8d06 linter: Add `preserve-caught-error` rule (#13748) (孔辉)
- 8c19b18 linter/exhaustive-deps: Implement fixer for dep in global scope (#13783) (camc314)
- 06bce8f linter/exhaustive-deps: Implement fixer for missing dep (#13782) (camc314)
- a8675f4 linter: Add eslint/class-methods-use-this rule (#12977) (Peter Cardenas)
- db33196 parser: Adds typescript rule for empty argument list (#13730) (Karan Kiri)
- 2751193 linter: Add `eslint/no-useless-computed-key` rule (#13428) (yefan)
- 9a205d1 regex-parser: Parse simple `TemplateLiterals` (#13265) (Sysix)

### 🐛 Bug Fixes

- 3af1e5d linter/no-unsafe-declaration-merging: Always mark first span as primary (#13830) (camc314)
- 1c43c7c linter: Keep message when merging composite fixes (#13827) (camc314)
- 26af302 linter/exhaustive-deps: Check stable value is on lhs of assignment expr (#13815) (camc314)
- 4bc12d0 linter/exhaustive-deps: Remove impossible comparison with parent kind (#13814) (camc314)
- 12baf5e linter/exhaustive-deps: Respect primary span when identifying disable directive location (#13781) (camc314)
- fa7400a linter/no-undef: False positive with `arguments` in functions (#13763) (camc314)
- 50e6e3c editor: Restrict servers paths for  `oxc.path.server` (#13740) (Sysix)
- b45077d editor: Strip leading slash for bin path on windows (#13738) (Sysix)
- 8fa6227 editor: Don't allow `oxc.path.server` for untrusted workspaces (#13734) (Sysix)
- 56da114 linter/react/jsx-handler-names: Do not detect the function name within the inline-function's body block (#13456) (Takuji Shimokawa)
- b2bc5b4 linter/react-perf/jsx-no-new-object-as-prop: Skip as/satisfies exprs (#13718) (camc314)
- ab51394 raw_transfer: Disable layout assertions on some 32-bit platforms (#13716) (overlookmotel)
- 09428f6 linter/plugins: Remove outdated comment (#13691) (overlookmotel)
- a294721 linter/plugins: Exit early if JS plugins enabled on unsupported platforms (#13689) (overlookmotel)
- 68a2280 linter/plugins: More graceful exit for `--experimental-js-plugins` CLI option (#13688) (overlookmotel)

### 🚜 Refactor

- 395d40d linter: Derive inmpls for `PartialEq`, `Eq` over manual ones (#13828) (camc314)
- 8e4cd8f linter/func-names: Use `run_once` over looping over all nodes (#13798) (camc314)
- 7f4e2fe eslint/func-names: Clean up implementation and improve documentation (#13601) (Antoine Zanardi)
- 137896a language_server: Split options for linting and formatting (#13627) (Sysix)
- 7346099 linter: Move `oxlint` application code into separate module (#13745) (overlookmotel)
- 6dd4107 linter: Remove `#[cfg(test)]` attributes from `tester` module (#13714) (overlookmotel)
- c40c6ef linter/plugins: Directory for JS plugins-related code (#13701) (overlookmotel)
- a0022c1 linter/plugins: Improve error messages for JS plugins (#13699) (overlookmotel)
- 1fd993f napi/oxlint: Rename `napi/oxlint2` to `napi/oxlint` (#13682) (overlookmotel)

### ⚡ Performance

- 90c8286 linter: Detect node types from `let..else` statements (#13690) (camchenry)
- 08c05df semantic: Make CFG construction a compile-time feature (#13678) (Boshen)

### 🎨 Styling

- 99a7638 linter: Add comments + re-organise imports (#13715) (overlookmotel)

### 🧪 Testing

- 18a1145 linter: Add debug assertions for skipping rules (#13724) (camc314)
- cb080de linter/no-unused-vars: Add test for non ASCII chars in JSX components (#13820) (camc314)
- b6eba27 linter/no-undef: Add more test cases for `arguments` (#13764) (camc314)
- fb2d087 linter: Set CWD for tests (#13722) (overlookmotel)