### PR TITLE
test(linter/plugins): normalize line breaks in snapshots

### DIFF
--- a/apps/oxlint/test/fixtures/basic_custom_plugin/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin/output.snap.md
@@ -3,7 +3,6 @@
 
 # stdout
 ```
-
   x basic-custom-plugin(no-debugger): Unexpected Debugger Statement
    ,-[files/index.js:1:1]
  1 | debugger;

--- a/apps/oxlint/test/fixtures/basic_custom_plugin_many_files/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin_many_files/output.snap.md
@@ -3,7 +3,6 @@
 
 # stdout
 ```
-
   x basic-custom-plugin(no-debugger): Unexpected Debugger Statement
    ,-[files/01.js:1:1]
  1 | debugger;

--- a/apps/oxlint/test/fixtures/basic_custom_plugin_multiple_rules/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin_multiple_rules/output.snap.md
@@ -3,7 +3,6 @@
 
 # stdout
 ```
-
   x basic-custom-plugin(no-debugger): Unexpected Debugger Statement
    ,-[files/index.js:1:1]
  1 | debugger;

--- a/apps/oxlint/test/fixtures/basic_custom_plugin_warn_severity/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin_warn_severity/output.snap.md
@@ -3,7 +3,6 @@
 
 # stdout
 ```
-
   ! basic-custom-plugin(no-debugger): Unexpected Debugger Statement
    ,-[files/index.js:1:1]
  1 | debugger;

--- a/apps/oxlint/test/fixtures/built_in_errors/output.snap.md
+++ b/apps/oxlint/test/fixtures/built_in_errors/output.snap.md
@@ -3,7 +3,6 @@
 
 # stdout
 ```
-
   x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
    ,-[files/index.js:1:1]
  1 | debugger;

--- a/apps/oxlint/test/fixtures/context_properties/output.snap.md
+++ b/apps/oxlint/test/fixtures/context_properties/output.snap.md
@@ -3,7 +3,6 @@
 
 # stdout
 ```
-
   x context-plugin(log-context): id: context-plugin/log-context
    ,-[files/1.js:1:1]
  1 | let x;

--- a/apps/oxlint/test/fixtures/createOnce/output.snap.md
+++ b/apps/oxlint/test/fixtures/createOnce/output.snap.md
@@ -3,7 +3,6 @@
 
 # stdout
 ```
-
   x create-once-plugin(after-only): after hook: filename: files/1.js
    ,-[files/1.js:1:1]
  1 | let x;

--- a/apps/oxlint/test/fixtures/custom_plugin_disable_directives/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_disable_directives/output.snap.md
@@ -3,7 +3,6 @@
 
 # stdout
 ```
-
   x test-plugin(no-var): Use let or const instead of var
    ,-[files/index.js:3:1]
  2 | 

--- a/apps/oxlint/test/fixtures/custom_plugin_import_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_import_error/output.snap.md
@@ -8,5 +8,4 @@ Failed to parse configuration file.
   x Failed to load JS plugin: ./plugin.js
   |   Error: whoops!
   |     at <root>/apps/oxlint/test/fixtures/custom_plugin_import_error/plugin.js:1:7
-
 ```

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_after_hook_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_after_hook_error/output.snap.md
@@ -3,7 +3,6 @@
 
 # stdout
 ```
-
   x Error running JS plugin.
   | File path: <root>/apps/oxlint/test/fixtures/custom_plugin_lint_after_hook_error/files/index.js
   | Error: Whoops!

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_before_hook_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_before_hook_error/output.snap.md
@@ -3,7 +3,6 @@
 
 # stdout
 ```
-
   x Error running JS plugin.
   | File path: <root>/apps/oxlint/test/fixtures/custom_plugin_lint_before_hook_error/files/index.js
   | Error: Whoops!

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_createOnce_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_createOnce_error/output.snap.md
@@ -8,5 +8,4 @@ Failed to parse configuration file.
   x Failed to load JS plugin: ./plugin.js
   |   Error: Whoops!
   |     at Object.createOnce (<root>/apps/oxlint/test/fixtures/custom_plugin_lint_createOnce_error/plugin.js:8:15)
-
 ```

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_create_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_create_error/output.snap.md
@@ -3,7 +3,6 @@
 
 # stdout
 ```
-
   x Error running JS plugin.
   | File path: <root>/apps/oxlint/test/fixtures/custom_plugin_lint_create_error/files/index.js
   | Error: Whoops!

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_fix_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_fix_error/output.snap.md
@@ -3,7 +3,6 @@
 
 # stdout
 ```
-
   x Error running JS plugin.
   | File path: <root>/apps/oxlint/test/fixtures/custom_plugin_lint_fix_error/files/index.js
   | Error: Whoops!

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_visit_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_visit_error/output.snap.md
@@ -3,7 +3,6 @@
 
 # stdout
 ```
-
   x Error running JS plugin.
   | File path: <root>/apps/oxlint/test/fixtures/custom_plugin_lint_visit_error/files/index.js
   | Error: Whoops!

--- a/apps/oxlint/test/fixtures/custom_plugin_missing_rule/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_missing_rule/output.snap.md
@@ -6,5 +6,4 @@
 Failed to parse configuration file.
 
   x Rule 'unknown-rule' not found in plugin 'basic-custom-plugin'
-
 ```

--- a/apps/oxlint/test/fixtures/custom_plugin_via_overrides/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_via_overrides/output.snap.md
@@ -3,7 +3,6 @@
 
 # stdout
 ```
-
   x basic-custom-plugin(no-debugger): Unexpected Debugger Statement
    ,-[files/index.js:1:1]
  1 | debugger;

--- a/apps/oxlint/test/fixtures/custom_plugin_via_overrides_missing_rule/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_via_overrides_missing_rule/output.snap.md
@@ -6,5 +6,4 @@
 Failed to build configuration.
 
   x Rule 'missing' not found in plugin 'basic-custom-plugin'
-
 ```

--- a/apps/oxlint/test/fixtures/definePlugin/eslint.snap.md
+++ b/apps/oxlint/test/fixtures/definePlugin/eslint.snap.md
@@ -3,7 +3,6 @@
 
 # stdout
 ```
-
 <root>/apps/oxlint/test/fixtures/definePlugin/files/1.js
   0:1  error  create body:
 this === rule: true                                                define-plugin-plugin/create
@@ -89,5 +88,4 @@ filename: files/2.js                                        define-plugin-plugin
 filename: files/2.js                                        define-plugin-plugin/create-once-no-hooks
 
 ✖ 35 problems (35 errors, 0 warnings)
-
 ```

--- a/apps/oxlint/test/fixtures/definePlugin/output.snap.md
+++ b/apps/oxlint/test/fixtures/definePlugin/output.snap.md
@@ -3,7 +3,6 @@
 
 # stdout
 ```
-
   x define-plugin-plugin(create): create body:
   | this === rule: true
    ,-[files/1.js:1:1]

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/eslint.snap.md
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/eslint.snap.md
@@ -3,7 +3,6 @@
 
 # stdout
 ```
-
 <root>/apps/oxlint/test/fixtures/definePlugin_and_defineRule/files/1.js
   0:1  error  create body:
 this === rule: true                                                define-plugin-and-rule-plugin/create
@@ -89,5 +88,4 @@ filename: files/2.js                                        define-plugin-and-ru
 filename: files/2.js                                        define-plugin-and-rule-plugin/create-once-no-hooks
 
 ✖ 35 problems (35 errors, 0 warnings)
-
 ```

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/output.snap.md
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/output.snap.md
@@ -3,7 +3,6 @@
 
 # stdout
 ```
-
   x define-plugin-and-rule-plugin(create): create body:
   | this === rule: true
    ,-[files/1.js:1:1]

--- a/apps/oxlint/test/fixtures/defineRule/eslint.snap.md
+++ b/apps/oxlint/test/fixtures/defineRule/eslint.snap.md
@@ -3,7 +3,6 @@
 
 # stdout
 ```
-
 <root>/apps/oxlint/test/fixtures/defineRule/files/1.js
   0:1  error  create body:
 this === rule: true                                                define-rule-plugin/create
@@ -89,5 +88,4 @@ filename: files/2.js                                        define-rule-plugin/c
 filename: files/2.js                                        define-rule-plugin/create-once-no-hooks
 
 ✖ 35 problems (35 errors, 0 warnings)
-
 ```

--- a/apps/oxlint/test/fixtures/defineRule/output.snap.md
+++ b/apps/oxlint/test/fixtures/defineRule/output.snap.md
@@ -3,7 +3,6 @@
 
 # stdout
 ```
-
   x define-rule-plugin(create): create body:
   | this === rule: true
    ,-[files/1.js:1:1]

--- a/apps/oxlint/test/fixtures/estree/output.snap.md
+++ b/apps/oxlint/test/fixtures/estree/output.snap.md
@@ -3,7 +3,6 @@
 
 # stdout
 ```
-
   x estree-check(check): Visited nodes:
   | * Program
   | * VariableDeclaration: let

--- a/apps/oxlint/test/fixtures/fixes/fixes_disabled.snap.md
+++ b/apps/oxlint/test/fixtures/fixes/fixes_disabled.snap.md
@@ -3,7 +3,6 @@
 
 # stdout
 ```
-
   x fixes-plugin(fixes): Remove debugger statement
    ,-[files/index.js:1:1]
  1 | debugger;

--- a/apps/oxlint/test/fixtures/load_paths/output.snap.md
+++ b/apps/oxlint/test/fixtures/load_paths/output.snap.md
@@ -3,7 +3,6 @@
 
 # stdout
 ```
-
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
    ,-[files/index.js:1:1]
  1 | debugger;

--- a/apps/oxlint/test/fixtures/missing_custom_plugin/output.snap.md
+++ b/apps/oxlint/test/fixtures/missing_custom_plugin/output.snap.md
@@ -7,5 +7,4 @@ Failed to parse configuration file.
 
   x Failed to load JS plugin: ./plugin.js
   |   Cannot find module './plugin.js'
-
 ```

--- a/apps/oxlint/test/fixtures/utf16_offsets/output.snap.md
+++ b/apps/oxlint/test/fixtures/utf16_offsets/output.snap.md
@@ -3,7 +3,6 @@
 
 # stdout
 ```
-
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
    ,-[files/index.js:1:1]
  1 | debugger;


### PR DESCRIPTION
Trim leading/trailing line breaks from `stdout` in test snapshots and convert `\r\n` to `\n`. This ensures tests will pass on Windows, and removes extraneous line breaks from snapshots.