### PR TITLE
feat(npm/oxc-types): convert to ES modules

### DIFF
--- a/npm/oxc-types/package.json
+++ b/npm/oxc-types/package.json
@@ -2,7 +2,7 @@
   "name": "@oxc-project/types",
   "version": "0.89.0",
   "description": "Types for Oxc AST nodes",
-  "type": "commonjs",
+  "type": "module",
   "keywords": [
     "AST",
     "Parser"


### PR DESCRIPTION
## Summary
- Convert npm/oxc-types package to ES modules by setting `"type": "module"` in package.json

## Test plan
- [ ] Verify TypeScript definitions continue to work with both CommonJS and ESM consumers
- [ ] Test imports in various module environments
- [ ] Run existing test suites

🤖 Generated with [Claude Code](https://claude.ai/code)