### PR TITLE
perf(parser): optimize `parse_simple_arrow_function_expression`

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -1273,10 +1273,12 @@ impl<'a> ParserImpl<'a> {
         let kind = self.cur_kind();
 
         // `x => {}`
-        if lhs.is_identifier_reference() && kind == Kind::Arrow {
+        if kind == Kind::Arrow
+            && let Expression::Identifier(ident) = &lhs
+        {
             let mut arrow_expr = self.parse_simple_arrow_function_expression(
                 span,
-                lhs,
+                ident,
                 /* async */ false,
                 allow_return_type_in_arrow_function,
             );


### PR DESCRIPTION
The function now accepts `IdentifierReference` instead of `Expression` to make its implementation simpler and avoid one match. Also all code around `self.ctx` is removed because it wasn't needed. This results in less code and a speedup in parser benchmarks of around 1% on my device.