### PR TITLE
feat(linter/plugins): implement `SourceCode#ast` property

### DIFF
--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -112,8 +112,13 @@ function lintFileImpl(filePath: string, bufferId: number, buffer: Uint8Array | n
 
   const sourceText = textDecoder.decode(buffer.subarray(0, sourceByteLen));
 
+  // Deserialize AST from buffer.
+  // `preserveParens` argument is `false`, to match ESLint.
+  // ESLint does not include `ParenthesizedExpression` nodes in its AST.
+  const program = deserializeProgramOnly(buffer, sourceText, sourceByteLen, false);
+
   const hasBOM = false; // TODO: Set this correctly
-  setupSourceForFile(sourceText, hasBOM);
+  setupSourceForFile(sourceText, hasBOM, program);
 
   // Get visitors for this file from all rules
   initCompiledVisitor();
@@ -150,9 +155,6 @@ function lintFileImpl(filePath: string, bufferId: number, buffer: Uint8Array | n
   // Some rules seen in the wild return an empty visitor object from `create` if some initial check fails
   // e.g. file extension is not one the rule acts on.
   if (needsVisit) {
-    // `preserveParens` argument is `false`, to match ESLint.
-    // ESLint does not include `ParenthesizedExpression` nodes in its AST.
-    const program = deserializeProgramOnly(buffer, sourceText, sourceByteLen, false);
     walkProgram(program, compiledVisitor);
 
     // Lazy implementation

--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -9,15 +9,19 @@ const { max } = Math;
 let sourceText: string | null = null;
 // Set before linting each file by `setupSourceForFile`.
 let hasBOM = false;
+// Set before linting each file by `setupSourceForFile`.
+let ast: Program | null = null;
 
 /**
  * Set up source for the file about to be linted.
  * @param sourceTextInput - Source text
  * @param hasBOMInput - `true` if file's original source text has Unicode BOM
+ * @param astInput - The AST program for the file
  */
-export function setupSourceForFile(sourceTextInput: string, hasBOMInput: boolean): void {
+export function setupSourceForFile(sourceTextInput: string, hasBOMInput: boolean, astInput: Program): void {
   sourceText = sourceTextInput;
   hasBOM = hasBOMInput;
+  ast = astInput;
 }
 
 /**
@@ -25,6 +29,7 @@ export function setupSourceForFile(sourceTextInput: string, hasBOMInput: boolean
  */
 export function resetSource(): void {
   sourceText = null;
+  ast = null;
 }
 
 // `SourceCode` object.
@@ -49,7 +54,7 @@ export const SOURCE_CODE = Object.freeze({
 
   // Get AST of the file.
   get ast(): Program {
-    throw new Error('`sourceCode.ast` not implemented yet'); // TODO
+    return ast;
   },
 
   // Get `ScopeManager` for the file.

--- a/apps/oxlint/test/fixtures/sourceCode/output.snap.md
+++ b/apps/oxlint/test/fixtures/sourceCode/output.snap.md
@@ -6,6 +6,7 @@
   x source-code-plugin(create): create:
   | text: "let foo, bar;\n"
   | getText(): "let foo, bar;\n"
+  | ast: "foo"
    ,-[files/1.js:1:1]
  1 | let foo, bar;
    : ^
@@ -21,6 +22,7 @@
   x source-code-plugin(create-once): before:
   | text: "let foo, bar;\n"
   | getText(): "let foo, bar;\n"
+  | ast: "foo"
    ,-[files/1.js:1:1]
  1 | let foo, bar;
    : ^
@@ -83,6 +85,7 @@
   x source-code-plugin(create): create:
   | text: "let qux;\n"
   | getText(): "let qux;\n"
+  | ast: "qux"
    ,-[files/2.js:1:1]
  1 | let qux;
    : ^
@@ -98,6 +101,7 @@
   x source-code-plugin(create-once): before:
   | text: "let qux;\n"
   | getText(): "let qux;\n"
+  | ast: "qux"
    ,-[files/2.js:1:1]
  1 | let qux;
    : ^


### PR DESCRIPTION
Add support for obtaining the AST via `context.sourceCode.ast`.