### PR TITLE
fix(linter): get cli args on JS side, to avoid runtime inconsistencies

### DIFF
--- a/apps/oxlint/src-js/bindings.d.ts
+++ b/apps/oxlint/src-js/bindings.d.ts
@@ -11,10 +11,11 @@ export type JsLoadPluginCb =
 /**
  * NAPI entry point.
  *
- * JS side passes in two callbacks:
- * 1. `load_plugin`: Load a JS plugin from a file path.
- * 2. `lint_file`: Lint a file.
+ * JS side passes in:
+ * 1. `args`: Command line arguments (process.argv.slice(2))
+ * 2. `load_plugin`: Load a JS plugin from a file path.
+ * 3. `lint_file`: Lint a file.
  *
  * Returns `true` if linting succeeded without errors, `false` otherwise.
  */
-export declare function lint(loadPlugin: JsLoadPluginCb, lintFile: JsLintFileCb): Promise<boolean>
+export declare function lint(args: Array<string>, loadPlugin: JsLoadPluginCb, lintFile: JsLintFileCb): Promise<boolean>

--- a/apps/oxlint/src-js/cli.ts
+++ b/apps/oxlint/src-js/cli.ts
@@ -20,8 +20,11 @@ function lintFileWrapper(filePath: string, bufferId: number, buffer: Uint8Array 
   return lintFile(filePath, bufferId, buffer, ruleIds);
 }
 
-// Call Rust, passing `loadPlugin` and `lintFile` as callbacks
-const success = await lint(loadPluginWrapper, lintFileWrapper);
+// Get command line arguments, skipping first 2 (node binary and script path)
+const args = process.argv.slice(2);
+
+// Call Rust, passing `loadPlugin` and `lintFile` as callbacks, and CLI arguments
+const success = await lint(args, loadPluginWrapper, lintFileWrapper);
 
 // Note: It's recommended to set `process.exitCode` instead of calling `process.exit()`.
 // `process.exit()` kills the process immediately and `stdout` may not be flushed before process dies.


### PR DESCRIPTION
fixes #14150

related: #14112, #14071

This seems to be the only reliable way to get arguments across different runtimes.

when running with deno, the args from `std::env::args_os()` look like:
```
[
    "/Users/cameron/.deno/bin/deno",
    "run",
    "--ext=js",
    "-A",
    "/Users/cameron/github/camc314/oxlint-repros/issue-14150/node_modules/.deno/oxlint@1.18.0/node_modules/oxlint/bin/oxlint",
    ".",
]
```

however `process.argv` looks like:
```
[
  "oxlint",
  "/Users/cameron/github/camc314/oxlint-repros/issue-14150/node_modules/.deno/oxlint@1.18.0/node_modules/oxlint/bin/oxlint",
  "."
]
```

so skipping the first two means that we end up with incorrect args that we're trying to parts.

There are (potentially) other solutions e.g. search for one of the args ending in`oxlint`, or other methods of trying to guess.

However, this feels like the most reliable solution. 