### PR TITLE
fix(formatter): print comments incorrectly if the node is without following a node

### DIFF
--- a/tasks/coverage/snapshots/formatter_typescript.snap
+++ b/tasks/coverage/snapshots/formatter_typescript.snap
@@ -2,7 +2,7 @@ commit: 261630d6
 
 formatter_typescript Summary:
 AST Parsed     : 8816/8816 (100.00%)
-Positive Passed: 8805/8816 (99.88%)
+Positive Passed: 8806/8816 (99.89%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdLikeInputDeclarationEmit.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/arrayFromAsync.ts
@@ -12,8 +12,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitCastReus
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions3.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccessExpressionInnerComments.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationClasses.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tryStatementInternalComments.ts
 


### PR DESCRIPTION
This is to avoid printing comments in the wrong places.