### PR TITLE
feat(napi/parser): `preserveParens` option for raw transfer

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1069,6 +1069,7 @@ pub enum ChainElement<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[estree(via = ParenthesizedExpressionConverter)]
 pub struct ParenthesizedExpression<'a> {
     pub span: Span,
     pub expression: Expression<'a>,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -773,11 +773,7 @@ impl ESTree for ChainElement<'_> {
 
 impl ESTree for ParenthesizedExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let mut state = serializer.serialize_struct();
-        state.serialize_field("type", &JsonSafeString("ParenthesizedExpression"));
-        state.serialize_field("expression", &self.expression);
-        state.serialize_span(self.span);
-        state.end();
+        crate::serialize::js::ParenthesizedExpressionConverter(self).serialize(serializer)
     }
 }
 

--- a/napi/parser/bench.bench.mjs
+++ b/napi/parser/bench.bench.mjs
@@ -101,7 +101,7 @@ for (const { filename, code } of fixtures) {
     const deserialize = isJsAst(buffer) ? deserializeJS : deserializeTS;
 
     benchRaw('parser_napi_raw_deser_only', () => {
-      deserialize(buffer, code, sourceByteLen);
+      deserialize(buffer, code, sourceByteLen, true);
     });
 
     // oxlint-disable-next-line no-unused-vars

--- a/napi/parser/generated/deserialize/js.mjs
+++ b/napi/parser/generated/deserialize/js.mjs
@@ -1,13 +1,13 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
-let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen;
+let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen, preserveParens;
 
 const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
   { fromCodePoint } = String;
 
-export function deserialize(buffer, sourceTextInput, sourceByteLenInput) {
+export function deserialize(buffer, sourceTextInput, sourceByteLenInput, preserveParensInput) {
   uint8 = buffer;
   uint32 = buffer.uint32;
   float64 = buffer.float64;
@@ -15,6 +15,7 @@ export function deserialize(buffer, sourceTextInput, sourceByteLenInput) {
   sourceText = sourceTextInput;
   sourceByteLen = sourceByteLenInput;
   sourceIsAscii = sourceText.length === sourceByteLen;
+  preserveParens = preserveParensInput;
 
   const data = deserializeRawTransferData(uint32[536870902]);
 
@@ -438,12 +439,16 @@ function deserializeChainExpression(pos) {
 }
 
 function deserializeParenthesizedExpression(pos) {
-  return {
-    type: 'ParenthesizedExpression',
-    expression: deserializeExpression(pos + 8),
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
-  };
+  let node = deserializeExpression(pos + 8);
+  if (preserveParens) {
+    node = {
+      type: 'ParenthesizedExpression',
+      expression: node,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
+    };
+  }
+  return node;
 }
 
 function deserializeDirective(pos) {

--- a/napi/parser/generated/deserialize/ts.mjs
+++ b/napi/parser/generated/deserialize/ts.mjs
@@ -1,13 +1,13 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
-let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen;
+let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen, preserveParens;
 
 const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
   { fromCodePoint } = String;
 
-export function deserialize(buffer, sourceTextInput, sourceByteLenInput) {
+export function deserialize(buffer, sourceTextInput, sourceByteLenInput, preserveParensInput) {
   uint8 = buffer;
   uint32 = buffer.uint32;
   float64 = buffer.float64;
@@ -15,6 +15,7 @@ export function deserialize(buffer, sourceTextInput, sourceByteLenInput) {
   sourceText = sourceTextInput;
   sourceByteLen = sourceByteLenInput;
   sourceIsAscii = sourceText.length === sourceByteLen;
+  preserveParens = preserveParensInput;
 
   const data = deserializeRawTransferData(uint32[536870902]);
 
@@ -488,12 +489,16 @@ function deserializeChainExpression(pos) {
 }
 
 function deserializeParenthesizedExpression(pos) {
-  return {
-    type: 'ParenthesizedExpression',
-    expression: deserializeExpression(pos + 8),
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
-  };
+  let node = deserializeExpression(pos + 8);
+  if (preserveParens) {
+    node = {
+      type: 'ParenthesizedExpression',
+      expression: node,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
+    };
+  }
+  return node;
 }
 
 function deserializeDirective(pos) {

--- a/napi/parser/raw-transfer/eager.mjs
+++ b/napi/parser/raw-transfer/eager.mjs
@@ -56,7 +56,10 @@ function deserialize(buffer, sourceText, sourceByteLen) {
   let data;
   if (isJsAst(buffer)) {
     if (deserializeJS === null) deserializeJS = require('../generated/deserialize/js.mjs').deserialize;
-    data = deserializeJS(buffer, sourceText, sourceByteLen);
+
+    // `preserveParens` argument is unconditionally `true` here. If `options` contains `preserveParens: false`,
+    // `ParenthesizedExpression` nodes won't be in AST anyway, so the value is irrelevant.
+    data = deserializeJS(buffer, sourceText, sourceByteLen, true);
 
     // Add a line comment for hashbang
     const { hashbang } = data.program;
@@ -65,7 +68,11 @@ function deserialize(buffer, sourceText, sourceByteLen) {
     }
   } else {
     if (deserializeTS === null) deserializeTS = require('../generated/deserialize/ts.mjs').deserialize;
-    data = deserializeTS(buffer, sourceText, sourceByteLen);
+
+    // `preserveParens` argument is unconditionally `true` here. If `options` contains `preserveParens: false`,
+    // `ParenthesizedExpression` nodes won't be in AST anyway, so the value is irrelevant.
+    data = deserializeTS(buffer, sourceText, sourceByteLen, true);
+
     // Note: Do not add line comment for hashbang, to match `@typescript-eslint/parser`.
     // See https://github.com/oxc-project/oxc/blob/ea784f5f082e4c53c98afde9bf983afd0b95e44e/napi/parser/src/lib.rs#L106-L130
   }

--- a/napi/parser/test/parse-raw.test.ts
+++ b/napi/parser/test/parse-raw.test.ts
@@ -264,3 +264,45 @@ it.concurrent('checks semantic', async () => {
   ret = parseSync('test.js', code, { experimentalRawTransfer: true, showSemanticErrors: true });
   expect(ret.errors.length).toBe(1);
 });
+
+describe.concurrent('`preserveParens` option', () => {
+  describe.concurrent('should not include parens when false', () => {
+    it.concurrent('JS', async () => {
+      const code = 'let x = (1 + 2);';
+
+      // @ts-ignore
+      let ret = parseSync('test.js', code, { experimentalRawTransfer: true, preserveParens: false });
+      expect(ret.errors.length).toBe(0);
+      expect(ret.program.body[0].declarations[0].init.type).toBe('BinaryExpression');
+    });
+
+    it.concurrent('TS', async () => {
+      const code = 'let x = (1 + 2);';
+
+      // @ts-ignore
+      let ret = parseSync('test.ts', code, { experimentalRawTransfer: true, preserveParens: false });
+      expect(ret.errors.length).toBe(0);
+      expect(ret.program.body[0].declarations[0].init.type).toBe('BinaryExpression');
+    });
+  });
+
+  describe.concurrent('should include parens when true', () => {
+    it.concurrent('JS', async () => {
+      const code = 'let x = (1 + 2);';
+
+      // @ts-ignore
+      let ret = parseSync('test.js', code, { experimentalRawTransfer: true, preserveParens: true });
+      expect(ret.errors.length).toBe(0);
+      expect(ret.program.body[0].declarations[0].init.type).toBe('ParenthesizedExpression');
+    });
+
+    it.concurrent('TS', async () => {
+      const code = 'let x = (1 + 2);';
+
+      // @ts-ignore
+      let ret = parseSync('test.ts', code, { experimentalRawTransfer: true, preserveParens: true });
+      expect(ret.errors.length).toBe(0);
+      expect(ret.program.body[0].declarations[0].init.type).toBe('ParenthesizedExpression');
+    });
+  });
+});

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -116,13 +116,13 @@ fn generate_deserializers(consts: Constants, schema: &Schema, codegen: &Codegen)
 
     #[rustfmt::skip]
     let prelude = format!("
-        let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen;
+        let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen, preserveParens;
 
         const textDecoder = new TextDecoder('utf-8', {{ ignoreBOM: true }}),
             decodeStr = textDecoder.decode.bind(textDecoder),
             {{ fromCodePoint }} = String;
 
-        export function deserialize(buffer, sourceTextInput, sourceByteLenInput) {{
+        export function deserialize(buffer, sourceTextInput, sourceByteLenInput, preserveParensInput) {{
             uint8 = buffer;
             uint32 = buffer.uint32;
             float64 = buffer.float64;
@@ -130,6 +130,7 @@ fn generate_deserializers(consts: Constants, schema: &Schema, codegen: &Codegen)
             sourceText = sourceTextInput;
             sourceByteLen = sourceByteLenInput;
             sourceIsAscii = sourceText.length === sourceByteLen;
+            preserveParens = preserveParensInput;
 
             const data = deserializeRawTransferData(uint32[{data_pointer_pos_32}]);
 


### PR DESCRIPTION
Partial fix for #13851.

Add a `preserveParens` argument to raw transfer `deserialize` functions. This is not useful in `oxc-parser`, but these generated files will be duplicated in `oxlint`, where this option is required to remove `ParenthesizedExpression`s from AST, to align with ESLint and TS-ESLint.