### PR TITLE
fix(napi/parser): fix example

### DIFF
--- a/napi/parser/example.mjs
+++ b/napi/parser/example.mjs
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { parseArgs } from 'node:util';
-import { parseSync } from './index.js';
+import { parseSync } from './index.mjs';
 
 // usage:
 // node napi/parser/example.mjs test.ts


### PR DESCRIPTION
Import path in `napi/parser` example was wrong. The entry point is now `index.mjs`.