### PR TITLE
fix(linter): fix cli argument parsing

### DIFF
--- a/apps/oxlint/src/run.rs
+++ b/apps/oxlint/src/run.rs
@@ -66,13 +66,10 @@ fn lint_impl(load_plugin: JsLoadPluginCb, lint_file: JsLintFileCb) -> CliRunResu
     init_tracing();
     init_miette();
 
-    let mut args = std::env::args_os();
-    // If first arg is `node`, also skip script path (`node script.js ...`).
-    // Otherwise, just skip first arg (`oxlint ...`).
-    if args.next().is_some_and(|arg| arg == "node") {
-        args.next();
-    }
-    let args = args.collect::<Vec<_>>();
+    // 1st arg is path to NodeJS binary.
+    // 2nd arg is path to `oxlint/.bin/oxlint` (in released packages)
+    // or `apps/oxlint/dist/cli.js` (in development).
+    let args = std::env::args_os().skip(2).collect::<Vec<_>>();
 
     let cmd = crate::cli::lint_command();
     let command = match cmd.run_inner(&*args) {


### PR DESCRIPTION
fixes #14071

Simplify CLI argument collection by unconditionally skipping the first two entries in std::env::args_os(). This ensures correct handling in wrapper scenarios (e.g., Node.js invocations via npm/pnpm) where the conditional "node" check may fail, such as with version managers like asdf. Previously, mis-skipping could lead to wrapper script paths (potentially containing "..") being passed to the CLI parser, triggering validation errors. Since oxlint is not always distributed via the node (no longer a binary), we don't have to worry about the case where we're not running in node.