### PR TITLE
test(language_server): add `test_and_snapshot_multiple_file`

### DIFF
--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -562,9 +562,7 @@ mod test {
     #[test]
     fn test_cross_module_no_cycle_nested_config() {
         Tester::new("fixtures/linter/cross_module_nested_config", None)
-            .test_and_snapshot_single_file("dep-a.ts");
-        Tester::new("fixtures/linter/cross_module_nested_config", None)
-            .test_and_snapshot_single_file("folder/folder-dep-a.ts");
+            .test_and_snapshot_multiple_file(&["dep-a.ts", "folder/folder-dep-a.ts"]);
     }
 
     #[test]
@@ -603,8 +601,10 @@ mod test {
     #[test]
     fn test_root_ignore_patterns() {
         let tester = Tester::new("fixtures/linter/ignore_patterns", None);
-        tester.test_and_snapshot_single_file("ignored-file.ts");
-        tester.test_and_snapshot_single_file("another_config/not-ignored-file.ts");
+        tester.test_and_snapshot_multiple_file(&[
+            "ignored-file.ts",
+            "another_config/not-ignored-file.ts",
+        ]);
     }
 
     #[test]

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_astro@debugger.astro.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_astro@debugger.astro.snap
@@ -1,7 +1,10 @@
 ---
 source: crates/oxc_language_server/src/tester.rs
-input_file: crates/oxc_language_server/fixtures/linter/astro/debugger.astro
 ---
+########## 
+file: fixtures/linter/astro/debugger.astro
+----------
+
 code: "eslint(no-debugger)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
 message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_cross_module@debugger.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_cross_module@debugger.ts.snap
@@ -1,7 +1,10 @@
 ---
 source: crates/oxc_language_server/src/tester.rs
-input_file: crates/oxc_language_server/fixtures/linter/cross_module/debugger.ts
 ---
+########## 
+file: fixtures/linter/cross_module/debugger.ts
+----------
+
 code: "eslint(no-debugger)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
 message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_cross_module@dep-a.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_cross_module@dep-a.ts.snap
@@ -1,7 +1,10 @@
 ---
 source: crates/oxc_language_server/src/tester.rs
-input_file: crates/oxc_language_server/fixtures/linter/cross_module/dep-a.ts
 ---
+########## 
+file: fixtures/linter/cross_module/dep-a.ts
+----------
+
 code: "eslint-plugin-import(no-cycle)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html"
 message: "Dependency cycle detected\nhelp: These paths form a cycle: \n-> ./dep-b.ts - fixtures/linter/cross_module/dep-b.ts\n-> ./dep-a.ts - fixtures/linter/cross_module/dep-a.ts"

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_cross_module_extended_config@dep-a.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_cross_module_extended_config@dep-a.ts.snap
@@ -1,7 +1,10 @@
 ---
 source: crates/oxc_language_server/src/tester.rs
-input_file: crates/oxc_language_server/fixtures/linter/cross_module_extended_config/dep-a.ts
 ---
+########## 
+file: fixtures/linter/cross_module_extended_config/dep-a.ts
+----------
+
 code: "eslint-plugin-import(no-cycle)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html"
 message: "Dependency cycle detected\nhelp: These paths form a cycle: \n-> ./dep-b.ts - fixtures/linter/cross_module_extended_config/dep-b.ts\n-> ./dep-a.ts - fixtures/linter/cross_module_extended_config/dep-a.ts"

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_cross_module_nested_config@dep-a.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_cross_module_nested_config@dep-a.ts.snap
@@ -1,5 +1,0 @@
----
-source: crates/oxc_language_server/src/tester.rs
-input_file: crates/oxc_language_server/fixtures/linter/cross_module_nested_config/dep-a.ts
----
-No diagnostic reports

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_cross_module_nested_config@dep-a.ts_folder__folder-dep-a.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_cross_module_nested_config@dep-a.ts_folder__folder-dep-a.ts.snap
@@ -1,7 +1,14 @@
 ---
 source: crates/oxc_language_server/src/tester.rs
-input_file: crates/oxc_language_server/fixtures/linter/cross_module_nested_config/folder/folder-dep-a.ts
 ---
+########## 
+file: fixtures/linter/cross_module_nested_config/dep-a.ts
+----------
+No diagnostic reports
+########## 
+file: fixtures/linter/cross_module_nested_config/folder/folder-dep-a.ts
+----------
+
 code: "eslint-plugin-import(no-cycle)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html"
 message: "Dependency cycle detected\nhelp: These paths form a cycle: \n-> ./folder-dep-b.ts - fixtures/linter/cross_module_nested_config/folder/folder-dep-b.ts\n-> ./folder-dep-a.ts - fixtures/linter/cross_module_nested_config/folder/folder-dep-a.ts"

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_deny_no_console@hello_world.js.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_deny_no_console@hello_world.js.snap
@@ -1,7 +1,10 @@
 ---
 source: crates/oxc_language_server/src/tester.rs
-input_file: crates/oxc_language_server/fixtures/linter/deny_no_console/hello_world.js
 ---
+########## 
+file: fixtures/linter/deny_no_console/hello_world.js
+----------
+
 code: "eslint(no-console)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html"
 message: "Unexpected console statement.\nhelp: Delete this console statement."

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_ignore_patterns@ignored-file.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_ignore_patterns@ignored-file.ts.snap
@@ -1,5 +1,0 @@
----
-source: crates/oxc_language_server/src/tester.rs
-input_file: crates/oxc_language_server/fixtures/linter/ignore_patterns/ignored-file.ts
----
-File is ignored

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_ignore_patterns@ignored-file.ts_another_config__not-ignored-file.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_ignore_patterns@ignored-file.ts_another_config__not-ignored-file.ts.snap
@@ -1,7 +1,14 @@
 ---
 source: crates/oxc_language_server/src/tester.rs
-input_file: crates/oxc_language_server/fixtures/linter/ignore_patterns/another_config/not-ignored-file.ts
 ---
+########## 
+file: fixtures/linter/ignore_patterns/ignored-file.ts
+----------
+File is ignored
+########## 
+file: fixtures/linter/ignore_patterns/another_config/not-ignored-file.ts
+----------
+
 code: "eslint(no-debugger)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
 message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_invalid_syntax@debugger.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_invalid_syntax@debugger.ts.snap
@@ -1,7 +1,10 @@
 ---
 source: crates/oxc_language_server/src/tester.rs
-input_file: crates/oxc_language_server/fixtures/linter/invalid_syntax/debugger.ts
 ---
+########## 
+file: fixtures/linter/invalid_syntax/debugger.ts
+----------
+
 code: ""
 code_description.href: "None"
 message: "Unexpected token"

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_issue_9958@issue.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_issue_9958@issue.ts.snap
@@ -1,7 +1,10 @@
 ---
 source: crates/oxc_language_server/src/tester.rs
-input_file: crates/oxc_language_server/fixtures/linter/issue_9958/issue.ts
 ---
+########## 
+file: fixtures/linter/issue_9958/issue.ts
+----------
+
 code: "eslint(no-extra-boolean-cast)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-extra-boolean-cast.html"
 message: "Redundant double negation\nhelp: Remove the double negation as it will already be coerced to a boolean"

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_lint_on_run_on_save@on-save.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_lint_on_run_on_save@on-save.ts.snap
@@ -1,7 +1,10 @@
 ---
 source: crates/oxc_language_server/src/tester.rs
-input_file: crates/oxc_language_server/fixtures/linter/lint_on_run/on_save/on-save.ts
 ---
+########## 
+file: fixtures/linter/lint_on_run/on_save/on-save.ts
+----------
+
 code: "typescript-eslint(no-floating-promises)"
 code_description.href: "None"
 message: "Promises must be awaited.\nhelp: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator."

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_lint_on_run_on_save@on-type.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_lint_on_run_on_save@on-type.ts.snap
@@ -1,5 +1,7 @@
 ---
 source: crates/oxc_language_server/src/tester.rs
-input_file: crates/oxc_language_server/fixtures/linter/lint_on_run/on_save/on-type.ts
 ---
+########## 
+file: fixtures/linter/lint_on_run/on_save/on-type.ts
+----------
 File is ignored

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_lint_on_run_on_type@on-save-no-type-aware.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_lint_on_run_on_type@on-save-no-type-aware.ts.snap
@@ -1,5 +1,7 @@
 ---
 source: crates/oxc_language_server/src/tester.rs
-input_file: crates/oxc_language_server/fixtures/linter/lint_on_run/on_type/on-save-no-type-aware.ts
 ---
+########## 
+file: fixtures/linter/lint_on_run/on_type/on-save-no-type-aware.ts
+----------
 File is ignored

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_lint_on_run_on_type@on-save.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_lint_on_run_on_type@on-save.ts.snap
@@ -1,7 +1,10 @@
 ---
 source: crates/oxc_language_server/src/tester.rs
-input_file: crates/oxc_language_server/fixtures/linter/lint_on_run/on_type/on-save.ts
 ---
+########## 
+file: fixtures/linter/lint_on_run/on_type/on-save.ts
+----------
+
 code: "eslint(no-debugger)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
 message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_lint_on_run_on_type@on-type.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_lint_on_run_on_type@on-type.ts.snap
@@ -1,7 +1,10 @@
 ---
 source: crates/oxc_language_server/src/tester.rs
-input_file: crates/oxc_language_server/fixtures/linter/lint_on_run/on_type/on-type.ts
 ---
+########## 
+file: fixtures/linter/lint_on_run/on_type/on-type.ts
+----------
+
 code: "eslint(no-debugger)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
 message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_multiple_suggestions@forward_ref.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_multiple_suggestions@forward_ref.ts.snap
@@ -1,7 +1,10 @@
 ---
 source: crates/oxc_language_server/src/tester.rs
-input_file: crates/oxc_language_server/fixtures/linter/multiple_suggestions/forward_ref.ts
 ---
+########## 
+file: fixtures/linter/multiple_suggestions/forward_ref.ts
+----------
+
 code: "eslint-plugin-react(forward-ref-uses-ref)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/react/forward-ref-uses-ref.html"
 message: "Components wrapped with `forwardRef` must have a `ref` parameter\nhelp: Add a `ref` parameter, or remove `forwardRef`"

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_no_errors@hello_world.js.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_no_errors@hello_world.js.snap
@@ -1,5 +1,7 @@
 ---
 source: crates/oxc_language_server/src/tester.rs
-input_file: crates/oxc_language_server/fixtures/linter/no_errors/hello_world.js
 ---
+########## 
+file: fixtures/linter/no_errors/hello_world.js
+----------
 No diagnostic reports

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_regexp_feature@index.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_regexp_feature@index.ts.snap
@@ -1,7 +1,10 @@
 ---
 source: crates/oxc_language_server/src/tester.rs
-input_file: crates/oxc_language_server/fixtures/linter/regexp_feature/index.ts
 ---
+########## 
+file: fixtures/linter/regexp_feature/index.ts
+----------
+
 code: "eslint(no-control-regex)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-control-regex.html"
 message: "Unexpected control character\nhelp: '\\u0000' is a control character."

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_svelte@debugger.svelte.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_svelte@debugger.svelte.snap
@@ -1,7 +1,10 @@
 ---
 source: crates/oxc_language_server/src/tester.rs
-input_file: crates/oxc_language_server/fixtures/linter/svelte/debugger.svelte
 ---
+########## 
+file: fixtures/linter/svelte/debugger.svelte
+----------
+
 code: "eslint(no-unassigned-vars)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unassigned-vars.html"
 message: "'title' is always 'undefined' because it's never assigned.\nhelp: Variable declared without assignment. Either assign a value or remove the declaration."

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_ts_path_alias@deep__src__dep-a.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_ts_path_alias@deep__src__dep-a.ts.snap
@@ -1,7 +1,10 @@
 ---
 source: crates/oxc_language_server/src/tester.rs
-input_file: crates/oxc_language_server/fixtures/linter/ts_path_alias/deep/src/dep-a.ts
 ---
+########## 
+file: fixtures/linter/ts_path_alias/deep/src/dep-a.ts
+----------
+
 code: "eslint-plugin-import(no-cycle)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html"
 message: "Dependency cycle detected\nhelp: These paths form a cycle: \n-> @/dep-b - fixtures/linter/ts_path_alias/deep/src/dep-b.ts\n-> ./dep-a.ts - fixtures/linter/ts_path_alias/deep/src/dep-a.ts"

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_tsgolint@no-floating-promises__index.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_tsgolint@no-floating-promises__index.ts.snap
@@ -1,7 +1,10 @@
 ---
 source: crates/oxc_language_server/src/tester.rs
-input_file: crates/oxc_language_server/fixtures/linter/tsgolint/no-floating-promises/index.ts
 ---
+########## 
+file: fixtures/linter/tsgolint/no-floating-promises/index.ts
+----------
+
 code: "typescript-eslint(no-floating-promises)"
 code_description.href: "None"
 message: "Promises must be awaited.\nhelp: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator."

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_unused_disabled_directives@test.js.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_unused_disabled_directives@test.js.snap
@@ -1,7 +1,10 @@
 ---
 source: crates/oxc_language_server/src/tester.rs
-input_file: crates/oxc_language_server/fixtures/linter/unused_disabled_directives/test.js
 ---
+########## 
+file: fixtures/linter/unused_disabled_directives/test.js
+----------
+
 code: "eslint(no-console)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html"
 message: "Unexpected console statement.\nhelp: Delete this console statement."

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_vue@debugger.vue.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_vue@debugger.vue.snap
@@ -1,7 +1,10 @@
 ---
 source: crates/oxc_language_server/src/tester.rs
-input_file: crates/oxc_language_server/fixtures/linter/vue/debugger.vue
 ---
+########## 
+file: fixtures/linter/vue/debugger.vue
+----------
+
 code: "eslint(no-debugger)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
 message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"


### PR DESCRIPTION
For some tests, you need to run multiple `cargo test -p oxc_language_server` commands, to catch all changes.
With this method, we can lint multiple files at ones and create a single snapshot for it.