### PR TITLE
fix(language_server): check if tsconfig path is a file before starting the `LintService`

### DIFF
--- a/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
+++ b/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
@@ -72,7 +72,10 @@ impl IsolatedLintHandler {
         let mut lint_service_options = LintServiceOptions::new(options.root_path.clone())
             .with_cross_module(options.use_cross_module);
 
-        if let Some(tsconfig_path) = &options.tsconfig_path {
+        if let Some(tsconfig_path) = &options.tsconfig_path
+            && tsconfig_path.is_file()
+        {
+            debug_assert!(tsconfig_path.is_absolute());
             lint_service_options = lint_service_options.with_tsconfig(tsconfig_path);
         }
 

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -156,10 +156,10 @@ impl ServerLinter {
             &IsolatedLintHandlerOptions {
                 use_cross_module,
                 root_path: root_path.to_path_buf(),
-                tsconfig_path: options
-                    .ts_config_path
-                    .as_ref()
-                    .map(|path| Path::new(path).to_path_buf()),
+                tsconfig_path: options.ts_config_path.as_ref().map(|path| {
+                    let path = Path::new(path).to_path_buf();
+                    if path.is_relative() { root_path.join(path) } else { path }
+                }),
             },
         );
 


### PR DESCRIPTION
`with_tsconfig()` has a debug assertion that the path is a file.
This was missing on the language server side and did silently fail on the VSCode tests.
https://github.com/oxc-project/oxc/blob/1337811da61a7b30b7a41292b6ad449ee6a168bb/crates/oxc_linter/src/service/mod.rs#L34-L45

<img width="1533" height="341" alt="screenshot of the test panic" src="https://github.com/user-attachments/assets/4cdb6391-9160-4642-a9c3-e196d8712f12" />
