### PR TITLE
feat(tasks/compat_data): add custom compat data for export namespace from

### DIFF
--- a/crates/oxc_compat/src/es_features.rs
+++ b/crates/oxc_compat/src/es_features.rs
@@ -54,6 +54,7 @@ pub enum ESFeature {
     ES2025DuplicateNamedCapturingGroupsRegex,
     ES2025RegexpModifiers,
     ES2026ExplicitResourceManagement,
+    ES2020ExportNamespaceFrom,
 }
 pub fn features() -> &'static FxHashMap<ESFeature, EngineTargets> {
     use ESFeature::*;
@@ -884,6 +885,23 @@ pub fn features() -> &'static FxHashMap<ESFeature, EngineTargets> {
                     (Firefox, Version(141u16, 0u16, 0u16)),
                     (Edge, Version(134u16, 0u16, 0u16)),
                     (Es, Version(2026u16, 0, 0)),
+                ])),
+            ),
+            (
+                ES2020ExportNamespaceFrom,
+                EngineTargets::new(FxHashMap::from_iter([
+                    (Samsung, Version(11u16, 0u16, 0u16)),
+                    (Node, Version(13u16, 2u16, 0u16)),
+                    (Firefox, Version(80u16, 0u16, 0u16)),
+                    (Chrome, Version(72u16, 0u16, 0u16)),
+                    (Safari, Version(14u16, 1u16, 0u16)),
+                    (Ios, Version(14u16, 5u16, 0u16)),
+                    (Edge, Version(79u16, 0u16, 0u16)),
+                    (OperaMobile, Version(51u16, 0u16, 0u16)),
+                    (Deno, Version(1u16, 0u16, 0u16)),
+                    (Electron, Version(5u16, 0u16, 0u16)),
+                    (Opera, Version(60u16, 0u16, 0u16)),
+                    (Es, Version(2020u16, 0, 0)),
                 ])),
             ),
         ])

--- a/tasks/compat_data/build.js
+++ b/tasks/compat_data/build.js
@@ -8,6 +8,7 @@ const interpolateAllResults = require('./compat-table/build-utils/interpolate-al
 const compareVersions = require('./compat-table/build-utils/compare-versions');
 const { addElectronSupportFromChromium } = require('./chromium-to-electron');
 const esFeatures = require(`./es-features`);
+const customCompatData = require('./custom-compat-data');
 
 const environments = [
   'chrome',
@@ -114,4 +115,7 @@ const generateData = (environments, items) => {
 
 const items = generateData(environments, esFeatures);
 
-fs.writeFileSync('./data.json', JSON.stringify(items, null, 2));
+// Merge custom compatibility data (for features not in compat-table)
+const allItems = [...items, ...customCompatData];
+
+fs.writeFileSync('./data.json', JSON.stringify(allItems, null, 2));

--- a/tasks/compat_data/custom-compat-data.js
+++ b/tasks/compat_data/custom-compat-data.js
@@ -1,0 +1,30 @@
+// Custom compatibility data for features not yet in compat-table
+// This file contains manually maintained browser support information
+
+const f = (es) => (item) => {
+  item.es = es;
+  return item;
+};
+
+const customEs2020 = [
+  {
+    name: 'ExportNamespaceFrom',
+    babel: 'transform-export-namespace-from',
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export#browser_compatibility
+    targets: {
+      chrome: '72',
+      opera: '60',
+      edge: '79',
+      firefox: '80',
+      safari: '14.1',
+      node: '13.2',
+      deno: '1.0',
+      ios: '14.5',
+      samsung: '11.0',
+      opera_mobile: '51',
+      electron: '5.0',
+    },
+  },
+].map(f('ES2020'));
+
+module.exports = [...customEs2020];

--- a/tasks/compat_data/data.json
+++ b/tasks/compat_data/data.json
@@ -1048,5 +1048,23 @@
       "firefox": "141",
       "node": "24"
     }
+  },
+  {
+    "name": "ExportNamespaceFrom",
+    "babel": "transform-export-namespace-from",
+    "targets": {
+      "chrome": "72",
+      "opera": "60",
+      "edge": "79",
+      "firefox": "80",
+      "safari": "14.1",
+      "node": "13.2",
+      "deno": "1.0",
+      "ios": "14.5",
+      "samsung": "11.0",
+      "opera_mobile": "51",
+      "electron": "5.0"
+    },
+    "es": "ES2020"
   }
 ]


### PR DESCRIPTION
Added a way to add custom compat data that doesn't exist in compat table. Also added the data for "export namespace from".