### PR TITLE
refactor(ast): remove unneccesary `#[estree(field_order)]` attrs

### DIFF
--- a/crates/oxc_ast/src/ast/comment.rs
+++ b/crates/oxc_ast/src/ast/comment.rs
@@ -123,7 +123,7 @@ impl<'alloc> CloneIn<'alloc> for CommentNewlines {
 #[ast]
 #[generate_derive(CloneIn, ContentEq, ESTree)]
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
-#[estree(add_fields(value = CommentValue), field_order(kind, value, span), no_ts_def)]
+#[estree(add_fields(value = CommentValue), no_ts_def)]
 pub struct Comment {
     /// The span of the comment text, with leading and trailing delimiters.
     pub span: Span,

--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -100,11 +100,7 @@ pub struct StringLiteral<'a> {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, Dummy, TakeIn, ContentEq, GetSpan, GetSpanMut, ESTree)]
-#[estree(
-    rename = "Literal",
-    add_fields(bigint = BigIntLiteralBigint),
-    field_order(value, raw, bigint, span),
-)]
+#[estree(rename = "Literal", add_fields(bigint = BigIntLiteralBigint))]
 pub struct BigIntLiteral<'a> {
     /// Node location in source code
     pub span: Span,

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -44,7 +44,7 @@ use super::{inherit_variants, js::*, literal::*};
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(
     rename = "Identifier",
-    add_fields(name = This, decorators = EmptyArray, optional = False),
+    add_fields(decorators = EmptyArray, name = This, optional = False),
     field_order(decorators, name, optional, type_annotation, span),
 )]
 pub struct TSThisParameter<'a> {


### PR DESCRIPTION
`span` is now automatically moved to be last field, so no need to specify field orders explicitly here.