### PR TITLE
fix(parser): forbid accessors named `constructor`

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -307,6 +307,11 @@ pub fn optional_accessor_property(span: Span) -> OxcDiagnostic {
 }
 
 #[cold]
+pub fn constructor_accessor(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Classes may not have a field named 'constructor'").with_label(span)
+}
+
+#[cold]
 pub fn optional_definite_property(span: Span) -> OxcDiagnostic {
     // NOTE: could not find an error code when tsc parses this; its parser panics.
     OxcDiagnostic::error("A property cannot be both optional and definite.")

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::{Box, Vec};
 use oxc_ast::ast::*;
 use oxc_ecmascript::PropName;
-use oxc_span::Span;
+use oxc_span::{GetSpan, Span};
 
 use crate::{
     Context, ParserImpl, StatementContext, diagnostics,
@@ -521,6 +521,9 @@ impl<'a> ParserImpl<'a> {
         if modifiers.contains(ModifierKind::Accessor) {
             if let Some(optional_span) = optional_span {
                 self.error(diagnostics::optional_accessor_property(optional_span));
+            }
+            if name.is_specific_string_literal("constructor") && !computed {
+                self.error(diagnostics::constructor_accessor(name.span()));
             }
             return self.parse_class_accessor_property(
                 span, name, computed, definite, modifiers, decorators,

--- a/tasks/coverage/misc/fail/oxc-14014.ts
+++ b/tasks/coverage/misc/fail/oxc-14014.ts
@@ -1,0 +1,6 @@
+class Bar {
+  accessor 'constructor'
+}
+abstract class Baz {
+  accessor 'constructor'
+}

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 49/49 (100.00%)
 Positive Passed: 49/49 (100.00%)
-Negative Passed: 90/90 (100.00%)
+Negative Passed: 91/91 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -2849,6 +2849,22 @@ Negative Passed: 90/90 (100.00%)
    ╭─[misc/fail/oxc-13617-4.ts:1:15]
  1 │ const foo: Foo<> = 1
    ·               ──
+   ╰────
+
+  × Classes may not have a field named 'constructor'
+   ╭─[misc/fail/oxc-14014.ts:2:12]
+ 1 │ class Bar {
+ 2 │   accessor 'constructor'
+   ·            ─────────────
+ 3 │ }
+   ╰────
+
+  × Classes may not have a field named 'constructor'
+   ╭─[misc/fail/oxc-14014.ts:5:12]
+ 4 │ abstract class Baz {
+ 5 │   accessor 'constructor'
+   ·            ─────────────
+ 6 │ }
    ╰────
 
   × Unexpected token


### PR DESCRIPTION
Re-creation of #14015. Closes #14014.