### PR TITLE
fix(codegen): don't inject parenthesis in optional chaining within new expressions

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -690,6 +690,7 @@ impl Gen for Function<'_> {
         let n = p.code_len();
         let wrap = self.is_expression()
             && ((p.start_of_stmt == n || p.start_of_default_export == n) || self.pife);
+        let ctx = ctx.and_forbid_call(false);
         p.wrap(wrap, |p| {
             p.print_space_before_identifier();
             p.add_source_mapping(self.span);
@@ -2263,6 +2264,7 @@ impl Gen for Class<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         let n = p.code_len();
         let wrap = self.is_expression() && (p.start_of_stmt == n || p.start_of_default_export == n);
+        let ctx = ctx.and_forbid_call(false);
         p.wrap(wrap, |p| {
             p.enter_class();
             p.print_decorators(&self.decorators, ctx);

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -42,6 +42,14 @@ fn export_type() {
 fn expr() {
     test("new (foo()).bar();", "new (foo()).bar();\n");
     test_minify("x in new Error()", "x in new Error;");
+    test(
+        "new function() { let a = foo?.bar().baz; return a; }();",
+        "new function() {\n\tlet a = foo?.bar().baz;\n\treturn a;\n}();\n",
+    );
+    test(
+        "new class { foo() { let a = foo?.bar().baz; return a; } }();",
+        "new class {\n\tfoo() {\n\t\tlet a = foo?.bar().baz;\n\t\treturn a;\n\t}\n}();\n",
+    );
 
     test("1000000000000000128.0.toFixed(0)", "0xde0b6b3a7640080.toFixed(0);\n");
     test_minify("1000000000000000128.0.toFixed(0)", "0xde0b6b3a7640080.toFixed(0);");


### PR DESCRIPTION
fixes #14127