### PR TITLE
feat(napi/parser): add `deserializeProgramOnly` deserializer function

### DIFF
--- a/napi/parser/generated/deserialize/js.mjs
+++ b/napi/parser/generated/deserialize/js.mjs
@@ -7,7 +7,15 @@ const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
   { fromCodePoint } = String;
 
-export function deserialize(buffer, sourceTextInput, sourceByteLenInput, preserveParensInput) {
+export function deserialize(buffer, sourceText, sourceByteLen, preserveParens) {
+  return deserializeWith(buffer, sourceText, sourceByteLen, preserveParens, deserializeRawTransferData);
+}
+
+export function deserializeProgramOnly(buffer, sourceText, sourceByteLen, preserveParens) {
+  return deserializeWith(buffer, sourceText, sourceByteLen, preserveParens, deserializeProgram);
+}
+
+function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, preserveParensInput, deserialize) {
   uint8 = buffer;
   uint32 = buffer.uint32;
   float64 = buffer.float64;
@@ -17,7 +25,7 @@ export function deserialize(buffer, sourceTextInput, sourceByteLenInput, preserv
   sourceIsAscii = sourceText.length === sourceByteLen;
   preserveParens = preserveParensInput;
 
-  const data = deserializeRawTransferData(uint32[536870902]);
+  const data = deserialize(uint32[536870902]);
 
   uint8 =
     uint32 =

--- a/napi/parser/generated/deserialize/ts.mjs
+++ b/napi/parser/generated/deserialize/ts.mjs
@@ -7,7 +7,15 @@ const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
   { fromCodePoint } = String;
 
-export function deserialize(buffer, sourceTextInput, sourceByteLenInput, preserveParensInput) {
+export function deserialize(buffer, sourceText, sourceByteLen, preserveParens) {
+  return deserializeWith(buffer, sourceText, sourceByteLen, preserveParens, deserializeRawTransferData);
+}
+
+export function deserializeProgramOnly(buffer, sourceText, sourceByteLen, preserveParens) {
+  return deserializeWith(buffer, sourceText, sourceByteLen, preserveParens, deserializeProgram);
+}
+
+function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, preserveParensInput, deserialize) {
   uint8 = buffer;
   uint32 = buffer.uint32;
   float64 = buffer.float64;
@@ -17,7 +25,7 @@ export function deserialize(buffer, sourceTextInput, sourceByteLenInput, preserv
   sourceIsAscii = sourceText.length === sourceByteLen;
   preserveParens = preserveParensInput;
 
-  const data = deserializeRawTransferData(uint32[536870902]);
+  const data = deserialize(uint32[536870902]);
 
   uint8 =
     uint32 =

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -122,7 +122,15 @@ fn generate_deserializers(consts: Constants, schema: &Schema, codegen: &Codegen)
             decodeStr = textDecoder.decode.bind(textDecoder),
             {{ fromCodePoint }} = String;
 
-        export function deserialize(buffer, sourceTextInput, sourceByteLenInput, preserveParensInput) {{
+        export function deserialize(buffer, sourceText, sourceByteLen, preserveParens) {{
+            return deserializeWith(buffer, sourceText, sourceByteLen, preserveParens, deserializeRawTransferData);
+        }}
+
+        export function deserializeProgramOnly(buffer, sourceText, sourceByteLen, preserveParens) {{
+            return deserializeWith(buffer, sourceText, sourceByteLen, preserveParens, deserializeProgram);
+        }}
+
+        function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, preserveParensInput, deserialize) {{
             uint8 = buffer;
             uint32 = buffer.uint32;
             float64 = buffer.float64;
@@ -132,7 +140,7 @@ fn generate_deserializers(consts: Constants, schema: &Schema, codegen: &Codegen)
             sourceIsAscii = sourceText.length === sourceByteLen;
             preserveParens = preserveParensInput;
 
-            const data = deserializeRawTransferData(uint32[{data_pointer_pos_32}]);
+            const data = deserialize(uint32[{data_pointer_pos_32}]);
 
             uint8 = uint32 = float64 = sourceText = undefined;
 


### PR DESCRIPTION
Pure refactor. Add a function `deserializeProgramOnly` to generated deserializer code. This function is not used in `oxc-parser`, but is needed to be able to reuse the same code in Oxlint.