### PR TITLE
perf(parser): cleanup and optimize re-lexing angle tokens

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -228,29 +228,35 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    pub(crate) fn re_lex_l_angle(&mut self) -> Kind {
+    pub(crate) fn re_lex_ts_l_angle(&mut self) -> bool {
         if self.fatal_error.is_some() {
-            return Kind::Eof;
+            return false;
         }
         let kind = self.cur_kind();
-        if matches!(kind, Kind::ShiftLeft | Kind::ShiftLeftEq | Kind::LtEq) {
-            self.token = self.lexer.re_lex_as_typescript_l_angle(kind);
-            self.token.kind()
+        if kind == Kind::ShiftLeft || kind == Kind::LtEq {
+            self.token = self.lexer.re_lex_as_typescript_l_angle(2);
+            true
+        } else if kind == Kind::ShiftLeftEq {
+            self.token = self.lexer.re_lex_as_typescript_l_angle(3);
+            true
         } else {
-            kind
+            kind == Kind::LAngle
         }
     }
 
-    pub(crate) fn re_lex_ts_r_angle(&mut self) -> Kind {
+    pub(crate) fn re_lex_ts_r_angle(&mut self) -> bool {
         if self.fatal_error.is_some() {
-            return Kind::Eof;
+            return false;
         }
         let kind = self.cur_kind();
-        if matches!(kind, Kind::ShiftRight | Kind::ShiftRight3) {
-            self.token = self.lexer.re_lex_as_typescript_r_angle(kind);
-            self.token.kind()
+        if kind == Kind::ShiftRight {
+            self.token = self.lexer.re_lex_as_typescript_r_angle(2);
+            true
+        } else if kind == Kind::ShiftRight3 {
+            self.token = self.lexer.re_lex_as_typescript_r_angle(3);
+            true
         } else {
-            kind
+            kind == Kind::RAngle
         }
     }
 

--- a/crates/oxc_parser/src/lexer/typescript.rs
+++ b/crates/oxc_parser/src/lexer/typescript.rs
@@ -2,28 +2,16 @@ use super::{Kind, Lexer, Token};
 
 impl Lexer<'_> {
     /// Re-tokenize '<<' or '<=' or '<<=' to '<'
-    pub(crate) fn re_lex_as_typescript_l_angle(&mut self, kind: Kind) -> Token {
-        let offset = match kind {
-            Kind::ShiftLeft | Kind::LtEq => 2,
-            Kind::ShiftLeftEq => 3,
-            _ => unreachable!(),
-        };
+    pub(crate) fn re_lex_as_typescript_l_angle(&mut self, offset: u32) -> Token {
         self.token.set_start(self.offset() - offset);
         self.source.back(offset as usize - 1);
-        let kind = Kind::LAngle;
-        self.finish_next(kind)
+        self.finish_next(Kind::LAngle)
     }
 
     /// Re-tokenize '>>' and '>>>' to '>'
-    pub(crate) fn re_lex_as_typescript_r_angle(&mut self, kind: Kind) -> Token {
-        let offset = match kind {
-            Kind::ShiftRight => 2,
-            Kind::ShiftRight3 => 3,
-            _ => unreachable!(),
-        };
+    pub(crate) fn re_lex_as_typescript_r_angle(&mut self, offset: u32) -> Token {
         self.token.set_start(self.offset() - offset);
         self.source.back(offset as usize - 1);
-        let kind = Kind::RAngle;
-        self.finish_next(kind)
+        self.finish_next(Kind::RAngle)
     }
 }

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -829,7 +829,7 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_type_arguments_of_type_reference(
         &mut self,
     ) -> Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
-        if !self.cur_token().is_on_new_line() && self.re_lex_l_angle() == Kind::LAngle {
+        if !self.cur_token().is_on_new_line() && self.re_lex_ts_l_angle() {
             let span = self.start_span();
             self.expect(Kind::LAngle);
             let (params, _) =
@@ -848,7 +848,7 @@ impl<'a> ParserImpl<'a> {
         &mut self,
     ) -> Box<'a, TSTypeParameterInstantiation<'a>> {
         let span = self.start_span();
-        if self.re_lex_l_angle() != Kind::LAngle {
+        if !self.re_lex_ts_l_angle() {
             return self.unexpected();
         }
         self.expect(Kind::LAngle);


### PR DESCRIPTION
Locally I'm seeing these improvements, but Codspeed doesn't show them :(

<img width="568" height="298" alt="image" src="https://github.com/user-attachments/assets/85b58f39-cb11-4094-b885-5a7a3a1ead32" />