### PR TITLE
fix(ci): exclude package.json from compat table update workflow change detection

### DIFF
--- a/.github/workflows/update_compat_table.yml
+++ b/.github/workflows/update_compat_table.yml
@@ -86,13 +86,15 @@ jobs:
         if: steps.check-update.outputs.update_needed == 'true'
         id: changes
         run: |
-          if git diff --quiet; then
+          # Check if any files other than package.json were changed
+          CHANGED_FILES=$(git diff --name-only | grep -v '^tasks/compat_data/package\.json$' || true)
+          if [ -z "$CHANGED_FILES" ]; then
             echo "has_changes=false" >> $GITHUB_OUTPUT
-            echo "No files were changed after build"
+            echo "No files were changed after build (excluding package.json)"
           else
             echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "Files changed:"
-            git diff --name-only
+            echo "Files changed (excluding package.json):"
+            echo "$CHANGED_FILES"
           fi
 
       - name: Create Pull Request


### PR DESCRIPTION
## Summary
- Modified the `update_compat_table.yml` workflow to exclude `package.json` from file change detection
- Prevents unnecessary PRs when only the SHA reference in package.json is updated

## Changes
The workflow now filters out `tasks/compat_data/package.json` when checking for changed files after the build process. This ensures that a PR is only created when actual compat data files are modified, not just the SHA reference.

## Test plan
- The workflow will run on its next scheduled execution (weekly on Monday at 00:00 UTC)
- Can be manually triggered via workflow_dispatch to verify the change works as expected
- The filtered git diff check will properly identify when only package.json changes versus when other files change

🤖 Generated with [Claude Code](https://claude.ai/code)