### PR TITLE
fix(linter/plugins): avoid lint warnings compiling WASM or big-endian

### DIFF
--- a/apps/oxlint/src/run.rs
+++ b/apps/oxlint/src/run.rs
@@ -99,6 +99,7 @@ fn lint_impl(load_plugin: JsLoadPluginCb, lint_file: JsLintFileCb) -> CliRunResu
         #[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
         #[expect(clippy::print_stderr)]
         {
+            let (_, _) = (load_plugin, lint_file);
             eprintln!(
                 "ERROR: JS plugins are only supported on 64-bit little-endian platforms at present"
             );


### PR DESCRIPTION
Prevent `unused_variables` lint warning when compiling `oxlint` on 32-bit or big-endian systems.