### PR TITLE
fix(linter/plugins): `defineRule` call `createOnce` lazily

### DIFF
--- a/apps/oxlint/src-js/plugins/load.ts
+++ b/apps/oxlint/src-js/plugins/load.ts
@@ -22,7 +22,7 @@ interface CreateRule {
   create: (context: Context) => Visitor;
 }
 
-interface CreateOnceRule {
+export interface CreateOnceRule {
   create?: (context: Context) => Visitor;
   createOnce: (context: Context) => VisitorWithHooks;
 }

--- a/apps/oxlint/test/__snapshots__/e2e.test.ts.snap
+++ b/apps/oxlint/test/__snapshots__/e2e.test.ts.snap
@@ -652,6 +652,12 @@ exports[`oxlint CLI > should support \`createOnce\` 1`] = `
    : ^
    \`----
 
+  x create-once-plugin(always-run): createOnce: call count: 1
+   ,-[files/1.js:1:1]
+ 1 | let x;
+   : ^
+   \`----
+
   x create-once-plugin(always-run): createOnce: filename: Cannot access \`context.filename\` in \`createOnce\`
    ,-[files/1.js:1:1]
  1 | let x;
@@ -772,6 +778,12 @@ exports[`oxlint CLI > should support \`createOnce\` 1`] = `
    : ^
    \`----
 
+  x create-once-plugin(always-run): createOnce: call count: 1
+   ,-[files/2.js:1:1]
+ 1 | let y;
+   : ^
+   \`----
+
   x create-once-plugin(always-run): createOnce: filename: Cannot access \`context.filename\` in \`createOnce\`
    ,-[files/2.js:1:1]
  1 | let y;
@@ -880,7 +892,7 @@ exports[`oxlint CLI > should support \`createOnce\` 1`] = `
    :     ^
    \`----
 
-Found 0 warnings and 40 errors.
+Found 0 warnings and 42 errors.
 Finished in Xms on 2 files using X threads."
 `;
 
@@ -893,16 +905,17 @@ exports[`oxlint CLI > should support \`defineRule\` + \`definePlugin\` 1`] = `
    : ^
    \`----
 
-  x define-rule-plugin(create-once): after hook:
-  | identNum: 2
+  x define-rule-plugin(create-once): before hook:
+  | createOnce call count: 1
+  | this === rule: true
   | filename: files/1.js
    ,-[files/1.js:1:1]
  1 | let a, b;
    : ^
    \`----
 
-  x define-rule-plugin(create-once): before hook:
-  | this === rule: true
+  x define-rule-plugin(create-once): after hook:
+  | identNum: 2
   | filename: files/1.js
    ,-[files/1.js:1:1]
  1 | let a, b;
@@ -1009,16 +1022,17 @@ exports[`oxlint CLI > should support \`defineRule\` + \`definePlugin\` 1`] = `
    : ^
    \`----
 
-  x define-rule-plugin(create-once): after hook:
-  | identNum: 2
+  x define-rule-plugin(create-once): before hook:
+  | createOnce call count: 1
+  | this === rule: true
   | filename: files/2.js
    ,-[files/2.js:1:1]
  1 | let c, d;
    : ^
    \`----
 
-  x define-rule-plugin(create-once): before hook:
-  | this === rule: true
+  x define-rule-plugin(create-once): after hook:
+  | identNum: 2
   | filename: files/2.js
    ,-[files/2.js:1:1]
  1 | let c, d;

--- a/apps/oxlint/test/__snapshots__/eslint-compat.test.ts.snap
+++ b/apps/oxlint/test/__snapshots__/eslint-compat.test.ts.snap
@@ -4,85 +4,87 @@ exports[`ESLint compatibility > \`defineRule\` + \`definePlugin\` should work 1`
 "
 <root>/apps/oxlint/test/fixtures/define/files/1.js
   0:1  error  create body:
-this === rule: true                       define-rule-plugin/create
+this === rule: true                                                define-rule-plugin/create
   0:1  error  before hook:
+createOnce call count: 1
 this === rule: true
 filename: files/1.js  define-rule-plugin/create-once
   0:1  error  before hook:
-filename: files/1.js                      define-rule-plugin/create-once-before-false
+filename: files/1.js                                               define-rule-plugin/create-once-before-false
   0:1  error  before hook:
-filename: files/1.js                      define-rule-plugin/create-once-before-only
+filename: files/1.js                                               define-rule-plugin/create-once-before-only
   0:1  error  after hook:
 identNum: 2
-filename: files/1.js           define-rule-plugin/create-once
+filename: files/1.js                                    define-rule-plugin/create-once
   0:1  error  after hook:
-filename: files/1.js                       define-rule-plugin/create-once-after-only
+filename: files/1.js                                                define-rule-plugin/create-once-after-only
   1:5  error  ident visit fn "a":
-filename: files/1.js               define-rule-plugin/create
+filename: files/1.js                                        define-rule-plugin/create
   1:5  error  ident visit fn "a":
 identNum: 1
-filename: files/1.js   define-rule-plugin/create-once
+filename: files/1.js                            define-rule-plugin/create-once
   1:5  error  ident visit fn "a":
-filename: files/1.js               define-rule-plugin/create-once-before-only
+filename: files/1.js                                        define-rule-plugin/create-once-before-only
   1:5  error  ident visit fn "a":
-filename: files/1.js               define-rule-plugin/create-once-after-only
+filename: files/1.js                                        define-rule-plugin/create-once-after-only
   1:5  error  ident visit fn "a":
-filename: files/1.js               define-rule-plugin/create-once-no-hooks
+filename: files/1.js                                        define-rule-plugin/create-once-no-hooks
   1:8  error  ident visit fn "b":
-filename: files/1.js               define-rule-plugin/create
+filename: files/1.js                                        define-rule-plugin/create
   1:8  error  ident visit fn "b":
 identNum: 2
-filename: files/1.js   define-rule-plugin/create-once
+filename: files/1.js                            define-rule-plugin/create-once
   1:8  error  ident visit fn "b":
-filename: files/1.js               define-rule-plugin/create-once-before-only
+filename: files/1.js                                        define-rule-plugin/create-once-before-only
   1:8  error  ident visit fn "b":
-filename: files/1.js               define-rule-plugin/create-once-after-only
+filename: files/1.js                                        define-rule-plugin/create-once-after-only
   1:8  error  ident visit fn "b":
-filename: files/1.js               define-rule-plugin/create-once-no-hooks
+filename: files/1.js                                        define-rule-plugin/create-once-no-hooks
 
 <root>/apps/oxlint/test/fixtures/define/files/2.js
   0:1  error  create body:
-this === rule: true                       define-rule-plugin/create
+this === rule: true                                                define-rule-plugin/create
   0:1  error  before hook:
+createOnce call count: 1
 this === rule: true
 filename: files/2.js  define-rule-plugin/create-once
   0:1  error  before hook:
-filename: files/2.js                      define-rule-plugin/create-once-before-false
+filename: files/2.js                                               define-rule-plugin/create-once-before-false
   0:1  error  before hook:
-filename: files/2.js                      define-rule-plugin/create-once-before-only
+filename: files/2.js                                               define-rule-plugin/create-once-before-only
   0:1  error  after hook:
 identNum: 2
-filename: files/2.js           define-rule-plugin/create-once
+filename: files/2.js                                    define-rule-plugin/create-once
   0:1  error  after hook:
-filename: files/2.js                       define-rule-plugin/create-once-before-false
+filename: files/2.js                                                define-rule-plugin/create-once-before-false
   0:1  error  after hook:
-filename: files/2.js                       define-rule-plugin/create-once-after-only
+filename: files/2.js                                                define-rule-plugin/create-once-after-only
   1:5  error  ident visit fn "c":
-filename: files/2.js               define-rule-plugin/create
+filename: files/2.js                                        define-rule-plugin/create
   1:5  error  ident visit fn "c":
 identNum: 1
-filename: files/2.js   define-rule-plugin/create-once
+filename: files/2.js                            define-rule-plugin/create-once
   1:5  error  ident visit fn "c":
-filename: files/2.js               define-rule-plugin/create-once-before-false
+filename: files/2.js                                        define-rule-plugin/create-once-before-false
   1:5  error  ident visit fn "c":
-filename: files/2.js               define-rule-plugin/create-once-before-only
+filename: files/2.js                                        define-rule-plugin/create-once-before-only
   1:5  error  ident visit fn "c":
-filename: files/2.js               define-rule-plugin/create-once-after-only
+filename: files/2.js                                        define-rule-plugin/create-once-after-only
   1:5  error  ident visit fn "c":
-filename: files/2.js               define-rule-plugin/create-once-no-hooks
+filename: files/2.js                                        define-rule-plugin/create-once-no-hooks
   1:8  error  ident visit fn "d":
-filename: files/2.js               define-rule-plugin/create
+filename: files/2.js                                        define-rule-plugin/create
   1:8  error  ident visit fn "d":
 identNum: 2
-filename: files/2.js   define-rule-plugin/create-once
+filename: files/2.js                            define-rule-plugin/create-once
   1:8  error  ident visit fn "d":
-filename: files/2.js               define-rule-plugin/create-once-before-false
+filename: files/2.js                                        define-rule-plugin/create-once-before-false
   1:8  error  ident visit fn "d":
-filename: files/2.js               define-rule-plugin/create-once-before-only
+filename: files/2.js                                        define-rule-plugin/create-once-before-only
   1:8  error  ident visit fn "d":
-filename: files/2.js               define-rule-plugin/create-once-after-only
+filename: files/2.js                                        define-rule-plugin/create-once-after-only
   1:8  error  ident visit fn "d":
-filename: files/2.js               define-rule-plugin/create-once-no-hooks
+filename: files/2.js                                        define-rule-plugin/create-once-no-hooks
 
 ✖ 35 problems (35 errors, 0 warnings)
 "

--- a/apps/oxlint/test/fixtures/createOnce/test_plugin/index.js
+++ b/apps/oxlint/test/fixtures/createOnce/test_plugin/index.js
@@ -8,8 +8,11 @@ const relativePath = sep === '/'
   ? path => path.slice(PARENT_DIR_PATH_LEN)
   : path => path.slice(PARENT_DIR_PATH_LEN).replace(/\\/g, '/');
 
+let createOnceCallCount = 0;
 const alwaysRunRule = {
   createOnce(context) {
+    createOnceCallCount++;
+
     const topLevelThis = this;
 
     // Check that these APIs throw here
@@ -21,6 +24,7 @@ const alwaysRunRule = {
 
     return {
       before() {
+        context.report({ message: `createOnce: call count: ${createOnceCallCount}`, node: SPAN });
         context.report({ message: `createOnce: this === rule: ${topLevelThis === alwaysRunRule}`, node: SPAN });
         context.report({ message: `createOnce: id: ${idError?.message}`, node: SPAN });
         context.report({ message: `createOnce: filename: ${filenameError?.message}`, node: SPAN });

--- a/apps/oxlint/test/fixtures/define/test_plugin/index.js
+++ b/apps/oxlint/test/fixtures/define/test_plugin/index.js
@@ -35,8 +35,11 @@ const createRule = defineRule({
 
 // This aims to test that `createOnce` is called once only, and `before` hook is called once per file.
 // i.e. Oxlint calls `createOnce` directly, and not the `create` method that `defineRule` adds to the rule.
+let createOnceCallCount = 0;
 const createOnceRule = defineRule({
   createOnce(context) {
+    createOnceCallCount++;
+
     // `fileNum` should be different for each file.
     // `identNum` should start at 1 for each file.
     let fileNum = 0, identNum;
@@ -54,6 +57,7 @@ const createOnceRule = defineRule({
 
         context.report({
           message: 'before hook:\n'
+            + `createOnce call count: ${createOnceCallCount}\n`
             + `this === rule: ${topLevelThis === createOnceRule}\n`
             + `filename: ${relativePath(context.filename)}`,
           node: SPAN,


### PR DESCRIPTION
Previously `defineRule`, when passed a rule with a `createOnce` method, would call `createOnce` immediately.

When the rule is used in Oxlint, this resulted in `createOnce` being called twice. `createOnce` might do some fairly expensive set-up work, so we only want to call it once (as the name suggests!).

Instead, `defineRule` don't call `createOnce` immediately. Call it the first time the `create` method which `defineRule` creates is called.

This means that, when using Oxlint:

1. `createOnce` is only called once.
2. `defineRule` call is cheaper.

i.e. the cost of making the rule ESLint-compatible is only paid when the user is running the rule in ESLint, not in Oxlint.
