### PR TITLE
test(editor): remove cross-module tests, covered by language server

### DIFF
--- a/editors/vscode/fixtures/cross_module/.oxlintrc.json
+++ b/editors/vscode/fixtures/cross_module/.oxlintrc.json
@@ -1,8 +1,0 @@
-{
-  "plugins": [
-    "import"
-  ],
-  "rules": {
-    "import/no-cycle": "error"
-  }
-}

--- a/editors/vscode/fixtures/cross_module/debugger.ts
+++ b/editors/vscode/fixtures/cross_module/debugger.ts
@@ -1,2 +1,0 @@
-// Debugger should be shown as a warning
-debugger;

--- a/editors/vscode/fixtures/cross_module/dep-a.ts
+++ b/editors/vscode/fixtures/cross_module/dep-a.ts
@@ -1,4 +1,0 @@
-// should report cycle detected
-import { b } from './dep-b.ts';
-
-b();

--- a/editors/vscode/fixtures/cross_module/dep-b.ts
+++ b/editors/vscode/fixtures/cross_module/dep-b.ts
@@ -1,4 +1,0 @@
-// this file is also included in dep-a.ts and dep-a.ts should report a no-cycle diagnostic
-import './dep-a.ts';
-
-export function b() { /* ... */ }

--- a/editors/vscode/fixtures/cross_module_extended_config/.oxlintrc.json
+++ b/editors/vscode/fixtures/cross_module_extended_config/.oxlintrc.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "./config/.oxlintrc.json"
-  ]
-}

--- a/editors/vscode/fixtures/cross_module_extended_config/config/.oxlintrc.json
+++ b/editors/vscode/fixtures/cross_module_extended_config/config/.oxlintrc.json
@@ -1,8 +1,0 @@
-{
-  "plugins": [
-    "import"
-  ],
-  "rules": {
-    "import/no-cycle": "error"
-  }
-}

--- a/editors/vscode/fixtures/cross_module_extended_config/dep-a.ts
+++ b/editors/vscode/fixtures/cross_module_extended_config/dep-a.ts
@@ -1,4 +1,0 @@
-// should report cycle detected
-import { b } from './dep-b.ts';
-
-b();

--- a/editors/vscode/fixtures/cross_module_extended_config/dep-b.ts
+++ b/editors/vscode/fixtures/cross_module_extended_config/dep-b.ts
@@ -1,4 +1,0 @@
-// this file is also included in dep-a.ts and dep-a.ts should report a no-cycle diagnostic
-import './dep-a.ts';
-
-export function b() { /* ... */ }

--- a/editors/vscode/fixtures/cross_module_nested_config/dep-a.ts
+++ b/editors/vscode/fixtures/cross_module_nested_config/dep-a.ts
@@ -1,4 +1,0 @@
-// should report cycle detected
-import { b } from './dep-b.ts';
-
-b();

--- a/editors/vscode/fixtures/cross_module_nested_config/dep-b.ts
+++ b/editors/vscode/fixtures/cross_module_nested_config/dep-b.ts
@@ -1,4 +1,0 @@
-// this file is also included in dep-a.ts and dep-a.ts should report a no-cycle diagnostic
-import './dep-a.ts';
-
-export function b() { /* ... */ }

--- a/editors/vscode/fixtures/cross_module_nested_config/folder/.oxlintrc.json
+++ b/editors/vscode/fixtures/cross_module_nested_config/folder/.oxlintrc.json
@@ -1,8 +1,0 @@
-{
-  "plugins": [
-    "import"
-  ],
-  "rules": {
-    "import/no-cycle": "error"
-  }
-}

--- a/editors/vscode/fixtures/cross_module_nested_config/folder/folder-dep-a.ts
+++ b/editors/vscode/fixtures/cross_module_nested_config/folder/folder-dep-a.ts
@@ -1,4 +1,0 @@
-// should report cycle detected
-import { b } from './folder-dep-b.ts';
-
-b();

--- a/editors/vscode/fixtures/cross_module_nested_config/folder/folder-dep-b.ts
+++ b/editors/vscode/fixtures/cross_module_nested_config/folder/folder-dep-b.ts
@@ -1,4 +1,0 @@
-// this file is also included in folder-dep-a.ts and folder-dep-a.ts should report a no-cycle diagnostic
-import './folder-dep-a.ts';
-
-export function b() { /* ... */ }

--- a/editors/vscode/tests/e2e_server.spec.ts
+++ b/editors/vscode/tests/e2e_server.spec.ts
@@ -274,56 +274,6 @@ suite('E2E Diagnostics', () => {
     assert(secondDiagnostics.length != 0);
   });
 
-  test('cross module', async () => {
-    await loadFixture('cross_module');
-    const diagnostics = await getDiagnostics('dep-a.ts');
-
-    strictEqual(diagnostics.length, 1);
-    assert(typeof diagnostics[0].code == 'object');
-    strictEqual(diagnostics[0].code.target.authority, 'oxc.rs');
-    assert(
-      diagnostics[0].message.startsWith("Dependency cycle detected"),
-    );
-    strictEqual(diagnostics[0].severity, DiagnosticSeverity.Error);
-    strictEqual(diagnostics[0].range.start.line, 1);
-    strictEqual(diagnostics[0].range.start.character, 18);
-    strictEqual(diagnostics[0].range.end.line, 1);
-    strictEqual(diagnostics[0].range.end.character, 30);
-  });
-
-  test('cross module with nested config', async () => {
-    await loadFixture('cross_module_nested_config');
-    const diagnostics = await getDiagnostics('folder/folder-dep-a.ts');
-
-    strictEqual(diagnostics.length, 1);
-    assert(typeof diagnostics[0].code == 'object');
-    strictEqual(diagnostics[0].code.target.authority, 'oxc.rs');
-    assert(
-      diagnostics[0].message.startsWith("Dependency cycle detected"),
-    );
-    strictEqual(diagnostics[0].severity, DiagnosticSeverity.Error);
-    strictEqual(diagnostics[0].range.start.line, 1);
-    strictEqual(diagnostics[0].range.start.character, 18);
-    strictEqual(diagnostics[0].range.end.line, 1);
-    strictEqual(diagnostics[0].range.end.character, 37);
-  });
-
-  test('cross module with extended config', async () => {
-    await loadFixture('cross_module_extended_config');
-    const diagnostics = await getDiagnostics('dep-a.ts');
-
-    assert(typeof diagnostics[0].code == 'object');
-    strictEqual(diagnostics[0].code.target.authority, 'oxc.rs');
-    assert(
-      diagnostics[0].message.startsWith("Dependency cycle detected"),
-    );
-    strictEqual(diagnostics[0].severity, DiagnosticSeverity.Error);
-    strictEqual(diagnostics[0].range.start.line, 1);
-    strictEqual(diagnostics[0].range.start.character, 18);
-    strictEqual(diagnostics[0].range.end.line, 1);
-    strictEqual(diagnostics[0].range.end.character, 30);
-  });
-
   test('formats code with `oxc.fmt.experimental`', async () => {
     await workspace.getConfiguration('oxc').update('fmt.experimental', true);
     await workspace.getConfiguration('editor').update('defaultFormatter', 'oxc.oxc-vscode');


### PR DESCRIPTION
The CI sometimes fails because of them.
Removing them because they are already included in `oxc_language_server` ServerLinter tests