### PR TITLE
test(linter/plugins): type-check test fixtures

### DIFF
--- a/apps/oxlint/test/fixtures/estree/files/index.ts
+++ b/apps/oxlint/test/fixtures/estree/files/index.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // dprint-ignore-file
 
 // All `Identifier`s

--- a/apps/oxlint/test/fixtures/estree/output.snap.md
+++ b/apps/oxlint/test/fixtures/estree/output.snap.md
@@ -33,18 +33,18 @@
   | * TSUnionType:exit: (types: TSStringKeyword, TSNumberKeyword)
   | * TSTypeAliasDeclaration:exit: (typeAnnotation: TSUnionType)
   | * Program:exit
-    ,-[files/index.ts:4:1]
-  3 |     // All `Identifier`s
-  4 | ,-> let a = { x: y };
-  5 | |   
-  6 | |   // No `ParenthesizedExpression`s in AST
-  7 | |   const b = (x * ((('str' + ((123))))));
-  8 | |   
-  9 | |   // TS syntax
- 10 | |   type T = string;
- 11 | |   
- 12 | |   // No `TSParenthesizedType`s in AST
- 13 | `-> type U = (((((string)) | ((number)))));
+    ,-[files/index.ts:5:1]
+  4 |     // All `Identifier`s
+  5 | ,-> let a = { x: y };
+  6 | |   
+  7 | |   // No `ParenthesizedExpression`s in AST
+  8 | |   const b = (x * ((('str' + ((123))))));
+  9 | |   
+ 10 | |   // TS syntax
+ 11 | |   type T = string;
+ 12 | |   
+ 13 | |   // No `TSParenthesizedType`s in AST
+ 14 | `-> type U = (((((string)) | ((number)))));
     `----
 
 Found 0 warnings and 1 error.

--- a/apps/oxlint/tsconfig.json
+++ b/apps/oxlint/tsconfig.json
@@ -9,7 +9,6 @@
   },
   "exclude": [
     "node_modules",
-    "fixtures",
-    "test/fixtures"
+    "fixtures"
   ]
 }


### PR DESCRIPTION
There's no reason to exclude these files from type-checking. Only 1 fixture file needs to be ignored.