### PR TITLE
feat(linter/plugins): `oxlint` export types

### DIFF
--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "main": "dist/index.js",
   "bin": "dist/cli.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "pnpm run build-napi-release && pnpm run build-js",
     "build-dev": "pnpm run build-napi && pnpm run build-js",
@@ -34,9 +35,13 @@
   "files": [
     "dist"
   ],
+  "dependencies": {
+    "@oxc-project/types": "workspace:^"
+  },
   "devDependencies": {
     "eslint": "^9.36.0",
     "execa": "^9.6.0",
+    "jiti": "^2.6.0",
     "tsdown": "0.15.1",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/apps/oxlint/src-js/index.ts
+++ b/apps/oxlint/src-js/index.ts
@@ -2,6 +2,11 @@ import type { Context } from './plugins/context.ts';
 import type { CreateOnceRule, Plugin, Rule } from './plugins/load.ts';
 import type { BeforeHook, Visitor, VisitorWithHooks } from './plugins/types.ts';
 
+export type { Context, Diagnostic } from './plugins/context.ts';
+export type { Fix, Fixer, FixFn, NodeOrToken, Range } from './plugins/fix.ts';
+export type { CreateOnceRule, CreateRule, Plugin, Rule } from './plugins/load.ts';
+export type { AfterHook, BeforeHook, RuleMeta, Visitor, VisitorWithHooks } from './plugins/types.ts';
+
 const { defineProperty, getPrototypeOf, hasOwn, setPrototypeOf, create: ObjectCreate } = Object;
 
 const dummyOptions: unknown[] = [],

--- a/apps/oxlint/src-js/plugins/fix.ts
+++ b/apps/oxlint/src-js/plugins/fix.ts
@@ -17,10 +17,10 @@ export type FixFn = (
 // Type of a fix, as returned by `fix` function.
 export type Fix = { range: Range; text: string };
 
-type Range = [number, number];
+export type Range = [number, number];
 
 // Currently we only support `Node`s, but will add support for `Token`s later
-interface NodeOrToken {
+export interface NodeOrToken {
   start: number;
   end: number;
 }
@@ -60,7 +60,7 @@ const FIXER = Object.freeze({
   },
 });
 
-type Fixer = typeof FIXER;
+export type Fixer = typeof FIXER;
 
 /**
  * Get fixes from a `Diagnostic`.

--- a/apps/oxlint/src-js/plugins/load.ts
+++ b/apps/oxlint/src-js/plugins/load.ts
@@ -20,7 +20,7 @@ export interface Plugin {
 // If `createOnce` method is present, `create` is ignored.
 export type Rule = CreateRule | CreateOnceRule;
 
-interface CreateRule {
+export interface CreateRule {
   meta?: RuleMeta;
   create: (context: Context) => Visitor;
 }

--- a/apps/oxlint/test/fixtures/definePlugin/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/definePlugin/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "jsPlugins": ["./plugin.js"],
+  "jsPlugins": ["./plugin.ts"],
   "categories": { "correctness": "off" },
   "rules": {
     "define-plugin-plugin/create": "error",

--- a/apps/oxlint/test/fixtures/definePlugin/eslint.config.js
+++ b/apps/oxlint/test/fixtures/definePlugin/eslint.config.js
@@ -1,4 +1,4 @@
-import plugin from './plugin.js';
+import plugin from './plugin.ts';
 
 export default [
   {

--- a/apps/oxlint/test/fixtures/definePlugin/plugin.ts
+++ b/apps/oxlint/test/fixtures/definePlugin/plugin.ts
@@ -1,5 +1,6 @@
 import { sep } from 'node:path';
-import { definePlugin, defineRule } from '../../../dist/index.js';
+import { definePlugin } from '../../../dist/index.js';
+import type { Rule } from '../../../dist/index.js';
 
 // `loc` is required for ESLint
 const SPAN = {
@@ -14,10 +15,10 @@ const SPAN = {
 const DIR_PATH_LEN = import.meta.dirname.length + 1;
 
 const relativePath = sep === '/'
-  ? path => path.slice(DIR_PATH_LEN)
-  : path => path.slice(DIR_PATH_LEN).replace(/\\/g, '/');
+  ? (path: string) => path.slice(DIR_PATH_LEN)
+  : (path: string) => path.slice(DIR_PATH_LEN).replace(/\\/g, '/');
 
-const createRule = defineRule({
+const createRule: Rule = {
   create(context) {
     context.report({ message: `create body:\nthis === rule: ${this === createRule}`, node: SPAN });
 
@@ -30,24 +31,26 @@ const createRule = defineRule({
       },
     };
   },
-});
+};
 
 // This aims to test that `createOnce` is called once only, and `before` hook is called once per file.
-// i.e. Oxlint calls `createOnce` directly, and not the `create` method that `defineRule` adds to the rule.
+// i.e. Oxlint calls `createOnce` directly, and not the `create` method that `defineRule` (via `definePlugin`)
+// adds to the rule.
 let createOnceCallCount = 0;
 
-const createOnceRule = defineRule({
+const createOnceRule: Rule = {
   createOnce(context) {
     createOnceCallCount++;
 
     // `fileNum` should be different for each file.
     // `identNum` should start at 1 for each file.
-    let fileNum = 0, identNum;
+    let fileNum = 0, identNum: number;
     // Note: Files are processed in unpredictable order, so `files/1.js` may be `fileNum` 1 or 2.
     // Therefore, collect all visits and check them in `after` hook of the 2nd file.
-    const visits = [];
+    const visits: { fileNum: number; identNum: number }[] = [];
 
-    // `this` should be the rule object returned by `defineRule`
+    // `this` should be the rule object
+    // oxlint-disable-next-line typescript-eslint/no-this-alias
     const topLevelThis = this;
 
     return {
@@ -102,10 +105,10 @@ const createOnceRule = defineRule({
       },
     };
   },
-});
+};
 
 // Tests that `before` hook returning `false` disables visiting AST for the file.
-const createOnceBeforeFalseRule = defineRule({
+const createOnceBeforeFalseRule: Rule = {
   createOnce(context) {
     return {
       before() {
@@ -134,11 +137,11 @@ const createOnceBeforeFalseRule = defineRule({
       },
     };
   },
-});
+};
 
 // These 3 rules test that `createOnce` without `before` and `after` hooks works correctly.
 
-const createOnceBeforeOnlyRule = defineRule({
+const createOnceBeforeOnlyRule: Rule = {
   createOnce(context) {
     return {
       before() {
@@ -157,9 +160,9 @@ const createOnceBeforeOnlyRule = defineRule({
       },
     };
   },
-});
+};
 
-const createOnceAfterOnlyRule = defineRule({
+const createOnceAfterOnlyRule: Rule = {
   createOnce(context) {
     return {
       Identifier(node) {
@@ -178,9 +181,9 @@ const createOnceAfterOnlyRule = defineRule({
       },
     };
   },
-});
+};
 
-const createOnceNoHooksRule = defineRule({
+const createOnceNoHooksRule: Rule = {
   createOnce(context) {
     return {
       Identifier(node) {
@@ -192,11 +195,11 @@ const createOnceNoHooksRule = defineRule({
       },
     };
   },
-});
+};
 
 export default definePlugin({
   meta: {
-    name: 'define-plugin-and-rule-plugin',
+    name: 'define-plugin-plugin',
   },
   rules: {
     create: createRule,

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "jsPlugins": ["./plugin.js"],
+  "jsPlugins": ["./plugin.ts"],
   "categories": { "correctness": "off" },
   "rules": {
     "define-plugin-and-rule-plugin/create": "error",

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/eslint.config.js
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/eslint.config.js
@@ -1,4 +1,4 @@
-import plugin from './plugin.js';
+import plugin from './plugin.ts';
 
 export default [
   {

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/plugin.ts
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/plugin.ts
@@ -1,5 +1,5 @@
 import { sep } from 'node:path';
-import { defineRule } from '../../../dist/index.js';
+import { definePlugin, defineRule } from '../../../dist/index.js';
 
 // `loc` is required for ESLint
 const SPAN = {
@@ -14,8 +14,8 @@ const SPAN = {
 const DIR_PATH_LEN = import.meta.dirname.length + 1;
 
 const relativePath = sep === '/'
-  ? path => path.slice(DIR_PATH_LEN)
-  : path => path.slice(DIR_PATH_LEN).replace(/\\/g, '/');
+  ? (path: string) => path.slice(DIR_PATH_LEN)
+  : (path: string) => path.slice(DIR_PATH_LEN).replace(/\\/g, '/');
 
 const createRule = defineRule({
   create(context) {
@@ -42,12 +42,13 @@ const createOnceRule = defineRule({
 
     // `fileNum` should be different for each file.
     // `identNum` should start at 1 for each file.
-    let fileNum = 0, identNum;
+    let fileNum = 0, identNum: number;
     // Note: Files are processed in unpredictable order, so `files/1.js` may be `fileNum` 1 or 2.
     // Therefore, collect all visits and check them in `after` hook of the 2nd file.
-    const visits = [];
+    const visits: { fileNum: number; identNum: number }[] = [];
 
     // `this` should be the rule object returned by `defineRule`
+    // oxlint-disable-next-line typescript-eslint/no-this-alias
     const topLevelThis = this;
 
     return {
@@ -194,9 +195,9 @@ const createOnceNoHooksRule = defineRule({
   },
 });
 
-export default {
+export default definePlugin({
   meta: {
-    name: 'define-rule-plugin',
+    name: 'define-plugin-and-rule-plugin',
   },
   rules: {
     create: createRule,
@@ -206,4 +207,4 @@ export default {
     'create-once-after-only': createOnceAfterOnlyRule,
     'create-once-no-hooks': createOnceNoHooksRule,
   },
-};
+});

--- a/apps/oxlint/test/fixtures/defineRule/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/defineRule/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "jsPlugins": ["./plugin.js"],
+  "jsPlugins": ["./plugin.ts"],
   "categories": { "correctness": "off" },
   "rules": {
     "define-rule-plugin/create": "error",

--- a/apps/oxlint/test/fixtures/defineRule/eslint.config.js
+++ b/apps/oxlint/test/fixtures/defineRule/eslint.config.js
@@ -1,4 +1,4 @@
-import plugin from './plugin.js';
+import plugin from './plugin.ts';
 
 export default [
   {

--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -1,7 +1,6 @@
-import { defineConfig } from 'tsdown';
+import { defineConfig, type UserConfig } from 'tsdown';
 
-export default defineConfig({
-  entry: ['src-js/index.ts', 'src-js/cli.ts', 'src-js/plugins/index.ts'],
+const commonConfig: UserConfig = {
   format: ['esm'],
   platform: 'node',
   target: 'node20',
@@ -19,5 +18,19 @@ export default defineConfig({
   // At present only compress syntax.
   // Don't mangle identifiers or remove whitespace, so `dist` code remains somewhat readable.
   minify: { compress: true, mangle: false, codegen: { removeWhitespace: false } },
-  attw: true,
-});
+};
+
+// Only generate `.d.ts` file for main export, not for CLI
+export default defineConfig([
+  {
+    entry: ['src-js/cli.ts', 'src-js/plugins/index.ts'],
+    ...commonConfig,
+    dts: false,
+  },
+  {
+    entry: 'src-js/index.ts',
+    ...commonConfig,
+    dts: true,
+    attw: true,
+  },
+]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,16 +49,23 @@ importers:
         version: 5.9.2
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/node@24.5.2)(@vitest/browser@3.2.4)(jiti@2.5.1)
+        version: 3.2.4(@types/node@24.5.2)(@vitest/browser@3.2.4)(jiti@2.6.0)
 
   apps/oxlint:
+    dependencies:
+      '@oxc-project/types':
+        specifier: workspace:^
+        version: link:../../npm/oxc-types
     devDependencies:
       eslint:
         specifier: ^9.36.0
-        version: 9.36.0(jiti@2.5.1)
+        version: 9.36.0(jiti@2.6.0)
       execa:
         specifier: ^9.6.0
         version: 9.6.0
+      jiti:
+        specifier: ^2.6.0
+        version: 2.6.0
       tsdown:
         specifier: 0.15.1
         version: 0.15.1(@arethetypeswrong/core@0.18.2)(publint@0.3.13)(typescript@5.9.2)
@@ -67,7 +74,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/node@24.5.2)(@vitest/browser@3.2.4)(jiti@2.5.1)
+        version: 3.2.4(@types/node@24.5.2)(@vitest/browser@3.2.4)(jiti@2.6.0)
 
   editors/vscode:
     dependencies:
@@ -116,7 +123,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/node@24.5.2)(@vitest/browser@3.2.4)(jiti@2.5.1)
+        version: 3.2.4(@types/node@24.5.2)(@vitest/browser@3.2.4)(jiti@2.6.0)
 
   napi/parser:
     dependencies:
@@ -126,7 +133,7 @@ importers:
     devDependencies:
       '@codspeed/vitest-plugin':
         specifier: ^4.0.0
-        version: 4.0.1(vite@7.1.6(@types/node@24.5.2)(jiti@2.5.1))(vitest@3.2.4)
+        version: 4.0.1(vite@7.1.6(@types/node@24.5.2)(jiti@2.6.0))(vitest@3.2.4)
       '@napi-rs/wasm-runtime':
         specifier: 'catalog:'
         version: 1.0.5
@@ -135,7 +142,7 @@ importers:
         version: 8.44.0
       '@vitest/browser':
         specifier: 3.2.4
-        version: 3.2.4(playwright@1.55.0)(vite@7.1.6(@types/node@24.5.2)(jiti@2.5.1))(vitest@3.2.4)
+        version: 3.2.4(playwright@1.55.0)(vite@7.1.6(@types/node@24.5.2)(jiti@2.6.0))(vitest@3.2.4)
       esbuild:
         specifier: ^0.25.0
         version: 0.25.10
@@ -150,7 +157,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/node@24.5.2)(@vitest/browser@3.2.4)(jiti@2.5.1)
+        version: 3.2.4(@types/node@24.5.2)(@vitest/browser@3.2.4)(jiti@2.6.0)
 
   napi/playground:
     dependencies:
@@ -165,7 +172,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/node@24.5.2)(@vitest/browser@3.2.4)(jiti@2.5.1)
+        version: 3.2.4(@types/node@24.5.2)(@vitest/browser@3.2.4)(jiti@2.6.0)
 
   npm/oxc-types: {}
 
@@ -3086,8 +3093,8 @@ packages:
     resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
     engines: {node: 20 || >=22}
 
-  jiti@2.5.1:
-    resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
+  jiti@2.6.0:
+    resolution: {integrity: sha512-VXe6RjJkBPj0ohtqaO8vSWP3ZhAKo66fKrFNCll4BTcwljPLz03pCbaNKfzGP5MbrCYcbJ7v0nOYYwUzTEIdXQ==}
     hasBin: true
 
   js-tokens@4.0.0:
@@ -4769,11 +4776,11 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@codspeed/vitest-plugin@4.0.1(vite@7.1.6(@types/node@24.5.2)(jiti@2.5.1))(vitest@3.2.4)':
+  '@codspeed/vitest-plugin@4.0.1(vite@7.1.6(@types/node@24.5.2)(jiti@2.6.0))(vitest@3.2.4)':
     dependencies:
       '@codspeed/core': 4.0.1
-      vite: 7.1.6(@types/node@24.5.2)(jiti@2.5.1)
-      vitest: 3.2.4(@types/node@24.5.2)(@vitest/browser@3.2.4)(jiti@2.5.1)
+      vite: 7.1.6(@types/node@24.5.2)(jiti@2.6.0)
+      vitest: 3.2.4(@types/node@24.5.2)(@vitest/browser@3.2.4)(jiti@2.6.0)
     transitivePeerDependencies:
       - debug
 
@@ -4870,9 +4877,9 @@ snapshots:
   '@esbuild/win32-x64@0.25.10':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.36.0(jiti@2.5.1))':
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.36.0(jiti@2.6.0))':
     dependencies:
-      eslint: 9.36.0(jiti@2.5.1)
+      eslint: 9.36.0(jiti@2.6.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
@@ -5883,16 +5890,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser@3.2.4(playwright@1.55.0)(vite@7.1.6(@types/node@24.5.2)(jiti@2.5.1))(vitest@3.2.4)':
+  '@vitest/browser@3.2.4(playwright@1.55.0)(vite@7.1.6(@types/node@24.5.2)(jiti@2.6.0))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/mocker': 3.2.4(vite@7.1.6(@types/node@24.5.2)(jiti@2.5.1))
+      '@vitest/mocker': 3.2.4(vite@7.1.6(@types/node@24.5.2)(jiti@2.6.0))
       '@vitest/utils': 3.2.4
       magic-string: 0.30.19
       sirv: 3.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.5.2)(@vitest/browser@3.2.4)(jiti@2.5.1)
+      vitest: 3.2.4(@types/node@24.5.2)(@vitest/browser@3.2.4)(jiti@2.6.0)
       ws: 8.18.3
     optionalDependencies:
       playwright: 1.55.0
@@ -5910,13 +5917,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.1.6(@types/node@24.5.2)(jiti@2.5.1))':
+  '@vitest/mocker@3.2.4(vite@7.1.6(@types/node@24.5.2)(jiti@2.6.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
-      vite: 7.1.6(@types/node@24.5.2)(jiti@2.5.1)
+      vite: 7.1.6(@types/node@24.5.2)(jiti@2.6.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -6577,9 +6584,9 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.36.0(jiti@2.5.1):
+  eslint@9.36.0(jiti@2.6.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.36.0(jiti@2.5.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.36.0(jiti@2.6.0))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.21.0
       '@eslint/config-helpers': 0.3.1
@@ -6615,7 +6622,7 @@ snapshots:
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
-      jiti: 2.5.1
+      jiti: 2.6.0
     transitivePeerDependencies:
       - supports-color
 
@@ -7096,7 +7103,7 @@ snapshots:
     dependencies:
       '@isaacs/cliui': 8.0.2
 
-  jiti@2.5.1: {}
+  jiti@2.6.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -8195,7 +8202,7 @@ snapshots:
     dependencies:
       '@quansync/fs': 0.1.5
       defu: 6.1.4
-      jiti: 2.5.1
+      jiti: 2.6.0
       quansync: 0.2.11
 
   underscore@1.13.7: {}
@@ -8247,13 +8254,13 @@ snapshots:
 
   version-range@4.15.0: {}
 
-  vite-node@3.2.4(@types/node@24.5.2)(jiti@2.5.1):
+  vite-node@3.2.4(@types/node@24.5.2)(jiti@2.6.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.6(@types/node@24.5.2)(jiti@2.5.1)
+      vite: 7.1.6(@types/node@24.5.2)(jiti@2.6.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -8268,7 +8275,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.1.6(@types/node@24.5.2)(jiti@2.5.1):
+  vite@7.1.6(@types/node@24.5.2)(jiti@2.6.0):
     dependencies:
       esbuild: 0.25.10
       fdir: 6.5.0(picomatch@4.0.3)
@@ -8279,13 +8286,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.5.2
       fsevents: 2.3.3
-      jiti: 2.5.1
+      jiti: 2.6.0
 
-  vitest@3.2.4(@types/node@24.5.2)(@vitest/browser@3.2.4)(jiti@2.5.1):
+  vitest@3.2.4(@types/node@24.5.2)(@vitest/browser@3.2.4)(jiti@2.6.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.6(@types/node@24.5.2)(jiti@2.5.1))
+      '@vitest/mocker': 3.2.4(vite@7.1.6(@types/node@24.5.2)(jiti@2.6.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -8303,12 +8310,12 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.1.6(@types/node@24.5.2)(jiti@2.5.1)
-      vite-node: 3.2.4(@types/node@24.5.2)(jiti@2.5.1)
+      vite: 7.1.6(@types/node@24.5.2)(jiti@2.6.0)
+      vite-node: 3.2.4(@types/node@24.5.2)(jiti@2.6.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.5.2
-      '@vitest/browser': 3.2.4(playwright@1.55.0)(vite@7.1.6(@types/node@24.5.2)(jiti@2.5.1))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.55.0)(vite@7.1.6(@types/node@24.5.2)(jiti@2.6.0))(vitest@3.2.4)
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
`oxlint` package export TS types. `defineRule` and `definePlugin` now give you type-safety and intellisense.

Writing plugins in TS is only supported on versions of NodeJS which support type-stripping. Have not added a library (e.g. Jiti) to support older NodeJS versions.

Probably some of the types are wrong. But I think this is a decent start.

"Are the types wrong" (added in #14177) is reporting an error in `index.d.ts`:

```ts
import { VisitorObject as Visitor } from "../dist/generated/visit/visitor.js";
//                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

because the file in `dist/generated/visit` is actually called `visitor.d.ts` (`.d.ts`, not `.js`).

I'm not sure if that's a mistake in Rolldown's bundling, "Are the types wrong" being too strict, or a genuine problem.

But regardless, TS seems to pick up the types from `visitor.d.ts`, so I think we can probably merge this and look into / fix it later.