### PR TITLE
build(linter): build `oxlint` locally with Mimalloc in release mode

### DIFF
--- a/.github/workflows/release_oxlint.yml
+++ b/.github/workflows/release_oxlint.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Build oxlint
         working-directory: apps/oxlint
-        run: ${{ matrix.build-oxlint }} --features allocator
+        run: ${{ matrix.build-oxlint }}
         shell: bash
         env:
           TARGET_CC: clang # for mimalloc

--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -10,7 +10,7 @@
     "build-test": "pnpm run build-napi-test && pnpm run build-js",
     "build-napi": "napi build --esm --platform --js ./bindings.js --dts ./bindings.d.ts --output-dir src-js --no-dts-cache",
     "build-napi-test": "pnpm run build-napi --features force_test_reporter",
-    "build-napi-release": "pnpm run build-napi --release",
+    "build-napi-release": "pnpm run build-napi --release --features allocator",
     "build-js": "node scripts/build.js",
     "test": "tsc && vitest --dir ./test run"
   },


### PR DESCRIPTION
Previously we built `oxlint` with Mimalloc enabled (`--features allocator`) when creating a public release, but we didn't enable Mimalloc in local release builds.

That's not ideal, as we often build in release mode locally to benchmark `oxlint`'s perf on large repos e.g. VS Code.

Always enable Mimalloc when building `oxlint` in release mode.
