### PR TITLE
ci(ast_changes): skip restoring dprint cache in AST Changes workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,7 @@ jobs:
           save-cache: ${{ github.ref_name == 'main' }}
 
       - name: Restore dprint plugin cache
+        if: steps.filter.outputs.src == 'true'
         uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           key: dprint-${{ hashFiles('dprint.json') }}

--- a/tasks/ast_tools/node_modules/@typescript-eslint/visitor-keys
+++ b/tasks/ast_tools/node_modules/@typescript-eslint/visitor-keys
@@ -1,0 +1,1 @@
+../../../../node_modules/.pnpm/@typescript-eslint+visitor-keys@8.44.0/node_modules/@typescript-eslint/visitor-keys


### PR DESCRIPTION
All the other steps of this workflow are skipped if no file match. I think we missed off the skip condition on this one step by accident.