### PR TITLE
feat(linter/plugins): implement `SourceCode#lines` property

### DIFF
--- a/apps/oxlint/test/fixtures/sourceCode/files/1.js
+++ b/apps/oxlint/test/fixtures/sourceCode/files/1.js
@@ -1,1 +1,4 @@
 let foo, bar;
+
+// x
+// y

--- a/apps/oxlint/test/fixtures/sourceCode/output.snap.md
+++ b/apps/oxlint/test/fixtures/sourceCode/output.snap.md
@@ -4,30 +4,35 @@
 # stdout
 ```
   x source-code-plugin(create): create:
-  | text: "let foo, bar;\n"
-  | getText(): "let foo, bar;\n"
+  | text: "let foo, bar;\n\n// x\n// y\n"
+  | getText(): "let foo, bar;\n\n// x\n// y\n"
+  | lines: ["let foo, bar;","","// x","// y",""]
   | ast: "foo"
   | visitorKeys: left, right
    ,-[files/1.js:1:1]
  1 | let foo, bar;
    : ^
+ 2 | 
    `----
 
   x source-code-plugin(create-once): after:
-  | source: "let foo, bar;\n"
+  | source: "let foo, bar;\n\n// x\n// y\n"
    ,-[files/1.js:1:1]
  1 | let foo, bar;
    : ^
+ 2 | 
    `----
 
   x source-code-plugin(create-once): before:
-  | text: "let foo, bar;\n"
-  | getText(): "let foo, bar;\n"
+  | text: "let foo, bar;\n\n// x\n// y\n"
+  | getText(): "let foo, bar;\n\n// x\n// y\n"
+  | lines: ["let foo, bar;","","// x","// y",""]
   | ast: "foo"
   | visitorKeys: left, right
    ,-[files/1.js:1:1]
  1 | let foo, bar;
    : ^
+ 2 | 
    `----
 
   x source-code-plugin(create): var decl:
@@ -35,6 +40,7 @@
    ,-[files/1.js:1:1]
  1 | let foo, bar;
    : ^^^^^^^^^^^^^
+ 2 | 
    `----
 
   x source-code-plugin(create-once): var decl:
@@ -42,6 +48,7 @@
    ,-[files/1.js:1:1]
  1 | let foo, bar;
    : ^^^^^^^^^^^^^
+ 2 | 
    `----
 
   x source-code-plugin(create): ident "foo":
@@ -52,6 +59,7 @@
    ,-[files/1.js:1:5]
  1 | let foo, bar;
    :     ^^^
+ 2 | 
    `----
 
   x source-code-plugin(create-once): ident "foo":
@@ -62,6 +70,7 @@
    ,-[files/1.js:1:5]
  1 | let foo, bar;
    :     ^^^
+ 2 | 
    `----
 
   x source-code-plugin(create): ident "bar":
@@ -72,6 +81,7 @@
    ,-[files/1.js:1:10]
  1 | let foo, bar;
    :          ^^^
+ 2 | 
    `----
 
   x source-code-plugin(create-once): ident "bar":
@@ -82,11 +92,13 @@
    ,-[files/1.js:1:10]
  1 | let foo, bar;
    :          ^^^
+ 2 | 
    `----
 
   x source-code-plugin(create): create:
   | text: "let qux;\n"
   | getText(): "let qux;\n"
+  | lines: ["let qux;",""]
   | ast: "qux"
   | visitorKeys: left, right
    ,-[files/2.js:1:1]
@@ -104,6 +116,7 @@
   x source-code-plugin(create-once): before:
   | text: "let qux;\n"
   | getText(): "let qux;\n"
+  | lines: ["let qux;",""]
   | ast: "qux"
   | visitorKeys: left, right
    ,-[files/2.js:1:1]

--- a/apps/oxlint/test/fixtures/sourceCode/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode/plugin.ts
@@ -13,6 +13,7 @@ const createRule: Rule = {
       message: 'create:\n' +
         `text: ${JSON.stringify(context.sourceCode.text)}\n` +
         `getText(): ${JSON.stringify(context.sourceCode.getText())}\n` +
+        `lines: ${JSON.stringify(context.sourceCode.lines)}\n` +
         // @ts-ignore
         `ast: "${ast.body[0].declarations[0].id.name}"\n` +
         `visitorKeys: ${context.sourceCode.visitorKeys.BinaryExpression.join(', ')}`,
@@ -55,6 +56,7 @@ const createOnceRule: Rule = {
           message: 'before:\n' +
             `text: ${JSON.stringify(context.sourceCode.text)}\n` +
             `getText(): ${JSON.stringify(context.sourceCode.getText())}\n` +
+            `lines: ${JSON.stringify(context.sourceCode.lines)}\n` +
             // @ts-ignore
             `ast: "${ast.body[0].declarations[0].id.name}"\n` +
             `visitorKeys: ${context.sourceCode.visitorKeys.BinaryExpression.join(', ')}`,


### PR DESCRIPTION
Add support for obtaining source text split into lines via `context.sourceCode.lines`.