### PR TITLE
test(linter/plugins): do not run `pnpm` in tests

### DIFF
--- a/apps/oxlint/test/eslint-compat.test.ts
+++ b/apps/oxlint/test/eslint-compat.test.ts
@@ -1,5 +1,8 @@
+import { join as pathJoin } from 'node:path';
 import { describe, it } from 'vitest';
 import { testFixtureWithCommand } from './utils.js';
+
+const ESLINT_PATH = pathJoin(import.meta.dirname, '../node_modules/.bin/eslint');
 
 /**
  * Run ESLint on a test fixture.
@@ -7,8 +10,8 @@ import { testFixtureWithCommand } from './utils.js';
  */
 async function testFixture(fixtureName: string): Promise<void> {
   await testFixtureWithCommand({
-    command: 'pnpx',
-    args: ['eslint'],
+    command: ESLINT_PATH,
+    args: [],
     fixtureName,
     snapshotName: 'eslint',
   });


### PR DESCRIPTION
Tests were using `pnpx eslint`, which downloads `eslint`. That's unnecessary because `eslint` is already a dev dependency of `apps/oxlint` package.