### PR TITLE
fix(linter): fix flaky import/no_cycle test

### DIFF
--- a/crates/oxc_linter/src/module_graph_visitor.rs
+++ b/crates/oxc_linter/src/module_graph_visitor.rs
@@ -1,4 +1,8 @@
-use std::{marker::PhantomData, path::PathBuf, sync::Arc};
+use std::{
+    marker::PhantomData,
+    path::PathBuf,
+    sync::{Arc, Weak},
+};
 
 use rustc_hash::FxHashSet;
 
@@ -189,7 +193,19 @@ impl ModuleGraphVisitor {
         enter: &mut EnterMod,
         leave: &mut LeaveMod,
     ) -> VisitFoldWhile<T> {
-        for (key, weak_module_record) in module_record.loaded_modules().iter() {
+        // Sort entries to ensure deterministic iteration order.
+        // The module graph is populated via parallel insertion (par_drain in runtime.rs),
+        // which causes non-deterministic insertion order into FxHashMap.
+        // Different iteration orders can cause cycle detection to find or miss cycles
+        // depending on which path reaches a node first (due to the `traversed` set).
+        let mut entries: Vec<_> = module_record
+            .loaded_modules()
+            .iter()
+            .map(|(k, v)| (k.clone(), Weak::clone(v)))
+            .collect();
+        entries.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+
+        for (key, weak_module_record) in entries {
             if self.depth > self.max_depth {
                 return VisitFoldWhile::Stop(accumulator.into_inner());
             }
@@ -202,7 +218,7 @@ impl ModuleGraphVisitor {
                 continue;
             }
 
-            let pair = (key, &loaded_module_record);
+            let pair = (&key, &loaded_module_record);
 
             if !filter(pair, module_record) {
                 continue;


### PR DESCRIPTION
## Summary

Fixes the flaky `import/no_cycle` test that was failing 2/10 times on Linux CI.

## Root Cause

The module graph is populated via parallel insertion (`par_drain` in `runtime.rs`), which causes non-deterministic insertion order into `FxHashMap`. Since hashmap iteration order depends on insertion order, this leads to:

1. Different iteration orders across test runs
2. Different graph traversal paths in the cycle detector
3. The `traversed` set preventing revisiting nodes means cycles can be found or missed depending on which path is explored first

## Solution

Sort the hashmap entries by key before iterating in `module_graph_visitor.rs` to ensure deterministic traversal order regardless of parallel insertion timing.

## Test Plan

- [x] `cargo test -p oxc_linter no_cycle` passes
- [x] Code formatted with `just fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)