### PR TITLE
feat(linter): add fix for `preserve-caught-error`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
+++ b/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
@@ -1,30 +1,35 @@
 use oxc_ast::AstKind;
 use oxc_ast::ast::{
-    Argument, BindingPattern, CatchClause, Expression, Function, ObjectExpression,
-    ObjectPropertyKind, PropertyKey, ThrowStatement, TryStatement,
+    Argument, BindingPattern, CatchClause, Expression, Function, IdentifierReference,
+    ObjectExpression, ObjectPropertyKind, PropertyKey, ThrowStatement, TryStatement,
 };
 use oxc_ast_visit::Visit;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{IsGlobalReference, ScopeFlags};
-use oxc_span::Span;
+use oxc_span::{GetSpan, Span};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
+const ADD_CAUSE_PROPERTY: &str = "Add cause property to the thrown error";
+const REPLACE_CAUSE_PROPERTY: &str = "Replace cause property value with the caught error";
+
 fn preserve_caught_error_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("preserve-caught-error")
+    OxcDiagnostic::warn("There is no cause error attached to this new thrown error.")
         .with_help(
-            "When re-throwing an error, preserve the original error using the 'cause' property",
+            "Preserve the original error by using the `cause` property when re-throwing errors.",
         )
         .with_label(span)
 }
 
 fn missing_catch_parameter_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("preserve-caught-error")
-        .with_help("Catch clause must have a parameter when 'requireCatchParameter' is enabled")
-        .with_label(span)
+    OxcDiagnostic::warn(
+        "The caught error is not accessible because the catch clause has no error parameter.",
+    )
+    .with_help("Add an error parameter to the catch clause to access the caught error.")
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
@@ -66,7 +71,114 @@ impl<'a> Visit<'a> for ThrowFinder<'a, '_> {
             return;
         }
 
-        self.ctx.diagnostic(preserve_caught_error_diagnostic(throw_stmt.span));
+        self.ctx.diagnostic_with_fix(preserve_caught_error_diagnostic(throw_stmt.span), |fixer| {
+            let Some(ident) = self.catch_param.get_identifier_name() else {
+                return fixer.noop();
+            };
+            let cause_prop_text = format!("cause: {}", ident.as_str());
+
+            match args.len() {
+                0 => {
+                    // find starting `(` of call after callee
+                    let src = throw_stmt.argument.span().source_text(fixer.source_text());
+                    if let Some(start_paren_idx) = src.find('(') {
+                        let mut fix = fixer.new_fix_with_capacity(3);
+                        #[expect(clippy::cast_possible_truncation)]
+                        let span = Span::sized(
+                            throw_stmt.argument.span().start + start_paren_idx as u32,
+                            1,
+                        );
+                        if let Expression::Identifier(ident) = callee
+                            && is_aggregate_error(ident, self.ctx)
+                        {
+                            // AggregateError takes options as its third argument
+                            fix.push(fixer.insert_text_after_range(span, "[], "));
+                        }
+                        fix.push(fixer.insert_text_after_range(span, "\"\", "));
+                        fix.push(
+                            fixer.insert_text_after_range(span, format!("{{ {cause_prop_text} }}")),
+                        );
+                        return fix.with_message(ADD_CAUSE_PROPERTY);
+                    }
+                }
+                1 => {
+                    let span = args[0].span();
+                    // insert comma
+                    let mut fix = fixer.new_fix_with_capacity(3);
+                    if let Expression::Identifier(ident) = callee
+                        && is_aggregate_error(ident, self.ctx)
+                    {
+                        // AggregateError takes options as its third argument
+                        fix.push(fixer.insert_text_after_range(span, ", \"\""));
+                    }
+                    fix.push(fixer.insert_text_after_range(span, ", "));
+                    fix.push(
+                        fixer.insert_text_after_range(span, format!("{{ {cause_prop_text} }}")),
+                    );
+                    return fix.with_message(ADD_CAUSE_PROPERTY);
+                }
+                2 => {
+                    if let Expression::Identifier(ident) = callee
+                        && is_aggregate_error(ident, self.ctx)
+                    {
+                        // AggregateError takes options as its third argument
+                        let span = args[1].span();
+                        let mut fix = fixer.new_fix_with_capacity(2);
+                        fix.push(fixer.insert_text_after_range(span, ", "));
+                        fix.push(
+                            fixer.insert_text_after_range(span, format!("{{ {cause_prop_text} }}")),
+                        );
+                        return fix.with_message(ADD_CAUSE_PROPERTY);
+                    }
+
+                    // if the second argument is an existing object, merge into it
+                    if let Argument::ObjectExpression(obj_expr) = &args[1] {
+                        let cause_prop = obj_expr.properties.iter().find(|prop| match prop {
+                            ObjectPropertyKind::ObjectProperty(prop) => {
+                                let PropertyKey::StaticIdentifier(ident) = &prop.key else {
+                                    return false;
+                                };
+                                ident.name == "cause"
+                            }
+                            ObjectPropertyKind::SpreadProperty(_) => true,
+                        });
+
+                        if let Some(cause_prop) = cause_prop {
+                            // if the identifier name is not the catch parameter, replace it
+                            if let ObjectPropertyKind::ObjectProperty(prop) = cause_prop
+                                && !is_catch_parameter(&prop.value, self.catch_param, self.ctx)
+                            {
+                                if prop.shorthand || prop.method || prop.kind.is_accessor() {
+                                    return fixer
+                                        .replace(prop.span(), cause_prop_text)
+                                        .with_message(REPLACE_CAUSE_PROPERTY);
+                                }
+                                return fixer
+                                    .replace(prop.value.span(), ident.as_str().to_string())
+                                    .with_message(REPLACE_CAUSE_PROPERTY);
+                            }
+                        } else if obj_expr.properties.is_empty() {
+                            return fixer
+                                .insert_text_after_range(
+                                    obj_expr.span().shrink_right(1),
+                                    format!(" {cause_prop_text} "),
+                                )
+                                .with_message(ADD_CAUSE_PROPERTY);
+                        } else if let Some(last_prop) = obj_expr.properties.last() {
+                            let mut fix = fixer.new_fix_with_capacity(2);
+                            fix.push(fixer.insert_text_after_range(last_prop.span(), ", "));
+                            fix.push(
+                                fixer.insert_text_after_range(last_prop.span(), cause_prop_text),
+                            );
+                            return fix.with_message(ADD_CAUSE_PROPERTY);
+                        }
+                    }
+                }
+                _ => {}
+            }
+
+            fixer.noop()
+        });
     }
 
     // Do not traverse into nested functions/closures within the catch block
@@ -80,7 +192,11 @@ fn is_builtin_error_constructor(expr: &Expression, ctx: &LintContext) -> bool {
 
     ident.is_global_reference_name("Error", ctx.scoping())
         || ident.is_global_reference_name("TypeError", ctx.scoping())
-        || ident.is_global_reference_name("AggregateError", ctx.scoping())
+        || is_aggregate_error(ident, ctx)
+}
+
+fn is_aggregate_error(ident: &IdentifierReference, ctx: &LintContext) -> bool {
+    ident.is_global_reference_name("AggregateError", ctx.scoping())
 }
 
 fn has_cause_property(
@@ -162,7 +278,7 @@ declare_oxc_lint!(
     PreserveCaughtError,
     eslint,
     suspicious,
-    pending,
+    conditional_fix,
     config = PreserveCaughtErrorOptions,
 );
 impl PreserveCaughtError {
@@ -542,8 +658,427 @@ fn test() {
 						}"#,
             None,
         ),
+        (
+            r#"try {} catch (error) {
+				throw new Error("Something failed", {
+					get cause() { return error; },
+					set cause(value) { error = value; },
+				});
+			}"#,
+            None,
+        ),
+    ];
+
+    let fix = vec![
+        (
+            r#"try {
+                        doSomething();
+                    } catch (err) {
+                        throw new Error("Something failed");
+                    }"#,
+            r#"try {
+                        doSomething();
+                    } catch (err) {
+                        throw new Error("Something failed", { cause: err });
+                    }"#,
+            None,
+        ),
+        (
+            r#"try {
+                        doSomething();
+                    } catch (error) {
+                        throw new Error("Failed");
+                    }"#,
+            r#"try {
+                        doSomething();
+                    } catch (error) {
+                        throw new Error("Failed", { cause: error });
+                    }"#,
+            None,
+        ),
+        (
+            r#"try {
+                        doSomething();
+                    } catch (error) {
+                        throw new Error("Failed", {});
+                    }"#,
+            r#"try {
+                        doSomething();
+                    } catch (error) {
+                        throw new Error("Failed", { cause: error });
+                    }"#,
+            None,
+        ),
+        (
+            r#"try {
+                        doSomething();
+                    } catch (error) {
+                        throw new Error("Failed", { existingOption: true, complexOption: { option: {} } });
+                    }"#,
+            r#"try {
+                        doSomething();
+                    } catch (error) {
+                        throw new Error("Failed", { existingOption: true, complexOption: { option: {} }, cause: error });
+                    }"#,
+            None,
+        ),
+        (
+            r#"try {
+                        doSomething();
+                    } catch (err) {
+                        throw new Error("Something failed", {});
+                    }"#,
+            r#"try {
+                        doSomething();
+                    } catch (err) {
+                        throw new Error("Something failed", { cause: err });
+                    }"#,
+            None,
+        ),
+        // Throwing a new error with unrelated cause
+        (
+            r#"try {
+                        doSomething();
+                    } catch (err) {
+                        const unrelated = new Error("other");
+                        throw new Error("Something failed", { cause: unrelated });
+                    }"#,
+            r#"try {
+                        doSomething();
+                    } catch (err) {
+                        const unrelated = new Error("other");
+                        throw new Error("Something failed", { cause: err });
+                    }"#,
+            None,
+        ),
+        // Throws a new Error, cause property is present but value is a different identifier
+        // Note: This should actually be a valid case since e === err, but still reporting as it's hard to track.
+        (
+            r#"try {
+                        doSomething();
+                    } catch (err) {
+                        const e = err;
+                        throw new Error("Something failed", { cause: e });
+                    }"#,
+            r#"try {
+                        doSomething();
+                    } catch (err) {
+                        const e = err;
+                        throw new Error("Something failed", { cause: err });
+                    }"#,
+            None,
+        ),
+        // Throws a new error, but is not using the full error as the cause
+        (
+            r#"try {
+                        doSomething();
+                    } catch (err) {
+                        throw new Error("Something failed", { cause: err.message });
+                    }"#,
+            r#"try {
+                        doSomething();
+                    } catch (err) {
+                        throw new Error("Something failed", { cause: err });
+                    }"#,
+            None,
+        ),
+        // Throw in a deeply nested catch block
+        (
+            r#"try {
+                doSomething();
+            } catch (error) {
+                if (shouldThrow) {
+                    while (true) {
+                        if (Math.random() > 0.5) {
+                            throw new Error("Failed without cause");
+                        }
+                    }
+                }
+            }"#,
+            r#"try {
+                doSomething();
+            } catch (error) {
+                if (shouldThrow) {
+                    while (true) {
+                        if (Math.random() > 0.5) {
+                            throw new Error("Failed without cause", { cause: error });
+                        }
+                    }
+                }
+            }"#,
+            None,
+        ),
+        // Throw deep inside a switch block
+        (
+            r#"try {
+                doSomething();
+            } catch (error) {
+                switch (error.code) {
+                    case "A":
+                        throw new Error("Type A");
+                    case "B":
+                        throw new Error("Type B", { cause: error });
+                    default:
+                        throw new Error("Other", { cause: error });
+                }
+            }"#,
+            r#"try {
+                doSomething();
+            } catch (error) {
+                switch (error.code) {
+                    case "A":
+                        throw new Error("Type A", { cause: error });
+                    case "B":
+                        throw new Error("Type B", { cause: error });
+                    default:
+                        throw new Error("Other", { cause: error });
+                }
+            }"#,
+            None,
+        ),
+        // Throw statement with template literal error message
+        (
+            r#"try {
+                doSomething();
+            } catch (error) {
+                throw new Error(`The certificate key "${chalk.yellow(keyFile)}" is invalid.\n${err.message}`);
+            }"#,
+            r#"try {
+                doSomething();
+            } catch (error) {
+                throw new Error(`The certificate key "${chalk.yellow(keyFile)}" is invalid.\n${err.message}`, { cause: error });
+            }"#,
+            None,
+        ),
+        // Throw statement with a variable error message
+        (
+            r#"try {
+                doSomething();
+            } catch (error) {
+                const errorMessage = "Operation failed";
+                throw new Error(errorMessage);
+            }"#,
+            r#"try {
+                doSomething();
+            } catch (error) {
+                const errorMessage = "Operation failed";
+                throw new Error(errorMessage, { cause: error });
+            }"#,
+            None,
+        ),
+        // Multiple throw statements within a catch block
+        (
+            r#"try {
+                doSomething();
+            } catch (err) {
+                if (err.code === "A") {
+                    throw new Error("Type A");
+                }
+                throw new TypeError("Fallback error");
+            }"#,
+            r#"try {
+                doSomething();
+            } catch (err) {
+                if (err.code === "A") {
+                    throw new Error("Type A", { cause: err });
+                }
+                throw new TypeError("Fallback error", { cause: err });
+            }"#,
+            None,
+        ),
+        // Fixes Error without new keyword
+        (
+            r#"try {
+                doSomething();
+            } catch (err) {
+                throw Error("Something failed");
+            }"#,
+            r#"try {
+                doSomething();
+            } catch (err) {
+                throw Error("Something failed", { cause: err });
+            }"#,
+            None,
+        ),
+        // Fixes labeled throw statement
+        (
+            r#"try {
+                doSomething();
+            } catch (err) {
+                my_label:
+                throw new Error("Failed without cause");
+            }"#,
+            r#"try {
+                doSomething();
+            } catch (err) {
+                my_label:
+                throw new Error("Failed without cause", { cause: err });
+            }"#,
+            None,
+        ),
+        // Fixes throw statement with empty error
+        (
+            r"try {
+                doSomething();
+            } catch (err) {
+                {
+                    throw new Error();
+                }
+            }",
+            r#"try {
+                doSomething();
+            } catch (err) {
+                {
+                    throw new Error("", { cause: err });
+                }
+            }"#,
+            None,
+        ),
+        // Fixes AggregateError, which accepts options as its third argument
+        (
+            r#"try {
+                doSomething();
+            } catch (err) {
+                {
+                    throw new AggregateError([], "Lorem ipsum");
+                }
+            }"#,
+            r#"try {
+                doSomething();
+            } catch (err) {
+                {
+                    throw new AggregateError([], "Lorem ipsum", { cause: err });
+                }
+            }"#,
+            None,
+        ),
+        // Fixes AggregateError with no message
+        (
+            r"try {
+                doSomething();
+            } catch (err) {
+                {
+                    throw new AggregateError();
+                }
+            }",
+            r#"try {
+                doSomething();
+            } catch (err) {
+                {
+                    throw new AggregateError([], "", { cause: err });
+                }
+            }"#,
+            None,
+        ),
+        // Fixes AggregateError with only an errors argument
+        (
+            r"try {
+                doSomething();
+            } catch (err) {
+                {
+                    throw new AggregateError([]);
+                }
+            }",
+            r#"try {
+                doSomething();
+            } catch (err) {
+                {
+                    throw new AggregateError([], "", { cause: err });
+                }
+            }"#,
+            None,
+        ),
+        // Throwing a new error with an unrelated variable named cause
+        (
+            r#"try {
+                        doSomething();
+                    } catch (err) {
+                        throw new Error("Something failed", { cause });
+                    }"#,
+            r#"try {
+                        doSomething();
+                    } catch (err) {
+                        throw new Error("Something failed", { cause: err });
+                    }"#,
+            None,
+        ),
+        // Make sure comments are preserved when fixing
+        (
+            r#"try {
+				doSomething();
+			} catch (error) {
+				throw new Error(
+					"Something went wrong" // some comments
+				);
+			}"#,
+            r#"try {
+				doSomething();
+			} catch (error) {
+				throw new Error(
+					"Something went wrong", { cause: error } // some comments
+				);
+			}"#,
+            None,
+        ),
+        // When an object property is computed, we cannot be sure it's not 'cause', so just add a new property
+        (
+            r#"try {
+                doSomething();
+            } catch (error) {
+                const cause = "desc";
+                throw new Error("Something failed", { [cause]: "Some error" });
+            }"#,
+            r#"try {
+                doSomething();
+            } catch (error) {
+                const cause = "desc";
+                throw new Error("Something failed", { [cause]: "Some error", cause: error });
+            }"#,
+            None,
+        ),
+        (
+            r#"try {
+                doSomething();
+			} catch (error) {
+                throw new Error("Something failed", { cause() { /* do something */ }  });
+			}"#,
+            r#"try {
+                doSomething();
+			} catch (error) {
+                throw new Error("Something failed", { cause: error  });
+			}"#,
+            None,
+        ),
+        // Fix getters and setters as cause
+        (
+            r#"try {
+                doSomething();
+            } catch (error) {
+                throw new Error("Something failed", { get cause() { } });
+            }"#,
+            r#"try {
+                doSomething();
+            } catch (error) {
+                throw new Error("Something failed", { cause: error });
+            }"#,
+            None,
+        ),
+        (
+            r#"try {
+                doSomething();
+            } catch (error) {
+                throw new Error("Something failed", { set cause(value) { } });
+            }"#,
+            r#"try {
+                doSomething();
+            } catch (error) {
+                throw new Error("Something failed", { cause: error });
+            }"#,
+            None,
+        ),
     ];
 
     Tester::new(PreserveCaughtError::NAME, PreserveCaughtError::PLUGIN, pass, fail)
+        .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/eslint_preserve_caught_error.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_preserve_caught_error.snap
@@ -1,214 +1,214 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:4:16]
  3 │                     } catch (err) {
  4 │                         throw new Error("Something failed");
    ·                         ────────────────────────────────────
  5 │                     }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:5:16]
  4 │                         const unrelated = new Error("other");
  5 │                         throw new Error("Something failed", { cause: unrelated });
    ·                         ──────────────────────────────────────────────────────────
  6 │                     }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:5:16]
  4 │                         const e = err;
  5 │                         throw new Error("Failed", { cause: e });
    ·                         ────────────────────────────────────────
  6 │                     }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:4:16]
  3 │                     } catch (error) {
  4 │                         throw new Error("Failed", { cause: error.message });
    ·                         ────────────────────────────────────────────────────
  5 │                     }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:7:28]
  6 │                                 if (Math.random() > 0.5) {
  7 │                                     throw new Error("Failed without cause");
    ·                                     ────────────────────────────────────────
  8 │                                 }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:6:24]
  5 │                             case "A":
  6 │                                 throw new Error("Type A");
    ·                                 ──────────────────────────
  7 │                             case "B":
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:4:16]
  3 │                         } catch (error) {
  4 │ ╭─▶                         throw new Error(`The certificate key "${chalk.yellow(keyFile)}" is invalid.
  5 │ ╰─▶             ${err.message}`);
  6 │                         }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:5:16]
  4 │                         const errorMessage = "Operation failed";
  5 │                         throw new Error(errorMessage);
    ·                         ──────────────────────────────
  6 │                     }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:5:16]
  4 │                         const errorMessage = "Operation failed";
  5 │                         throw new Error(errorMessage, { existingOption: true, complexOption: { moreOptions: {} } });
    ·                         ────────────────────────────────────────────────────────────────────────────────────────────
  6 │                     }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:5:20]
  4 │                         if (err.code === "A") {
  5 │                             throw new Error("Type A");
    ·                             ──────────────────────────
  6 │                         }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:7:16]
  6 │                         }
  7 │                         throw new TypeError("Fallback error");
    ·                         ──────────────────────────────────────
  8 │                     }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:4:16]
  3 │                     } catch (err) {
  4 │                         throw Error("Something failed");
    ·                         ────────────────────────────────
  5 │                     }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:4:16]
  3 │                         my_label:
  4 │                         throw new Error("Failed without cause");
    ·                         ────────────────────────────────────────
  5 │                     }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:4:20]
  3 │                         {
  4 │                             throw new Error("Something went wrong");
    ·                             ────────────────────────────────────────
  5 │                         }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:4:20]
  3 │                         {
  4 │                             throw new Error();
    ·                             ──────────────────
  5 │                         }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:4:20]
  3 │                         {
  4 │                             throw new AggregateError([], "Lorem ipsum");
    ·                             ────────────────────────────────────────────
  5 │                         }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:4:20]
  3 │                         {
  4 │                             throw new AggregateError();
    ·                             ───────────────────────────
  5 │                         }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:4:20]
  3 │                         {
  4 │                             throw new AggregateError([]);
    ·                             ─────────────────────────────
  5 │                         }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): The caught error is not accessible because the catch clause has no error parameter.
    ╭─[preserve_caught_error.tsx:3:8]
  2 │                             doSomething();
  3 │ ╭─▶                     } catch {
  4 │ │                           throw new Error("Something went wrong");
  5 │ ╰─▶                     }
    ╰────
-  help: Catch clause must have a parameter when 'requireCatchParameter' is enabled
+  help: Add an error parameter to the catch clause to access the caught error.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:4:16]
  3 │                     } catch (err) {
  4 │                         throw new Error("Something failed", { cause });
    ·                         ───────────────────────────────────────────────
  5 │                     }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:4:8]
  3 │                         } catch ({ message }) {
  4 │                             throw new Error(message);
    ·                             ─────────────────────────
  5 │                         }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:4:8]
  3 │                         } catch ({ ...error }) {
  4 │                             throw new Error(error.message);
    ·                             ───────────────────────────────
  5 │                         }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:6:9]
  5 │                                 const error = anotherError;
  6 │                                 throw new Error("Something went wrong", { cause: error });
    ·                                 ──────────────────────────────────────────────────────────
  7 │                             }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:4:8]
  3 │                             } catch (error) {
  4 │ ╭─▶                             throw new Error(
@@ -216,31 +216,42 @@ source: crates/oxc_linter/src/tester.rs
  6 │ ╰─▶                             );
  7 │                             }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:4:8]
  3 │                         } catch (err) {
  4 │                             throw new Error("Something failed", {});
    ·                             ────────────────────────────────────────
  5 │                         }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:5:7]
  4 │                         const cause = "desc";
  5 │                         throw new Error("Something failed", { [cause]: "Some error" });
    ·                         ───────────────────────────────────────────────────────────────
  6 │                     }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
 
-  ⚠ eslint(preserve-caught-error): preserve-caught-error
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
    ╭─[preserve_caught_error.tsx:4:7]
  3 │                         } catch (error) {
  4 │                         throw new Error("Something failed", { cause() { /* do something */ }  });
    ·                         ─────────────────────────────────────────────────────────────────────────
  5 │                         }
    ╰────
-  help: When re-throwing an error, preserve the original error using the 'cause' property
+  help: Preserve the original error by using the `cause` property when re-throwing errors.
+
+  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
+   ╭─[preserve_caught_error.tsx:2:5]
+ 1 │     try {} catch (error) {
+ 2 │ ╭─▶                 throw new Error("Something failed", {
+ 3 │ │                       get cause() { return error; },
+ 4 │ │                       set cause(value) { error = value; },
+ 5 │ ╰─▶                 });
+ 6 │                 }
+   ╰────
+  help: Preserve the original error by using the `cause` property when re-throwing errors.


### PR DESCRIPTION
Ported over the tests from `typescript-eslint`. I also improved the diagnostic messages that were pre-existing. I believe the fixer now supports all of the same cases that `typescript-eslint` does, but I didn't check that the fixing logic is 1:1.