### PR TITLE
ci(test): skip doctests in Test big-endian CI task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,11 @@ jobs:
           save-cache: ${{ github.ref_name == 'main' }}
           cache-key: s390x-unknown-linux-gnu
           tools: cross
-      - run: cross test --workspace --all-features --exclude website --target s390x-unknown-linux-gnu
+      - run: cross --version
+      # `--lib --bins --tests` to skip doctests which are very slow to run via `cross`.
+      # https://github.com/cross-rs/cross/issues/1703
+      # Exclude NAPI crates because of linker errors.
+      - run: cross test --workspace --lib --bins --tests --all-features --exclude website --exclude oxc_minify_napi --exclude oxc_parser_napi --exclude oxc_playground_napi --exclude oxc_transform_napi --target s390x-unknown-linux-gnu
       # Run separately to avoid feature unification problems with `oxlint`
       - run: cross test -p website --target s390x-unknown-linux-gnu
 


### PR DESCRIPTION
Skip doctests in Test big-endian CI task, because they're slow.

This cuts over a minute off the time to run the "Test big-endian" CI task.

For some reason, once I added `--lib --bins --tests`, got linker errors compiling NAPI packages. So skip them - I don't believe they have tests anyway, and even if they do, we likely don't need to run them on big-endian. Code which behaves differently depending on endianness is in other crates with unit tests there.