### PR TITLE
refactor(semantic): do not use `Astnodes::get_node` for `check_unresolved_exports`

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -278,9 +278,6 @@ impl<'a> SemanticBuilder<'a> {
         }
 
         debug_assert_eq!(self.unresolved_references.scope_depth(), 1);
-        if self.check_syntax_error && !self.source_type.is_typescript() {
-            checker::check_unresolved_exports(&self);
-        }
         self.scoping.set_root_unresolved_references(
             self.unresolved_references.into_root().into_iter().map(|(k, v)| (k.as_str(), v)),
         );

--- a/crates/oxc_semantic/src/unresolved_stack.rs
+++ b/crates/oxc_semantic/src/unresolved_stack.rs
@@ -74,17 +74,6 @@ impl<'a> UnresolvedReferencesStack<'a> {
 
     /// Get unresolved references hash map for current scope
     #[inline]
-    pub(crate) fn root(&self) -> &TempUnresolvedReferences<'a> {
-        // SAFETY: `stack.len() > current_scope_depth` initially.
-        // Thereafter, `stack` never shrinks, only grows.
-        // `current_scope_depth` is only increased in `increment_scope_depth`,
-        // and it grows `stack` to ensure `stack.len()` always exceeds `current_scope_depth`.
-        // So this read is always guaranteed to be in bounds.
-        unsafe { self.stack.get_unchecked(0) }
-    }
-
-    /// Get unresolved references hash map for current scope
-    #[inline]
     pub(crate) fn current_mut(&mut self) -> &mut TempUnresolvedReferences<'a> {
         // SAFETY: `stack.len() > current_scope_depth` initially.
         // Thereafter, `stack` never shrinks, only grows.


### PR DESCRIPTION
part of oxc-project/backlog#183