### PR TITLE
refactor(napi/parser): remove unnecessary `#[estree(field_order)]` attr

### DIFF
--- a/napi/parser/src/raw_transfer_types.rs
+++ b/napi/parser/src/raw_transfer_types.rs
@@ -129,7 +129,7 @@ impl From<Severity> for ErrorSeverity {
 
 #[ast]
 #[generate_derive(ESTree)]
-#[estree(no_type, no_ts_def, field_order(message, span))]
+#[estree(no_type, no_ts_def)]
 pub struct ErrorLabel<'a> {
     pub message: Option<Atom<'a>>,
     pub span: Span,


### PR DESCRIPTION
`span` is now automatically moved to be last field, so no need to specify field order explicitly here.