### PR TITLE
test(linter/plugins): format test fixtures

### DIFF
--- a/apps/oxlint/test/fixtures/basic_custom_plugin/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
-    "plugins": ["./plugin.js"],
-    "rules": {
-        "basic-custom-plugin/no-debugger": "error"
-    }
+  "plugins": ["./plugin.js"],
+  "rules": {
+    "basic-custom-plugin/no-debugger": "error"
+  }
 }

--- a/apps/oxlint/test/fixtures/basic_custom_plugin/plugin.js
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin/plugin.js
@@ -1,14 +1,14 @@
 export default {
   meta: {
-    name: "basic-custom-plugin",
+    name: 'basic-custom-plugin',
   },
   rules: {
-    "no-debugger": {
+    'no-debugger': {
       create(context) {
         return {
           DebuggerStatement(debuggerStatement) {
             context.report({
-              message: "Unexpected Debugger Statement",
+              message: 'Unexpected Debugger Statement',
               node: debuggerStatement,
             });
           },

--- a/apps/oxlint/test/fixtures/basic_custom_plugin_many_files/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin_many_files/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
-    "plugins": ["./plugin.js"],
-    "rules": {
-        "basic-custom-plugin/no-debugger": "error"
-    }
+  "plugins": ["./plugin.js"],
+  "rules": {
+    "basic-custom-plugin/no-debugger": "error"
+  }
 }

--- a/apps/oxlint/test/fixtures/basic_custom_plugin_many_files/plugin.js
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin_many_files/plugin.js
@@ -1,14 +1,14 @@
 export default {
   meta: {
-    name: "basic-custom-plugin",
+    name: 'basic-custom-plugin',
   },
   rules: {
-    "no-debugger": {
+    'no-debugger': {
       create(context) {
         return {
           DebuggerStatement(debuggerStatement) {
             context.report({
-              message: "Unexpected Debugger Statement",
+              message: 'Unexpected Debugger Statement',
               node: debuggerStatement,
             });
           },

--- a/apps/oxlint/test/fixtures/basic_custom_plugin_multiple_rules/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin_multiple_rules/.oxlintrc.json
@@ -1,8 +1,8 @@
 {
-    "plugins": ["./plugin.js"],
-    "rules": {
-        "basic-custom-plugin/no-debugger": "error",
-        "basic-custom-plugin/no-debugger-2": "error",
-        "basic-custom-plugin/no-identifiers-named-foo": "error"
-    }
+  "plugins": ["./plugin.js"],
+  "rules": {
+    "basic-custom-plugin/no-debugger": "error",
+    "basic-custom-plugin/no-debugger-2": "error",
+    "basic-custom-plugin/no-identifiers-named-foo": "error"
+  }
 }

--- a/apps/oxlint/test/fixtures/basic_custom_plugin_multiple_rules/plugin.js
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin_multiple_rules/plugin.js
@@ -1,38 +1,38 @@
 export default {
   meta: {
-    name: "basic-custom-plugin",
+    name: 'basic-custom-plugin',
   },
   rules: {
-    "no-debugger": {
+    'no-debugger': {
       create(context) {
         return {
           DebuggerStatement(debuggerStatement) {
             context.report({
-              message: "Unexpected Debugger Statement",
+              message: 'Unexpected Debugger Statement',
               node: debuggerStatement,
             });
           },
         };
       },
     },
-    "no-debugger-2": {
+    'no-debugger-2': {
       create(context) {
         return {
           DebuggerStatement(debuggerStatement) {
             context.report({
-              message: "Unexpected Debugger Statement",
+              message: 'Unexpected Debugger Statement',
               node: debuggerStatement,
             });
           },
         };
       },
     },
-    "no-identifiers-named-foo": {
+    'no-identifiers-named-foo': {
       create(context) {
         return {
           Identifier(ident) {
-            if (ident.name == "foo") {
-              context.report({ message: "Unexpected Identifier named foo", node: ident});
+            if (ident.name == 'foo') {
+              context.report({ message: 'Unexpected Identifier named foo', node: ident });
             }
           },
         };

--- a/apps/oxlint/test/fixtures/basic_custom_plugin_warn_severity/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin_warn_severity/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
-    "plugins": ["./plugin.js"],
-    "rules": {
-        "basic-custom-plugin/no-debugger": "warn"
-    }
+  "plugins": ["./plugin.js"],
+  "rules": {
+    "basic-custom-plugin/no-debugger": "warn"
+  }
 }

--- a/apps/oxlint/test/fixtures/basic_custom_plugin_warn_severity/plugin.js
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin_warn_severity/plugin.js
@@ -1,14 +1,14 @@
 export default {
   meta: {
-    name: "basic-custom-plugin",
+    name: 'basic-custom-plugin',
   },
   rules: {
-    "no-debugger": {
+    'no-debugger': {
       create(context) {
         return {
           DebuggerStatement(debuggerStatement) {
             context.report({
-              message: "Unexpected Debugger Statement",
+              message: 'Unexpected Debugger Statement',
               node: debuggerStatement,
             });
           },

--- a/apps/oxlint/test/fixtures/context_properties/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/context_properties/.oxlintrc.json
@@ -1,7 +1,7 @@
 {
-    "plugins": ["./plugin.js"],
-    "categories": {"correctness": "off"},
-    "rules": {
-        "context-plugin/log-context": "error"
-    }
+  "plugins": ["./plugin.js"],
+  "categories": { "correctness": "off" },
+  "rules": {
+    "context-plugin/log-context": "error"
+  }
 }

--- a/apps/oxlint/test/fixtures/context_properties/plugin.js
+++ b/apps/oxlint/test/fixtures/context_properties/plugin.js
@@ -30,16 +30,16 @@ const rule = {
     return {
       VariableDeclaration(node) {
         if (this !== undefined) context.report({ message: 'this !== undefined', node });
-      }
+      },
     };
   },
 };
 
 export default {
   meta: {
-    name: "context-plugin",
+    name: 'context-plugin',
   },
   rules: {
-    "log-context": rule,
+    'log-context': rule,
   },
 };

--- a/apps/oxlint/test/fixtures/createOnce/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/createOnce/.oxlintrc.json
@@ -1,11 +1,11 @@
 {
-    "plugins": ["./plugin.js"],
-    "categories": {"correctness": "off"},
-    "rules": {
-        "create-once-plugin/always-run": "error",
-        "create-once-plugin/skip-run": "error",
-        "create-once-plugin/before-only": "error",
-        "create-once-plugin/after-only": "error",
-        "create-once-plugin/no-hooks": "error"
-    }
+  "plugins": ["./plugin.js"],
+  "categories": { "correctness": "off" },
+  "rules": {
+    "create-once-plugin/always-run": "error",
+    "create-once-plugin/skip-run": "error",
+    "create-once-plugin/before-only": "error",
+    "create-once-plugin/after-only": "error",
+    "create-once-plugin/no-hooks": "error"
+  }
 }

--- a/apps/oxlint/test/fixtures/createOnce/plugin.js
+++ b/apps/oxlint/test/fixtures/createOnce/plugin.js
@@ -117,14 +117,14 @@ const noHooksRule = {
 
 export default {
   meta: {
-    name: "create-once-plugin",
+    name: 'create-once-plugin',
   },
   rules: {
-    "always-run": alwaysRunRule,
-    "skip-run": skipRunRule,
-    "before-only": beforeOnlyRule,
-    "after-only": afterOnlyRule,
-    "no-hooks": noHooksRule,
+    'always-run': alwaysRunRule,
+    'skip-run': skipRunRule,
+    'before-only': beforeOnlyRule,
+    'after-only': afterOnlyRule,
+    'no-hooks': noHooksRule,
   },
 };
 

--- a/apps/oxlint/test/fixtures/custom_plugin_disable_directives/files/index.js
+++ b/apps/oxlint/test/fixtures/custom_plugin_disable_directives/files/index.js
@@ -1,3 +1,5 @@
+// dprint-ignore-file
+
 var shouldError = 1;
 
 // oxlint-disable-next-line test-plugin/no-var

--- a/apps/oxlint/test/fixtures/custom_plugin_disable_directives/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_disable_directives/output.snap.md
@@ -5,41 +5,42 @@
 ```
 
   x test-plugin(no-var): Use let or const instead of var
-   ,-[files/index.js:1:1]
- 1 | var shouldError = 1;
-   : ^^^^^^^^^^^^^^^^^^^^
+   ,-[files/index.js:3:1]
  2 | 
+ 3 | var shouldError = 1;
+   : ^^^^^^^^^^^^^^^^^^^^
+ 4 | 
    `----
 
   x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
-    ,-[files/index.js:10:1]
-  9 | // should trigger an error
- 10 | debugger;
+    ,-[files/index.js:12:1]
+ 11 | // should trigger an error
+ 12 | debugger;
     : ^^^^^^^^^
- 11 | 
+ 13 | 
     `----
   help: Remove the debugger statement
 
   x test-plugin(no-var): Use let or const instead of var
-    ,-[files/index.js:16:1]
- 15 | /* oxlint-disable-next-line test-plugin */ // `test-plugin` should be `test-plugin/no-var`
- 16 | var incorrectlyDisabled = 4;
+    ,-[files/index.js:18:1]
+ 17 | /* oxlint-disable-next-line test-plugin */ // `test-plugin` should be `test-plugin/no-var`
+ 18 | var incorrectlyDisabled = 4;
     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- 17 | 
+ 19 | 
     `----
 
   x test-plugin(no-var): Use let or const instead of var
-    ,-[files/index.js:19:1]
- 18 | /* oxlint-disable-next-line no-var */ // `no-var` should be `test-plugin/no-var`
- 19 | var anotherIncorrectlyDisabled = 4;
+    ,-[files/index.js:21:1]
+ 20 | /* oxlint-disable-next-line no-var */ // `no-var` should be `test-plugin/no-var`
+ 21 | var anotherIncorrectlyDisabled = 4;
     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- 20 | 
+ 22 | 
     `----
 
   x test-plugin(no-var): Use let or const instead of var
-    ,-[files/index.js:22:1]
- 21 | // This var should trigger an error again
- 22 | var shouldErrorAgain = 3;
+    ,-[files/index.js:24:1]
+ 23 | // This var should trigger an error again
+ 24 | var shouldErrorAgain = 3;
     : ^^^^^^^^^^^^^^^^^^^^^^^^^
     `----
 

--- a/apps/oxlint/test/fixtures/custom_plugin_disable_directives/plugin.js
+++ b/apps/oxlint/test/fixtures/custom_plugin_disable_directives/plugin.js
@@ -1,15 +1,15 @@
 export default {
   meta: {
-    name: "test-plugin",
+    name: 'test-plugin',
   },
   rules: {
-    "no-var": {
+    'no-var': {
       create(context) {
         return {
           VariableDeclaration(node) {
-            if (node.kind === "var") {
+            if (node.kind === 'var') {
               context.report({
-                message: "Use let or const instead of var",
+                message: 'Use let or const instead of var',
                 node: node,
               });
             }

--- a/apps/oxlint/test/fixtures/custom_plugin_import_error/plugin.js
+++ b/apps/oxlint/test/fixtures/custom_plugin_import_error/plugin.js
@@ -1,1 +1,1 @@
-throw new Error("whoops!");
+throw new Error('whoops!');

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_after_hook_error/plugin.js
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_after_hook_error/plugin.js
@@ -1,13 +1,13 @@
 export default {
   meta: {
-    name: "error-plugin",
+    name: 'error-plugin',
   },
   rules: {
     error: {
       createOnce(_context) {
         return {
           after() {
-            throw new Error("Whoops!");
+            throw new Error('Whoops!');
           },
         };
       },

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_before_hook_error/plugin.js
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_before_hook_error/plugin.js
@@ -1,13 +1,13 @@
 export default {
   meta: {
-    name: "error-plugin",
+    name: 'error-plugin',
   },
   rules: {
     error: {
       createOnce(_context) {
         return {
           before() {
-            throw new Error("Whoops!");
+            throw new Error('Whoops!');
           },
         };
       },

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_createOnce_error/plugin.js
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_createOnce_error/plugin.js
@@ -1,11 +1,11 @@
 export default {
   meta: {
-    name: "error-plugin",
+    name: 'error-plugin',
   },
   rules: {
     error: {
       createOnce(_context) {
-        throw new Error("Whoops!");
+        throw new Error('Whoops!');
       },
     },
   },

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_create_error/plugin.js
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_create_error/plugin.js
@@ -1,11 +1,11 @@
 export default {
   meta: {
-    name: "error-plugin",
+    name: 'error-plugin',
   },
   rules: {
     error: {
       create(_context) {
-        throw new Error("Whoops!");
+        throw new Error('Whoops!');
       },
     },
   },

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_fix_error/plugin.js
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_fix_error/plugin.js
@@ -1,6 +1,6 @@
 export default {
   meta: {
-    name: "error-plugin",
+    name: 'error-plugin',
   },
   rules: {
     error: {
@@ -8,10 +8,10 @@ export default {
         return {
           Identifier(node) {
             context.report({
-              message: "Identifier found",
+              message: 'Identifier found',
               node,
               fix() {
-                throw new Error("Whoops!");
+                throw new Error('Whoops!');
               },
             });
           },

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_visit_error/plugin.js
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_visit_error/plugin.js
@@ -1,13 +1,13 @@
 export default {
   meta: {
-    name: "error-plugin",
+    name: 'error-plugin',
   },
   rules: {
     error: {
       create(_context) {
         return {
           Identifier(_node) {
-            throw new Error("Whoops!");
+            throw new Error('Whoops!');
           },
         };
       },

--- a/apps/oxlint/test/fixtures/custom_plugin_missing_rule/plugin.js
+++ b/apps/oxlint/test/fixtures/custom_plugin_missing_rule/plugin.js
@@ -1,6 +1,6 @@
 export default {
   meta: {
-    name: "basic-custom-plugin",
+    name: 'basic-custom-plugin',
   },
   rules: {},
 };

--- a/apps/oxlint/test/fixtures/custom_plugin_via_overrides/plugin.js
+++ b/apps/oxlint/test/fixtures/custom_plugin_via_overrides/plugin.js
@@ -1,14 +1,14 @@
 export default {
   meta: {
-    name: "basic-custom-plugin",
+    name: 'basic-custom-plugin',
   },
   rules: {
-    "no-debugger": {
+    'no-debugger': {
       create(context) {
         return {
           DebuggerStatement(debuggerStatement) {
             context.report({
-              message: "Unexpected Debugger Statement",
+              message: 'Unexpected Debugger Statement',
               node: debuggerStatement,
             });
           },

--- a/apps/oxlint/test/fixtures/custom_plugin_via_overrides_missing_rule/plugin.js
+++ b/apps/oxlint/test/fixtures/custom_plugin_via_overrides_missing_rule/plugin.js
@@ -1,14 +1,14 @@
 export default {
   meta: {
-    name: "basic-custom-plugin",
+    name: 'basic-custom-plugin',
   },
   rules: {
-    "no-debugger": {
+    'no-debugger': {
       create(context) {
         return {
           DebuggerStatement(debuggerStatement) {
             context.report({
-              message: "Unexpected Debugger Statement",
+              message: 'Unexpected Debugger Statement',
               node: debuggerStatement,
             });
           },

--- a/apps/oxlint/test/fixtures/definePlugin/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/definePlugin/.oxlintrc.json
@@ -1,12 +1,12 @@
 {
-    "plugins": ["./plugin.js"],
-    "categories": {"correctness": "off"},
-    "rules": {
-        "define-plugin-plugin/create": "error",
-        "define-plugin-plugin/create-once": "error",
-        "define-plugin-plugin/create-once-before-false": "error",
-        "define-plugin-plugin/create-once-before-only": "error",
-        "define-plugin-plugin/create-once-after-only": "error",
-        "define-plugin-plugin/create-once-no-hooks": "error"
-    }
+  "plugins": ["./plugin.js"],
+  "categories": { "correctness": "off" },
+  "rules": {
+    "define-plugin-plugin/create": "error",
+    "define-plugin-plugin/create-once": "error",
+    "define-plugin-plugin/create-once-before-false": "error",
+    "define-plugin-plugin/create-once-before-only": "error",
+    "define-plugin-plugin/create-once-after-only": "error",
+    "define-plugin-plugin/create-once-no-hooks": "error"
+  }
 }

--- a/apps/oxlint/test/fixtures/definePlugin/eslint.config.js
+++ b/apps/oxlint/test/fixtures/definePlugin/eslint.config.js
@@ -2,17 +2,17 @@ import plugin from './plugin.js';
 
 export default [
   {
-    files: ["files/*.js"],
+    files: ['files/*.js'],
     plugins: {
-      "define-plugin-plugin": plugin,
+      'define-plugin-plugin': plugin,
     },
     rules: {
-      "define-plugin-plugin/create": "error",
-      "define-plugin-plugin/create-once": "error",
-      "define-plugin-plugin/create-once-before-false": "error",
-      "define-plugin-plugin/create-once-before-only": "error",
-      "define-plugin-plugin/create-once-after-only": "error",
-      "define-plugin-plugin/create-once-no-hooks": "error",
+      'define-plugin-plugin/create': 'error',
+      'define-plugin-plugin/create-once': 'error',
+      'define-plugin-plugin/create-once-before-false': 'error',
+      'define-plugin-plugin/create-once-before-only': 'error',
+      'define-plugin-plugin/create-once-after-only': 'error',
+      'define-plugin-plugin/create-once-no-hooks': 'error',
     },
   },
 ];

--- a/apps/oxlint/test/fixtures/definePlugin/plugin.js
+++ b/apps/oxlint/test/fixtures/definePlugin/plugin.js
@@ -56,10 +56,10 @@ const createOnceRule = {
         identNum = 0;
 
         context.report({
-          message: 'before hook:\n'
-            + `createOnce call count: ${createOnceCallCount}\n`
-            + `this === rule: ${topLevelThis === createOnceRule}\n`
-            + `filename: ${relativePath(context.filename)}`,
+          message: 'before hook:\n' +
+            `createOnce call count: ${createOnceCallCount}\n` +
+            `this === rule: ${topLevelThis === createOnceRule}\n` +
+            `filename: ${relativePath(context.filename)}`,
           node: SPAN,
         });
       },
@@ -68,17 +68,17 @@ const createOnceRule = {
         visits.push({ fileNum, identNum });
 
         context.report({
-          message: `ident visit fn "${node.name}":\n`
-            + `identNum: ${identNum}\n`
-            + `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` +
+            `identNum: ${identNum}\n` +
+            `filename: ${relativePath(context.filename)}`,
           node,
         });
       },
       after() {
         context.report({
-          message: 'after hook:\n'
-            + `identNum: ${identNum}\n`
-            + `filename: ${relativePath(context.filename)}`,
+          message: 'after hook:\n' +
+            `identNum: ${identNum}\n` +
+            `filename: ${relativePath(context.filename)}`,
           node: SPAN,
         });
 
@@ -93,8 +93,8 @@ const createOnceRule = {
           ];
 
           if (
-            visits.length !== expectedVisits.length
-            || visits.some((v, i) => v.fileNum !== expectedVisits[i].fileNum || v.identNum !== expectedVisits[i].identNum)
+            visits.length !== expectedVisits.length ||
+            visits.some((v, i) => v.fileNum !== expectedVisits[i].fileNum || v.identNum !== expectedVisits[i].identNum)
           ) {
             context.report({ message: `Unexpected visits: ${JSON.stringify(visits)}`, node: SPAN });
           }
@@ -110,8 +110,8 @@ const createOnceBeforeFalseRule = {
     return {
       before() {
         context.report({
-          message: 'before hook:\n'
-            + `filename: ${relativePath(context.filename)}`,
+          message: 'before hook:\n' +
+            `filename: ${relativePath(context.filename)}`,
           node: SPAN,
         });
 
@@ -120,15 +120,15 @@ const createOnceBeforeFalseRule = {
       },
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\n`
-            + `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` +
+            `filename: ${relativePath(context.filename)}`,
           node,
         });
       },
       after() {
         context.report({
-          message: 'after hook:\n'
-            + `filename: ${relativePath(context.filename)}`,
+          message: 'after hook:\n' +
+            `filename: ${relativePath(context.filename)}`,
           node: SPAN,
         });
       },
@@ -143,15 +143,15 @@ const createOnceBeforeOnlyRule = {
     return {
       before() {
         context.report({
-          message: 'before hook:\n'
-            + `filename: ${relativePath(context.filename)}`,
+          message: 'before hook:\n' +
+            `filename: ${relativePath(context.filename)}`,
           node: SPAN,
         });
       },
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\n`
-            + `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` +
+            `filename: ${relativePath(context.filename)}`,
           node,
         });
       },
@@ -164,15 +164,15 @@ const createOnceAfterOnlyRule = {
     return {
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\n`
-            + `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` +
+            `filename: ${relativePath(context.filename)}`,
           node,
         });
       },
       after() {
         context.report({
-          message: 'after hook:\n'
-            + `filename: ${relativePath(context.filename)}`,
+          message: 'after hook:\n' +
+            `filename: ${relativePath(context.filename)}`,
           node: SPAN,
         });
       },
@@ -185,8 +185,8 @@ const createOnceNoHooksRule = {
     return {
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\n`
-            + `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` +
+            `filename: ${relativePath(context.filename)}`,
           node,
         });
       },
@@ -196,14 +196,14 @@ const createOnceNoHooksRule = {
 
 export default definePlugin({
   meta: {
-    name: "define-plugin-plugin",
+    name: 'define-plugin-plugin',
   },
   rules: {
     create: createRule,
-    "create-once": createOnceRule,
-    "create-once-before-false": createOnceBeforeFalseRule,
-    "create-once-before-only": createOnceBeforeOnlyRule,
-    "create-once-after-only": createOnceAfterOnlyRule,
-    "create-once-no-hooks": createOnceNoHooksRule,
+    'create-once': createOnceRule,
+    'create-once-before-false': createOnceBeforeFalseRule,
+    'create-once-before-only': createOnceBeforeOnlyRule,
+    'create-once-after-only': createOnceAfterOnlyRule,
+    'create-once-no-hooks': createOnceNoHooksRule,
   },
 });

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/.oxlintrc.json
@@ -1,12 +1,12 @@
 {
-    "plugins": ["./plugin.js"],
-    "categories": {"correctness": "off"},
-    "rules": {
-        "define-plugin-and-rule-plugin/create": "error",
-        "define-plugin-and-rule-plugin/create-once": "error",
-        "define-plugin-and-rule-plugin/create-once-before-false": "error",
-        "define-plugin-and-rule-plugin/create-once-before-only": "error",
-        "define-plugin-and-rule-plugin/create-once-after-only": "error",
-        "define-plugin-and-rule-plugin/create-once-no-hooks": "error"
-    }
+  "plugins": ["./plugin.js"],
+  "categories": { "correctness": "off" },
+  "rules": {
+    "define-plugin-and-rule-plugin/create": "error",
+    "define-plugin-and-rule-plugin/create-once": "error",
+    "define-plugin-and-rule-plugin/create-once-before-false": "error",
+    "define-plugin-and-rule-plugin/create-once-before-only": "error",
+    "define-plugin-and-rule-plugin/create-once-after-only": "error",
+    "define-plugin-and-rule-plugin/create-once-no-hooks": "error"
+  }
 }

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/eslint.config.js
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/eslint.config.js
@@ -2,17 +2,17 @@ import plugin from './plugin.js';
 
 export default [
   {
-    files: ["files/*.js"],
+    files: ['files/*.js'],
     plugins: {
-      "define-plugin-and-rule-plugin": plugin,
+      'define-plugin-and-rule-plugin': plugin,
     },
     rules: {
-      "define-plugin-and-rule-plugin/create": "error",
-      "define-plugin-and-rule-plugin/create-once": "error",
-      "define-plugin-and-rule-plugin/create-once-before-false": "error",
-      "define-plugin-and-rule-plugin/create-once-before-only": "error",
-      "define-plugin-and-rule-plugin/create-once-after-only": "error",
-      "define-plugin-and-rule-plugin/create-once-no-hooks": "error",
+      'define-plugin-and-rule-plugin/create': 'error',
+      'define-plugin-and-rule-plugin/create-once': 'error',
+      'define-plugin-and-rule-plugin/create-once-before-false': 'error',
+      'define-plugin-and-rule-plugin/create-once-before-only': 'error',
+      'define-plugin-and-rule-plugin/create-once-after-only': 'error',
+      'define-plugin-and-rule-plugin/create-once-no-hooks': 'error',
     },
   },
 ];

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/plugin.js
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/plugin.js
@@ -55,10 +55,10 @@ const createOnceRule = defineRule({
         identNum = 0;
 
         context.report({
-          message: 'before hook:\n'
-            + `createOnce call count: ${createOnceCallCount}\n`
-            + `this === rule: ${topLevelThis === createOnceRule}\n`
-            + `filename: ${relativePath(context.filename)}`,
+          message: 'before hook:\n' +
+            `createOnce call count: ${createOnceCallCount}\n` +
+            `this === rule: ${topLevelThis === createOnceRule}\n` +
+            `filename: ${relativePath(context.filename)}`,
           node: SPAN,
         });
       },
@@ -67,17 +67,17 @@ const createOnceRule = defineRule({
         visits.push({ fileNum, identNum });
 
         context.report({
-          message: `ident visit fn "${node.name}":\n`
-            + `identNum: ${identNum}\n`
-            + `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` +
+            `identNum: ${identNum}\n` +
+            `filename: ${relativePath(context.filename)}`,
           node,
         });
       },
       after() {
         context.report({
-          message: 'after hook:\n'
-            + `identNum: ${identNum}\n`
-            + `filename: ${relativePath(context.filename)}`,
+          message: 'after hook:\n' +
+            `identNum: ${identNum}\n` +
+            `filename: ${relativePath(context.filename)}`,
           node: SPAN,
         });
 
@@ -92,8 +92,8 @@ const createOnceRule = defineRule({
           ];
 
           if (
-            visits.length !== expectedVisits.length
-            || visits.some((v, i) => v.fileNum !== expectedVisits[i].fileNum || v.identNum !== expectedVisits[i].identNum)
+            visits.length !== expectedVisits.length ||
+            visits.some((v, i) => v.fileNum !== expectedVisits[i].fileNum || v.identNum !== expectedVisits[i].identNum)
           ) {
             context.report({ message: `Unexpected visits: ${JSON.stringify(visits)}`, node: SPAN });
           }
@@ -109,8 +109,8 @@ const createOnceBeforeFalseRule = defineRule({
     return {
       before() {
         context.report({
-          message: 'before hook:\n'
-            + `filename: ${relativePath(context.filename)}`,
+          message: 'before hook:\n' +
+            `filename: ${relativePath(context.filename)}`,
           node: SPAN,
         });
 
@@ -119,15 +119,15 @@ const createOnceBeforeFalseRule = defineRule({
       },
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\n`
-            + `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` +
+            `filename: ${relativePath(context.filename)}`,
           node,
         });
       },
       after() {
         context.report({
-          message: 'after hook:\n'
-            + `filename: ${relativePath(context.filename)}`,
+          message: 'after hook:\n' +
+            `filename: ${relativePath(context.filename)}`,
           node: SPAN,
         });
       },
@@ -142,15 +142,15 @@ const createOnceBeforeOnlyRule = defineRule({
     return {
       before() {
         context.report({
-          message: 'before hook:\n'
-            + `filename: ${relativePath(context.filename)}`,
+          message: 'before hook:\n' +
+            `filename: ${relativePath(context.filename)}`,
           node: SPAN,
         });
       },
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\n`
-            + `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` +
+            `filename: ${relativePath(context.filename)}`,
           node,
         });
       },
@@ -163,15 +163,15 @@ const createOnceAfterOnlyRule = defineRule({
     return {
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\n`
-            + `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` +
+            `filename: ${relativePath(context.filename)}`,
           node,
         });
       },
       after() {
         context.report({
-          message: 'after hook:\n'
-            + `filename: ${relativePath(context.filename)}`,
+          message: 'after hook:\n' +
+            `filename: ${relativePath(context.filename)}`,
           node: SPAN,
         });
       },
@@ -184,8 +184,8 @@ const createOnceNoHooksRule = defineRule({
     return {
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\n`
-            + `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` +
+            `filename: ${relativePath(context.filename)}`,
           node,
         });
       },
@@ -195,14 +195,14 @@ const createOnceNoHooksRule = defineRule({
 
 export default definePlugin({
   meta: {
-    name: "define-plugin-and-rule-plugin",
+    name: 'define-plugin-and-rule-plugin',
   },
   rules: {
     create: createRule,
-    "create-once": createOnceRule,
-    "create-once-before-false": createOnceBeforeFalseRule,
-    "create-once-before-only": createOnceBeforeOnlyRule,
-    "create-once-after-only": createOnceAfterOnlyRule,
-    "create-once-no-hooks": createOnceNoHooksRule,
+    'create-once': createOnceRule,
+    'create-once-before-false': createOnceBeforeFalseRule,
+    'create-once-before-only': createOnceBeforeOnlyRule,
+    'create-once-after-only': createOnceAfterOnlyRule,
+    'create-once-no-hooks': createOnceNoHooksRule,
   },
 });

--- a/apps/oxlint/test/fixtures/defineRule/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/defineRule/.oxlintrc.json
@@ -1,12 +1,12 @@
 {
-    "plugins": ["./plugin.js"],
-    "categories": {"correctness": "off"},
-    "rules": {
-        "define-rule-plugin/create": "error",
-        "define-rule-plugin/create-once": "error",
-        "define-rule-plugin/create-once-before-false": "error",
-        "define-rule-plugin/create-once-before-only": "error",
-        "define-rule-plugin/create-once-after-only": "error",
-        "define-rule-plugin/create-once-no-hooks": "error"
-    }
+  "plugins": ["./plugin.js"],
+  "categories": { "correctness": "off" },
+  "rules": {
+    "define-rule-plugin/create": "error",
+    "define-rule-plugin/create-once": "error",
+    "define-rule-plugin/create-once-before-false": "error",
+    "define-rule-plugin/create-once-before-only": "error",
+    "define-rule-plugin/create-once-after-only": "error",
+    "define-rule-plugin/create-once-no-hooks": "error"
+  }
 }

--- a/apps/oxlint/test/fixtures/defineRule/eslint.config.js
+++ b/apps/oxlint/test/fixtures/defineRule/eslint.config.js
@@ -2,17 +2,17 @@ import plugin from './plugin.js';
 
 export default [
   {
-    files: ["files/*.js"],
+    files: ['files/*.js'],
     plugins: {
-      "define-rule-plugin": plugin,
+      'define-rule-plugin': plugin,
     },
     rules: {
-      "define-rule-plugin/create": "error",
-      "define-rule-plugin/create-once": "error",
-      "define-rule-plugin/create-once-before-false": "error",
-      "define-rule-plugin/create-once-before-only": "error",
-      "define-rule-plugin/create-once-after-only": "error",
-      "define-rule-plugin/create-once-no-hooks": "error",
+      'define-rule-plugin/create': 'error',
+      'define-rule-plugin/create-once': 'error',
+      'define-rule-plugin/create-once-before-false': 'error',
+      'define-rule-plugin/create-once-before-only': 'error',
+      'define-rule-plugin/create-once-after-only': 'error',
+      'define-rule-plugin/create-once-no-hooks': 'error',
     },
   },
 ];

--- a/apps/oxlint/test/fixtures/defineRule/plugin.js
+++ b/apps/oxlint/test/fixtures/defineRule/plugin.js
@@ -55,10 +55,10 @@ const createOnceRule = defineRule({
         identNum = 0;
 
         context.report({
-          message: 'before hook:\n'
-            + `createOnce call count: ${createOnceCallCount}\n`
-            + `this === rule: ${topLevelThis === createOnceRule}\n`
-            + `filename: ${relativePath(context.filename)}`,
+          message: 'before hook:\n' +
+            `createOnce call count: ${createOnceCallCount}\n` +
+            `this === rule: ${topLevelThis === createOnceRule}\n` +
+            `filename: ${relativePath(context.filename)}`,
           node: SPAN,
         });
       },
@@ -67,17 +67,17 @@ const createOnceRule = defineRule({
         visits.push({ fileNum, identNum });
 
         context.report({
-          message: `ident visit fn "${node.name}":\n`
-            + `identNum: ${identNum}\n`
-            + `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` +
+            `identNum: ${identNum}\n` +
+            `filename: ${relativePath(context.filename)}`,
           node,
         });
       },
       after() {
         context.report({
-          message: 'after hook:\n'
-            + `identNum: ${identNum}\n`
-            + `filename: ${relativePath(context.filename)}`,
+          message: 'after hook:\n' +
+            `identNum: ${identNum}\n` +
+            `filename: ${relativePath(context.filename)}`,
           node: SPAN,
         });
 
@@ -92,8 +92,8 @@ const createOnceRule = defineRule({
           ];
 
           if (
-            visits.length !== expectedVisits.length
-            || visits.some((v, i) => v.fileNum !== expectedVisits[i].fileNum || v.identNum !== expectedVisits[i].identNum)
+            visits.length !== expectedVisits.length ||
+            visits.some((v, i) => v.fileNum !== expectedVisits[i].fileNum || v.identNum !== expectedVisits[i].identNum)
           ) {
             context.report({ message: `Unexpected visits: ${JSON.stringify(visits)}`, node: SPAN });
           }
@@ -109,8 +109,8 @@ const createOnceBeforeFalseRule = defineRule({
     return {
       before() {
         context.report({
-          message: 'before hook:\n'
-            + `filename: ${relativePath(context.filename)}`,
+          message: 'before hook:\n' +
+            `filename: ${relativePath(context.filename)}`,
           node: SPAN,
         });
 
@@ -119,15 +119,15 @@ const createOnceBeforeFalseRule = defineRule({
       },
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\n`
-            + `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` +
+            `filename: ${relativePath(context.filename)}`,
           node,
         });
       },
       after() {
         context.report({
-          message: 'after hook:\n'
-            + `filename: ${relativePath(context.filename)}`,
+          message: 'after hook:\n' +
+            `filename: ${relativePath(context.filename)}`,
           node: SPAN,
         });
       },
@@ -142,15 +142,15 @@ const createOnceBeforeOnlyRule = defineRule({
     return {
       before() {
         context.report({
-          message: 'before hook:\n'
-            + `filename: ${relativePath(context.filename)}`,
+          message: 'before hook:\n' +
+            `filename: ${relativePath(context.filename)}`,
           node: SPAN,
         });
       },
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\n`
-            + `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` +
+            `filename: ${relativePath(context.filename)}`,
           node,
         });
       },
@@ -163,15 +163,15 @@ const createOnceAfterOnlyRule = defineRule({
     return {
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\n`
-            + `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` +
+            `filename: ${relativePath(context.filename)}`,
           node,
         });
       },
       after() {
         context.report({
-          message: 'after hook:\n'
-            + `filename: ${relativePath(context.filename)}`,
+          message: 'after hook:\n' +
+            `filename: ${relativePath(context.filename)}`,
           node: SPAN,
         });
       },
@@ -184,8 +184,8 @@ const createOnceNoHooksRule = defineRule({
     return {
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\n`
-            + `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` +
+            `filename: ${relativePath(context.filename)}`,
           node,
         });
       },
@@ -195,14 +195,14 @@ const createOnceNoHooksRule = defineRule({
 
 export default {
   meta: {
-    name: "define-rule-plugin",
+    name: 'define-rule-plugin',
   },
   rules: {
     create: createRule,
-    "create-once": createOnceRule,
-    "create-once-before-false": createOnceBeforeFalseRule,
-    "create-once-before-only": createOnceBeforeOnlyRule,
-    "create-once-after-only": createOnceAfterOnlyRule,
-    "create-once-no-hooks": createOnceNoHooksRule,
+    'create-once': createOnceRule,
+    'create-once-before-false': createOnceBeforeFalseRule,
+    'create-once-before-only': createOnceBeforeOnlyRule,
+    'create-once-after-only': createOnceAfterOnlyRule,
+    'create-once-no-hooks': createOnceNoHooksRule,
   },
 };

--- a/apps/oxlint/test/fixtures/estree/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/estree/.oxlintrc.json
@@ -1,9 +1,9 @@
 {
-    "plugins": ["./plugin.js"],
-    "categories": {
-      "correctness": "off"
-    },
-    "rules": {
-        "estree-check/check": "error"
-    }
+  "plugins": ["./plugin.js"],
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    "estree-check/check": "error"
+  }
 }

--- a/apps/oxlint/test/fixtures/estree/files/index.ts
+++ b/apps/oxlint/test/fixtures/estree/files/index.ts
@@ -1,3 +1,5 @@
+// dprint-ignore-file
+
 // All `Identifier`s
 let a = { x: y };
 

--- a/apps/oxlint/test/fixtures/estree/output.snap.md
+++ b/apps/oxlint/test/fixtures/estree/output.snap.md
@@ -34,18 +34,18 @@
   | * TSUnionType:exit: (types: TSStringKeyword, TSNumberKeyword)
   | * TSTypeAliasDeclaration:exit: (typeAnnotation: TSUnionType)
   | * Program:exit
-    ,-[files/index.ts:2:1]
-  1 |     // All `Identifier`s
-  2 | ,-> let a = { x: y };
-  3 | |   
-  4 | |   // No `ParenthesizedExpression`s in AST
-  5 | |   const b = (x * ((('str' + ((123))))));
-  6 | |   
-  7 | |   // TS syntax
-  8 | |   type T = string;
-  9 | |   
- 10 | |   // No `TSParenthesizedType`s in AST
- 11 | `-> type U = (((((string)) | ((number)))));
+    ,-[files/index.ts:4:1]
+  3 |     // All `Identifier`s
+  4 | ,-> let a = { x: y };
+  5 | |   
+  6 | |   // No `ParenthesizedExpression`s in AST
+  7 | |   const b = (x * ((('str' + ((123))))));
+  8 | |   
+  9 | |   // TS syntax
+ 10 | |   type T = string;
+ 11 | |   
+ 12 | |   // No `TSParenthesizedType`s in AST
+ 13 | `-> type U = (((((string)) | ((number)))));
     `----
 
 Found 0 warnings and 1 error.

--- a/apps/oxlint/test/fixtures/estree/plugin.js
+++ b/apps/oxlint/test/fixtures/estree/plugin.js
@@ -1,6 +1,6 @@
 export default {
   meta: {
-    name: "estree-check",
+    name: 'estree-check',
   },
   rules: {
     check: {

--- a/apps/oxlint/test/fixtures/fixes/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/fixes/.oxlintrc.json
@@ -1,9 +1,9 @@
 {
-    "plugins": ["./plugin.js"],
-    "categories": {
-      "correctness": "off"
-    },
-    "rules": {
-        "fixes-plugin/fixes": "error"
-    }
+  "plugins": ["./plugin.js"],
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    "fixes-plugin/fixes": "error"
+  }
 }

--- a/apps/oxlint/test/fixtures/fixes/plugin.js
+++ b/apps/oxlint/test/fixtures/fixes/plugin.js
@@ -1,11 +1,11 @@
 export default {
   meta: {
-    name: "fixes-plugin",
+    name: 'fixes-plugin',
   },
   rules: {
-    "fixes": {
+    'fixes': {
       meta: {
-        fixable: "code",
+        fixable: 'code',
       },
       create(context) {
         let debuggerCount = 0;
@@ -15,7 +15,7 @@ export default {
 
             let thisIsReport;
             const report = {
-              message: "Remove debugger statement",
+              message: 'Remove debugger statement',
               node,
               fix(fixer) {
                 thisIsReport = this === report;
@@ -29,68 +29,68 @@ export default {
           },
           Identifier(node) {
             switch (node.name) {
-              case "a":
+              case 'a':
                 return context.report({
                   message: 'Replace "a" with "daddy"',
                   node,
                   fix(fixer) {
-                    return fixer.replaceText(node, "daddy");
+                    return fixer.replaceText(node, 'daddy');
                   },
                 });
-              case "b":
+              case 'b':
                 return context.report({
                   message: 'Replace "b" with "abacus"',
                   node,
                   fix(fixer) {
-                    return fixer.replaceTextRange([node.start, node.end], "abacus");
+                    return fixer.replaceTextRange([node.start, node.end], 'abacus');
                   },
                 });
-              case "c":
+              case 'c':
                 return context.report({
                   message: 'Prefix "c" with "magi"',
                   node,
                   fix(fixer) {
-                    return fixer.insertTextBefore(node, "magi");
+                    return fixer.insertTextBefore(node, 'magi');
                   },
                 });
-              case "d":
+              case 'd':
                 return context.report({
                   message: 'Prefix "d" with "damne"',
                   node,
                   fix(fixer) {
-                    return fixer.insertTextBeforeRange([node.start, node.end], "damne");
+                    return fixer.insertTextBeforeRange([node.start, node.end], 'damne');
                   },
                 });
-              case "e":
+              case 'e':
                 return context.report({
                   message: 'Postfix "e" with "lephant"',
                   node,
                   fix(fixer) {
-                    return fixer.insertTextAfter(node, "lephant");
+                    return fixer.insertTextAfter(node, 'lephant');
                   },
                 });
-              case "f":
+              case 'f':
                 return context.report({
                   message: 'Postfix "f" with "eck"',
                   node,
                   fix(fixer) {
-                    return fixer.insertTextAfterRange([node.start, node.end], "eck");
+                    return fixer.insertTextAfterRange([node.start, node.end], 'eck');
                   },
                 });
-              case "g":
+              case 'g':
                 return context.report({
                   message: 'Replace "g" with "numpty"',
                   node,
                   fix(fixer) {
                     // Fixes can be in any order
                     return [
-                      fixer.insertTextAfter(node, "ty"),
-                      fixer.replaceText(node, "mp"),
-                      fixer.insertTextBefore(node, "nu"),
+                      fixer.insertTextAfter(node, 'ty'),
+                      fixer.replaceText(node, 'mp'),
+                      fixer.insertTextBefore(node, 'nu'),
                     ];
                   },
                 });
-              case "h":
+              case 'h':
                 return context.report({
                   message: 'Replace "h" with "dangermouse"',
                   node,
@@ -98,24 +98,24 @@ export default {
                     // Fixes can be in any order
                     const range = [node.start, node.end];
                     return [
-                      fixer.replaceTextRange(range, "er"),
-                      fixer.insertTextAfterRange(range, "mouse"),
-                      fixer.insertTextBeforeRange(range, "dang"),
+                      fixer.replaceTextRange(range, 'er'),
+                      fixer.insertTextAfterRange(range, 'mouse'),
+                      fixer.insertTextBeforeRange(range, 'dang'),
                     ];
                   },
                 });
-              case "i":
+              case 'i':
                 return context.report({
                   message: 'Replace "i" with "granular"',
                   node,
                   // `fix` can be a generator function
                   *fix(fixer) {
-                    yield fixer.insertTextBefore(node, "gra");
-                    yield fixer.replaceText(node, "nu");
-                    yield fixer.insertTextAfter(node, "lar");
+                    yield fixer.insertTextBefore(node, 'gra');
+                    yield fixer.replaceText(node, 'nu');
+                    yield fixer.insertTextAfter(node, 'lar');
                   },
                 });
-              case "j":
+              case 'j':
                 return context.report({
                   message: 'Replace "j" with "cowabunga"',
                   node,
@@ -123,9 +123,9 @@ export default {
                   *fix(fixer) {
                     // Fixes can be in any order
                     const range = [node.start, node.end];
-                    yield fixer.insertTextAfterRange(range, "bunga");
-                    yield fixer.replaceTextRange(range, "a");
-                    yield fixer.insertTextBeforeRange(range, "cow");
+                    yield fixer.insertTextAfterRange(range, 'bunga');
+                    yield fixer.replaceTextRange(range, 'a');
+                    yield fixer.insertTextBeforeRange(range, 'cow');
                   },
                 });
             }

--- a/apps/oxlint/test/fixtures/load_paths/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/load_paths/.oxlintrc.json
@@ -1,18 +1,18 @@
 {
-    "plugins": [
-      "./plugins/test_plugin1.js",
-      "./plugins/test_plugin2.cjs",
-      "./plugins/test_plugin3.mjs",
-      "./plugins/test_plugin4",
-      "test_plugin5",
-      "test_plugin6"
-    ],
-    "rules": {
-        "plugin1/no-debugger": "error",
-        "plugin2/no-debugger": "error",
-        "plugin3/no-debugger": "error",
-        "plugin4/no-debugger": "error",
-        "plugin5/no-debugger": "error",
-        "plugin6/no-debugger": "error"
-    }
+  "plugins": [
+    "./plugins/test_plugin1.js",
+    "./plugins/test_plugin2.cjs",
+    "./plugins/test_plugin3.mjs",
+    "./plugins/test_plugin4",
+    "test_plugin5",
+    "test_plugin6"
+  ],
+  "rules": {
+    "plugin1/no-debugger": "error",
+    "plugin2/no-debugger": "error",
+    "plugin3/no-debugger": "error",
+    "plugin4/no-debugger": "error",
+    "plugin5/no-debugger": "error",
+    "plugin6/no-debugger": "error"
+  }
 }

--- a/apps/oxlint/test/fixtures/load_paths/plugins/test_plugin1.js
+++ b/apps/oxlint/test/fixtures/load_paths/plugins/test_plugin1.js
@@ -1,14 +1,14 @@
 export default {
   meta: {
-    name: "plugin1",
+    name: 'plugin1',
   },
   rules: {
-    "no-debugger": {
+    'no-debugger': {
       create(context) {
         return {
           DebuggerStatement(debuggerStatement) {
             context.report({
-              message: "Unexpected Debugger Statement",
+              message: 'Unexpected Debugger Statement',
               node: debuggerStatement,
             });
           },

--- a/apps/oxlint/test/fixtures/load_paths/plugins/test_plugin2.cjs
+++ b/apps/oxlint/test/fixtures/load_paths/plugins/test_plugin2.cjs
@@ -2,15 +2,15 @@
 
 module.exports = {
   meta: {
-    name: "plugin2",
+    name: 'plugin2',
   },
   rules: {
-    "no-debugger": {
+    'no-debugger': {
       create(context) {
         return {
           DebuggerStatement(debuggerStatement) {
             context.report({
-              message: "Unexpected Debugger Statement",
+              message: 'Unexpected Debugger Statement',
               node: debuggerStatement,
             });
           },

--- a/apps/oxlint/test/fixtures/load_paths/plugins/test_plugin3.mjs
+++ b/apps/oxlint/test/fixtures/load_paths/plugins/test_plugin3.mjs
@@ -1,14 +1,14 @@
 export default {
   meta: {
-    name: "plugin3",
+    name: 'plugin3',
   },
   rules: {
-    "no-debugger": {
+    'no-debugger': {
       create(context) {
         return {
           DebuggerStatement(debuggerStatement) {
             context.report({
-              message: "Unexpected Debugger Statement",
+              message: 'Unexpected Debugger Statement',
               node: debuggerStatement,
             });
           },

--- a/apps/oxlint/test/fixtures/load_paths/plugins/test_plugin4/index.js
+++ b/apps/oxlint/test/fixtures/load_paths/plugins/test_plugin4/index.js
@@ -1,14 +1,14 @@
 export default {
   meta: {
-    name: "plugin4",
+    name: 'plugin4',
   },
   rules: {
-    "no-debugger": {
+    'no-debugger': {
       create(context) {
         return {
           DebuggerStatement(debuggerStatement) {
             context.report({
-              message: "Unexpected Debugger Statement",
+              message: 'Unexpected Debugger Statement',
               node: debuggerStatement,
             });
           },

--- a/apps/oxlint/test/fixtures/missing_custom_plugin/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/missing_custom_plugin/.oxlintrc.json
@@ -1,5 +1,3 @@
 {
-    "plugins": [
-        "./plugin.js"
-    ]
+  "plugins": ["./plugin.js"]
 }

--- a/apps/oxlint/test/fixtures/utf16_offsets/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/utf16_offsets/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
-    "plugins": ["./plugin.js"],
-    "rules": {
-        "utf16-plugin/no-debugger": "error"
-    }
+  "plugins": ["./plugin.js"],
+  "rules": {
+    "utf16-plugin/no-debugger": "error"
+  }
 }

--- a/apps/oxlint/test/fixtures/utf16_offsets/plugin.js
+++ b/apps/oxlint/test/fixtures/utf16_offsets/plugin.js
@@ -1,9 +1,9 @@
 export default {
   meta: {
-    name: "utf16-plugin",
+    name: 'utf16-plugin',
   },
   rules: {
-    "no-debugger": {
+    'no-debugger': {
       create(context) {
         return {
           DebuggerStatement(debuggerStatement) {

--- a/dprint.json
+++ b/dprint.json
@@ -20,6 +20,8 @@
     "pnpm-lock.yaml",
     "apps/oxlint/src-js/bindings.js",
     "apps/oxlint/src-js/bindings.d.ts",
+    "!apps/oxlint/test/fixtures/**",
+    "apps/oxlint/test/fixtures/**/*.snap.md",
     "napi/{transform,minify,playground}/index.js",
     "napi/{parser,transform,minify,playground}/**/index.d.ts",
     "napi/{parser,transform,minify,playground}/**/*.wasi-browser.js",


### PR DESCRIPTION
Pure refactor. Format files in `test/fixtures` directory. Only changes to fixture files are to add `// dprint-ignore-file` comments to 2 of them.