### PR TITLE
refactor(semantic): move AstNode::cfg_id to struct of arrays in AstNodes

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
@@ -260,7 +260,7 @@ impl Rule for NoFallthrough {
         let AstKind::SwitchStatement(switch) = node.kind() else { return };
 
         let cfg = ctx.cfg();
-        let switch_id = node.cfg_id();
+        let switch_id = ctx.nodes().cfg_id(node.id());
         let graph = cfg.graph();
 
         let (cfg_ids, tests, default, exit) = get_switch_semantic_cases(ctx, node, switch);
@@ -438,7 +438,7 @@ fn get_switch_semantic_cases(
     let graph = cfg.graph();
     let has_default = switch.cases.iter().any(SwitchCase::is_default_case);
     let (mut cfg_ids, tests, exit) = graph
-        .edges_directed(node.cfg_id(), Direction::Outgoing)
+        .edges_directed(ctx.nodes().cfg_id(node.id()), Direction::Outgoing)
         .fold((Vec::new(), Vec::new(), None), |(mut cfg_ids, mut conds, exit), it| {
             let target = it.target();
             if !matches!(it.weight(), EdgeType::Normal) {

--- a/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
@@ -75,7 +75,7 @@ impl Rule for NoThisBeforeSuper {
                     }
                 }
                 AstKind::Super(_) => {
-                    let basic_block_id = node.cfg_id();
+                    let basic_block_id = ctx.nodes().cfg_id(node.id());
                     if let AstKind::CallExpression(call_expr) = ctx.nodes().parent_kind(node.id()) {
                         let has_this_or_super_in_args =
                             Self::contains_this_or_super_in_args(&call_expr.arguments);
@@ -92,7 +92,7 @@ impl Rule for NoThisBeforeSuper {
                     }
                 }
                 AstKind::ThisExpression(_) => {
-                    let basic_block_id = node.cfg_id();
+                    let basic_block_id = ctx.nodes().cfg_id(node.id());
                     if !basic_blocks_with_super_called.contains(&basic_block_id) {
                         basic_blocks_with_local_violations
                             .entry(basic_block_id)
@@ -109,7 +109,7 @@ impl Rule for NoThisBeforeSuper {
         for node in wanted_nodes {
             let output = Self::analyze(
                 cfg,
-                node.cfg_id(),
+                ctx.nodes().cfg_id(node.id()),
                 &basic_blocks_with_super_called,
                 &basic_blocks_with_local_violations,
                 false,

--- a/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
@@ -68,12 +68,13 @@ impl Rule for NoUnreachable {
         let mut infinite_loops = Vec::new();
 
         // Set the root as reachable.
-        unreachables[root.cfg_id().index()] = false;
+        let root_cfg_id = ctx.nodes().cfg_id(root.id());
+        unreachables[root_cfg_id.index()] = false;
 
         // In our first path we first check if each block is definitely unreachable, If it is then
         // we set it as such, If we encounter an infinite loop we keep its end block since it can
         // prevent other reachable blocks from ever getting executed.
-        let _: Control<()> = depth_first_search(graph, Some(root.cfg_id()), |event| {
+        let _: Control<()> = depth_first_search(graph, Some(root_cfg_id), |event| {
             if let DfsEvent::Finish(node, _) = event {
                 let unreachable = cfg.basic_block(node).is_unreachable();
                 unreachables[node.index()] = unreachable;
@@ -168,7 +169,7 @@ impl Rule for NoUnreachable {
                 continue;
             }
 
-            if unreachables[node.cfg_id().index()] {
+            if unreachables[ctx.nodes().cfg_id(node.id()).index()] {
                 ctx.diagnostic(no_unreachable_diagnostic(node.kind().span()));
             }
         }

--- a/crates/oxc_linter/src/rules/promise/always_return.rs
+++ b/crates/oxc_linter/src/rules/promise/always_return.rs
@@ -332,7 +332,7 @@ fn is_nodejs_terminal_statement(node: &AstNode) -> bool {
 fn has_no_return_code_path(node: &AstNode, ctx: &LintContext) -> bool {
     let cfg = ctx.cfg();
     let graph = cfg.graph();
-    let output = set_depth_first_search(graph, Some(node.cfg_id()), |event| {
+    let output = set_depth_first_search(graph, Some(ctx.nodes().cfg_id(node.id())), |event| {
         match event {
             // We only need to check paths that are normal or jump.
             DfsEvent::TreeEdge(a, b) => {

--- a/crates/oxc_linter/src/rules/react/require_render_return.rs
+++ b/crates/oxc_linter/src/rules/react/require_render_return.rs
@@ -116,7 +116,7 @@ fn contains_return_statement(node: &AstNode, ctx: &LintContext) -> bool {
     let cfg = ctx.cfg();
     let state = neighbors_filtered_by_edge_weight(
         cfg.graph(),
-        node.cfg_id(),
+        ctx.nodes().cfg_id(node.id()),
         &|edge| match edge {
             // We only care about normal edges having a return statement.
             EdgeType::Jump | EdgeType::Normal => None,

--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -275,8 +275,8 @@ impl Rule for RulesOfHooks {
             return;
         }
 
-        let node_cfg_id = node.cfg_id();
-        let func_cfg_id = parent_func.cfg_id();
+        let node_cfg_id = ctx.nodes().cfg_id(node.id());
+        let func_cfg_id = ctx.nodes().cfg_id(parent_func.id());
 
         // there is no branch between us and our parent function
         if node_cfg_id == func_cfg_id {
@@ -296,7 +296,7 @@ impl Rule for RulesOfHooks {
             return ctx.diagnostic(diagnostics::loop_hook(span, hook_name));
         }
 
-        if has_conditional_path_accept_throw(cfg, parent_func, node) {
+        if has_conditional_path_accept_throw(ctx.nodes(), cfg, parent_func, node) {
             #[expect(clippy::needless_return)]
             return ctx.diagnostic(diagnostics::conditional_hook(span, hook_name));
         }
@@ -304,12 +304,13 @@ impl Rule for RulesOfHooks {
 }
 
 fn has_conditional_path_accept_throw(
+    nodes: &AstNodes<'_>,
     cfg: &ControlFlowGraph,
     from: &AstNode<'_>,
     to: &AstNode<'_>,
 ) -> bool {
-    let from_graph_id = from.cfg_id();
-    let to_graph_id = to.cfg_id();
+    let from_graph_id = nodes.cfg_id(from.id());
+    let to_graph_id = nodes.cfg_id(to.id());
     let graph = cfg.graph();
     if graph
         .edges(to_graph_id)

--- a/crates/oxc_semantic/examples/cfg.rs
+++ b/crates/oxc_semantic/examples/cfg.rs
@@ -96,7 +96,7 @@ fn main() -> std::io::Result<()> {
 
     let mut ast_nodes_by_block = FxHashMap::<_, Vec<_>>::default();
     for node in semantic.semantic.nodes() {
-        let block = node.cfg_id();
+        let block = semantic.semantic.nodes().cfg_id(node.id());
         let block_ix = cfg.graph.node_weight(block).unwrap();
         ast_nodes_by_block.entry(*block_ix).or_default().push(node);
     }


### PR DESCRIPTION
part of oxc-project/backlog#183

Reduces AstNode from 32 to 24 bytes in the linter pipeline.