### PR TITLE
fix(editor): execute `oxc.path.server` in win32 with shell

### DIFF
--- a/editors/vscode/client/PathValidator.ts
+++ b/editors/vscode/client/PathValidator.ts
@@ -8,7 +8,7 @@
  *
  * The check for malicious characters is not needed, but it's an additional layer of security.
  * When using `shell: true` in `LanguageClient.ServerOptions`, it can be vulnerable to command injection.
- * Even though we are not using `shell: true`, it's a good practice to validate the input.
+ * We are using `shell: true` only on Windows when the paths ends with `node_modules/.bin/oxc_language_server`.
  */
 export function validateSafeBinaryPath(binary: string): boolean {
   // Check for path traversal (including Windows variants)

--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -130,7 +130,7 @@ export async function activate(context: ExtensionContext) {
   );
 
   async function findBinary(): Promise<string> {
-    let bin = configService.getUserServerBinPath();
+    const bin = configService.getUserServerBinPath();
     if (workspace.isTrusted && bin) {
       try {
         await fsPromises.access(bin);
@@ -168,6 +168,12 @@ export async function activate(context: ExtensionContext) {
           command: path!,
           args: ['--lsp'],
           options: {
+            // On Windows we need to run the binary in a shell to be able to execute the shell npm bin script.
+            // Searching for the right `.exe` file inside `node_modules/` is not reliable as it depends on
+            // the package manager used (npm, yarn, pnpm, etc) and the package version.
+            // The npm bin script is a shell script that points to the actual binary.
+            // Security: We validated the userDefinedBinary in `configService.getUserServerBinPath()`.
+            shell: process.platform === 'win32',
             env: serverEnv,
           },
         };


### PR DESCRIPTION
closes #14167
This allows cross-platform configuration in a project.
The project can now define `oxc.path.server` to `node_modules/.bin/oxc_language_server` and windows will pick it up too.

 With `validateSafeBinaryPath` in `Pathvalidator.ts`, we should be sure that bad actors can not harm the user's machine.

This is needed because the VSCode extension will not ship the language server in the future.
