### PR TITLE
fix(parser): forbid readonly in parser instead of semantic

### DIFF
--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -70,12 +70,11 @@ impl<'a> ParserImpl<'a> {
         let decorators = self.parse_decorators();
         let modifiers = self.parse_modifiers(false, false);
         if self.is_ts {
-            let mut allowed_modifiers = ModifierFlags::READONLY;
-            if func_kind == FunctionKind::Constructor {
-                allowed_modifiers = allowed_modifiers
-                    .union(ModifierFlags::ACCESSIBILITY)
-                    .union(ModifierFlags::OVERRIDE);
-            }
+            let allowed_modifiers = if func_kind == FunctionKind::Constructor {
+                ModifierFlags::ACCESSIBILITY | ModifierFlags::OVERRIDE | ModifierFlags::READONLY
+            } else {
+                ModifierFlags::empty()
+            };
             self.verify_modifiers(
                 &modifiers,
                 allowed_modifiers,

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -12870,6 +12870,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  9 │   readonly *[e?.e]?() { }
    ╰────
 
+  × TS(1090): 'readonly' modifier cannot appear on a parameter.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:3:9]
+ 2 │     not_constructor(
+ 3 │         readonly r,
+   ·         ────────
+ 4 │         public pu: number,
+   ╰────
+
   × TS(1090): 'public' modifier cannot appear on a parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:4:9]
  3 │         readonly r,
@@ -12902,6 +12910,22 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  8 │         // Also works on AssignmentPattern
    ╰────
 
+  × TS(1090): 'readonly' modifier cannot appear on a parameter.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:7:16]
+ 6 │         private pi?: number,
+ 7 │         public readonly pur,
+   ·                ────────
+ 8 │         // Also works on AssignmentPattern
+   ╰────
+
+  × TS(1090): 'readonly' modifier cannot appear on a parameter.
+    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:9:9]
+  8 │         // Also works on AssignmentPattern
+  9 │         readonly x = 0,
+    ·         ────────
+ 10 │         public y?: number = 0) {}
+    ╰────
+
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:10:9]
   9 │         readonly x = 0,
@@ -12910,38 +12934,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  11 │ }
     ╰────
 
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:3:9]
- 2 │     not_constructor(
- 3 │         readonly r,
-   ·         ──────────
- 4 │         public pu: number,
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:4:9]
- 3 │         readonly r,
- 4 │         public pu: number,
-   ·         ─────────────────
- 5 │         protected po?,
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:5:9]
- 4 │         public pu: number,
- 5 │         protected po?,
-   ·         ─────────────
- 6 │         private pi?: number,
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:6:9]
- 5 │         protected po?,
- 6 │         private pi?: number,
-   ·         ───────────────────
- 7 │         public readonly pur,
-   ╰────
-
   × A required parameter cannot follow an optional parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:7:9]
  6 │         private pi?: number,
@@ -12949,30 +12941,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·         ───────────────────
  8 │         // Also works on AssignmentPattern
    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:7:9]
- 6 │         private pi?: number,
- 7 │         public readonly pur,
-   ·         ───────────────────
- 8 │         // Also works on AssignmentPattern
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:9:9]
-  8 │         // Also works on AssignmentPattern
-  9 │         readonly x = 0,
-    ·         ──────────────
- 10 │         public y?: number = 0) {}
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:10:9]
-  9 │         readonly x = 0,
- 10 │         public y?: number = 0) {}
-    ·         ─────────────────────
- 11 │ }
-    ╰────
 
   × TS(18010): An accessibility modifier cannot be used with a private identifier.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/private-fields-modifier-private/input.ts:2:3]
@@ -13158,6 +13126,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·             ──
    ╰────
 
+  × TS(1090): 'readonly' modifier cannot appear on a parameter.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:2:3]
+ 1 │ function foo(
+ 2 │   readonly r,
+   ·   ────────
+ 3 │   public pu: number,
+   ╰────
+
   × TS(1090): 'public' modifier cannot appear on a parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:3:3]
  2 │   readonly r,
@@ -13190,6 +13166,22 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  7 │   readonly x = 0,
    ╰────
 
+  × TS(1090): 'readonly' modifier cannot appear on a parameter.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:6:10]
+ 5 │   private pi?: number,
+ 6 │   public readonly pur,
+   ·          ────────
+ 7 │   readonly x = 0,
+   ╰────
+
+  × TS(1090): 'readonly' modifier cannot appear on a parameter.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:7:3]
+ 6 │   public readonly pur,
+ 7 │   readonly x = 0,
+   ·   ────────
+ 8 │   public y?: number = 0
+   ╰────
+
   × TS(1090): 'public' modifier cannot appear on a parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:8:3]
  7 │   readonly x = 0,
@@ -13198,68 +13190,12 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  9 │ ) {}
    ╰────
 
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:2:3]
- 1 │ function foo(
- 2 │   readonly r,
-   ·   ──────────
- 3 │   public pu: number,
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:3:3]
- 2 │   readonly r,
- 3 │   public pu: number,
-   ·   ─────────────────
- 4 │   protected po?,
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:4:3]
- 3 │   public pu: number,
- 4 │   protected po?,
-   ·   ─────────────
- 5 │   private pi?: number,
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:5:3]
- 4 │   protected po?,
- 5 │   private pi?: number,
-   ·   ───────────────────
- 6 │   public readonly pur,
-   ╰────
-
   × A required parameter cannot follow an optional parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:6:3]
  5 │   private pi?: number,
  6 │   public readonly pur,
    ·   ───────────────────
  7 │   readonly x = 0,
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:6:3]
- 5 │   private pi?: number,
- 6 │   public readonly pur,
-   ·   ───────────────────
- 7 │   readonly x = 0,
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:7:3]
- 6 │   public readonly pur,
- 7 │   readonly x = 0,
-   ·   ──────────────
- 8 │   public y?: number = 0
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:8:3]
- 7 │   readonly x = 0,
- 8 │   public y?: number = 0
-   ·   ─────────────────────
- 9 │ ) {}
    ╰────
 
   × A required parameter cannot follow an optional parameter.

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -309,28 +309,22 @@ Negative Passed: 90/90 (100.00%)
  3 │ }
    ╰────
 
-  × A parameter property is only allowed in a constructor implementation.
+  × TS(1090): 'readonly' modifier cannot appear on a parameter.
    ╭─[misc/fail/oxc-11713-26.ts:1:14]
  1 │ function foo(readonly parameter) {}
-   ·              ──────────────────
+   ·              ────────
    ╰────
 
-  × A parameter property is only allowed in a constructor implementation.
+  × TS(1090): 'readonly' modifier cannot appear on a parameter.
    ╭─[misc/fail/oxc-11713-27.ts:1:20]
  1 │ class Foo { method(readonly parameter) {} }
-   ·                    ──────────────────
+   ·                    ────────
    ╰────
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
    ╭─[misc/fail/oxc-11713-3.ts:1:14]
  1 │ function foo(private parameter) {}
    ·              ───────
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[misc/fail/oxc-11713-3.ts:1:14]
- 1 │ function foo(private parameter) {}
-   ·              ─────────────────
    ╰────
 
   × 'declare' modifier cannot be used here.

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -4449,12 +4449,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·          ──────
    ╰────
 
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[typescript/tests/cases/compiler/ArrowFunctionExpression1.ts:1:10]
- 1 │ var v = (public x: string) => { };
-   ·          ────────────────
-   ╰────
-
   × Constructor implementation is missing.
    ╭─[typescript/tests/cases/compiler/ClassDeclaration10.ts:2:4]
  1 │ class C {
@@ -4608,27 +4602,11 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  3 │ }
    ╰────
 
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[typescript/tests/cases/compiler/MemberAccessorDeclaration15.ts:2:12]
- 1 │ class C {
- 2 │    set Foo(public a: number) { }
-   ·            ────────────────
- 3 │ }
-   ╰────
-
   × TS(1090): 'public' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/compiler/ParameterList13.ts:2:10]
  1 │ interface I {
  2 │     new (public x);
    ·          ──────
- 3 │ }
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[typescript/tests/cases/compiler/ParameterList13.ts:2:10]
- 1 │ interface I {
- 2 │     new (public x);
-   ·          ────────
  3 │ }
    ╰────
 
@@ -4639,24 +4617,10 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  2 │ }
    ╰────
 
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[typescript/tests/cases/compiler/ParameterList4.ts:1:12]
- 1 │ function F(public A) {
-   ·            ────────
- 2 │ }
-   ╰────
-
   × TS(1090): 'public' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/compiler/ParameterList5.ts:1:16]
  1 │ function A(): (public B) => C {
    ·                ──────
- 2 │ }
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[typescript/tests/cases/compiler/ParameterList5.ts:1:16]
- 1 │ function A(): (public B) => C {
-   ·                ────────
  2 │ }
    ╰────
 
@@ -4665,14 +4629,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  1 │ class C {
  2 │   constructor(C: (public A) => any) {
    ·                   ──────
- 3 │   }
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[typescript/tests/cases/compiler/ParameterList6.ts:2:19]
- 1 │ class C {
- 2 │   constructor(C: (public A) => any) {
-   ·                   ────────
  3 │   }
    ╰────
 
@@ -4761,22 +4717,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  2 │     set X(public v) { }
  3 │     static set X(public v2) { }
    ·                  ──────
- 4 │ }
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[typescript/tests/cases/compiler/accessorParameterAccessibilityModifier.ts:2:11]
- 1 │ class C {
- 2 │     set X(public v) { }
-   ·           ────────
- 3 │     static set X(public v2) { }
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[typescript/tests/cases/compiler/accessorParameterAccessibilityModifier.ts:3:18]
- 2 │     set X(public v) { }
- 3 │     static set X(public v2) { }
-   ·                  ─────────
  4 │ }
    ╰────
 
@@ -10981,14 +10921,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  3 │     }
    ╰────
 
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[typescript/tests/cases/compiler/parameterPropertyOutsideConstructor.ts:2:9]
- 1 │ class C {
- 2 │     foo(public x) {
-   ·         ────────
- 3 │     }
-   ╰────
-
   × Expected `,` but found `:`
    ╭─[typescript/tests/cases/compiler/parametersSyntaxErrorNoCrash1.ts:3:28]
  2 │ 
@@ -11547,27 +11479,27 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  4 │ 
    ╰────
 
-  × A parameter property is only allowed in a constructor implementation.
+  × TS(1090): 'readonly' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/compiler/readonlyInNonPropertyParameters.ts:3:9]
  2 │ class X {
  3 │     method(readonly x: number) {}
-   ·            ──────────────────
+   ·            ────────
  4 │     set x(readonly value: number) {}
    ╰────
 
-  × A parameter property is only allowed in a constructor implementation.
+  × TS(1090): 'readonly' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/compiler/readonlyInNonPropertyParameters.ts:4:8]
  3 │     method(readonly x: number) {}
  4 │     set x(readonly value: number) {}
-   ·           ──────────────────────
+   ·           ────────
  5 │ }
    ╰────
 
-  × A parameter property is only allowed in a constructor implementation.
+  × TS(1090): 'readonly' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/compiler/readonlyInNonPropertyParameters.ts:6:2]
  5 │ }
  6 │ (readonly x) => 0;
-   ·  ──────────
+   ·  ────────
  7 │ // OK to use `readonly` as a name
    ╰────
 
@@ -15182,20 +15114,20 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  9 │ }
    ╰────
 
+  × TS(1090): 'readonly' modifier cannot appear on a parameter.
+   ╭─[typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/readonlyInAmbientClass.ts:3:9]
+ 2 │     constructor(readonly x: number);
+ 3 │     method(readonly x: number);
+   ·            ────────
+ 4 │ }
+   ╰────
+
   × TS(2369): A parameter property is only allowed in a constructor implementation.
    ╭─[typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/readonlyInAmbientClass.ts:2:14]
  1 │ declare class C{
  2 │     constructor(readonly x: number);
    ·                 ──────────────────
  3 │     method(readonly x: number);
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/readonlyInAmbientClass.ts:3:9]
- 2 │     constructor(readonly x: number);
- 3 │     method(readonly x: number);
-   ·            ──────────────────
- 4 │ }
    ╰────
 
   × TS(1030): 'readonly' modifier already seen.
@@ -22223,14 +22155,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  26 │ }
     ╰────
 
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/override/overrideParameterProperty.ts:25:5]
- 24 │ 
- 25 │   m(override p1: "hello") {}
-    ·     ────────────────────
- 26 │ }
-    ╰────
-
   × Cannot use `await` as an identifier in an async context
    ╭─[typescript/tests/cases/conformance/parser/ecmascript2018/asyncGenerators/parser.asyncGenerators.classMethods.es2018.ts:2:15]
  1 │ class C4 {
@@ -22362,12 +22286,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression1.ts:1:10]
  1 │ var v = (public x: string) => { };
    ·          ──────
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression1.ts:1:10]
- 1 │ var v = (public x: string) => { };
-   ·          ────────────────
    ╰────
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
@@ -23619,14 +23537,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  3 │ }
    ╰────
 
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration15.ts:2:12]
- 1 │ class C {
- 2 │    set Foo(public a: number) { }
-   ·            ────────────────
- 3 │ }
-   ╰────
-
   × A 'set' accessor cannot have an initializer.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration16.ts:2:11]
  1 │ class C {
@@ -23842,14 +23752,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  3 │ }
    ╰────
 
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList13.ts:2:10]
- 1 │ interface I {
- 2 │     new (public x);
-   ·          ────────
- 3 │ }
-   ╰────
-
   × A required parameter cannot follow an optional parameter.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList3.ts:2:9]
  1 │ class C {
@@ -23865,24 +23767,10 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  2 │ }
    ╰────
 
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList4.ts:1:12]
- 1 │ function F(public A) {
-   ·            ────────
- 2 │ }
-   ╰────
-
   × TS(1090): 'public' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList5.ts:1:16]
  1 │ function A(): (public B) => C {
    ·                ──────
- 2 │ }
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList5.ts:1:16]
- 1 │ function A(): (public B) => C {
-   ·                ────────
  2 │ }
    ╰────
 
@@ -23891,14 +23779,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  1 │ class C {
  2 │   constructor(C: (public A) => any) {
    ·                   ──────
- 3 │   }
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList6.ts:2:19]
- 1 │ class C {
- 2 │   constructor(C: (public A) => any) {
-   ·                   ────────
  3 │   }
    ╰────
 
@@ -26728,326 +26608,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  38 │ }
     ╰────
 
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:3:14]
- 2 │ 
- 3 │ function foo(public x, private y) { }
-   ·              ────────
- 4 │ var f = function foo(public x, private y) { }
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:3:24]
- 2 │ 
- 3 │ function foo(public x, private y) { }
-   ·                        ─────────
- 4 │ var f = function foo(public x, private y) { }
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:4:22]
- 3 │ function foo(public x, private y) { }
- 4 │ var f = function foo(public x, private y) { }
-   ·                      ────────
- 5 │ var f2 = function (public x, private y) { }
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:4:32]
- 3 │ function foo(public x, private y) { }
- 4 │ var f = function foo(public x, private y) { }
-   ·                                ─────────
- 5 │ var f2 = function (public x, private y) { }
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:5:20]
- 4 │ var f = function foo(public x, private y) { }
- 5 │ var f2 = function (public x, private y) { }
-   ·                    ────────
- 6 │ var f3 = (x, private y) => { }
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:5:30]
- 4 │ var f = function foo(public x, private y) { }
- 5 │ var f2 = function (public x, private y) { }
-   ·                              ─────────
- 6 │ var f3 = (x, private y) => { }
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:6:14]
- 5 │ var f2 = function (public x, private y) { }
- 6 │ var f3 = (x, private y) => { }
-   ·              ─────────
- 7 │ var f4 = <T>(public x: T, y: T) => { }
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-   ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:7:14]
- 6 │ var f3 = (x, private y) => { }
- 7 │ var f4 = <T>(public x: T, y: T) => { }
-   ·              ───────────
- 8 │ 
-   ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:9:15]
-  8 │ 
-  9 │ function foo2(private x: string, public y: number) { }
-    ·               ─────────────────
- 10 │ var f5 = function foo(private x: string, public y: number) { }
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:9:34]
-  8 │ 
-  9 │ function foo2(private x: string, public y: number) { }
-    ·                                  ────────────────
- 10 │ var f5 = function foo(private x: string, public y: number) { }
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:10:23]
-  9 │ function foo2(private x: string, public y: number) { }
- 10 │ var f5 = function foo(private x: string, public y: number) { }
-    ·                       ─────────────────
- 11 │ var f6 = function (private x: string, public y: number) { }
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:10:42]
-  9 │ function foo2(private x: string, public y: number) { }
- 10 │ var f5 = function foo(private x: string, public y: number) { }
-    ·                                          ────────────────
- 11 │ var f6 = function (private x: string, public y: number) { }
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:11:20]
- 10 │ var f5 = function foo(private x: string, public y: number) { }
- 11 │ var f6 = function (private x: string, public y: number) { }
-    ·                    ─────────────────
- 12 │ var f7 = (private x: string, public y: number) => { }
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:11:39]
- 10 │ var f5 = function foo(private x: string, public y: number) { }
- 11 │ var f6 = function (private x: string, public y: number) { }
-    ·                                       ────────────────
- 12 │ var f7 = (private x: string, public y: number) => { }
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:12:11]
- 11 │ var f6 = function (private x: string, public y: number) { }
- 12 │ var f7 = (private x: string, public y: number) => { }
-    ·           ─────────────────
- 13 │ var f8 = <T>(private x: T, public y: T) => { }
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:12:30]
- 11 │ var f6 = function (private x: string, public y: number) { }
- 12 │ var f7 = (private x: string, public y: number) => { }
-    ·                              ────────────────
- 13 │ var f8 = <T>(private x: T, public y: T) => { }
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:13:14]
- 12 │ var f7 = (private x: string, public y: number) => { }
- 13 │ var f8 = <T>(private x: T, public y: T) => { }
-    ·              ────────────
- 14 │ 
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:13:28]
- 12 │ var f7 = (private x: string, public y: number) => { }
- 13 │ var f8 = <T>(private x: T, public y: T) => { }
-    ·                            ───────────
- 14 │ 
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:16:9]
- 15 │ class C {
- 16 │     foo(public x, private y) { }
-    ·         ────────
- 17 │     foo2(public x: number, private y: string) { }
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:16:19]
- 15 │ class C {
- 16 │     foo(public x, private y) { }
-    ·                   ─────────
- 17 │     foo2(public x: number, private y: string) { }
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:17:10]
- 16 │     foo(public x, private y) { }
- 17 │     foo2(public x: number, private y: string) { }
-    ·          ────────────────
- 18 │     foo3<T>(public x: T, private y: T) { }
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:17:28]
- 16 │     foo(public x, private y) { }
- 17 │     foo2(public x: number, private y: string) { }
-    ·                            ─────────────────
- 18 │     foo3<T>(public x: T, private y: T) { }
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:18:13]
- 17 │     foo2(public x: number, private y: string) { }
- 18 │     foo3<T>(public x: T, private y: T) { }
-    ·             ───────────
- 19 │ }
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:18:26]
- 17 │     foo2(public x: number, private y: string) { }
- 18 │     foo3<T>(public x: T, private y: T) { }
-    ·                          ────────────
- 19 │ }
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:22:6]
- 21 │ interface I {
- 22 │     (private x, public y);
-    ·      ─────────
- 23 │     (private x: string, public y: number);
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:22:17]
- 21 │ interface I {
- 22 │     (private x, public y);
-    ·                 ────────
- 23 │     (private x: string, public y: number);
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:23:6]
- 22 │     (private x, public y);
- 23 │     (private x: string, public y: number);
-    ·      ─────────────────
- 24 │     foo(private x, public y);
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:23:25]
- 22 │     (private x, public y);
- 23 │     (private x: string, public y: number);
-    ·                         ────────────────
- 24 │     foo(private x, public y);
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:24:9]
- 23 │     (private x: string, public y: number);
- 24 │     foo(private x, public y);
-    ·         ─────────
- 25 │     foo(public x: number, y: string);
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:24:20]
- 23 │     (private x: string, public y: number);
- 24 │     foo(private x, public y);
-    ·                    ────────
- 25 │     foo(public x: number, y: string);
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:25:9]
- 24 │     foo(private x, public y);
- 25 │     foo(public x: number, y: string);
-    ·         ────────────────
- 26 │     foo3<T>(x: T, private y: T);
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:26:19]
- 25 │     foo(public x: number, y: string);
- 26 │     foo3<T>(x: T, private y: T);
-    ·                   ────────────
- 27 │ }
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:30:9]
- 29 │ var a: {
- 30 │     foo(public x, private y);
-    ·         ────────
- 31 │     foo2(private x: number, public y: string);
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:30:19]
- 29 │ var a: {
- 30 │     foo(public x, private y);
-    ·                   ─────────
- 31 │     foo2(private x: number, public y: string);
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:31:10]
- 30 │     foo(public x, private y);
- 31 │     foo2(private x: number, public y: string);
-    ·          ─────────────────
- 32 │ };
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:31:29]
- 30 │     foo(public x, private y);
- 31 │     foo2(private x: number, public y: string);
-    ·                             ────────────────
- 32 │ };
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:35:9]
- 34 │ var b = {
- 35 │     foo(public x, y) { },
-    ·         ────────
- 36 │     a: function foo(x: number, private y: string) { },
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:36:32]
- 35 │     foo(public x, y) { },
- 36 │     a: function foo(x: number, private y: string) { },
-    ·                                ─────────────────
- 37 │     b: <T>(public x: T, private y: T) => { }
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:37:12]
- 36 │     a: function foo(x: number, private y: string) { },
- 37 │     b: <T>(public x: T, private y: T) => { }
-    ·            ───────────
- 38 │ }
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:37:25]
- 36 │     a: function foo(x: number, private y: string) { },
- 37 │     b: <T>(public x: T, private y: T) => { }
-    ·                         ────────────
- 38 │ }
-    ╰────
-
   × Identifier `x` has already been declared
    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithDuplicateParameters.ts:6:11]
  5 │ var f2 = function (x, x) { }
@@ -27239,38 +26799,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  29 │ }
     ╰────
 
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters.ts:16:10]
- 15 │ interface I {
- 16 │     new (public x);
-    ·          ────────
- 17 │ }
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters.ts:20:10]
- 19 │ interface I2 {
- 20 │     new (private x);
-    ·          ─────────
- 21 │ }
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters.ts:24:10]
- 23 │ var a: {
- 24 │     new (public x);
-    ·          ────────
- 25 │ }
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters.ts:28:10]
- 27 │ var b: {
- 28 │     new (private x);
-    ·          ─────────
- 29 │ }
-    ╰────
-
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters2.ts:19:10]
  18 │ interface I {
@@ -27365,70 +26893,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  14 │     constructor(private x);
     ·                 ─────────
  15 │     constructor(private y) { }
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters2.ts:19:10]
- 18 │ interface I {
- 19 │     new (public x);
-    ·          ────────
- 20 │     new (public x);
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters2.ts:20:10]
- 19 │     new (public x);
- 20 │     new (public x);
-    ·          ────────
- 21 │ }
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters2.ts:24:10]
- 23 │ interface I2 {
- 24 │     new (private x);
-    ·          ─────────
- 25 │     new (private x);
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters2.ts:25:10]
- 24 │     new (private x);
- 25 │     new (private x);
-    ·          ─────────
- 26 │ }
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters2.ts:29:10]
- 28 │ var a: {
- 29 │     new (public x);
-    ·          ────────
- 30 │     new (public y);
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters2.ts:30:10]
- 29 │     new (public x);
- 30 │     new (public y);
-    ·          ────────
- 31 │ }
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters2.ts:34:10]
- 33 │ var b: {
- 34 │     new (private x);
-    ·          ─────────
- 35 │     new (private y);
-    ╰────
-
-  × A parameter property is only allowed in a constructor implementation.
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters2.ts:35:10]
- 34 │     new (private x);
- 35 │     new (private y);
-    ·          ─────────
- 36 │ }
     ╰────
 
   × A rest parameter must be last in a parameter list


### PR DESCRIPTION
Closes #13883

This also fixes duplicate essentially same diagnostics coming from parser and semantic each.