### PR TITLE
fix(tools): fix `just oxlint` and `just watch-oxlint`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,9 +11,6 @@ allocs = "run -p oxc_track_memory_allocations --profile coverage --"
 rule = "run -p rulegen"
 lintgen = "run -p oxc_linter_codegen"
 
-# Build oxlint in release mode
-oxlint = "build --release -p oxlint --bin oxlint --features allocator"
-
 # Fix napi breaking in test environment <https://github.com/napi-rs/napi-rs/issues/1005#issuecomment-1011034770>
 # To be able to run unit tests on macOS, support compilation to 'x86_64-apple-darwin'.
 [target.'cfg(target_vendor = "apple")']

--- a/justfile
+++ b/justfile
@@ -140,10 +140,10 @@ ast:
 
 # Build oxlint in release build
 oxlint:
-  cargo oxlint
+  pnpm -C apps/oxlint run build
 
 watch-oxlint *args='':
-  just watch 'cargo run -p oxlint -- --disable-nested-config {{args}}'
+  just watch 'node apps/oxlint/dist/cli.js --disable-nested-config {{args}}'
 
 # Create a new lint rule for any plugin
 new-rule name plugin='eslint':


### PR DESCRIPTION
Fix `just oxlint` and `just watch-oxlint`. They were broken because `oxlint` is now a NAPI package.

Remove `cargo oxlint` command, because `oxlint` needs to be built with NAPI-RS now.
