### PR TITLE
perf(parser): cleanup and optimize various parsing functions

### DIFF
--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -187,7 +187,7 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_class_body(&mut self) -> Box<'a, ClassBody<'a>> {
         let span = self.start_span();
-        let class_elements = self.parse_normal_list(Kind::LCurly, Kind::RCurly, |p| {
+        let class_elements = self.parse_normal_list_breakable(Kind::LCurly, Kind::RCurly, |p| {
             // Skip empty class element `;`
             if p.eat(Kind::Semicolon) {
                 while p.eat(Kind::Semicolon) {}

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -91,7 +91,8 @@ impl<'a> ParserImpl<'a> {
             Kind::Do => self.parse_do_while_statement(),
             Kind::While => self.parse_while_statement(),
             Kind::For => self.parse_for_statement(),
-            Kind::Break | Kind::Continue => self.parse_break_or_continue_statement(),
+            Kind::Continue => self.parse_continue_statement(),
+            Kind::Break => self.parse_break_statement(),
             Kind::With => self.parse_with_statement(),
             Kind::Switch => self.parse_switch_statement(),
             Kind::Throw => self.parse_throw_statement(),
@@ -206,13 +207,9 @@ impl<'a> ParserImpl<'a> {
     /// Section 14.2 Block Statement
     pub(crate) fn parse_block(&mut self) -> Box<'a, BlockStatement<'a>> {
         let span = self.start_span();
-        self.expect(Kind::LCurly);
-        let mut body = self.ast.vec();
-        while !self.at(Kind::RCurly) && !self.has_fatal_error() {
-            let stmt = self.parse_statement_list_item(StatementContext::StatementList);
-            body.push(stmt);
-        }
-        self.expect(Kind::RCurly);
+        let body = self.parse_normal_list(Kind::LCurly, Kind::RCurly, |p| {
+            p.parse_statement_list_item(StatementContext::StatementList)
+        });
         self.ast.alloc_block_statement(self.end_span(span), body)
     }
 
@@ -232,7 +229,7 @@ impl<'a> ParserImpl<'a> {
             start_span,
             kind,
             VariableDeclarationParent::Statement,
-            &Modifiers::empty(),
+            false,
         );
 
         if stmt_ctx.is_single_statement() && decl.kind.is_lexical() {
@@ -315,10 +312,25 @@ impl<'a> ParserImpl<'a> {
 
         // `for (const` | `for (var`
         match self.cur_kind() {
-            Kind::Const | Kind::Var => {
+            Kind::Const => {
                 let start_span = self.start_span();
-                return self
-                    .parse_variable_declaration_for_statement(span, start_span, None, r#await);
+                self.bump_any();
+                return self.parse_variable_declaration_for_statement(
+                    span,
+                    start_span,
+                    VariableDeclarationKind::Const,
+                    r#await,
+                );
+            }
+            Kind::Var => {
+                let start_span = self.start_span();
+                self.bump_any();
+                return self.parse_variable_declaration_for_statement(
+                    span,
+                    start_span,
+                    VariableDeclarationKind::Var,
+                    r#await,
+                );
             }
             Kind::Let => {
                 // `for (let`
@@ -330,7 +342,7 @@ impl<'a> ParserImpl<'a> {
                     return self.parse_variable_declaration_for_statement(
                         span,
                         start_span,
-                        Some(VariableDeclarationKind::Let),
+                        VariableDeclarationKind::Let,
                         r#await,
                     );
                 }
@@ -403,40 +415,25 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         span: u32,
         start_span: u32,
-        decl_kind: Option<VariableDeclarationKind>,
+        decl_kind: VariableDeclarationKind,
         r#await: bool,
     ) -> Statement<'a> {
         let init_declaration = self.context(Context::empty(), Context::In, |p| {
-            let decl_ctx = VariableDeclarationParent::For;
-            let kind = if let Some(kind) = decl_kind {
-                kind
-            } else {
-                let kind = p.get_variable_declaration_kind();
-                p.bump_any();
-                kind
-            };
-            p.parse_variable_declaration(start_span, kind, decl_ctx, &Modifiers::empty())
+            p.parse_variable_declaration(
+                start_span,
+                decl_kind,
+                VariableDeclarationParent::For,
+                false,
+            )
         });
 
         self.parse_any_for_loop(span, init_declaration, r#await)
     }
 
     fn is_using_declaration(&mut self) -> bool {
-        self.lookahead(|p| {
-            p.is_next_token_binding_identifier_or_start_of_object_destructuring_on_same_line(false)
-        })
-    }
-
-    fn is_next_token_binding_identifier_or_start_of_object_destructuring_on_same_line(
-        &mut self,
-        disallow_of: bool,
-    ) -> bool {
-        self.bump_any();
-        if disallow_of && self.at(Kind::Of) {
-            return false;
-        }
-        (self.cur_kind().is_binding_identifier() || self.at(Kind::LCurly))
-            && !self.cur_token().is_on_new_line()
+        let token = self.lexer.peek_token();
+        let kind = token.kind();
+        (kind.is_binding_identifier() || kind == Kind::LCurly) && !token.is_on_new_line()
     }
 
     fn parse_using_declaration_for_statement(&mut self, span: u32, r#await: bool) -> Statement<'a> {
@@ -495,10 +492,10 @@ impl<'a> ParserImpl<'a> {
                 self.check_missing_initializer(d);
             }
         }
-        let test = if !self.at(Kind::Semicolon) && !self.at(Kind::RParen) {
-            Some(self.context(Context::In, Context::empty(), ParserImpl::parse_expr))
-        } else {
+        let test = if matches!(self.cur_kind(), Kind::Semicolon | Kind::RParen) {
             None
+        } else {
+            Some(self.context(Context::In, Context::empty(), ParserImpl::parse_expr))
         };
         self.expect(Kind::Semicolon);
         let update = if self.at(Kind::RParen) {
@@ -549,20 +546,23 @@ impl<'a> ParserImpl<'a> {
     }
 
     /// Section 14.8 Continue Statement
-    /// Section 14.9 Break Statement
-    fn parse_break_or_continue_statement(&mut self) -> Statement<'a> {
+    fn parse_continue_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
-        let kind = self.cur_kind();
-        self.bump_any(); // bump `break` or `continue`
+        self.bump_any(); // bump `continue`
         let label =
             if self.can_insert_semicolon() { None } else { Some(self.parse_label_identifier()) };
         self.asi();
-        let end_span = self.end_span(span);
-        match kind {
-            Kind::Break => self.ast.statement_break(end_span, label),
-            Kind::Continue => self.ast.statement_continue(end_span, label),
-            _ => unreachable!(),
-        }
+        self.ast.statement_continue(self.end_span(span), label)
+    }
+
+    /// Section 14.9 Break Statement
+    fn parse_break_statement(&mut self) -> Statement<'a> {
+        let span = self.start_span();
+        self.bump_any(); // bump `break`
+        let label =
+            if self.can_insert_semicolon() { None } else { Some(self.parse_label_identifier()) };
+        self.asi();
+        self.ast.statement_break(self.end_span(span), label)
     }
 
     /// Section 14.10 Return Statement
@@ -604,7 +604,7 @@ impl<'a> ParserImpl<'a> {
         self.ast.statement_switch(self.end_span(span), discriminant, cases)
     }
 
-    pub(crate) fn parse_switch_case(&mut self) -> Option<SwitchCase<'a>> {
+    pub(crate) fn parse_switch_case(&mut self) -> SwitchCase<'a> {
         let span = self.start_span();
         let test = match self.cur_kind() {
             Kind::Default => {
@@ -626,7 +626,7 @@ impl<'a> ParserImpl<'a> {
             let stmt = self.parse_statement_list_item(StatementContext::StatementList);
             consequent.push(stmt);
         }
-        Some(self.ast.switch_case(self.end_span(span), test, consequent))
+        self.ast.switch_case(self.end_span(span), test, consequent)
     }
 
     /// Section 14.14 Throw Statement

--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -159,12 +159,8 @@ impl<'a> Modifiers<'a> {
     ///  `modifiers`. E.g., if `modifiers` is empty, then so is `flags``.
     #[must_use]
     pub(crate) fn new(modifiers: Option<Vec<'a, Modifier>>, flags: ModifierFlags) -> Self {
-        if let Some(modifiers) = modifiers {
-            Self { modifiers: Some(modifiers), flags }
-        } else {
-            debug_assert!(flags.is_empty());
-            Self { modifiers: None, flags: ModifierFlags::empty() }
-        }
+        debug_assert_eq!(modifiers.is_none(), flags.is_empty());
+        Self { modifiers, flags }
     }
 
     pub fn empty() -> Self {
@@ -297,10 +293,10 @@ impl std::fmt::Display for ModifierKind {
 
 impl<'a> ParserImpl<'a> {
     pub(crate) fn eat_modifiers_before_declaration(&mut self) -> Modifiers<'a> {
-        let mut flags = ModifierFlags::empty();
         if !self.at_modifier() {
-            return Modifiers::new(None, flags);
+            return Modifiers::empty();
         }
+        let mut flags = ModifierFlags::empty();
         let mut modifiers = self.ast.vec();
         while self.at_modifier() {
             let span = self.start_span();

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -653,9 +653,8 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_type_literal(&mut self) -> TSType<'a> {
         let span = self.start_span();
-        let member_list = self.parse_normal_list(Kind::LCurly, Kind::RCurly, |p| {
-            Some(Self::parse_ts_type_signature(p))
-        });
+        let member_list =
+            self.parse_normal_list(Kind::LCurly, Kind::RCurly, Self::parse_ts_type_signature);
         self.ast.ts_type_type_literal(self.end_span(span), member_list)
     }
 


### PR DESCRIPTION
- Avoid unnecessary Option wrapping and checks by splitting parse_normal_list function into a breakable and non-breakable variant
- Avoid unnecessary Option wrapping and checks in parse_variable_declaration_for_statement function
- Break up parse_break_or_continue_statement function into function for break and continue
- Remove unnecessary checks in is_using_declaration and use cheaper lexer.peek_token()
- Make parse_variable_declaration take `declare: bool` instead of `&Modifiers` avoid constructing empty Modifiers
- some other minor code improvements

I hope these changes are not too much and therefore difficult to review. It's now less code with better performance. I was in the flow of refactoring and couldn't stop :)

Edit:

I don't see the improvements on Codspeed I'm seeing locally when running `cargo benchmark --bench parser` against main... Feel free to close my PR if there are no verifiable performance improvements. My local output:

<img width="569" height="358" alt="image" src="https://github.com/user-attachments/assets/f9ef95b0-34e2-4630-9500-ccc0b8380229" />