### PR TITLE
feat(linter/plugins): implement `SourceCode#visitorKeys` property

### DIFF
--- a/apps/oxlint/scripts/build.js
+++ b/apps/oxlint/scripts/build.js
@@ -33,6 +33,7 @@ const parserFilePaths = [
   'generated/lazy/walk.js',
   */
   'generated/deserialize/ts.js',
+  'generated/visit/keys.js',
   'generated/visit/types.js',
   'generated/visit/visitor.d.ts',
   'generated/visit/walk.js',

--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module';
 import {
   DATA_POINTER_POS_32,
   SOURCE_LEN_OFFSET,
@@ -10,6 +11,8 @@ import { deserializeProgramOnly } from '../../dist/generated/deserialize/ts.js';
 import type { Program } from '@oxc-project/types';
 import type { Scope, ScopeManager, Variable } from './scope.ts';
 import type { BufferWithArrays, Comment, LineColumn, Node, NodeOrToken, Token } from './types.ts';
+
+const require = createRequire(import.meta.url);
 
 const { max } = Math;
 
@@ -27,6 +30,9 @@ let hasBOM = false;
 let sourceText: string | null = null;
 let sourceByteLen: number = 0;
 let ast: Program | null = null;
+
+// Lazily populated when `SOURCE_CODE.visitorKeys` is accessed.
+let visitorKeys: { [key: string]: string[] } | null = null;
 
 /**
  * Set up source for the file about to be linted.
@@ -118,7 +124,9 @@ export const SOURCE_CODE = Object.freeze({
 
   // Get visitor keys to traverse this AST.
   get visitorKeys(): { [key: string]: string[] } {
-    throw new Error('`sourceCode.visitorKeys` not implemented yet'); // TODO
+    // This is the path relative to `plugins.js` file in `dist` directory
+    if (visitorKeys === null) visitorKeys = require('./generated/visit/keys.js').default;
+    return visitorKeys;
   },
 
   // Get parser services for the file.

--- a/apps/oxlint/test/fixtures/sourceCode/output.snap.md
+++ b/apps/oxlint/test/fixtures/sourceCode/output.snap.md
@@ -7,6 +7,7 @@
   | text: "let foo, bar;\n"
   | getText(): "let foo, bar;\n"
   | ast: "foo"
+  | visitorKeys: left, right
    ,-[files/1.js:1:1]
  1 | let foo, bar;
    : ^
@@ -23,6 +24,7 @@
   | text: "let foo, bar;\n"
   | getText(): "let foo, bar;\n"
   | ast: "foo"
+  | visitorKeys: left, right
    ,-[files/1.js:1:1]
  1 | let foo, bar;
    : ^
@@ -86,6 +88,7 @@
   | text: "let qux;\n"
   | getText(): "let qux;\n"
   | ast: "qux"
+  | visitorKeys: left, right
    ,-[files/2.js:1:1]
  1 | let qux;
    : ^
@@ -102,6 +105,7 @@
   | text: "let qux;\n"
   | getText(): "let qux;\n"
   | ast: "qux"
+  | visitorKeys: left, right
    ,-[files/2.js:1:1]
  1 | let qux;
    : ^

--- a/apps/oxlint/test/fixtures/sourceCode/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode/plugin.ts
@@ -14,7 +14,8 @@ const createRule: Rule = {
         `text: ${JSON.stringify(context.sourceCode.text)}\n` +
         `getText(): ${JSON.stringify(context.sourceCode.getText())}\n` +
         // @ts-ignore
-        `ast: "${ast.body[0].declarations[0].id.name}"`,
+        `ast: "${ast.body[0].declarations[0].id.name}"\n` +
+        `visitorKeys: ${context.sourceCode.visitorKeys.BinaryExpression.join(', ')}`,
       node: SPAN,
     });
 
@@ -55,7 +56,8 @@ const createOnceRule: Rule = {
             `text: ${JSON.stringify(context.sourceCode.text)}\n` +
             `getText(): ${JSON.stringify(context.sourceCode.getText())}\n` +
             // @ts-ignore
-            `ast: "${ast.body[0].declarations[0].id.name}"`,
+            `ast: "${ast.body[0].declarations[0].id.name}"\n` +
+            `visitorKeys: ${context.sourceCode.visitorKeys.BinaryExpression.join(', ')}`,
           node: SPAN,
         });
       },


### PR DESCRIPTION
Add support for obtaining visitor keys for AST via `context.sourceCode.visitorKeys`.