### PR TITLE
fix(linter/plugins): make `null` a valid value for `meta.fixable`

### DIFF
--- a/apps/oxlint/src-js/plugins/load.ts
+++ b/apps/oxlint/src-js/plugins/load.ts
@@ -131,7 +131,7 @@ async function loadPluginImpl(path: string): Promise<PluginDetails> {
       let { fixable } = ruleMeta;
       if (fixable === void 0) {
         fixable = null;
-      } else if (fixable !== 'code' && fixable !== 'whitespace') {
+      } else if (fixable !== null && fixable !== 'code' && fixable !== 'whitespace') {
         throw new TypeError('Invalid `meta.fixable`');
       }
 

--- a/apps/oxlint/src-js/plugins/types.ts
+++ b/apps/oxlint/src-js/plugins/types.ts
@@ -43,6 +43,6 @@ export interface EnterExit {
 // Rule metadata.
 // TODO: Fill in all properties.
 export interface RuleMeta {
-  fixable?: 'code' | 'whitespace';
+  fixable?: 'code' | 'whitespace' | null | undefined;
   [key: string]: unknown;
 }


### PR DESCRIPTION
`null` is a valid value for `meta.fixable`. Make it so.