### PR TITLE
feat(npm/oxfmt): convert to ES modules

### DIFF
--- a/npm/oxfmt/package.json
+++ b/npm/oxfmt/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oxfmt",
   "version": "0.2.0",
-  "type": "commonjs",
+  "type": "module",
   "description": "Formatter for the JavaScript Oxidation Compiler",
   "keywords": [],
   "author": "Boshen and oxc contributors",


### PR DESCRIPTION
## Summary
- Convert npm/oxfmt package to ES modules by setting `"type": "module"` in package.json

## Test plan
- [ ] Verify CLI binary continues to work correctly
- [ ] Test package installation and execution
- [ ] Run existing test suites
- [ ] Confirm formatter functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)