### PR TITLE
fix(language_server): Replace invalid LSP_MAX_INT ranges with zero ranges

### DIFF
--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -19,10 +19,6 @@ type ConcurrentHashMap<K, V> = papaya::HashMap<K, V, FxBuildHasher>;
 
 const OXC_CONFIG_FILE: &str = ".oxlintrc.json";
 
-// max range for LSP integer is 2^31 - 1
-// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#baseTypes
-const LSP_MAX_INT: u32 = 2u32.pow(31) - 1;
-
 #[tokio::main]
 async fn main() {
     env_logger::init();

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_invalid_syntax@debugger.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_invalid_syntax@debugger.ts.snap
@@ -8,7 +8,7 @@ file: fixtures/linter/invalid_syntax/debugger.ts
 code: ""
 code_description.href: "None"
 message: "Unexpected token"
-range: Range { start: Position { line: 2147483647, character: 2147483647 }, end: Position { line: 2147483647, character: 2147483647 } }
+range: Range { start: Position { line: 0, character: 0 }, end: Position { line: 0, character: 0 } }
 related_information: None
 severity: Some(Error)
 source: Some("oxc")


### PR DESCRIPTION
## Summary

Fixes "Range#create called with invalid arguments" error reported in oxc-project/coc-oxc#50

When diagnostics had no related span information, the language server was using `LSP_MAX_INT` (2147483647) as a fallback position, which is invalid for LSP ranges and caused editors to reject the diagnostic.

## Changes

- Changed the fallback range from `LSP_MAX_INT` to `(0, 0)` when no span information is available
- Removed unused `LSP_MAX_INT` constant
- Updated test snapshot to reflect the new valid range behavior

## Test Plan

- [x] All existing tests pass
- [x] Updated snapshot test confirms the fix works correctly
- The fix uses a zero range `(0, 0)` which is a standard practice for diagnostics without specific location information

Fixes oxc-project/coc-oxc#50

🤖 Generated with [Claude Code](https://claude.ai/code)