### PR TITLE
refactor(napi): move scripts into `scripts` directory

### DIFF
--- a/napi/minify/package.json
+++ b/napi/minify/package.json
@@ -8,7 +8,7 @@
     "build-dev": "napi build --esm --platform",
     "build-test": "pnpm run build-dev",
     "build": "pnpm run build-dev --features allocator --release",
-    "postbuild-dev": "node patch.mjs",
+    "postbuild-dev": "node scripts/patch.js",
     "test": "tsc && vitest run --dir ./test"
   },
   "engines": {

--- a/napi/minify/scripts/patch.js
+++ b/napi/minify/scripts/patch.js
@@ -1,7 +1,9 @@
 import fs from 'node:fs';
+import { join as pathJoin } from 'node:path';
 
-const filename = './index.js';
-let data = fs.readFileSync(filename, 'utf-8');
+const path = pathJoin(import.meta.dirname, '../index.js');
+
+let data = fs.readFileSync(path, 'utf-8');
 data = data.replace(
   '\nif (!nativeBinding) {',
   (s) =>
@@ -15,4 +17,4 @@ if (!nativeBinding && globalThis.process?.versions?.["webcontainer"]) {
 }
 ` + s,
 );
-fs.writeFileSync(filename, data);
+fs.writeFileSync(path, data);

--- a/napi/parser/src-js/wrap.js
+++ b/napi/parser/src-js/wrap.js
@@ -20,7 +20,7 @@ export function wrap(result) {
   };
 }
 
-// Used by `napi/playground/patch.mjs`.
+// Used by `napi/playground/scripts/patch.js`.
 //
 // Set `value` field of `Literal`s which are `BigInt`s or `RegExp`s.
 //

--- a/napi/playground/package.json
+++ b/napi/playground/package.json
@@ -14,8 +14,8 @@
   },
   "scripts": {
     "build-test": "echo 'Skipped because there are no tests.'",
-    "build-dev": "pnpm run build:napi && node patch.mjs",
-    "build": "pnpm run build:napi --release && node patch.mjs",
+    "build-dev": "pnpm run build:napi && node scripts/patch.js",
+    "build": "pnpm run build:napi --release && node scripts/patch.js",
     "build:napi": "napi build --platform --esm --target wasm32-wasip1-threads"
   },
   "dependencies": {

--- a/napi/playground/scripts/patch.js
+++ b/napi/playground/scripts/patch.js
@@ -1,7 +1,9 @@
 import fs from 'node:fs';
+import { join as pathJoin } from 'node:path';
 
-const filename = './playground.wasi-browser.js';
-let data = fs.readFileSync(filename, 'utf-8');
+const path = pathJoin(import.meta.dirname, '../playground.wasi-browser.js');
+
+let data = fs.readFileSync(path, 'utf-8');
 data = data.replace(
   `export const Oxc = __napiModule.exports.Oxc`,
   `
@@ -24,4 +26,4 @@ export function Oxc() {
 }
 `,
 );
-fs.writeFileSync(filename, data);
+fs.writeFileSync(path, data);

--- a/napi/transform/package.json
+++ b/napi/transform/package.json
@@ -8,7 +8,7 @@
     "build-dev": "napi build --esm --platform",
     "build-test": "pnpm run build-dev",
     "build": "pnpm run build-dev --features allocator --release",
-    "postbuild-dev": "node patch.mjs",
+    "postbuild-dev": "node scripts/patch.js",
     "test": "tsc && vitest run --dir ./test"
   },
   "engines": {

--- a/napi/transform/scripts/patch.js
+++ b/napi/transform/scripts/patch.js
@@ -1,7 +1,9 @@
 import fs from 'node:fs';
+import { join as pathJoin } from 'node:path';
 
-const filename = './index.js';
-let data = fs.readFileSync(filename, 'utf-8');
+const path = pathJoin(import.meta.dirname, '../index.js');
+
+let data = fs.readFileSync(path, 'utf-8');
 data = data.replace(
   '\nif (!nativeBinding) {',
   (s) =>
@@ -15,4 +17,4 @@ if (!nativeBinding && globalThis.process?.versions?.["webcontainer"]) {
 }
 ` + s,
 );
-fs.writeFileSync(filename, data);
+fs.writeFileSync(path, data);


### PR DESCRIPTION
Move all build scripts in `napi` packages into a `scripts` dir. These packages don't have root directories with tons of files like `napi/parser` and `apps/oxlint` do, but IMO it's preferable to have a consistent directory structure in all NAPI packages.

Also, rename these scripts from `.mjs` to `.js`, since these packages are ESM.
