### PR TITLE
fix(napi/transform): fix define plugin not applying DCE correctly

### DIFF
--- a/crates/oxc/src/compiler.rs
+++ b/crates/oxc/src/compiler.rs
@@ -198,7 +198,7 @@ pub trait CompilerInterface {
                 Compressor::new(&allocator).dead_code_elimination_with_scoping(
                     &mut program,
                     scoping,
-                    CompressOptions::smallest(),
+                    CompressOptions::dce(),
                 );
             }
         }

--- a/napi/transform/test/transform.test.ts
+++ b/napi/transform/test/transform.test.ts
@@ -290,6 +290,16 @@ describe('define plugin', () => {
     // Replaced `undefined` with `void 0` by DCE.
     expect(ret.code).toEqual('new (void 0)();\n');
   });
+
+  it('keeps debugger', () => {
+    const code = 'Foo; debugger;';
+    const ret = transform('test.js', code, {
+      define: {
+        Foo: 'Bar',
+      },
+    });
+    expect(ret.code).toEqual('Bar;\ndebugger;\n');
+  });
 });
 
 describe('inject plugin', () => {


### PR DESCRIPTION
DCE options was using "smallest", hence `debugger` was removed.

fixes #14260