### PR TITLE
fix(minifier): handle __proto__ when inlining single-use variables

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -1605,6 +1605,17 @@ impl<'a> PeepholeOptimizations {
                                         ctx,
                                     )
                                 {
+                                    if prop.shorthand && prop.key.is_specific_id("__proto__") {
+                                        // { __proto__ } -> { ['__proto__']: value }
+                                        prop.computed = true;
+                                        prop.key =
+                                            PropertyKey::from(ctx.ast.expression_string_literal(
+                                                prop.key.span(),
+                                                "__proto__",
+                                                None,
+                                            ));
+                                    }
+                                    prop.shorthand = false;
                                     return Some(changed);
                                 }
                             }

--- a/crates/oxc_minifier/tests/peephole/inline_single_use_variable.rs
+++ b/crates/oxc_minifier/tests/peephole/inline_single_use_variable.rs
@@ -212,6 +212,15 @@ fn test_inline_single_use_variable() {
         "function wrapper() { var x = a; for (let a of x) console.log(a) }",
         "function wrapper() { var x = a; for (let a of x) console.log(a) }",
     );
+
+    test(
+        "function wrapper() { var __proto__ = []; return { __proto__: __proto__ } }",
+        "function wrapper() { return { __proto__: [] } }",
+    );
+    test(
+        "function wrapper() { var __proto__ = []; return { __proto__ } }",
+        "function wrapper() { return { ['__proto__']: [] } }",
+    );
 }
 
 #[test]

--- a/tasks/coverage/snapshots/minifier_node_compat.snap
+++ b/tasks/coverage/snapshots/minifier_node_compat.snap
@@ -2,10 +2,8 @@ commit: ed0d6ba5
 
 minifier_node_compat Summary:
 AST Parsed     : 938/938 (100.00%)
-Positive Passed: 928/938 (98.93%)
+Positive Passed: 929/938 (99.04%)
 execution_result: tasks/coverage/ES2015/annex b›__proto__ in object literals›basic support
-
-execution_result: tasks/coverage/ES2015/annex b›__proto__ in object literals›not a shorthand property
 
 execution_result: tasks/coverage/ES2015/built-ins›Proxy›"getOwnPropertyDescriptor" handler invariants
 


### PR DESCRIPTION
```js
function wrapper() { var __proto__ = []; return { __proto__ } }
```
was compressed to
```js
function wrapper() { return { [] } }
```
. This PR fixes this bug.
