### PR TITLE
style(linter): import `Serialize` at top level

### DIFF
--- a/apps/oxlint/src/output_formatter/gitlab.rs
+++ b/apps/oxlint/src/output_formatter/gitlab.rs
@@ -1,5 +1,7 @@
 use std::hash::{DefaultHasher, Hash, Hasher};
 
+use serde::Serialize;
+
 use oxc_diagnostics::{
     Error, Severity,
     reporter::{DiagnosticReporter, DiagnosticResult, Info},
@@ -10,19 +12,19 @@ use crate::output_formatter::InternalFormatter;
 #[derive(Debug, Default)]
 pub struct GitlabOutputFormatter;
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, Serialize)]
 struct GitlabErrorLocationLinesJson {
     begin: usize,
     end: usize,
 }
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, Serialize)]
 struct GitlabErrorLocationJson {
     path: String,
     lines: GitlabErrorLocationLinesJson,
 }
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, Serialize)]
 struct GitlabErrorJson {
     description: String,
     check_name: String,

--- a/apps/oxlint/src/output_formatter/json.rs
+++ b/apps/oxlint/src/output_formatter/json.rs
@@ -1,13 +1,13 @@
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::{cell::RefCell, rc::Rc};
+
+use miette::JSONReportHandler;
+use serde::Serialize;
 
 use oxc_diagnostics::{
     Error,
     reporter::{DiagnosticReporter, DiagnosticResult},
 };
 use oxc_linter::{RuleCategory, rules::RULES};
-
-use miette::JSONReportHandler;
 
 use crate::output_formatter::InternalFormatter;
 
@@ -18,7 +18,7 @@ pub struct JsonOutputFormatter {
 
 impl InternalFormatter for JsonOutputFormatter {
     fn all_rules(&self) -> Option<String> {
-        #[derive(Debug, serde::Serialize)]
+        #[derive(Debug, Serialize)]
         struct RuleInfoJson<'a> {
             scope: &'a str,
             value: &'a str,


### PR DESCRIPTION
Pure code style change. Import `Serialize` at top level, to reduce repeated code.