### PR TITLE
ci(release_oxlint): stop uploading binaries to github, node.js is now required

### DIFF
--- a/.github/workflows/release_oxlint.yml
+++ b/.github/workflows/release_oxlint.yml
@@ -232,10 +232,8 @@ jobs:
         with:
           body: ${{ steps.run.outputs.CHANGELOG }}
           draft: false
-          files: oxlint-*
           name: oxlint v${{ needs.check.outputs.version }}
           tag_name: oxlint_v${{ needs.check.outputs.version }}
-          fail_on_unmatched_files: true
           target_commitish: ${{ github.sha }}
 
       - name: wait 3 minutes for smoke test


### PR DESCRIPTION
closes #14100