### PR TITLE
fix(allocator): fix lint warning building WASM

### DIFF
--- a/crates/oxc_allocator/src/pool/mod.rs
+++ b/crates/oxc_allocator/src/pool/mod.rs
@@ -55,6 +55,7 @@ impl AllocatorPool {
 
         #[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
         {
+            let _thread_count = thread_count; // Avoid unused vars lint warning
             panic!("Fixed size allocators are only supported on 64-bit little-endian platforms");
         }
     }


### PR DESCRIPTION
`thread_count` var is unused on 32-bit platforms, causing a lint warning when building playground.