### PR TITLE
perf(language_server): avoid cloning on message conversion

### DIFF
--- a/crates/oxc_diagnostics/src/lib.rs
+++ b/crates/oxc_diagnostics/src/lib.rs
@@ -338,4 +338,9 @@ impl OxcDiagnostic {
     pub fn with_source_code<T: SourceCode + Send + Sync + 'static>(self, code: T) -> Error {
         Error::from(self).with_source_code(code)
     }
+
+    /// Consumes the diagnostic and returns the inner owned data.
+    pub fn inner_owned(self) -> OxcDiagnosticInner {
+        *self.inner
+    }
 }

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -729,7 +729,7 @@ impl Runtime {
                                         messages.lock().unwrap().extend(
                                             diagnostics.into_iter().map(|diagnostic| {
                                                 oxc_diagnostic_to_message_with_position(
-                                                    &diagnostic,
+                                                    diagnostic,
                                                     source_text,
                                                     rope,
                                                 )
@@ -754,7 +754,7 @@ impl Runtime {
                         messages.lock().unwrap().extend(section_messages.iter().map(|message| {
                             let message = message_cloner.clone_message(message);
 
-                            message_to_message_with_position(&message, source_text, rope)
+                            message_to_message_with_position(message, source_text, rope)
                         }));
                     },
                 );

--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -383,7 +383,7 @@ impl TsGoLintState {
 
                                             let mut message_with_position: MessageWithPosition<'_> =
                                                 message_to_message_with_position(
-                                                    &Message::from_tsgo_lint_diagnostic(
+                                                    Message::from_tsgo_lint_diagnostic(
                                                         tsgolint_diagnostic,
                                                         &source_text,
                                                     ),


### PR DESCRIPTION
Tested it with one `no-debugger` rule on a file (100 times).

Main:
```
heaptrack stats:
        allocations:            172985
        leaked allocations:     580
        temporary allocations:  53112
```

This PR:

```
heaptrack stats:
        allocations:            170985
        leaked allocations:     580
        temporary allocations:  53111
```