### PR TITLE
feat(tasks/lint-rules): add `unicorn/no-named-default` to not supported rules

### DIFF
--- a/tasks/lint_rules/src/oxlint-rules.mjs
+++ b/tasks/lint_rules/src/oxlint-rules.mjs
@@ -58,6 +58,8 @@ const NOT_SUPPORTED_RULE_NAMES = new Set([
   'react/jsx-props-no-multi-spaces', // stylistic rule
   'unicorn/no-for-loop', // this rule suggest using `Array.prototype.entries` which is slow https://github.com/oxc-project/oxc/issues/11311, furthermore, `typescript/prefer-for-of` covers most cases
 
+  'unicorn/no-named-default', // implemented via import/no-named-default
+
   'regexp/no-invalid-regexp', // handled by eslint/no-invalid-regexp
   'regexp/no-useless-escape', // handled by eslint/no-useless-escape
   'regexp/no-useless-backreference', // handled by eslint/no-useless-backreference


### PR DESCRIPTION
this is already implemented via `import/no-named-default`