### PR TITLE
fix(mangler): allow using typescript keywords as variable names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2106,6 +2106,7 @@ dependencies = [
  "oxc_parser",
  "oxc_semantic",
  "oxc_span",
+ "oxc_syntax",
  "rustc-hash",
 ]
 

--- a/crates/oxc_mangler/Cargo.toml
+++ b/crates/oxc_mangler/Cargo.toml
@@ -27,6 +27,7 @@ oxc_data_structures = { workspace = true, features = ["inline_string"] }
 oxc_index = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
+oxc_syntax = { workspace = true }
 
 itertools = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -421,7 +421,7 @@ impl<'t> Mangler<'t> {
                 count += 1;
                 // Do not mangle keywords and unresolved references
                 let n = name.as_str();
-                if !is_keyword(n)
+                if !oxc_syntax::keyword::is_reserved_keyword(n)
                     && !is_special_name(n)
                     && !root_unresolved_references.contains_key(n)
                     && !(root_bindings.contains_key(n)
@@ -603,14 +603,6 @@ impl<'t> SlotFrequency<'t> {
     fn new(temp_allocator: &'t Allocator) -> Self {
         Self { slot: 0, frequency: 0, symbol_ids: Vec::new_in(temp_allocator) }
     }
-}
-
-#[rustfmt::skip]
-fn is_keyword(s: &str) -> bool {
-    matches!(s, "as" | "do" | "if" | "in" | "is" | "of" | "any" | "for" | "get"
-            | "let" | "new" | "out" | "set" | "try" | "var" | "case" | "else"
-            | "enum" | "from" | "meta" | "null" | "this" | "true" | "type"
-            | "void" | "with")
 }
 
 // Maximum length of string is 15 (`slot_4294967295` for `u32::MAX`).

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -11,7 +11,7 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 544.10 kB  | 71.04 kB   | 72.48 kB   | 25.78 kB   | 26.20 kB   |          2 | lodash.js  
 
-555.77 kB  | 267.39 kB  | 270.13 kB  | 88.02 kB   | 90.80 kB   |          2 | d3.js      
+555.77 kB  | 267.39 kB  | 270.13 kB  | 88.01 kB   | 90.80 kB   |          2 | d3.js      
 
 1.01 MB    | 439.40 kB  | 458.89 kB  | 122.06 kB  | 126.71 kB  |          2 | bundle.min.js 
 
@@ -19,9 +19,9 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 2.14 MB    | 711.15 kB  | 724.14 kB  | 160.43 kB  | 181.07 kB  |          2 | victory.js 
 
-3.20 MB    | 1.00 MB    | 1.01 MB    | 322.53 kB  | 331.56 kB  |          3 | echarts.js 
+3.20 MB    | 1.00 MB    | 1.01 MB    | 322.59 kB  | 331.56 kB  |          3 | echarts.js 
 
 6.69 MB    | 2.22 MB    | 2.31 MB    | 458.41 kB  | 488.28 kB  |          4 | antd.js    
 
-10.95 MB   | 3.33 MB    | 3.49 MB    | 853.38 kB  | 915.50 kB  |          4 | typescript.js 
+10.95 MB   | 3.33 MB    | 3.49 MB    | 853.34 kB  | 915.50 kB  |          4 | typescript.js 
 


### PR DESCRIPTION
`as`, `any` should be allowed to use as a variable name.