### PR TITLE
feat(napi/playground): add configurable CFG generation

### DIFF
--- a/napi/playground/index.d.ts
+++ b/napi/playground/index.d.ts
@@ -119,6 +119,7 @@ export interface OxcRunOptions {
   mangle: boolean
   scope: boolean
   symbol: boolean
+  cfg: boolean
 }
 
 export interface OxcTransformerOptions {

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -248,7 +248,7 @@ impl Oxc {
         }
         let semantic_ret = semantic_builder
             .with_check_syntax_error(parser_options.semantic_errors)
-            .with_cfg(true)
+            .with_cfg(run_options.cfg)
             .build(program);
         self.diagnostics.extend(semantic_ret.errors);
 
@@ -376,7 +376,7 @@ impl Oxc {
         // Only lint if there are no syntax errors
         if run_options.lint && self.diagnostics.is_empty() {
             let external_plugin_store = ExternalPluginStore::default();
-            let semantic_ret = SemanticBuilder::new().with_cfg(true).build(program);
+            let semantic_ret = SemanticBuilder::new().with_cfg(run_options.cfg).build(program);
             let semantic = semantic_ret.semantic;
             let lint_config = if linter_options.config.is_some() {
                 let oxlintrc =

--- a/napi/playground/src/options.rs
+++ b/napi/playground/src/options.rs
@@ -31,6 +31,7 @@ pub struct OxcRunOptions {
     pub mangle: bool,
     pub scope: bool,
     pub symbol: bool,
+    pub cfg: bool,
 }
 
 #[napi(object)]


### PR DESCRIPTION
## Summary
- Add `cfg` field to `OxcRunOptions` to control Control Flow Graph generation in semantic analysis
- Replace hardcoded `with_cfg(true)` calls with configurable `run_options.cfg` option
- Update TypeScript definitions to include the new `cfg` boolean field

## Motivation
Previously, CFG generation was always enabled (`with_cfg(true)`) in both the main semantic analysis and linter semantic analysis. This change allows users to control CFG generation for better performance when CFG data is not needed.

## Changes
- **napi/playground/src/options.rs**: Add `cfg: bool` field to `OxcRunOptions` struct
- **napi/playground/src/lib.rs**: 
  - Update `build_semantic` method to use `run_options.cfg` instead of hardcoded `true`
  - Update `run_linter` method to use `run_options.cfg` instead of hardcoded `true`
- **napi/playground/index.d.ts**: Add `cfg: boolean` to TypeScript definitions

## Test plan
- [ ] Verify compilation succeeds
- [ ] Test NAPI playground with `cfg: true` (should work as before)
- [ ] Test NAPI playground with `cfg: false` (should skip CFG generation for better performance)

🤖 Generated with [Claude Code](https://claude.ai/code)