### PR TITLE
test(linter/plugins): specify path to `node` in tests

### DIFF
--- a/apps/oxlint/test/e2e.test.ts
+++ b/apps/oxlint/test/e2e.test.ts
@@ -26,7 +26,9 @@ async function testFixture(fixtureName: string, options?: TestOptions): Promise<
   const args = options?.args ?? [];
 
   await testFixtureWithCommand({
-    command: 'node',
+    // Use current NodeJS executable, rather than `node`, to avoid problems with a Node version manager
+    // installed on system resulting in using wrong NodeJS version
+    command: process.execPath,
     args: [CLI_PATH, ...args, 'files'],
     fixtureName,
     snapshotName: options?.snapshotName ?? 'output',


### PR DESCRIPTION
Make tests for Oxlint more robust by specifying the current NodeJS executable to run `oxlint` with. I was hitting problems locally with a node version manager resulting in running the tests in an older NodeJS version.
