### PR TITLE
release(oxfmt): v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1944,7 +1944,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_formatter"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "cow-utils",
  "oxc_allocator",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "oxfmt"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bpaf",
  "cow-utils",

--- a/apps/oxfmt/CHANGELOG.md
+++ b/apps/oxfmt/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.3.0] - 2025-09-19
+
+### 🐛 Bug Fixes
+
+- 55775ce oxfmt: Fix up the half-finished lines (#13840) (leaysgur)
+
+### ⚡ Performance
+
+- 59db021 oxfmt: Walk and format at the same time (#13838) (leaysgur)
+
+
 ## [0.2.0] - 2025-09-16
 
 ### 💥 BREAKING CHANGES

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxfmt"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_formatter/CHANGELOG.md
+++ b/crates/oxc_formatter/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.3.0] - 2025-09-19
+
+### 🚀 Features
+
+- 2cead8b formatter: Keep parser options consistent for all formatter usages (#13884) (Dunqing)
+
+### 🐛 Bug Fixes
+
+- c96f7e9 formatter: Add parentheses for `await` and `yield` inside `PrivateInExpression` (#13863) (Noel Kim (김민혁))
+- eae4845 formatter: Add parentheses for mixed types (#13862) (Noel Kim (김민혁))
+- 57108c0 formatter: Keep computed name in enum (#13848) (Noel Kim (김민혁))
+- 5c3645b formatter: Handle decorators correctly for class expressions in export (#13845) (Dunqing)
+- 3cf1a41 formatter: Missing parenthesis for `TSAsExpression` (#13842) (Dunqing)
+- 25edd03 formatter: Missing parenthesis for `TSTypeAssertion` (#13841) (Dunqing)
+- 72144e9 formatter: Missing trailing semicolon in `TSSignature` (#13823) (Dunqing)
+- f643093 formatter: Missing parenthesis for expression of `decorator` (#13813) (Dunqing)
+- b43ad49 formatter: Add parentheses for `PrivateInExpression` in super class (#13806) (Noel Kim (김민혁))
+- 7879f85 formatter: Add parentheses inside `UpdateExpression` (#13825) (Noel Kim (김민혁))
+- 7371bad formatter: Add parentheses inside `TSIntersectionType` (#13821) (Noel Kim (김민혁))
+
+
 ## [0.2.0] - 2025-09-16
 
 ### 🚀 Features

--- a/crates/oxc_formatter/Cargo.toml
+++ b/crates/oxc_formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_formatter"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/npm/oxfmt/CHANGELOG.md
+++ b/npm/oxfmt/CHANGELOG.md
@@ -4,4 +4,16 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.3.0] - 2025-09-19
+
+### 🚀 Features
+
+- b52389a node: Bump `engines` field to require Node.js 20.19.0+ for ESM support (#13879) (Copilot)
+- 25437db npm/oxfmt: Convert to ES modules (#13877) (Boshen)
+
+### 📚 Documentation
+
+- 2a35745 oxfmt: The current version does not work; DO NOT USE. (#13844) (Boshen)
+
+
 

--- a/npm/oxfmt/package.json
+++ b/npm/oxfmt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxfmt",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "Formatter for the JavaScript Oxidation Compiler",
   "keywords": [],


### PR DESCRIPTION
## [0.3.0] - 2025-09-19

### 🚀 Features

- 2cead8b formatter: Keep parser options consistent for all formatter usages (#13884) (Dunqing)
- b52389a node: Bump `engines` field to require Node.js 20.19.0+ for ESM support (#13879) (Copilot)
- 25437db npm/oxfmt: Convert to ES modules (#13877) (Boshen)

### 🐛 Bug Fixes

- 55775ce oxfmt: Fix up the half-finished lines (#13840) (leaysgur)
- c96f7e9 formatter: Add parentheses for `await` and `yield` inside `PrivateInExpression` (#13863) (Noel Kim (김민혁))
- eae4845 formatter: Add parentheses for mixed types (#13862) (Noel Kim (김민혁))
- 57108c0 formatter: Keep computed name in enum (#13848) (Noel Kim (김민혁))
- 5c3645b formatter: Handle decorators correctly for class expressions in export (#13845) (Dunqing)
- 3cf1a41 formatter: Missing parenthesis for `TSAsExpression` (#13842) (Dunqing)
- 25edd03 formatter: Missing parenthesis for `TSTypeAssertion` (#13841) (Dunqing)
- 72144e9 formatter: Missing trailing semicolon in `TSSignature` (#13823) (Dunqing)
- f643093 formatter: Missing parenthesis for expression of `decorator` (#13813) (Dunqing)
- b43ad49 formatter: Add parentheses for `PrivateInExpression` in super class (#13806) (Noel Kim (김민혁))
- 7879f85 formatter: Add parentheses inside `UpdateExpression` (#13825) (Noel Kim (김민혁))
- 7371bad formatter: Add parentheses inside `TSIntersectionType` (#13821) (Noel Kim (김민혁))

### 📚 Documentation

- 2a35745 oxfmt: The current version does not work; DO NOT USE. (#13844) (Boshen)

### ⚡ Performance

- 59db021 oxfmt: Walk and format at the same time (#13838) (leaysgur)