### PR TITLE
feat(formatter/sort-imports): Add options.order: asc|desc

### DIFF
--- a/crates/oxc_formatter/src/ir_transform/sort_imports.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports.rs
@@ -171,7 +171,10 @@ impl SortImportsTransform {
                     if 1 < import_units.len() {
                         // TODO: Sort based on `options.groups`, `options.type`, etc...
                         // TODO: Consider `options.ignore_case`, `special_characters`, removing `?raw`, etc...
-                        import_units.sort_by_key(|unit| unit.get_source(prev_elements));
+                        import_units.sort_by(|a, b| {
+                            let ord = a.get_source(prev_elements).cmp(b.get_source(prev_elements));
+                            if self.options.order.is_desc() { ord.reverse() } else { ord }
+                        });
                     }
 
                     let preserve_empty_line = self.options.partition_by_newline;

--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -915,12 +915,57 @@ impl fmt::Display for OperatorPosition {
     }
 }
 
+// ---
+
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct SortImports {
+    /// Sort order (asc or desc).
+    pub order: SortOrder,
     /// Partition imports by newlines.
     pub partition_by_newline: bool,
     /// Partition imports by comments.
     pub partition_by_comment: bool,
     /// Sort side effects imports.
     pub sort_side_effects: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub enum SortOrder {
+    /// Sort in ascending order (A-Z).
+    #[default]
+    Asc,
+    /// Sort in descending order (Z-A).
+    Desc,
+}
+
+impl SortOrder {
+    pub const fn is_asc(self) -> bool {
+        matches!(self, Self::Asc)
+    }
+
+    pub const fn is_desc(self) -> bool {
+        matches!(self, Self::Desc)
+    }
+}
+
+impl FromStr for SortOrder {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "asc" => Ok(Self::Asc),
+            "desc" => Ok(Self::Desc),
+            _ => Err("Value not supported for SortOrder. Supported values are 'asc' and 'desc'."),
+        }
+    }
+}
+
+impl fmt::Display for SortOrder {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let s = match self {
+            SortOrder::Asc => "ASC",
+            SortOrder::Desc => "DESC",
+        };
+        f.write_str(s)
+    }
 }

--- a/crates/oxc_formatter/tests/ir_transform/sort_imports.rs
+++ b/crates/oxc_formatter/tests/ir_transform/sort_imports.rs
@@ -1,5 +1,5 @@
 use super::assert_format;
-use oxc_formatter::{FormatOptions, QuoteStyle, Semicolons, SortImports};
+use oxc_formatter::{FormatOptions, QuoteStyle, Semicolons, SortImports, SortOrder};
 
 #[test]
 fn should_not_sort_by_default() {
@@ -654,6 +654,56 @@ import C from "c";
 
 import A from "a";
 import B from "b";
+"#,
+    );
+}
+
+// ---
+
+#[test]
+fn should_sort_by_order() {
+    // Z-A
+    assert_format(
+        r#"
+import { log } from "./log";
+import { log10 } from "./log10";
+import { log1p } from "./log1p";
+import { log2 } from "./log2";
+"#,
+        &FormatOptions {
+            experimental_sort_imports: Some(SortImports {
+                order: SortOrder::Desc,
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        r#"
+import { log2 } from "./log2";
+import { log1p } from "./log1p";
+import { log10 } from "./log10";
+import { log } from "./log";
+"#,
+    );
+    // A-Z - default
+    assert_format(
+        r#"
+import { log } from "./log";
+import { log10 } from "./log10";
+import { log1p } from "./log1p";
+import { log2 } from "./log2";
+"#,
+        &FormatOptions {
+            experimental_sort_imports: Some(SortImports {
+                order: SortOrder::Asc,
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        r#"
+import { log } from "./log";
+import { log10 } from "./log10";
+import { log1p } from "./log1p";
+import { log2 } from "./log2";
 "#,
     );
 }


### PR DESCRIPTION
Part of #14253 

Implement `order` option.