### PR TITLE
chore(pnpm): add `@oxc-project/*` to `minimumReleaseAgeExclude`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,6 +19,7 @@ verifyDepsBeforeRun: install
 # To reduce the risk of installing compromised packages.
 minimumReleaseAge: 1440 # 1 day
 minimumReleaseAgeExclude:
+  - '@oxc-project/*'
   - '@oxfmt/*'
   - '@oxlint-tsgolint/*'
   - '@oxlint/*'


### PR DESCRIPTION
```
pnpm i
Scope: all 14 workspace projects
/home/sysix/dev/oxc/apps/oxlint:
 ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @oxc-project/types@=0.92.0 published by Tue Sep 23 2025 22:05:04 GMT+0200 (Central European Summer Time) while fetching it from https://registry.npmjs.org/. Version 0.92.0 satisfies the specs but was released at Wed Sep 24 2025 06:18:45 GMT+0200 (Central European Summer Time)

This error happened while installing the dependencies of tsdown@0.15.1
 at rolldown@1.0.0-beta.40

The latest release of @oxc-project/types is "0.92.0". Published at 9/24/2025 6:18:45 AM

If you need the full list of all 86 published versions run "$ pnpm view @oxc-project/types versions".

If you want to install the matched version ignoring the time it was published, you can add the package name to the minimumReleaseAgeExclude setting. Read more about it: https://pnpm.io/settings#minimumreleaseageexclude
```

Removed the package-lock.json because of a weird npm bug. 
After fixing this bug, this is not needed anymore, but still usefull maybe?