### PR TITLE
refactor(napi/parser): use minifier to generate JS/TS raw transfer deserializers from single source

### DIFF
--- a/crates/oxc_ast/src/serialize/literal.rs
+++ b/crates/oxc_ast/src/serialize/literal.rs
@@ -195,8 +195,8 @@ impl ESTree for RegExpFlagsConverter<'_> {
 #[ast_meta]
 #[estree(raw_deser = r#"
     const tail = DESER[bool](POS_OFFSET.tail),
-        start = DESER[u32](POS_OFFSET.span.start) /* IF_TS */ - 1 /* END_IF_TS */,
-        end = DESER[u32](POS_OFFSET.span.end) /* IF_TS */ + 2 - tail /* END_IF_TS */,
+        start = IS_TS ? DESER[u32](POS_OFFSET.span.start) - 1 : DESER[u32](POS_OFFSET.span.start),
+        end = IS_TS ? DESER[u32](POS_OFFSET.span.end) + 2 - tail : DESER[u32](POS_OFFSET.span.end),
         value = DESER[TemplateElementValue](POS_OFFSET.value);
     if (value.cooked !== null && DESER[bool](POS_OFFSET.lone_surrogates)) {
         value.cooked = value.cooked

--- a/crates/oxc_ast/src/serialize/mod.rs
+++ b/crates/oxc_ast/src/serialize/mod.rs
@@ -124,31 +124,29 @@ impl Program<'_> {
     const body = DESER[Vec<Directive>](POS_OFFSET.directives);
     body.push(...DESER[Vec<Statement>](POS_OFFSET.body));
 
-    /* IF_JS */
-    const start = DESER[u32](POS_OFFSET.span.start);
-    /* END_IF_JS */
-
     const end = DESER[u32](POS_OFFSET.span.end);
 
-    /* IF_TS */
     let start;
-    if (body.length > 0) {
-        const first = body[0];
-        start = first.start;
-        if (first.type === 'ExportNamedDeclaration' || first.type === 'ExportDefaultDeclaration') {
-            const { declaration } = first;
-            if (
-                declaration !== null && declaration.type === 'ClassDeclaration'
-                && declaration.decorators.length > 0
-            ) {
-                const decoratorStart = declaration.decorators[0].start;
-                if (decoratorStart < start) start = decoratorStart;
+    if (IS_TS) {
+        if (body.length > 0) {
+            const first = body[0];
+            start = first.start;
+            if (first.type === 'ExportNamedDeclaration' || first.type === 'ExportDefaultDeclaration') {
+                const { declaration } = first;
+                if (
+                    declaration !== null && declaration.type === 'ClassDeclaration'
+                    && declaration.decorators.length > 0
+                ) {
+                    const decoratorStart = declaration.decorators[0].start;
+                    if (decoratorStart < start) start = decoratorStart;
+                }
             }
+        } else {
+            start = end;
         }
     } else {
-        start = end;
+        start = DESER[u32](POS_OFFSET.span.start);
     }
-    /* END_IF_TS */
 
     const program = {
         type: 'Program',

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -34,7 +34,8 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, preservePa
 function deserializeProgram(pos) {
   let body = deserializeVecDirective(pos + 72);
   body.push(...deserializeVecStatement(pos + 96));
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let end = deserializeU32(pos + 4), start;
+  start = deserializeU32(pos);
   return {
     type: 'Program',
     body,
@@ -778,7 +779,9 @@ function deserializeFormalParameters(pos) {
 }
 
 function deserializeFormalParameter(pos) {
-  return deserializeBindingPatternKind(pos + 32);
+  let param;
+  param = deserializeBindingPatternKind(pos + 32);
+  return param;
 }
 
 function deserializeFunctionBody(pos) {

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -814,8 +814,11 @@ function deserializeBindingRestElement(pos) {
 }
 
 function deserializeFunction(pos) {
-  let params = deserializeBoxFormalParameters(pos + 56), thisParam = deserializeOptionBoxTSThisParameter(pos + 48);
-  thisParam !== null && params.unshift(thisParam);
+  let params = deserializeBoxFormalParameters(pos + 56);
+  {
+    let thisParam = deserializeOptionBoxTSThisParameter(pos + 48);
+    thisParam !== null && params.unshift(thisParam);
+  }
   return {
     type: deserializeFunctionType(pos + 84),
     id: deserializeOptionBindingIdentifier(pos + 8),
@@ -851,26 +854,28 @@ function deserializeFormalParameters(pos) {
 }
 
 function deserializeFormalParameter(pos) {
-  let accessibility = deserializeOptionTSAccessibility(pos + 64),
-    readonly = deserializeBool(pos + 65),
-    override = deserializeBool(pos + 66),
-    param;
-  if (accessibility === null && !readonly && !override) {
-    param = deserializeBindingPatternKind(pos + 32);
-    param.decorators = deserializeVecDecorator(pos + 8);
-    param.optional = deserializeBool(pos + 56);
-    param.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 48);
-  } else {param = {
-      type: 'TSParameterProperty',
-      accessibility,
-      decorators: deserializeVecDecorator(pos + 8),
-      override,
-      parameter: deserializeBindingPattern(pos + 32),
-      readonly,
-      static: false,
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
-    };}
+  let param;
+  {
+    let accessibility = deserializeOptionTSAccessibility(pos + 64),
+      readonly = deserializeBool(pos + 65),
+      override = deserializeBool(pos + 66);
+    if (accessibility === null && !readonly && !override) {
+      param = deserializeBindingPatternKind(pos + 32);
+      param.decorators = deserializeVecDecorator(pos + 8);
+      param.optional = deserializeBool(pos + 56);
+      param.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 48);
+    } else {param = {
+        type: 'TSParameterProperty',
+        accessibility,
+        decorators: deserializeVecDecorator(pos + 8),
+        override,
+        parameter: deserializeBindingPattern(pos + 32),
+        readonly,
+        static: false,
+        start: deserializeU32(pos),
+        end: deserializeU32(pos + 4),
+      };}
+  }
   return param;
 }
 


### PR DESCRIPTION
Pure refactor. Makes only minor cosmetic changes to the generated raw transfer deserializer code, mainly just alters *how* that code is generated.

Previously we generated the source for the 2 different deserializers (JS and TS) separately, with the JS deserializer leaving out some fields e.g. `typeAnnotation`.

Instead, generate only 1 base implementation, with TS-only fields gated by `IS_TS`. `IS_TS` is defined as a `const` at top of the file.

```js
const IS_TS = true;

function deserializeFunction(pos) {
  const params = deserializeBoxFormalParameters(pos + 56);
  if (IS_TS) {
    const thisParam = deserializeOptionBoxTSThisParameter(pos + 48);
    if (thisParam !== null) params.unshift(thisParam);
  }

  return {
    type: deserializeFunctionType(pos + 84),
    params,
    ...(IS_TS && {
      declare: deserializeBool(pos + 87),
      typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 40),
    }),
    // ... etc ...
  };
}
```

Then we generate both the JS and TS deserializers from this same file, by setting the `IS_TS` const to `true` or `false`, and using minifier to shake out the dead code.

This:

1. Simplifies custom deserializers.
2. Opens the door to add more `const` flags, e.g. `RANGES` to switch on/off including `range` field in AST nodes.
