### PR TITLE
fix(linter/plugins): add types export to `npm/oxlint`

### DIFF
--- a/npm/oxlint/package.json
+++ b/npm/oxlint/package.json
@@ -18,6 +18,7 @@
     "oxlint": "bin/oxlint",
     "oxc_language_server": "bin/oxc_language_server"
   },
+  "types": "dist/index.d.ts",
   "funding": {
     "url": "https://github.com/sponsors/Boshen"
   },


### PR DESCRIPTION
#14163 added types to `oxlint`, but neglected to add the types export to `npm/oxlint` package. Fix that.