### PR TITLE
feat(napi/playground): add configurable semantic error checking

### DIFF
--- a/napi/playground/index.d.ts
+++ b/napi/playground/index.d.ts
@@ -105,6 +105,7 @@ export interface OxcParserOptions {
   allowReturnOutsideFunction: boolean
   preserveParens: boolean
   allowV8Intrinsics: boolean
+  semanticErrors: boolean
 }
 
 export interface OxcRunOptions {

--- a/napi/playground/src/options.rs
+++ b/napi/playground/src/options.rs
@@ -40,6 +40,7 @@ pub struct OxcParserOptions {
     pub allow_return_outside_function: bool,
     pub preserve_parens: bool,
     pub allow_v8_intrinsics: bool,
+    pub semantic_errors: bool,
 }
 
 #[napi(object)]


### PR DESCRIPTION
## Summary
- Added a new `semanticErrors` field to `OxcParserOptions` to allow users to control whether semantic syntax errors should be checked and reported
- Updated the `build_semantic` method to use this configuration option
- Semantic errors are now only collected when explicitly enabled through the configuration

## Changes
- Add `semantic_errors: bool` field to `OxcParserOptions` struct in `napi/playground/src/options.rs`
- Update `build_semantic` method in `napi/playground/src/lib.rs` to:
  - Accept `parser_options` parameter
  - Use `parser_options.semantic_errors` for `with_check_syntax_error()`
  - Conditionally collect errors based on the configuration
- Auto-generated TypeScript definitions updated to include the new field

## Test plan
Tested manually by creating a simple Node.js script that:
1. Parses code with duplicate variable declarations (semantic error)
2. Tests with `semanticErrors: true` - confirms error is reported
3. Tests with `semanticErrors: false` - confirms no error is reported

The feature works as expected, providing users with control over semantic error checking.

🤖 Generated with [Claude Code](https://claude.ai/code)