### PR TITLE
docs(ast): document `JSDocUnknownType`

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1745,6 +1745,7 @@ pub struct JSDocNonNullableType<'a> {
     pub postfix: bool,
 }
 
+/// `type T = (?)`
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]


### PR DESCRIPTION
I wasn't sure what this AST node is when implementing ESTree AST in oxlint plugins. Document it.