### PR TITLE
feat(npm/runtime): convert to ES modules

### DIFF
--- a/npm/runtime/package.json
+++ b/npm/runtime/package.json
@@ -9,6 +9,10 @@
     "directory": "npm/runtime"
   },
   "homepage": "https://oxc.rs",
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  },
+  "type": "module",
   "exports": {
     "./helpers/OverloadYield": [
       {
@@ -1058,9 +1062,5 @@
     "./regenerator": "./regenerator/index.js",
     "./regenerator/*.js": "./regenerator/*.js",
     "./regenerator/": "./regenerator/"
-  },
-  "engines": {
-    "node": "^20.19.0 || >=22.12.0"
-  },
-  "type": "commonjs"
+  }
 }


### PR DESCRIPTION
## Summary
- Convert npm/runtime package to ES modules by setting `"type": "module"` in package.json

## Test plan
- [ ] Verify existing exports continue to work
- [ ] Test both CommonJS and ESM consumers can import helpers correctly
- [ ] Run existing test suites

🤖 Generated with [Claude Code](https://claude.ai/code)