### PR TITLE
feat(codegen): call `code.shrink_to_fit()` to reduce peak memory pressure

### DIFF
--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -225,7 +225,11 @@ impl<'a> Codegen<'a> {
         }
         program.print(&mut self, Context::default());
         let legal_comments = self.handle_eof_linked_or_external_comments(program);
-        let code = self.code.into_string();
+        // Running checker.ts prints
+        // dbg!(self.code.capacity()); // 2922154
+        let mut code = self.code.into_string();
+        code.shrink_to_fit();
+        // dbg!(code.capacity()); // 2383824
         let map = self.sourcemap_builder.map(SourcemapBuilder::into_sourcemap);
         CodegenReturn { code, map, legal_comments }
     }


### PR DESCRIPTION
The other data structure that require this optimization is `Sourcemap::tokens`.

I'll need to test both changes together in Rolldown.