### PR TITLE
test(transformer): enable `export-type-star-from` test

### DIFF
--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 41d96516
 
-Passed: 705/1212
+Passed: 706/1213
 
 # All Passed:
 * babel-plugin-transform-logical-assignment-operators
@@ -1440,7 +1440,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-typescript (48/158)
+# babel-plugin-transform-typescript (49/159)
 * cast/as-expression/input.ts
 Unresolved references mismatch:
 after transform: ["T", "x"]

--- a/tasks/transform_conformance/src/constants.rs
+++ b/tasks/transform_conformance/src/constants.rs
@@ -89,8 +89,6 @@ pub const SKIP_TESTS: &[&str] = &[
     // Report error for deprecate option or oxc doesn’t follow error message
     "babel-plugin-transform-typescript/test/fixtures/opts/allowDeclareFields",
     "babel-plugin-transform-react-jsx/test/fixtures/react-automatic/should-throw-when-filter-is-specified",
-    // Not standard JavaScript or typescript syntax
-    "babel-plugin-transform-typescript/test/fixtures/exports/export-type-star-from",
     // The output is valid and semantically correct
     // but does not match Babel's expected output
     "babel-plugin-transform-typescript/test/fixtures/namespace/canonical",


### PR DESCRIPTION
I believe this is a valid code now. The test passes as well.

https://github.com/babel/babel/blob/main/packages/babel-generator/test/fixtures/typescript/export-type-star-from/input.ts
