### PR TITLE
perf(linter/plugins): flatten `LintFileResult` fields

### DIFF
--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -11,7 +11,8 @@ interface Diagnostic {
 // Diagnostic in form sent to Rust
 interface DiagnosticReport {
   message: string;
-  loc: { start: number; end: number };
+  start: number;
+  end: number;
   ruleIndex: number;
 }
 
@@ -115,9 +116,12 @@ export class Context {
    */
   report(diagnostic: Diagnostic): void {
     const { ruleIndex } = getInternal(this, 'report errors');
+    // TODO: Validate `diagnostic`
+    const { node } = diagnostic;
     diagnostics.push({
       message: diagnostic.message,
-      loc: { start: diagnostic.node.start, end: diagnostic.node.end },
+      start: node.start,
+      end: node.end,
       ruleIndex,
     });
   }

--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -29,11 +29,6 @@ pub enum PluginLoadResult {
 pub struct LintFileResult {
     pub rule_index: u32,
     pub message: String,
-    pub loc: Loc,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct Loc {
     pub start: u32,
     pub end: u32,
 }

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -408,7 +408,7 @@ impl Linter {
             Ok(diagnostics) => {
                 for diagnostic in diagnostics {
                     // Convert UTF-16 offsets back to UTF-8
-                    let mut span = Span::new(diagnostic.loc.start, diagnostic.loc.end);
+                    let mut span = Span::new(diagnostic.start, diagnostic.end);
                     span_converter.convert_span_back(&mut span);
 
                     let (external_rule_id, severity) =


### PR DESCRIPTION
Small perf optimization. Make `start` and `end` fields of `LintFileResult`, and remove intermediate struct `Loc`. This makes these objects cheaper to construct on JS side, and faster to deserialize.