### PR TITLE
refactor(napi/parser): remove outdated comment

### DIFF
--- a/napi/parser/wrap.mjs
+++ b/napi/parser/wrap.mjs
@@ -1,6 +1,3 @@
-// Note: This code is repeated in `wrap.cjs`.
-// Any changes should be applied in that file too.
-
 export function wrap(result) {
   let program, module, comments, errors;
   return {


### PR DESCRIPTION
Pure refactor. `wrap.cjs` no longer exists, so this comment is outdated. Remove it.