### PR TITLE
test(linter/plugins): test `createOnce` returning no visitor functions

### DIFF
--- a/apps/oxlint/test/fixtures/definePlugin/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/definePlugin/.oxlintrc.json
@@ -7,6 +7,7 @@
     "define-plugin-plugin/create-once-before-false": "error",
     "define-plugin-plugin/create-once-before-only": "error",
     "define-plugin-plugin/create-once-after-only": "error",
+    "define-plugin-plugin/create-once-hooks-only": "error",
     "define-plugin-plugin/create-once-no-hooks": "error"
   }
 }

--- a/apps/oxlint/test/fixtures/definePlugin/eslint.config.js
+++ b/apps/oxlint/test/fixtures/definePlugin/eslint.config.js
@@ -12,6 +12,7 @@ export default [
       'define-plugin-plugin/create-once-before-false': 'error',
       'define-plugin-plugin/create-once-before-only': 'error',
       'define-plugin-plugin/create-once-after-only': 'error',
+      'define-plugin-plugin/create-once-hooks-only': 'error',
       'define-plugin-plugin/create-once-no-hooks': 'error',
     },
   },

--- a/apps/oxlint/test/fixtures/definePlugin/eslint.snap.md
+++ b/apps/oxlint/test/fixtures/definePlugin/eslint.snap.md
@@ -14,11 +14,15 @@ filename: files/1.js  define-plugin-plugin/create-once
 filename: files/1.js                                               define-plugin-plugin/create-once-before-false
   0:1  error  before hook:
 filename: files/1.js                                               define-plugin-plugin/create-once-before-only
+  0:1  error  before hook:
+filename: files/1.js                                               define-plugin-plugin/create-once-hooks-only
   0:1  error  after hook:
 identNum: 2
 filename: files/1.js                                    define-plugin-plugin/create-once
   0:1  error  after hook:
 filename: files/1.js                                                define-plugin-plugin/create-once-after-only
+  0:1  error  after hook:
+filename: files/1.js                                                define-plugin-plugin/create-once-hooks-only
   1:5  error  ident visit fn "a":
 filename: files/1.js                                        define-plugin-plugin/create
   1:5  error  ident visit fn "a":
@@ -53,6 +57,8 @@ filename: files/2.js  define-plugin-plugin/create-once
 filename: files/2.js                                               define-plugin-plugin/create-once-before-false
   0:1  error  before hook:
 filename: files/2.js                                               define-plugin-plugin/create-once-before-only
+  0:1  error  before hook:
+filename: files/2.js                                               define-plugin-plugin/create-once-hooks-only
   0:1  error  after hook:
 identNum: 2
 filename: files/2.js                                    define-plugin-plugin/create-once
@@ -60,6 +66,8 @@ filename: files/2.js                                    define-plugin-plugin/cre
 filename: files/2.js                                                define-plugin-plugin/create-once-before-false
   0:1  error  after hook:
 filename: files/2.js                                                define-plugin-plugin/create-once-after-only
+  0:1  error  after hook:
+filename: files/2.js                                                define-plugin-plugin/create-once-hooks-only
   1:5  error  ident visit fn "c":
 filename: files/2.js                                        define-plugin-plugin/create
   1:5  error  ident visit fn "c":
@@ -87,7 +95,7 @@ filename: files/2.js                                        define-plugin-plugin
   1:8  error  ident visit fn "d":
 filename: files/2.js                                        define-plugin-plugin/create-once-no-hooks
 
-✖ 35 problems (35 errors, 0 warnings)
+✖ 39 problems (39 errors, 0 warnings)
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/definePlugin/output.snap.md
+++ b/apps/oxlint/test/fixtures/definePlugin/output.snap.md
@@ -48,6 +48,20 @@
    : ^
    `----
 
+  x define-plugin-plugin(create-once-hooks-only): before hook:
+  | filename: files/1.js
+   ,-[files/1.js:1:1]
+ 1 | let a, b;
+   : ^
+   `----
+
+  x define-plugin-plugin(create-once-hooks-only): after hook:
+  | filename: files/1.js
+   ,-[files/1.js:1:1]
+ 1 | let a, b;
+   : ^
+   `----
+
   x define-plugin-plugin(create): ident visit fn "a":
   | filename: files/1.js
    ,-[files/1.js:1:5]
@@ -172,6 +186,20 @@
    : ^
    `----
 
+  x define-plugin-plugin(create-once-hooks-only): before hook:
+  | filename: files/2.js
+   ,-[files/2.js:1:1]
+ 1 | let c, d;
+   : ^
+   `----
+
+  x define-plugin-plugin(create-once-hooks-only): after hook:
+  | filename: files/2.js
+   ,-[files/2.js:1:1]
+ 1 | let c, d;
+   : ^
+   `----
+
   x define-plugin-plugin(create): ident visit fn "c":
   | filename: files/2.js
    ,-[files/2.js:1:5]
@@ -258,7 +286,7 @@
    :        ^
    `----
 
-Found 0 warnings and 35 errors.
+Found 0 warnings and 39 errors.
 Finished in Xms on 2 files using X threads.
 ```
 

--- a/apps/oxlint/test/fixtures/definePlugin/plugin.ts
+++ b/apps/oxlint/test/fixtures/definePlugin/plugin.ts
@@ -139,7 +139,7 @@ const createOnceBeforeFalseRule: Rule = {
   },
 };
 
-// These 3 rules test that `createOnce` without `before` and `after` hooks works correctly.
+// These 4 rules test that `createOnce` without `before` and `after` hooks works correctly.
 
 const createOnceBeforeOnlyRule: Rule = {
   createOnce(context) {
@@ -183,6 +183,27 @@ const createOnceAfterOnlyRule: Rule = {
   },
 };
 
+const createOnceHooksOnlyRule: Rule = {
+  createOnce(context) {
+    return {
+      before() {
+        context.report({
+          message: 'before hook:\n' +
+            `filename: ${relativePath(context.filename)}`,
+          node: SPAN,
+        });
+      },
+      after() {
+        context.report({
+          message: 'after hook:\n' +
+            `filename: ${relativePath(context.filename)}`,
+          node: SPAN,
+        });
+      },
+    };
+  },
+};
+
 const createOnceNoHooksRule: Rule = {
   createOnce(context) {
     return {
@@ -207,6 +228,7 @@ export default definePlugin({
     'create-once-before-false': createOnceBeforeFalseRule,
     'create-once-before-only': createOnceBeforeOnlyRule,
     'create-once-after-only': createOnceAfterOnlyRule,
+    'create-once-hooks-only': createOnceHooksOnlyRule,
     'create-once-no-hooks': createOnceNoHooksRule,
   },
 });

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/.oxlintrc.json
@@ -7,6 +7,7 @@
     "define-plugin-and-rule-plugin/create-once-before-false": "error",
     "define-plugin-and-rule-plugin/create-once-before-only": "error",
     "define-plugin-and-rule-plugin/create-once-after-only": "error",
+    "define-plugin-and-rule-plugin/create-once-hooks-only": "error",
     "define-plugin-and-rule-plugin/create-once-no-hooks": "error"
   }
 }

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/eslint.config.js
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/eslint.config.js
@@ -12,6 +12,7 @@ export default [
       'define-plugin-and-rule-plugin/create-once-before-false': 'error',
       'define-plugin-and-rule-plugin/create-once-before-only': 'error',
       'define-plugin-and-rule-plugin/create-once-after-only': 'error',
+      'define-plugin-and-rule-plugin/create-once-hooks-only': 'error',
       'define-plugin-and-rule-plugin/create-once-no-hooks': 'error',
     },
   },

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/eslint.snap.md
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/eslint.snap.md
@@ -14,11 +14,15 @@ filename: files/1.js  define-plugin-and-rule-plugin/create-once
 filename: files/1.js                                               define-plugin-and-rule-plugin/create-once-before-false
   0:1  error  before hook:
 filename: files/1.js                                               define-plugin-and-rule-plugin/create-once-before-only
+  0:1  error  before hook:
+filename: files/1.js                                               define-plugin-and-rule-plugin/create-once-hooks-only
   0:1  error  after hook:
 identNum: 2
 filename: files/1.js                                    define-plugin-and-rule-plugin/create-once
   0:1  error  after hook:
 filename: files/1.js                                                define-plugin-and-rule-plugin/create-once-after-only
+  0:1  error  after hook:
+filename: files/1.js                                                define-plugin-and-rule-plugin/create-once-hooks-only
   1:5  error  ident visit fn "a":
 filename: files/1.js                                        define-plugin-and-rule-plugin/create
   1:5  error  ident visit fn "a":
@@ -53,6 +57,8 @@ filename: files/2.js  define-plugin-and-rule-plugin/create-once
 filename: files/2.js                                               define-plugin-and-rule-plugin/create-once-before-false
   0:1  error  before hook:
 filename: files/2.js                                               define-plugin-and-rule-plugin/create-once-before-only
+  0:1  error  before hook:
+filename: files/2.js                                               define-plugin-and-rule-plugin/create-once-hooks-only
   0:1  error  after hook:
 identNum: 2
 filename: files/2.js                                    define-plugin-and-rule-plugin/create-once
@@ -60,6 +66,8 @@ filename: files/2.js                                    define-plugin-and-rule-p
 filename: files/2.js                                                define-plugin-and-rule-plugin/create-once-before-false
   0:1  error  after hook:
 filename: files/2.js                                                define-plugin-and-rule-plugin/create-once-after-only
+  0:1  error  after hook:
+filename: files/2.js                                                define-plugin-and-rule-plugin/create-once-hooks-only
   1:5  error  ident visit fn "c":
 filename: files/2.js                                        define-plugin-and-rule-plugin/create
   1:5  error  ident visit fn "c":
@@ -87,7 +95,7 @@ filename: files/2.js                                        define-plugin-and-ru
   1:8  error  ident visit fn "d":
 filename: files/2.js                                        define-plugin-and-rule-plugin/create-once-no-hooks
 
-✖ 35 problems (35 errors, 0 warnings)
+✖ 39 problems (39 errors, 0 warnings)
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/output.snap.md
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/output.snap.md
@@ -48,6 +48,20 @@
    : ^
    `----
 
+  x define-plugin-and-rule-plugin(create-once-hooks-only): before hook:
+  | filename: files/1.js
+   ,-[files/1.js:1:1]
+ 1 | let a, b;
+   : ^
+   `----
+
+  x define-plugin-and-rule-plugin(create-once-hooks-only): after hook:
+  | filename: files/1.js
+   ,-[files/1.js:1:1]
+ 1 | let a, b;
+   : ^
+   `----
+
   x define-plugin-and-rule-plugin(create): ident visit fn "a":
   | filename: files/1.js
    ,-[files/1.js:1:5]
@@ -172,6 +186,20 @@
    : ^
    `----
 
+  x define-plugin-and-rule-plugin(create-once-hooks-only): before hook:
+  | filename: files/2.js
+   ,-[files/2.js:1:1]
+ 1 | let c, d;
+   : ^
+   `----
+
+  x define-plugin-and-rule-plugin(create-once-hooks-only): after hook:
+  | filename: files/2.js
+   ,-[files/2.js:1:1]
+ 1 | let c, d;
+   : ^
+   `----
+
   x define-plugin-and-rule-plugin(create): ident visit fn "c":
   | filename: files/2.js
    ,-[files/2.js:1:5]
@@ -258,7 +286,7 @@
    :        ^
    `----
 
-Found 0 warnings and 35 errors.
+Found 0 warnings and 39 errors.
 Finished in Xms on 2 files using X threads.
 ```
 

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/plugin.ts
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/plugin.ts
@@ -137,7 +137,7 @@ const createOnceBeforeFalseRule = defineRule({
   },
 });
 
-// These 3 rules test that `createOnce` without `before` and `after` hooks works correctly.
+// These 4 rules test that `createOnce` without `before` and `after` hooks works correctly.
 
 const createOnceBeforeOnlyRule = defineRule({
   createOnce(context) {
@@ -181,6 +181,27 @@ const createOnceAfterOnlyRule = defineRule({
   },
 });
 
+const createOnceHooksOnlyRule = defineRule({
+  createOnce(context) {
+    return {
+      before() {
+        context.report({
+          message: 'before hook:\n' +
+            `filename: ${relativePath(context.filename)}`,
+          node: SPAN,
+        });
+      },
+      after() {
+        context.report({
+          message: 'after hook:\n' +
+            `filename: ${relativePath(context.filename)}`,
+          node: SPAN,
+        });
+      },
+    };
+  },
+});
+
 const createOnceNoHooksRule = defineRule({
   createOnce(context) {
     return {
@@ -205,6 +226,7 @@ export default definePlugin({
     'create-once-before-false': createOnceBeforeFalseRule,
     'create-once-before-only': createOnceBeforeOnlyRule,
     'create-once-after-only': createOnceAfterOnlyRule,
+    'create-once-hooks-only': createOnceHooksOnlyRule,
     'create-once-no-hooks': createOnceNoHooksRule,
   },
 });

--- a/apps/oxlint/test/fixtures/defineRule/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/defineRule/.oxlintrc.json
@@ -7,6 +7,7 @@
     "define-rule-plugin/create-once-before-false": "error",
     "define-rule-plugin/create-once-before-only": "error",
     "define-rule-plugin/create-once-after-only": "error",
+    "define-rule-plugin/create-once-hooks-only": "error",
     "define-rule-plugin/create-once-no-hooks": "error"
   }
 }

--- a/apps/oxlint/test/fixtures/defineRule/eslint.config.js
+++ b/apps/oxlint/test/fixtures/defineRule/eslint.config.js
@@ -12,6 +12,7 @@ export default [
       'define-rule-plugin/create-once-before-false': 'error',
       'define-rule-plugin/create-once-before-only': 'error',
       'define-rule-plugin/create-once-after-only': 'error',
+      'define-rule-plugin/create-once-hooks-only': 'error',
       'define-rule-plugin/create-once-no-hooks': 'error',
     },
   },

--- a/apps/oxlint/test/fixtures/defineRule/eslint.snap.md
+++ b/apps/oxlint/test/fixtures/defineRule/eslint.snap.md
@@ -14,11 +14,15 @@ filename: files/1.js  define-rule-plugin/create-once
 filename: files/1.js                                               define-rule-plugin/create-once-before-false
   0:1  error  before hook:
 filename: files/1.js                                               define-rule-plugin/create-once-before-only
+  0:1  error  before hook:
+filename: files/1.js                                               define-rule-plugin/create-once-hooks-only
   0:1  error  after hook:
 identNum: 2
 filename: files/1.js                                    define-rule-plugin/create-once
   0:1  error  after hook:
 filename: files/1.js                                                define-rule-plugin/create-once-after-only
+  0:1  error  after hook:
+filename: files/1.js                                                define-rule-plugin/create-once-hooks-only
   1:5  error  ident visit fn "a":
 filename: files/1.js                                        define-rule-plugin/create
   1:5  error  ident visit fn "a":
@@ -53,6 +57,8 @@ filename: files/2.js  define-rule-plugin/create-once
 filename: files/2.js                                               define-rule-plugin/create-once-before-false
   0:1  error  before hook:
 filename: files/2.js                                               define-rule-plugin/create-once-before-only
+  0:1  error  before hook:
+filename: files/2.js                                               define-rule-plugin/create-once-hooks-only
   0:1  error  after hook:
 identNum: 2
 filename: files/2.js                                    define-rule-plugin/create-once
@@ -60,6 +66,8 @@ filename: files/2.js                                    define-rule-plugin/creat
 filename: files/2.js                                                define-rule-plugin/create-once-before-false
   0:1  error  after hook:
 filename: files/2.js                                                define-rule-plugin/create-once-after-only
+  0:1  error  after hook:
+filename: files/2.js                                                define-rule-plugin/create-once-hooks-only
   1:5  error  ident visit fn "c":
 filename: files/2.js                                        define-rule-plugin/create
   1:5  error  ident visit fn "c":
@@ -87,7 +95,7 @@ filename: files/2.js                                        define-rule-plugin/c
   1:8  error  ident visit fn "d":
 filename: files/2.js                                        define-rule-plugin/create-once-no-hooks
 
-✖ 35 problems (35 errors, 0 warnings)
+✖ 39 problems (39 errors, 0 warnings)
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/defineRule/output.snap.md
+++ b/apps/oxlint/test/fixtures/defineRule/output.snap.md
@@ -48,6 +48,20 @@
    : ^
    `----
 
+  x define-rule-plugin(create-once-hooks-only): before hook:
+  | filename: files/1.js
+   ,-[files/1.js:1:1]
+ 1 | let a, b;
+   : ^
+   `----
+
+  x define-rule-plugin(create-once-hooks-only): after hook:
+  | filename: files/1.js
+   ,-[files/1.js:1:1]
+ 1 | let a, b;
+   : ^
+   `----
+
   x define-rule-plugin(create): ident visit fn "a":
   | filename: files/1.js
    ,-[files/1.js:1:5]
@@ -172,6 +186,20 @@
    : ^
    `----
 
+  x define-rule-plugin(create-once-hooks-only): before hook:
+  | filename: files/2.js
+   ,-[files/2.js:1:1]
+ 1 | let c, d;
+   : ^
+   `----
+
+  x define-rule-plugin(create-once-hooks-only): after hook:
+  | filename: files/2.js
+   ,-[files/2.js:1:1]
+ 1 | let c, d;
+   : ^
+   `----
+
   x define-rule-plugin(create): ident visit fn "c":
   | filename: files/2.js
    ,-[files/2.js:1:5]
@@ -258,7 +286,7 @@
    :        ^
    `----
 
-Found 0 warnings and 35 errors.
+Found 0 warnings and 39 errors.
 Finished in Xms on 2 files using X threads.
 ```
 

--- a/apps/oxlint/test/fixtures/defineRule/plugin.ts
+++ b/apps/oxlint/test/fixtures/defineRule/plugin.ts
@@ -137,7 +137,7 @@ const createOnceBeforeFalseRule = defineRule({
   },
 });
 
-// These 3 rules test that `createOnce` without `before` and `after` hooks works correctly.
+// These 4 rules test that `createOnce` without `before` and `after` hooks works correctly.
 
 const createOnceBeforeOnlyRule = defineRule({
   createOnce(context) {
@@ -181,6 +181,27 @@ const createOnceAfterOnlyRule = defineRule({
   },
 });
 
+const createOnceHooksOnlyRule = defineRule({
+  createOnce(context) {
+    return {
+      before() {
+        context.report({
+          message: 'before hook:\n' +
+            `filename: ${relativePath(context.filename)}`,
+          node: SPAN,
+        });
+      },
+      after() {
+        context.report({
+          message: 'after hook:\n' +
+            `filename: ${relativePath(context.filename)}`,
+          node: SPAN,
+        });
+      },
+    };
+  },
+});
+
 const createOnceNoHooksRule = defineRule({
   createOnce(context) {
     return {
@@ -205,6 +226,7 @@ export default {
     'create-once-before-false': createOnceBeforeFalseRule,
     'create-once-before-only': createOnceBeforeOnlyRule,
     'create-once-after-only': createOnceAfterOnlyRule,
+    'create-once-hooks-only': createOnceHooksOnlyRule,
     'create-once-no-hooks': createOnceNoHooksRule,
   },
 };


### PR DESCRIPTION
Add a test to make sure `createOnce` can return an object with only `before` and `after` hooks (no visitor functions) and that both hooks are called for each file in this case.