### PR TITLE
perf(napi/parser, linter/plugins): remove runtime `preserveParens` option from raw transfer deserializers

### DIFF
--- a/.github/generated/ast_changes_watch_list.yml
+++ b/.github/generated/ast_changes_watch_list.yml
@@ -71,6 +71,7 @@ src:
   - 'napi/parser/generated/deserialize/js_range.js'
   - 'napi/parser/generated/deserialize/ts.js'
   - 'napi/parser/generated/deserialize/ts_range.js'
+  - 'napi/parser/generated/deserialize/ts_range_no_parens.js'
   - 'napi/parser/generated/lazy/constructors.js'
   - 'napi/parser/generated/lazy/types.js'
   - 'napi/parser/generated/lazy/walk.js'

--- a/apps/oxlint/scripts/build.js
+++ b/apps/oxlint/scripts/build.js
@@ -32,7 +32,7 @@ const parserFilePaths = [
   'generated/lazy/types.js',
   'generated/lazy/walk.js',
   */
-  'generated/deserialize/ts_range.js',
+  'generated/deserialize/ts_range_no_parens.js',
   'generated/visit/keys.js',
   'generated/visit/types.js',
   'generated/visit/visitor.d.ts',

--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -6,7 +6,8 @@ import {
   // @ts-expect-error
 } from '../generated/constants.js';
 // @ts-expect-error we need to generate `.d.ts` file for this module
-import { deserializeProgramOnly } from '../../dist/generated/deserialize/ts_range.js';
+// We use the deserializer which removes `ParenthesizedExpression`s from AST to match ESLint
+import { deserializeProgramOnly } from '../../dist/generated/deserialize/ts_range_no_parens.js';
 
 import type { Program } from '@oxc-project/types';
 import type { Scope, ScopeManager, Variable } from './scope.ts';
@@ -67,10 +68,7 @@ function initSourceText(): void {
  */
 function initAst(): void {
   if (sourceText === null) initSourceText();
-
-  // `preserveParens` argument is `false`, to match ESLint.
-  // ESLint does not include `ParenthesizedExpression` nodes in its AST.
-  ast = deserializeProgramOnly(buffer, sourceText, sourceByteLen, false);
+  ast = deserializeProgramOnly(buffer, sourceText, sourceByteLen);
 }
 
 /**

--- a/crates/oxc_ast/src/serialize/js.rs
+++ b/crates/oxc_ast/src/serialize/js.rs
@@ -449,7 +449,7 @@ impl ESTree for AssignmentTargetPropertyIdentifierInit<'_> {
 
 /// Converter for [`ParenthesizedExpression`].
 ///
-/// In raw transfer, do not produce a `ParenthesizedExpression` node in AST if `preserveParens` is false.
+/// In raw transfer, do not produce a `ParenthesizedExpression` node in AST if `PRESERVE_PARENS` is false.
 ///
 /// Not useful in `oxc-parser`, as can use parser option `preserve_parens`.
 /// Required for `oxlint` plugins where we run parser with `preserve_parens` set to `true`,
@@ -459,7 +459,7 @@ impl ESTree for AssignmentTargetPropertyIdentifierInit<'_> {
 #[ast_meta]
 #[estree(raw_deser = "
     let node = DESER[Expression](POS_OFFSET.expression);
-    if (preserveParens) {
+    if (PRESERVE_PARENS) {
         let start, end;
         node = {
             type: 'ParenthesizedExpression',

--- a/crates/oxc_ast/src/serialize/ts.rs
+++ b/crates/oxc_ast/src/serialize/ts.rs
@@ -427,7 +427,7 @@ impl ESTree for TSFunctionTypeParams<'_, '_> {
 
 /// Converter for [`TSParenthesizedType`].
 ///
-/// In raw transfer, do not produce a `TSParenthesizedType` node in AST if `preserveParens` is false.
+/// In raw transfer, do not produce a `TSParenthesizedType` node in AST if `PRESERVE_PARENS` is false.
 ///
 /// Not useful in `oxc-parser`, as can use parser option `preserve_parens`.
 /// Required for `oxlint` plugins where we run parser with `preserve_parens` set to `true`,
@@ -437,7 +437,7 @@ impl ESTree for TSFunctionTypeParams<'_, '_> {
 #[ast_meta]
 #[estree(raw_deser = "
     let node = DESER[TSType](POS_OFFSET.type_annotation);
-    if (preserveParens) {
+    if (PRESERVE_PARENS) {
         let start, end;
         node = {
             type: 'TSParenthesizedType',

--- a/napi/parser/generated/deserialize/js_range.js
+++ b/napi/parser/generated/deserialize/js_range.js
@@ -1,27 +1,26 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
-let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen, preserveParens;
+let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen;
 const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
   { fromCodePoint } = String;
 
-export function deserialize(buffer, sourceText, sourceByteLen, preserveParens) {
-  return deserializeWith(buffer, sourceText, sourceByteLen, preserveParens, deserializeRawTransferData);
+export function deserialize(buffer, sourceText, sourceByteLen) {
+  return deserializeWith(buffer, sourceText, sourceByteLen, deserializeRawTransferData);
 }
 
-export function deserializeProgramOnly(buffer, sourceText, sourceByteLen, preserveParens) {
-  return deserializeWith(buffer, sourceText, sourceByteLen, preserveParens, deserializeProgram);
+export function deserializeProgramOnly(buffer, sourceText, sourceByteLen) {
+  return deserializeWith(buffer, sourceText, sourceByteLen, deserializeProgram);
 }
 
-function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, preserveParensInput, deserialize) {
+function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, deserialize) {
   uint8 = buffer;
   uint32 = buffer.uint32;
   float64 = buffer.float64;
   sourceText = sourceTextInput;
   sourceByteLen = sourceByteLenInput;
   sourceIsAscii = sourceText.length === sourceByteLen;
-  preserveParens = preserveParensInput;
   let data = deserialize(uint32[536870902]);
   uint8 =
     uint32 =
@@ -1025,7 +1024,7 @@ function deserializeChainElement(pos) {
 
 function deserializeParenthesizedExpression(pos) {
   let node = deserializeExpression(pos + 8);
-  if (preserveParens) {
+  {
     let start, end;
     node = {
       type: 'ParenthesizedExpression',
@@ -2918,7 +2917,7 @@ function deserializeTSIntersectionType(pos) {
 
 function deserializeTSParenthesizedType(pos) {
   let node = deserializeTSType(pos + 8);
-  if (preserveParens) {
+  {
     let start, end;
     node = {
       type: 'TSParenthesizedType',

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -1,27 +1,26 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
-let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen, preserveParens;
+let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen;
 const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
   { fromCodePoint } = String;
 
-export function deserialize(buffer, sourceText, sourceByteLen, preserveParens) {
-  return deserializeWith(buffer, sourceText, sourceByteLen, preserveParens, deserializeRawTransferData);
+export function deserialize(buffer, sourceText, sourceByteLen) {
+  return deserializeWith(buffer, sourceText, sourceByteLen, deserializeRawTransferData);
 }
 
-export function deserializeProgramOnly(buffer, sourceText, sourceByteLen, preserveParens) {
-  return deserializeWith(buffer, sourceText, sourceByteLen, preserveParens, deserializeProgram);
+export function deserializeProgramOnly(buffer, sourceText, sourceByteLen) {
+  return deserializeWith(buffer, sourceText, sourceByteLen, deserializeProgram);
 }
 
-function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, preserveParensInput, deserialize) {
+function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, deserialize) {
   uint8 = buffer;
   uint32 = buffer.uint32;
   float64 = buffer.float64;
   sourceText = sourceTextInput;
   sourceByteLen = sourceByteLenInput;
   sourceIsAscii = sourceText.length === sourceByteLen;
-  preserveParens = preserveParensInput;
   let data = deserialize(uint32[536870902]);
   uint8 =
     uint32 =
@@ -1033,12 +1032,12 @@ function deserializeChainElement(pos) {
 
 function deserializeParenthesizedExpression(pos) {
   let node = deserializeExpression(pos + 8);
-  preserveParens && (node = {
+  node = {
     type: 'ParenthesizedExpression',
     expression: node,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-  });
+  };
   return node;
 }
 
@@ -2915,12 +2914,12 @@ function deserializeTSIntersectionType(pos) {
 
 function deserializeTSParenthesizedType(pos) {
   let node = deserializeTSType(pos + 8);
-  preserveParens && (node = {
+  node = {
     type: 'TSParenthesizedType',
     typeAnnotation: node,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-  });
+  };
   return node;
 }
 

--- a/napi/parser/generated/deserialize/ts_range.js
+++ b/napi/parser/generated/deserialize/ts_range.js
@@ -1,27 +1,26 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
-let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen, preserveParens;
+let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen;
 const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
   { fromCodePoint } = String;
 
-export function deserialize(buffer, sourceText, sourceByteLen, preserveParens) {
-  return deserializeWith(buffer, sourceText, sourceByteLen, preserveParens, deserializeRawTransferData);
+export function deserialize(buffer, sourceText, sourceByteLen) {
+  return deserializeWith(buffer, sourceText, sourceByteLen, deserializeRawTransferData);
 }
 
-export function deserializeProgramOnly(buffer, sourceText, sourceByteLen, preserveParens) {
-  return deserializeWith(buffer, sourceText, sourceByteLen, preserveParens, deserializeProgram);
+export function deserializeProgramOnly(buffer, sourceText, sourceByteLen) {
+  return deserializeWith(buffer, sourceText, sourceByteLen, deserializeProgram);
 }
 
-function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, preserveParensInput, deserialize) {
+function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, deserialize) {
   uint8 = buffer;
   uint32 = buffer.uint32;
   float64 = buffer.float64;
   sourceText = sourceTextInput;
   sourceByteLen = sourceByteLenInput;
   sourceIsAscii = sourceText.length === sourceByteLen;
-  preserveParens = preserveParensInput;
   let data = deserialize(uint32[536870902]);
   uint8 =
     uint32 =
@@ -1069,7 +1068,7 @@ function deserializeChainElement(pos) {
 
 function deserializeParenthesizedExpression(pos) {
   let node = deserializeExpression(pos + 8);
-  if (preserveParens) {
+  {
     let start, end;
     node = {
       type: 'ParenthesizedExpression',
@@ -3046,7 +3045,7 @@ function deserializeTSIntersectionType(pos) {
 
 function deserializeTSParenthesizedType(pos) {
   let node = deserializeTSType(pos + 8);
-  if (preserveParens) {
+  {
     let start, end;
     node = {
       type: 'TSParenthesizedType',

--- a/napi/parser/src-js/raw-transfer/eager.js
+++ b/napi/parser/src-js/raw-transfer/eager.js
@@ -68,9 +68,7 @@ function deserialize(buffer, sourceText, sourceByteLen, range) {
     ).deserialize;
   }
 
-  // `preserveParens` argument is unconditionally `true` here. If `options` contains `preserveParens: false`,
-  // `ParenthesizedExpression` nodes won't be in AST anyway, so the value is irrelevant.
-  const data = deserializeThis(buffer, sourceText, sourceByteLen, true);
+  const data = deserializeThis(buffer, sourceText, sourceByteLen);
 
   // Add a line comment for hashbang if JS.
   // Do not add comment if TS, to match `@typescript-eslint/parser`.


### PR DESCRIPTION
We had a runtime `preserveParens` option in deserializers to cater for linter, but it was not used in parser. Convert it to a compile-time option instead.