### PR TITLE
fix(linter): support let-chains in codegen node type detection

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -152,7 +152,8 @@ impl RuleRunner for crate::rules::eslint::no_bitwise::NoBitwise {
 }
 
 impl RuleRunner for crate::rules::eslint::no_caller::NoCaller {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::StaticMemberExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_case_declarations::NoCaseDeclarations {
@@ -273,7 +274,8 @@ impl RuleRunner for crate::rules::eslint::no_empty_pattern::NoEmptyPattern {
 }
 
 impl RuleRunner for crate::rules::eslint::no_empty_static_block::NoEmptyStaticBlock {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::StaticBlock]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_eq_null::NoEqNull {
@@ -386,7 +388,8 @@ impl RuleRunner for crate::rules::eslint::no_negated_condition::NoNegatedConditi
 }
 
 impl RuleRunner for crate::rules::eslint::no_nested_ternary::NoNestedTernary {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ConditionalExpression]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_new::NoNew {
@@ -613,7 +616,8 @@ impl RuleRunner for crate::rules::eslint::no_useless_rename::NoUselessRename {
 }
 
 impl RuleRunner for crate::rules::eslint::no_var::NoVar {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::VariableDeclaration]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_void::NoVoid {
@@ -693,7 +697,8 @@ impl RuleRunner for crate::rules::eslint::require_await::RequireAwait {
 }
 
 impl RuleRunner for crate::rules::eslint::require_yield::RequireYield {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Function]));
 }
 
 impl RuleRunner for crate::rules::eslint::sort_imports::SortImports {
@@ -1176,7 +1181,8 @@ impl RuleRunner for crate::rules::jsx_a11y::aria_props::AriaProps {
 }
 
 impl RuleRunner for crate::rules::jsx_a11y::aria_role::AriaRole {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXElement]));
 }
 
 impl RuleRunner for crate::rules::jsx_a11y::aria_unsupported_elements::AriaUnsupportedElements {
@@ -1384,7 +1390,8 @@ impl RuleRunner for crate::rules::nextjs::no_title_in_document_head::NoTitleInDo
 }
 
 impl RuleRunner for crate::rules::nextjs::no_typos::NoTypos {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ExportNamedDeclaration]));
 }
 
 impl RuleRunner for crate::rules::nextjs::no_unwanted_polyfillio::NoUnwantedPolyfillio {
@@ -1915,7 +1922,8 @@ impl RuleRunner for crate::rules::typescript::no_dynamic_delete::NoDynamicDelete
 }
 
 impl RuleRunner for crate::rules::typescript::no_empty_interface::NoEmptyInterface {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TSInterfaceDeclaration]));
 }
 
 impl RuleRunner for crate::rules::typescript::no_empty_object_type::NoEmptyObjectType {
@@ -2433,7 +2441,8 @@ impl RuleRunner
 }
 
 impl RuleRunner for crate::rules::unicorn::no_process_exit::NoProcessExit {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
 }
 
 impl RuleRunner


### PR DESCRIPTION
fixes the potential regression introduced by https://github.com/oxc-project/oxc/commit/c778cba9d5e828b7d021fe32297e798954e35575