### PR TITLE
refactor(linter): rename `LintRunner` to `CliRunner`

### DIFF
--- a/apps/oxlint/src/lib.rs
+++ b/apps/oxlint/src/lib.rs
@@ -12,7 +12,7 @@ mod tester;
 
 /// Re-exported CLI-related items for use in `tasks/website`.
 pub mod cli {
-    pub use super::{command::*, lint::LintRunner, result::CliRunResult};
+    pub use super::{command::*, lint::CliRunner, result::CliRunResult};
 }
 
 // Only include code to run linter when the `napi` feature is enabled.

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -28,13 +28,13 @@ use crate::{
 use oxc_linter::LintIgnoreMatcher;
 
 #[derive(Debug)]
-pub struct LintRunner {
+pub struct CliRunner {
     options: LintCommand,
     cwd: PathBuf,
     external_linter: Option<ExternalLinter>,
 }
 
-impl LintRunner {
+impl CliRunner {
     pub(crate) fn new(options: LintCommand, external_linter: Option<ExternalLinter>) -> Self {
         Self {
             options,
@@ -411,7 +411,7 @@ impl LintRunner {
     }
 }
 
-impl LintRunner {
+impl CliRunner {
     const DEFAULT_OXLINTRC: &'static str = ".oxlintrc.json";
 
     #[must_use]
@@ -618,7 +618,7 @@ fn render_report(handler: &GraphicalReportHandler, diagnostic: &OxcDiagnostic) -
 mod test {
     use std::{fs, path::PathBuf};
 
-    use super::LintRunner;
+    use super::CliRunner;
     use crate::tester::Tester;
 
     // lints the full directory of fixtures,
@@ -988,14 +988,14 @@ mod test {
 
     #[test]
     fn test_init_config() {
-        assert!(!fs::exists(LintRunner::DEFAULT_OXLINTRC).unwrap());
+        assert!(!fs::exists(CliRunner::DEFAULT_OXLINTRC).unwrap());
 
         let args = &["--init"];
         Tester::new().with_cwd("fixtures".into()).test(args);
 
-        assert!(fs::exists(LintRunner::DEFAULT_OXLINTRC).unwrap());
+        assert!(fs::exists(CliRunner::DEFAULT_OXLINTRC).unwrap());
 
-        fs::remove_file(LintRunner::DEFAULT_OXLINTRC).unwrap();
+        fs::remove_file(CliRunner::DEFAULT_OXLINTRC).unwrap();
     }
 
     #[test]
@@ -1190,17 +1190,17 @@ mod test {
 
         // Test case 1: Invalid path that should fail
         let invalid_config = PathBuf::from("child/../../fixtures/linter/eslintrc.json");
-        let result = LintRunner::find_oxlint_config(&cwd, Some(&invalid_config));
+        let result = CliRunner::find_oxlint_config(&cwd, Some(&invalid_config));
         assert!(result.is_err(), "Expected config lookup to fail with invalid path");
 
         // Test case 2: Valid path that should pass
         let valid_config = PathBuf::from("fixtures/linter/eslintrc.json");
-        let result = LintRunner::find_oxlint_config(&cwd, Some(&valid_config));
+        let result = CliRunner::find_oxlint_config(&cwd, Some(&valid_config));
         assert!(result.is_ok(), "Expected config lookup to succeed with valid path");
 
         // Test case 3: Valid path using parent directory (..) syntax that should pass
         let valid_parent_config = PathBuf::from("fixtures/linter/../linter/eslintrc.json");
-        let result = LintRunner::find_oxlint_config(&cwd, Some(&valid_parent_config));
+        let result = CliRunner::find_oxlint_config(&cwd, Some(&valid_parent_config));
         assert!(result.is_ok(), "Expected config lookup to succeed with parent directory syntax");
 
         // Verify the resolved path is correct

--- a/apps/oxlint/src/run.rs
+++ b/apps/oxlint/src/run.rs
@@ -10,7 +10,7 @@ use napi::{
 };
 use napi_derive::napi;
 
-use crate::{lint::LintRunner, result::CliRunResult};
+use crate::{lint::CliRunner, result::CliRunResult};
 
 /// JS callback to load a JS plugin.
 #[napi]
@@ -113,7 +113,7 @@ fn lint_impl(load_plugin: JsLoadPluginCb, lint_file: JsLintFileCb) -> CliRunResu
     // See `https://github.com/rust-lang/rust/issues/60673`.
     let mut stdout = BufWriter::new(std::io::stdout());
 
-    LintRunner::new(command, external_linter).run(&mut stdout)
+    CliRunner::new(command, external_linter).run(&mut stdout)
 }
 
 /// Initialize the data which relies on `is_atty` system calls so they don't block subsequent threads.

--- a/apps/oxlint/src/tester.rs
+++ b/apps/oxlint/src/tester.rs
@@ -3,7 +3,7 @@ use std::{env, path::PathBuf};
 use cow_utils::CowUtils;
 use lazy_regex::Regex;
 
-use crate::cli::{LintRunner, lint_command};
+use crate::cli::{CliRunner, lint_command};
 
 pub struct Tester {
     cwd: PathBuf,
@@ -32,7 +32,7 @@ impl Tester {
 
         let options = lint_command().run_inner(new_args.as_slice()).unwrap();
         let mut output = Vec::new();
-        let _ = LintRunner::new(options, None).with_cwd(self.cwd.clone()).run(&mut output);
+        let _ = CliRunner::new(options, None).with_cwd(self.cwd.clone()).run(&mut output);
     }
 
     pub fn test_fix(file: &str, before: &str, after: &str) {
@@ -78,7 +78,7 @@ impl Tester {
                 format!("working directory: {}\n", relative_dir.to_str().unwrap()).as_bytes(),
             );
             output.extend_from_slice(b"----------\n");
-            let result = LintRunner::new(options, None).with_cwd(self.cwd.clone()).run(&mut output);
+            let result = CliRunner::new(options, None).with_cwd(self.cwd.clone()).run(&mut output);
 
             output.extend_from_slice(b"----------\n");
             output.extend_from_slice(format!("CLI result: {result:?}\n").as_bytes());


### PR DESCRIPTION
This commit renames `LintRunner` to `CliRunner` . This change is being made in preparation for introducing a new `LintRunner` component in the future. 



In future, `LintRunner`​ (living in `oxc_linter`​) will handle the tsgolint/oxlint coordination (and state storage between the two phases)