### PR TITLE
perf(linter/plugins): use singleton for `SourceCode`

### DIFF
--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -6,6 +6,7 @@ import {
 } from '../generated/constants.js';
 import { diagnostics, setupContextForFile } from './context.js';
 import { registeredRules } from './load.js';
+import { resetSource, setupSourceForFile } from './source_code.js';
 import { assertIs, getErrorMessage } from './utils.js';
 import { addVisitorToCompiled, compiledVisitor, finalizeCompiledVisitor, initCompiledVisitor } from './visitor.js';
 
@@ -111,6 +112,9 @@ function lintFileImpl(filePath: string, bufferId: number, buffer: Uint8Array | n
 
   const sourceText = textDecoder.decode(buffer.subarray(0, sourceByteLen));
 
+  const hasBOM = false; // TODO: Set this correctly
+  setupSourceForFile(sourceText, hasBOM);
+
   // Get visitors for this file from all rules
   initCompiledVisitor();
 
@@ -118,7 +122,7 @@ function lintFileImpl(filePath: string, bufferId: number, buffer: Uint8Array | n
     const ruleId = ruleIds[i],
       ruleAndContext = registeredRules[ruleId];
     const { rule, context } = ruleAndContext;
-    setupContextForFile(context, i, filePath, sourceText);
+    setupContextForFile(context, i, filePath);
 
     let { visitor } = ruleAndContext;
     if (visitor === null) {
@@ -175,4 +179,7 @@ function lintFileImpl(filePath: string, bufferId: number, buffer: Uint8Array | n
     // Reset array, ready for next file
     afterHooks.length = 0;
   }
+
+  // Reset source, to free memory
+  resetSource();
 }

--- a/apps/oxlint/test/fixtures/sourceCode/output.snap.md
+++ b/apps/oxlint/test/fixtures/sourceCode/output.snap.md
@@ -4,8 +4,8 @@
 # stdout
 ```
   x source-code-plugin(create): create:
-  | sourceCode.text: "let foo, bar;\n"
-  | sourceCode.getText(): "let foo, bar;\n"
+  | text: "let foo, bar;\n"
+  | getText(): "let foo, bar;\n"
    ,-[files/1.js:1:1]
  1 | let foo, bar;
    : ^
@@ -19,8 +19,8 @@
    `----
 
   x source-code-plugin(create-once): before:
-  | sourceCode.text: "let foo, bar;\n"
-  | sourceCode.getText(): "let foo, bar;\n"
+  | text: "let foo, bar;\n"
+  | getText(): "let foo, bar;\n"
    ,-[files/1.js:1:1]
  1 | let foo, bar;
    : ^
@@ -81,8 +81,8 @@
    `----
 
   x source-code-plugin(create): create:
-  | sourceCode.text: "let qux;\n"
-  | sourceCode.getText(): "let qux;\n"
+  | text: "let qux;\n"
+  | getText(): "let qux;\n"
    ,-[files/2.js:1:1]
  1 | let qux;
    : ^
@@ -96,8 +96,8 @@
    `----
 
   x source-code-plugin(create-once): before:
-  | sourceCode.text: "let qux;\n"
-  | sourceCode.getText(): "let qux;\n"
+  | text: "let qux;\n"
+  | getText(): "let qux;\n"
    ,-[files/2.js:1:1]
  1 | let qux;
    : ^

--- a/apps/oxlint/test/fixtures/sourceCode/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode/plugin.ts
@@ -6,8 +6,8 @@ const createRule: Rule = {
   create(context) {
     context.report({
       message: 'create:\n' +
-        `sourceCode.text: ${JSON.stringify(context.sourceCode.text)}\n` +
-        `sourceCode.getText(): ${JSON.stringify(context.sourceCode.getText())}`,
+        `text: ${JSON.stringify(context.sourceCode.text)}\n` +
+        `getText(): ${JSON.stringify(context.sourceCode.getText())}`,
       node: SPAN,
     });
 
@@ -38,8 +38,8 @@ const createOnceRule: Rule = {
       before() {
         context.report({
           message: 'before:\n' +
-            `sourceCode.text: ${JSON.stringify(context.sourceCode.text)}\n` +
-            `sourceCode.getText(): ${JSON.stringify(context.sourceCode.getText())}`,
+            `text: ${JSON.stringify(context.sourceCode.text)}\n` +
+            `getText(): ${JSON.stringify(context.sourceCode.getText())}`,
           node: SPAN,
         });
       },


### PR DESCRIPTION
Only 1 file is linted at a time, so it's unnecessary for each rule to have its own instance of `SourceCode`. Replace `SourceCode` class with a singleton object `SOURCE_CODE` which is reused for all rules, on all files.