### PR TITLE
fix(linter/plugins): improve error for no JS plugins

### DIFF
--- a/apps/oxlint/test/__snapshots__/e2e.test.ts.snap
+++ b/apps/oxlint/test/__snapshots__/e2e.test.ts.snap
@@ -447,7 +447,7 @@ exports[`oxlint CLI > should report an error if a a rule is not found within a c
 exports[`oxlint CLI > should report an error if a custom plugin in config but JS plugins are not enabled 1`] = `
 "Failed to parse configuration file.
 
-  x JS plugins are not supported without \`--experimental-js-plugins\` CLI option
+  x \`plugins\` config contains './test_plugin'. JS plugins are not supported without \`--experimental-js-plugins\` CLI option
 "
 `;
 

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -162,8 +162,11 @@ impl ConfigStoreBuilder {
         }
 
         if !external_plugins.is_empty() {
-            let external_linter =
-                external_linter.ok_or(ConfigBuilderError::NoExternalLinterConfigured)?;
+            let Some(external_linter) = external_linter else {
+                #[expect(clippy::missing_panics_doc, reason = "infallible")]
+                let plugin_specifier = external_plugins.iter().next().unwrap().clone();
+                return Err(ConfigBuilderError::NoExternalLinterConfigured { plugin_specifier });
+            };
 
             let resolver = Resolver::default();
 
@@ -573,7 +576,9 @@ pub enum ConfigBuilderError {
         error: String,
     },
     ExternalRuleLookupError(ExternalRuleLookupError),
-    NoExternalLinterConfigured,
+    NoExternalLinterConfigured {
+        plugin_specifier: String,
+    },
 }
 
 impl Display for ConfigBuilderError {
@@ -597,9 +602,10 @@ impl Display for ConfigBuilderError {
                 write!(f, "Failed to load JS plugin: {plugin_specifier}\n  {error}")?;
                 Ok(())
             }
-            ConfigBuilderError::NoExternalLinterConfigured => {
-                f.write_str(
-                    "JS plugins are not supported without `--experimental-js-plugins` CLI option",
+            ConfigBuilderError::NoExternalLinterConfigured { plugin_specifier } => {
+                write!(
+                    f,
+                    "`plugins` config contains '{plugin_specifier}'. JS plugins are not supported without `--experimental-js-plugins` CLI option",
                 )?;
                 Ok(())
             }


### PR DESCRIPTION
Improve the error message when an unrecognised name is found in `plugins` config. Specify the offending entry in plugins. This should guide users to what the problem is, and avoid confusion like in #13739.
