### PR TITLE
refactor(linter/plugins): flatten directory structure of `dist`

### DIFF
--- a/apps/oxlint/src-js/cli.ts
+++ b/apps/oxlint/src-js/cli.ts
@@ -9,7 +9,8 @@ let lintFile: typeof lintFileWrapper | null = null;
 function loadPluginWrapper(path: string): Promise<string> {
   if (loadPlugin === null) {
     const require = createRequire(import.meta.url);
-    ({ loadPlugin, lintFile } = require('./plugins/index.js'));
+    // `plugins.js` is in root of `dist`. See `tsdown.config.ts`.
+    ({ loadPlugin, lintFile } = require('./plugins.js'));
   }
   return loadPlugin(path);
 }

--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -23,7 +23,10 @@ const commonConfig: UserConfig = {
 // Only generate `.d.ts` file for main export, not for CLI
 export default defineConfig([
   {
-    entry: ['src-js/cli.ts', 'src-js/plugins/index.ts'],
+    entry: {
+      cli: 'src-js/cli.ts',
+      plugins: 'src-js/plugins/index.ts',
+    },
     ...commonConfig,
     dts: false,
   },


### PR DESCRIPTION
Pure refactor. There's no need for a subdirectory in `dist` for the lazy-loaded plugins code. Flatten it.