### PR TITLE
test(linter/plugins): tests for different import styles

### DIFF
--- a/apps/oxlint/.gitignore
+++ b/apps/oxlint/.gitignore
@@ -1,3 +1,3 @@
-node_modules/
+/node_modules/
+/dist/
 *.node
-dist/

--- a/apps/oxlint/test/__snapshots__/e2e.test.ts.snap
+++ b/apps/oxlint/test/__snapshots__/e2e.test.ts.snap
@@ -395,6 +395,55 @@ Found 20 warnings and 20 errors.
 Finished in Xms on 20 files using X threads."
 `;
 
+exports[`oxlint CLI > should load a custom plugin with various import styles 1`] = `
+"
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\\eslint(no-debugger)]8;;\\: \`debugger\` statement is not allowed
+   ,-[index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   \`----
+  help: Remove the debugger statement
+
+  x plugin1(no-debugger): Unexpected Debugger Statement
+   ,-[index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   \`----
+
+  x plugin2(no-debugger): Unexpected Debugger Statement
+   ,-[index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   \`----
+
+  x plugin3(no-debugger): Unexpected Debugger Statement
+   ,-[index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   \`----
+
+  x plugin4(no-debugger): Unexpected Debugger Statement
+   ,-[index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   \`----
+
+  x plugin5(no-debugger): Unexpected Debugger Statement
+   ,-[index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   \`----
+
+  x plugin6(no-debugger): Unexpected Debugger Statement
+   ,-[index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   \`----
+
+Found 1 warning and 6 errors.
+Finished in Xms on 1 file using X threads."
+`;
+
 exports[`oxlint CLI > should receive data via \`context\` 1`] = `
 "
   x context-plugin(log-context): id: context-plugin/log-context

--- a/apps/oxlint/test/e2e.test.ts
+++ b/apps/oxlint/test/e2e.test.ts
@@ -76,6 +76,12 @@ describe('oxlint CLI', () => {
     expect(normalizeOutput(stdout)).toMatchSnapshot();
   });
 
+  it('should load a custom plugin with various import styles', async () => {
+    const { stdout, exitCode } = await runOxlint('test/fixtures/load_paths');
+    expect(exitCode).toBe(1);
+    expect(normalizeOutput(stdout)).toMatchSnapshot();
+  });
+
   it('should load a custom plugin with multiple files', async () => {
     const { stdout, exitCode } = await runOxlint('test/fixtures/basic_custom_plugin_many_files');
     expect(exitCode).toBe(1);

--- a/apps/oxlint/test/fixtures/load_paths/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/load_paths/.oxlintrc.json
@@ -1,0 +1,19 @@
+{
+    "plugins": [
+      "./plugins/test_plugin1.js",
+      "./plugins/test_plugin2.cjs",
+      "./plugins/test_plugin3.mjs",
+      "./plugins/test_plugin4",
+      "test_plugin5",
+      "test_plugin6"
+    ],
+    "rules": {
+        "plugin1/no-debugger": "error",
+        "plugin2/no-debugger": "error",
+        "plugin3/no-debugger": "error",
+        "plugin4/no-debugger": "error",
+        "plugin5/no-debugger": "error",
+        "plugin6/no-debugger": "error"
+    },
+    "ignorePatterns": ["plugins/**", "node_modules/**"]
+}

--- a/apps/oxlint/test/fixtures/load_paths/index.js
+++ b/apps/oxlint/test/fixtures/load_paths/index.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/fixtures/load_paths/node_modules/test_plugin5/index.js
+++ b/apps/oxlint/test/fixtures/load_paths/node_modules/test_plugin5/index.js
@@ -1,0 +1,19 @@
+export default {
+  meta: {
+    name: "plugin5",
+  },
+  rules: {
+    "no-debugger": {
+      create(context) {
+        return {
+          DebuggerStatement(debuggerStatement) {
+            context.report({
+              message: "Unexpected Debugger Statement",
+              node: debuggerStatement,
+            });
+          },
+        };
+      },
+    },
+  },
+};

--- a/apps/oxlint/test/fixtures/load_paths/node_modules/test_plugin5/package.json
+++ b/apps/oxlint/test/fixtures/load_paths/node_modules/test_plugin5/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-plugin5",
+  "type": "module",
+  "main": "index.js"
+}

--- a/apps/oxlint/test/fixtures/load_paths/node_modules/test_plugin6/package.json
+++ b/apps/oxlint/test/fixtures/load_paths/node_modules/test_plugin6/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-plugin6",
+  "type": "commonjs",
+  "main": "plugin.js"
+}

--- a/apps/oxlint/test/fixtures/load_paths/node_modules/test_plugin6/plugin.js
+++ b/apps/oxlint/test/fixtures/load_paths/node_modules/test_plugin6/plugin.js
@@ -1,0 +1,21 @@
+'use strict';
+
+module.exports = {
+  meta: {
+    name: "plugin6",
+  },
+  rules: {
+    "no-debugger": {
+      create(context) {
+        return {
+          DebuggerStatement(debuggerStatement) {
+            context.report({
+              message: "Unexpected Debugger Statement",
+              node: debuggerStatement,
+            });
+          },
+        };
+      },
+    },
+  },
+};

--- a/apps/oxlint/test/fixtures/load_paths/plugins/test_plugin1.js
+++ b/apps/oxlint/test/fixtures/load_paths/plugins/test_plugin1.js
@@ -1,0 +1,19 @@
+export default {
+  meta: {
+    name: "plugin1",
+  },
+  rules: {
+    "no-debugger": {
+      create(context) {
+        return {
+          DebuggerStatement(debuggerStatement) {
+            context.report({
+              message: "Unexpected Debugger Statement",
+              node: debuggerStatement,
+            });
+          },
+        };
+      },
+    },
+  },
+};

--- a/apps/oxlint/test/fixtures/load_paths/plugins/test_plugin2.cjs
+++ b/apps/oxlint/test/fixtures/load_paths/plugins/test_plugin2.cjs
@@ -1,0 +1,21 @@
+'use strict';
+
+module.exports = {
+  meta: {
+    name: "plugin2",
+  },
+  rules: {
+    "no-debugger": {
+      create(context) {
+        return {
+          DebuggerStatement(debuggerStatement) {
+            context.report({
+              message: "Unexpected Debugger Statement",
+              node: debuggerStatement,
+            });
+          },
+        };
+      },
+    },
+  },
+};

--- a/apps/oxlint/test/fixtures/load_paths/plugins/test_plugin3.mjs
+++ b/apps/oxlint/test/fixtures/load_paths/plugins/test_plugin3.mjs
@@ -1,0 +1,19 @@
+export default {
+  meta: {
+    name: "plugin3",
+  },
+  rules: {
+    "no-debugger": {
+      create(context) {
+        return {
+          DebuggerStatement(debuggerStatement) {
+            context.report({
+              message: "Unexpected Debugger Statement",
+              node: debuggerStatement,
+            });
+          },
+        };
+      },
+    },
+  },
+};

--- a/apps/oxlint/test/fixtures/load_paths/plugins/test_plugin4/index.js
+++ b/apps/oxlint/test/fixtures/load_paths/plugins/test_plugin4/index.js
@@ -1,0 +1,19 @@
+export default {
+  meta: {
+    name: "plugin4",
+  },
+  rules: {
+    "no-debugger": {
+      create(context) {
+        return {
+          DebuggerStatement(debuggerStatement) {
+            context.report({
+              message: "Unexpected Debugger Statement",
+              node: debuggerStatement,
+            });
+          },
+        };
+      },
+    },
+  },
+};


### PR DESCRIPTION
Add tests for importing plugins via various path styles and module formats:

* CommonJS
* ESM
* Relative path to file
* Relative path to directory
* Package in `node_modules`
