### PR TITLE
feat(linter/plugins): add `meta` property to rules

### DIFF
--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -1,3 +1,5 @@
+import type { RuleMeta } from './types.ts';
+
 // Diagnostic in form passed by user to `Context#report()`
 interface Diagnostic {
   message: string;
@@ -64,6 +66,8 @@ interface InternalContext {
   filePath: string;
   // Options
   options: unknown[];
+  // Rule metadata
+  meta: RuleMeta;
 }
 
 /**
@@ -80,12 +84,13 @@ export class Context {
    * @class
    * @param fullRuleName - Rule name, in form `<plugin>/<rule>`
    */
-  constructor(fullRuleName: string) {
+  constructor(fullRuleName: string, meta: RuleMeta) {
     this.#internal = {
       id: fullRuleName,
       filePath: '',
       ruleIndex: -1,
       options: [],
+      meta,
     };
   }
 

--- a/apps/oxlint/src-js/plugins/types.ts
+++ b/apps/oxlint/src-js/plugins/types.ts
@@ -39,3 +39,9 @@ export interface EnterExit {
   enter: VisitFn | null;
   exit: VisitFn | null;
 }
+
+// Rule metadata.
+// TODO: Fill in all properties.
+export interface RuleMeta {
+  [key: string]: unknown;
+}


### PR DESCRIPTION
Add `meta` property to `Rule`. Currently it doesn't do much, except make the `Rule` type compatible with ESLint. But need `rule.meta` for supporting fixes (PR to come).