### PR TITLE
feat(compat): implement `Display` for `EngineTargets`

### DIFF
--- a/crates/oxc_compat/src/engine.rs
+++ b/crates/oxc_compat/src/engine.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, sync::OnceLock};
+use std::{fmt::Display, str::FromStr, sync::OnceLock};
 
 use browserslist::Version;
 use cow_utils::CowUtils;
@@ -76,6 +76,30 @@ impl FromStr for Engine {
     }
 }
 
+impl Display for Engine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            Self::Chrome => "chrome",
+            Self::Deno => "deno",
+            Self::Edge => "edge",
+            Self::Firefox => "firefox",
+            Self::Hermes => "hermes",
+            Self::Ie => "ie",
+            Self::Ios => "ios",
+            Self::Node => "node",
+            Self::Opera => "opera",
+            Self::Rhino => "rhino",
+            Self::Safari => "safari",
+            Self::Samsung => "samsung",
+            Self::Electron => "electron",
+            Self::OperaMobile => "opera_mobile",
+            Self::Android => "android",
+            Self::Es => "es",
+        };
+        f.write_str(name)
+    }
+}
+
 fn engines() -> &'static FxHashMap<&'static str, Engine> {
     static ENGINES: OnceLock<FxHashMap<&'static str, Engine>> = OnceLock::new();
     ENGINES.get_or_init(|| {
@@ -97,4 +121,33 @@ fn engines() -> &'static FxHashMap<&'static str, Engine> {
             ("android", Engine::Android),
         ])
     })
+}
+
+#[test]
+fn test_displayed_value_is_parsable() {
+    let engines = vec![
+        Engine::Chrome,
+        Engine::Deno,
+        Engine::Edge,
+        Engine::Firefox,
+        Engine::Hermes,
+        Engine::Ie,
+        Engine::Ios,
+        Engine::Node,
+        Engine::Opera,
+        Engine::Rhino,
+        Engine::Safari,
+        Engine::Samsung,
+        Engine::Electron,
+        Engine::OperaMobile,
+        Engine::Android,
+        Engine::Es,
+    ];
+    for engine in engines {
+        // Engine::ES is handled by `ESTarget`
+        if engine == Engine::Es {
+            continue;
+        }
+        assert!(engine.to_string().parse::<Engine>().is_ok(), "\"{engine}\" should be parsable");
+    }
 }

--- a/crates/oxc_compat/src/engine_targets.rs
+++ b/crates/oxc_compat/src/engine_targets.rs
@@ -1,5 +1,5 @@
 use std::{
-    fmt::Debug,
+    fmt::{Debug, Display},
     ops::{Deref, DerefMut},
     str::FromStr,
 };
@@ -33,6 +33,23 @@ impl Deref for EngineTargets {
 impl DerefMut for EngineTargets {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
+    }
+}
+
+impl Display for EngineTargets {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (idx, (engine, version)) in self.iter().enumerate() {
+            if idx > 0 {
+                f.write_str(",")?;
+            }
+            f.write_str(&engine.to_string())?;
+            if *engine == Engine::Es {
+                f.write_str(&version.0.to_string())?;
+            } else {
+                f.write_str(&version.to_string())?;
+            }
+        }
+        Ok(())
     }
 }
 
@@ -132,4 +149,16 @@ impl EngineTargets {
         engine_targets.insert(Engine::Es, es_target.unwrap_or(ESTarget::default()).version());
         Ok(engine_targets)
     }
+}
+
+#[test]
+fn test_displayed_value_is_parsable() {
+    let target = EngineTargets::new(FxHashMap::from_iter([
+        (Engine::Chrome, Version(139, 0, 0)),
+        (Engine::Deno, Version(2, 5, 1)),
+        (Engine::Es, Version(2024, 0, 0)),
+    ]));
+    let s = target.to_string();
+    let parsed = EngineTargets::from_target(&s).unwrap();
+    assert_eq!(target.0, parsed.0);
 }


### PR DESCRIPTION
Implemented `Display` for `EngineTargets` for this line in Rolldown
https://github.com/rolldown/rolldown/blob/64fb622e6f00b9b456945104a39bad786f77dc3f/crates/rolldown_binding/src/utils/minify_options_conversion.rs#L23