### PR TITLE
test(linter/plugins): test returning `false` from `before` hook skips visitation in ESLint

### DIFF
--- a/apps/oxlint/test/__snapshots__/e2e.test.ts.snap
+++ b/apps/oxlint/test/__snapshots__/e2e.test.ts.snap
@@ -916,6 +916,13 @@ exports[`oxlint CLI > should support \`defineRule\` + \`definePlugin\` 1`] = `
    : ^
    \`----
 
+  x define-rule-plugin(create-once-before-false): before hook:
+  | filename: files/1.js
+   ,-[files/1.js:1:1]
+ 1 | let a, b;
+   : ^
+   \`----
+
   x define-rule-plugin(create-once-before-only): before hook:
   | filename: files/1.js
    ,-[files/1.js:1:1]
@@ -1025,6 +1032,20 @@ exports[`oxlint CLI > should support \`defineRule\` + \`definePlugin\` 1`] = `
    : ^
    \`----
 
+  x define-rule-plugin(create-once-before-false): before hook:
+  | filename: files/2.js
+   ,-[files/2.js:1:1]
+ 1 | let c, d;
+   : ^
+   \`----
+
+  x define-rule-plugin(create-once-before-false): after hook:
+  | filename: files/2.js
+   ,-[files/2.js:1:1]
+ 1 | let c, d;
+   : ^
+   \`----
+
   x define-rule-plugin(create-once-before-only): before hook:
   | filename: files/2.js
    ,-[files/2.js:1:1]
@@ -1048,6 +1069,13 @@ exports[`oxlint CLI > should support \`defineRule\` + \`definePlugin\` 1`] = `
    \`----
 
   x define-rule-plugin(create-once-after-only): ident visit fn "c":
+  | filename: files/2.js
+   ,-[files/2.js:1:5]
+ 1 | let c, d;
+   :     ^
+   \`----
+
+  x define-rule-plugin(create-once-before-false): ident visit fn "c":
   | filename: files/2.js
    ,-[files/2.js:1:5]
  1 | let c, d;
@@ -1090,6 +1118,13 @@ exports[`oxlint CLI > should support \`defineRule\` + \`definePlugin\` 1`] = `
    :        ^
    \`----
 
+  x define-rule-plugin(create-once-before-false): ident visit fn "d":
+  | filename: files/2.js
+   ,-[files/2.js:1:8]
+ 1 | let c, d;
+   :        ^
+   \`----
+
   x define-rule-plugin(create-once-before-only): ident visit fn "d":
   | filename: files/2.js
    ,-[files/2.js:1:8]
@@ -1104,7 +1139,7 @@ exports[`oxlint CLI > should support \`defineRule\` + \`definePlugin\` 1`] = `
    :        ^
    \`----
 
-Found 0 warnings and 30 errors.
+Found 0 warnings and 35 errors.
 Finished in Xms on 2 files using X threads."
 `;
 

--- a/apps/oxlint/test/__snapshots__/eslint-compat.test.ts.snap
+++ b/apps/oxlint/test/__snapshots__/eslint-compat.test.ts.snap
@@ -9,6 +9,8 @@ this === rule: true                       define-rule-plugin/create
 this === rule: true
 filename: files/1.js  define-rule-plugin/create-once
   0:1  error  before hook:
+filename: files/1.js                      define-rule-plugin/create-once-before-false
+  0:1  error  before hook:
 filename: files/1.js                      define-rule-plugin/create-once-before-only
   0:1  error  after hook:
 identNum: 2
@@ -45,10 +47,14 @@ this === rule: true                       define-rule-plugin/create
 this === rule: true
 filename: files/2.js  define-rule-plugin/create-once
   0:1  error  before hook:
+filename: files/2.js                      define-rule-plugin/create-once-before-false
+  0:1  error  before hook:
 filename: files/2.js                      define-rule-plugin/create-once-before-only
   0:1  error  after hook:
 identNum: 2
 filename: files/2.js           define-rule-plugin/create-once
+  0:1  error  after hook:
+filename: files/2.js                       define-rule-plugin/create-once-before-false
   0:1  error  after hook:
 filename: files/2.js                       define-rule-plugin/create-once-after-only
   1:5  error  ident visit fn "c":
@@ -57,6 +63,8 @@ filename: files/2.js               define-rule-plugin/create
 identNum: 1
 filename: files/2.js   define-rule-plugin/create-once
   1:5  error  ident visit fn "c":
+filename: files/2.js               define-rule-plugin/create-once-before-false
+  1:5  error  ident visit fn "c":
 filename: files/2.js               define-rule-plugin/create-once-before-only
   1:5  error  ident visit fn "c":
 filename: files/2.js               define-rule-plugin/create-once-after-only
@@ -68,12 +76,14 @@ filename: files/2.js               define-rule-plugin/create
 identNum: 2
 filename: files/2.js   define-rule-plugin/create-once
   1:8  error  ident visit fn "d":
+filename: files/2.js               define-rule-plugin/create-once-before-false
+  1:8  error  ident visit fn "d":
 filename: files/2.js               define-rule-plugin/create-once-before-only
   1:8  error  ident visit fn "d":
 filename: files/2.js               define-rule-plugin/create-once-after-only
   1:8  error  ident visit fn "d":
 filename: files/2.js               define-rule-plugin/create-once-no-hooks
 
-✖ 30 problems (30 errors, 0 warnings)
+✖ 35 problems (35 errors, 0 warnings)
 "
 `;

--- a/apps/oxlint/test/fixtures/define/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/define/.oxlintrc.json
@@ -4,6 +4,7 @@
     "rules": {
         "define-rule-plugin/create": "error",
         "define-rule-plugin/create-once": "error",
+        "define-rule-plugin/create-once-before-false": "error",
         "define-rule-plugin/create-once-before-only": "error",
         "define-rule-plugin/create-once-after-only": "error",
         "define-rule-plugin/create-once-no-hooks": "error"

--- a/apps/oxlint/test/fixtures/define/eslint.config.js
+++ b/apps/oxlint/test/fixtures/define/eslint.config.js
@@ -9,6 +9,7 @@ export default [
     rules: {
       "define-rule-plugin/create": "error",
       "define-rule-plugin/create-once": "error",
+      "define-rule-plugin/create-once-before-false": "error",
       "define-rule-plugin/create-once-before-only": "error",
       "define-rule-plugin/create-once-after-only": "error",
       "define-rule-plugin/create-once-no-hooks": "error",

--- a/apps/oxlint/test/fixtures/define/test_plugin/index.js
+++ b/apps/oxlint/test/fixtures/define/test_plugin/index.js
@@ -100,6 +100,38 @@ const createOnceRule = defineRule({
   },
 });
 
+// Tests that `before` hook returning `false` disables visiting AST for the file.
+const createOnceBeforeFalseRule = defineRule({
+  createOnce(context) {
+    return {
+      before() {
+        context.report({
+          message: 'before hook:\n'
+            + `filename: ${relativePath(context.filename)}`,
+          node: SPAN,
+        });
+
+        // Only visit AST for `files/2.js`
+        return context.filename.endsWith('2.js');
+      },
+      Identifier(node) {
+        context.report({
+          message: `ident visit fn "${node.name}":\n`
+            + `filename: ${relativePath(context.filename)}`,
+          node: { ...SPAN, ...node },
+        });
+      },
+      after() {
+        context.report({
+          message: 'after hook:\n'
+            + `filename: ${relativePath(context.filename)}`,
+          node: SPAN,
+        });
+      },
+    };
+  },
+});
+
 // These 3 rules test that `createOnce` without `before` and `after` hooks works correctly.
 
 const createOnceBeforeOnlyRule = defineRule({
@@ -165,6 +197,7 @@ export default definePlugin({
   rules: {
     create: createRule,
     "create-once": createOnceRule,
+    "create-once-before-false": createOnceBeforeFalseRule,
     "create-once-before-only": createOnceBeforeOnlyRule,
     "create-once-after-only": createOnceAfterOnlyRule,
     "create-once-no-hooks": createOnceNoHooksRule,


### PR DESCRIPTION
Add tests that a rule which is made ESLint-compatible by using `defineRule` skips AST traversal for the file in ESLint if `before` hook returns `false` - same as it does in Oxlint.