### PR TITLE
feat(linter): move `no-unused-expressions` to correctness

### DIFF
--- a/apps/oxlint/src/snapshots/_--ignore-path fixtures__linter__.customignore --no-ignore fixtures__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-path fixtures__linter__.customignore --no-ignore fixtures__linter__nan.js@oxlint.snap
@@ -6,6 +6,13 @@ arguments: --ignore-path fixtures/linter/.customignore --no-ignore fixtures/lint
 working directory: 
 ----------
 
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\eslint(no-unused-expressions)]8;;\: Expected expression to be used
+   ,-[fixtures/linter/nan.js:1:1]
+ 1 | 123 == NaN;
+   : ^^^^^^^^^^^
+   `----
+  help: Consider using this expression or removing it
+
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/use-isnan.html\eslint(use-isnan)]8;;\: Requires calls to isNaN() when checking for NaN
    ,-[fixtures/linter/nan.js:1:8]
  1 | 123 == NaN;
@@ -13,8 +20,8 @@ working directory:
    `----
   help: Use the isNaN function to compare with NaN.
 
-Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Found 2 warnings and 0 errors.
+Finished in <variable>ms on 1 file with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--ignore-pattern _____.js --ignore-pattern _____.vue fixtures__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-pattern _____.js --ignore-pattern _____.vue fixtures__linter@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --ignore-pattern **/*.js --ignore-pattern **/*.vue fixtures/linter
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 88 rules using 1 threads.
+Finished in <variable>ms on 0 files with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--import-plugin -A all -D no-cycle fixtures__flow__@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--import-plugin -A all -D no-cycle fixtures__flow__@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --import-plugin -A all -D no-cycle fixtures/flow/
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 2 files with 90 rules using 1 threads.
+Finished in <variable>ms on 2 files with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--import-plugin fixtures__flow__index.mjs@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--import-plugin fixtures__flow__index.mjs@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --import-plugin fixtures/flow/index.mjs
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
@@ -23,7 +23,7 @@ working directory:
   help: Remove the appending `.skip`
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 100 rules using 1 threads.
+Finished in <variable>ms on 1 file with 101 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-D correctness fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-D correctness fixtures__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file with 89 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-W correctness -A no-debugger fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W correctness -A no-debugger fixtures__linter__debugger.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -W correctness -A no-debugger fixtures/linter/debugger.js
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 87 rules using 1 threads.
+Finished in <variable>ms on 1 file with 88 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__eslintrc_env__eslintrc_no_env.json fixtures__eslintrc_env__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__eslintrc_env__eslintrc_no_env.json fixtures__eslintrc_env__test.js@oxlint.snap
@@ -13,7 +13,7 @@ working directory:
    `----
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__no_undef__eslintrc.json fixtures__no_undef__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__no_undef__eslintrc.json fixtures__no_undef__test.js@oxlint.snap
@@ -13,7 +13,7 @@ working directory:
    `----
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension@oxlint.snap
@@ -12,7 +12,7 @@ working directory:
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension__main.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension__main.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/config_ignore_patterns/ignore_extension/eslintrc.json fix
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 88 rules using 1 threads.
+Finished in <variable>ms on 0 files with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_env__eslintrc_env_browser.json fixtures__eslintrc_env__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_env__eslintrc_env_browser.json fixtures__eslintrc_env__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/eslintrc_env/eslintrc_env_browser.json fixtures/eslintrc_
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_off__eslintrc.json fixtures__eslintrc_off__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_off__eslintrc.json fixtures__eslintrc_off__test.js@oxlint.snap
@@ -12,7 +12,7 @@ working directory:
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/eslintrc_vitest_replace/eslintrc.json fixtures/eslintrc_v
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__linter__eslintrc.json fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__linter__eslintrc.json fixtures__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file with 89 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_console_off__eslintrc.json fixtures__no_console_off__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_console_off__eslintrc.json fixtures__no_console_off__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/no_console_off/eslintrc.json fixtures/no_console_off/test
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_empty_allow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_allow_empty_catch__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_empty_allow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_allow_empty_catch__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/no_empty_allow_empty_catch/eslintrc.json -W no-empty fixt
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_empty_disallow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_disallow_empty_catch__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_empty_disallow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_disallow_empty_catch__test.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove this block or add a comment inside it
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.js -c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.ts -c fixtures__overrides__.oxlintrc.json fixtures__overrides__other.jsx@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.js -c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.ts -c fixtures__overrides__.oxlintrc.json fixtures__overrides__other.jsx@oxlint.snap
@@ -15,7 +15,7 @@ working directory:
   help: Replace var with let or const
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------
@@ -42,7 +42,7 @@ working directory:
   help: Delete this console statement.
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------
@@ -61,7 +61,7 @@ working directory:
   help: Replace var with let or const
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__overrides__directories-config.json fixtures__overrides@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__overrides__directories-config.json fixtures__overrides@oxlint.snap
@@ -35,7 +35,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 2 warnings and 2 errors.
-Finished in <variable>ms on 7 files with 87 rules using 1 threads.
+Finished in <variable>ms on 7 files with 88 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json --disable-typescript-plugin fixtures__typescript_eslint__test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json --disable-typescript-plugin fixtures__typescript_eslint__test.ts@oxlint.snap
@@ -22,8 +22,16 @@ working directory:
    : ^^^^^^^^^^^^^^^^
    `----
 
-Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 51 rules using 1 threads.
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\eslint(no-unused-expressions)]8;;\: Expected expression to be used
+   ,-[fixtures/typescript_eslint/test.ts:4:1]
+ 3 | 
+ 4 | 9007199254740993 // no-loss-of-precision
+   : ^^^^^^^^^^^^^^^^
+   `----
+  help: Consider using this expression or removing it
+
+Found 2 warnings and 1 error.
+Finished in <variable>ms on 1 file with 52 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json fixtures__typescript_eslint__test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json fixtures__typescript_eslint__test.ts@oxlint.snap
@@ -30,8 +30,16 @@ working directory:
    : ^^^^^^^^^^^^^^^^
    `----
 
-Found 2 warnings and 1 error.
-Finished in <variable>ms on 1 file with 63 rules using 1 threads.
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\eslint(no-unused-expressions)]8;;\: Expected expression to be used
+   ,-[fixtures/typescript_eslint/test.ts:4:1]
+ 3 | 
+ 4 | 9007199254740993 // no-loss-of-precision
+   : ^^^^^^^^^^^^^^^^
+   `----
+  help: Consider using this expression or removing it
+
+Found 3 warnings and 1 error.
+Finished in <variable>ms on 1 file with 64 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__astro__debugger.astro@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__astro__debugger.astro@oxlint.snap
@@ -43,7 +43,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 4 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter@oxlint.snap
@@ -21,6 +21,13 @@ working directory:
    `----
   help: Remove the debugger statement
 
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\eslint(no-unused-expressions)]8;;\: Expected expression to be used
+   ,-[fixtures/linter/nan.js:1:1]
+ 1 | 123 == NaN;
+   : ^^^^^^^^^^^
+   `----
+  help: Consider using this expression or removing it
+
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/use-isnan.html\eslint(use-isnan)]8;;\: Requires calls to isNaN() when checking for NaN
    ,-[fixtures/linter/nan.js:1:8]
  1 | 123 == NaN;
@@ -28,8 +35,8 @@ working directory:
    `----
   help: Use the isNaN function to compare with NaN.
 
-Found 3 warnings and 0 errors.
-Finished in <variable>ms on 3 files with 88 rules using 1 threads.
+Found 4 warnings and 0 errors.
+Finished in <variable>ms on 3 files with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js fixtures__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js fixtures__linter__nan.js@oxlint.snap
@@ -13,6 +13,13 @@ working directory:
    `----
   help: Remove the debugger statement
 
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\eslint(no-unused-expressions)]8;;\: Expected expression to be used
+   ,-[fixtures/linter/nan.js:1:1]
+ 1 | 123 == NaN;
+   : ^^^^^^^^^^^
+   `----
+  help: Consider using this expression or removing it
+
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/use-isnan.html\eslint(use-isnan)]8;;\: Requires calls to isNaN() when checking for NaN
    ,-[fixtures/linter/nan.js:1:8]
  1 | 123 == NaN;
@@ -20,8 +27,8 @@ working directory:
    `----
   help: Use the isNaN function to compare with NaN.
 
-Found 2 warnings and 0 errors.
-Finished in <variable>ms on 2 files with 88 rules using 1 threads.
+Found 3 warnings and 0 errors.
+Finished in <variable>ms on 2 files with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter__js_as_jsx.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__js_as_jsx.js@oxlint.snap
@@ -15,7 +15,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__svelte__debugger.svelte@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__svelte__debugger.svelte@oxlint.snap
@@ -34,7 +34,7 @@ working directory:
   help: Variable declared without assignment. Either assign a value or remove the declaration.
 
 Found 3 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__vue__debugger.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__vue__debugger.vue@oxlint.snap
@@ -25,7 +25,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 2 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__vue__empty.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__vue__empty.vue@oxlint.snap
@@ -6,7 +6,7 @@ arguments: fixtures/vue/empty.vue
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_foo.asdf@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_foo.asdf@oxlint.snap
@@ -6,7 +6,7 @@ arguments: foo.asdf
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 88 rules using 1 threads.
+Finished in <variable>ms on 0 files with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__ignore_directory_-c eslintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__ignore_directory_-c eslintrc.json@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/config_ignore_patterns/ignore_directory
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__with_oxlintrc_-c .__test__eslintrc.json --ignore-pattern _.ts .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__with_oxlintrc_-c .__test__eslintrc.json --ignore-pattern _.ts .@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c ./test/eslintrc.json --ignore-pattern *.ts .
 working directory: fixtures/config_ignore_patterns/with_oxlintrc
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 88 rules using 1 threads.
+Finished in <variable>ms on 0 files with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__disable_eslint_and_unicorn_alias_rules_-c .oxlintrc-eslint.json test.js -c .oxlintrc-unicorn.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__disable_eslint_and_unicorn_alias_rules_-c .oxlintrc-eslint.json test.js -c .oxlintrc-unicorn.json test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c .oxlintrc-eslint.json test.js
 working directory: fixtures/disable_eslint_and_unicorn_alias_rules
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 51 rules using 1 threads.
+Finished in <variable>ms on 1 file with 52 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------
@@ -16,7 +16,7 @@ arguments: -c .oxlintrc-unicorn.json test.js
 working directory: fixtures/disable_eslint_and_unicorn_alias_rules
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 64 rules using 1 threads.
+Finished in <variable>ms on 1 file with 65 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__dot_folder_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__dot_folder_@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/dot_folder
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--config extends_rules_config.json console.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--config extends_rules_config.json console.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/extends_config
   help: Delete this console statement.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--config relative_paths__extends_extends_config.json console.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--config relative_paths__extends_extends_config.json console.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/extends_config
   help: Delete this console statement.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--disable-nested-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--disable-nested-config@oxlint.snap
@@ -31,7 +31,7 @@ working directory: fixtures/extends_config
   help: Remove the debugger statement
 
 Found 3 warnings and 0 errors.
-Finished in <variable>ms on 4 files with 88 rules using 1 threads.
+Finished in <variable>ms on 4 files with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__import-cycle_--import-plugin -D import__no-cycle@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__import-cycle_--import-plugin -D import__no-cycle@oxlint.snap
@@ -27,7 +27,7 @@ working directory: fixtures/import-cycle
         -> ./b - fixtures/import-cycle/b.ts
 
 Found 0 warnings and 2 errors.
-Finished in <variable>ms on 2 files with 91 rules using 1 threads.
+Finished in <variable>ms on 2 files with 92 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__import_-c .oxlintrc.json test.js -c .oxlintrc-import-x.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__import_-c .oxlintrc.json test.js -c .oxlintrc-import-x.json test.js@oxlint.snap
@@ -15,7 +15,7 @@ working directory: fixtures/import
    `----
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 53 rules using 1 threads.
+Finished in <variable>ms on 1 file with 54 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------
@@ -34,7 +34,7 @@ working directory: fixtures/import
    `----
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 53 rules using 1 threads.
+Finished in <variable>ms on 1 file with 54 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__issue_10394_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__issue_10394_-c .oxlintrc.json@oxlint.snap
@@ -15,7 +15,7 @@ working directory: fixtures/issue_10394
   help: "Write a meaningful title for your test"
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__issue_11054_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__issue_11054_-c .oxlintrc.json@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c .oxlintrc.json
 working directory: fixtures/issue_11054
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__issue_11644_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__issue_11644_-c .oxlintrc.json@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c .oxlintrc.json
 working directory: fixtures/issue_11644
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 160 rules using 1 threads.
+Finished in <variable>ms on 1 file with 161 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__linter_debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__linter_debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/linter
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__overrides_env_globals_-c .oxlintrc.json .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__overrides_env_globals_-c .oxlintrc.json .@oxlint.snap
@@ -51,7 +51,7 @@ working directory: fixtures/overrides_env_globals
    `----
 
 Found 5 warnings and 0 errors.
-Finished in <variable>ms on 3 files with 88 rules using 1 threads.
+Finished in <variable>ms on 3 files with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__overrides_with_plugin_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__overrides_with_plugin_-c .oxlintrc.json@oxlint.snap
@@ -42,7 +42,7 @@ working directory: fixtures/overrides_with_plugin
   help: Consider removing this declaration.
 
 Found 2 warnings and 2 errors.
-Finished in <variable>ms on 2 files with 88 rules using 1 threads.
+Finished in <variable>ms on 2 files with 89 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__report_unused_directives_-c .oxlintrc.json --report-unused-disable-directives test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__report_unused_directives_-c .oxlintrc.json --report-unused-disable-directives test.js@oxlint.snap
@@ -64,7 +64,7 @@ working directory: fixtures/report_unused_directives
     `----
 
 Found 7 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__two_rules_with_same_rule_name_-c .oxlintrc.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__two_rules_with_same_rule_name_-c .oxlintrc.json test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c .oxlintrc.json test.js
 working directory: fixtures/two_rules_with_same_rule_name
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 64 rules using 1 threads.
+Finished in <variable>ms on 1 file with 65 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/test/__snapshots__/e2e.test.ts.snap
+++ b/apps/oxlint/test/__snapshots__/e2e.test.ts.snap
@@ -1710,6 +1710,14 @@ exports[`oxlint CLI > should work with multiple rules 1`] = `
    : ^^^
    \`----
 
-Found 1 warning and 3 errors.
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\\eslint(no-unused-expressions)]8;;\\: Expected expression to be used
+   ,-[index.js:3:1]
+ 2 | 
+ 3 | foo;
+   : ^^^^
+   \`----
+  help: Consider using this expression or removing it
+
+Found 2 warnings and 3 errors.
 Finished in Xms on 1 file using X threads."
 `;

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_tsgolint@no-floating-promises__index.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_tsgolint@no-floating-promises__index.ts.snap
@@ -5,6 +5,19 @@ source: crates/oxc_language_server/src/tester.rs
 file: fixtures/linter/tsgolint/no-floating-promises/index.ts
 ----------
 
+code: "eslint(no-unused-expressions)"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html"
+message: "Expected expression to be used\nhelp: Consider using this expression or removing it"
+range: Range { start: Position { line: 1, character: 0 }, end: Position { line: 1, character: 8 } }
+related_information[0].message: ""
+related_information[0].location.uri: "file://<variable>/fixtures/linter/tsgolint/no-floating-promises/index.ts"
+related_information[0].location.range: Range { start: Position { line: 1, character: 0 }, end: Position { line: 1, character: 8 } }
+severity: Some(Warning)
+source: Some("oxc")
+tags: None
+fixed: None
+
+
 code: "typescript-eslint(no-floating-promises)"
 code_description.href: "None"
 message: "Promises must be awaited.\nhelp: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator."

--- a/crates/oxc_linter/src/rules/eslint/no_unused_expressions.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_expressions.rs
@@ -5,24 +5,30 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
+use schemars::JsonSchema;
 use serde_json::Value;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_unused_expressions_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow unused expressions")
-        .with_help("Consider removing this expression")
+    OxcDiagnostic::warn("Expected expression to be used")
+        .with_help("Consider using this expression or removing it")
         .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]
 pub struct NoUnusedExpressions(Box<NoUnusedExpressionsConfig>);
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct NoUnusedExpressionsConfig {
+    /// When set to `true`, allows short circuit evaluations in expressions.
     allow_short_circuit: bool,
+    /// When set to `true`, allows ternary operators in expressions.
     allow_ternary: bool,
+    /// When set to `true`, allows tagged template literals in expressions.
     allow_tagged_templates: bool,
+    /// When set to `true`, enforces the rule for unused JSX expressions also.
     enforce_for_jsx: bool,
 }
 
@@ -50,7 +56,8 @@ declare_oxc_lint!(
     /// ```
     NoUnusedExpressions,
     eslint,
-    restriction
+    correctness,
+    config = NoUnusedExpressionsConfig,
 );
 
 impl Rule for NoUnusedExpressions {

--- a/crates/oxc_linter/src/snapshots/eslint_no_unused_expressions.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unused_expressions.snap
@@ -1,290 +1,290 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ 0
    · ─
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ a
    · ─
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ f(), 0
    · ──────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:2]
  1 │ {0}
    ·  ─
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ []
    · ──
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ a && b();
    · ─────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ a() || false
    · ────────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ a || (b = c)
    · ────────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ a ? b() || (c = d) : e
    · ──────────────────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ `untagged template literal`
    · ───────────────────────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ tag`tagged template literal`
    · ────────────────────────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ a && b()
    · ────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ a ? b() : c()
    · ─────────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ a || b
    · ──────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ a() && b
    · ────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ a ? b : 0
    · ─────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ a ? b : c()
    · ───────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ foo.bar;
    · ────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ !a
    · ──
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ +a
    · ──
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:23]
  1 │ "directive one"; f(); "directive two";
    ·                       ────────────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:39]
  1 │ function foo() {"directive one"; f(); "directive two"; }
    ·                                       ────────────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:10]
  1 │ if (0) { "not a directive"; f(); }
    ·          ──────────────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:34]
  1 │ function foo() { var foo = true; "use strict"; }
    ·                                  ─────────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:35]
  1 │ var foo = () => { var foo = true; "use strict"; }
    ·                                   ─────────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ `untagged template literal`
    · ───────────────────────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ `untagged template literal`
    · ───────────────────────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ tag`tagged template literal`
    · ────────────────────────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ obj?.foo
    · ────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ obj?.foo.bar
    · ────────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ obj?.foo().bar
    · ──────────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ <div />
    · ───────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ <></>
    · ─────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:20]
  1 │ class C { static { 'use strict'; } }
    ·                    ─────────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:2:4]
  1 │ class C { static {
  2 │             'foo'
    ·             ─────
  3 │             'bar'
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:3:4]
  2 │             'foo'
  3 │             'bar'
    ·             ─────
  4 │              } }
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:2:11]
  1 │ 
  2 │             if (0) 0;
    ·                    ──
  3 │                   
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:2:4]
  1 │ 
  2 │             f(0), {};
    ·             ─────────
  3 │                   
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:2:4]
  1 │ 
  2 │             a, b();
    ·             ───────
  3 │                   
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:2:4]
  1 │     
  2 │ ╭─▶             a() &&
@@ -293,167 +293,167 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶               };
  6 │                       
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:2:4]
  1 │ 
  2 │             a?.b;
    ·             ─────
  3 │                   
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:2:4]
  1 │ 
  2 │             (a?.b).c;
    ·             ─────────
  3 │                   
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:2:4]
  1 │ 
  2 │             a?.['b'];
    ·             ─────────
  3 │                   
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:2:4]
  1 │ 
  2 │             (a?.['b']).c;
    ·             ─────────────
  3 │                   
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:2:4]
  1 │ 
  2 │             a?.b()?.c;
    ·             ──────────
  3 │                   
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:2:4]
  1 │ 
  2 │             (a?.b()).c;
    ·             ───────────
  3 │                   
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:2:4]
  1 │ 
  2 │             one[2]?.[3][4];
    ·             ───────────────
  3 │                   
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:2:4]
  1 │ 
  2 │             one.two?.three.four;
    ·             ────────────────────
  3 │                   
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:4:6]
  3 │               const foo = true;
  4 │               'use strict';
    ·               ─────────────
  5 │             }
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:6:6]
  5 │ 
  6 │               'use strict';
    ·               ─────────────
  7 │             }
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:5:6]
  4 │ 
  5 │               'use strict';
    ·               ─────────────
  6 │             }
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ foo && foo?.bar;
    · ────────────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ foo ? foo?.bar : bar.baz;
    · ─────────────────────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:3:4]
  2 │             class Foo<T> {}
  3 │             Foo<string>;
    ·             ────────────
  4 │                   
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:1]
  1 │ Map<string, string>;
    · ────────────────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:3:4]
  2 │             declare const foo: number | undefined;
  3 │             foo;
    ·             ────
  4 │                   
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:3:4]
  2 │             declare const foo: number | undefined;
  3 │             foo as any;
    ·             ───────────
  4 │                   
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:3:4]
  2 │             declare const foo: number | undefined;
  3 │             foo!;
    ·             ─────
  4 │                   
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it
 
-  ⚠ eslint(no-unused-expressions): Disallow unused expressions
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:1:36]
  1 │ const _func = (value: number) => { value + 1; }
    ·                                    ──────────
    ╰────
-  help: Consider removing this expression
+  help: Consider using this expression or removing it


### PR DESCRIPTION
- closes https://github.com/oxc-project/oxc/issues/13796

Moves `no-unused-expressions` rule to be `correctness` and run by default. Also updates the config to have a JSON schema so that we can show the auto-generate the config options on the website.