### PR TITLE
refactor(linter): reduce scope of clippy attr

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -1,5 +1,4 @@
 #![expect(clippy::self_named_module_files)] // for rules.rs
-#![allow(clippy::literal_string_with_formatting_args)]
 
 use std::{path::Path, rc::Rc};
 

--- a/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
@@ -144,6 +144,7 @@ impl PreferToContain {
 fn tests() {
     use crate::tester::Tester;
 
+    #[expect(clippy::literal_string_with_formatting_args)]
     let pass = vec![
         ("expect.hasAssertions", None),
         ("expect.hasAssertions()", None),
@@ -178,6 +179,7 @@ fn tests() {
         ("expect(a.includes(b)).toEqual(0 as boolean);", None),
     ];
 
+    #[expect(clippy::literal_string_with_formatting_args)]
     let fail = vec![
         ("expect(a.includes(b)).toEqual(true);", None),
         ("expect(a.includes(b,),).toEqual(true,)", None),

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
@@ -607,6 +607,7 @@ fn test() {
         "[ ...new Uint8Array([ 1, 2, 3 ]) ].map(byte => byte.toString())",
     ];
 
+    #[expect(clippy::literal_string_with_formatting_args)]
     let fail = vec![
         r"const array = [...[a]]",
         r"const object = {...{a}}",


### PR DESCRIPTION
Instead of opting out from this clippy warning for the whole crate, opt out explicitly at the few places it occurs.
