### PR TITLE
refactor(language_server): refactor ignore code action logic as a linter fix

### DIFF
--- a/crates/oxc_language_server/src/linter/error_with_position.rs
+++ b/crates/oxc_language_server/src/linter/error_with_position.rs
@@ -13,7 +13,6 @@ use crate::LSP_MAX_INT;
 pub struct DiagnosticReport {
     pub diagnostic: lsp_types::Diagnostic,
     pub fixed_content: PossibleFixContent,
-    pub rule_name: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -145,6 +144,5 @@ pub fn message_with_position_to_lsp_diagnostic_report(
                 fixes.iter().map(fix_with_position_to_fix_content).collect(),
             ),
         },
-        rule_name: message.code.number.as_ref().map(std::string::ToString::to_string),
     }
 }

--- a/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
+++ b/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
@@ -134,7 +134,6 @@ impl IsolatedLintHandler {
                         data: None,
                     },
                     fixed_content: PossibleFixContent::None,
-                    rule_name: None,
                 });
             }
         }

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_astro@debugger.astro.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_astro@debugger.astro.snap
@@ -15,7 +15,58 @@ related_information[0].location.range: Range { start: Position { line: 1, charac
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
-fixed: Single(FixedContent { message: Some("Remove the debugger statement"), code: "", range: Range { start: Position { line: 1, character: 0 }, end: Position { line: 1, character: 8 } } })
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Remove the debugger statement",
+            ),
+            code: "",
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: 8,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this line",
+            ),
+            code: "// oxlint-disable-next-line no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this file",
+            ),
+            code: "// oxlint-disable no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)
 
 
 code: "eslint(no-debugger)"
@@ -28,7 +79,58 @@ related_information[0].location.range: Range { start: Position { line: 10, chara
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
-fixed: Single(FixedContent { message: Some("Remove the debugger statement"), code: "", range: Range { start: Position { line: 10, character: 2 }, end: Position { line: 10, character: 10 } } })
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Remove the debugger statement",
+            ),
+            code: "",
+            range: Range {
+                start: Position {
+                    line: 10,
+                    character: 2,
+                },
+                end: Position {
+                    line: 10,
+                    character: 10,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this line",
+            ),
+            code: "// oxlint-disable-next-line no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 10,
+                    character: 0,
+                },
+                end: Position {
+                    line: 10,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this file",
+            ),
+            code: "// oxlint-disable no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)
 
 
 code: "eslint(no-debugger)"
@@ -41,7 +143,58 @@ related_information[0].location.range: Range { start: Position { line: 14, chara
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
-fixed: Single(FixedContent { message: Some("Remove the debugger statement"), code: "", range: Range { start: Position { line: 14, character: 2 }, end: Position { line: 14, character: 10 } } })
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Remove the debugger statement",
+            ),
+            code: "",
+            range: Range {
+                start: Position {
+                    line: 14,
+                    character: 2,
+                },
+                end: Position {
+                    line: 14,
+                    character: 10,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this line",
+            ),
+            code: "// oxlint-disable-next-line no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 14,
+                    character: 0,
+                },
+                end: Position {
+                    line: 14,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this file",
+            ),
+            code: "// oxlint-disable no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)
 
 
 code: "eslint(no-debugger)"
@@ -54,4 +207,55 @@ related_information[0].location.range: Range { start: Position { line: 18, chara
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
-fixed: Single(FixedContent { message: Some("Remove the debugger statement"), code: "", range: Range { start: Position { line: 18, character: 2 }, end: Position { line: 18, character: 10 } } })
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Remove the debugger statement",
+            ),
+            code: "",
+            range: Range {
+                start: Position {
+                    line: 18,
+                    character: 2,
+                },
+                end: Position {
+                    line: 18,
+                    character: 10,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this line",
+            ),
+            code: "// oxlint-disable-next-line no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 18,
+                    character: 0,
+                },
+                end: Position {
+                    line: 18,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this file",
+            ),
+            code: "// oxlint-disable no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_cross_module@debugger.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_cross_module@debugger.ts.snap
@@ -15,4 +15,55 @@ related_information[0].location.range: Range { start: Position { line: 1, charac
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
-fixed: Single(FixedContent { message: Some("Remove the debugger statement"), code: "", range: Range { start: Position { line: 1, character: 0 }, end: Position { line: 1, character: 9 } } })
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Remove the debugger statement",
+            ),
+            code: "",
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: 9,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this line",
+            ),
+            code: "// oxlint-disable-next-line no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this file",
+            ),
+            code: "// oxlint-disable no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_cross_module@dep-a.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_cross_module@dep-a.ts.snap
@@ -15,4 +15,39 @@ related_information[0].location.range: Range { start: Position { line: 1, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
-fixed: None
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Disable no-cycle for this line",
+            ),
+            code: "// oxlint-disable-next-line no-cycle\n",
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-cycle for this file",
+            ),
+            code: "// oxlint-disable no-cycle\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_cross_module_extended_config@dep-a.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_cross_module_extended_config@dep-a.ts.snap
@@ -15,4 +15,39 @@ related_information[0].location.range: Range { start: Position { line: 1, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
-fixed: None
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Disable no-cycle for this line",
+            ),
+            code: "// oxlint-disable-next-line no-cycle\n",
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-cycle for this file",
+            ),
+            code: "// oxlint-disable no-cycle\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_cross_module_nested_config@dep-a.ts_folder__folder-dep-a.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_cross_module_nested_config@dep-a.ts_folder__folder-dep-a.ts.snap
@@ -19,4 +19,39 @@ related_information[0].location.range: Range { start: Position { line: 1, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
-fixed: None
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Disable no-cycle for this line",
+            ),
+            code: "// oxlint-disable-next-line no-cycle\n",
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-cycle for this file",
+            ),
+            code: "// oxlint-disable no-cycle\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_deny_no_console@hello_world.js.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_deny_no_console@hello_world.js.snap
@@ -15,4 +15,39 @@ related_information[0].location.range: Range { start: Position { line: 0, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
-fixed: None
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Disable no-console for this line",
+            ),
+            code: "// oxlint-disable-next-line no-console\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-console for this file",
+            ),
+            code: "// oxlint-disable no-console\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_ignore_patterns@ignored-file.ts_another_config__not-ignored-file.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_ignore_patterns@ignored-file.ts_another_config__not-ignored-file.ts.snap
@@ -19,4 +19,55 @@ related_information[0].location.range: Range { start: Position { line: 0, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
-fixed: Single(FixedContent { message: Some("Remove the debugger statement"), code: "", range: Range { start: Position { line: 0, character: 0 }, end: Position { line: 0, character: 9 } } })
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Remove the debugger statement",
+            ),
+            code: "",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 9,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this line",
+            ),
+            code: "// oxlint-disable-next-line no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this file",
+            ),
+            code: "// oxlint-disable no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_issue_9958@issue.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_issue_9958@issue.ts.snap
@@ -15,7 +15,42 @@ related_information[0].location.range: Range { start: Position { line: 3, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
-fixed: None
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Disable no-extra-boolean-cast for this line",
+            ),
+            code: "// oxlint-disable-next-line no-extra-boolean-cast\n",
+            range: Range {
+                start: Position {
+                    line: 3,
+                    character: 0,
+                },
+                end: Position {
+                    line: 3,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-extra-boolean-cast for this file",
+            ),
+            code: "// oxlint-disable no-extra-boolean-cast\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)
 
 
 code: "typescript-eslint(no-non-null-asserted-optional-chain)"
@@ -31,7 +66,42 @@ related_information[1].location.range: Range { start: Position { line: 11, chara
 severity: Some(Error)
 source: Some("oxc")
 tags: None
-fixed: None
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Disable no-non-null-asserted-optional-chain for this line",
+            ),
+            code: "// oxlint-disable-next-line no-non-null-asserted-optional-chain\n",
+            range: Range {
+                start: Position {
+                    line: 11,
+                    character: 0,
+                },
+                end: Position {
+                    line: 11,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-non-null-asserted-optional-chain for this file",
+            ),
+            code: "// oxlint-disable no-non-null-asserted-optional-chain\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)
 
 
 code: "None"

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_lint_on_run_on_save@on-save.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_lint_on_run_on_save@on-save.ts.snap
@@ -15,4 +15,71 @@ related_information[0].location.range: Range { start: Position { line: 7, charac
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
-fixed: Multiple([FixedContent { message: Some("Promises must be awaited."), code: "void ", range: Range { start: Position { line: 7, character: 0 }, end: Position { line: 7, character: 0 } } }, FixedContent { message: Some("Promises must be awaited."), code: "await ", range: Range { start: Position { line: 7, character: 0 }, end: Position { line: 7, character: 0 } } }])
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Promises must be awaited.",
+            ),
+            code: "void ",
+            range: Range {
+                start: Position {
+                    line: 7,
+                    character: 0,
+                },
+                end: Position {
+                    line: 7,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Promises must be awaited.",
+            ),
+            code: "await ",
+            range: Range {
+                start: Position {
+                    line: 7,
+                    character: 0,
+                },
+                end: Position {
+                    line: 7,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-floating-promises for this line",
+            ),
+            code: "// oxlint-disable-next-line no-floating-promises\n",
+            range: Range {
+                start: Position {
+                    line: 7,
+                    character: 0,
+                },
+                end: Position {
+                    line: 7,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-floating-promises for this file",
+            ),
+            code: "// oxlint-disable no-floating-promises\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_lint_on_run_on_type@on-save.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_lint_on_run_on_type@on-save.ts.snap
@@ -15,7 +15,58 @@ related_information[0].location.range: Range { start: Position { line: 1, charac
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
-fixed: Single(FixedContent { message: Some("Remove the debugger statement"), code: "", range: Range { start: Position { line: 1, character: 0 }, end: Position { line: 1, character: 9 } } })
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Remove the debugger statement",
+            ),
+            code: "",
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: 9,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this line",
+            ),
+            code: "// oxlint-disable-next-line no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this file",
+            ),
+            code: "// oxlint-disable no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)
 
 
 code: "typescript-eslint(no-floating-promises)"
@@ -28,4 +79,71 @@ related_information[0].location.range: Range { start: Position { line: 7, charac
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
-fixed: Multiple([FixedContent { message: Some("Promises must be awaited."), code: "void ", range: Range { start: Position { line: 7, character: 0 }, end: Position { line: 7, character: 0 } } }, FixedContent { message: Some("Promises must be awaited."), code: "await ", range: Range { start: Position { line: 7, character: 0 }, end: Position { line: 7, character: 0 } } }])
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Promises must be awaited.",
+            ),
+            code: "void ",
+            range: Range {
+                start: Position {
+                    line: 7,
+                    character: 0,
+                },
+                end: Position {
+                    line: 7,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Promises must be awaited.",
+            ),
+            code: "await ",
+            range: Range {
+                start: Position {
+                    line: 7,
+                    character: 0,
+                },
+                end: Position {
+                    line: 7,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-floating-promises for this line",
+            ),
+            code: "// oxlint-disable-next-line no-floating-promises\n",
+            range: Range {
+                start: Position {
+                    line: 7,
+                    character: 0,
+                },
+                end: Position {
+                    line: 7,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-floating-promises for this file",
+            ),
+            code: "// oxlint-disable no-floating-promises\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_lint_on_run_on_type@on-type.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_lint_on_run_on_type@on-type.ts.snap
@@ -15,4 +15,55 @@ related_information[0].location.range: Range { start: Position { line: 1, charac
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
-fixed: Single(FixedContent { message: Some("Remove the debugger statement"), code: "", range: Range { start: Position { line: 1, character: 0 }, end: Position { line: 1, character: 9 } } })
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Remove the debugger statement",
+            ),
+            code: "",
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: 9,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this line",
+            ),
+            code: "// oxlint-disable-next-line no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this file",
+            ),
+            code: "// oxlint-disable no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_multiple_suggestions@forward_ref.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_multiple_suggestions@forward_ref.ts.snap
@@ -15,4 +15,71 @@ related_information[0].location.range: Range { start: Position { line: 0, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
-fixed: Multiple([FixedContent { message: Some("remove `forwardRef` wrapper"), code: "(props) => {}", range: Range { start: Position { line: 0, character: 0 }, end: Position { line: 0, character: 25 } } }, FixedContent { message: Some("add `ref` parameter"), code: "(props, ref)", range: Range { start: Position { line: 0, character: 11 }, end: Position { line: 0, character: 18 } } }])
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "remove `forwardRef` wrapper",
+            ),
+            code: "(props) => {}",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 25,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "add `ref` parameter",
+            ),
+            code: "(props, ref)",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 11,
+                },
+                end: Position {
+                    line: 0,
+                    character: 18,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable forward-ref-uses-ref for this line",
+            ),
+            code: "// oxlint-disable-next-line forward-ref-uses-ref\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable forward-ref-uses-ref for this file",
+            ),
+            code: "// oxlint-disable forward-ref-uses-ref\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_regexp_feature@index.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_regexp_feature@index.ts.snap
@@ -15,7 +15,42 @@ related_information[0].location.range: Range { start: Position { line: 1, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
-fixed: None
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Disable no-control-regex for this line",
+            ),
+            code: "// oxlint-disable-next-line no-control-regex\n",
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-control-regex for this file",
+            ),
+            code: "// oxlint-disable no-control-regex\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)
 
 
 code: "eslint(no-useless-escape)"
@@ -28,4 +63,55 @@ related_information[0].location.range: Range { start: Position { line: 0, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
-fixed: Single(FixedContent { message: Some("Replace `\\/` with `/`."), code: "/", range: Range { start: Position { line: 0, character: 16 }, end: Position { line: 0, character: 18 } } })
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Replace `\\/` with `/`.",
+            ),
+            code: "/",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 16,
+                },
+                end: Position {
+                    line: 0,
+                    character: 18,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-useless-escape for this line",
+            ),
+            code: "// oxlint-disable-next-line no-useless-escape\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-useless-escape for this file",
+            ),
+            code: "// oxlint-disable no-useless-escape\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_svelte@debugger.svelte.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_svelte@debugger.svelte.snap
@@ -15,7 +15,42 @@ related_information[0].location.range: Range { start: Position { line: 3, charac
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
-fixed: None
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Disable no-unassigned-vars for this line",
+            ),
+            code: "// oxlint-disable-next-line no-unassigned-vars\n",
+            range: Range {
+                start: Position {
+                    line: 3,
+                    character: 0,
+                },
+                end: Position {
+                    line: 3,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-unassigned-vars for this file",
+            ),
+            code: "// oxlint-disable no-unassigned-vars\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)
 
 
 code: "eslint(no-unassigned-vars)"
@@ -28,7 +63,42 @@ related_information[0].location.range: Range { start: Position { line: 4, charac
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
-fixed: None
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Disable no-unassigned-vars for this line",
+            ),
+            code: "// oxlint-disable-next-line no-unassigned-vars\n",
+            range: Range {
+                start: Position {
+                    line: 4,
+                    character: 0,
+                },
+                end: Position {
+                    line: 4,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-unassigned-vars for this file",
+            ),
+            code: "// oxlint-disable no-unassigned-vars\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)
 
 
 code: "eslint(no-debugger)"
@@ -41,4 +111,55 @@ related_information[0].location.range: Range { start: Position { line: 1, charac
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
-fixed: Single(FixedContent { message: Some("Remove the debugger statement"), code: "", range: Range { start: Position { line: 1, character: 1 }, end: Position { line: 1, character: 10 } } })
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Remove the debugger statement",
+            ),
+            code: "",
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 1,
+                },
+                end: Position {
+                    line: 1,
+                    character: 10,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this line",
+            ),
+            code: "// oxlint-disable-next-line no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this file",
+            ),
+            code: "// oxlint-disable no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_ts_path_alias@deep__src__dep-a.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_ts_path_alias@deep__src__dep-a.ts.snap
@@ -15,4 +15,39 @@ related_information[0].location.range: Range { start: Position { line: 1, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
-fixed: None
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Disable no-cycle for this line",
+            ),
+            code: "// oxlint-disable-next-line no-cycle\n",
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-cycle for this file",
+            ),
+            code: "// oxlint-disable no-cycle\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_tsgolint@no-floating-promises__index.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_tsgolint@no-floating-promises__index.ts.snap
@@ -15,7 +15,42 @@ related_information[0].location.range: Range { start: Position { line: 1, charac
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
-fixed: None
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Disable no-unused-expressions for this line",
+            ),
+            code: "// oxlint-disable-next-line no-unused-expressions\n",
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-unused-expressions for this file",
+            ),
+            code: "// oxlint-disable no-unused-expressions\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)
 
 
 code: "typescript-eslint(no-floating-promises)"
@@ -28,7 +63,74 @@ related_information[0].location.range: Range { start: Position { line: 1, charac
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
-fixed: Multiple([FixedContent { message: Some("Promises must be awaited."), code: "void ", range: Range { start: Position { line: 1, character: 0 }, end: Position { line: 1, character: 0 } } }, FixedContent { message: Some("Promises must be awaited."), code: "await ", range: Range { start: Position { line: 1, character: 0 }, end: Position { line: 1, character: 0 } } }])
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Promises must be awaited.",
+            ),
+            code: "void ",
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Promises must be awaited.",
+            ),
+            code: "await ",
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-floating-promises for this line",
+            ),
+            code: "// oxlint-disable-next-line no-floating-promises\n",
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-floating-promises for this file",
+            ),
+            code: "// oxlint-disable no-floating-promises\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)
 
 
 code: "typescript-eslint(no-floating-promises)"
@@ -41,7 +143,74 @@ related_information[0].location.range: Range { start: Position { line: 7, charac
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
-fixed: Multiple([FixedContent { message: Some("Promises must be awaited."), code: "void ", range: Range { start: Position { line: 7, character: 0 }, end: Position { line: 7, character: 0 } } }, FixedContent { message: Some("Promises must be awaited."), code: "await ", range: Range { start: Position { line: 7, character: 0 }, end: Position { line: 7, character: 0 } } }])
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Promises must be awaited.",
+            ),
+            code: "void ",
+            range: Range {
+                start: Position {
+                    line: 7,
+                    character: 0,
+                },
+                end: Position {
+                    line: 7,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Promises must be awaited.",
+            ),
+            code: "await ",
+            range: Range {
+                start: Position {
+                    line: 7,
+                    character: 0,
+                },
+                end: Position {
+                    line: 7,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-floating-promises for this line",
+            ),
+            code: "// oxlint-disable-next-line no-floating-promises\n",
+            range: Range {
+                start: Position {
+                    line: 7,
+                    character: 0,
+                },
+                end: Position {
+                    line: 7,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-floating-promises for this file",
+            ),
+            code: "// oxlint-disable no-floating-promises\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)
 
 
 code: "typescript-eslint(no-floating-promises)"
@@ -54,7 +223,74 @@ related_information[0].location.range: Range { start: Position { line: 9, charac
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
-fixed: Multiple([FixedContent { message: Some("Promises must be awaited."), code: "void ", range: Range { start: Position { line: 9, character: 0 }, end: Position { line: 9, character: 0 } } }, FixedContent { message: Some("Promises must be awaited."), code: "await ", range: Range { start: Position { line: 9, character: 0 }, end: Position { line: 9, character: 0 } } }])
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Promises must be awaited.",
+            ),
+            code: "void ",
+            range: Range {
+                start: Position {
+                    line: 9,
+                    character: 0,
+                },
+                end: Position {
+                    line: 9,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Promises must be awaited.",
+            ),
+            code: "await ",
+            range: Range {
+                start: Position {
+                    line: 9,
+                    character: 0,
+                },
+                end: Position {
+                    line: 9,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-floating-promises for this line",
+            ),
+            code: "// oxlint-disable-next-line no-floating-promises\n",
+            range: Range {
+                start: Position {
+                    line: 9,
+                    character: 0,
+                },
+                end: Position {
+                    line: 9,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-floating-promises for this file",
+            ),
+            code: "// oxlint-disable no-floating-promises\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)
 
 
 code: "typescript-eslint(no-floating-promises)"
@@ -67,7 +303,74 @@ related_information[0].location.range: Range { start: Position { line: 11, chara
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
-fixed: Multiple([FixedContent { message: Some("Promises must be awaited."), code: "void ", range: Range { start: Position { line: 11, character: 0 }, end: Position { line: 11, character: 0 } } }, FixedContent { message: Some("Promises must be awaited."), code: "await ", range: Range { start: Position { line: 11, character: 0 }, end: Position { line: 11, character: 0 } } }])
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Promises must be awaited.",
+            ),
+            code: "void ",
+            range: Range {
+                start: Position {
+                    line: 11,
+                    character: 0,
+                },
+                end: Position {
+                    line: 11,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Promises must be awaited.",
+            ),
+            code: "await ",
+            range: Range {
+                start: Position {
+                    line: 11,
+                    character: 0,
+                },
+                end: Position {
+                    line: 11,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-floating-promises for this line",
+            ),
+            code: "// oxlint-disable-next-line no-floating-promises\n",
+            range: Range {
+                start: Position {
+                    line: 11,
+                    character: 0,
+                },
+                end: Position {
+                    line: 11,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-floating-promises for this file",
+            ),
+            code: "// oxlint-disable no-floating-promises\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)
 
 
 code: "typescript-eslint(no-floating-promises)"
@@ -80,4 +383,39 @@ related_information[0].location.range: Range { start: Position { line: 13, chara
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
-fixed: None
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Disable no-floating-promises for this line",
+            ),
+            code: "// oxlint-disable-next-line no-floating-promises\n",
+            range: Range {
+                start: Position {
+                    line: 13,
+                    character: 0,
+                },
+                end: Position {
+                    line: 13,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-floating-promises for this file",
+            ),
+            code: "// oxlint-disable no-floating-promises\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_unused_disabled_directives@test.js.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_unused_disabled_directives@test.js.snap
@@ -15,7 +15,42 @@ related_information[0].location.range: Range { start: Position { line: 9, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
-fixed: None
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Disable no-console for this line",
+            ),
+            code: "// oxlint-disable-next-line no-console\n",
+            range: Range {
+                start: Position {
+                    line: 9,
+                    character: 0,
+                },
+                end: Position {
+                    line: 9,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-console for this file",
+            ),
+            code: "// oxlint-disable no-console\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)
 
 
 code: "eslint(no-debugger)"
@@ -28,7 +63,58 @@ related_information[0].location.range: Range { start: Position { line: 2, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
-fixed: Single(FixedContent { message: Some("Remove the debugger statement"), code: "", range: Range { start: Position { line: 2, character: 2 }, end: Position { line: 2, character: 11 } } })
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Remove the debugger statement",
+            ),
+            code: "",
+            range: Range {
+                start: Position {
+                    line: 2,
+                    character: 2,
+                },
+                end: Position {
+                    line: 2,
+                    character: 11,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this line",
+            ),
+            code: "// oxlint-disable-next-line no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 2,
+                    character: 0,
+                },
+                end: Position {
+                    line: 2,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this file",
+            ),
+            code: "// oxlint-disable no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)
 
 
 code: ""
@@ -41,7 +127,24 @@ related_information[0].location.range: Range { start: Position { line: 0, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
-fixed: Single(FixedContent { message: Some("remove unused disable directive"), code: "", range: Range { start: Position { line: 0, character: 2 }, end: Position { line: 0, character: 56 } } })
+fixed: Single(
+    FixedContent {
+        message: Some(
+            "remove unused disable directive",
+        ),
+        code: "",
+        range: Range {
+            start: Position {
+                line: 0,
+                character: 2,
+            },
+            end: Position {
+                line: 0,
+                character: 56,
+            },
+        },
+    },
+)
 
 
 code: ""
@@ -54,7 +157,24 @@ related_information[0].location.range: Range { start: Position { line: 5, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
-fixed: Single(FixedContent { message: Some("remove unused disable directive"), code: "", range: Range { start: Position { line: 5, character: 39 }, end: Position { line: 5, character: 52 } } })
+fixed: Single(
+    FixedContent {
+        message: Some(
+            "remove unused disable directive",
+        ),
+        code: "",
+        range: Range {
+            start: Position {
+                line: 5,
+                character: 39,
+            },
+            end: Position {
+                line: 5,
+                character: 52,
+            },
+        },
+    },
+)
 
 
 code: ""
@@ -67,4 +187,21 @@ related_information[0].location.range: Range { start: Position { line: 8, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
-fixed: Single(FixedContent { message: Some("remove unused disable directive"), code: "", range: Range { start: Position { line: 8, character: 2 }, end: Position { line: 8, character: 52 } } })
+fixed: Single(
+    FixedContent {
+        message: Some(
+            "remove unused disable directive",
+        ),
+        code: "",
+        range: Range {
+            start: Position {
+                line: 8,
+                character: 2,
+            },
+            end: Position {
+                line: 8,
+                character: 52,
+            },
+        },
+    },
+)

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_vue@debugger.vue.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_vue@debugger.vue.snap
@@ -15,7 +15,58 @@ related_information[0].location.range: Range { start: Position { line: 5, charac
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
-fixed: Single(FixedContent { message: Some("Remove the debugger statement"), code: "", range: Range { start: Position { line: 5, character: 4 }, end: Position { line: 5, character: 12 } } })
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Remove the debugger statement",
+            ),
+            code: "",
+            range: Range {
+                start: Position {
+                    line: 5,
+                    character: 4,
+                },
+                end: Position {
+                    line: 5,
+                    character: 12,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this line",
+            ),
+            code: "// oxlint-disable-next-line no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 5,
+                    character: 0,
+                },
+                end: Position {
+                    line: 5,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this file",
+            ),
+            code: "// oxlint-disable no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)
 
 
 code: "eslint(no-debugger)"
@@ -28,4 +79,55 @@ related_information[0].location.range: Range { start: Position { line: 10, chara
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
-fixed: Single(FixedContent { message: Some("Remove the debugger statement"), code: "", range: Range { start: Position { line: 10, character: 4 }, end: Position { line: 10, character: 13 } } })
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Remove the debugger statement",
+            ),
+            code: "",
+            range: Range {
+                start: Position {
+                    line: 10,
+                    character: 4,
+                },
+                end: Position {
+                    line: 10,
+                    character: 13,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this line",
+            ),
+            code: "// oxlint-disable-next-line no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 10,
+                    character: 0,
+                },
+                end: Position {
+                    line: 10,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this file",
+            ),
+            code: "// oxlint-disable no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)

--- a/crates/oxc_language_server/src/tester.rs
+++ b/crates/oxc_language_server/src/tester.rs
@@ -91,7 +91,7 @@ range: {range:?}
 severity: {severity:?}
 source: {source:?}
 tags: {tags:?}
-fixed: {fixed:?}
+fixed: {fixed:#?}
 "
     )
 }

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -753,7 +753,6 @@ impl Runtime {
 
                         messages.lock().unwrap().extend(section_messages.iter().map(|message| {
                             let message = message_cloner.clone_message(message);
-
                             message_to_message_with_position(message, source_text, rope)
                         }));
                     },


### PR DESCRIPTION
part of https://github.com/oxc-project/oxc/issues/11707
`disable rule for this file` are only valid for the current `SubContextHost` and will produce syntax error for vue files.
A comment like this will be added.
```
// oxlint-disable no-debugger
<script>
debugger;
</script>
```

This is the first part to refactor the logic, by moving it nearer to the linter, where the source text / sections are available.
Probably needs some LSP feature flag for the message to pass the information of the current `ContextSubHost` source text offset.