### PR TITLE
refactor(napi/parser): freeze `visitorKeys` export

### DIFF
--- a/napi/parser/generated/visit/keys.mjs
+++ b/napi/parser/generated/visit/keys.mjs
@@ -1,7 +1,7 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/estree_visit.rs`.
 
-export default {
+export default Object.freeze({
   // Leaf nodes
   DebuggerStatement: [],
   EmptyStatement: [],
@@ -169,4 +169,4 @@ export default {
   TSTypeQuery: ['exprName', 'typeArguments'],
   TSTypeReference: ['typeName', 'typeArguments'],
   TSUnionType: ['types'],
-};
+});

--- a/tasks/ast_tools/src/generators/estree_visit.rs
+++ b/tasks/ast_tools/src/generators/estree_visit.rs
@@ -170,7 +170,7 @@ fn generate(codegen: &Codegen) -> Codes {
 
     #[rustfmt::skip]
     let mut visitor_keys = string!("
-        export default {
+        export default Object.freeze({
             // Leaf nodes
     ");
 
@@ -299,7 +299,7 @@ fn generate(codegen: &Codegen) -> Codes {
         {walk_fns}
     ");
 
-    visitor_keys.push_str("};");
+    visitor_keys.push_str("});");
 
     let nodes_count = nodes.len();
     let leaf_nodes_count = leaf_nodes_count.unwrap();


### PR DESCRIPTION
Freeze `visitorKeys` which `oxc-parser` exports. This follows TS-ESLint, and will be useful for `oxlint`.