### PR TITLE
perf(linter/plugins): load methods of globals into local vars

### DIFF
--- a/apps/oxlint/src-js/index.ts
+++ b/apps/oxlint/src-js/index.ts
@@ -2,7 +2,7 @@ import type { Context } from './plugins/context.ts';
 import type { CreateOnceRule, Plugin, Rule } from './plugins/load.ts';
 import type { BeforeHook, Visitor, VisitorWithHooks } from './plugins/types.ts';
 
-const { defineProperty, getPrototypeOf, hasOwn, setPrototypeOf } = Object;
+const { defineProperty, getPrototypeOf, hasOwn, setPrototypeOf, create: ObjectCreate } = Object;
 
 const dummyOptions: unknown[] = [],
   dummyReport = () => {};
@@ -104,7 +104,7 @@ function createContextAndVisitor(rule: CreateOnceRule): {
   // Really, `context` should be an instance of `Context`, which would throw error on accessing e.g. `id`
   // in body of `createOnce`. But any such bugs should have been caught when testing the rule in Oxlint,
   // so should be OK to take this shortcut.
-  const context = Object.create(null, {
+  const context = ObjectCreate(null, {
     id: { value: '', enumerable: true, configurable: true },
     options: { value: dummyOptions, enumerable: true, configurable: true },
     report: { value: dummyReport, enumerable: true, configurable: true },

--- a/apps/oxlint/src-js/plugins/load.ts
+++ b/apps/oxlint/src-js/plugins/load.ts
@@ -3,6 +3,8 @@ import { getErrorMessage } from './utils.js';
 
 import type { AfterHook, BeforeHook, Visitor, VisitorWithHooks } from './types.ts';
 
+const ObjectKeys = Object.keys;
+
 // Linter plugin, comprising multiple rules
 export interface Plugin {
   meta: {
@@ -86,7 +88,7 @@ async function loadPluginImpl(path: string): Promise<string> {
   const pluginName = plugin.meta.name;
   const offset = registeredRules.length;
   const { rules } = plugin;
-  const ruleNames = Object.keys(rules);
+  const ruleNames = ObjectKeys(rules);
   const ruleNamesLen = ruleNames.length;
 
   for (let i = 0; i < ruleNamesLen; i++) {

--- a/apps/oxlint/src-js/plugins/visitor.ts
+++ b/apps/oxlint/src-js/plugins/visitor.ts
@@ -85,7 +85,8 @@ import { assertIs } from './utils.js';
 
 import type { CompiledVisitorEntry, EnterExit, Node, VisitFn, Visitor } from './types.ts';
 
-const { isArray } = Array;
+const ObjectKeys = Object.keys,
+  { isArray } = Array;
 
 // Types for temporary state of entries of `compiledVisitor`
 // between calling `initCompiledVisitor` and `finalizeCompiledVisitor`.
@@ -210,7 +211,7 @@ export function addVisitorToCompiled(visitor: Visitor): void {
   }
 
   // Exit if is empty visitor
-  const keys = Object.keys(visitor),
+  const keys = ObjectKeys(visitor),
     keysLen = keys.length;
   if (keysLen === 0) return;
 


### PR DESCRIPTION
Small perf optimization. All the code in `apps/oxlint` loads methods of global object e.g. `Object`, `Array` into local vars, for faster access. Continue that convention in these files.