### PR TITLE
refactor(benchmark): consolidate features into compiler and linter

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -57,28 +57,34 @@ jobs:
     if: needs.determine-matrix.outputs.matrix != '[]'
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        component: ${{ fromJSON(needs.determine-matrix.outputs.matrix) }}
+        include: ${{ fromJSON(needs.determine-matrix.outputs.matrix) }}
     name: Bench ${{ matrix.component }}
     steps:
       - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
 
-      - uses: oxc-project/setup-rust@d286d43bc1f606abbd98096666ff8be68c8d5f57 # v1.0.2
+      - uses: oxc-project/setup-rust@5e7ddbacb109aa3e6ed4391afc589c7f6ba090d7 # v1.0.4
         with:
-          cache-key: benchmark-${{ matrix.component }}
+          cache-key: benchmark-${{ matrix.feature }}
           save-cache: ${{ github.ref_name == 'main' }}
           tools: cargo-codspeed
 
       - name: Build benchmark
         env:
           RUSTFLAGS: "-C debuginfo=1 -C strip=none -g --cfg codspeed"
-          MATRIX_COMPONENT: ${{ matrix.component }}
         run: |
-          cargo build --release -p oxc_benchmark --bench ${MATRIX_COMPONENT} \
-            --no-default-features --features ${MATRIX_COMPONENT} --features codspeed
+          if [ "${{ matrix.component }}" = "linter" ]; then
+            cargo build --release -p oxc_benchmark --bench linter \
+              --no-default-features --features ${{ matrix.feature }} --features codspeed
+          else
+            cargo build --release -p oxc_benchmark \
+              --bench lexer --bench parser --bench transformer --bench semantic \
+              --bench minifier --bench codegen --bench formatter \
+              --no-default-features --features ${{ matrix.feature }} --features codspeed
+          fi
           mkdir -p target/codspeed/instrumentation/oxc_benchmark
-          mv target/release/deps/${MATRIX_COMPONENT}-* target/codspeed/instrumentation/oxc_benchmark
+          mv target/release/deps/${{ matrix.component }}-* target/codspeed/instrumentation/oxc_benchmark
           rm target/codspeed/instrumentation/oxc_benchmark/*.d
 
       - name: Run benchmark
@@ -87,4 +93,4 @@ jobs:
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: instrumentation
-          run: cargo codspeed run
+          run: cargo codspeed run ${{ matrix.component }}

--- a/tasks/benchmark/Cargo.toml
+++ b/tasks/benchmark/Cargo.toml
@@ -83,66 +83,22 @@ serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 
 [features]
-default = [
-  "lexer",
-  "parser",
-  "transformer",
-  "semantic",
-  "minifier",
-  "codegen",
-  "linter",
-  "formatter",
-]
+default = ["compiler", "linter"]
 codspeed = ["criterion2/codspeed"]
 codspeed_napi = ["criterion2/codspeed", "dep:serde", "dep:serde_json"]
 
-# Features for running each benchmark separately with minimum dependencies that benchmark needs.
-# e.g. `cargo bench -p oxc_benchmark --bench parser --no-default-features --features parser`
-lexer = [
+# Features for running benchmarks with minimum dependencies.
+# "compiler" feature includes: lexer, parser, transformer, semantic, minifier, codegen, formatter
+# "linter" feature includes: linter
+compiler = [
   "dep:oxc_allocator",
   "dep:oxc_ast",
   "dep:oxc_ast_visit",
-  "dep:oxc_parser",
-  "dep:oxc_span",
-  "dep:oxc_tasks_common",
-]
-parser = [
-  "dep:oxc_allocator",
-  "dep:oxc_ast",
-  "dep:oxc_ast_visit",
-  "dep:oxc_parser",
-  "dep:oxc_span",
-  "dep:oxc_tasks_common",
-]
-transformer = [
-  "dep:oxc_allocator",
-  "dep:oxc_isolated_declarations",
-  "dep:oxc_parser",
-  "dep:oxc_semantic",
-  "dep:oxc_span",
-  "dep:oxc_tasks_common",
-  "dep:oxc_transformer",
-]
-semantic = [
-  "dep:oxc_allocator",
-  "dep:oxc_parser",
-  "dep:oxc_semantic",
-  "dep:oxc_span",
-  "dep:oxc_tasks_common",
-]
-minifier = [
-  "dep:oxc_allocator",
-  "dep:oxc_minifier",
-  "dep:oxc_mangler",
-  "dep:oxc_parser",
-  "dep:oxc_semantic",
-  "dep:oxc_span",
-  "dep:oxc_tasks_common",
-  "transformer",
-]
-codegen = [
-  "dep:oxc_allocator",
   "dep:oxc_codegen",
+  "dep:oxc_formatter",
+  "dep:oxc_isolated_declarations",
+  "dep:oxc_mangler",
+  "dep:oxc_minifier",
   "dep:oxc_parser",
   "dep:oxc_semantic",
   "dep:oxc_span",
@@ -158,4 +114,3 @@ linter = [
   "dep:oxc_tasks_common",
   "oxc_semantic/cfg",
 ]
-formatter = ["dep:oxc_allocator", "dep:oxc_parser", "dep:oxc_formatter", "dep:oxc_span", "dep:oxc_tasks_common"]


### PR DESCRIPTION
closes https://github.com/oxc-project/oxc/issues/14007

- Replace 8 individual benchmark features with 2: compiler and linter
- Update matrix script to return objects with component and feature fields
- Simplify workflow to use cargo codspeed build/run with feature mapping

🤖 Generated with [Claude Code](https://claude.ai/code)

This balances build speed and cache size, it was saving 7 separate caches of 280MB each component + 400MB for the linter, it's now 200-300MB for the "compiler".