### PR TITLE
refactor(linter/plugins): `SourceCode#getText` use `range`

### DIFF
--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -149,7 +149,8 @@ export const SOURCE_CODE = Object.freeze({
     if (!node) return sourceText;
 
     // ESLint ignores falsy values for `beforeCount` and `afterCount`
-    let { start, end } = node;
+    const { range } = node;
+    let start = range[0], end = range[1];
     if (beforeCount) start = max(start - beforeCount, 0);
     if (afterCount) end += afterCount;
     return sourceText.slice(start, end);


### PR DESCRIPTION
`sourceCode.getText` use AST node's `range` field instead of `start` and `end`. This is what ESLint does.