### PR TITLE
refactor(linter/plugins): convert `Node` type to interface

### DIFF
--- a/apps/oxlint/src-js/index.ts
+++ b/apps/oxlint/src-js/index.ts
@@ -5,7 +5,7 @@ import type { BeforeHook, Visitor, VisitorWithHooks } from './plugins/types.ts';
 export type { Context, Diagnostic } from './plugins/context.ts';
 export type { Fix, Fixer, FixFn, NodeOrToken, Range } from './plugins/fix.ts';
 export type { CreateOnceRule, CreateRule, Plugin, Rule } from './plugins/load.ts';
-export type { AfterHook, BeforeHook, RuleMeta, Visitor, VisitorWithHooks } from './plugins/types.ts';
+export type { AfterHook, BeforeHook, Node, RuleMeta, Visitor, VisitorWithHooks } from './plugins/types.ts';
 
 const { defineProperty, getPrototypeOf, hasOwn, setPrototypeOf, create: ObjectCreate } = Object;
 

--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -1,14 +1,12 @@
 import { getFixes } from './fix.js';
 
 import type { Fix, FixFn } from './fix.ts';
+import type { Node } from './types.ts';
 
 // Diagnostic in form passed by user to `Context#report()`
 export interface Diagnostic {
   message: string;
-  node: {
-    start: number;
-    end: number;
-  };
+  node: Node;
   fix?: FixFn;
 }
 

--- a/apps/oxlint/src-js/plugins/fix.ts
+++ b/apps/oxlint/src-js/plugins/fix.ts
@@ -1,6 +1,7 @@
 import { assertIs } from './utils.js';
 
 import type { Diagnostic, InternalContext } from './context.ts';
+import type { Node } from './types.ts';
 
 const { prototype: ArrayPrototype, from: ArrayFrom } = Array,
   { getPrototypeOf, hasOwn, prototype: ObjectPrototype } = Object,
@@ -20,10 +21,7 @@ export type Fix = { range: Range; text: string };
 export type Range = [number, number];
 
 // Currently we only support `Node`s, but will add support for `Token`s later
-export interface NodeOrToken {
-  start: number;
-  end: number;
-}
+export type NodeOrToken = Node;
 
 // Fixer, passed as argument to `fix` function passed to `Context#report()`.
 //

--- a/apps/oxlint/src-js/plugins/types.ts
+++ b/apps/oxlint/src-js/plugins/types.ts
@@ -26,8 +26,10 @@ export interface VisitorWithHooks extends Visitor {
 export type VisitFn = (node: Node) => void;
 
 // AST node type.
-// We'll make this type a union later on.
-export type Node = { type: string; start: number; end: number; [key: string]: unknown };
+export interface Node {
+  start: number;
+  end: number;
+}
 
 // Element of compiled visitor array.
 // * `VisitFn | null` for leaf nodes.


### PR DESCRIPTION
Make `Node` type an `interface Node` instead of `type Node`. We can then use it in more places.