### PR TITLE
perf(minifier): use oxc_data_structures::stack::Stack for ClassSymbolsStack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2120,6 +2120,7 @@ dependencies = [
  "oxc_ast_visit",
  "oxc_codegen",
  "oxc_compat",
+ "oxc_data_structures",
  "oxc_ecmascript",
  "oxc_mangler",
  "oxc_parser",

--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -26,6 +26,7 @@ oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_codegen = { workspace = true }
 oxc_compat = { workspace = true }
+oxc_data_structures = { workspace = true, features = ["stack"] }
 oxc_ecmascript = { workspace = true }
 oxc_mangler = { workspace = true }
 oxc_parser = { workspace = true }

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -124,7 +124,7 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
                 ctx.scoping_mut().delete_reference(*reference_id_to_remove);
             }
         }
-        debug_assert!(ctx.state.class_symbols_stack.is_empty());
+        debug_assert!(ctx.state.class_symbols_stack.is_exhausted());
     }
 
     fn exit_statements(&mut self, stmts: &mut Vec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {

--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -4,11 +4,11 @@ checker.ts                 | 2.92 MB        ||          84074 |          14190 |
 
 cal.com.tsx                | 1.06 MB        ||          40526 |           3033 ||          37074 |           4733 | 1.654 MB      
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             82 |              8 ||             30 |              6 | 992 B         
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             83 |              8 ||             30 |              6 | 992 B         
 
 pdf.mjs                    | 567.30 kB      ||          19823 |           2900 ||          47400 |           7781 | 1.624 MB      
 
-antd.js                    | 6.69 MB        ||          99854 |          13518 ||         331725 |          70117 | 17.407 MB     
+antd.js                    | 6.69 MB        ||          99855 |          13518 ||         331725 |          70117 | 17.407 MB     
 
-binder.ts                  | 193.08 kB      ||           4768 |            974 ||           7059 |            834 | 201.192 kB    
+binder.ts                  | 193.08 kB      ||           4769 |            974 ||           7059 |            834 | 201.192 kB    
 


### PR DESCRIPTION
Changed `ClassSymbolsStack` to `Stack` from normal `Vec`.