### PR TITLE
fix(linter/plugins): fix TS type for fixer methods

### DIFF
--- a/apps/oxlint/src-js/plugins/fix.ts
+++ b/apps/oxlint/src-js/plugins/fix.ts
@@ -19,7 +19,10 @@ export type Fix = { range: Range; text: string };
 type Range = [number, number];
 
 // Currently we only support `Node`s, but will add support for `Token`s later
-type NodeOrToken = Node;
+interface NodeOrToken {
+  start: number;
+  end: number;
+}
 
 // Fixer, passed as argument to `fix` function passed to `Context#report()`.
 //


### PR DESCRIPTION
Another faulty type I found. `NodeOrToken` type was too restrictive. The `node` argument passed to fixer methods just needs to have `start` and `end` properties.