### PR TITLE
test(linter/plugins): align ESLint plugin with Oxlint

### DIFF
--- a/apps/oxlint/test/__snapshots__/eslint-compat.test.ts.snap
+++ b/apps/oxlint/test/__snapshots__/eslint-compat.test.ts.snap
@@ -4,43 +4,43 @@ exports[`ESLint compatibility > \`defineRule\` + \`definePlugin\` should work 1`
 "
 <root>/apps/oxlint/test/fixtures/define/files/1.js
   0:1  error  create body:
-this === rule: true                       testPlugin/create
+this === rule: true                       define-rule-plugin/create
   0:1  error  before hook:
 this === rule: true
-filename: files/1.js  testPlugin/create-once
+filename: files/1.js  define-rule-plugin/create-once
   0:1  error  after hook:
 identNum: 2
-filename: files/1.js           testPlugin/create-once
+filename: files/1.js           define-rule-plugin/create-once
   1:5  error  ident visit fn "a":
-filename: files/1.js               testPlugin/create
+filename: files/1.js               define-rule-plugin/create
   1:5  error  ident visit fn "a":
 identNum: 1
-filename: files/1.js   testPlugin/create-once
+filename: files/1.js   define-rule-plugin/create-once
   1:8  error  ident visit fn "b":
-filename: files/1.js               testPlugin/create
+filename: files/1.js               define-rule-plugin/create
   1:8  error  ident visit fn "b":
 identNum: 2
-filename: files/1.js   testPlugin/create-once
+filename: files/1.js   define-rule-plugin/create-once
 
 <root>/apps/oxlint/test/fixtures/define/files/2.js
   0:1  error  create body:
-this === rule: true                       testPlugin/create
+this === rule: true                       define-rule-plugin/create
   0:1  error  before hook:
 this === rule: true
-filename: files/2.js  testPlugin/create-once
+filename: files/2.js  define-rule-plugin/create-once
   0:1  error  after hook:
 identNum: 2
-filename: files/2.js           testPlugin/create-once
+filename: files/2.js           define-rule-plugin/create-once
   1:5  error  ident visit fn "c":
-filename: files/2.js               testPlugin/create
+filename: files/2.js               define-rule-plugin/create
   1:5  error  ident visit fn "c":
 identNum: 1
-filename: files/2.js   testPlugin/create-once
+filename: files/2.js   define-rule-plugin/create-once
   1:8  error  ident visit fn "d":
-filename: files/2.js               testPlugin/create
+filename: files/2.js               define-rule-plugin/create
   1:8  error  ident visit fn "d":
 identNum: 2
-filename: files/2.js   testPlugin/create-once
+filename: files/2.js   define-rule-plugin/create-once
 
 ✖ 14 problems (14 errors, 0 warnings)
 "

--- a/apps/oxlint/test/fixtures/define/eslint.config.js
+++ b/apps/oxlint/test/fixtures/define/eslint.config.js
@@ -4,11 +4,11 @@ export default [
   {
     files: ["files/*.js"],
     plugins: {
-      testPlugin,
+      "define-rule-plugin": testPlugin,
     },
     rules: {
-      "testPlugin/create": "error",
-      "testPlugin/create-once": "error",
+      "define-rule-plugin/create": "error",
+      "define-rule-plugin/create-once": "error",
     },
   },
 ];


### PR DESCRIPTION
Minor refactor of tests. Name the plugin the same in ESLint config as Oxlint config, for easier comparison of the 2.