### PR TITLE
fix(language_server): don't lint file on code action when it is already ignored

### DIFF
--- a/crates/oxc_language_server/src/linter/error_with_position.rs
+++ b/crates/oxc_language_server/src/linter/error_with_position.rs
@@ -9,7 +9,7 @@ use oxc_diagnostics::Severity;
 
 use crate::LSP_MAX_INT;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct DiagnosticReport {
     pub diagnostic: lsp_types::Diagnostic,
     pub fixed_content: PossibleFixContent,
@@ -23,8 +23,9 @@ pub struct FixedContent {
     pub range: Range,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum PossibleFixContent {
+    #[default]
     None,
     Single(FixedContent),
     Multiple(Vec<FixedContent>),

--- a/editors/vscode/tests/code_actions.spec.ts
+++ b/editors/vscode/tests/code_actions.spec.ts
@@ -16,7 +16,8 @@ import {
   activateExtension,
   fixturesWorkspaceUri,
   loadFixture,
-  sleep
+  sleep,
+  testSingleFolderMode
 } from './test-helpers';
 import assert = require('assert');
 
@@ -35,11 +36,11 @@ teardown(async () => {
 });
 
 suite('code actions', () => {
-  test('listed code actions', async () => {
+  // flaky test for multi workspace mode
+  testSingleFolderMode('listed code actions', async () => {
     await loadFixture('debugger');
     const fileUri = Uri.joinPath(fixturesWorkspaceUri(), 'fixtures', 'debugger.js');
     // await window.showTextDocument(fileUri); -- should also work without opening the file
-    await sleep(500); // ¯\_(ツ)_/¯ -- test it again when adding/removing tests
 
     const codeActions: ProviderResult<Array<CodeAction>> = await commands.executeCommand(
       'vscode.executeCodeActionProvider',


### PR DESCRIPTION
part of oxc-project/oxc-vscode#23

## before:
Even if the file is ignored or not supported by both linters, the code actions would re trigger a lint task.

## after:
respect the `None` result which indicates the ignore status