### PR TITLE
release(crates): v0.91.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1655,7 +1655,7 @@ checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
 name = "oxc"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -1747,7 +1747,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "bitflags 2.9.4",
  "oxc_allocator",
@@ -1762,7 +1762,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_cfg"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "bitflags 2.9.4",
  "itertools",
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_codegen"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "bitflags 2.9.4",
  "cow-utils",
@@ -1906,14 +1906,14 @@ dependencies = [
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "ropey",
 ]
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1922,7 +1922,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1935,7 +1935,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_estree"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1969,7 +1969,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_isolated_declarations"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "bitflags 2.9.4",
  "insta",
@@ -2079,7 +2079,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_mangler"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "itertools",
  "oxc_allocator",
@@ -2094,7 +2094,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_minifier"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "cow-utils",
  "insta",
@@ -2118,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_minify_napi"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "mimalloc-safe",
  "napi",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_napi"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -2171,7 +2171,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "bitflags 2.9.4",
  "cow-utils",
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser_napi"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "mimalloc-safe",
  "napi",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "bitflags 2.9.4",
  "oxc_allocator",
@@ -2293,7 +2293,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_semantic"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "insta",
  "itertools",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -2344,7 +2344,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "bitflags 2.9.4",
  "cow-utils",
@@ -2418,7 +2418,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_transform_napi"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "mimalloc-safe",
  "napi",
@@ -2432,7 +2432,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "base64",
  "compact_str",
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer_plugins"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "cow-utils",
  "insta",
@@ -2491,7 +2491,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_traverse"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "itoa",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,32 +103,32 @@ multiple_crate_versions = "allow"
 
 [workspace.dependencies]
 # publish = true
-oxc = { version = "0.90.0", path = "crates/oxc" }
-oxc_allocator = { version = "0.90.0", path = "crates/oxc_allocator" }
-oxc_ast = { version = "0.90.0", path = "crates/oxc_ast" }
-oxc_ast_macros = { version = "0.90.0", path = "crates/oxc_ast_macros" }
-oxc_ast_visit = { version = "0.90.0", path = "crates/oxc_ast_visit" }
-oxc_cfg = { version = "0.90.0", path = "crates/oxc_cfg" }
-oxc_codegen = { version = "0.90.0", path = "crates/oxc_codegen" }
-oxc_data_structures = { version = "0.90.0", path = "crates/oxc_data_structures" }
-oxc_diagnostics = { version = "0.90.0", path = "crates/oxc_diagnostics" }
-oxc_ecmascript = { version = "0.90.0", path = "crates/oxc_ecmascript" }
-oxc_estree = { version = "0.90.0", path = "crates/oxc_estree" }
-oxc_isolated_declarations = { version = "0.90.0", path = "crates/oxc_isolated_declarations" }
-oxc_mangler = { version = "0.90.0", path = "crates/oxc_mangler" }
-oxc_minifier = { version = "0.90.0", path = "crates/oxc_minifier" }
-oxc_minify_napi = { version = "0.90.0", path = "napi/minify" }
-oxc_napi = { version = "0.90.0", path = "crates/oxc_napi" }
-oxc_parser = { version = "0.90.0", path = "crates/oxc_parser", features = ["regular_expression"] }
-oxc_parser_napi = { version = "0.90.0", path = "napi/parser" }
-oxc_regular_expression = { version = "0.90.0", path = "crates/oxc_regular_expression" }
-oxc_semantic = { version = "0.90.0", path = "crates/oxc_semantic" }
-oxc_span = { version = "0.90.0", path = "crates/oxc_span" }
-oxc_syntax = { version = "0.90.0", path = "crates/oxc_syntax" }
-oxc_transform_napi = { version = "0.90.0", path = "napi/transform" }
-oxc_transformer = { version = "0.90.0", path = "crates/oxc_transformer" }
-oxc_transformer_plugins = { version = "0.90.0", path = "crates/oxc_transformer_plugins" }
-oxc_traverse = { version = "0.90.0", path = "crates/oxc_traverse" }
+oxc = { version = "0.91.0", path = "crates/oxc" }
+oxc_allocator = { version = "0.91.0", path = "crates/oxc_allocator" }
+oxc_ast = { version = "0.91.0", path = "crates/oxc_ast" }
+oxc_ast_macros = { version = "0.91.0", path = "crates/oxc_ast_macros" }
+oxc_ast_visit = { version = "0.91.0", path = "crates/oxc_ast_visit" }
+oxc_cfg = { version = "0.91.0", path = "crates/oxc_cfg" }
+oxc_codegen = { version = "0.91.0", path = "crates/oxc_codegen" }
+oxc_data_structures = { version = "0.91.0", path = "crates/oxc_data_structures" }
+oxc_diagnostics = { version = "0.91.0", path = "crates/oxc_diagnostics" }
+oxc_ecmascript = { version = "0.91.0", path = "crates/oxc_ecmascript" }
+oxc_estree = { version = "0.91.0", path = "crates/oxc_estree" }
+oxc_isolated_declarations = { version = "0.91.0", path = "crates/oxc_isolated_declarations" }
+oxc_mangler = { version = "0.91.0", path = "crates/oxc_mangler" }
+oxc_minifier = { version = "0.91.0", path = "crates/oxc_minifier" }
+oxc_minify_napi = { version = "0.91.0", path = "napi/minify" }
+oxc_napi = { version = "0.91.0", path = "crates/oxc_napi" }
+oxc_parser = { version = "0.91.0", path = "crates/oxc_parser", features = ["regular_expression"] }
+oxc_parser_napi = { version = "0.91.0", path = "napi/parser" }
+oxc_regular_expression = { version = "0.91.0", path = "crates/oxc_regular_expression" }
+oxc_semantic = { version = "0.91.0", path = "crates/oxc_semantic" }
+oxc_span = { version = "0.91.0", path = "crates/oxc_span" }
+oxc_syntax = { version = "0.91.0", path = "crates/oxc_syntax" }
+oxc_transform_napi = { version = "0.91.0", path = "napi/transform" }
+oxc_transformer = { version = "0.91.0", path = "crates/oxc_transformer" }
+oxc_transformer_plugins = { version = "0.91.0", path = "crates/oxc_transformer_plugins" }
+oxc_traverse = { version = "0.91.0", path = "crates/oxc_traverse" }
 
 # publish = false
 oxc_formatter = { path = "crates/oxc_formatter" }

--- a/crates/oxc/CHANGELOG.md
+++ b/crates/oxc/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.88.0] - 2025-09-15
 
 ### ⚡ Performance

--- a/crates/oxc/Cargo.toml
+++ b/crates/oxc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_allocator/CHANGELOG.md
+++ b/crates/oxc_allocator/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.91.0] - 2025-09-19
+
+### 🐛 Bug Fixes
+
+- 91c88e2 allocator: Fix lint warning building WASM (#13897) (overlookmotel)
+
+
 
 
 ## [0.88.0] - 2025-09-15

--- a/crates/oxc_allocator/Cargo.toml
+++ b/crates/oxc_allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_allocator"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ast/CHANGELOG.md
+++ b/crates/oxc_ast/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.90.0] - 2025-09-18
 
 ### 🚀 Features

--- a/crates/oxc_ast/Cargo.toml
+++ b/crates/oxc_ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ast"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ast_macros/CHANGELOG.md
+++ b/crates/oxc_ast_macros/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.82.3] - 2025-08-20
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_ast_macros/Cargo.toml
+++ b/crates/oxc_ast_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ast_macros"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ast_visit/CHANGELOG.md
+++ b/crates/oxc_ast_visit/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.83.0] - 2025-08-29
 
 ### 🚀 Features

--- a/crates/oxc_ast_visit/Cargo.toml
+++ b/crates/oxc_ast_visit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ast_visit"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_cfg/CHANGELOG.md
+++ b/crates/oxc_cfg/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.82.0] - 2025-08-12
 
 ### 🚜 Refactor

--- a/crates/oxc_cfg/Cargo.toml
+++ b/crates/oxc_cfg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_cfg"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_codegen/CHANGELOG.md
+++ b/crates/oxc_codegen/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.88.0] - 2025-09-15
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_codegen"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_data_structures/CHANGELOG.md
+++ b/crates/oxc_data_structures/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.88.0] - 2025-09-15
 
 ### 💥 BREAKING CHANGES

--- a/crates/oxc_data_structures/Cargo.toml
+++ b/crates/oxc_data_structures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_data_structures"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_diagnostics/CHANGELOG.md
+++ b/crates/oxc_diagnostics/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.90.0] - 2025-09-18
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_diagnostics/Cargo.toml
+++ b/crates/oxc_diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_diagnostics"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ecmascript/CHANGELOG.md
+++ b/crates/oxc_ecmascript/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.86.0] - 2025-08-31
 
 ### 🚀 Features

--- a/crates/oxc_ecmascript/Cargo.toml
+++ b/crates/oxc_ecmascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ecmascript"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_estree/CHANGELOG.md
+++ b/crates/oxc_estree/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.88.0] - 2025-09-15
 
 ### 🚜 Refactor

--- a/crates/oxc_estree/Cargo.toml
+++ b/crates/oxc_estree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_estree"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_isolated_declarations/CHANGELOG.md
+++ b/crates/oxc_isolated_declarations/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.83.0] - 2025-08-29
 
 ### 🚜 Refactor

--- a/crates/oxc_isolated_declarations/Cargo.toml
+++ b/crates/oxc_isolated_declarations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_isolated_declarations"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_mangler/CHANGELOG.md
+++ b/crates/oxc_mangler/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.86.0] - 2025-08-31
 
 ### 🚀 Features

--- a/crates/oxc_mangler/Cargo.toml
+++ b/crates/oxc_mangler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_mangler"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_minifier/CHANGELOG.md
+++ b/crates/oxc_minifier/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
+
 ## [0.89.0] - 2025-09-15
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_minifier"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_napi/CHANGELOG.md
+++ b/crates/oxc_napi/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.80.0] - 2025-08-03
 
 ### 📚 Documentation

--- a/crates/oxc_napi/Cargo.toml
+++ b/crates/oxc_napi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_napi"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_parser/CHANGELOG.md
+++ b/crates/oxc_parser/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.91.0] - 2025-09-19
+
+### 🐛 Bug Fixes
+
+- f067159 parser: Forbid readonly in parser instead of semantic (#13905) (Ulrich Stark)
+
+
 ## [0.90.0] - 2025-09-18
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_parser/Cargo.toml
+++ b/crates/oxc_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_parser"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_regular_expression/CHANGELOG.md
+++ b/crates/oxc_regular_expression/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.88.0] - 2025-09-15
 
 ### 🚀 Features

--- a/crates/oxc_regular_expression/Cargo.toml
+++ b/crates/oxc_regular_expression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_regular_expression"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_semantic/CHANGELOG.md
+++ b/crates/oxc_semantic/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.91.0] - 2025-09-19
+
+### 🐛 Bug Fixes
+
+- f067159 parser: Forbid readonly in parser instead of semantic (#13905) (Ulrich Stark)
+
+
 
 
 ## [0.88.0] - 2025-09-15

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_semantic"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_span/CHANGELOG.md
+++ b/crates/oxc_span/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.88.0] - 2025-09-15
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_span/Cargo.toml
+++ b/crates/oxc_span/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_span"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_syntax/CHANGELOG.md
+++ b/crates/oxc_syntax/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.88.0] - 2025-09-15
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_syntax/Cargo.toml
+++ b/crates/oxc_syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_syntax"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_transformer/CHANGELOG.md
+++ b/crates/oxc_transformer/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.90.0] - 2025-09-18
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_transformer/Cargo.toml
+++ b/crates/oxc_transformer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_transformer"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_transformer_plugins/CHANGELOG.md
+++ b/crates/oxc_transformer_plugins/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.87.0] - 2025-09-08
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_transformer_plugins/Cargo.toml
+++ b/crates/oxc_transformer_plugins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_transformer_plugins"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_traverse/CHANGELOG.md
+++ b/crates/oxc_traverse/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.87.0] - 2025-09-08
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_traverse/Cargo.toml
+++ b/crates/oxc_traverse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_traverse"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/minify/CHANGELOG.md
+++ b/napi/minify/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.91.0] - 2025-09-19
+
+### 🐛 Bug Fixes
+
+- 21bbf95 napi: Rebuild bindings file for NAPI packages (#13889) (overlookmotel)
+
+
+## [0.91.0] - 2025-09-19
+
+### 🐛 Bug Fixes
+
+- 21bbf95 napi: Rebuild bindings file for NAPI packages (#13889) (overlookmotel)
+
+
 ## [0.90.0] - 2025-09-18
 
 ### 🚀 Features

--- a/napi/minify/Cargo.toml
+++ b/napi/minify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_minify_napi"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/minify/index.js
+++ b/napi/minify/index.js
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-android-arm64')
         const bindingPackageVersion = require('@oxc-minify/binding-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-android-arm-eabi')
         const bindingPackageVersion = require('@oxc-minify/binding-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -117,8 +117,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-win32-x64-msvc')
         const bindingPackageVersion = require('@oxc-minify/binding-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -133,8 +133,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-win32-ia32-msvc')
         const bindingPackageVersion = require('@oxc-minify/binding-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -149,8 +149,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-win32-arm64-msvc')
         const bindingPackageVersion = require('@oxc-minify/binding-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -168,8 +168,8 @@ function requireNative() {
     try {
       const binding = require('@oxc-minify/binding-darwin-universal')
       const bindingPackageVersion = require('@oxc-minify/binding-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -184,8 +184,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-darwin-x64')
         const bindingPackageVersion = require('@oxc-minify/binding-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -200,8 +200,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-darwin-arm64')
         const bindingPackageVersion = require('@oxc-minify/binding-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -220,8 +220,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-freebsd-x64')
         const bindingPackageVersion = require('@oxc-minify/binding-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -236,8 +236,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-freebsd-arm64')
         const bindingPackageVersion = require('@oxc-minify/binding-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -257,8 +257,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-x64-musl')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -273,8 +273,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-x64-gnu')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-arm64-musl')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -307,8 +307,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-arm64-gnu')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-arm-musleabihf')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -341,8 +341,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-loong64-musl')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -375,8 +375,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-loong64-gnu')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-riscv64-musl')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -409,8 +409,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-riscv64-gnu')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -426,8 +426,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-linux-ppc64-gnu')
         const bindingPackageVersion = require('@oxc-minify/binding-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -442,8 +442,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-linux-s390x-gnu')
         const bindingPackageVersion = require('@oxc-minify/binding-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -462,8 +462,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-openharmony-arm64')
         const bindingPackageVersion = require('@oxc-minify/binding-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -478,8 +478,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-openharmony-x64')
         const bindingPackageVersion = require('@oxc-minify/binding-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -494,8 +494,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-openharmony-arm')
         const bindingPackageVersion = require('@oxc-minify/binding-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/napi/minify/package.json
+++ b/napi/minify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-minify",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "type": "module",
   "main": "index.js",
   "browser": "browser.js",

--- a/napi/parser/CHANGELOG.md
+++ b/napi/parser/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.91.0] - 2025-09-19
+
+### 🐛 Bug Fixes
+
+- bd2fa90 napi/parser: Move `browser.js` file (#13918) (overlookmotel)
+- 5ff91bc napi/parser: Fix example (#13887) (overlookmotel)
+- 21bbf95 napi: Rebuild bindings file for NAPI packages (#13889) (overlookmotel)
+
+### 🚜 Refactor
+
+- 329b7e7 napi/parser: Move scripts to `scripts` directory (#13900) (overlookmotel)
+- ac3e9e9 napi/parser: Move JS code into `src-js` directory (#13899) (overlookmotel)
+- 2cef8ec napi/parser: Remove outdated comment (#13886) (overlookmotel)
+
+
+## [0.91.0] - 2025-09-19
+
+### 🐛 Bug Fixes
+
+- bd2fa90 napi/parser: Move `browser.js` file (#13918) (overlookmotel)
+- 5ff91bc napi/parser: Fix example (#13887) (overlookmotel)
+- 21bbf95 napi: Rebuild bindings file for NAPI packages (#13889) (overlookmotel)
+
+### 🚜 Refactor
+
+- 329b7e7 napi/parser: Move scripts to `scripts` directory (#13900) (overlookmotel)
+- ac3e9e9 napi/parser: Move JS code into `src-js` directory (#13899) (overlookmotel)
+- 2cef8ec napi/parser: Remove outdated comment (#13886) (overlookmotel)
+
+
 ## [0.90.0] - 2025-09-18
 
 ### 🚀 Features

--- a/napi/parser/Cargo.toml
+++ b/napi/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_parser_napi"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-parser",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "type": "commonjs",
   "main": "src-js/index.mjs",
   "browser": "src-js/wasm.mjs",

--- a/napi/parser/src-js/bindings.mjs
+++ b/napi/parser/src-js/bindings.mjs
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-android-arm64')
         const bindingPackageVersion = require('@oxc-parser/binding-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-android-arm-eabi')
         const bindingPackageVersion = require('@oxc-parser/binding-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -117,8 +117,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-win32-x64-msvc')
         const bindingPackageVersion = require('@oxc-parser/binding-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -133,8 +133,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-win32-ia32-msvc')
         const bindingPackageVersion = require('@oxc-parser/binding-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -149,8 +149,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-win32-arm64-msvc')
         const bindingPackageVersion = require('@oxc-parser/binding-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -168,8 +168,8 @@ function requireNative() {
     try {
       const binding = require('@oxc-parser/binding-darwin-universal')
       const bindingPackageVersion = require('@oxc-parser/binding-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -184,8 +184,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-darwin-x64')
         const bindingPackageVersion = require('@oxc-parser/binding-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -200,8 +200,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-darwin-arm64')
         const bindingPackageVersion = require('@oxc-parser/binding-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -220,8 +220,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-freebsd-x64')
         const bindingPackageVersion = require('@oxc-parser/binding-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -236,8 +236,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-freebsd-arm64')
         const bindingPackageVersion = require('@oxc-parser/binding-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -257,8 +257,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-x64-musl')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -273,8 +273,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-x64-gnu')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-arm64-musl')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -307,8 +307,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-arm64-gnu')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-arm-musleabihf')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -341,8 +341,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-loong64-musl')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -375,8 +375,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-loong64-gnu')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-riscv64-musl')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -409,8 +409,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-riscv64-gnu')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -426,8 +426,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-linux-ppc64-gnu')
         const bindingPackageVersion = require('@oxc-parser/binding-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -442,8 +442,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-linux-s390x-gnu')
         const bindingPackageVersion = require('@oxc-parser/binding-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -462,8 +462,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-openharmony-arm64')
         const bindingPackageVersion = require('@oxc-parser/binding-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -478,8 +478,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-openharmony-x64')
         const bindingPackageVersion = require('@oxc-parser/binding-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -494,8 +494,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-openharmony-arm')
         const bindingPackageVersion = require('@oxc-parser/binding-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/napi/transform/CHANGELOG.md
+++ b/napi/transform/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.91.0] - 2025-09-19
+
+### 🐛 Bug Fixes
+
+- 21bbf95 napi: Rebuild bindings file for NAPI packages (#13889) (overlookmotel)
+
+
+## [0.91.0] - 2025-09-19
+
+### 🐛 Bug Fixes
+
+- 21bbf95 napi: Rebuild bindings file for NAPI packages (#13889) (overlookmotel)
+
+
 ## [0.90.0] - 2025-09-18
 
 ### 🚀 Features

--- a/napi/transform/Cargo.toml
+++ b/napi/transform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_transform_napi"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/transform/index.js
+++ b/napi/transform/index.js
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-android-arm64')
         const bindingPackageVersion = require('@oxc-transform/binding-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-android-arm-eabi')
         const bindingPackageVersion = require('@oxc-transform/binding-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -117,8 +117,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-win32-x64-msvc')
         const bindingPackageVersion = require('@oxc-transform/binding-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -133,8 +133,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-win32-ia32-msvc')
         const bindingPackageVersion = require('@oxc-transform/binding-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -149,8 +149,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-win32-arm64-msvc')
         const bindingPackageVersion = require('@oxc-transform/binding-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -168,8 +168,8 @@ function requireNative() {
     try {
       const binding = require('@oxc-transform/binding-darwin-universal')
       const bindingPackageVersion = require('@oxc-transform/binding-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -184,8 +184,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-darwin-x64')
         const bindingPackageVersion = require('@oxc-transform/binding-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -200,8 +200,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-darwin-arm64')
         const bindingPackageVersion = require('@oxc-transform/binding-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -220,8 +220,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-freebsd-x64')
         const bindingPackageVersion = require('@oxc-transform/binding-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -236,8 +236,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-freebsd-arm64')
         const bindingPackageVersion = require('@oxc-transform/binding-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -257,8 +257,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-x64-musl')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -273,8 +273,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-x64-gnu')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-arm64-musl')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -307,8 +307,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-arm64-gnu')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-arm-musleabihf')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -341,8 +341,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-loong64-musl')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -375,8 +375,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-loong64-gnu')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-riscv64-musl')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -409,8 +409,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-riscv64-gnu')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -426,8 +426,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-linux-ppc64-gnu')
         const bindingPackageVersion = require('@oxc-transform/binding-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -442,8 +442,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-linux-s390x-gnu')
         const bindingPackageVersion = require('@oxc-transform/binding-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -462,8 +462,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-openharmony-arm64')
         const bindingPackageVersion = require('@oxc-transform/binding-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -478,8 +478,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-openharmony-x64')
         const bindingPackageVersion = require('@oxc-transform/binding-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -494,8 +494,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-openharmony-arm')
         const bindingPackageVersion = require('@oxc-transform/binding-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.90.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.90.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.91.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.91.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/napi/transform/package.json
+++ b/napi/transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-transform",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "type": "module",
   "main": "index.js",
   "browser": "browser.js",

--- a/npm/oxc-types/CHANGELOG.md
+++ b/npm/oxc-types/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.90.0] - 2025-09-18
 
 ### 🚀 Features

--- a/npm/oxc-types/package.json
+++ b/npm/oxc-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxc-project/types",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "description": "Types for Oxc AST nodes",
   "type": "module",
   "keywords": [

--- a/npm/runtime/CHANGELOG.md
+++ b/npm/runtime/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.90.0] - 2025-09-18
 
 ### 🚀 Features

--- a/npm/runtime/package.json
+++ b/npm/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxc-project/runtime",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "description": "Oxc's modular runtime helpers",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
DO NOT MERGE. I (@overlookmotel) triggered the pre-release workflow, just to test #13895.

## [0.91.0] - 2025-09-19

### 🐛 Bug Fixes

- bd2fa90 napi/parser: Move `browser.js` file (#13918) (overlookmotel)
- f067159 parser: Forbid readonly in parser instead of semantic (#13905) (Ulrich Stark)
- 91c88e2 allocator: Fix lint warning building WASM (#13897) (overlookmotel)
- 5ff91bc napi/parser: Fix example (#13887) (overlookmotel)
- 21bbf95 napi: Rebuild bindings file for NAPI packages (#13889) (overlookmotel)

### 🚜 Refactor

- 329b7e7 napi/parser: Move scripts to `scripts` directory (#13900) (overlookmotel)
- ac3e9e9 napi/parser: Move JS code into `src-js` directory (#13899) (overlookmotel)
- 2cef8ec napi/parser: Remove outdated comment (#13886) (overlookmotel)