### PR TITLE
test(linter/plugins): improve ESLint compat tests

### DIFF
--- a/apps/oxlint/test/fixtures/definePlugin/plugin.js
+++ b/apps/oxlint/test/fixtures/definePlugin/plugin.js
@@ -1,8 +1,7 @@
 import { sep } from 'node:path';
 import { definePlugin } from '../../../dist/index.js';
 
-// `loc` field is required for ESLint.
-// TODO: Remove this workaround when AST nodes have a `loc` field.
+// `loc` is required for ESLint
 const SPAN = {
   start: 0,
   end: 0,
@@ -26,7 +25,7 @@ const createRule = {
       Identifier(node) {
         context.report({
           message: `ident visit fn "${node.name}":\nfilename: ${relativePath(context.filename)}`,
-          node: { ...SPAN, ...node },
+          node,
         });
       },
     };
@@ -72,7 +71,7 @@ const createOnceRule = {
           message: `ident visit fn "${node.name}":\n`
             + `identNum: ${identNum}\n`
             + `filename: ${relativePath(context.filename)}`,
-          node: { ...SPAN, ...node },
+          node,
         });
       },
       after() {
@@ -123,7 +122,7 @@ const createOnceBeforeFalseRule = {
         context.report({
           message: `ident visit fn "${node.name}":\n`
             + `filename: ${relativePath(context.filename)}`,
-          node: { ...SPAN, ...node },
+          node,
         });
       },
       after() {
@@ -153,7 +152,7 @@ const createOnceBeforeOnlyRule = {
         context.report({
           message: `ident visit fn "${node.name}":\n`
             + `filename: ${relativePath(context.filename)}`,
-          node: { ...SPAN, ...node },
+          node,
         });
       },
     };
@@ -167,7 +166,7 @@ const createOnceAfterOnlyRule = {
         context.report({
           message: `ident visit fn "${node.name}":\n`
             + `filename: ${relativePath(context.filename)}`,
-          node: { ...SPAN, ...node },
+          node,
         });
       },
       after() {
@@ -188,7 +187,7 @@ const createOnceNoHooksRule = {
         context.report({
           message: `ident visit fn "${node.name}":\n`
             + `filename: ${relativePath(context.filename)}`,
-          node: { ...SPAN, ...node },
+          node,
         });
       },
     };

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/plugin.js
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/plugin.js
@@ -1,8 +1,7 @@
 import { sep } from 'node:path';
 import { definePlugin, defineRule } from '../../../dist/index.js';
 
-// `loc` field is required for ESLint.
-// TODO: Remove this workaround when AST nodes have a `loc` field.
+// `loc` is required for ESLint
 const SPAN = {
   start: 0,
   end: 0,
@@ -26,7 +25,7 @@ const createRule = defineRule({
       Identifier(node) {
         context.report({
           message: `ident visit fn "${node.name}":\nfilename: ${relativePath(context.filename)}`,
-          node: { ...SPAN, ...node },
+          node,
         });
       },
     };
@@ -71,7 +70,7 @@ const createOnceRule = defineRule({
           message: `ident visit fn "${node.name}":\n`
             + `identNum: ${identNum}\n`
             + `filename: ${relativePath(context.filename)}`,
-          node: { ...SPAN, ...node },
+          node,
         });
       },
       after() {
@@ -122,7 +121,7 @@ const createOnceBeforeFalseRule = defineRule({
         context.report({
           message: `ident visit fn "${node.name}":\n`
             + `filename: ${relativePath(context.filename)}`,
-          node: { ...SPAN, ...node },
+          node,
         });
       },
       after() {
@@ -152,7 +151,7 @@ const createOnceBeforeOnlyRule = defineRule({
         context.report({
           message: `ident visit fn "${node.name}":\n`
             + `filename: ${relativePath(context.filename)}`,
-          node: { ...SPAN, ...node },
+          node,
         });
       },
     };
@@ -166,7 +165,7 @@ const createOnceAfterOnlyRule = defineRule({
         context.report({
           message: `ident visit fn "${node.name}":\n`
             + `filename: ${relativePath(context.filename)}`,
-          node: { ...SPAN, ...node },
+          node,
         });
       },
       after() {
@@ -187,7 +186,7 @@ const createOnceNoHooksRule = defineRule({
         context.report({
           message: `ident visit fn "${node.name}":\n`
             + `filename: ${relativePath(context.filename)}`,
-          node: { ...SPAN, ...node },
+          node,
         });
       },
     };

--- a/apps/oxlint/test/fixtures/defineRule/plugin.js
+++ b/apps/oxlint/test/fixtures/defineRule/plugin.js
@@ -1,8 +1,7 @@
 import { sep } from 'node:path';
 import { defineRule } from '../../../dist/index.js';
 
-// `loc` field is required for ESLint.
-// TODO: Remove this workaround when AST nodes have a `loc` field.
+// `loc` is required for ESLint
 const SPAN = {
   start: 0,
   end: 0,
@@ -26,7 +25,7 @@ const createRule = defineRule({
       Identifier(node) {
         context.report({
           message: `ident visit fn "${node.name}":\nfilename: ${relativePath(context.filename)}`,
-          node: { ...SPAN, ...node },
+          node,
         });
       },
     };
@@ -71,7 +70,7 @@ const createOnceRule = defineRule({
           message: `ident visit fn "${node.name}":\n`
             + `identNum: ${identNum}\n`
             + `filename: ${relativePath(context.filename)}`,
-          node: { ...SPAN, ...node },
+          node,
         });
       },
       after() {
@@ -122,7 +121,7 @@ const createOnceBeforeFalseRule = defineRule({
         context.report({
           message: `ident visit fn "${node.name}":\n`
             + `filename: ${relativePath(context.filename)}`,
-          node: { ...SPAN, ...node },
+          node,
         });
       },
       after() {
@@ -152,7 +151,7 @@ const createOnceBeforeOnlyRule = defineRule({
         context.report({
           message: `ident visit fn "${node.name}":\n`
             + `filename: ${relativePath(context.filename)}`,
-          node: { ...SPAN, ...node },
+          node,
         });
       },
     };
@@ -166,7 +165,7 @@ const createOnceAfterOnlyRule = defineRule({
         context.report({
           message: `ident visit fn "${node.name}":\n`
             + `filename: ${relativePath(context.filename)}`,
-          node: { ...SPAN, ...node },
+          node,
         });
       },
       after() {
@@ -187,7 +186,7 @@ const createOnceNoHooksRule = defineRule({
         context.report({
           message: `ident visit fn "${node.name}":\n`
             + `filename: ${relativePath(context.filename)}`,
-          node: { ...SPAN, ...node },
+          node,
         });
       },
     };


### PR DESCRIPTION
Adding `loc` to nodes should not be required for plugins to work in ESLint (and it isn't). Remove this from the test cases.