### PR TITLE
chore(infra): add publint

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/oxc-project/oxc.git",
+    "url": "git+https://github.com/oxc-project/oxc.git",
     "directory": "editors/vscode"
   },
   "categories": [

--- a/napi/minify/package.json
+++ b/napi/minify/package.json
@@ -8,6 +8,7 @@
     "build-dev": "napi build --esm --platform",
     "build-test": "pnpm run build-dev",
     "build": "pnpm run build-dev --features allocator --release",
+    "postbuild": "publint",
     "postbuild-dev": "node scripts/patch.js",
     "test": "tsc && vitest run --dir ./test"
   },
@@ -42,8 +43,8 @@
     "access": "public"
   },
   "devDependencies": {
-    "vitest": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "napi": {
     "binaryName": "minify",

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -8,6 +8,7 @@
     "build-dev": "napi build --esm --platform --js bindings.js --dts index.d.ts --output-dir src-js",
     "build-test": "pnpm run build-dev --profile coverage",
     "build": "pnpm run build-dev --features allocator --release",
+    "postbuild": "publint",
     "postbuild-dev": "node scripts/patch.js",
     "build-wasi": "pnpm run build-dev --release --target wasm32-wasip1-threads",
     "build-npm-dir": "rm -rf npm-dir && napi create-npm-dirs --npm-dir npm-dir && pnpm napi artifacts --npm-dir npm-dir --output-dir src-js",

--- a/napi/playground/package.json
+++ b/napi/playground/package.json
@@ -16,7 +16,8 @@
     "build-test": "echo 'Skipped because there are no tests.'",
     "build-dev": "pnpm run build:napi && node scripts/patch.js",
     "build": "pnpm run build:napi --release && node scripts/patch.js",
-    "build:napi": "napi build --platform --esm --target wasm32-wasip1-threads"
+    "build:napi": "napi build --platform --esm --target wasm32-wasip1-threads",
+    "postbuild": "publint"
   },
   "dependencies": {
     "@napi-rs/wasm-runtime": "catalog:"

--- a/napi/transform/package.json
+++ b/napi/transform/package.json
@@ -8,6 +8,7 @@
     "build-dev": "napi build --esm --platform",
     "build-test": "pnpm run build-dev",
     "build": "pnpm run build-dev --features allocator --release",
+    "postbuild": "publint",
     "postbuild-dev": "node scripts/patch.js",
     "test": "tsc && vitest run --dir ./test"
   },
@@ -42,8 +43,8 @@
     "access": "public"
   },
   "devDependencies": {
-    "vitest": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "napi": {
     "binaryName": "transform",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "oxlint": "^1.12.0",
     "oxlint-tsgolint": "0.2.0",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "publint": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     '@napi-rs/wasm-runtime':
       specifier: 1.0.5
       version: 1.0.5
+    publint:
+      specifier: 0.3.13
+      version: 0.3.13
     typescript:
       specifier: 5.9.2
       version: 5.9.2
@@ -38,6 +41,9 @@ importers:
       oxlint-tsgolint:
         specifier: 0.2.0
         version: 0.2.0
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.13
       typescript:
         specifier: 'catalog:'
         version: 5.9.2
@@ -55,7 +61,7 @@ importers:
         version: 9.6.0
       tsdown:
         specifier: 0.15.1
-        version: 0.15.1(@arethetypeswrong/core@0.18.2)(typescript@5.9.2)
+        version: 0.15.1(@arethetypeswrong/core@0.18.2)(publint@0.3.13)(typescript@5.9.2)
       typescript:
         specifier: 'catalog:'
         version: 5.9.2
@@ -1521,6 +1527,10 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@publint/pack@0.1.2':
+    resolution: {integrity: sha512-S+9ANAvUmjutrshV4jZjaiG8XQyuJIZ8a4utWmN/vW1sgQ9IfBnPndwkmQYw53QmouOIytT874u65HEmu6H5jw==}
+    engines: {node: '>=18'}
 
   '@quansync/fs@0.1.5':
     resolution: {integrity: sha512-lNS9hL2aS2NZgNW7BBj+6EBl4rOf8l+tQ0eRY6JWCI8jI2kc53gSoqbjojU0OnAWhzoXiOjFyGsHcDGePB3lhA==}
@@ -3315,6 +3325,10 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
 
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -3453,6 +3467,9 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  package-manager-detector@1.3.0:
+    resolution: {integrity: sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ==}
 
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
@@ -3593,6 +3610,11 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  publint@0.3.13:
+    resolution: {integrity: sha512-NC+lph09+BRO9LJgKlIy3WQXyu6/6WDQ0dCA60KALUwdKVf3PfGuC6fY8I+oKB/5kEPh50aOSUz+6yWy1n4EfA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
@@ -3728,6 +3750,10 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
 
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -5524,6 +5550,8 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@publint/pack@0.1.2': {}
+
   '@quansync/fs@0.1.5':
     dependencies:
       quansync: 0.2.11
@@ -7311,6 +7339,8 @@ snapshots:
       yargs-parser: 21.1.1
       yargs-unparser: 2.0.0
 
+  mri@1.2.0: {}
+
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
@@ -7463,6 +7493,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  package-manager-detector@1.3.0: {}
+
   pako@1.0.11: {}
 
   parent-module@1.0.1:
@@ -7588,6 +7620,13 @@ snapshots:
       ipaddr.js: 1.9.1
 
   proxy-from-env@1.1.0: {}
+
+  publint@0.3.13:
+    dependencies:
+      '@publint/pack': 0.1.2
+      package-manager-detector: 1.3.0
+      picocolors: 1.1.1
+      sade: 1.8.1
 
   pump@3.0.3:
     dependencies:
@@ -7794,6 +7833,10 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
 
   safe-buffer@5.1.2: {}
 
@@ -8086,7 +8129,7 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  tsdown@0.15.1(@arethetypeswrong/core@0.18.2)(typescript@5.9.2):
+  tsdown@0.15.1(@arethetypeswrong/core@0.18.2)(publint@0.3.13)(typescript@5.9.2):
     dependencies:
       ansis: 4.1.0
       cac: 6.7.14
@@ -8104,6 +8147,7 @@ snapshots:
       unconfig: 7.3.3
     optionalDependencies:
       '@arethetypeswrong/core': 0.18.2
+      publint: 0.3.13
       typescript: 5.9.2
     transitivePeerDependencies:
       - '@ts-macro/tsc'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,9 +10,10 @@ packages:
 
 catalog:
   '@napi-rs/cli': 3.2.0
+  '@napi-rs/wasm-runtime': 1.0.5
+  publint: 0.3.13
   typescript: 5.9.2
   vitest: 3.2.4
-  '@napi-rs/wasm-runtime': 1.0.5
 
 verifyDepsBeforeRun: install
 


### PR DESCRIPTION
close #13768 

Setup [publint](https://publint.dev/) and fix warnings.
target directory: `napi/` and `editor/vscode`. (I couldn’t determine whether I should include the `npm/` directory or not.)
