### PR TITLE
refactor(semantic): split Reference into SoA pattern

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/block_scoped_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/block_scoped_var.rs
@@ -165,7 +165,7 @@ fn run_for_all_references(
         .for_each(|reference| {
             ctx.diagnostic(use_outside_scope_diagnostic(
                 pattern.span(),
-                ctx.reference_span(reference),
+                ctx.reference_span(&reference),
                 name,
             ));
         });

--- a/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
@@ -90,7 +90,7 @@ impl Rule for NoClassAssign {
                     ctx.diagnostic(no_class_assign_diagnostic(
                         symbol_table.symbol_name(symbol_id),
                         symbol_table.symbol_span(symbol_id),
-                        ctx.semantic().reference_span(reference),
+                        ctx.semantic().reference_span(&reference),
                     ));
                 }
             }

--- a/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
@@ -58,7 +58,7 @@ impl Rule for NoConstAssign {
                     ctx.diagnostic(no_const_assign_diagnostic(
                         symbol_table.symbol_name(symbol_id),
                         symbol_table.symbol_span(symbol_id),
-                        ctx.semantic().reference_span(reference),
+                        ctx.semantic().reference_span(&reference),
                     ));
                 }
             }

--- a/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
@@ -56,7 +56,7 @@ impl Rule for NoExAssign {
             for reference in symbol_table.get_resolved_references(symbol_id) {
                 if reference.is_write() {
                     ctx.diagnostic(no_ex_assign_diagnostic(
-                        ctx.semantic().reference_span(reference),
+                        ctx.semantic().reference_span(&reference),
                     ));
                 }
             }

--- a/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
@@ -91,7 +91,7 @@ impl Rule for NoExtendNative {
         for reference_id_list in ctx.scoping().root_unresolved_references_ids() {
             for reference_id in reference_id_list {
                 let reference = symbols.get_reference(reference_id);
-                let name = ctx.semantic().reference_name(reference);
+                let name = ctx.semantic().reference_name(&reference);
                 // If the referenced name does not appear to be a global object, skip it.
                 if !ctx.env_contains_var(name) {
                     continue;

--- a/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
@@ -75,7 +75,7 @@ impl Rule for NoFuncAssign {
                 if reference.is_write() {
                     ctx.diagnostic(no_func_assign_diagnostic(
                         symbol_table.symbol_name(symbol_id),
-                        ctx.semantic().reference_span(reference),
+                        ctx.semantic().reference_span(&reference),
                     ));
                 }
             }

--- a/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
@@ -75,7 +75,7 @@ impl Rule for NoGlobalAssign {
                 {
                     ctx.diagnostic(no_global_assign_diagnostic(
                         name,
-                        ctx.semantic().reference_span(reference),
+                        ctx.semantic().reference_span(&reference),
                     ));
                 }
             }

--- a/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
@@ -79,7 +79,7 @@ impl Rule for NoImportAssign {
                                 }
                                 _ => return,
                             }
-                            && span != ctx.semantic().reference_span(reference)
+                            && span != ctx.semantic().reference_span(&reference)
                         {
                             return ctx.diagnostic(no_import_assign_diagnostic(expr.span()));
                         }
@@ -94,7 +94,7 @@ impl Rule for NoImportAssign {
                                 check_namespace_member_assignment(
                                     &member_expr.object,
                                     parent_node,
-                                    reference,
+                                    &reference,
                                     ctx,
                                     condition_met,
                                 );
@@ -108,7 +108,7 @@ impl Rule for NoImportAssign {
                                 check_namespace_member_assignment(
                                     &member_expr.object,
                                     parent_node,
-                                    reference,
+                                    &reference,
                                     ctx,
                                     condition_met,
                                 );
@@ -123,7 +123,7 @@ impl Rule for NoImportAssign {
                         && is_argument_of_well_known_mutation_function(reference.node_id(), ctx))
                 {
                     ctx.diagnostic(no_import_assign_diagnostic(
-                        ctx.semantic().reference_span(reference),
+                        ctx.semantic().reference_span(&reference),
                     ));
                 }
             }

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -57,7 +57,7 @@ impl Rule for NoUndef {
                     continue;
                 }
 
-                let name = ctx.semantic().reference_name(reference);
+                let name = ctx.semantic().reference_name(&reference);
 
                 if ctx.env_contains_var(name) {
                     continue;

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
@@ -73,7 +73,7 @@ impl<'s, 'a> Symbol<'s, 'a> {
     }
 
     #[inline]
-    pub fn references(&self) -> impl DoubleEndedIterator<Item = &Reference> + '_ + use<'_> {
+    pub fn references(&self) -> impl DoubleEndedIterator<Item = Reference> + '_ + use<'_> {
         self.scoping().get_resolved_references(self.id)
     }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
@@ -117,8 +117,8 @@ impl<'a> Symbol<'_, 'a> {
 
             if reference.is_write() {
                 if do_reassignment_checks
-                    && (self.is_assigned_to_ignored_destructure(reference, options)
-                        || self.is_used_in_for_of_loop(reference))
+                    && (self.is_assigned_to_ignored_destructure(&reference, options)
+                        || self.is_used_in_for_of_loop(&reference))
                 {
                     return true;
                 }
@@ -134,7 +134,7 @@ impl<'a> Symbol<'_, 'a> {
 
             if reference.is_type() {
                 // e.g. `type Foo = Array<Foo>`
-                if do_type_self_usage_checks && self.is_type_self_usage(reference) {
+                if do_type_self_usage_checks && self.is_type_self_usage(&reference) {
                     continue;
                 }
 
@@ -144,7 +144,7 @@ impl<'a> Symbol<'_, 'a> {
                 // ```
                 if options.report_vars_only_used_as_types
                     && !self.flags().intersects(SymbolFlags::TypeImport.union(SymbolFlags::Import))
-                    && self.reference_contains_type_query(reference)
+                    && self.reference_contains_type_query(&reference)
                 {
                     continue;
                 }
@@ -152,7 +152,7 @@ impl<'a> Symbol<'_, 'a> {
                 // function foo(): foo { }
                 // ```
                 if self
-                    .get_ref_relevant_node(reference)
+                    .get_ref_relevant_node(&reference)
                     .is_some_and(|node| self.declaration().span().contains_inclusive(node.span()))
                 {
                     continue;
@@ -164,17 +164,17 @@ impl<'a> Symbol<'_, 'a> {
             // ======================= Read usage checks =======================
 
             // e.g. `let a = 0; a = a + 1`
-            if do_reassignment_checks && self.is_self_reassignment(reference) {
+            if do_reassignment_checks && self.is_self_reassignment(&reference) {
                 continue;
             }
 
             // e.g. reference on `a` in expression `let a = 0; let b = (a++, 0);`
-            if do_discarded_read_checks && self.is_discarded_read(reference) {
+            if do_discarded_read_checks && self.is_discarded_read(&reference) {
                 continue;
             }
 
             // e.g. `function foo() { foo() }`
-            if do_self_call_check && self.is_self_call(reference) {
+            if do_self_call_check && self.is_self_call(&reference) {
                 continue;
             }
 
@@ -836,7 +836,7 @@ impl<'a> Symbol<'_, 'a> {
     }
 
     pub fn has_reference_used_as_type_query(&self) -> bool {
-        self.references().any(|reference| self.reference_contains_type_query(reference))
+        self.references().any(|reference| self.reference_contains_type_query(&reference))
     }
 
     fn reference_contains_type_query(&self, reference: &Reference) -> bool {

--- a/crates/oxc_linter/src/rules/eslint/no_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_var.rs
@@ -83,7 +83,7 @@ fn is_written_to(binding_pat: &BindingPattern, ctx: &LintContext) -> bool {
         BindingPatternKind::BindingIdentifier(binding_ident) => ctx
             .semantic()
             .symbol_references(binding_ident.symbol_id())
-            .any(oxc_semantic::Reference::is_write),
+            .any(|r| r.is_write()),
         BindingPatternKind::ObjectPattern(object_pat) => {
             if object_pat.properties.iter().any(|prop| is_written_to(&prop.value, ctx)) {
                 return true;

--- a/crates/oxc_linter/src/rules/eslint/no_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_var.rs
@@ -80,10 +80,9 @@ impl Rule for NoVar {
 
 fn is_written_to(binding_pat: &BindingPattern, ctx: &LintContext) -> bool {
     match &binding_pat.kind {
-        BindingPatternKind::BindingIdentifier(binding_ident) => ctx
-            .semantic()
-            .symbol_references(binding_ident.symbol_id())
-            .any(|r| r.is_write()),
+        BindingPatternKind::BindingIdentifier(binding_ident) => {
+            ctx.semantic().symbol_references(binding_ident.symbol_id()).any(|r| r.is_write())
+        }
         BindingPatternKind::ObjectPattern(object_pat) => {
             if object_pat.properties.iter().any(|prop| is_written_to(&prop.value, ctx)) {
                 return true;

--- a/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
+++ b/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
@@ -134,7 +134,7 @@ fn collect_jest_reference_id(
     for reference_id in reference_id_list {
         let reference = symbol_table.get_reference(reference_id);
 
-        if !is_jest_call(ctx.semantic().reference_name(reference)) {
+        if !is_jest_call(ctx.semantic().reference_name(&reference)) {
             continue;
         }
         let parent_node = nodes.parent_node(reference.node_id());
@@ -161,7 +161,7 @@ fn handle_jest_set_time_out<'a>(
 
         let parent_node = nodes.parent_node(reference.node_id());
 
-        if !is_jest_call(ctx.semantic().reference_name(reference)) {
+        if !is_jest_call(ctx.semantic().reference_name(&reference)) {
             if is_jest_fn_call(parent_node, id_to_jest_node_map, ctx) {
                 for (jest_reference_id, span) in jest_reference_id_list {
                     if jest_reference_id > &reference_id {

--- a/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
+++ b/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
@@ -82,7 +82,7 @@ impl Rule for NoJasmineGlobals {
                     ctx.diagnostic(no_jasmine_globals_diagnostic(
                         error,
                         help,
-                        ctx.semantic().reference_span(reference),
+                        ctx.semantic().reference_span(&reference),
                     ));
                 }
             }

--- a/crates/oxc_linter/src/rules/promise/no_nesting.rs
+++ b/crates/oxc_linter/src/rules/promise/no_nesting.rs
@@ -170,7 +170,7 @@ fn can_safely_unnest(
 fn uses_closest_cb_vars(closest_cb_scope_id: ScopeId, cb_span: Span, ctx: &LintContext) -> bool {
     for (_, binding_symbol_id) in ctx.scoping().get_bindings(closest_cb_scope_id) {
         for usage in ctx.semantic().symbol_references(*binding_symbol_id) {
-            let usage_span: Span = ctx.reference_span(usage);
+            let usage_span: Span = ctx.reference_span(&usage);
             if cb_span.contains_inclusive(usage_span) {
                 // Cannot unnest this nested promise as the nested cb refers to a variable
                 // defined in the parent promise callback scope. Unnesting would result in

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -10,7 +10,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::{Reference, SymbolId};
+use oxc_semantic::SymbolId;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
@@ -412,7 +412,7 @@ fn is_only_has_type_references(symbol_id: SymbolId, ctx: &LintContext) -> bool {
     if peekable_iter.peek().is_none() {
         return false;
     }
-    peekable_iter.all(Reference::is_type)
+    peekable_iter.all(|r| r.is_type())
 }
 
 struct FixOptions<'a, 'b> {

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
@@ -93,7 +93,7 @@ fn has_assignment_before_node(
     let symbol_table = ctx.scoping();
 
     for reference in symbol_table.get_resolved_references(symbol_id) {
-        if reference.is_write() && ctx.semantic().reference_span(reference).end < parent_span_end {
+        if reference.is_write() && ctx.semantic().reference_span(&reference).end < parent_span_end {
             return true;
         }
     }

--- a/crates/oxc_minifier/src/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditions.rs
@@ -200,8 +200,7 @@ impl<'a> PeepholeOptimizations {
             return;
         }
 
-        let reference = ctx.scoping_mut().get_reference_mut(write_id_ref.reference_id());
-        reference.flags_mut().insert(ReferenceFlags::Read);
+        ctx.scoping_mut().reference_flags_mut(write_id_ref.reference_id()).insert(ReferenceFlags::Read);
 
         let new_op = logical_expr.operator.to_assignment_operator();
         expr.operator = new_op;

--- a/crates/oxc_minifier/src/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditions.rs
@@ -200,7 +200,9 @@ impl<'a> PeepholeOptimizations {
             return;
         }
 
-        ctx.scoping_mut().reference_flags_mut(write_id_ref.reference_id()).insert(ReferenceFlags::Read);
+        ctx.scoping_mut()
+            .reference_flags_mut(write_id_ref.reference_id())
+            .insert(ReferenceFlags::Read);
 
         let new_op = logical_expr.operator.to_assignment_operator();
         expr.operator = new_op;

--- a/crates/oxc_minifier/src/peephole/minimize_logical_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_logical_expression.rs
@@ -281,8 +281,7 @@ impl<'a> PeepholeOptimizations {
     /// But assignment expressions changes the value, so we should add ReferenceFlags::Read.
     pub fn mark_assignment_target_as_read(assign_target: &AssignmentTarget, ctx: &mut Ctx<'a, '_>) {
         if let AssignmentTarget::AssignmentTargetIdentifier(id) = assign_target {
-            let reference = ctx.scoping_mut().get_reference_mut(id.reference_id());
-            reference.flags_mut().insert(ReferenceFlags::Read);
+            ctx.scoping_mut().reference_flags_mut(id.reference_id()).insert(ReferenceFlags::Read);
         }
     }
 }

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -272,7 +272,7 @@ impl<'a> SemanticBuilder<'a> {
                 self.nodes.len() as u32,
                 self.scoping.scopes_len() as u32,
                 self.scoping.symbols_len() as u32,
-                self.scoping.references.len() as u32,
+                self.scoping.references_len() as u32,
             );
             stats.assert_accurate(actual_stats);
         }
@@ -521,9 +521,7 @@ impl<'a> SemanticBuilder<'a> {
             if let Some(symbol_id) = bindings.get(name.as_str()).copied() {
                 let symbol_flags = self.scoping.symbol_flags(symbol_id);
                 references.retain(|&reference_id| {
-                    let reference = &mut self.scoping.references[reference_id];
-
-                    let flags = reference.flags_mut();
+                    let flags = self.scoping.reference_flags_mut(reference_id);
 
                     // Determine the symbol whether can be referenced by this reference.
                     let resolved = (flags.is_value() && symbol_flags.can_be_referenced_by_value())
@@ -552,7 +550,7 @@ impl<'a> SemanticBuilder<'a> {
                         //                                            make sure the reference is a type only.
                         *flags = ReferenceFlags::Type;
                     }
-                    reference.set_symbol_id(symbol_id);
+                    self.scoping.set_reference_symbol_id(reference_id, symbol_id);
                     self.scoping.add_resolved_reference(symbol_id, reference_id);
 
                     false

--- a/crates/oxc_semantic/src/is_global_reference.rs
+++ b/crates/oxc_semantic/src/is_global_reference.rs
@@ -10,7 +10,7 @@ pub trait IsGlobalReference {
 
 impl IsGlobalReference for ReferenceId {
     fn is_global_reference(&self, scoping: &Scoping) -> bool {
-        scoping.references[*self].symbol_id().is_none()
+        scoping.reference_symbol_ids[*self].is_none()
     }
 
     fn is_global_reference_name(&self, _name: &str, _scoping: &Scoping) -> bool {

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -195,7 +195,7 @@ impl<'a> Semantic<'a> {
             self.nodes.len() as u32,
             self.scoping.scopes_len() as u32,
             self.scoping.symbols_len() as u32,
-            self.scoping.references.len() as u32,
+            self.scoping.references_len() as u32,
         )
     }
 
@@ -216,7 +216,7 @@ impl<'a> Semantic<'a> {
     pub fn symbol_references(
         &self,
         symbol_id: SymbolId,
-    ) -> impl Iterator<Item = &Reference> + '_ + use<'_> {
+    ) -> impl Iterator<Item = Reference> + '_ + use<'_> {
         self.scoping.get_resolved_references(symbol_id)
     }
 
@@ -324,7 +324,7 @@ mod tests {
         let allocator = Allocator::default();
         let source_type: SourceType = SourceType::default().with_typescript(true);
         let semantic = get_semantic(&allocator, source, source_type);
-        assert_eq!(semantic.scoping().references.len(), 1);
+        assert_eq!(semantic.scoping().references_len(), 1);
     }
 
     #[test]
@@ -448,7 +448,7 @@ mod tests {
                 num_refs == 1,
                 "expected to find 1 reference to '{target_symbol_name}' but {num_refs} were found\n\nsource:\n{source}"
             );
-            let ref_type = a_refs[0];
+            let ref_type = &a_refs[0];
             if flags.is_write() {
                 assert!(
                     ref_type.is_write(),

--- a/crates/oxc_semantic/tests/conformance/test_identifier_reference.rs
+++ b/crates/oxc_semantic/tests/conformance/test_identifier_reference.rs
@@ -70,7 +70,7 @@ impl ConformanceTest for IdentifierReferenceTest {
 
         let reference = semantic.scoping().get_reference(reference_id);
         if reference.node_id() != node.id() {
-            return node_id_mismatch(node.id(), id, reference_id, reference);
+            return node_id_mismatch(node.id(), id, reference_id, &reference);
         }
 
         TestResult::Pass

--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -1053,8 +1053,7 @@ impl<'a> ArrowFunctionConverter<'a> {
         // If no symbol ID, it means there is no variable named `arguments` in the scope.
         // The following code is just to sync semantics.
         if symbol_id.is_none() {
-            let reference = ctx.scoping_mut().get_reference_mut(reference_id);
-            reference.set_symbol_id(binding.symbol_id);
+            ctx.scoping_mut().set_reference_symbol_id(reference_id, binding.symbol_id);
             ctx.scoping_mut().delete_root_unresolved_reference(&ident.name, reference_id);
             ctx.scoping_mut().add_resolved_reference(binding.symbol_id, reference_id);
         }

--- a/crates/oxc_transformer/src/common/duplicate.rs
+++ b/crates/oxc_transformer/src/common/duplicate.rs
@@ -103,8 +103,7 @@ impl<'a> TransformCtx<'a> {
                 }
 
                 // Previously `x += 1` (`x` read + write), but moving to `_x = x` (`x` read only)
-                let reference = ctx.scoping_mut().get_reference_mut(reference_id);
-                *reference.flags_mut() = ReferenceFlags::Read;
+                *ctx.scoping_mut().reference_flags_mut(reference_id) = ReferenceFlags::Read;
 
                 self.var_declarations.create_uid_var(&ident.name, ctx)
             }

--- a/crates/oxc_transformer/src/decorator/legacy/metadata.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/metadata.rs
@@ -90,7 +90,7 @@
 use oxc_allocator::{Box as ArenaBox, TakeIn};
 use oxc_ast::ast::*;
 use oxc_data_structures::stack::SparseStack;
-use oxc_semantic::{Reference, ReferenceFlags, SymbolId};
+use oxc_semantic::{ReferenceFlags, SymbolId};
 use oxc_span::{ContentEq, SPAN};
 use oxc_traverse::{MaybeBoundIdentifier, Traverse};
 use rustc_hash::FxHashMap;
@@ -259,7 +259,7 @@ impl<'a> LegacyDecoratorMetadata<'a, '_> {
         // If the enum doesn't have any type references, that implies that no decorators
         // refer to this enum, so there is no need to infer its type.
         let has_type_reference =
-            ctx.scoping().get_resolved_references(symbol_id).any(Reference::is_type);
+            ctx.scoping().get_resolved_references(symbol_id).any(|r| r.is_type());
         if has_type_reference {
             let enum_type = Self::infer_enum_type(&decl.body.members);
             self.enum_types.insert(symbol_id, enum_type);

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -153,13 +153,15 @@ impl<'a> ExponentiationOperator<'a, '_> {
         let mut temp_var_inits = ctx.ast.vec();
 
         // Make sure side-effects of evaluating `left` only happen once
-        let reference = ctx.scoping.scoping_mut().get_reference_mut(ident.reference_id());
+        let reference = ctx.scoping.scoping().get_reference(ident.reference_id());
+        let symbol_id = reference.symbol_id();
+        let scoping_mut = ctx.scoping.scoping_mut();
 
         // `left **= right` is being transformed to `left = Math.pow(left, right)`,
         // so `left` in `left =` is no longer being read from
-        *reference.flags_mut() = ReferenceFlags::Write;
+        *scoping_mut.reference_flags_mut(ident.reference_id()) = ReferenceFlags::Write;
 
-        let pow_left = if let Some(symbol_id) = reference.symbol_id() {
+        let pow_left = if let Some(symbol_id) = symbol_id {
             // This variable is declared in scope so evaluating it multiple times can't trigger a getter.
             // No need for a temp var.
             ctx.create_bound_ident_expr(SPAN, ident.name, symbol_id, ReferenceFlags::Read)

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -141,9 +141,9 @@ impl<'a> LogicalAssignmentOperators<'a, '_> {
         ident: &IdentifierReference<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> (Expression<'a>, AssignmentTarget<'a>) {
-        let reference = ctx.scoping_mut().get_reference_mut(ident.reference_id());
-        *reference.flags_mut() = ReferenceFlags::Read;
+        let reference = ctx.scoping().get_reference(ident.reference_id());
         let symbol_id = reference.symbol_id();
+        *ctx.scoping_mut().reference_flags_mut(ident.reference_id()) = ReferenceFlags::Read;
         let left_expr = Expression::Identifier(ctx.alloc(ident.clone()));
 
         let ident = ctx.create_ident_reference(SPAN, ident.name, symbol_id, ReferenceFlags::Write);

--- a/crates/oxc_transformer/src/es2022/class_properties/static_block_and_prop_init.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/static_block_and_prop_init.rs
@@ -131,7 +131,7 @@ impl<'a> ClassProperties<'a, '_> {
         ident.name = temp_binding.name;
 
         let symbols = ctx.scoping_mut();
-        symbols.get_reference_mut(reference_id).set_symbol_id(temp_binding.symbol_id);
+        symbols.set_reference_symbol_id(reference_id, temp_binding.symbol_id);
         symbols.delete_resolved_reference(symbol_id, reference_id);
         symbols.add_resolved_reference(temp_binding.symbol_id, reference_id);
     }


### PR DESCRIPTION
## Summary

This PR refactors the storage of `Reference` structs in `Scoping` from Array of Structs (AoS) to Structure of Arrays (SoA) pattern for improved memory efficiency and cache locality.

## Changes

- **Replaced single `references` field with three separate IndexVec fields:**
  - `reference_node_ids: IndexVec<ReferenceId, NodeId>`
  - `reference_symbol_ids: IndexVec<ReferenceId, Option<SymbolId>>`
  - `reference_flags: IndexVec<ReferenceId, ReferenceFlags>`

- **Updated all methods in `Scoping` to work with the new SoA pattern:**
  - `create_reference` - now pushes to three separate vectors
  - `get_reference` - reconstructs `Reference` from the three fields
  - Added `references_len()` for getting the count
  - Added `set_reference_symbol_id()` and `reference_flags_mut()` for direct field access

- **Fixed all dependent code across the codebase:**
  - Updated transformer code to use new setter methods instead of `get_reference_mut`
  - Updated linter code to handle `Reference` values instead of references
  - Fixed method calls that now return owned `Reference` values

## Benefits

This SoA refactoring improves:
- **Memory efficiency** - Better data packing and reduced memory fragmentation
- **Cache locality** - Similar data grouped together, beneficial when iterating over specific fields
- **Performance** - Reduced cache misses when accessing only specific fields of references

## Test Plan

- [x] All existing tests pass (`cargo test`)
- [x] No compilation warnings (`cargo check`)

🤖 Generated with [Claude Code](https://claude.ai/code)