### PR TITLE
refactor(syntax): remove unnecessary `#[estree(field_order)]` attr

### DIFF
--- a/crates/oxc_syntax/src/module_record.rs
+++ b/crates/oxc_syntax/src/module_record.rs
@@ -87,7 +87,7 @@ impl<'a> ModuleRecord<'a> {
 #[ast]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[generate_derive(ESTree)]
-#[estree(no_type, no_ts_def, field_order(name, span))]
+#[estree(no_type, no_ts_def)]
 pub struct NameSpan<'a> {
     /// Name
     #[estree(rename = "value")]


### PR DESCRIPTION
`span` is now automatically moved to be last field, so no need to specify field order explicitly here.