### PR TITLE
fix(tasks): git ignore `node-compat-table` submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ tasks/coverage/test262/
 tasks/coverage/typescript/
 tasks/coverage/acorn-test262/
 tasks/coverage/acorn-test262-diff/
+tasks/coverage/node-compat-table/
 tasks/prettier_conformance/prettier/
 
 # Ignore accidental files from the root


### PR DESCRIPTION
#13925 added a submodule `node-compat-table`. Add it to `.gitignore` with the other submodules.