### PR TITLE
refactor(linter): make disable directives own the rule name

### DIFF
--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -32,7 +32,7 @@ pub struct ContextSubHost<'a> {
     pub(super) module_record: Arc<ModuleRecord>,
     /// Information about specific rules that should be disabled or enabled, via comment directives like
     /// `eslint-disable` or `eslint-disable-next-line`.
-    pub(super) disable_directives: DisableDirectives<'a>,
+    pub(super) disable_directives: DisableDirectives,
     // Specific framework options, for example, whether the context is inside `<script setup>` in Vue files.
     pub(super) framework_options: FrameworkOptions,
     /// The source text offset of the sub host
@@ -93,7 +93,7 @@ impl<'a> ContextSubHost<'a> {
     }
 
     /// Shared reference to the [`DisableDirectives`]
-    pub fn disable_directives(&self) -> &DisableDirectives<'a> {
+    pub fn disable_directives(&self) -> &DisableDirectives {
         &self.disable_directives
     }
 }
@@ -202,7 +202,7 @@ impl<'a> ContextHost<'a> {
     }
 
     /// Shared reference to the [`DisableDirectives`] of the current script block.
-    pub fn disable_directives(&self) -> &DisableDirectives<'a> {
+    pub fn disable_directives(&self) -> &DisableDirectives {
         &self.current_sub_host().disable_directives
     }
 
@@ -309,7 +309,7 @@ impl<'a> ContextHost<'a> {
             "Unused eslint-enable directive (no matching eslint-disable directives were found).";
         for (rule_name, enable_comment_span) in self.disable_directives().unused_enable_comments() {
             unused_directive_diagnostics.push((
-                rule_name.map_or(Cow::Borrowed(message_for_enable), |name| {
+                rule_name.as_ref().map_or(Cow::Borrowed(message_for_enable), |name| {
                     Cow::Owned(format!(
                         "Unused eslint-enable directive (no matching eslint-disable directives were found for {name})."
                     ))

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -125,7 +125,7 @@ impl<'a> LintContext<'a> {
 
     /// List of all disable directives in the file being linted.
     #[inline]
-    pub fn disable_directives(&self) -> &DisableDirectives<'a> {
+    pub fn disable_directives(&self) -> &DisableDirectives {
         self.parent.disable_directives()
     }
 

--- a/crates/oxc_linter/src/rules/unicorn/no_abusive_eslint_disable.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_abusive_eslint_disable.rs
@@ -62,7 +62,7 @@ impl Rule for NoAbusiveEslintDisable {
                 }
                 RuleCommentType::Single(rules) => {
                     for rule in rules {
-                        if !is_valid_rule_name(rule.rule_name) {
+                        if !is_valid_rule_name(&rule.rule_name) {
                             ctx.diagnostic(no_abusive_eslint_disable_diagnostic(comment.span));
                         }
                     }


### PR DESCRIPTION
doing this obviously has a perf and memory implication. The alternative is that we have to keep the source text in memory until tsgolint has finished linting (and all source files must be in memory the whole time), which is a worse trade off. Now that disable directives struct owns the rule names we can drop the source text (reducing memory usage) while tsgolint runs