### PR TITLE
fix(parser): forbid abstract class members with implementation in parser instead of semantic

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -692,6 +692,33 @@ pub fn index_signature_type_annotation(span: Span) -> OxcDiagnostic {
 }
 
 #[cold]
+pub fn abstract_method_cannot_have_implementation(name: &str, span: Span) -> OxcDiagnostic {
+    ts_error(
+        "1245",
+        format!("Method '{name}' cannot have an implementation because it is marked abstract."),
+    )
+    .with_label(span)
+}
+
+#[cold]
+pub fn abstract_property_cannot_have_initializer(name: &str, span: Span) -> OxcDiagnostic {
+    ts_error(
+        "1267",
+        format!("Property '{name}' cannot have an initializer because it is marked abstract."),
+    )
+    .with_label(span)
+}
+
+#[cold]
+pub fn abstract_accessor_cannot_have_implementation(name: &str, span: Span) -> OxcDiagnostic {
+    ts_error(
+        "1318",
+        format!("Accessor '{name}' cannot have an implementation because it is marked abstract."),
+    )
+    .with_label(span)
+}
+
+#[cold]
 pub fn unexpected_export(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Unexpected export.").with_label(span)
 }

--- a/crates/oxc_semantic/src/checker/mod.rs
+++ b/crates/oxc_semantic/src/checker/mod.rs
@@ -81,7 +81,6 @@ pub fn check<'a>(kind: AstKind<'a>, ctx: &SemanticBuilder<'a>) {
         AstKind::MethodDefinition(method) => {
             ts::check_method_definition(method, ctx);
         }
-        AstKind::PropertyDefinition(prop) => ts::check_property_definition(prop, ctx),
         AstKind::ObjectProperty(prop) => {
             ts::check_object_property(prop, ctx);
         }

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -5,7 +5,7 @@ use rustc_hash::FxHashMap;
 
 use oxc_ast::{AstKind, ast::*};
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_ecmascript::{BoundNames, PropName};
+use oxc_ecmascript::BoundNames;
 use oxc_span::{Atom, GetSpan, Span};
 
 use crate::{builder::SemanticBuilder, diagnostics::redeclaration};
@@ -289,48 +289,6 @@ fn reserved_type_name(span: Span, reserved_name: &str, syntax_name: &str) -> Oxc
     ts_error("2414", format!("{syntax_name} name cannot be '{reserved_name}'")).with_label(span)
 }
 
-fn abstract_element_cannot_have_initializer(
-    code: &'static str,
-    elem_name: &str,
-    prop_name: &str,
-    span: Span,
-    init_or_impl: &str,
-) -> OxcDiagnostic {
-    ts_error(
-        code,
-        format!(
-            "{elem_name} '{prop_name}' cannot have an {init_or_impl} because it is marked abstract."
-        ),
-    )
-    .with_label(span)
-}
-
-/// TS(1245): Method 'foo' cannot have an implementation because it is marked abstract.
-fn abstract_method_cannot_have_implementation(method_name: &str, span: Span) -> OxcDiagnostic {
-    abstract_element_cannot_have_initializer("1245", "Method", method_name, span, "implementation")
-}
-
-/// TS(1267): Property 'foo' cannot have an initializer because it is marked abstract.
-fn abstract_property_cannot_have_initializer(prop_name: &str, span: Span) -> OxcDiagnostic {
-    abstract_element_cannot_have_initializer("1267", "Property", prop_name, span, "initializer")
-}
-
-/// TS(1318): Accessor 'foo' cannot have an implementation because it is marked abstract.
-///
-/// Applies to getters/setters
-///
-/// > TS's original message, `An abstract accessor cannot have an
-/// > implementation.`, is less helpful than the one provided here.
-fn abstract_accessor_cannot_have_implementation(accessor_name: &str, span: Span) -> OxcDiagnostic {
-    abstract_element_cannot_have_initializer(
-        "1318",
-        "Accessor",
-        accessor_name,
-        span,
-        "implementation",
-    )
-}
-
 /// 'abstract' modifier can only appear on a class, method, or property declaration. (1242)
 fn illegal_abstract_modifier(span: Span) -> OxcDiagnostic {
     ts_error(
@@ -372,23 +330,6 @@ pub fn check_method_definition<'a>(method: &MethodDefinition<'a>, ctx: &Semantic
         // constructors cannot be abstract, no matter what
         if method.kind.is_constructor() {
             ctx.error(illegal_abstract_modifier(method.key.span()));
-        } else if method.value.body.is_some() {
-            // abstract class elements cannot have bodies or initializers
-            let (method_name, span) = method.key.prop_name().unwrap_or_else(|| {
-                let key_span = method.key.span();
-                (&ctx.source_text[key_span], key_span)
-            });
-            match method.kind {
-                MethodDefinitionKind::Method => {
-                    ctx.error(abstract_method_cannot_have_implementation(method_name, span));
-                }
-                MethodDefinitionKind::Get | MethodDefinitionKind::Set => {
-                    ctx.error(abstract_accessor_cannot_have_implementation(method_name, span));
-                }
-                // abstract classes can have concrete methods. Constructors cannot
-                // have abstract modifiers, but this gets checked during parsing
-                MethodDefinitionKind::Constructor => {}
-            }
         }
     }
 
@@ -405,16 +346,6 @@ pub fn check_method_definition<'a>(method: &MethodDefinition<'a>, ctx: &Semantic
     // Illegal to have `get foo();` or `set foo(a)`
     if method.kind.is_accessor() && is_empty_body && !is_abstract && !is_declare {
         ctx.error(accessor_without_body(method.key.span()));
-    }
-}
-
-pub fn check_property_definition<'a>(prop: &PropertyDefinition<'a>, ctx: &SemanticBuilder<'a>) {
-    if prop.r#type.is_abstract() && prop.value.is_some() {
-        let (prop_name, span) = prop.key.prop_name().unwrap_or_else(|| {
-            let key_span = prop.key.span();
-            (&ctx.source_text[key_span], key_span)
-        });
-        ctx.error(abstract_property_cannot_have_initializer(prop_name, span));
     }
 }
 

--- a/tasks/coverage/misc/fail/oxc-14013.ts
+++ b/tasks/coverage/misc/fail/oxc-14013.ts
@@ -3,11 +3,11 @@ abstract class Foo {
 
   abstract method() { }
 
-  abstract get accessor() {
+  abstract get getter() {
     return 1;
   }
 
-  abstract set accessor(value: number) {
+  abstract set setter(value: number) {
     
   }
 }

--- a/tasks/coverage/misc/fail/oxc-14013.ts
+++ b/tasks/coverage/misc/fail/oxc-14013.ts
@@ -1,0 +1,13 @@
+abstract class Foo {
+  abstract prop = 3;
+
+  abstract method() { }
+
+  abstract get accessor() {
+    return 1;
+  }
+
+  abstract set accessor(value: number) {
+    
+  }
+}

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -12630,6 +12630,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  2 │ }
    ╰────
 
+  × TS(1245): Method 'd' cannot have an implementation because it is marked abstract.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/generator-method-with-modifiers/input.ts:5:13]
+ 4 │   static *c() {}
+ 5 │   abstract *d() {}
+   ·             ─
+ 6 │   readonly *e() {}
+   ╰────
+
   × TS(1024): 'readonly' modifier can only appear on a property declaration or index signature.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/generator-method-with-modifiers/input.ts:6:3]
  5 │   abstract *d() {}
@@ -12644,14 +12652,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  7 │   declare *f() {}
    ·   ───────
  8 │   protected *g() {}
-   ╰────
-
-  × TS(1245): Method 'd' cannot have an implementation because it is marked abstract.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/generator-method-with-modifiers/input.ts:5:13]
- 4 │   static *c() {}
- 5 │   abstract *d() {}
-   ·             ─
- 6 │   readonly *e() {}
    ╰────
 
   × TS(1244): Abstract methods can only appear within an abstract class.
@@ -12766,6 +12766,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  4 │ }
    ╰────
 
+  × TS(1245): Method 'd' cannot have an implementation because it is marked abstract.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/optional-generator-method-with-invalid-modifiers/input.ts:2:13]
+ 1 │ class C {
+ 2 │   abstract *d?() { }
+   ·             ─
+ 3 │   readonly *e?() { }
+   ╰────
+
   × TS(1024): 'readonly' modifier can only appear on a property declaration or index signature.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/optional-generator-method-with-invalid-modifiers/input.ts:3:3]
  2 │   abstract *d?() { }
@@ -12780,6 +12788,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  4 │   declare *f?() { }
    ·   ───────
  5 │ }
+   ╰────
+
+  × TS(1245): Method 'd?.d' cannot have an implementation because it is marked abstract.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/optional-generator-method-with-invalid-modifiers/input.ts:8:14]
+ 7 │ class A {
+ 8 │   abstract *[d?.d]?() { }
+   ·              ────
+ 9 │   readonly *[e?.e]?() { }
    ╰────
 
   × TS(1024): 'readonly' modifier can only appear on a property declaration or index signature.
@@ -12798,28 +12814,12 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  11 │ }
     ╰────
 
-  × TS(1245): Method 'd' cannot have an implementation because it is marked abstract.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/optional-generator-method-with-invalid-modifiers/input.ts:2:13]
- 1 │ class C {
- 2 │   abstract *d?() { }
-   ·             ─
- 3 │   readonly *e?() { }
-   ╰────
-
   × TS(1244): Abstract methods can only appear within an abstract class.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/optional-generator-method-with-invalid-modifiers/input.ts:2:13]
  1 │ class C {
  2 │   abstract *d?() { }
    ·             ─
  3 │   readonly *e?() { }
-   ╰────
-
-  × TS(1245): Method 'd?.d' cannot have an implementation because it is marked abstract.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/optional-generator-method-with-invalid-modifiers/input.ts:8:14]
- 7 │ class A {
- 8 │   abstract *[d?.d]?() { }
-   ·              ────
- 9 │   readonly *[e?.e]?() { }
    ╰────
 
   × TS(1244): Abstract methods can only appear within an abstract class.

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 49/49 (100.00%)
 Positive Passed: 49/49 (100.00%)
-Negative Passed: 91/91 (100.00%)
+Negative Passed: 92/92 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -2850,6 +2850,38 @@ Negative Passed: 91/91 (100.00%)
  1 │ const foo: Foo<> = 1
    ·               ──
    ╰────
+
+  × TS(1267): Property 'prop' cannot have an initializer because it is marked abstract.
+   ╭─[misc/fail/oxc-14013.ts:2:12]
+ 1 │ abstract class Foo {
+ 2 │   abstract prop = 3;
+   ·            ────
+ 3 │ 
+   ╰────
+
+  × TS(1245): Method 'method' cannot have an implementation because it is marked abstract.
+   ╭─[misc/fail/oxc-14013.ts:4:12]
+ 3 │ 
+ 4 │   abstract method() { }
+   ·            ──────
+ 5 │ 
+   ╰────
+
+  × TS(1318): Accessor 'accessor' cannot have an implementation because it is marked abstract.
+   ╭─[misc/fail/oxc-14013.ts:6:16]
+ 5 │ 
+ 6 │   abstract get accessor() {
+   ·                ────────
+ 7 │     return 1;
+   ╰────
+
+  × TS(1318): Accessor 'accessor' cannot have an implementation because it is marked abstract.
+    ╭─[misc/fail/oxc-14013.ts:10:16]
+  9 │ 
+ 10 │   abstract set accessor(value: number) {
+    ·                ────────
+ 11 │     
+    ╰────
 
   × Classes may not have a field named 'constructor'
    ╭─[misc/fail/oxc-14014.ts:2:12]

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -2867,19 +2867,19 @@ Negative Passed: 92/92 (100.00%)
  5 │ 
    ╰────
 
-  × TS(1318): Accessor 'accessor' cannot have an implementation because it is marked abstract.
+  × TS(1318): Accessor 'getter' cannot have an implementation because it is marked abstract.
    ╭─[misc/fail/oxc-14013.ts:6:16]
  5 │ 
- 6 │   abstract get accessor() {
-   ·                ────────
+ 6 │   abstract get getter() {
+   ·                ──────
  7 │     return 1;
    ╰────
 
-  × TS(1318): Accessor 'accessor' cannot have an implementation because it is marked abstract.
+  × TS(1318): Accessor 'setter' cannot have an implementation because it is marked abstract.
     ╭─[misc/fail/oxc-14013.ts:10:16]
   9 │ 
- 10 │   abstract set accessor(value: number) {
-    ·                ────────
+ 10 │   abstract set setter(value: number) {
+    ·                ──────
  11 │     
     ╰────
 

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -14637,20 +14637,20 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  30 │ 
     ╰────
 
-  × TS(1244): Abstract methods can only appear within an abstract class.
-   ╭─[typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMethodInNonAbstractClass.ts:2:14]
- 1 │ class A {
- 2 │     abstract foo();
-   ·              ───
- 3 │ }
-   ╰────
-
   × TS(1245): Method 'foo' cannot have an implementation because it is marked abstract.
    ╭─[typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMethodInNonAbstractClass.ts:6:14]
  5 │ class B {
  6 │     abstract foo() {}
    ·              ───
  7 │ }
+   ╰────
+
+  × TS(1244): Abstract methods can only appear within an abstract class.
+   ╭─[typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMethodInNonAbstractClass.ts:2:14]
+ 1 │ class A {
+ 2 │     abstract foo();
+   ·              ───
+ 3 │ }
    ╰────
 
   × TS(1244): Abstract methods can only appear within an abstract class.
@@ -16141,6 +16141,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  29 │ }
     ╰────
 
+  × TS(1267): Property '#quux' cannot have an initializer because it is marked abstract.
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNamesIncompatibleModifiers.ts:32:14]
+ 31 │ abstract class B {
+ 32 │     abstract #quux = 3;      // Error
+    ·              ─────
+ 33 │ }
+    ╰────
+
   × Getters and setters must have an implementation.
     ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNamesIncompatibleModifiers.ts:25:17]
  24 │     readonly set #quxProp(value: number) {  }    // Error
@@ -16155,14 +16163,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  26 │     declare set #whatProp(value: number)         // Error
     ·                 ─────────
  27 │     async get #asyncProp() { return 1; }         // Error
-    ╰────
-
-  × TS(1267): Property '#quux' cannot have an initializer because it is marked abstract.
-    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNamesIncompatibleModifiers.ts:32:14]
- 31 │ abstract class B {
- 32 │     abstract #quux = 3;      // Error
-    ·              ─────
- 33 │ }
     ╰────
 
   × Private identifier '#prop' is not allowed outside class bodies


### PR DESCRIPTION
The following four cases are now errors in parser instead of semantic errors.
[TS Playground](https://www.typescriptlang.org/play/?#code/IYIwzgLgTsDGEAJYBthjAgYge2wg3gFAIKiQzwIAOU2VCAvAgMwDchxp40ciAtgFMIAC2wATABQBKAggC+HEmR6UA5kITqIEAVGkFOJKEICuUAHYIAjOxILOyiojAaX23RIBuwZCYEAuBHMTPhBdGSISEk4FOSA) for reference.
Closes #14013 

```typescript
abstract class Foo {
  abstract prop = 3;

  abstract method() { }

  abstract get getter() {
    return 1;
  }

  abstract set setter(value: number) {
    
  }
}
```