### PR TITLE
feat(linter/plugins): move custom JS plugin config to `jsPlugins`

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use bpaf::Bpaf;
-use oxc_linter::{AllowWarnDeny, BuiltinLintPlugins, FixKind, LintPlugins};
+use oxc_linter::{AllowWarnDeny, FixKind, LintPlugins};
 
 use crate::output_formatter::OutputFormat;
 
@@ -378,27 +378,25 @@ impl OverrideToggle {
 
 impl EnablePlugins {
     pub fn apply_overrides(&self, plugins: &mut LintPlugins) {
-        self.react_plugin.inspect(|yes| plugins.builtin.set(BuiltinLintPlugins::REACT, yes));
-        self.unicorn_plugin.inspect(|yes| plugins.builtin.set(BuiltinLintPlugins::UNICORN, yes));
-        self.oxc_plugin.inspect(|yes| plugins.builtin.set(BuiltinLintPlugins::OXC, yes));
-        self.typescript_plugin
-            .inspect(|yes| plugins.builtin.set(BuiltinLintPlugins::TYPESCRIPT, yes));
-        self.import_plugin.inspect(|yes| plugins.builtin.set(BuiltinLintPlugins::IMPORT, yes));
-        self.jsdoc_plugin.inspect(|yes| plugins.builtin.set(BuiltinLintPlugins::JSDOC, yes));
-        self.jest_plugin.inspect(|yes| plugins.builtin.set(BuiltinLintPlugins::JEST, yes));
-        self.vitest_plugin.inspect(|yes| plugins.builtin.set(BuiltinLintPlugins::VITEST, yes));
-        self.jsx_a11y_plugin.inspect(|yes| plugins.builtin.set(BuiltinLintPlugins::JSX_A11Y, yes));
-        self.nextjs_plugin.inspect(|yes| plugins.builtin.set(BuiltinLintPlugins::NEXTJS, yes));
-        self.react_perf_plugin
-            .inspect(|yes| plugins.builtin.set(BuiltinLintPlugins::REACT_PERF, yes));
-        self.promise_plugin.inspect(|yes| plugins.builtin.set(BuiltinLintPlugins::PROMISE, yes));
-        self.node_plugin.inspect(|yes| plugins.builtin.set(BuiltinLintPlugins::NODE, yes));
-        self.regex_plugin.inspect(|yes| plugins.builtin.set(BuiltinLintPlugins::REGEX, yes));
-        self.vue_plugin.inspect(|yes| plugins.builtin.set(BuiltinLintPlugins::VUE, yes));
+        self.react_plugin.inspect(|yes| plugins.set(LintPlugins::REACT, yes));
+        self.unicorn_plugin.inspect(|yes| plugins.set(LintPlugins::UNICORN, yes));
+        self.oxc_plugin.inspect(|yes| plugins.set(LintPlugins::OXC, yes));
+        self.typescript_plugin.inspect(|yes| plugins.set(LintPlugins::TYPESCRIPT, yes));
+        self.import_plugin.inspect(|yes| plugins.set(LintPlugins::IMPORT, yes));
+        self.jsdoc_plugin.inspect(|yes| plugins.set(LintPlugins::JSDOC, yes));
+        self.jest_plugin.inspect(|yes| plugins.set(LintPlugins::JEST, yes));
+        self.vitest_plugin.inspect(|yes| plugins.set(LintPlugins::VITEST, yes));
+        self.jsx_a11y_plugin.inspect(|yes| plugins.set(LintPlugins::JSX_A11Y, yes));
+        self.nextjs_plugin.inspect(|yes| plugins.set(LintPlugins::NEXTJS, yes));
+        self.react_perf_plugin.inspect(|yes| plugins.set(LintPlugins::REACT_PERF, yes));
+        self.promise_plugin.inspect(|yes| plugins.set(LintPlugins::PROMISE, yes));
+        self.node_plugin.inspect(|yes| plugins.set(LintPlugins::NODE, yes));
+        self.regex_plugin.inspect(|yes| plugins.set(LintPlugins::REGEX, yes));
+        self.vue_plugin.inspect(|yes| plugins.set(LintPlugins::VUE, yes));
 
         // Without this, jest plugins adapted to vitest will not be enabled.
         if self.vitest_plugin.is_enabled() && self.jest_plugin.is_not_set() {
-            plugins.builtin.set(BuiltinLintPlugins::JEST, true);
+            plugins.set(LintPlugins::JEST, true);
         }
     }
 }
@@ -435,9 +433,7 @@ pub struct InlineConfigOptions {
 
 #[cfg(test)]
 mod plugins {
-    use rustc_hash::FxHashSet;
-
-    use oxc_linter::{BuiltinLintPlugins, LintPlugins};
+    use oxc_linter::LintPlugins;
 
     use super::{EnablePlugins, OverrideToggle};
 
@@ -458,12 +454,11 @@ mod plugins {
             unicorn_plugin: OverrideToggle::Disable,
             ..EnablePlugins::default()
         };
-        let expected = BuiltinLintPlugins::default()
-            .union(BuiltinLintPlugins::REACT)
-            .difference(BuiltinLintPlugins::UNICORN);
+        let expected =
+            LintPlugins::default().union(LintPlugins::REACT).difference(LintPlugins::UNICORN);
 
         enable.apply_overrides(&mut plugins);
-        assert_eq!(plugins, LintPlugins::new(expected, FxHashSet::default()));
+        assert_eq!(plugins, expected);
     }
 
     #[test]
@@ -471,10 +466,7 @@ mod plugins {
         let mut plugins = LintPlugins::default();
         let enable =
             EnablePlugins { vitest_plugin: OverrideToggle::Enable, ..EnablePlugins::default() };
-        let expected = LintPlugins::new(
-            BuiltinLintPlugins::default() | BuiltinLintPlugins::VITEST | BuiltinLintPlugins::JEST,
-            FxHashSet::default(),
-        );
+        let expected = LintPlugins::default() | LintPlugins::VITEST | LintPlugins::JEST;
 
         enable.apply_overrides(&mut plugins);
         assert_eq!(plugins, expected);

--- a/apps/oxlint/src/snapshots/_-c fixtures__print_config__ban_rules__eslintrc.json -A all -D eqeqeq --print-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__print_config__ban_rules__eslintrc.json -A all -D eqeqeq --print-config@oxlint.snap
@@ -11,6 +11,7 @@ working directory:
     "typescript",
     "oxc"
   ],
+  "jsPlugins": null,
   "categories": {},
   "rules": {
     "eqeqeq": [

--- a/apps/oxlint/src/snapshots/fixtures_-A all --print-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures_-A all --print-config@oxlint.snap
@@ -11,6 +11,7 @@ working directory: fixtures
     "typescript",
     "oxc"
   ],
+  "jsPlugins": null,
   "categories": {},
   "rules": {},
   "settings": {

--- a/apps/oxlint/test/fixtures/basic_custom_plugin/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["./plugin.js"],
+  "jsPlugins": ["./plugin.js"],
   "rules": {
     "basic-custom-plugin/no-debugger": "error"
   }

--- a/apps/oxlint/test/fixtures/basic_custom_plugin_many_files/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin_many_files/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["./plugin.js"],
+  "jsPlugins": ["./plugin.js"],
   "rules": {
     "basic-custom-plugin/no-debugger": "error"
   }

--- a/apps/oxlint/test/fixtures/basic_custom_plugin_multiple_rules/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin_multiple_rules/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["./plugin.js"],
+  "jsPlugins": ["./plugin.js"],
   "rules": {
     "basic-custom-plugin/no-debugger": "error",
     "basic-custom-plugin/no-debugger-2": "error",

--- a/apps/oxlint/test/fixtures/basic_custom_plugin_warn_severity/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin_warn_severity/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["./plugin.js"],
+  "jsPlugins": ["./plugin.js"],
   "rules": {
     "basic-custom-plugin/no-debugger": "warn"
   }

--- a/apps/oxlint/test/fixtures/context_properties/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/context_properties/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["./plugin.js"],
+  "jsPlugins": ["./plugin.js"],
   "categories": { "correctness": "off" },
   "rules": {
     "context-plugin/log-context": "error"

--- a/apps/oxlint/test/fixtures/createOnce/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/createOnce/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["./plugin.js"],
+  "jsPlugins": ["./plugin.js"],
   "categories": { "correctness": "off" },
   "rules": {
     "create-once-plugin/always-run": "error",

--- a/apps/oxlint/test/fixtures/custom_plugin_disable_directives/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_disable_directives/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["./plugin.js"],
+  "jsPlugins": ["./plugin.js"],
   "categories": { "correctness": "off" },
   "rules": {
     "test-plugin/no-var": "error",

--- a/apps/oxlint/test/fixtures/custom_plugin_import_error/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_import_error/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["./plugin.js"],
+  "jsPlugins": ["./plugin.js"],
   "categories": { "correctness": "off" },
   "rules": {
     "basic-custom-plugin/unknown-rule": "error"

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_after_hook_error/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_after_hook_error/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["./plugin.js"],
+  "jsPlugins": ["./plugin.js"],
   "categories": { "correctness": "off" },
   "rules": {
     "error-plugin/error": "error"

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_before_hook_error/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_before_hook_error/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["./plugin.js"],
+  "jsPlugins": ["./plugin.js"],
   "categories": { "correctness": "off" },
   "rules": {
     "error-plugin/error": "error"

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_createOnce_error/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_createOnce_error/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["./plugin.js"],
+  "jsPlugins": ["./plugin.js"],
   "categories": { "correctness": "off" },
   "rules": {
     "error-plugin/error": "error"

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_create_error/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_create_error/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["./plugin.js"],
+  "jsPlugins": ["./plugin.js"],
   "categories": { "correctness": "off" },
   "rules": {
     "error-plugin/error": "error"

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_fix_error/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_fix_error/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["./plugin.js"],
+  "jsPlugins": ["./plugin.js"],
   "categories": { "correctness": "off" },
   "rules": {
     "error-plugin/error": "error"

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_visit_error/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_visit_error/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["./plugin.js"],
+  "jsPlugins": ["./plugin.js"],
   "categories": { "correctness": "off" },
   "rules": {
     "error-plugin/error": "error"

--- a/apps/oxlint/test/fixtures/custom_plugin_missing_rule/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_missing_rule/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["./plugin.js"],
+  "jsPlugins": ["./plugin.js"],
   "categories": { "correctness": "off" },
   "rules": {
     "basic-custom-plugin/unknown-rule": "error"

--- a/apps/oxlint/test/fixtures/custom_plugin_via_overrides/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_via_overrides/.oxlintrc.json
@@ -2,7 +2,7 @@
   "overrides": [
     {
       "files": ["*.js"],
-      "plugins": ["./plugin.js"],
+      "jsPlugins": ["./plugin.js"],
       "rules": {
         "basic-custom-plugin/no-debugger": "error"
       }

--- a/apps/oxlint/test/fixtures/custom_plugin_via_overrides_missing_rule/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_via_overrides_missing_rule/.oxlintrc.json
@@ -5,7 +5,7 @@
   "overrides": [
     {
       "files": ["*.js"],
-      "plugins": ["./plugin.js"],
+      "jsPlugins": ["./plugin.js"],
       "rules": {
         "basic-custom-plugin/missing": "error"
       }

--- a/apps/oxlint/test/fixtures/definePlugin/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/definePlugin/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["./plugin.js"],
+  "jsPlugins": ["./plugin.js"],
   "categories": { "correctness": "off" },
   "rules": {
     "define-plugin-plugin/create": "error",

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["./plugin.js"],
+  "jsPlugins": ["./plugin.js"],
   "categories": { "correctness": "off" },
   "rules": {
     "define-plugin-and-rule-plugin/create": "error",

--- a/apps/oxlint/test/fixtures/defineRule/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/defineRule/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["./plugin.js"],
+  "jsPlugins": ["./plugin.js"],
   "categories": { "correctness": "off" },
   "rules": {
     "define-rule-plugin/create": "error",

--- a/apps/oxlint/test/fixtures/estree/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/estree/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["./plugin.js"],
+  "jsPlugins": ["./plugin.js"],
   "categories": {
     "correctness": "off"
   },

--- a/apps/oxlint/test/fixtures/fixes/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/fixes/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["./plugin.js"],
+  "jsPlugins": ["./plugin.js"],
   "categories": {
     "correctness": "off"
   },

--- a/apps/oxlint/test/fixtures/load_paths/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/load_paths/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": [
+  "jsPlugins": [
     "./plugins/test_plugin1.js",
     "./plugins/test_plugin2.cjs",
     "./plugins/test_plugin3.mjs",

--- a/apps/oxlint/test/fixtures/missing_custom_plugin/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/missing_custom_plugin/.oxlintrc.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["./plugin.js"]
+  "jsPlugins": ["./plugin.js"]
 }

--- a/apps/oxlint/test/fixtures/utf16_offsets/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/utf16_offsets/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["./plugin.js"],
+  "jsPlugins": ["./plugin.js"],
   "rules": {
     "utf16-plugin/no-debugger": "error"
   }

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -6,13 +6,13 @@ use std::{
 use rustc_hash::FxHashMap;
 
 use crate::{
-    AllowWarnDeny, LintPlugins,
+    AllowWarnDeny,
     external_plugin_store::{ExternalPluginStore, ExternalRuleId},
     rules::{RULES, RuleEnum},
 };
 
 use super::{
-    BuiltinLintPlugins, LintConfig, OxlintEnv, OxlintGlobals, categories::OxlintCategories,
+    LintConfig, LintPlugins, OxlintEnv, OxlintGlobals, categories::OxlintCategories,
     overrides::GlobSet,
 };
 
@@ -117,8 +117,8 @@ impl Config {
         }
     }
 
-    pub fn plugins(&self) -> &LintPlugins {
-        &self.base.config.plugins
+    pub fn plugins(&self) -> LintPlugins {
+        self.base.config.plugins
     }
 
     pub fn rules(&self) -> &Arc<[(RuleEnum, AllowWarnDeny)]> {
@@ -156,29 +156,24 @@ impl Config {
 
         let mut env = self.base.config.env.clone();
         let mut globals = self.base.config.globals.clone();
-        let mut plugins = self.base.config.plugins.clone();
+        let mut plugins = self.base.config.plugins;
 
         for override_config in overrides_to_apply.clone() {
-            if let Some(override_plugins) = &override_config.plugins {
-                plugins.builtin |= override_plugins.builtin;
-                for p in &override_plugins.external {
-                    plugins.external.insert(p.clone());
-                }
+            if let Some(override_plugins) = override_config.plugins {
+                plugins |= override_plugins;
             }
         }
 
         let mut rules = self
             .base_rules
             .iter()
-            .filter(|(rule, _)| {
-                plugins.builtin.contains(BuiltinLintPlugins::from(rule.plugin_name()))
-            })
+            .filter(|(rule, _)| plugins.contains(LintPlugins::from(rule.plugin_name())))
             .cloned()
             .collect::<FxHashMap<_, _>>();
 
         let all_rules = RULES
             .iter()
-            .filter(|rule| plugins.builtin.contains(BuiltinLintPlugins::from(rule.plugin_name())))
+            .filter(|rule| plugins.contains(LintPlugins::from(rule.plugin_name())))
             .cloned()
             .collect::<Vec<_>>();
 
@@ -186,20 +181,20 @@ impl Config {
 
         // Track which plugins have already had their category rules applied.
         // Start with the root plugins since they already have categories applied in base_rules.
-        let mut configured_plugins = self.base.config.plugins.builtin;
+        let mut configured_plugins = self.base.config.plugins;
 
         for override_config in overrides_to_apply {
-            if let Some(override_plugins) = &override_config.plugins
-                && *override_plugins != plugins
+            if let Some(override_plugins) = override_config.plugins
+                && override_plugins != plugins
             {
                 // Only apply categories to plugins that:
                 // 1. Are in the current accumulated plugin set
                 // 2. Have NOT been configured yet (not in root or previous overrides)
-                let unconfigured_plugins = plugins.builtin & !configured_plugins;
+                let unconfigured_plugins = plugins & !configured_plugins;
 
                 if !unconfigured_plugins.is_empty() {
                     for (rule, severity) in all_rules.iter().filter_map(|rule| {
-                        let rule_plugin = BuiltinLintPlugins::from(rule.plugin_name());
+                        let rule_plugin = LintPlugins::from(rule.plugin_name());
                         // Only apply categories to rules from unconfigured plugins
                         if unconfigured_plugins.contains(rule_plugin) {
                             self.categories
@@ -310,8 +305,8 @@ impl ConfigStore {
         &self.base.base.rules
     }
 
-    pub fn plugins(&self) -> &LintPlugins {
-        &self.base.base.config.plugins
+    pub fn plugins(&self) -> LintPlugins {
+        self.base.base.config.plugins
     }
 
     pub(crate) fn get_related_config(&self, path: &Path) -> &Config {
@@ -355,13 +350,12 @@ impl ConfigStore {
 mod test {
     use std::{path::PathBuf, str::FromStr};
 
-    use rustc_hash::{FxHashMap, FxHashSet};
+    use rustc_hash::FxHashMap;
     use serde_json::Value;
 
     use super::{ConfigStore, ResolvedOxlintOverrides};
     use crate::{
-        AllowWarnDeny, BuiltinLintPlugins, ExternalPluginStore, LintPlugins, RuleCategory,
-        RuleEnum,
+        AllowWarnDeny, ExternalPluginStore, LintPlugins, RuleCategory, RuleEnum,
         config::{
             LintConfig, OxlintEnv, OxlintGlobals, OxlintSettings,
             categories::OxlintCategories,
@@ -424,14 +418,13 @@ mod test {
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             env: None,
             files: GlobSet::new(vec!["*.test.{ts,tsx}"]),
-            plugins: Some(LintPlugins::new(
-                BuiltinLintPlugins::REACT
-                    .union(BuiltinLintPlugins::TYPESCRIPT)
-                    .union(BuiltinLintPlugins::UNICORN)
-                    .union(BuiltinLintPlugins::OXC)
-                    .union(BuiltinLintPlugins::JSX_A11Y),
-                FxHashSet::default(),
-            )),
+            plugins: Some(
+                LintPlugins::REACT
+                    | LintPlugins::TYPESCRIPT
+                    | LintPlugins::UNICORN
+                    | LintPlugins::OXC
+                    | LintPlugins::JSX_A11Y,
+            ),
             globals: None,
             rules: ResolvedOxlintOverrideRules { builtin_rules: vec![], external_rules: vec![] },
         }]);
@@ -570,15 +563,12 @@ mod test {
 
     #[test]
     fn test_add_plugins() {
-        let base_config = LintConfig {
-            plugins: LintPlugins::new(BuiltinLintPlugins::IMPORT, FxHashSet::default()),
-            ..Default::default()
-        };
+        let base_config = LintConfig { plugins: LintPlugins::IMPORT, ..Default::default() };
         let overrides = ResolvedOxlintOverrides::new(vec![
             ResolvedOxlintOverride {
                 env: None,
                 files: GlobSet::new(vec!["*.jsx", "*.tsx"]),
-                plugins: Some(LintPlugins::new(BuiltinLintPlugins::REACT, FxHashSet::default())),
+                plugins: Some(LintPlugins::REACT),
                 globals: None,
                 rules: ResolvedOxlintOverrideRules {
                     builtin_rules: vec![],
@@ -588,10 +578,7 @@ mod test {
             ResolvedOxlintOverride {
                 env: None,
                 files: GlobSet::new(vec!["*.ts", "*.tsx"]),
-                plugins: Some(LintPlugins::new(
-                    BuiltinLintPlugins::TYPESCRIPT,
-                    FxHashSet::default(),
-                )),
+                plugins: Some(LintPlugins::TYPESCRIPT),
                 globals: None,
                 rules: ResolvedOxlintOverrideRules {
                     builtin_rules: vec![],
@@ -606,31 +593,24 @@ mod test {
             ExternalPluginStore::default(),
         );
 
-        assert_eq!(store.base.base.config.plugins.builtin, BuiltinLintPlugins::IMPORT);
+        assert_eq!(store.base.base.config.plugins, LintPlugins::IMPORT);
 
         let app = store.resolve("other.mjs".as_ref()).config;
-        assert_eq!(app.plugins.builtin, BuiltinLintPlugins::IMPORT);
+        assert_eq!(app.plugins, LintPlugins::IMPORT);
 
         let app = store.resolve("App.jsx".as_ref()).config;
-        assert_eq!(app.plugins.builtin, BuiltinLintPlugins::IMPORT | BuiltinLintPlugins::REACT);
+        assert_eq!(app.plugins, LintPlugins::IMPORT | LintPlugins::REACT);
 
         let app = store.resolve("App.ts".as_ref()).config;
-        assert_eq!(
-            app.plugins.builtin,
-            BuiltinLintPlugins::IMPORT | BuiltinLintPlugins::TYPESCRIPT
-        );
+        assert_eq!(app.plugins, LintPlugins::IMPORT | LintPlugins::TYPESCRIPT);
 
         let app = store.resolve("App.tsx".as_ref()).config;
-        assert_eq!(
-            app.plugins.builtin,
-            BuiltinLintPlugins::IMPORT | BuiltinLintPlugins::REACT | BuiltinLintPlugins::TYPESCRIPT
-        );
+        assert_eq!(app.plugins, LintPlugins::IMPORT | LintPlugins::REACT | LintPlugins::TYPESCRIPT);
     }
 
     #[test]
     fn test_add_env() {
-        let base_config =
-            LintConfig { plugins: BuiltinLintPlugins::ESLINT.into(), ..Default::default() };
+        let base_config = LintConfig { plugins: LintPlugins::ESLINT, ..Default::default() };
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             env: Some(OxlintEnv::from_iter(["es2024".to_string()])),
             files: GlobSet::new(vec!["*.tsx"]),
@@ -675,8 +655,7 @@ mod test {
 
     #[test]
     fn test_add_globals() {
-        let base_config =
-            LintConfig { plugins: BuiltinLintPlugins::ESLINT.into(), ..Default::default() };
+        let base_config = LintConfig { plugins: LintPlugins::ESLINT, ..Default::default() };
 
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             files: GlobSet::new(vec!["*.tsx"]),
@@ -702,7 +681,7 @@ mod test {
     #[test]
     fn test_replace_globals() {
         let base_config = LintConfig {
-            plugins: BuiltinLintPlugins::ESLINT.into(),
+            plugins: LintPlugins::ESLINT,
             globals: from_json!({
                 "React": "readonly",
                 "Secret": "writeable"
@@ -739,12 +718,7 @@ mod test {
 
         // Root config with react, typescript, unicorn plugins and restriction category
         let base_config = LintConfig {
-            plugins: LintPlugins::new(
-                BuiltinLintPlugins::REACT
-                    | BuiltinLintPlugins::TYPESCRIPT
-                    | BuiltinLintPlugins::UNICORN,
-                FxHashSet::default(),
-            ),
+            plugins: LintPlugins::REACT | LintPlugins::TYPESCRIPT | LintPlugins::UNICORN,
             env: OxlintEnv::default(),
             settings: OxlintSettings::default(),
             globals: OxlintGlobals::default(),
@@ -761,10 +735,7 @@ mod test {
             ResolvedOxlintOverride {
                 env: None,
                 files: GlobSet::new(vec!["*.{ts,tsx,mts}"]),
-                plugins: Some(LintPlugins::new(
-                    BuiltinLintPlugins::TYPESCRIPT,
-                    FxHashSet::default(),
-                )),
+                plugins: Some(LintPlugins::TYPESCRIPT),
                 globals: None,
                 rules: ResolvedOxlintOverrideRules {
                     builtin_rules: vec![],
@@ -775,7 +746,7 @@ mod test {
             ResolvedOxlintOverride {
                 env: None,
                 files: GlobSet::new(vec!["*.{ts,tsx}"]),
-                plugins: Some(LintPlugins::new(BuiltinLintPlugins::REACT, FxHashSet::default())),
+                plugins: Some(LintPlugins::REACT),
                 globals: None,
                 rules: ResolvedOxlintOverrideRules {
                     builtin_rules: vec![(
@@ -789,7 +760,7 @@ mod test {
             ResolvedOxlintOverride {
                 env: None,
                 files: GlobSet::new(vec!["*.{ts,tsx,mts}"]),
-                plugins: Some(LintPlugins::new(BuiltinLintPlugins::UNICORN, FxHashSet::default())),
+                plugins: Some(LintPlugins::UNICORN),
                 globals: None,
                 rules: ResolvedOxlintOverrideRules {
                     builtin_rules: vec![],
@@ -834,7 +805,7 @@ mod test {
 
         // Root config with only typescript plugin
         let base_config = LintConfig {
-            plugins: LintPlugins::new(BuiltinLintPlugins::TYPESCRIPT, FxHashSet::default()),
+            plugins: (LintPlugins::TYPESCRIPT),
             env: OxlintEnv::default(),
             settings: OxlintSettings::default(),
             globals: OxlintGlobals::default(),
@@ -849,7 +820,7 @@ mod test {
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             env: None,
             files: GlobSet::new(vec!["*.tsx"]),
-            plugins: Some(LintPlugins::new(BuiltinLintPlugins::REACT, FxHashSet::default())),
+            plugins: Some(LintPlugins::REACT),
             globals: None,
             rules: ResolvedOxlintOverrideRules { builtin_rules: vec![], external_rules: vec![] },
         }]);
@@ -938,7 +909,7 @@ mod test {
 
         // Root config with react plugin
         let base_config = LintConfig {
-            plugins: LintPlugins::new(BuiltinLintPlugins::REACT, FxHashSet::default()),
+            plugins: (LintPlugins::REACT),
             env: OxlintEnv::default(),
             settings: OxlintSettings::default(),
             globals: OxlintGlobals::default(),
@@ -959,7 +930,7 @@ mod test {
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             env: None,
             files: GlobSet::new(vec!["*.tsx"]),
-            plugins: Some(LintPlugins::new(BuiltinLintPlugins::TYPESCRIPT, FxHashSet::default())),
+            plugins: Some(LintPlugins::TYPESCRIPT),
             globals: None,
             rules: ResolvedOxlintOverrideRules { builtin_rules: vec![], external_rules: vec![] },
         }]);

--- a/crates/oxc_linter/src/config/mod.rs
+++ b/crates/oxc_linter/src/config/mod.rs
@@ -18,7 +18,7 @@ pub use globals::{GlobalValue, OxlintGlobals};
 pub use ignore_matcher::LintIgnoreMatcher;
 pub use overrides::OxlintOverrides;
 pub use oxlintrc::Oxlintrc;
-pub use plugins::{BuiltinLintPlugins, LintPlugins};
+pub use plugins::LintPlugins;
 pub use rules::{ESLintRule, OxlintRules};
 pub use settings::{OxlintSettings, jsdoc::JSDocPluginSettings};
 

--- a/crates/oxc_linter/src/config/overrides.rs
+++ b/crates/oxc_linter/src/config/overrides.rs
@@ -3,6 +3,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
+use rustc_hash::FxHashSet;
 use schemars::{JsonSchema, r#gen, schema::Schema};
 use serde::{Deserialize, Deserializer, Serialize};
 
@@ -92,6 +93,10 @@ pub struct OxlintOverride {
     #[serde(default)]
     pub plugins: Option<LintPlugins>,
 
+    /// JS plugins for this override.
+    #[serde(rename = "jsPlugins")]
+    pub external_plugins: Option<FxHashSet<String>>,
+
     #[serde(default)]
     pub rules: OxlintRules,
 }
@@ -133,10 +138,9 @@ impl GlobSet {
 
 #[cfg(test)]
 mod test {
-    use crate::config::{globals::GlobalValue, plugins::BuiltinLintPlugins};
+    use crate::config::{globals::GlobalValue, plugins::LintPlugins};
 
     use super::*;
-    use rustc_hash::FxHashSet;
     use serde_json::{from_value, json};
 
     #[test]
@@ -169,23 +173,14 @@ mod test {
             "plugins": [],
         }))
         .unwrap();
-        assert_eq!(
-            config.plugins,
-            Some(LintPlugins::new(BuiltinLintPlugins::empty(), FxHashSet::default()))
-        );
+        assert_eq!(config.plugins, Some(LintPlugins::empty()));
 
         let config: OxlintOverride = from_value(json!({
             "files": ["*.tsx"],
             "plugins": ["typescript", "react"],
         }))
         .unwrap();
-        assert_eq!(
-            config.plugins,
-            Some(LintPlugins::new(
-                BuiltinLintPlugins::REACT | BuiltinLintPlugins::TYPESCRIPT,
-                FxHashSet::default()
-            ))
-        );
+        assert_eq!(config.plugins, Some(LintPlugins::REACT | LintPlugins::TYPESCRIPT));
     }
 
     #[test]

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -12,7 +12,7 @@ use serde::{
 use oxc_diagnostics::{Error, OxcDiagnostic};
 
 use crate::{
-    AllowWarnDeny, BuiltinLintPlugins, ExternalPluginStore,
+    AllowWarnDeny, ExternalPluginStore, LintPlugins,
     external_plugin_store::{ExternalRuleId, ExternalRuleLookupError},
     rules::{RULES, RuleEnum},
     utils::{is_eslint_rule_adapted_to_typescript, is_jest_rule_adapted_to_vitest},
@@ -87,7 +87,7 @@ impl OxlintRules {
                 let severity = rule_config.severity;
 
                 // TODO(camc314): remove the `plugin_name == "eslint"`
-                if plugin_name == "eslint" || !BuiltinLintPlugins::from(plugin_name).is_empty() {
+                if plugin_name == "eslint" || !LintPlugins::from(plugin_name).is_empty() {
                     let rule = rules_map.get(&plugin_name).copied().or_else(|| {
                         all_rules
                             .iter()

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -11,8 +11,8 @@ use oxc_semantic::Semantic;
 use oxc_span::{SourceType, Span};
 
 use crate::{
-    AllowWarnDeny, FrameworkFlags, LintPlugins,
-    config::LintConfig,
+    AllowWarnDeny, FrameworkFlags,
+    config::{LintConfig, LintPlugins},
     disable_directives::{DisableDirectives, DisableDirectivesBuilder, RuleCommentType},
     fixer::{Fix, FixKind, Message, PossibleFixes},
     frameworks::{self, FrameworkOptions},
@@ -223,8 +223,8 @@ impl<'a> ContextHost<'a> {
     }
 
     #[inline]
-    pub fn plugins(&self) -> &LintPlugins {
-        &self.config.plugins
+    pub fn plugins(&self) -> LintPlugins {
+        self.config.plugins
     }
 
     /// Add a diagnostic message to the end of the list of diagnostics. Can be used

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -50,8 +50,8 @@ mod tester;
 
 pub use crate::{
     config::{
-        BuiltinLintPlugins, Config, ConfigBuilderError, ConfigStore, ConfigStoreBuilder,
-        ESLintRule, LintIgnoreMatcher, LintPlugins, Oxlintrc, ResolvedLinterState,
+        Config, ConfigBuilderError, ConfigStore, ConfigStoreBuilder, ESLintRule, LintIgnoreMatcher,
+        LintPlugins, Oxlintrc, ResolvedLinterState,
     },
     context::{ContextSubHost, LintContext},
     external_linter::{

--- a/crates/oxc_linter/src/snapshots/schema_json.snap
+++ b/crates/oxc_linter/src/snapshots/schema_json.snap
@@ -51,6 +51,18 @@ expression: json
         "type": "string"
       }
     },
+    "jsPlugins": {
+      "description": "JS plugins.",
+      "default": null,
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
     "overrides": {
       "description": "Add, remove, or otherwise reconfigure rules for specific files or groups of files.",
       "allOf": [
@@ -430,6 +442,17 @@ expression: json
               "type": "null"
             }
           ]
+        },
+        "jsPlugins": {
+          "description": "JS plugins for this override.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
         },
         "plugins": {
           "description": "Optionally change what plugins are enabled for this override. When\nomitted, the base config's plugins are used.",

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -15,8 +15,8 @@ use oxc_allocator::Allocator;
 use oxc_diagnostics::{GraphicalReportHandler, GraphicalTheme, NamedSource};
 
 use crate::{
-    AllowWarnDeny, BuiltinLintPlugins, ConfigStore, ConfigStoreBuilder, LintPlugins, LintService,
-    LintServiceOptions, Linter, Oxlintrc, RuleEnum,
+    AllowWarnDeny, ConfigStore, ConfigStoreBuilder, LintPlugins, LintService, LintServiceOptions,
+    Linter, Oxlintrc, RuleEnum,
     external_plugin_store::ExternalPluginStore,
     fixer::{FixKind, Fixer},
     options::LintOptions,
@@ -306,37 +306,37 @@ impl Tester {
     }
 
     pub fn with_import_plugin(mut self, yes: bool) -> Self {
-        self.plugins.builtin.set(BuiltinLintPlugins::IMPORT, yes);
+        self.plugins.set(LintPlugins::IMPORT, yes);
         self
     }
 
     pub fn with_jest_plugin(mut self, yes: bool) -> Self {
-        self.plugins.builtin.set(BuiltinLintPlugins::JEST, yes);
+        self.plugins.set(LintPlugins::JEST, yes);
         self
     }
 
     pub fn with_vitest_plugin(mut self, yes: bool) -> Self {
-        self.plugins.builtin.set(BuiltinLintPlugins::VITEST, yes);
+        self.plugins.set(LintPlugins::VITEST, yes);
         self
     }
 
     pub fn with_jsx_a11y_plugin(mut self, yes: bool) -> Self {
-        self.plugins.builtin.set(BuiltinLintPlugins::JSX_A11Y, yes);
+        self.plugins.set(LintPlugins::JSX_A11Y, yes);
         self
     }
 
     pub fn with_nextjs_plugin(mut self, yes: bool) -> Self {
-        self.plugins.builtin.set(BuiltinLintPlugins::NEXTJS, yes);
+        self.plugins.set(LintPlugins::NEXTJS, yes);
         self
     }
 
     pub fn with_react_perf_plugin(mut self, yes: bool) -> Self {
-        self.plugins.builtin.set(BuiltinLintPlugins::REACT_PERF, yes);
+        self.plugins.set(LintPlugins::REACT_PERF, yes);
         self
     }
 
     pub fn with_node_plugin(mut self, yes: bool) -> Self {
-        self.plugins.builtin.set(BuiltinLintPlugins::NODE, yes);
+        self.plugins.set(LintPlugins::NODE, yes);
         self
     }
 
@@ -518,9 +518,7 @@ impl Tester {
                         )
                         .unwrap()
                     })
-                    .with_builtin_plugins(
-                        self.plugins.builtin.union(BuiltinLintPlugins::from(self.plugin_name)),
-                    )
+                    .with_builtin_plugins(self.plugins | LintPlugins::from(self.plugin_name))
                     .with_rule(rule, AllowWarnDeny::Warn)
                     .build(&external_plugin_store)
                     .unwrap(),

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -47,6 +47,18 @@
         "type": "string"
       }
     },
+    "jsPlugins": {
+      "description": "JS plugins.",
+      "default": null,
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
     "overrides": {
       "description": "Add, remove, or otherwise reconfigure rules for specific files or groups of files.",
       "allOf": [
@@ -426,6 +438,17 @@
               "type": "null"
             }
           ]
+        },
+        "jsPlugins": {
+          "description": "JS plugins for this override.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
         },
         "plugins": {
           "description": "Optionally change what plugins are enabled for this override. When\nomitted, the base config's plugins are used.",

--- a/tasks/website/src/linter/rules/doc_page.rs
+++ b/tasks/website/src/linter/rules/doc_page.rs
@@ -6,7 +6,7 @@ use std::{
     path::PathBuf,
 };
 
-use oxc_linter::{BuiltinLintPlugins, table::RuleTableRow};
+use oxc_linter::{LintPlugins, table::RuleTableRow};
 use schemars::{
     JsonSchema, SchemaGenerator,
     schema::{InstanceType, Schema, SchemaObject, SingleOrVec},
@@ -172,8 +172,8 @@ fn rule_source(rule: &RuleTableRow) -> String {
 /// - Example: `eslint` => true
 /// - Example: `jest` => false
 fn is_default_plugin(plugin: &str) -> bool {
-    let plugin = BuiltinLintPlugins::from(plugin);
-    BuiltinLintPlugins::default().contains(plugin)
+    let plugin = LintPlugins::from(plugin);
+    LintPlugins::default().contains(plugin)
 }
 
 /// Returns the normalized plugin name.
@@ -181,7 +181,7 @@ fn is_default_plugin(plugin: &str) -> bool {
 /// - Example: `eslint` -> `eslint`
 /// - Example: `jsx_a11y` -> `jsx-a11y`
 fn get_normalized_plugin_name(plugin: &str) -> &str {
-    BuiltinLintPlugins::from(plugin).into()
+    LintPlugins::from(plugin).into()
 }
 
 fn how_to_use(rule: &RuleTableRow) -> String {

--- a/tasks/website/src/linter/snapshots/schema_markdown.snap
+++ b/tasks/website/src/linter/snapshots/schema_markdown.snap
@@ -193,6 +193,15 @@ default: `[]`
 Globs to ignore during linting. These are resolved from the configuration file path.
 
 
+## jsPlugins
+
+type: `string[]`
+
+default: `null`
+
+JS plugins.
+
+
 ## overrides
 
 type: `array`
@@ -215,6 +224,14 @@ type: `string[]`
 
 
 A set of glob patterns.
+
+
+#### overrides[n].jsPlugins
+
+type: `string[]`
+
+
+JS plugins for this override.
 
 
 #### overrides[n].rules


### PR DESCRIPTION
Fixes #12432.

JS plugins were previously configured by adding them to `plugins` array in config file. Instead, move them to a separate `jsPlugins` array.

Before:

```json
{
  "plugins": ["oxc", "react", "./custom-plugin.js"],
}
```

After:

```json
{
  "plugins": ["oxc", "react"],
  "jsPlugins": ["./custom-plugin.js"],
}
```
