### PR TITLE
refactor(linter/plugins): rename `--experimental-js-plugins` to `--js-plugins`

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -50,9 +50,9 @@ pub struct LintCommand {
     #[bpaf(switch, hide_usage)]
     pub type_aware: bool,
 
-    /// Enables JS plugins.
+    /// Enables JS plugins (experimental).
     #[bpaf(switch, hide)]
-    pub experimental_js_plugins: bool,
+    pub js_plugins: bool,
 
     #[bpaf(external)]
     pub inline_config_options: InlineConfigOptions,

--- a/apps/oxlint/src/run.rs
+++ b/apps/oxlint/src/run.rs
@@ -89,7 +89,7 @@ fn lint_impl(load_plugin: JsLoadPluginCb, lint_file: JsLintFileCb) -> CliRunResu
 
     command.handle_threads();
 
-    let external_linter = if command.experimental_js_plugins {
+    let external_linter = if command.js_plugins {
         // JS plugins are only supported on 64-bit little-endian platforms at present
         #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
         {

--- a/apps/oxlint/test/__snapshots__/e2e.test.ts.snap
+++ b/apps/oxlint/test/__snapshots__/e2e.test.ts.snap
@@ -496,7 +496,7 @@ exports[`oxlint CLI > should report an error if a a rule is not found within a c
 exports[`oxlint CLI > should report an error if a custom plugin in config but JS plugins are not enabled 1`] = `
 "Failed to parse configuration file.
 
-  x \`plugins\` config contains './test_plugin'. JS plugins are not supported without \`--experimental-js-plugins\` CLI option
+  x \`plugins\` config contains './test_plugin'. JS plugins are not supported without \`--js-plugins\` CLI option. Note: JS plugin support is experimental.
 "
 `;
 

--- a/apps/oxlint/test/e2e.test.ts
+++ b/apps/oxlint/test/e2e.test.ts
@@ -17,7 +17,7 @@ async function runOxlintWithoutPlugins(cwd: string, args: string[] = []) {
 }
 
 async function runOxlint(cwd: string, args: string[] = []) {
-  return await runOxlintWithoutPlugins(cwd, ['--experimental-js-plugins', ...args]);
+  return await runOxlintWithoutPlugins(cwd, ['--js-plugins', ...args]);
 }
 
 function normalizeOutput(output: string): string {

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -605,7 +605,7 @@ impl Display for ConfigBuilderError {
             ConfigBuilderError::NoExternalLinterConfigured { plugin_specifier } => {
                 write!(
                     f,
-                    "`plugins` config contains '{plugin_specifier}'. JS plugins are not supported without `--experimental-js-plugins` CLI option",
+                    "`plugins` config contains '{plugin_specifier}'. JS plugins are not supported without `--js-plugins` CLI option. Note: JS plugin support is experimental.",
                 )?;
                 Ok(())
             }

--- a/npm/oxlint/bin/oxlint
+++ b/npm/oxlint/bin/oxlint
@@ -4,7 +4,7 @@
 // Even if runtime supports require(ESM), can't use `require` here, because `dist/cli.js`
 // uses top-level `await`.
 //
-// `dist/cli.js` uses require(ESM) internally, but only on path where `--experimental-js-plugins`
+// `dist/cli.js` uses require(ESM) internally, but only on path where `--js-plugins`
 // CLI option is used. So we still support runtimes without require(ESM) for users who aren't
 // using experimental options.
 import("../dist/cli.js").catch(onError);


### PR DESCRIPTION
Change CLI option to enable JS plugins from `--experimental-js-plugins` to `--js-plugins`. We'll make it clear in docs that JS plugins are experimental and not covered by semver.