### PR TITLE
refactor(napi/parser): remove outdated file

### DIFF
--- a/napi/parser/browser.js
+++ b/napi/parser/browser.js
@@ -1,1 +1,0 @@
-export * from '@oxc-parser/binding-wasm32-wasi'


### PR DESCRIPTION
`browser.js` is not used in `napi/parser` - `wasm.mjs` plays this role. `browser.js` file appears to be a left-over from a past version, before we had the `wrap` function.