### PR TITLE
ci(coverage): fix Code Coverage CI task

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,7 +2,8 @@
 # Do not append `--` or it will break IDEs
 ck = "check --workspace --all-features --all-targets --locked"
 lint = "clippy --workspace --all-targets --all-features"
-codecov = "llvm-cov --workspace --ignore-filename-regex tasks"
+# Skip `tasks/website` due to linker errors with `oxlint`
+codecov = "llvm-cov --workspace --ignore-filename-regex tasks --exclude website"
 coverage = "run -p oxc_coverage --profile coverage --"
 benchmark = "bench -p oxc_benchmark"
 minsize = "run -p oxc_minsize --profile coverage --"

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -6,6 +6,11 @@ permissions: {}
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - "**.rs"
+      - ".github/workflows/codecov.yml"
   push:
     branches:
       - main

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -6,11 +6,6 @@ permissions: {}
 
 on:
   workflow_dispatch:
-  pull_request:
-    types: [opened, synchronize]
-    paths:
-      - "**.rs"
-      - ".github/workflows/codecov.yml"
   push:
     branches:
       - main


### PR DESCRIPTION
Fixes #13866.

Skip `tasks/website` in Code Coverage CI task, because it fails with linker errors.