### PR TITLE
test(napi/parser): align fixture version with other tasks

### DIFF
--- a/napi/parser/bench.bench.js
+++ b/napi/parser/bench.bench.js
@@ -19,7 +19,7 @@ let fixtureUrls = [
   'https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@main/cal.com.tsx',
   'https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@main/RadixUIAdoptionSection.jsx',
   'https://cdn.jsdelivr.net/npm/pdfjs-dist@4.0.269/build/pdf.mjs',
-  'https://cdn.jsdelivr.net/npm/antd@5.12.5/dist/antd.js',
+  'https://cdn.jsdelivr.net/npm/antd@4.16.1/dist/antd.js',
 ];
 
 // For sharding in CI - specify single fixture to run benchmarks on

--- a/napi/parser/test/parse-raw.test.ts
+++ b/napi/parser/test/parse-raw.test.ts
@@ -66,7 +66,7 @@ const benchFixtureUrls = [
   // Heavy with classes (554K)
   'https://cdn.jsdelivr.net/npm/pdfjs-dist@4.0.269/build/pdf.mjs',
   // ES5 (3.9M)
-  'https://cdn.jsdelivr.net/npm/antd@5.12.5/dist/antd.js',
+  'https://cdn.jsdelivr.net/npm/antd@4.16.1/dist/antd.js',
 ];
 
 await mkdir(TARGET_DIR_PATH, { recursive: true });


### PR DESCRIPTION
#13465 aligned the version of `antd.js` used in different Rust tasks to v4.16.1. But it missed a couple of places in `napi/parser` tests/benchmarks. Align these to same version too.

Misalignment was problematic as the tasks using these fixtures all download the file to same location (`target` dir) and don't re-download if the file is already present. This lead to unpredictable results depending on which task you ran first, and so which version was downloaded.
