### PR TITLE
feat(ast_tools): add `Schema::structs_and_enums` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1781,6 +1781,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "lazy-regex",
+ "oxc_data_structures",
  "oxc_index",
  "phf",
  "phf_codegen",

--- a/tasks/ast_tools/Cargo.toml
+++ b/tasks/ast_tools/Cargo.toml
@@ -14,6 +14,8 @@ test = true
 doctest = false
 
 [dependencies]
+oxc_data_structures = { workspace = true, features = ["slice_iter"] }
+
 bitflags = { workspace = true }
 bpaf = { workspace = true, features = ["autocomplete", "bright-color", "derive"] }
 convert_case = { workspace = true }


### PR DESCRIPTION
Add a `structs_and_enums` method to `Schema` which returns an iterator over all struct and enum definitions, skipping primitives, boxes, vecs, etc. This will be useful in many places in `oxc_ast_tools`.