### PR TITLE
refactor(linter/plugins): simplify creation of `context` in `defineRule` ESLint shim

### DIFF
--- a/apps/oxlint/src-js/index.ts
+++ b/apps/oxlint/src-js/index.ts
@@ -9,9 +9,6 @@ export type { AfterHook, BeforeHook, RuleMeta, Visitor, VisitorWithHooks } from 
 
 const { defineProperty, getPrototypeOf, hasOwn, setPrototypeOf, create: ObjectCreate } = Object;
 
-const dummyOptions: unknown[] = [],
-  dummyReport = () => {};
-
 /**
  * Define a plugin.
  *
@@ -114,8 +111,8 @@ function createContextAndVisitor(rule: CreateOnceRule): {
   // so should be OK to take this shortcut.
   const context = ObjectCreate(null, {
     id: { value: '', enumerable: true, configurable: true },
-    options: { value: dummyOptions, enumerable: true, configurable: true },
-    report: { value: dummyReport, enumerable: true, configurable: true },
+    options: { value: null, enumerable: true, configurable: true },
+    report: { value: null, enumerable: true, configurable: true },
   });
 
   let { before: beforeHook, after: afterHook, ...visitor } = createOnce.call(rule, context) as VisitorWithHooks;


### PR DESCRIPTION
The `dummyOptions` and `dummyReport` default values are a useless complication. These values should never be accessed anyway - they're overridden before visitor methods access `context` - so `null` is fine.

I originally thought that storing objects of the right type here would help with making functions that touch the object monomorphic, but I now believe that to be mistaken. The property just has to be there to maintain consistent object shape, but what the *values* of the properties are doesn't matter.