### PR TITLE
fix(napi/parser, linter/plugins): add `range` field to `TemplateElement`

### DIFF
--- a/crates/oxc_ast/src/serialize/literal.rs
+++ b/crates/oxc_ast/src/serialize/literal.rs
@@ -202,7 +202,7 @@ impl ESTree for RegExpFlagsConverter<'_> {
         value.cooked = value.cooked
             .replace(/\uFFFD(.{4})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)));
     }
-    { type: 'TemplateElement', value, tail, start, end }
+    { type: 'TemplateElement', value, tail, start, end, ...(RANGE && { range: [start, end] }) }
 "#)]
 pub struct TemplateElementConverter<'a, 'b>(pub &'b TemplateElement<'a>);
 

--- a/napi/parser/generated/deserialize/js_range.js
+++ b/napi/parser/generated/deserialize/js_range.js
@@ -490,6 +490,7 @@ function deserializeTemplateElement(pos) {
     tail,
     start,
     end,
+    range: [start, end],
   };
 }
 

--- a/napi/parser/generated/deserialize/ts_range.js
+++ b/napi/parser/generated/deserialize/ts_range.js
@@ -514,6 +514,7 @@ function deserializeTemplateElement(pos) {
     tail,
     start,
     end,
+    range: [start, end],
   };
 }
 

--- a/napi/parser/generated/deserialize/ts_range_no_parens.js
+++ b/napi/parser/generated/deserialize/ts_range_no_parens.js
@@ -514,6 +514,7 @@ function deserializeTemplateElement(pos) {
     tail,
     start,
     end,
+    range: [start, end],
   };
 }
 


### PR DESCRIPTION
Fix missing `range` field in `TemplateElement` in raw transfer deserializers.