### PR TITLE
test(linter/plugins): include stderr output in snapshots

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -239,7 +239,6 @@ impl CliRunner {
         if external_plugin_store.is_empty() {
             external_linter = None;
         } else {
-            #[cfg(not(any(test, feature = "force_test_reporter")))]
             #[expect(clippy::print_stderr)]
             {
                 eprintln!(

--- a/apps/oxlint/test/fixtures/basic_custom_plugin/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin/output.snap.md
@@ -19,3 +19,9 @@
 Found 1 warning and 1 error.
 Finished in Xms on 1 file using X threads.
 ```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/basic_custom_plugin_many_files/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin_many_files/output.snap.md
@@ -266,3 +266,9 @@
 Found 20 warnings and 20 errors.
 Finished in Xms on 20 files using X threads.
 ```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/basic_custom_plugin_multiple_rules/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin_multiple_rules/output.snap.md
@@ -43,3 +43,9 @@
 Found 2 warnings and 3 errors.
 Finished in Xms on 1 file using X threads.
 ```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/basic_custom_plugin_warn_severity/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin_warn_severity/output.snap.md
@@ -19,3 +19,9 @@
 Found 2 warnings and 0 errors.
 Finished in Xms on 1 file using X threads.
 ```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/built_in_errors/output.snap.md
+++ b/apps/oxlint/test/fixtures/built_in_errors/output.snap.md
@@ -13,3 +13,7 @@
 Found 0 warnings and 1 error.
 Finished in Xms on 1 file using X threads.
 ```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/built_in_no_errors/output.snap.md
+++ b/apps/oxlint/test/fixtures/built_in_no_errors/output.snap.md
@@ -6,3 +6,7 @@
 Found 0 warnings and 0 errors.
 Finished in Xms on 1 file using X threads.
 ```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/context_properties/output.snap.md
+++ b/apps/oxlint/test/fixtures/context_properties/output.snap.md
@@ -42,3 +42,9 @@
 Found 0 warnings and 6 errors.
 Finished in Xms on 2 files using X threads.
 ```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/createOnce/output.snap.md
+++ b/apps/oxlint/test/fixtures/createOnce/output.snap.md
@@ -258,3 +258,9 @@
 Found 0 warnings and 42 errors.
 Finished in Xms on 2 files using X threads.
 ```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/custom_plugin_disable_directives/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_disable_directives/output.snap.md
@@ -46,3 +46,9 @@
 Found 0 warnings and 5 errors.
 Finished in Xms on 1 file using X threads.
 ```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/custom_plugin_import_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_import_error/output.snap.md
@@ -9,3 +9,7 @@ Failed to parse configuration file.
   |   Error: whoops!
   |     at <root>/apps/oxlint/test/fixtures/custom_plugin_import_error/plugin.js:1:7
 ```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_after_hook_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_after_hook_error/output.snap.md
@@ -11,3 +11,9 @@
 Found 0 warnings and 1 error.
 Finished in Xms on 1 file using X threads.
 ```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_before_hook_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_before_hook_error/output.snap.md
@@ -11,3 +11,9 @@
 Found 0 warnings and 1 error.
 Finished in Xms on 1 file using X threads.
 ```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_createOnce_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_createOnce_error/output.snap.md
@@ -9,3 +9,7 @@ Failed to parse configuration file.
   |   Error: Whoops!
   |     at Object.createOnce (<root>/apps/oxlint/test/fixtures/custom_plugin_lint_createOnce_error/plugin.js:8:15)
 ```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_create_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_create_error/output.snap.md
@@ -11,3 +11,9 @@
 Found 0 warnings and 1 error.
 Finished in Xms on 1 file using X threads.
 ```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_fix_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_fix_error/output.snap.md
@@ -12,3 +12,9 @@
 Found 0 warnings and 1 error.
 Finished in Xms on 1 file using X threads.
 ```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_visit_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_visit_error/output.snap.md
@@ -11,3 +11,9 @@
 Found 0 warnings and 1 error.
 Finished in Xms on 1 file using X threads.
 ```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/custom_plugin_missing_rule/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_missing_rule/output.snap.md
@@ -7,3 +7,7 @@ Failed to parse configuration file.
 
   x Rule 'unknown-rule' not found in plugin 'basic-custom-plugin'
 ```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/custom_plugin_via_overrides/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_via_overrides/output.snap.md
@@ -19,3 +19,9 @@
 Found 1 warning and 1 error.
 Finished in Xms on 1 file using X threads.
 ```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/custom_plugin_via_overrides_missing_rule/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_via_overrides_missing_rule/output.snap.md
@@ -7,3 +7,7 @@ Failed to build configuration.
 
   x Rule 'missing' not found in plugin 'basic-custom-plugin'
 ```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/definePlugin/eslint.snap.md
+++ b/apps/oxlint/test/fixtures/definePlugin/eslint.snap.md
@@ -89,3 +89,7 @@ filename: files/2.js                                        define-plugin-plugin
 
 ✖ 35 problems (35 errors, 0 warnings)
 ```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/definePlugin/output.snap.md
+++ b/apps/oxlint/test/fixtures/definePlugin/output.snap.md
@@ -261,3 +261,9 @@
 Found 0 warnings and 35 errors.
 Finished in Xms on 2 files using X threads.
 ```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/eslint.snap.md
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/eslint.snap.md
@@ -89,3 +89,7 @@ filename: files/2.js                                        define-plugin-and-ru
 
 ✖ 35 problems (35 errors, 0 warnings)
 ```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/output.snap.md
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/output.snap.md
@@ -261,3 +261,9 @@
 Found 0 warnings and 35 errors.
 Finished in Xms on 2 files using X threads.
 ```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/defineRule/eslint.snap.md
+++ b/apps/oxlint/test/fixtures/defineRule/eslint.snap.md
@@ -89,3 +89,7 @@ filename: files/2.js                                        define-rule-plugin/c
 
 ✖ 35 problems (35 errors, 0 warnings)
 ```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/defineRule/output.snap.md
+++ b/apps/oxlint/test/fixtures/defineRule/output.snap.md
@@ -261,3 +261,9 @@
 Found 0 warnings and 35 errors.
 Finished in Xms on 2 files using X threads.
 ```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/estree/output.snap.md
+++ b/apps/oxlint/test/fixtures/estree/output.snap.md
@@ -50,3 +50,9 @@
 Found 0 warnings and 1 error.
 Finished in Xms on 1 file using X threads.
 ```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/fixes/fixes_disabled.snap.md
+++ b/apps/oxlint/test/fixtures/fixes/fixes_disabled.snap.md
@@ -101,6 +101,12 @@ Found 0 warnings and 12 errors.
 Finished in Xms on 1 file using X threads.
 ```
 
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```
+
 # Code after
 ```
 debugger;

--- a/apps/oxlint/test/fixtures/fixes/fixes_enabled.snap.md
+++ b/apps/oxlint/test/fixtures/fixes/fixes_enabled.snap.md
@@ -7,6 +7,12 @@ Found 0 warnings and 0 errors.
 Finished in Xms on 1 file using X threads.
 ```
 
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```
+
 # Code after
 ```
 

--- a/apps/oxlint/test/fixtures/load_paths/output.snap.md
+++ b/apps/oxlint/test/fixtures/load_paths/output.snap.md
@@ -49,3 +49,9 @@
 Found 1 warning and 6 errors.
 Finished in Xms on 1 file using X threads.
 ```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/missing_custom_plugin/output.snap.md
+++ b/apps/oxlint/test/fixtures/missing_custom_plugin/output.snap.md
@@ -8,3 +8,7 @@ Failed to parse configuration file.
   x Failed to load JS plugin: ./plugin.js
   |   Cannot find module './plugin.js'
 ```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/utf16_offsets/output.snap.md
+++ b/apps/oxlint/test/fixtures/utf16_offsets/output.snap.md
@@ -55,3 +55,9 @@
 Found 3 warnings and 3 errors.
 Finished in Xms on 1 file using X threads.
 ```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/utils.ts
+++ b/apps/oxlint/test/utils.ts
@@ -32,7 +32,7 @@ interface TestFixtureOptions {
 export async function testFixtureWithCommand(options: TestFixtureOptions): Promise<void> {
   const fixtureDirPath = pathJoin(FIXTURES_DIR_PATH, options.fixtureName);
 
-  let { stdout, exitCode } = await execa(options.command, options.args, {
+  let { stdout, stderr, exitCode } = await execa(options.command, options.args, {
     cwd: fixtureDirPath,
     reject: false,
   });
@@ -40,8 +40,10 @@ export async function testFixtureWithCommand(options: TestFixtureOptions): Promi
   const snapshotPath = pathJoin(fixtureDirPath, `${options.snapshotName}.snap.md`);
 
   stdout = normalizeStdout(stdout);
+  stderr = normalizeStdout(stderr);
   let snapshot = `# Exit code\n${exitCode}\n\n` +
-    `# stdout\n\`\`\`\n${stdout}\`\`\`\n`;
+    `# stdout\n\`\`\`\n${stdout}\`\`\`\n\n` +
+    `# stderr\n\`\`\`\n${stderr}\`\`\`\n`;
 
   if (options.getExtraSnapshotData) {
     const extraSnapshots = await options.getExtraSnapshotData(fixtureDirPath);


### PR DESCRIPTION
Include `stderr` output in test snapshots. This makes sure that the "JS plugins are experimental" warning is not output if user doesn't use JS plugins.