### PR TITLE
docs(napi/parser, napi/transform): correct README examples

### DIFF
--- a/napi/parser/README.md
+++ b/napi/parser/README.md
@@ -93,15 +93,15 @@ export interface EcmaScriptModule {
 ## API
 
 ```javascript
-import oxc from 'oxc-parser';
+import { parseSync } from 'oxc-parser';
 
 const code = 'const url: String = /* 🤨 */ import.meta.url;';
 
 // File extension is used to determine which dialect to parse source as.
 const filename = 'test.tsx';
 
-const result = oxc.parseSync(filename, code);
-// or `await oxc.parseAsync(filename, code)`
+const result = parseSync(filename, code);
+// or `await parseAsync(filename, code)`
 
 // An array of errors, if any.
 console.log(result.errors);

--- a/napi/transform/README.md
+++ b/napi/transform/README.md
@@ -6,9 +6,9 @@ This is alpha software and may yield incorrect results, feel free to [submit a b
 
 ```javascript
 import assert from 'assert';
-import oxc from 'oxc-transform';
+import { transform } from 'oxc-transform';
 
-const { code, declaration, errors } = oxc.transform(
+const { code, declaration, errors } = transform(
   'test.ts',
   'class A<T> {}',
   {
@@ -17,6 +17,7 @@ const { code, declaration, errors } = oxc.transform(
     },
   },
 );
+// or `await transformAsync(filename, code, options)`
 
 assert.equal(code, 'class A {}\n');
 assert.equal(declaration, 'declare class A<T> {}\n');
@@ -31,9 +32,9 @@ Conforms to TypeScript compiler's `--isolatedDeclarations` `.d.ts` emit.
 
 ```javascript
 import assert from 'assert';
-import oxc from 'oxc-transform';
+import { isolatedDeclaration } from 'oxc-transform';
 
-const { map, code, errors } = oxc.isolatedDeclaration('test.ts', 'class A {}');
+const { map, code, errors } = isolatedDeclaration('test.ts', 'class A {}');
 
 assert.equal(code, 'declare class A {}\n');
 assert(errors.length == 0);


### PR DESCRIPTION
Docs were out of date. `oxc-parser` and `oxc-transform` packages are now ESM-only, so the code examples would no longer run. Correct them.