### PR TITLE
ci(benchmark): fix slow valgrind installation

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -64,7 +64,7 @@ jobs:
     steps:
       - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
 
-      - uses: oxc-project/setup-rust@5e7ddbacb109aa3e6ed4391afc589c7f6ba090d7 # v1.0.4
+      - uses: oxc-project/setup-rust@f78b3964e121f889426634f0eaeeb09fccecac08 # v1.0.6
         with:
           cache-key: benchmark-${{ matrix.feature }}
           save-cache: ${{ github.ref_name == 'main' }}


### PR DESCRIPTION
* See https://github.com/oxc-project/setup-rust/blob/f78b3964e121f889426634f0eaeeb09fccecac08/action.yml#L95-L126
* https://github.com/CodSpeedHQ/runner/issues/121#issuecomment-3334150343