### PR TITLE
fix(linter/plugins): error on JS plugin with reserved name

### DIFF
--- a/apps/oxlint/test/e2e.test.ts
+++ b/apps/oxlint/test/e2e.test.ts
@@ -65,6 +65,10 @@ describe('oxlint CLI', () => {
     await testFixture('missing_custom_plugin');
   });
 
+  it('should report an error if a custom plugin has a reserved name', async () => {
+    await testFixture('reserved_name');
+  });
+
   it('should report an error if a custom plugin throws an error during import', async () => {
     await testFixture('custom_plugin_import_error');
   });

--- a/apps/oxlint/test/fixtures/reserved_name/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/reserved_name/.oxlintrc.json
@@ -1,0 +1,3 @@
+{
+  "jsPlugins": ["./plugin.ts"]
+}

--- a/apps/oxlint/test/fixtures/reserved_name/output.snap.md
+++ b/apps/oxlint/test/fixtures/reserved_name/output.snap.md
@@ -1,0 +1,15 @@
+# Exit code
+1
+
+# stdout
+```
+Failed to parse configuration file.
+
+  x Plugin name 'import' is reserved, and cannot be used for JS plugins
+```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/reserved_name/plugin.ts
+++ b/apps/oxlint/test/fixtures/reserved_name/plugin.ts
@@ -1,0 +1,10 @@
+import type { Plugin } from '../../../dist/index.js';
+
+const plugin: Plugin = {
+  meta: {
+    name: 'import', // Reserved name
+  },
+  rules: {},
+};
+
+export default plugin;


### PR DESCRIPTION
Raise an error if a JS plugin has same name as a built-in plugin e.g. `import`. It'd be impossible to know whether `import/rule-name` was referring to the built-in rule, or the JS plugin's rule of same name.