### PR TITLE
perf(linter): remove allocation in `CompositeFix::merge_fixes`

### DIFF
--- a/crates/oxc_linter/src/fixer/fix.rs
+++ b/crates/oxc_linter/src/fixer/fix.rs
@@ -587,7 +587,6 @@ impl<'a> CompositeFix<'a> {
         };
 
         output.push_str(after);
-        output.shrink_to_fit();
 
         let mut fix = Fix::new(output, Span::new(start, end));
         if let Some(message) = merged_fix_message {


### PR DESCRIPTION
`String::shrink_to_fit` will generally reallocate in order to reduce the `String`'s capacity to minimum size. 

In `merge_fixes`, the size of the `String` is unlikely to be excessively over-sized - in best case, it's exactly the right size, and in worst case it's twice as large than it needs to be. The reallocation probably costs more than the gain of clawing back a few bytes of memory. So remove this operation.