### PR TITLE
fix(language_server): output correct position for parser & semantic errors

### DIFF
--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_invalid_syntax@debugger.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_invalid_syntax@debugger.ts.snap
@@ -8,8 +8,10 @@ file: fixtures/linter/invalid_syntax/debugger.ts
 code: ""
 code_description.href: "None"
 message: "Unexpected token"
-range: Range { start: Position { line: 2147483647, character: 2147483647 }, end: Position { line: 2147483647, character: 2147483647 } }
-related_information: None
+range: Range { start: Position { line: 0, character: 9 }, end: Position { line: 0, character: 10 } }
+related_information[0].message: ""
+related_information[0].location.uri: "file://<variable>/fixtures/linter/invalid_syntax/debugger.ts"
+related_information[0].location.range: Range { start: Position { line: 0, character: 9 }, end: Position { line: 0, character: 10 } }
 severity: Some(Error)
 source: Some("oxc")
 tags: None


### PR DESCRIPTION
see https://github.com/oxc-project/coc-oxc/issues/50 

The "real" error should still be on the editor side.