### PR TITLE
refactor(ci): remove dead code from benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,6 @@ on:
       - "Cargo.lock"
       - "rust-toolchain.toml"
       - ".github/workflows/benchmark.yml"
-      - "tasks/benchmark/codspeed/*.mjs"
   push:
     branches:
       - main
@@ -30,7 +29,6 @@ on:
       - "Cargo.lock"
       - "rust-toolchain.toml"
       - ".github/workflows/benchmark.yml"
-      - "tasks/benchmark/codspeed/*.mjs"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}


### PR DESCRIPTION
The files `tasks/benchmark/codspeed/*.mjs` no longer exist. Remove these lines from the workflow.