### PR TITLE
feat(mangler): mangle private class members

### DIFF
--- a/crates/oxc/src/compiler.rs
+++ b/crates/oxc/src/compiler.rs
@@ -5,7 +5,7 @@ use oxc_ast::ast::Program;
 use oxc_codegen::{Codegen, CodegenOptions, CodegenReturn};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_isolated_declarations::{IsolatedDeclarations, IsolatedDeclarationsOptions};
-use oxc_mangler::{MangleOptions, Mangler};
+use oxc_mangler::{MangleOptions, Mangler, ManglerReturn};
 use oxc_minifier::{CompressOptions, Compressor};
 use oxc_parser::{ParseOptions, Parser, ParserReturn};
 use oxc_semantic::{Scoping, SemanticBuilder, SemanticBuilderReturn};
@@ -282,7 +282,7 @@ pub trait CompilerInterface {
         Compressor::new(allocator).build(program, options);
     }
 
-    fn mangle(&self, program: &mut Program<'_>, options: MangleOptions) -> Scoping {
+    fn mangle(&self, program: &mut Program<'_>, options: MangleOptions) -> ManglerReturn {
         Mangler::new().with_options(options).build(program)
     }
 
@@ -290,13 +290,20 @@ pub trait CompilerInterface {
         &self,
         program: &Program<'_>,
         source_path: &Path,
-        scoping: Option<Scoping>,
+        mangler_return: Option<ManglerReturn>,
         options: CodegenOptions,
     ) -> CodegenReturn {
         let mut options = options;
         if self.enable_sourcemap() {
             options.source_map_path = Some(source_path.to_path_buf());
         }
-        Codegen::new().with_options(options).with_scoping(scoping).build(program)
+        let (scoping, class_private_mappings) = mangler_return
+            .map(|m| (Some(m.scoping), Some(m.class_private_mappings)))
+            .unwrap_or_default();
+        Codegen::new()
+            .with_options(options)
+            .with_scoping(scoping)
+            .with_private_member_mappings(class_private_mappings)
+            .build(program)
     }
 }

--- a/crates/oxc_minifier/examples/mangler.rs
+++ b/crates/oxc_minifier/examples/mangler.rs
@@ -62,6 +62,10 @@ fn main() -> std::io::Result<()> {
 fn mangler(source_text: &str, source_type: SourceType, options: MangleOptions) -> String {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
-    let symbol_table = Mangler::new().with_options(options).build(&ret.program);
-    Codegen::new().with_scoping(Some(symbol_table)).build(&ret.program).code
+    let mangler_return = Mangler::new().with_options(options).build(&ret.program);
+    Codegen::new()
+        .with_scoping(Some(mangler_return.scoping))
+        .with_private_member_mappings(Some(mangler_return.class_private_mappings))
+        .build(&ret.program)
+        .code
 }

--- a/crates/oxc_minifier/tests/mangler/snapshots/private_member_mangling.snap
+++ b/crates/oxc_minifier/tests/mangler/snapshots/private_member_mangling.snap
@@ -1,0 +1,84 @@
+---
+source: crates/oxc_minifier/tests/mangler/mod.rs
+---
+class Foo { #privateField = 1; method() { return this.#privateField; } }
+class Foo {
+	#e = 1;
+	method() {
+		return this.#e;
+	}
+}
+
+class Foo { #a = 1; #b = 2; method() { return this.#a + this.#b; } }
+class Foo {
+	#e = 1;
+	#t = 2;
+	method() {
+		return this.#e + this.#t;
+	}
+}
+
+class Foo { #method() { return 1; } publicMethod() { return this.#method(); } }
+class Foo {
+	#e() {
+		return 1;
+	}
+	publicMethod() {
+		return this.#e();
+	}
+}
+
+class Foo { #field; #method() { return this.#field; } get() { return this.#method(); } }
+class Foo {
+	#e;
+	#t() {
+		return this.#e;
+	}
+	get() {
+		return this.#t();
+	}
+}
+
+class Foo { #x; check() { return #x in this; } }
+class Foo {
+	#e;
+	check() {
+		return #e in this;
+	}
+}
+
+class Outer { #outerField = 1; inner() { return class Inner { #innerField = 2; get() { return this.#innerField; } }; } }
+class Outer {
+	#e = 1;
+	inner() {
+		return class e {
+			#e = 2;
+			get() {
+				return this.#e;
+			}
+		};
+	}
+}
+
+class Foo { publicField = 1; #privateField = 2; getSum() { return this.publicField + this.#privateField; } }
+class Foo {
+	publicField = 1;
+	#e = 2;
+	getSum() {
+		return this.publicField + this.#e;
+	}
+}
+
+class A { #field = 1; #method() { return this.#field; } } class B { #field = 2; #method() { return this.#field; } }
+class A {
+	#e = 1;
+	#t() {
+		return this.#e;
+	}
+}
+class B {
+	#e = 2;
+	#t() {
+		return this.#e;
+	}
+}


### PR DESCRIPTION
Mangle private class members. For example, transform
```js
class C {
  #foo = 0;
  #bar() {}
}
```
to
```js
class C {
  #e = 0;
  #t() {}
}
```
.

The private members for each classes are collected from `semantic.classes()`. The renaming happens in the codegen. This way we don't need additional traverse.