### PR TITLE
fix(build): bump package version in `apps/oxlint` in pre-release workflow

### DIFF
--- a/.github/workflows/reusable_prepare_release.yml
+++ b/.github/workflows/reusable_prepare_release.yml
@@ -50,6 +50,23 @@ jobs:
             echo EOF
           } >> $GITHUB_OUTPUT
 
+      - uses: oxc-project/setup-node@fdbf0dfd334c4e6d56ceeb77d91c76339c2a0885 # v1.0.4
+        if: ${{ inputs.name == 'crates' || inputs.name == 'oxlint' }}
+
+      # Run NAPI-RS build, because NAPI-RS uses version from `package.json` in the bindings file,
+      # which is committed to the repo. The version has just been bumped in previous step.
+      # We don't use the compiled `.node` binary, so only do a development build, as it's faster.
+      - name: Rebuild NAPI packages bindings
+        if: ${{ inputs.name == 'crates' }}
+        run: |
+          pnpm --filter oxc-minify run build-dev
+          pnpm --filter oxc-parser run build-dev
+          pnpm --filter oxc-transform run build-dev
+
+      - name: Rebuild Oxlint NAPI bindings
+        if: ${{ inputs.name == 'oxlint' }}
+        run: pnpm --filter oxlint run build-dev
+
       # update `Cargo.lock`
       - run: cargo check
 

--- a/oxc_release.toml
+++ b/oxc_release.toml
@@ -17,6 +17,7 @@ name = "oxlint"
 scopes_for_breaking_change = ["lint"]
 versioned_files = [
   "apps/oxlint/Cargo.toml",
+  "apps/oxlint/package.json",
   "crates/oxc_linter/Cargo.toml",
   "editors/vscode/package.json",
   "npm/oxlint/package.json",


### PR DESCRIPTION
Package version is used by NAPI-RS in the bindings file it generates.

Adapt the pre-release workflow to run NAPI-RS build when creating a release PR, so that the version number in bindings files matches the new version number.

This change covers all NAPI packages in `crates` pre-release workflow, and also `oxlint` in its pre-release workflow.
