### PR TITLE
feat(npm/oxlint): convert to ES modules

### DIFF
--- a/apps/oxlint/scripts/build.js
+++ b/apps/oxlint/scripts/build.js
@@ -20,15 +20,6 @@ writeFileSync(bindingsPath, bindingsJs);
 console.log('Building with tsdown...');
 execSync('pnpm tsdown', { stdio: 'inherit', cwd: oxlintDirPath });
 
-// Add `package.json` to `dist` dir.
-// `npm/oxlint` package is CommonJS, so we need this file to tell Node.js that `dist` is ESM.
-console.log('Adding package.json to dist...');
-writeFileSync(
-  join(distDirPath, 'package.json'),
-  JSON.stringify({ type: 'module' }, null, 2) + '\n',
-);
-console.log('- Created package.json');
-
 // Copy files from `napi/parser` to `apps/oxlint/dist`
 console.log('Copying files from parser...');
 

--- a/crates/oxc_allocator/Cargo.toml
+++ b/crates/oxc_allocator/Cargo.toml
@@ -8,10 +8,10 @@ homepage.workspace = true
 include = ["/src"]
 keywords.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 rust-version.workspace = true
 description.workspace = true
-publish = true
 
 [lints]
 workspace = true

--- a/crates/oxc_ast/Cargo.toml
+++ b/crates/oxc_ast/Cargo.toml
@@ -8,10 +8,10 @@ homepage.workspace = true
 include = ["/src"]
 keywords.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 rust-version.workspace = true
 description.workspace = true
-publish = true
 
 [lints]
 workspace = true

--- a/crates/oxc_ast_visit/Cargo.toml
+++ b/crates/oxc_ast_visit/Cargo.toml
@@ -8,10 +8,10 @@ homepage.workspace = true
 include = ["/src"]
 keywords.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 rust-version.workspace = true
 description.workspace = true
-publish = true
 
 [lints]
 workspace = true

--- a/crates/oxc_diagnostics/Cargo.toml
+++ b/crates/oxc_diagnostics/Cargo.toml
@@ -8,10 +8,10 @@ homepage.workspace = true
 include = ["/src"]
 keywords.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 rust-version.workspace = true
 description.workspace = true
-publish = true
 
 [lints]
 workspace = true

--- a/crates/oxc_parser/Cargo.toml
+++ b/crates/oxc_parser/Cargo.toml
@@ -8,10 +8,10 @@ homepage.workspace = true
 include = ["/examples", "/src"]
 keywords.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 rust-version.workspace = true
 description.workspace = true
-publish = true
 
 [lints]
 workspace = true

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -8,10 +8,10 @@ homepage.workspace = true
 include = ["/examples", "/src"]
 keywords.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 rust-version.workspace = true
 description.workspace = true
-publish = true
 
 [lints]
 workspace = true

--- a/npm/oxlint/bin/oxc_language_server
+++ b/npm/oxlint/bin/oxc_language_server
@@ -1,5 +1,11 @@
 #!/usr/bin/env node
 
+import { readFileSync } from "fs";
+import { spawnSync, execSync } from "child_process";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+
 const isMusl = () => {
   let musl = false;
   if (process.platform === "linux") {
@@ -17,7 +23,6 @@ const isMusl = () => {
 const isFileMusl = (f) => f.includes("libc.musl-") || f.includes("ld-musl-");
 
 const isMuslFromFilesystem = () => {
-  const { readFileSync } = require("fs");
   try {
     return readFileSync("/usr/bin/ldd", "utf-8").includes("musl");
   } catch {
@@ -46,8 +51,7 @@ const isMuslFromReport = () => {
 
 const isMuslFromChildProcess = () => {
   try {
-    return require("child_process")
-      .execSync("ldd --version", { encoding: "utf8" })
+    return execSync("ldd --version", { encoding: "utf8" })
       .includes("musl");
   } catch (e) {
     // If we reach this case, we don't know if the system is musl or not, so is better to just fallback to false
@@ -95,7 +99,7 @@ const PLATFORMS = {
 let binPath = PLATFORMS[platform]?.[arch]?.[isMusl() ? "musl" : "gnu"];
 
 if (binPath) {
-  const result = require("child_process").spawnSync(
+  const result = spawnSync(
     require.resolve(binPath),
     process.argv.slice(2),
     {

--- a/npm/oxlint/bin/oxlint
+++ b/npm/oxlint/bin/oxlint
@@ -1,19 +1,3 @@
 #!/usr/bin/env node
 
-// This script is run as CommonJS, so use dynamic import to load ESM module `dist/cli.js`.
-// Even if runtime supports require(ESM), can't use `require` here, because `dist/cli.js`
-// uses top-level `await`.
-//
-// `dist/cli.js` uses require(ESM) internally, but only on path where `--js-plugins`
-// CLI option is used. So we still support runtimes without require(ESM) for users who aren't
-// using experimental options.
-import("../dist/cli.js").catch(onError);
-
-function onError(err) {
-  console.error(err);
-  // Note: NodeJS recommends setting `process.exitCode` instead of calling `process.exit()`.
-  // `process.exit()` kills the process immediately and `stdout` may not be flushed before process dies.
-  // https://nodejs.org/api/process.html#processexitcode
-  // Process should exit immediately after this anyway, because event loop is empty.
-  process.exitCode = 1;
-}
+import "../dist/cli.js";

--- a/npm/oxlint/package.json
+++ b/npm/oxlint/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oxlint",
   "version": "1.16.0",
-  "type": "commonjs",
+  "type": "module",
   "description": "Linter for the JavaScript Oxidation Compiler",
   "keywords": [],
   "author": "Boshen and oxc contributors",


### PR DESCRIPTION
## Summary
- Convert npm/oxlint package to ES modules by setting `"type": "module"` in package.json

## Test plan
- [ ] Verify CLI binaries continue to work correctly
- [ ] Test package installation and execution
- [ ] Run existing test suites
- [ ] Confirm language server binary still functions

🤖 Generated with [Claude Code](https://claude.ai/code)