### PR TITLE
fix(linter): fix lint errors building `oxlint`

### DIFF
--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -1,9 +1,7 @@
 use std::{
-    borrow::Cow,
     collections::BTreeSet,
     ffi::OsStr,
     io::{ErrorKind, Read, Write},
-    mem,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -601,6 +599,8 @@ impl From<TsGoLintDiagnostic> for OxcDiagnostic {
 impl Message<'_> {
     /// Converts a `TsGoLintDiagnostic` into a `Message` with possible fixes.
     fn from_tsgo_lint_diagnostic(mut val: TsGoLintDiagnostic, source_text: &str) -> Self {
+        use std::{borrow::Cow, mem};
+
         let mut fixes =
             Vec::with_capacity(usize::from(!val.fixes.is_empty()) + val.suggestions.len());
 


### PR DESCRIPTION
Fix "unused imports" lint errors when building `oxlint`. These were introduced in #14092 (my mistake).