### PR TITLE
fix(semantic): don't report abstract method with implementation twice

### DIFF
--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -389,7 +389,6 @@ pub fn check_method_definition<'a>(method: &MethodDefinition<'a>, ctx: &Semantic
                 // have abstract modifiers, but this gets checked during parsing
                 MethodDefinitionKind::Constructor => {}
             }
-            ctx.error(abstract_method_cannot_have_implementation(method_name, span));
         }
     }
 

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -12388,22 +12388,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  3 │ }
    ╰────
 
-  × TS(1245): Method 'method' cannot have an implementation because it is marked abstract.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/abstract-method-with-body/input.ts:2:12]
- 1 │ abstract class Foo {
- 2 │   abstract method() {}
-   ·            ──────
- 3 │ }
-   ╰────
-
-  × TS(1245): Method 'foo()' cannot have an implementation because it is marked abstract.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/abstract-method-with-body-computed/input.ts:2:13]
- 1 │ abstract class Foo {
- 2 │   abstract [foo()]() {}
-   ·             ─────
- 3 │ }
-   ╰────
-
   × TS(1245): Method 'foo()' cannot have an implementation because it is marked abstract.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/abstract-method-with-body-computed/input.ts:2:13]
  1 │ abstract class Foo {
@@ -12670,14 +12654,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  6 │   readonly *e() {}
    ╰────
 
-  × TS(1245): Method 'd' cannot have an implementation because it is marked abstract.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/generator-method-with-modifiers/input.ts:5:13]
- 4 │   static *c() {}
- 5 │   abstract *d() {}
-   ·             ─
- 6 │   readonly *e() {}
-   ╰────
-
   × TS(1244): Abstract methods can only appear within an abstract class.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/generator-method-with-modifiers/input.ts:5:13]
  4 │   static *c() {}
@@ -12830,28 +12806,12 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  3 │   readonly *e?() { }
    ╰────
 
-  × TS(1245): Method 'd' cannot have an implementation because it is marked abstract.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/optional-generator-method-with-invalid-modifiers/input.ts:2:13]
- 1 │ class C {
- 2 │   abstract *d?() { }
-   ·             ─
- 3 │   readonly *e?() { }
-   ╰────
-
   × TS(1244): Abstract methods can only appear within an abstract class.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/optional-generator-method-with-invalid-modifiers/input.ts:2:13]
  1 │ class C {
  2 │   abstract *d?() { }
    ·             ─
  3 │   readonly *e?() { }
-   ╰────
-
-  × TS(1245): Method 'd?.d' cannot have an implementation because it is marked abstract.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/optional-generator-method-with-invalid-modifiers/input.ts:8:14]
- 7 │ class A {
- 8 │   abstract *[d?.d]?() { }
-   ·              ────
- 9 │   readonly *[e?.e]?() { }
    ╰────
 
   × TS(1245): Method 'd?.d' cannot have an implementation because it is marked abstract.

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -14533,23 +14533,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  4 │    abstract set b(x: string);
    ╰────
 
-  × TS(1245): Method 'aa' cannot have an implementation because it is marked abstract.
-   ╭─[typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractAccessor.ts:3:17]
- 2 │    abstract get a();
- 3 │    abstract get aa() { return 1; } // error
-   ·                 ──
- 4 │    abstract set b(x: string);
-   ╰────
-
   × TS(1318): Accessor 'bb' cannot have an implementation because it is marked abstract.
-   ╭─[typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractAccessor.ts:5:17]
- 4 │    abstract set b(x: string);
- 5 │    abstract set bb(x: string) {} // error
-   ·                 ──
- 6 │ }
-   ╰────
-
-  × TS(1245): Method 'bb' cannot have an implementation because it is marked abstract.
    ╭─[typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractAccessor.ts:5:17]
  4 │    abstract set b(x: string);
  5 │    abstract set bb(x: string) {} // error
@@ -14669,28 +14653,12 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  7 │ }
    ╰────
 
-  × TS(1245): Method 'foo' cannot have an implementation because it is marked abstract.
-   ╭─[typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMethodInNonAbstractClass.ts:6:14]
- 5 │ class B {
- 6 │     abstract foo() {}
-   ·              ───
- 7 │ }
-   ╰────
-
   × TS(1244): Abstract methods can only appear within an abstract class.
    ╭─[typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMethodInNonAbstractClass.ts:6:14]
  5 │ class B {
  6 │     abstract foo() {}
    ·              ───
  7 │ }
-   ╰────
-
-  × TS(1245): Method 'foo' cannot have an implementation because it is marked abstract.
-   ╭─[typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMethodWithImplementation.ts:2:14]
- 1 │ abstract class A {
- 2 │     abstract foo() {}
-   ·              ───
- 3 │ }
    ╰────
 
   × TS(1245): Method 'foo' cannot have an implementation because it is marked abstract.


### PR DESCRIPTION
The match above the deleted line already reports depending on the kind of method.