### PR TITLE
refactor(napi/parser): itemize files in `package.json`

### DIFF
--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -38,8 +38,25 @@
     "url": "https://github.com/sponsors/Boshen"
   },
   "files": [
-    "generated",
-    "src-js"
+    "generated/constants.mjs",
+    "generated/deserialize/js.mjs",
+    "generated/deserialize/ts.mjs",
+    "generated/lazy/constructors.mjs",
+    "generated/lazy/types.mjs",
+    "generated/lazy/walk.mjs",
+    "src-js/bindings.mjs",
+    "src-js/index.d.ts",
+    "src-js/index.mjs",
+    "src-js/wasm.mjs",
+    "src-js/webcontainer-fallback.js",
+    "src-js/wrap.mjs",
+    "src-js/raw-transfer/common.mjs",
+    "src-js/raw-transfer/eager.mjs",
+    "src-js/raw-transfer/lazy.mjs",
+    "src-js/raw-transfer/lazy-common.mjs",
+    "src-js/raw-transfer/node-array.mjs",
+    "src-js/raw-transfer/supported.mjs",
+    "src-js/raw-transfer/visitor.mjs"
   ],
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",


### PR DESCRIPTION
#13899 made the `files` array in `package.json` for `napi/parser` package a short list of directories. Revert to an itemized list of all files to be included in NPM package.

This is for compatibility with the release workflow which checks the list of files in `package.json` against file system. It fails when `files` list contains directories.