### PR TITLE
fix(ast_tools): enable `oxc_ast_tools` to be run from any directory

### DIFF
--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -357,7 +357,7 @@ fn main() {
     // Write outputs to disk
     if !options.dry_run {
         for output in outputs {
-            output.write_to_file().unwrap();
+            output.write_to_file(codegen.root_path()).unwrap();
         }
     }
 }
@@ -428,7 +428,7 @@ fn generate_updated_proc_macro(codegen: &Codegen) -> RawOutput {
     // Load `oxc_ast_macros` crate's `lib.rs` file.
     // Substitute list of used attrs into `#[proc_macro_derive(Ast, attributes(...))]`.
     let path = format!("{AST_MACROS_CRATE_PATH}/src/lib.rs");
-    let code = fs::read_to_string(&path).unwrap();
+    let code = fs::read_to_string(codegen.root_path().join(&path)).unwrap();
     let (start, end) = code.split_once("#[proc_macro_derive(").unwrap();
     let (_, end) = end.split_once(")]").unwrap();
     assert!(end.starts_with("\npub fn ast_derive("));

--- a/tasks/ast_tools/src/output/mod.rs
+++ b/tasks/ast_tools/src/output/mod.rs
@@ -79,25 +79,26 @@ pub struct RawOutput {
 
 impl RawOutput {
     /// Write [`RawOutput`] to file
-    pub fn write_to_file(&self) -> io::Result<()> {
+    pub fn write_to_file(&self, root_path: &Path) -> io::Result<()> {
         log!("Write {}... ", &self.path);
-        let result = write_to_file_impl(&self.content, &self.path);
+        let result = write_to_file_impl(&self.content, &self.path, root_path);
         log_result!(result);
         result
     }
 }
 
-fn write_to_file_impl(data: &[u8], path: &str) -> io::Result<()> {
+fn write_to_file_impl(data: &[u8], path: &str, root_path: &Path) -> io::Result<()> {
+    let path = root_path.join(path);
+
     // If contents hasn't changed, don't touch the file
-    if let Ok(existing_data) = fs::read(path)
+    if let Ok(existing_data) = fs::read(&path)
         && existing_data == data
     {
         return Ok(());
     }
 
-    let path = Path::new(path);
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
+    if let Some(parent_path) = path.parent() {
+        fs::create_dir_all(parent_path)?;
     }
     fs::write(path, data)
 }

--- a/tasks/ast_tools/src/parse/load.rs
+++ b/tasks/ast_tools/src/parse/load.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use std::{fs, path::Path};
 
 use indexmap::map::Entry;
 use syn::{
@@ -31,8 +31,9 @@ pub fn load_file(
     file_path: &str,
     skeletons: &mut FxIndexMap<String, Skeleton>,
     meta_skeletons: &mut FxIndexMap<String, Skeleton>,
+    root_path: &Path,
 ) {
-    let content = fs::read_to_string(file_path).unwrap();
+    let content = fs::read_to_string(root_path.join(file_path)).unwrap();
 
     let file = parse_file(content.as_str()).unwrap();
 

--- a/tasks/ast_tools/src/parse/mod.rs
+++ b/tasks/ast_tools/src/parse/mod.rs
@@ -47,6 +47,8 @@
 //! [`Derive`]: crate::Derive
 //! [`Generator`]: crate::Generator
 
+use std::path::Path;
+
 use oxc_index::IndexVec;
 
 use crate::{
@@ -80,7 +82,13 @@ pub fn parse_files(file_paths: &[&str], codegen: &Codegen) -> Schema {
         .enumerate()
         .map(|(file_id, &file_path)| {
             let file_id = FileId::from_usize(file_id);
-            analyse_file(file_id, file_path, &mut skeletons, &mut meta_skeletons)
+            analyse_file(
+                file_id,
+                file_path,
+                &mut skeletons,
+                &mut meta_skeletons,
+                codegen.root_path(),
+            )
         })
         .collect::<IndexVec<_, _>>();
 
@@ -96,9 +104,10 @@ fn analyse_file(
     file_path: &str,
     skeletons: &mut FxIndexMap<String, Skeleton>,
     meta_skeletons: &mut FxIndexMap<String, Skeleton>,
+    root_path: &Path,
 ) -> File {
     log!("Load {file_path}... ");
-    load_file(file_id, file_path, skeletons, meta_skeletons);
+    load_file(file_id, file_path, skeletons, meta_skeletons, root_path);
     log_success!();
 
     File::new(file_path)


### PR DESCRIPTION
Get path to root of repo from `CARGO_MANIFEST_DIR` env var rather than `env::current_dir`, so it doesn't depend on `cwd`.

This means that you can run `cargo run -p oxc_ast_tools` from anywhere in the repo, which is really useful when working on parser + linter NAPI packages which contain generated code.

The root path will also be used in another PR to follow which generates an ESTree walker.
