### PR TITLE
release(oxlint): v1.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2000,7 +2000,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_language_server"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "env_logger",
  "futures",
@@ -2023,7 +2023,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_linter"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "bitflags 2.9.4",
  "constcat",
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "oxlint"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "bpaf",
  "cow-utils",

--- a/apps/oxlint/CHANGELOG.md
+++ b/apps/oxlint/CHANGELOG.md
@@ -4,6 +4,124 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.19.0] - 2025-09-29
+
+### 🚀 Features
+
+- acd1266 linter/plugins: `oxlint` export types (#14163) (overlookmotel)
+- 00954de linter/plugins: Remove `--js-plugins` CLI option (#14134) (overlookmotel)
+- b4d716f linter/plugins: Move custom JS plugin config to `jsPlugins` (#14133) (overlookmotel)
+- 9c3afea linter/plugins: Support fixes (#14094) (overlookmotel)
+- 1472147 linter: Move `no-unused-expressions` to correctness (#14099) (camchenry)
+- c796966 linter/plugins: Add `meta` property to rules (#14089) (overlookmotel)
+
+### 🐛 Bug Fixes
+
+- 39a171e linter: Get cli args on JS side, to avoid runtime inconsistencies (#14223) (camc314)
+- e045391 linter/plugins: Error on JS plugin with reserved name (#14226) (overlookmotel)
+- 37f6b09 linter/plugins: Make `null` a valid value for `meta.fixable` (#14204) (overlookmotel)
+- e9a14d1 linter/plugins: Allow `fix` function to return `undefined` (#14182) (overlookmotel)
+- ee9ecbe linter/plugins: Fix TS type for fixer methods (#14166) (overlookmotel)
+- 03d1684 linter/plugins: Output warning on first JS plugin load (#14165) (overlookmotel)
+- 9716f7c linter/plugins: Fix TS types (#14162) (overlookmotel)
+- 4a4fce8 linter: Fix cli argument parsing (#14112) (camc314)
+- 9f3e2bc linter/plugins: Output errors thrown in JS plugins (#14096) (overlookmotel)
+- d8e9cc5 linter/plugins: Validate type of `before` and `after` hooks (#14086) (overlookmotel)
+
+### 🚜 Refactor
+
+- 61ec0a7 linter/plugins: Simplify creation of `context` in `defineRule` ESLint shim (#14206) (overlookmotel)
+- 3b1fe6f linter/plugins: Flatten directory structure of `dist` (#14199) (overlookmotel)
+- d52cba6 linter: Bump TSDown to latest (#14198) (overlookmotel)
+- 983dd1b linter/plugins: Add `Fixer` type (#14180) (overlookmotel)
+- 2f8b076 linter/plugins: Remove dead code (#14178) (overlookmotel)
+- e69cd86 linter/plugins: `loadPluginImpl` return an object (#14087) (overlookmotel)
+
+### 📚 Documentation
+
+- b19f5bc linter/plugins: Improve JSDoc comments for `definePlugin` and `defineRule` (#14159) (overlookmotel)
+
+### ⚡ Performance
+
+- 2575065 linter/plugins: Store if rule is fixable as boolean (#14205) (overlookmotel)
+
+### 🧪 Testing
+
+- a9b603e linter/plugins: Convert all plugins in tests to TS (#14200) (overlookmotel)
+- 6ff3a23 linter/plugins: Add tests for `.ts`, `.mts`, `.cts` plugin files (#14164) (overlookmotel)
+- 8988d64 linter/plugins: Add line breaks to plugins files (#14181) (overlookmotel)
+- 52db331 linter/plugins: Type-check test fixtures (#14158) (overlookmotel)
+- aca083a linter/plugins: Include stderr output in snapshots (#14155) (overlookmotel)
+- a3c8f46 linter/plugins: Do not run `pnpm` in tests (#14157) (overlookmotel)
+- 0029b7f linter/plugins: Normalize line breaks in snapshots (#14154) (overlookmotel)
+- 7f2c101 linter/plugins: Specify path to `node` in tests (#14152) (overlookmotel)
+- fc14abc linter/plugins: Format test fixtures (#14125) (overlookmotel)
+- a6f965f linter/plugins: Simplify configs in test fixtures (#14124) (overlookmotel)
+- b1685f7 linter/plugins: Refactor tests (#14123) (overlookmotel)
+- 788e495 linter/plugins: Improve ESLint compat tests (#14119) (overlookmotel)
+- 5750077 linter/plugins: Fix file paths in snapshots (#14115) (overlookmotel)
+- 5c862f9 linter/plugins: Standardize test fixture structure (#14114) (overlookmotel)
+
+
+## [1.19.0] - 2025-09-29
+
+### 🚀 Features
+
+- acd1266 linter/plugins: `oxlint` export types (#14163) (overlookmotel)
+- 00954de linter/plugins: Remove `--js-plugins` CLI option (#14134) (overlookmotel)
+- b4d716f linter/plugins: Move custom JS plugin config to `jsPlugins` (#14133) (overlookmotel)
+- 9c3afea linter/plugins: Support fixes (#14094) (overlookmotel)
+- 1472147 linter: Move `no-unused-expressions` to correctness (#14099) (camchenry)
+- c796966 linter/plugins: Add `meta` property to rules (#14089) (overlookmotel)
+
+### 🐛 Bug Fixes
+
+- 39a171e linter: Get cli args on JS side, to avoid runtime inconsistencies (#14223) (camc314)
+- e045391 linter/plugins: Error on JS plugin with reserved name (#14226) (overlookmotel)
+- 37f6b09 linter/plugins: Make `null` a valid value for `meta.fixable` (#14204) (overlookmotel)
+- e9a14d1 linter/plugins: Allow `fix` function to return `undefined` (#14182) (overlookmotel)
+- ee9ecbe linter/plugins: Fix TS type for fixer methods (#14166) (overlookmotel)
+- 03d1684 linter/plugins: Output warning on first JS plugin load (#14165) (overlookmotel)
+- 9716f7c linter/plugins: Fix TS types (#14162) (overlookmotel)
+- 4a4fce8 linter: Fix cli argument parsing (#14112) (camc314)
+- 9f3e2bc linter/plugins: Output errors thrown in JS plugins (#14096) (overlookmotel)
+- d8e9cc5 linter/plugins: Validate type of `before` and `after` hooks (#14086) (overlookmotel)
+
+### 🚜 Refactor
+
+- 61ec0a7 linter/plugins: Simplify creation of `context` in `defineRule` ESLint shim (#14206) (overlookmotel)
+- 3b1fe6f linter/plugins: Flatten directory structure of `dist` (#14199) (overlookmotel)
+- d52cba6 linter: Bump TSDown to latest (#14198) (overlookmotel)
+- 983dd1b linter/plugins: Add `Fixer` type (#14180) (overlookmotel)
+- 2f8b076 linter/plugins: Remove dead code (#14178) (overlookmotel)
+- e69cd86 linter/plugins: `loadPluginImpl` return an object (#14087) (overlookmotel)
+
+### 📚 Documentation
+
+- b19f5bc linter/plugins: Improve JSDoc comments for `definePlugin` and `defineRule` (#14159) (overlookmotel)
+
+### ⚡ Performance
+
+- 2575065 linter/plugins: Store if rule is fixable as boolean (#14205) (overlookmotel)
+
+### 🧪 Testing
+
+- a9b603e linter/plugins: Convert all plugins in tests to TS (#14200) (overlookmotel)
+- 6ff3a23 linter/plugins: Add tests for `.ts`, `.mts`, `.cts` plugin files (#14164) (overlookmotel)
+- 8988d64 linter/plugins: Add line breaks to plugins files (#14181) (overlookmotel)
+- 52db331 linter/plugins: Type-check test fixtures (#14158) (overlookmotel)
+- aca083a linter/plugins: Include stderr output in snapshots (#14155) (overlookmotel)
+- a3c8f46 linter/plugins: Do not run `pnpm` in tests (#14157) (overlookmotel)
+- 0029b7f linter/plugins: Normalize line breaks in snapshots (#14154) (overlookmotel)
+- 7f2c101 linter/plugins: Specify path to `node` in tests (#14152) (overlookmotel)
+- fc14abc linter/plugins: Format test fixtures (#14125) (overlookmotel)
+- a6f965f linter/plugins: Simplify configs in test fixtures (#14124) (overlookmotel)
+- b1685f7 linter/plugins: Refactor tests (#14123) (overlookmotel)
+- 788e495 linter/plugins: Improve ESLint compat tests (#14119) (overlookmotel)
+- 5750077 linter/plugins: Fix file paths in snapshots (#14115) (overlookmotel)
+- 5c862f9 linter/plugins: Standardize test fixture structure (#14114) (overlookmotel)
+
+
 ## [1.18.0] - 2025-09-24
 
 ### 🐛 Bug Fixes

--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxlint"
-version = "1.18.0"
+version = "1.19.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "type": "module",
   "main": "dist/index.js",
   "bin": "dist/cli.js",

--- a/apps/oxlint/src-js/bindings.js
+++ b/apps/oxlint/src-js/bindings.js
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/android-arm64')
         const bindingPackageVersion = require('@oxlint/android-arm64/package.json').version
-        if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/android-arm-eabi')
         const bindingPackageVersion = require('@oxlint/android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -117,8 +117,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/win32-x64')
         const bindingPackageVersion = require('@oxlint/win32-x64/package.json').version
-        if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -133,8 +133,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/win32-ia32')
         const bindingPackageVersion = require('@oxlint/win32-ia32/package.json').version
-        if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -149,8 +149,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/win32-arm64')
         const bindingPackageVersion = require('@oxlint/win32-arm64/package.json').version
-        if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -168,8 +168,8 @@ function requireNative() {
     try {
       const binding = require('@oxlint/darwin-universal')
       const bindingPackageVersion = require('@oxlint/darwin-universal/package.json').version
-      if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -184,8 +184,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/darwin-x64')
         const bindingPackageVersion = require('@oxlint/darwin-x64/package.json').version
-        if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -200,8 +200,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/darwin-arm64')
         const bindingPackageVersion = require('@oxlint/darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -220,8 +220,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/freebsd-x64')
         const bindingPackageVersion = require('@oxlint/freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -236,8 +236,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/freebsd-arm64')
         const bindingPackageVersion = require('@oxlint/freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -257,8 +257,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-x64-musl')
           const bindingPackageVersion = require('@oxlint/linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -273,8 +273,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-x64-gnu')
           const bindingPackageVersion = require('@oxlint/linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-arm64-musl')
           const bindingPackageVersion = require('@oxlint/linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -307,8 +307,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-arm64-gnu')
           const bindingPackageVersion = require('@oxlint/linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-arm-musleabihf')
           const bindingPackageVersion = require('@oxlint/linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -341,8 +341,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-arm-gnueabihf')
           const bindingPackageVersion = require('@oxlint/linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-loong64-musl')
           const bindingPackageVersion = require('@oxlint/linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -375,8 +375,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-loong64-gnu')
           const bindingPackageVersion = require('@oxlint/linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-riscv64-musl')
           const bindingPackageVersion = require('@oxlint/linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -409,8 +409,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-riscv64-gnu')
           const bindingPackageVersion = require('@oxlint/linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -426,8 +426,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/linux-ppc64-gnu')
         const bindingPackageVersion = require('@oxlint/linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -442,8 +442,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/linux-s390x-gnu')
         const bindingPackageVersion = require('@oxlint/linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -462,8 +462,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/openharmony-arm64')
         const bindingPackageVersion = require('@oxlint/openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -478,8 +478,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/openharmony-x64')
         const bindingPackageVersion = require('@oxlint/openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -494,8 +494,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/openharmony-arm')
         const bindingPackageVersion = require('@oxlint/openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '1.18.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.18.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.19.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.19.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/crates/oxc_language_server/CHANGELOG.md
+++ b/crates/oxc_language_server/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.19.0] - 2025-09-29
+
+### 🚀 Features
+
+- 1472147 linter: Move `no-unused-expressions` to correctness (#14099) (camchenry)
+
+### 🐛 Bug Fixes
+
+- e37c435 language_server: Correct position for "ignore this rule for this file" in vue/astro/svelte files (#14187) (Sysix)
+- d36d227 language_server: Don't lint file on code action when it is already ignored (#13976) (Sysix)
+- 353bfe7 language_server: Check if tsconfig path is a file before starting the `LintService` (#14126) (Sysix)
+
+### 🚜 Refactor
+
+- 7a0eb57 language_server: Refactor ignore code action logic as a linter fix (#14183) (Sysix)
+
+### 📚 Documentation
+
+- b83b1bd language_server: Docs for `Backend` struct (#14172) (Sysix)
+- 3106ba0 language_server: Docs for `WorkspaceWorker` (#14161) (Sysix)
+
+### 🧪 Testing
+
+- be58d6d language_server: Fix test for ServerFormatter in windows (#14210) (Sysix)
+- d7041c1 language_server: Add linebreaks for formatter snapshot (#14173) (Sysix)
+
+
 
 ## [1.17.0] - 2025-09-23
 

--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_language_server"
-version = "1.18.0"
+version = "1.19.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_linter/CHANGELOG.md
+++ b/crates/oxc_linter/CHANGELOG.md
@@ -4,6 +4,54 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.19.0] - 2025-09-29
+
+### 🚀 Features
+
+- eb6345f linter/unicorn: Implement no-array-callback-reference (#14230) (camc314)
+- c64fa61 linter: Add `import/no-named-export` rule (#14229) (yefan)
+- d30159b linter: Fix for unsorted keys (#14225) (Hamir Mahal)
+- c0e461f linter: Add `unicorn/no-array-sort` rule (#14117) (Cason Kervis)
+- 00954de linter/plugins: Remove `--js-plugins` CLI option (#14134) (overlookmotel)
+- b4d716f linter/plugins: Move custom JS plugin config to `jsPlugins` (#14133) (overlookmotel)
+- 60f0b3f linter: Add fix for `preserve-caught-error` (#14104) (Cam McHenry)
+- 2d74c17 linter/no-multiple-resolved: Implement promise rule no-multiple-resolved (#13420) (Li Wei)
+- 5e05d1b semantic: Put jsdoc behind linter feature, remove runtime flag (#14140) (Boshen)
+- 71af1aa semantic: Add "linter" feature (#14139) (Boshen)
+- 1a6d7ae linter: Add `vue/max-props` rule (#14039) (yefan)
+- 9c3afea linter/plugins: Support fixes (#14094) (overlookmotel)
+- 1472147 linter: Move `no-unused-expressions` to correctness (#14099) (camchenry)
+- 8b7c784 linter: Add react/jsx-pascal-case rule (#12165) (Mikhail Baev)
+
+### 🐛 Bug Fixes
+
+- e045391 linter/plugins: Error on JS plugin with reserved name (#14226) (overlookmotel)
+- 6005015 linter: Correctly handle CRLF when inserting disable comments in framework files (#14228) (shulaoda)
+- e37c435 language_server: Correct position for "ignore this rule for this file" in vue/astro/svelte files (#14187) (Sysix)
+- 03d1684 linter/plugins: Output warning on first JS plugin load (#14165) (overlookmotel)
+- fc7026d linter: Add missing `NODE_TYPES`, `cfg_id` method for no-multiple-resolved (#14147) (camc314)
+- 180c790 linter: Fix false positive in `no-restricted-globals` (#14135) (yefan)
+- 9f3e2bc linter/plugins: Output errors thrown in JS plugins (#14096) (overlookmotel)
+- 357a2d3 linter: Add support for `tsgolint.exe` on Windows (#14101) (camchenry)
+- 2604b28 linter: Fix lint errors building `oxlint` (#14095) (overlookmotel)
+
+### 🚜 Refactor
+
+- 4c3f1ac linter: Move `BUILT_IN_ERRORS` to utils file (#14221) (camc314)
+- 7a0eb57 language_server: Refactor ignore code action logic as a linter fix (#14183) (Sysix)
+- 497236e semantic: Move AstNode::cfg_id to struct of arrays in AstNodes (#14137) (Boshen)
+- 5ba765c semantic: Move AstNode::flags to struct of arrays in AstNodes (#14136) (Boshen)
+- ffc810d linter: `preserve-caught-errors`: rename config and add docs (#14103) (camchenry)
+- f91db73 linter: Add `CompositeFix::merge_fixes_fallible` method (#14093) (overlookmotel)
+- e55ffe0 curly: Enhance curly brace rule configuration and handling (#13498) (Antoine Zanardi)
+- 2fb69fd eslint/eqeqeq: Clean up implementation and improve documentation (#13527) (Antoine Zanardi)
+
+### ⚡ Performance
+
+- b6d2546 linter: Reduce string cloning in tsgo fixes (#14092) (overlookmotel)
+- c94c5dc linter: Remove allocation in `CompositeFix::merge_fixes` (#14090) (overlookmotel)
+
+
 ## [1.18.0] - 2025-09-24
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_linter"
-version = "1.18.0"
+version = "1.19.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.19.0] - 2025-09-29
+
+### 🐛 Bug Fixes
+
+- f8abab2 editor: Stricter path validation for `oxc.path.server` (#14202) (Sysix)
+- d36d227 language_server: Don't lint file on code action when it is already ignored (#13976) (Sysix)
+
+### 🧪 Testing
+
+- d985aeb editor: Remove cross-module tests, covered by language server (#14156) (Sysix)
+
+
 
 ## [1.17.0] - 2025-09-23
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "oxc-vscode",
   "description": "oxc vscode extension",
   "license": "MIT",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "icon": "icon.png",
   "publisher": "oxc",
   "displayName": "Oxc",

--- a/npm/oxlint/CHANGELOG.md
+++ b/npm/oxlint/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.19.0] - 2025-09-29
+
+### 🚀 Features
+
+- b4d716f linter/plugins: Move custom JS plugin config to `jsPlugins` (#14133) (overlookmotel)
+
+### 🐛 Bug Fixes
+
+- 8879b5a linter/plugins: Add types export to `npm/oxlint` (#14219) (overlookmotel)
+
+
 
 ## [1.17.0] - 2025-09-23
 

--- a/npm/oxlint/package.json
+++ b/npm/oxlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "type": "module",
   "description": "Linter for the JavaScript Oxidation Compiler",
   "keywords": [],


### PR DESCRIPTION
## [1.19.0] - 2025-09-29

### 🚀 Features

- eb6345f linter/unicorn: Implement no-array-callback-reference (#14230) (camc314)
- c64fa61 linter: Add `import/no-named-export` rule (#14229) (yefan)
- d30159b linter: Fix for unsorted keys (#14225) (Hamir Mahal)
- acd1266 linter/plugins: `oxlint` export types (#14163) (overlookmotel)
- c0e461f linter: Add `unicorn/no-array-sort` rule (#14117) (Cason Kervis)
- 00954de linter/plugins: Remove `--js-plugins` CLI option (#14134) (overlookmotel)
- b4d716f linter/plugins: Move custom JS plugin config to `jsPlugins` (#14133) (overlookmotel)
- 60f0b3f linter: Add fix for `preserve-caught-error` (#14104) (Cam McHenry)
- 2d74c17 linter/no-multiple-resolved: Implement promise rule no-multiple-resolved (#13420) (Li Wei)
- 5e05d1b semantic: Put jsdoc behind linter feature, remove runtime flag (#14140) (Boshen)
- 71af1aa semantic: Add "linter" feature (#14139) (Boshen)
- 1a6d7ae linter: Add `vue/max-props` rule (#14039) (yefan)
- 9c3afea linter/plugins: Support fixes (#14094) (overlookmotel)
- 1472147 linter: Move `no-unused-expressions` to correctness (#14099) (camchenry)
- 8b7c784 linter: Add react/jsx-pascal-case rule (#12165) (Mikhail Baev)
- c796966 linter/plugins: Add `meta` property to rules (#14089) (overlookmotel)

### 🐛 Bug Fixes

- 39a171e linter: Get cli args on JS side, to avoid runtime inconsistencies (#14223) (camc314)
- e045391 linter/plugins: Error on JS plugin with reserved name (#14226) (overlookmotel)
- 6005015 linter: Correctly handle CRLF when inserting disable comments in framework files (#14228) (shulaoda)
- 37f6b09 linter/plugins: Make `null` a valid value for `meta.fixable` (#14204) (overlookmotel)
- 8879b5a linter/plugins: Add types export to `npm/oxlint` (#14219) (overlookmotel)
- e37c435 language_server: Correct position for "ignore this rule for this file" in vue/astro/svelte files (#14187) (Sysix)
- f8abab2 editor: Stricter path validation for `oxc.path.server` (#14202) (Sysix)
- e9a14d1 linter/plugins: Allow `fix` function to return `undefined` (#14182) (overlookmotel)
- ee9ecbe linter/plugins: Fix TS type for fixer methods (#14166) (overlookmotel)
- 03d1684 linter/plugins: Output warning on first JS plugin load (#14165) (overlookmotel)
- 9716f7c linter/plugins: Fix TS types (#14162) (overlookmotel)
- d36d227 language_server: Don't lint file on code action when it is already ignored (#13976) (Sysix)
- 353bfe7 language_server: Check if tsconfig path is a file before starting the `LintService` (#14126) (Sysix)
- fc7026d linter: Add missing `NODE_TYPES`, `cfg_id` method for no-multiple-resolved (#14147) (camc314)
- 180c790 linter: Fix false positive in `no-restricted-globals` (#14135) (yefan)
- 4a4fce8 linter: Fix cli argument parsing (#14112) (camc314)
- 9f3e2bc linter/plugins: Output errors thrown in JS plugins (#14096) (overlookmotel)
- 357a2d3 linter: Add support for `tsgolint.exe` on Windows (#14101) (camchenry)
- 2604b28 linter: Fix lint errors building `oxlint` (#14095) (overlookmotel)
- d8e9cc5 linter/plugins: Validate type of `before` and `after` hooks (#14086) (overlookmotel)

### 🚜 Refactor

- 4c3f1ac linter: Move `BUILT_IN_ERRORS` to utils file (#14221) (camc314)
- 61ec0a7 linter/plugins: Simplify creation of `context` in `defineRule` ESLint shim (#14206) (overlookmotel)
- 7a0eb57 language_server: Refactor ignore code action logic as a linter fix (#14183) (Sysix)
- 3b1fe6f linter/plugins: Flatten directory structure of `dist` (#14199) (overlookmotel)
- d52cba6 linter: Bump TSDown to latest (#14198) (overlookmotel)
- 983dd1b linter/plugins: Add `Fixer` type (#14180) (overlookmotel)
- 2f8b076 linter/plugins: Remove dead code (#14178) (overlookmotel)
- 497236e semantic: Move AstNode::cfg_id to struct of arrays in AstNodes (#14137) (Boshen)
- 5ba765c semantic: Move AstNode::flags to struct of arrays in AstNodes (#14136) (Boshen)
- ffc810d linter: `preserve-caught-errors`: rename config and add docs (#14103) (camchenry)
- f91db73 linter: Add `CompositeFix::merge_fixes_fallible` method (#14093) (overlookmotel)
- e55ffe0 curly: Enhance curly brace rule configuration and handling (#13498) (Antoine Zanardi)
- 2fb69fd eslint/eqeqeq: Clean up implementation and improve documentation (#13527) (Antoine Zanardi)
- e69cd86 linter/plugins: `loadPluginImpl` return an object (#14087) (overlookmotel)

### 📚 Documentation

- b83b1bd language_server: Docs for `Backend` struct (#14172) (Sysix)
- 3106ba0 language_server: Docs for `WorkspaceWorker` (#14161) (Sysix)
- b19f5bc linter/plugins: Improve JSDoc comments for `definePlugin` and `defineRule` (#14159) (overlookmotel)

### ⚡ Performance

- 2575065 linter/plugins: Store if rule is fixable as boolean (#14205) (overlookmotel)
- b6d2546 linter: Reduce string cloning in tsgo fixes (#14092) (overlookmotel)
- c94c5dc linter: Remove allocation in `CompositeFix::merge_fixes` (#14090) (overlookmotel)

### 🧪 Testing

- be58d6d language_server: Fix test for ServerFormatter in windows (#14210) (Sysix)
- a9b603e linter/plugins: Convert all plugins in tests to TS (#14200) (overlookmotel)
- 6ff3a23 linter/plugins: Add tests for `.ts`, `.mts`, `.cts` plugin files (#14164) (overlookmotel)
- 8988d64 linter/plugins: Add line breaks to plugins files (#14181) (overlookmotel)
- d7041c1 language_server: Add linebreaks for formatter snapshot (#14173) (Sysix)
- 52db331 linter/plugins: Type-check test fixtures (#14158) (overlookmotel)
- aca083a linter/plugins: Include stderr output in snapshots (#14155) (overlookmotel)
- a3c8f46 linter/plugins: Do not run `pnpm` in tests (#14157) (overlookmotel)
- d985aeb editor: Remove cross-module tests, covered by language server (#14156) (Sysix)
- 0029b7f linter/plugins: Normalize line breaks in snapshots (#14154) (overlookmotel)
- 7f2c101 linter/plugins: Specify path to `node` in tests (#14152) (overlookmotel)
- fc14abc linter/plugins: Format test fixtures (#14125) (overlookmotel)
- a6f965f linter/plugins: Simplify configs in test fixtures (#14124) (overlookmotel)
- b1685f7 linter/plugins: Refactor tests (#14123) (overlookmotel)
- 788e495 linter/plugins: Improve ESLint compat tests (#14119) (overlookmotel)
- 5750077 linter/plugins: Fix file paths in snapshots (#14115) (overlookmotel)
- 5c862f9 linter/plugins: Standardize test fixture structure (#14114) (overlookmotel)