### PR TITLE
test(linter/plugins): simplify configs in test fixtures

### DIFF
--- a/apps/oxlint/test/e2e.test.ts
+++ b/apps/oxlint/test/e2e.test.ts
@@ -28,7 +28,7 @@ async function testFixture(fixtureName: string, options?: TestOptions): Promise<
 
   await testFixtureWithCommand({
     command: 'node',
-    args: [CLI_PATH, ...args],
+    args: [CLI_PATH, ...args, 'files'],
     fixtureName,
     snapshotName: options?.snapshotName ?? 'output',
     getExtraSnapshotData: options?.getExtraSnapshotData,

--- a/apps/oxlint/test/fixtures/basic_custom_plugin/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin/.oxlintrc.json
@@ -2,6 +2,5 @@
     "plugins": ["./plugin.js"],
     "rules": {
         "basic-custom-plugin/no-debugger": "error"
-    },
-    "ignorePatterns": ["**/*", "!files/**"]
+    }
 }

--- a/apps/oxlint/test/fixtures/basic_custom_plugin_many_files/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin_many_files/.oxlintrc.json
@@ -2,6 +2,5 @@
     "plugins": ["./plugin.js"],
     "rules": {
         "basic-custom-plugin/no-debugger": "error"
-    },
-    "ignorePatterns": ["**/*", "!files/**"]
+    }
 }

--- a/apps/oxlint/test/fixtures/basic_custom_plugin_multiple_rules/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin_multiple_rules/.oxlintrc.json
@@ -4,6 +4,5 @@
         "basic-custom-plugin/no-debugger": "error",
         "basic-custom-plugin/no-debugger-2": "error",
         "basic-custom-plugin/no-identifiers-named-foo": "error"
-    },
-    "ignorePatterns": ["**/*", "!files/**"]
+    }
 }

--- a/apps/oxlint/test/fixtures/basic_custom_plugin_warn_severity/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin_warn_severity/.oxlintrc.json
@@ -2,6 +2,5 @@
     "plugins": ["./plugin.js"],
     "rules": {
         "basic-custom-plugin/no-debugger": "warn"
-    },
-    "ignorePatterns": ["**/*", "!files/**"]
+    }
 }

--- a/apps/oxlint/test/fixtures/built_in_errors/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/built_in_errors/.oxlintrc.json
@@ -1,5 +1,4 @@
 {
   "categories": { "correctness": "off" },
-  "rules": { "no-debugger": "error" },
-  "ignorePatterns": ["**/*", "!files/**"]
+  "rules": { "no-debugger": "error" }
 }

--- a/apps/oxlint/test/fixtures/built_in_no_errors/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/built_in_no_errors/.oxlintrc.json
@@ -1,5 +1,4 @@
 {
   "categories": { "correctness": "off" },
-  "rules": { "no-debugger": "error" },
-  "ignorePatterns": ["**/*", "!files/**"]
+  "rules": { "no-debugger": "error" }
 }

--- a/apps/oxlint/test/fixtures/context_properties/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/context_properties/.oxlintrc.json
@@ -3,6 +3,5 @@
     "categories": {"correctness": "off"},
     "rules": {
         "context-plugin/log-context": "error"
-    },
-    "ignorePatterns": ["**/*", "!files/**"]
+    }
 }

--- a/apps/oxlint/test/fixtures/createOnce/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/createOnce/.oxlintrc.json
@@ -7,6 +7,5 @@
         "create-once-plugin/before-only": "error",
         "create-once-plugin/after-only": "error",
         "create-once-plugin/no-hooks": "error"
-    },
-    "ignorePatterns": ["**/*", "!files/**"]
+    }
 }

--- a/apps/oxlint/test/fixtures/custom_plugin_disable_directives/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_disable_directives/.oxlintrc.json
@@ -4,6 +4,5 @@
   "rules": {
     "test-plugin/no-var": "error",
     "no-debugger": "error"
-  },
-  "ignorePatterns": ["**/*", "!files/**"]
+  }
 }

--- a/apps/oxlint/test/fixtures/custom_plugin_import_error/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_import_error/.oxlintrc.json
@@ -3,6 +3,5 @@
   "categories": { "correctness": "off" },
   "rules": {
     "basic-custom-plugin/unknown-rule": "error"
-  },
-  "ignorePatterns": ["**/*", "!files/**"]
+  }
 }

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_after_hook_error/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_after_hook_error/.oxlintrc.json
@@ -3,6 +3,5 @@
   "categories": { "correctness": "off" },
   "rules": {
     "error-plugin/error": "error"
-  },
-  "ignorePatterns": ["**/*", "!files/**"]
+  }
 }

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_before_hook_error/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_before_hook_error/.oxlintrc.json
@@ -3,6 +3,5 @@
   "categories": { "correctness": "off" },
   "rules": {
     "error-plugin/error": "error"
-  },
-  "ignorePatterns": ["**/*", "!files/**"]
+  }
 }

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_createOnce_error/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_createOnce_error/.oxlintrc.json
@@ -3,6 +3,5 @@
   "categories": { "correctness": "off" },
   "rules": {
     "error-plugin/error": "error"
-  },
-  "ignorePatterns": ["**/*", "!files/**"]
+  }
 }

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_create_error/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_create_error/.oxlintrc.json
@@ -3,6 +3,5 @@
   "categories": { "correctness": "off" },
   "rules": {
     "error-plugin/error": "error"
-  },
-  "ignorePatterns": ["**/*", "!files/**"]
+  }
 }

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_fix_error/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_fix_error/.oxlintrc.json
@@ -3,6 +3,5 @@
   "categories": { "correctness": "off" },
   "rules": {
     "error-plugin/error": "error"
-  },
-  "ignorePatterns": ["**/*", "!files/**"]
+  }
 }

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_visit_error/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_visit_error/.oxlintrc.json
@@ -3,6 +3,5 @@
   "categories": { "correctness": "off" },
   "rules": {
     "error-plugin/error": "error"
-  },
-  "ignorePatterns": ["**/*", "!files/**"]
+  }
 }

--- a/apps/oxlint/test/fixtures/custom_plugin_missing_rule/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_missing_rule/.oxlintrc.json
@@ -3,6 +3,5 @@
   "categories": { "correctness": "off" },
   "rules": {
     "basic-custom-plugin/unknown-rule": "error"
-  },
-  "ignorePatterns": ["**/*", "!files/**"]
+  }
 }

--- a/apps/oxlint/test/fixtures/custom_plugin_via_overrides/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_via_overrides/.oxlintrc.json
@@ -7,6 +7,5 @@
         "basic-custom-plugin/no-debugger": "error"
       }
     }
-  ],
-  "ignorePatterns": ["**/*", "!files/**"]
+  ]
 }

--- a/apps/oxlint/test/fixtures/custom_plugin_via_overrides_missing_rule/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_via_overrides_missing_rule/.oxlintrc.json
@@ -10,6 +10,5 @@
         "basic-custom-plugin/missing": "error"
       }
     }
-  ],
-  "ignorePatterns": ["**/*", "!files/**"]
+  ]
 }

--- a/apps/oxlint/test/fixtures/definePlugin/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/definePlugin/.oxlintrc.json
@@ -8,6 +8,5 @@
         "define-plugin-plugin/create-once-before-only": "error",
         "define-plugin-plugin/create-once-after-only": "error",
         "define-plugin-plugin/create-once-no-hooks": "error"
-    },
-    "ignorePatterns": ["**/*", "!files/**"]
+    }
 }

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/.oxlintrc.json
@@ -8,6 +8,5 @@
         "define-plugin-and-rule-plugin/create-once-before-only": "error",
         "define-plugin-and-rule-plugin/create-once-after-only": "error",
         "define-plugin-and-rule-plugin/create-once-no-hooks": "error"
-    },
-    "ignorePatterns": ["**/*", "!files/**"]
+    }
 }

--- a/apps/oxlint/test/fixtures/defineRule/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/defineRule/.oxlintrc.json
@@ -8,6 +8,5 @@
         "define-rule-plugin/create-once-before-only": "error",
         "define-rule-plugin/create-once-after-only": "error",
         "define-rule-plugin/create-once-no-hooks": "error"
-    },
-    "ignorePatterns": ["**/*", "!files/**"]
+    }
 }

--- a/apps/oxlint/test/fixtures/estree/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/estree/.oxlintrc.json
@@ -5,6 +5,5 @@
     },
     "rules": {
         "estree-check/check": "error"
-    },
-    "ignorePatterns": ["**/*", "!files/**"]
+    }
 }

--- a/apps/oxlint/test/fixtures/fixes/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/fixes/.oxlintrc.json
@@ -5,6 +5,5 @@
     },
     "rules": {
         "fixes-plugin/fixes": "error"
-    },
-    "ignorePatterns": ["**/*", "!files/**"]
+    }
 }

--- a/apps/oxlint/test/fixtures/load_paths/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/load_paths/.oxlintrc.json
@@ -14,6 +14,5 @@
         "plugin4/no-debugger": "error",
         "plugin5/no-debugger": "error",
         "plugin6/no-debugger": "error"
-    },
-    "ignorePatterns": ["**/*", "!files/**"]
+    }
 }

--- a/apps/oxlint/test/fixtures/missing_custom_plugin/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/missing_custom_plugin/.oxlintrc.json
@@ -1,6 +1,5 @@
 {
     "plugins": [
         "./plugin.js"
-    ],
-    "ignorePatterns": ["**/*", "!files/**"]
+    ]
 }

--- a/apps/oxlint/test/fixtures/utf16_offsets/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/utf16_offsets/.oxlintrc.json
@@ -2,6 +2,5 @@
     "plugins": ["./plugin.js"],
     "rules": {
         "utf16-plugin/no-debugger": "error"
-    },
-    "ignorePatterns": ["**/*", "!files/**"]
+    }
 }


### PR DESCRIPTION
Pure refactor. Remove `"ignorePatterns": ["**/*", "!files/**"]` from `.oxlintrc.json` in every test fixture, by running `oxlint` with `oxlint --js-plugins files`.
