### PR TITLE
feat(formatter/sort-imports): Wrap `ImportDeclaration` with `JsLabels`

### DIFF
--- a/crates/oxc_formatter/examples/sort_imports.rs
+++ b/crates/oxc_formatter/examples/sort_imports.rs
@@ -12,6 +12,9 @@ use pico_args::Arguments;
 fn main() -> Result<(), String> {
     let mut args = Arguments::from_env();
     let show_ir = args.contains("--ir");
+    let partition_by_newline = args.contains("--partition_by_newline");
+    let partition_by_comment = args.contains("--partition_by_comment");
+    let sort_side_effects = args.contains("--sort_side_effects");
     let name = args.free_from_str().unwrap_or_else(|_| "test.js".to_string());
 
     // Read source file
@@ -42,9 +45,9 @@ fn main() -> Result<(), String> {
     // Format the parsed code
     let options = FormatOptions {
         experimental_sort_imports: Some(SortImports {
-            partition_by_newline: true,
-            partition_by_comment: false,
-            sort_side_effects: true,
+            partition_by_newline,
+            partition_by_comment,
+            sort_side_effects,
         }),
         ..Default::default()
     };
@@ -61,6 +64,12 @@ fn main() -> Result<(), String> {
         let code = formatter.build(&ret.program);
         println!("{code}");
     }
+
+    println!("=======================");
+    println!(
+        "Formatted with {:#?}",
+        SortImports { partition_by_newline, partition_by_comment, sort_side_effects }
+    );
 
     Ok(())
 }

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -98,6 +98,8 @@ impl<'a> Formatter<'a> {
 #[derive(Copy, Clone, Debug)]
 pub(crate) enum JsLabels {
     MemberChain,
+    /// For `ir_transform/sort_imports`
+    ImportDeclaration,
 }
 
 impl Label for JsLabels {
@@ -108,6 +110,7 @@ impl Label for JsLabels {
     fn debug_name(&self) -> &'static str {
         match self {
             Self::MemberChain => "MemberChain",
+            Self::ImportDeclaration => "ImportDeclaration",
         }
     }
 }

--- a/crates/oxc_formatter/src/write/import_declaration.rs
+++ b/crates/oxc_formatter/src/write/import_declaration.rs
@@ -4,8 +4,8 @@ use oxc_span::GetSpan;
 use oxc_syntax::identifier::is_identifier_name;
 
 use crate::{
-    Format, FormatResult, FormatTrailingCommas, QuoteProperties, TrailingSeparator, best_fitting,
-    format_args,
+    Format, FormatResult, FormatTrailingCommas, JsLabels, QuoteProperties, TrailingSeparator,
+    best_fitting, format_args,
     formatter::{
         Formatter,
         prelude::*,
@@ -27,13 +27,17 @@ impl<'a> Format<'a> for ImportOrExportKind {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ImportDeclaration<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, ["import", space(), self.import_kind])?;
+        let decl = &format_once(|f| {
+            write!(f, ["import", space(), self.import_kind])?;
 
-        if let Some(specifiers) = self.specifiers() {
-            write!(f, [specifiers, space(), "from", space()])?;
-        }
+            if let Some(specifiers) = self.specifiers() {
+                write!(f, [specifiers, space(), "from", space()])?;
+            }
 
-        write!(f, [self.source(), self.with_clause(), OptionalSemicolon])
+            write!(f, [self.source(), self.with_clause(), OptionalSemicolon])
+        });
+
+        write!(f, [labelled(LabelId::of(JsLabels::ImportDeclaration), decl)])
     }
 }
 


### PR DESCRIPTION
Part of #14253

This will help us to distinguish between the following in IR elements.

```js
import "x"
// vs
import("y")
```