### PR TITLE
feat(napi/transform): add async transform function

### DIFF
--- a/napi/transform/index.d.ts
+++ b/napi/transform/index.d.ts
@@ -437,6 +437,22 @@ export interface StyledComponentsOptions {
 export declare function transform(filename: string, sourceText: string, options?: TransformOptions | undefined | null): TransformResult
 
 /**
+ * Transpile a JavaScript or TypeScript into a target ECMAScript version, asynchronously.
+ *
+ * Note: This function can be slower than `transform` due to the overhead of spawning a thread.
+ *
+ * @param filename The name of the file being transformed. If this is a
+ * relative path, consider setting the {@link TransformOptions#cwd} option.
+ * @param sourceText the source code itself
+ * @param options The options for the transformation. See {@link
+ * TransformOptions} for more information.
+ *
+ * @returns a promise that resolves to an object containing the transformed code,
+ * source maps, and any errors that occurred during parsing or transformation.
+ */
+export declare function transformAsync(filename: string, sourceText: string, options?: TransformOptions | undefined | null): Promise<TransformResult>
+
+/**
  * Options for transforming a JavaScript or TypeScript file.
  *
  * @see {@link transform}

--- a/napi/transform/index.js
+++ b/napi/transform/index.js
@@ -565,9 +565,10 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { Severity, HelperMode, isolatedDeclaration, moduleRunnerTransform, transform } = nativeBinding
+const { Severity, HelperMode, isolatedDeclaration, moduleRunnerTransform, transform, transformAsync } = nativeBinding
 export { Severity }
 export { HelperMode }
 export { isolatedDeclaration }
 export { moduleRunnerTransform }
 export { transform }
+export { transformAsync }

--- a/napi/transform/transform.wasi-browser.js
+++ b/napi/transform/transform.wasi-browser.js
@@ -61,3 +61,4 @@ export const HelperMode = __napiModule.exports.HelperMode
 export const isolatedDeclaration = __napiModule.exports.isolatedDeclaration
 export const moduleRunnerTransform = __napiModule.exports.moduleRunnerTransform
 export const transform = __napiModule.exports.transform
+export const transformAsync = __napiModule.exports.transformAsync

--- a/napi/transform/transform.wasi.cjs
+++ b/napi/transform/transform.wasi.cjs
@@ -113,3 +113,4 @@ module.exports.HelperMode = __napiModule.exports.HelperMode
 module.exports.isolatedDeclaration = __napiModule.exports.isolatedDeclaration
 module.exports.moduleRunnerTransform = __napiModule.exports.moduleRunnerTransform
 module.exports.transform = __napiModule.exports.transform
+module.exports.transformAsync = __napiModule.exports.transformAsync


### PR DESCRIPTION
## Summary

This PR adds an async transform function to the NAPI transform package, following the same pattern used in the parser package for consistency.

Closes #10900

## Changes

- Added `transformAsync` function that returns a Promise
- Implemented `TransformTask` struct with `napi::Task` trait
- Reuses existing transform logic from the synchronous version
- Added comprehensive tests to verify async behavior

## Test Plan

Added tests in `test/transform.test.ts` that verify:
- Async function works correctly
- Produces identical results to sync version
- Properly handles errors

All existing tests continue to pass.

🤖 Generated with [Claude Code](https://claude.ai/code)