### PR TITLE
fix(linter/jsx-handler-name): improve handler name position in error messages

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
@@ -142,12 +142,9 @@ fn build_event_handler_regex(handler_prefix: &str, handler_prop_prefix: &str) ->
     if prefix_pattern.is_empty() || prop_prefix_pattern.is_empty() {
         return None;
     }
-    let regex = RegexBuilder::new(
-        format!(r"^((props\.({prop_prefix_pattern}))|((.*\.)?({prefix_pattern})))[0-9]*[A-Z].*$")
-            .as_str(),
-    )
-    .build()
-    .expect("Failed to compile regex for event handler prefixes");
+    let regex = RegexBuilder::new(format!(r"^((.*\.)?({prefix_pattern}))[0-9]*[A-Z].*$").as_str())
+        .build()
+        .expect("Failed to compile regex for event handler prefixes");
     Some(regex)
 }
 

--- a/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
@@ -304,6 +304,8 @@ impl Rule for JsxHandlerNames {
                 if !self.check_local_variables && !value_expr.is_member_expression() {
                     return;
                 }
+                // For other expressions types, use the whole content inside the braces as the handler name,
+                // which will be marked as a bad handler name if the prop key is an event handler prop.
                 let span = expression_container.span.shrink(1);
                 (Some(normalize_handler_name(ctx.source_range(span))), span, false)
             }
@@ -613,6 +615,8 @@ fn test() {
                 serde_json::json!([{ "checkLocalVariables": true, "ignoreComponentNames": ["MyLib*"] }]),
             ),
         ),
+        ("<TestComponent onChange={true} />", None), // ok if not checking local variables (the same behavior as eslint version)
+        ("<TestComponent onChange={'value'} />", None), // ok if not checking local variables (the same behavior as eslint version)
     ];
 
     let fail = vec![
@@ -688,6 +692,14 @@ fn test() {
             Some(
                 serde_json::json!([{ "checkLocalVariables": true, "ignoreComponentNames": ["MyLibrary*"] }]),
             ),
+        ),
+        (
+            "<TestComponent onChange={true} />",
+            Some(serde_json::json!([{ "checkLocalVariables": true }])),
+        ),
+        (
+            "<TestComponent onChange={'value'} />",
+            Some(serde_json::json!([{ "checkLocalVariables": true }])),
         ),
     ];
 

--- a/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
@@ -161,7 +161,7 @@ fn build_event_handler_prop_regex(handler_prop_prefix: &str) -> Option<Regex> {
     if prop_prefix_pattern.is_empty() {
         return None;
     }
-    let regex = RegexBuilder::new(format!(r"^(({prop_prefix_pattern})[A-Z].*|ref)$").as_str())
+    let regex = RegexBuilder::new(format!(r"^({prop_prefix_pattern})[A-Z].*$").as_str())
         .build()
         .expect("Failed to compile regex for event handler prop prefixes");
     Some(regex)
@@ -325,6 +325,7 @@ impl Rule for JsxHandlerNames {
 
         let prop_is_event_handler = self.match_event_handler_props_name(prop_key);
         let is_handler_name_correct = handler_name.as_ref().map_or(Some(false), |name| {
+            // if the event handler is a property of "props", the handler name can also start with the prop prefix.
             if is_props_handler && self.match_event_handler_props_name(name).unwrap_or(false) {
                 return Some(true);
             }

--- a/crates/oxc_linter/src/snapshots/react_jsx_handler_names.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_handler_names.snap
@@ -181,3 +181,17 @@ source: crates/oxc_linter/src/tester.rs
  8 │                 </div>
    ╰────
   help: Prop key for handleButton must begin with 'on'
+
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: true
+   ╭─[jsx_handler_names.tsx:1:26]
+ 1 │ <TestComponent onChange={true} />
+   ·                          ────
+   ╰────
+  help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
+
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: 'value'
+   ╭─[jsx_handler_names.tsx:1:26]
+ 1 │ <TestComponent onChange={'value'} />
+   ·                          ───────
+   ╰────
+  help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only

--- a/crates/oxc_linter/src/snapshots/react_jsx_handler_names.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_handler_names.snap
@@ -2,58 +2,65 @@
 source: crates/oxc_linter/src/tester.rs
 ---
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: doSomethingOnChange
-   ╭─[jsx_handler_names.tsx:1:25]
+   ╭─[jsx_handler_names.tsx:1:31]
  1 │ <TestComponent onChange={this.doSomethingOnChange} />
-   ·                         ──────────────────────────
+   ·                               ───────────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handlerChange
-   ╭─[jsx_handler_names.tsx:1:25]
+   ╭─[jsx_handler_names.tsx:1:31]
  1 │ <TestComponent onChange={this.handlerChange} />
-   ·                         ────────────────────
+   ·                               ─────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle
-   ╭─[jsx_handler_names.tsx:1:25]
+   ╭─[jsx_handler_names.tsx:1:31]
  1 │ <TestComponent onChange={this.handle} />
-   ·                         ─────────────
+   ·                               ──────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle2
-   ╭─[jsx_handler_names.tsx:1:25]
+   ╭─[jsx_handler_names.tsx:1:31]
  1 │ <TestComponent onChange={this.handle2} />
-   ·                         ──────────────
+   ·                               ───────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handl3Change
-   ╭─[jsx_handler_names.tsx:1:25]
+   ╭─[jsx_handler_names.tsx:1:31]
  1 │ <TestComponent onChange={this.handl3Change} />
-   ·                         ───────────────────
+   ·                               ────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handle4change
-   ╭─[jsx_handler_names.tsx:1:25]
+   ╭─[jsx_handler_names.tsx:1:31]
  1 │ <TestComponent onChange={this.handle4change} />
-   ·                         ────────────────────
+   ·                               ─────────────
+   ╰────
+  help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
+
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: doSomethingOnChange
+   ╭─[jsx_handler_names.tsx:1:37]
+ 1 │ <TestComponent onChange={this.props.doSomethingOnChange} />
+   ·                                     ───────────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: takeCareOfChange
-   ╭─[jsx_handler_names.tsx:1:25]
+   ╭─[jsx_handler_names.tsx:1:26]
  1 │ <TestComponent onChange={takeCareOfChange} />
-   ·                         ──────────────────
+   ·                          ────────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: takeCareOfChange
-   ╭─[jsx_handler_names.tsx:1:25]
+   ╭─[jsx_handler_names.tsx:1:37]
  1 │ <TestComponent onChange={() => this.takeCareOfChange()} />
-   ·                         ───────────────────────────────
+   ·                                     ────────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
@@ -93,9 +100,9 @@ source: crates/oxc_linter/src/tester.rs
   help: Prop key for handleChange must begin with 'on'
 
   ⚠ eslint-plugin-react(jsx-handler-names): Bad handler name
-   ╭─[jsx_handler_names.tsx:1:25]
+   ╭─[jsx_handler_names.tsx:1:32]
  1 │ <TestComponent onChange={() => { handleChange() }} />
-   ·                         ──────────────────────────
+   ·                                ──────────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
@@ -114,9 +121,9 @@ source: crates/oxc_linter/src/tester.rs
   help: Prop key for handleChange must begin with 'when'
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: handleChange
-   ╭─[jsx_handler_names.tsx:1:25]
+   ╭─[jsx_handler_names.tsx:1:26]
  1 │ <TestComponent onChange={handleChange} />
-   ·                         ──────────────
+   ·                          ────────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'when|on' only
 
@@ -128,9 +135,9 @@ source: crates/oxc_linter/src/tester.rs
   help: Prop key for handleChange must begin with 'when|on'
 
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: onChange
-   ╭─[jsx_handler_names.tsx:1:25]
+   ╭─[jsx_handler_names.tsx:1:31]
  1 │ <TestComponent onChange={this.onChange} />
-   ·                         ───────────────
+   ·                               ────────
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 

--- a/crates/oxc_linter/src/snapshots/react_jsx_handler_names.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_handler_names.snap
@@ -50,6 +50,20 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
 
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: onChange
+   ╭─[jsx_handler_names.tsx:1:41]
+ 1 │ <TestComponent onChange={this.props.obj.onChange} />
+   ·                                         ────────
+   ╰────
+  help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
+
+  ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: onChange
+   ╭─[jsx_handler_names.tsx:1:36]
+ 1 │ <TestComponent onChange={props.obj.onChange} />
+   ·                                    ────────
+   ╰────
+  help: Handler function for onChange prop key must be a camelCase name beginning with 'handle' only
+
   ⚠ eslint-plugin-react(jsx-handler-names): Invalid handler name: takeCareOfChange
    ╭─[jsx_handler_names.tsx:1:26]
  1 │ <TestComponent onChange={takeCareOfChange} />


### PR DESCRIPTION
With this change, when an event handler name is detected, the underline in the error message will point only to the event handler name.