### PR TITLE
test(linter/plugins): add line breaks to plugins files

### DIFF
--- a/apps/oxlint/test/fixtures/definePlugin/plugin.js
+++ b/apps/oxlint/test/fixtures/definePlugin/plugin.js
@@ -36,6 +36,7 @@ const createRule = {
 // i.e. Oxlint calls `createOnce` directly, and not the `create` method that `defineRule` (via `definePlugin`)
 // adds to the rule.
 let createOnceCallCount = 0;
+
 const createOnceRule = {
   createOnce(context) {
     createOnceCallCount++;

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/plugin.js
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/plugin.js
@@ -35,6 +35,7 @@ const createRule = defineRule({
 // This aims to test that `createOnce` is called once only, and `before` hook is called once per file.
 // i.e. Oxlint calls `createOnce` directly, and not the `create` method that `defineRule` adds to the rule.
 let createOnceCallCount = 0;
+
 const createOnceRule = defineRule({
   createOnce(context) {
     createOnceCallCount++;

--- a/apps/oxlint/test/fixtures/defineRule/plugin.js
+++ b/apps/oxlint/test/fixtures/defineRule/plugin.js
@@ -35,6 +35,7 @@ const createRule = defineRule({
 // This aims to test that `createOnce` is called once only, and `before` hook is called once per file.
 // i.e. Oxlint calls `createOnce` directly, and not the `create` method that `defineRule` adds to the rule.
 let createOnceCallCount = 0;
+
 const createOnceRule = defineRule({
   createOnce(context) {
     createOnceCallCount++;


### PR DESCRIPTION
Style change only. Add line breaks to make the code easier to read.