### PR TITLE
perf(linter/plugins): store if rule is fixable as boolean

### DIFF
--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -1,7 +1,6 @@
 import { getFixes } from './fix.js';
 
 import type { Fix, FixFn } from './fix.ts';
-import type { RuleMeta } from './types.ts';
 
 // Diagnostic in form passed by user to `Context#report()`
 export interface Diagnostic {
@@ -70,8 +69,8 @@ export interface InternalContext {
   filePath: string;
   // Options
   options: unknown[];
-  // Rule metadata
-  meta: RuleMeta;
+  // `true` if rule can provide fixes (`meta.fixable` in `RuleMeta` is 'code' or 'whitespace')
+  isFixable: boolean;
 }
 
 /**
@@ -88,13 +87,13 @@ export class Context {
    * @class
    * @param fullRuleName - Rule name, in form `<plugin>/<rule>`
    */
-  constructor(fullRuleName: string, meta: RuleMeta) {
+  constructor(fullRuleName: string, isFixable: boolean) {
     this.#internal = {
       id: fullRuleName,
       filePath: '',
       ruleIndex: -1,
       options: [],
-      meta,
+      isFixable,
     };
   }
 

--- a/apps/oxlint/src-js/plugins/fix.ts
+++ b/apps/oxlint/src-js/plugins/fix.ts
@@ -144,7 +144,7 @@ export function getFixes(diagnostic: Diagnostic, internal: InternalContext): Fix
 
   // ESLint does not throw this error if `fix` function returns only falsy values.
   // We've already exited if that is the case, so we're reproducing that behavior.
-  if (internal.meta.fixable === null) {
+  if (internal.isFixable === false) {
     throw new Error('Fixable rules must set the `meta.fixable` property to "code" or "whitespace".');
   }
 


### PR DESCRIPTION
Small optimization. Store if a rule is fixable as a single `isFixable` boolean, instead of putting the whole `RuleMeta` object in `Context`.

This is more efficient on memory, and a boolean is faster to check as it's stored inline in the object, as opposed to strings which are stored as a reference to another object on the heap.