### PR TITLE
feat(npm/runtime): revert back to CJS

### DIFF
--- a/npm/runtime/package.json
+++ b/npm/runtime/package.json
@@ -12,7 +12,7 @@
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   },
-  "type": "module",
+  "type": "commonjs",
   "exports": {
     "./helpers/OverloadYield": [
       {


### PR DESCRIPTION
This package was originally designed for dual export with cjs entry. Keep it this way.