### PR TITLE
chore(tasks/coverage): exclude node-compat-table from dprint and typos

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -17,6 +17,7 @@ extend-exclude = [
   "crates/oxc_syntax/src/xml_entities.rs",
   "pnpm-lock.yaml",
   "tasks/coverage/babel",
+  "tasks/coverage/node-compat-table",
   "tasks/coverage/test262",
   "tasks/coverage/typescript",
   "tasks/coverage/snapshots",

--- a/dprint.json
+++ b/dprint.json
@@ -10,6 +10,7 @@
   "toml": {
   },
   "excludes": [
+    "tasks/coverage/node-compat-table",
     "tasks/coverage/misc",
     "**/tests/**",
     "**/fixtures/**",


### PR DESCRIPTION
Follow up to #13925. Excluded node-compat-table directory from dprint and typos.