### PR TITLE
test(linter/plugins): fix file paths in snapshots

### DIFF
--- a/apps/oxlint/test/__snapshots__/e2e.test.ts.snap
+++ b/apps/oxlint/test/__snapshots__/e2e.test.ts.snap
@@ -693,7 +693,7 @@ exports[`oxlint CLI > should report an error if a custom plugin throws an error 
 exports[`oxlint CLI > should report an error if a custom plugin throws an error during linting > in \`after\` hook 1`] = `
 "
   x Error running JS plugin.
-  | File path: <root>/oxc/apps/oxlint/test/fixtures/custom_plugin_lint_after_hook_error/files/index.js
+  | File path: <root>/apps/oxlint/test/fixtures/custom_plugin_lint_after_hook_error/files/index.js
   | Error: Whoops!
   |     at after (<root>/apps/oxlint/test/fixtures/custom_plugin_lint_after_hook_error/plugin.js:10:19)
 
@@ -704,7 +704,7 @@ Finished in Xms on 1 file using X threads."
 exports[`oxlint CLI > should report an error if a custom plugin throws an error during linting > in \`before\` hook 1`] = `
 "
   x Error running JS plugin.
-  | File path: <root>/oxc/apps/oxlint/test/fixtures/custom_plugin_lint_before_hook_error/files/index.js
+  | File path: <root>/apps/oxlint/test/fixtures/custom_plugin_lint_before_hook_error/files/index.js
   | Error: Whoops!
   |     at before (<root>/apps/oxlint/test/fixtures/custom_plugin_lint_before_hook_error/plugin.js:10:19)
 
@@ -715,7 +715,7 @@ Finished in Xms on 1 file using X threads."
 exports[`oxlint CLI > should report an error if a custom plugin throws an error during linting > in \`create\` method 1`] = `
 "
   x Error running JS plugin.
-  | File path: <root>/oxc/apps/oxlint/test/fixtures/custom_plugin_lint_create_error/files/index.js
+  | File path: <root>/apps/oxlint/test/fixtures/custom_plugin_lint_create_error/files/index.js
   | Error: Whoops!
   |     at Object.create (<root>/apps/oxlint/test/fixtures/custom_plugin_lint_create_error/plugin.js:8:15)
 
@@ -735,7 +735,7 @@ exports[`oxlint CLI > should report an error if a custom plugin throws an error 
 exports[`oxlint CLI > should report an error if a custom plugin throws an error during linting > in \`fix\` function 1`] = `
 "
   x Error running JS plugin.
-  | File path: <root>/oxc/apps/oxlint/test/fixtures/custom_plugin_lint_fix_error/files/index.js
+  | File path: <root>/apps/oxlint/test/fixtures/custom_plugin_lint_fix_error/files/index.js
   | Error: Whoops!
   |     at Object.fix (<root>/apps/oxlint/test/fixtures/custom_plugin_lint_fix_error/plugin.js:14:23)
   |     at Identifier (<root>/apps/oxlint/test/fixtures/custom_plugin_lint_fix_error/plugin.js:10:21)
@@ -747,7 +747,7 @@ Finished in Xms on 1 file using X threads."
 exports[`oxlint CLI > should report an error if a custom plugin throws an error during linting > in visit function 1`] = `
 "
   x Error running JS plugin.
-  | File path: <root>/oxc/apps/oxlint/test/fixtures/custom_plugin_lint_visit_error/files/index.js
+  | File path: <root>/apps/oxlint/test/fixtures/custom_plugin_lint_visit_error/files/index.js
   | Error: Whoops!
   |     at Identifier (<root>/apps/oxlint/test/fixtures/custom_plugin_lint_visit_error/plugin.js:10:19)
 

--- a/apps/oxlint/test/e2e.test.ts
+++ b/apps/oxlint/test/e2e.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from 'vitest';
 import { execa } from 'execa';
 
 const PACKAGE_ROOT_PATH = dirname(import.meta.dirname);
-const ROOT_PATH = pathJoin(PACKAGE_ROOT_PATH, '../../../');
+const ROOT_PATH = pathJoin(PACKAGE_ROOT_PATH, '../../');
 const CLI_PATH = pathJoin(PACKAGE_ROOT_PATH, 'dist/cli.js');
 const ROOT_URL = new URL('../../../', import.meta.url).href;
 const FIXTURES_URL = new URL('./fixtures/', import.meta.url).href;


### PR DESCRIPTION
Test snapshots for JS plugins had incorrect paths where plugin throws an error. Fix that.