### PR TITLE
fix(language_server): use the first Span of the message as the primary Diagnostic range

### DIFF
--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -19,10 +19,6 @@ type ConcurrentHashMap<K, V> = papaya::HashMap<K, V, FxBuildHasher>;
 
 const OXC_CONFIG_FILE: &str = ".oxlintrc.json";
 
-// max range for LSP integer is 2^31 - 1
-// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#baseTypes
-const LSP_MAX_INT: u32 = 2u32.pow(31) - 1;
-
 #[tokio::main]
 async fn main() {
     env_logger::init();

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_issue_9958@issue.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_issue_9958@issue.ts.snap
@@ -56,7 +56,7 @@ fixed: Multiple(
 code: "typescript-eslint(no-non-null-asserted-optional-chain)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-non-null-asserted-optional-chain.html"
 message: "Optional chain expressions can return undefined by design: using a non-null assertion is unsafe and wrong.\nhelp: Remove the non-null assertion."
-range: Range { start: Position { line: 11, character: 18 }, end: Position { line: 11, character: 19 } }
+range: Range { start: Position { line: 11, character: 21 }, end: Position { line: 11, character: 22 } }
 related_information[0].message: "non-null assertion made after optional chain"
 related_information[0].location.uri: "file://<variable>/fixtures/linter/issue_9958/issue.ts"
 related_information[0].location.range: Range { start: Position { line: 11, character: 21 }, end: Position { line: 11, character: 22 } }
@@ -106,11 +106,11 @@ fixed: Multiple(
 
 code: "None"
 code_description.href: "None"
-message: "non-null assertion made after optional chain"
-range: Range { start: Position { line: 11, character: 21 }, end: Position { line: 11, character: 22 } }
+message: "optional chain used"
+range: Range { start: Position { line: 11, character: 18 }, end: Position { line: 11, character: 19 } }
 related_information[0].message: "original diagnostic"
 related_information[0].location.uri: "file://<variable>/fixtures/linter/issue_9958/issue.ts"
-related_information[0].location.range: Range { start: Position { line: 11, character: 18 }, end: Position { line: 11, character: 19 } }
+related_information[0].location.range: Range { start: Position { line: 11, character: 21 }, end: Position { line: 11, character: 22 } }
 severity: Some(Hint)
 source: Some("oxc")
 tags: None

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -88,7 +88,7 @@ use crate::{
 
 #[cfg(feature = "language_server")]
 pub use crate::lsp::{
-    FixWithPosition, MessageWithPosition, PossibleFixesWithPosition,
+    FixWithPosition, MessageWithPosition, PossibleFixesWithPosition, SpanPositionMessage,
     oxc_diagnostic_to_message_with_position,
 };
 

--- a/crates/oxc_linter/src/lsp.rs
+++ b/crates/oxc_linter/src/lsp.rs
@@ -20,6 +20,7 @@ impl<'a> SpanPositionMessage<'a> {
         Self { start, end, message: None }
     }
 
+    #[must_use]
     pub fn with_message(mut self, message: Option<Cow<'a, str>>) -> Self {
         self.message = message;
         self
@@ -38,7 +39,7 @@ impl<'a> SpanPositionMessage<'a> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct SpanPosition {
     pub line: u32,
     pub character: u32,


### PR DESCRIPTION
This PR aligns the main label/span with `oxlint`.
`oxlint` will use the first available span as the error. The LSP should use this span for the red line.

```
let a: {
  b?: {
    c: number;
  };
} = {};

for(var i = 0; i < 10; i--){}
console.log(a?.b?.c!);
```

Note that `file.ts:7:16` means the line/column number and is linkable.

```
  ⚠ eslint(for-direction): The update clause in this loop moves the variable in the wrong direction
   ╭─[for_direction.ts:7:16]
 6 │ 
 7 │ for(var i = 0; i < 10; i--){}
   ·                ───┬──  ─┬─
   ·                   │     ╰── with this update
   ·                   ╰── This test moves in the wrong direction
 8 │ console.log(a?.b?.c!);
   ╰────
  help: Use while loop for intended infinite loop

  ⚠ typescript-eslint(no-non-null-asserted-optional-chain): Optional chain expressions can return undefined by design: using a non-null assertion is unsafe and wrong.
   ╭─[for_direction.ts:8:20]
 7 │ for(var i = 0; i < 10; i--){}
 8 │ console.log(a?.b?.c!);
   ·                 ┬  ┬
   ·                 │  ╰── non-null assertion made after optional chain
   ·                 ╰── optional chain used
 9 │ 
   ╰────
  help: Remove the non-null assertion.
```

https://github.com/oxc-project/oxc/blob/main/crates/oxc_language_server/fixtures/linter/issue_9958/issue.ts

Main:
<img width="258" height="88" alt="grafik" src="https://github.com/user-attachments/assets/7da86f38-9789-4e04-b08b-18aa783a93ed" />

This PR:
<img width="265" height="108" alt="grafik" src="https://github.com/user-attachments/assets/2a031f84-04c3-49a8-8409-a3b1822c55a5" />
