### PR TITLE
feat(formatter): keep parser options consistent for all formatter usages

### DIFF
--- a/crates/oxc_formatter/examples/formatter.rs
+++ b/crates/oxc_formatter/examples/formatter.rs
@@ -34,9 +34,12 @@ fn main() -> Result<(), String> {
     // Parse the source code
     let ret = Parser::new(&allocator, &source_text, source_type)
         .with_options(ParseOptions {
-            preserve_parens: false,
+            parse_regular_expression: false,
+            // Enable all syntax features
             allow_v8_intrinsics: true,
-            ..ParseOptions::default()
+            allow_return_outside_function: true,
+            // `oxc_formatter` expects this to be false
+            preserve_parens: false,
         })
         .parse();
 

--- a/tasks/benchmark/benches/formatter.rs
+++ b/tasks/benchmark/benches/formatter.rs
@@ -15,7 +15,14 @@ fn bench_formatter(criterion: &mut Criterion) {
         group.bench_function(id, |b| {
             b.iter_with_setup_wrapper(|runner| {
                 allocator.reset();
-                let parse_options = ParseOptions { preserve_parens: false, ..Default::default() };
+                let parse_options = ParseOptions {
+                    parse_regular_expression: false,
+                    // Enable all syntax features
+                    allow_v8_intrinsics: true,
+                    allow_return_outside_function: true,
+                    // `oxc_formatter` expects this to be false
+                    preserve_parens: false,
+                };
                 let program = Parser::new(&allocator, source_text, source_type)
                     .with_options(parse_options)
                     .parse()

--- a/tasks/coverage/snapshots/formatter_babel.snap
+++ b/tasks/coverage/snapshots/formatter_babel.snap
@@ -2,15 +2,11 @@ commit: 41d96516
 
 formatter_babel Summary:
 AST Parsed     : 2423/2423 (100.00%)
-Positive Passed: 2417/2423 (99.75%)
+Positive Passed: 2419/2423 (99.83%)
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/basic/try-statement/input.js
 
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/regression/13750/input.js
 
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/sourcetype-commonjs/top-level-return/input.js
-A 'return' statement can only be used within a function body.
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/sourcetype-commonjs/top-level-return-asi/input.js
-A 'return' statement can only be used within a function body.
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/class/division/input.js
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/top-level-await-unambiguous/module/input.js

--- a/tasks/coverage/src/tools/formatter.rs
+++ b/tasks/coverage/src/tools/formatter.rs
@@ -20,7 +20,14 @@ fn get_result(source_text: &str, source_type: SourceType) -> TestResult {
     let options = FormatOptions::default();
 
     let allocator = Allocator::default();
-    let parse_options = ParseOptions { preserve_parens: false, ..ParseOptions::default() };
+    let parse_options = ParseOptions {
+        parse_regular_expression: false,
+        // Enable all syntax features
+        allow_v8_intrinsics: true,
+        allow_return_outside_function: true,
+        // `oxc_formatter` expects this to be false
+        preserve_parens: false,
+    };
     let ParserReturn { program, .. } =
         Parser::new(&allocator, source_text, source_type).with_options(parse_options).parse();
     let source_text1 = Formatter::new(&allocator, options.clone()).build(&program);

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -422,9 +422,12 @@ impl TestRunner {
         let source_type = source_type.with_jsx(source_type.is_javascript());
         let ret = Parser::new(&allocator, source_text, source_type)
             .with_options(ParseOptions {
-                preserve_parens: false,
+                parse_regular_expression: false,
+                // Enable all syntax features
                 allow_v8_intrinsics: true,
-                ..ParseOptions::default()
+                allow_return_outside_function: true,
+                // `oxc_formatter` expects this to be false
+                preserve_parens: false,
             })
             .parse();
         Formatter::new(&allocator, formatter_options).build(&ret.program)


### PR DESCRIPTION
Copy from oxfmt
https://github.com/oxc-project/oxc/blob/adda5f56de542ce178f0c68f5732d60166c278b2/apps/oxfmt/src/service.rs#L45-L54