### PR TITLE
fix(language_server): correct position for "ignore this rule for this file" in vue/astro/svelte files

### DIFF
--- a/crates/oxc_language_server/fixtures/linter/vue/debugger.vue
+++ b/crates/oxc_language_server/fixtures/linter/vue/debugger.vue
@@ -2,9 +2,7 @@
     <div>Hello World</div>
 </template>
 
-<script>
-    debugger
-</script>
+<script>debugger;</script>
 
 <script setup lang="ts" generic="T extends Record<string, string>">
     let foo: T; // test ts syntax

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_astro@debugger.astro.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_astro@debugger.astro.snap
@@ -56,11 +56,11 @@ fixed: Multiple(
             code: "// oxlint-disable no-debugger\n",
             range: Range {
                 start: Position {
-                    line: 0,
+                    line: 1,
                     character: 0,
                 },
                 end: Position {
-                    line: 0,
+                    line: 1,
                     character: 0,
                 },
             },
@@ -120,11 +120,11 @@ fixed: Multiple(
             code: "// oxlint-disable no-debugger\n",
             range: Range {
                 start: Position {
-                    line: 0,
+                    line: 10,
                     character: 0,
                 },
                 end: Position {
-                    line: 0,
+                    line: 10,
                     character: 0,
                 },
             },
@@ -184,11 +184,11 @@ fixed: Multiple(
             code: "// oxlint-disable no-debugger\n",
             range: Range {
                 start: Position {
-                    line: 0,
+                    line: 14,
                     character: 0,
                 },
                 end: Position {
-                    line: 0,
+                    line: 14,
                     character: 0,
                 },
             },
@@ -248,11 +248,11 @@ fixed: Multiple(
             code: "// oxlint-disable no-debugger\n",
             range: Range {
                 start: Position {
-                    line: 0,
+                    line: 18,
                     character: 0,
                 },
                 end: Position {
-                    line: 0,
+                    line: 18,
                     character: 0,
                 },
             },

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_svelte@debugger.svelte.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_svelte@debugger.svelte.snap
@@ -40,11 +40,11 @@ fixed: Multiple(
             code: "// oxlint-disable no-unassigned-vars\n",
             range: Range {
                 start: Position {
-                    line: 0,
+                    line: 1,
                     character: 0,
                 },
                 end: Position {
-                    line: 0,
+                    line: 1,
                     character: 0,
                 },
             },
@@ -88,11 +88,11 @@ fixed: Multiple(
             code: "// oxlint-disable no-unassigned-vars\n",
             range: Range {
                 start: Position {
-                    line: 0,
+                    line: 1,
                     character: 0,
                 },
                 end: Position {
-                    line: 0,
+                    line: 1,
                     character: 0,
                 },
             },
@@ -152,11 +152,11 @@ fixed: Multiple(
             code: "// oxlint-disable no-debugger\n",
             range: Range {
                 start: Position {
-                    line: 0,
+                    line: 1,
                     character: 0,
                 },
                 end: Position {
-                    line: 0,
+                    line: 1,
                     character: 0,
                 },
             },

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_vue@debugger.vue.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_vue@debugger.vue.snap
@@ -8,10 +8,10 @@ file: fixtures/linter/vue/debugger.vue
 code: "eslint(no-debugger)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
 message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"
-range: Range { start: Position { line: 5, character: 4 }, end: Position { line: 5, character: 12 } }
+range: Range { start: Position { line: 4, character: 8 }, end: Position { line: 4, character: 17 } }
 related_information[0].message: ""
 related_information[0].location.uri: "file://<variable>/fixtures/linter/vue/debugger.vue"
-related_information[0].location.range: Range { start: Position { line: 5, character: 4 }, end: Position { line: 5, character: 12 } }
+related_information[0].location.range: Range { start: Position { line: 4, character: 8 }, end: Position { line: 4, character: 17 } }
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
@@ -24,12 +24,12 @@ fixed: Multiple(
             code: "",
             range: Range {
                 start: Position {
-                    line: 5,
-                    character: 4,
+                    line: 4,
+                    character: 8,
                 },
                 end: Position {
-                    line: 5,
-                    character: 12,
+                    line: 4,
+                    character: 17,
                 },
             },
         },
@@ -40,11 +40,11 @@ fixed: Multiple(
             code: "// oxlint-disable-next-line no-debugger\n",
             range: Range {
                 start: Position {
-                    line: 5,
+                    line: 4,
                     character: 0,
                 },
                 end: Position {
-                    line: 5,
+                    line: 4,
                     character: 0,
                 },
             },
@@ -53,15 +53,15 @@ fixed: Multiple(
             message: Some(
                 "Disable no-debugger for this file",
             ),
-            code: "// oxlint-disable no-debugger\n",
+            code: "\n// oxlint-disable no-debugger\n",
             range: Range {
                 start: Position {
-                    line: 0,
-                    character: 0,
+                    line: 4,
+                    character: 8,
                 },
                 end: Position {
-                    line: 0,
-                    character: 0,
+                    line: 4,
+                    character: 8,
                 },
             },
         },
@@ -72,10 +72,10 @@ fixed: Multiple(
 code: "eslint(no-debugger)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
 message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"
-range: Range { start: Position { line: 10, character: 4 }, end: Position { line: 10, character: 13 } }
+range: Range { start: Position { line: 8, character: 4 }, end: Position { line: 8, character: 13 } }
 related_information[0].message: ""
 related_information[0].location.uri: "file://<variable>/fixtures/linter/vue/debugger.vue"
-related_information[0].location.range: Range { start: Position { line: 10, character: 4 }, end: Position { line: 10, character: 13 } }
+related_information[0].location.range: Range { start: Position { line: 8, character: 4 }, end: Position { line: 8, character: 13 } }
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
@@ -88,11 +88,11 @@ fixed: Multiple(
             code: "",
             range: Range {
                 start: Position {
-                    line: 10,
+                    line: 8,
                     character: 4,
                 },
                 end: Position {
-                    line: 10,
+                    line: 8,
                     character: 13,
                 },
             },
@@ -104,11 +104,11 @@ fixed: Multiple(
             code: "// oxlint-disable-next-line no-debugger\n",
             range: Range {
                 start: Position {
-                    line: 10,
+                    line: 8,
                     character: 0,
                 },
                 end: Position {
-                    line: 10,
+                    line: 8,
                     character: 0,
                 },
             },
@@ -120,11 +120,11 @@ fixed: Multiple(
             code: "// oxlint-disable no-debugger\n",
             range: Range {
                 start: Position {
-                    line: 0,
+                    line: 7,
                     character: 0,
                 },
                 end: Position {
-                    line: 0,
+                    line: 7,
                     character: 0,
                 },
             },

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -174,7 +174,7 @@ impl<'a> ContextHost<'a> {
     }
 
     /// The current [`ContextSubHost`]
-    fn current_sub_host(&self) -> &ContextSubHost<'a> {
+    pub fn current_sub_host(&self) -> &ContextSubHost<'a> {
         &self.sub_hosts[self.current_sub_host_index.get()]
     }
 

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -247,7 +247,14 @@ impl<'a> LintContext<'a> {
     /// Use [`LintContext::diagnostic_with_fix`] to provide an automatic fix.
     #[inline]
     pub fn diagnostic(&self, diagnostic: OxcDiagnostic) {
+        #[cfg(not(feature = "language_server"))]
         self.add_diagnostic(Message::new(diagnostic, PossibleFixes::None));
+
+        #[cfg(feature = "language_server")]
+        self.add_diagnostic(
+            Message::new(diagnostic, PossibleFixes::None)
+                .with_section_offset(self.parent.current_sub_host().source_text_offset),
+        );
     }
 
     /// Report a lint rule violation and provide an automatic fix.
@@ -358,7 +365,14 @@ impl<'a> LintContext<'a> {
     {
         let (diagnostic, fix) = self.create_fix(fix_kind, fix, diagnostic);
         if let Some(fix) = fix {
+            #[cfg(not(feature = "language_server"))]
             self.add_diagnostic(Message::new(diagnostic, PossibleFixes::Single(fix)));
+
+            #[cfg(feature = "language_server")]
+            self.add_diagnostic(
+                Message::new(diagnostic, PossibleFixes::Single(fix))
+                    .with_section_offset(self.parent.current_sub_host().source_text_offset),
+            );
         } else {
             self.diagnostic(diagnostic);
         }
@@ -387,7 +401,14 @@ impl<'a> LintContext<'a> {
         if fixes_result.is_empty() {
             self.diagnostic(diagnostic);
         } else {
+            #[cfg(not(feature = "language_server"))]
             self.add_diagnostic(Message::new(diagnostic, PossibleFixes::Multiple(fixes_result)));
+
+            #[cfg(feature = "language_server")]
+            self.add_diagnostic(
+                Message::new(diagnostic, PossibleFixes::Multiple(fixes_result))
+                    .with_section_offset(self.parent.current_sub_host().source_text_offset),
+            );
         }
     }
 

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -224,6 +224,8 @@ pub struct Message<'a> {
     pub fixes: PossibleFixes<'a>,
     span: Span,
     fixed: bool,
+    #[cfg(feature = "language_server")]
+    pub section_offset: u32,
 }
 
 impl<'new> CloneIn<'new> for Message<'_> {
@@ -235,6 +237,8 @@ impl<'new> CloneIn<'new> for Message<'_> {
             fixes: self.fixes.clone_in(allocator),
             span: self.span,
             fixed: self.fixed,
+            #[cfg(feature = "language_server")]
+            section_offset: self.section_offset,
         }
     }
 }
@@ -249,7 +253,20 @@ impl<'a> Message<'a> {
             .map(|span| Span::new(span.offset() as u32, (span.offset() + span.len()) as u32))
             .unwrap_or_default();
 
-        Self { error, span, fixes, fixed: false }
+        Self {
+            error,
+            span,
+            fixes,
+            fixed: false,
+            #[cfg(feature = "language_server")]
+            section_offset: 0,
+        }
+    }
+
+    #[cfg(feature = "language_server")]
+    pub fn with_section_offset(mut self, section_offset: u32) -> Self {
+        self.section_offset = section_offset;
+        self
     }
 
     /// move the offset of all spans to the right


### PR DESCRIPTION
Put the correct position for the `disable this rule for this file` code action on Vue and other files.

![ignore-fix-vue](https://github.com/user-attachments/assets/6b26da29-4a28-47a5-81c8-c90b07c47cea)

closes #11707
