### PR TITLE
refactor(linter/plugins): export AST types direct from `oxlint` package

### DIFF
--- a/.github/generated/ast_changes_watch_list.yml
+++ b/.github/generated/ast_changes_watch_list.yml
@@ -4,6 +4,8 @@
 src:
   - '.github/generated/ast_changes_watch_list.yml'
   - 'apps/oxlint/src-js/generated/constants.js'
+  - 'apps/oxlint/src-js/generated/types.d.ts'
+  - 'apps/oxlint/src-js/generated/visitor.d.ts'
   - 'apps/oxlint/src/generated/raw_transfer_constants.rs'
   - 'crates/oxc_allocator/src/generated/assert_layouts.rs'
   - 'crates/oxc_allocator/src/generated/fixed_size_constants.rs'

--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -35,9 +35,6 @@
   "files": [
     "dist"
   ],
-  "dependencies": {
-    "@oxc-project/types": "workspace:^"
-  },
   "devDependencies": {
     "eslint": "^9.36.0",
     "execa": "^9.6.0",

--- a/apps/oxlint/scripts/build.js
+++ b/apps/oxlint/scripts/build.js
@@ -35,7 +35,6 @@ const parserFilePaths = [
   'generated/deserialize/ts_range_parent_no_parens.js',
   'generated/visit/keys.js',
   'generated/visit/types.js',
-  'generated/visit/visitor.d.ts',
   'generated/visit/walk.js',
 ];
 

--- a/apps/oxlint/src-js/generated/types.d.ts
+++ b/apps/oxlint/src-js/generated/types.d.ts
@@ -1,0 +1,1894 @@
+// Auto-generated code, DO NOT EDIT DIRECTLY!
+// To edit this generated file you have to edit `tasks/ast_tools/src/generators/typescript.rs`.
+
+export interface Program extends Span {
+  type: 'Program';
+  body: Array<Directive | Statement>;
+  sourceType: ModuleKind;
+  hashbang: Hashbang | null;
+  parent?: null;
+}
+
+export type Expression =
+  | BooleanLiteral
+  | NullLiteral
+  | NumericLiteral
+  | BigIntLiteral
+  | RegExpLiteral
+  | StringLiteral
+  | TemplateLiteral
+  | IdentifierReference
+  | MetaProperty
+  | Super
+  | ArrayExpression
+  | ArrowFunctionExpression
+  | AssignmentExpression
+  | AwaitExpression
+  | BinaryExpression
+  | CallExpression
+  | ChainExpression
+  | Class
+  | ConditionalExpression
+  | Function
+  | ImportExpression
+  | LogicalExpression
+  | NewExpression
+  | ObjectExpression
+  | ParenthesizedExpression
+  | SequenceExpression
+  | TaggedTemplateExpression
+  | ThisExpression
+  | UnaryExpression
+  | UpdateExpression
+  | YieldExpression
+  | PrivateInExpression
+  | JSXElement
+  | JSXFragment
+  | TSAsExpression
+  | TSSatisfiesExpression
+  | TSTypeAssertion
+  | TSNonNullExpression
+  | TSInstantiationExpression
+  | V8IntrinsicExpression
+  | MemberExpression;
+
+export interface IdentifierName extends Span {
+  type: 'Identifier';
+  decorators?: [];
+  name: string;
+  optional?: false;
+  typeAnnotation?: null;
+  parent?: Node;
+}
+
+export interface IdentifierReference extends Span {
+  type: 'Identifier';
+  decorators?: [];
+  name: string;
+  optional?: false;
+  typeAnnotation?: null;
+  parent?: Node;
+}
+
+export interface BindingIdentifier extends Span {
+  type: 'Identifier';
+  decorators?: [];
+  name: string;
+  optional?: false;
+  typeAnnotation?: null;
+  parent?: Node;
+}
+
+export interface LabelIdentifier extends Span {
+  type: 'Identifier';
+  decorators?: [];
+  name: string;
+  optional?: false;
+  typeAnnotation?: null;
+  parent?: Node;
+}
+
+export interface ThisExpression extends Span {
+  type: 'ThisExpression';
+  parent?: Node;
+}
+
+export interface ArrayExpression extends Span {
+  type: 'ArrayExpression';
+  elements: Array<ArrayExpressionElement>;
+  parent?: Node;
+}
+
+export type ArrayExpressionElement = SpreadElement | null | Expression;
+
+export interface ObjectExpression extends Span {
+  type: 'ObjectExpression';
+  properties: Array<ObjectPropertyKind>;
+  parent?: Node;
+}
+
+export type ObjectPropertyKind = ObjectProperty | SpreadElement;
+
+export interface ObjectProperty extends Span {
+  type: 'Property';
+  kind: PropertyKind;
+  key: PropertyKey;
+  value: Expression;
+  method: boolean;
+  shorthand: boolean;
+  computed: boolean;
+  optional?: false;
+  parent?: Node;
+}
+
+export type PropertyKey = IdentifierName | PrivateIdentifier | Expression;
+
+export type PropertyKind = 'init' | 'get' | 'set';
+
+export interface TemplateLiteral extends Span {
+  type: 'TemplateLiteral';
+  quasis: Array<TemplateElement>;
+  expressions: Array<Expression>;
+  parent?: Node;
+}
+
+export interface TaggedTemplateExpression extends Span {
+  type: 'TaggedTemplateExpression';
+  tag: Expression;
+  typeArguments?: TSTypeParameterInstantiation | null;
+  quasi: TemplateLiteral;
+  parent?: Node;
+}
+
+export interface TemplateElement extends Span {
+  type: 'TemplateElement';
+  value: TemplateElementValue;
+  tail: boolean;
+  parent?: Node;
+}
+
+export interface TemplateElementValue {
+  raw: string;
+  cooked: string | null;
+}
+
+export type MemberExpression = ComputedMemberExpression | StaticMemberExpression | PrivateFieldExpression;
+
+export interface ComputedMemberExpression extends Span {
+  type: 'MemberExpression';
+  object: Expression;
+  property: Expression;
+  optional: boolean;
+  computed: true;
+  parent?: Node;
+}
+
+export interface StaticMemberExpression extends Span {
+  type: 'MemberExpression';
+  object: Expression;
+  property: IdentifierName;
+  optional: boolean;
+  computed: false;
+  parent?: Node;
+}
+
+export interface PrivateFieldExpression extends Span {
+  type: 'MemberExpression';
+  object: Expression;
+  property: PrivateIdentifier;
+  optional: boolean;
+  computed: false;
+  parent?: Node;
+}
+
+export interface CallExpression extends Span {
+  type: 'CallExpression';
+  callee: Expression;
+  typeArguments?: TSTypeParameterInstantiation | null;
+  arguments: Array<Argument>;
+  optional: boolean;
+  parent?: Node;
+}
+
+export interface NewExpression extends Span {
+  type: 'NewExpression';
+  callee: Expression;
+  typeArguments?: TSTypeParameterInstantiation | null;
+  arguments: Array<Argument>;
+  parent?: Node;
+}
+
+export interface MetaProperty extends Span {
+  type: 'MetaProperty';
+  meta: IdentifierName;
+  property: IdentifierName;
+  parent?: Node;
+}
+
+export interface SpreadElement extends Span {
+  type: 'SpreadElement';
+  argument: Expression;
+  parent?: Node;
+}
+
+export type Argument = SpreadElement | Expression;
+
+export interface UpdateExpression extends Span {
+  type: 'UpdateExpression';
+  operator: UpdateOperator;
+  prefix: boolean;
+  argument: SimpleAssignmentTarget;
+  parent?: Node;
+}
+
+export interface UnaryExpression extends Span {
+  type: 'UnaryExpression';
+  operator: UnaryOperator;
+  argument: Expression;
+  prefix: true;
+  parent?: Node;
+}
+
+export interface BinaryExpression extends Span {
+  type: 'BinaryExpression';
+  left: Expression;
+  operator: BinaryOperator;
+  right: Expression;
+  parent?: Node;
+}
+
+export interface PrivateInExpression extends Span {
+  type: 'BinaryExpression';
+  left: PrivateIdentifier;
+  operator: 'in';
+  right: Expression;
+  parent?: Node;
+}
+
+export interface LogicalExpression extends Span {
+  type: 'LogicalExpression';
+  left: Expression;
+  operator: LogicalOperator;
+  right: Expression;
+  parent?: Node;
+}
+
+export interface ConditionalExpression extends Span {
+  type: 'ConditionalExpression';
+  test: Expression;
+  consequent: Expression;
+  alternate: Expression;
+  parent?: Node;
+}
+
+export interface AssignmentExpression extends Span {
+  type: 'AssignmentExpression';
+  operator: AssignmentOperator;
+  left: AssignmentTarget;
+  right: Expression;
+  parent?: Node;
+}
+
+export type AssignmentTarget = SimpleAssignmentTarget | AssignmentTargetPattern;
+
+export type SimpleAssignmentTarget =
+  | IdentifierReference
+  | TSAsExpression
+  | TSSatisfiesExpression
+  | TSNonNullExpression
+  | TSTypeAssertion
+  | MemberExpression;
+
+export type AssignmentTargetPattern = ArrayAssignmentTarget | ObjectAssignmentTarget;
+
+export interface ArrayAssignmentTarget extends Span {
+  type: 'ArrayPattern';
+  decorators?: [];
+  elements: Array<AssignmentTargetMaybeDefault | AssignmentTargetRest | null>;
+  optional?: false;
+  typeAnnotation?: null;
+  parent?: Node;
+}
+
+export interface ObjectAssignmentTarget extends Span {
+  type: 'ObjectPattern';
+  decorators?: [];
+  properties: Array<AssignmentTargetProperty | AssignmentTargetRest>;
+  optional?: false;
+  typeAnnotation?: null;
+  parent?: Node;
+}
+
+export interface AssignmentTargetRest extends Span {
+  type: 'RestElement';
+  decorators?: [];
+  argument: AssignmentTarget;
+  optional?: false;
+  typeAnnotation?: null;
+  value?: null;
+  parent?: Node;
+}
+
+export type AssignmentTargetMaybeDefault = AssignmentTargetWithDefault | AssignmentTarget;
+
+export interface AssignmentTargetWithDefault extends Span {
+  type: 'AssignmentPattern';
+  decorators?: [];
+  left: AssignmentTarget;
+  right: Expression;
+  optional?: false;
+  typeAnnotation?: null;
+  parent?: Node;
+}
+
+export type AssignmentTargetProperty = AssignmentTargetPropertyIdentifier | AssignmentTargetPropertyProperty;
+
+export interface AssignmentTargetPropertyIdentifier extends Span {
+  type: 'Property';
+  kind: 'init';
+  key: IdentifierReference;
+  value: IdentifierReference | AssignmentTargetWithDefault;
+  method: false;
+  shorthand: true;
+  computed: false;
+  optional?: false;
+  parent?: Node;
+}
+
+export interface AssignmentTargetPropertyProperty extends Span {
+  type: 'Property';
+  kind: 'init';
+  key: PropertyKey;
+  value: AssignmentTargetMaybeDefault;
+  method: false;
+  shorthand: false;
+  computed: boolean;
+  optional?: false;
+  parent?: Node;
+}
+
+export interface SequenceExpression extends Span {
+  type: 'SequenceExpression';
+  expressions: Array<Expression>;
+  parent?: Node;
+}
+
+export interface Super extends Span {
+  type: 'Super';
+  parent?: Node;
+}
+
+export interface AwaitExpression extends Span {
+  type: 'AwaitExpression';
+  argument: Expression;
+  parent?: Node;
+}
+
+export interface ChainExpression extends Span {
+  type: 'ChainExpression';
+  expression: ChainElement;
+  parent?: Node;
+}
+
+export type ChainElement = CallExpression | TSNonNullExpression | MemberExpression;
+
+export interface ParenthesizedExpression extends Span {
+  type: 'ParenthesizedExpression';
+  expression: Expression;
+  parent?: Node;
+}
+
+export type Statement =
+  | BlockStatement
+  | BreakStatement
+  | ContinueStatement
+  | DebuggerStatement
+  | DoWhileStatement
+  | EmptyStatement
+  | ExpressionStatement
+  | ForInStatement
+  | ForOfStatement
+  | ForStatement
+  | IfStatement
+  | LabeledStatement
+  | ReturnStatement
+  | SwitchStatement
+  | ThrowStatement
+  | TryStatement
+  | WhileStatement
+  | WithStatement
+  | Declaration
+  | ModuleDeclaration;
+
+export interface Directive extends Span {
+  type: 'ExpressionStatement';
+  expression: StringLiteral;
+  directive: string;
+  parent?: Node;
+}
+
+export interface Hashbang extends Span {
+  type: 'Hashbang';
+  value: string;
+  parent?: Node;
+}
+
+export interface BlockStatement extends Span {
+  type: 'BlockStatement';
+  body: Array<Statement>;
+  parent?: Node;
+}
+
+export type Declaration =
+  | VariableDeclaration
+  | Function
+  | Class
+  | TSTypeAliasDeclaration
+  | TSInterfaceDeclaration
+  | TSEnumDeclaration
+  | TSModuleDeclaration
+  | TSImportEqualsDeclaration;
+
+export interface VariableDeclaration extends Span {
+  type: 'VariableDeclaration';
+  kind: VariableDeclarationKind;
+  declarations: Array<VariableDeclarator>;
+  declare?: boolean;
+  parent?: Node;
+}
+
+export type VariableDeclarationKind = 'var' | 'let' | 'const' | 'using' | 'await using';
+
+export interface VariableDeclarator extends Span {
+  type: 'VariableDeclarator';
+  id: BindingPattern;
+  init: Expression | null;
+  definite?: boolean;
+  parent?: Node;
+}
+
+export interface EmptyStatement extends Span {
+  type: 'EmptyStatement';
+  parent?: Node;
+}
+
+export interface ExpressionStatement extends Span {
+  type: 'ExpressionStatement';
+  expression: Expression;
+  directive?: string | null;
+  parent?: Node;
+}
+
+export interface IfStatement extends Span {
+  type: 'IfStatement';
+  test: Expression;
+  consequent: Statement;
+  alternate: Statement | null;
+  parent?: Node;
+}
+
+export interface DoWhileStatement extends Span {
+  type: 'DoWhileStatement';
+  body: Statement;
+  test: Expression;
+  parent?: Node;
+}
+
+export interface WhileStatement extends Span {
+  type: 'WhileStatement';
+  test: Expression;
+  body: Statement;
+  parent?: Node;
+}
+
+export interface ForStatement extends Span {
+  type: 'ForStatement';
+  init: ForStatementInit | null;
+  test: Expression | null;
+  update: Expression | null;
+  body: Statement;
+  parent?: Node;
+}
+
+export type ForStatementInit = VariableDeclaration | Expression;
+
+export interface ForInStatement extends Span {
+  type: 'ForInStatement';
+  left: ForStatementLeft;
+  right: Expression;
+  body: Statement;
+  parent?: Node;
+}
+
+export type ForStatementLeft = VariableDeclaration | AssignmentTarget;
+
+export interface ForOfStatement extends Span {
+  type: 'ForOfStatement';
+  await: boolean;
+  left: ForStatementLeft;
+  right: Expression;
+  body: Statement;
+  parent?: Node;
+}
+
+export interface ContinueStatement extends Span {
+  type: 'ContinueStatement';
+  label: LabelIdentifier | null;
+  parent?: Node;
+}
+
+export interface BreakStatement extends Span {
+  type: 'BreakStatement';
+  label: LabelIdentifier | null;
+  parent?: Node;
+}
+
+export interface ReturnStatement extends Span {
+  type: 'ReturnStatement';
+  argument: Expression | null;
+  parent?: Node;
+}
+
+export interface WithStatement extends Span {
+  type: 'WithStatement';
+  object: Expression;
+  body: Statement;
+  parent?: Node;
+}
+
+export interface SwitchStatement extends Span {
+  type: 'SwitchStatement';
+  discriminant: Expression;
+  cases: Array<SwitchCase>;
+  parent?: Node;
+}
+
+export interface SwitchCase extends Span {
+  type: 'SwitchCase';
+  test: Expression | null;
+  consequent: Array<Statement>;
+  parent?: Node;
+}
+
+export interface LabeledStatement extends Span {
+  type: 'LabeledStatement';
+  label: LabelIdentifier;
+  body: Statement;
+  parent?: Node;
+}
+
+export interface ThrowStatement extends Span {
+  type: 'ThrowStatement';
+  argument: Expression;
+  parent?: Node;
+}
+
+export interface TryStatement extends Span {
+  type: 'TryStatement';
+  block: BlockStatement;
+  handler: CatchClause | null;
+  finalizer: BlockStatement | null;
+  parent?: Node;
+}
+
+export interface CatchClause extends Span {
+  type: 'CatchClause';
+  param: BindingPattern | null;
+  body: BlockStatement;
+  parent?: Node;
+}
+
+export interface DebuggerStatement extends Span {
+  type: 'DebuggerStatement';
+  parent?: Node;
+}
+
+export type BindingPattern =
+  & ({
+    optional?: boolean;
+    typeAnnotation?: TSTypeAnnotation | null;
+  })
+  & (BindingIdentifier | ObjectPattern | ArrayPattern | AssignmentPattern);
+
+export type BindingPatternKind = BindingIdentifier | ObjectPattern | ArrayPattern | AssignmentPattern;
+
+export interface AssignmentPattern extends Span {
+  type: 'AssignmentPattern';
+  decorators?: [];
+  left: BindingPattern;
+  right: Expression;
+  optional?: false;
+  typeAnnotation?: null;
+  parent?: Node;
+}
+
+export interface ObjectPattern extends Span {
+  type: 'ObjectPattern';
+  decorators?: [];
+  properties: Array<BindingProperty | BindingRestElement>;
+  optional?: false;
+  typeAnnotation?: null;
+  parent?: Node;
+}
+
+export interface BindingProperty extends Span {
+  type: 'Property';
+  kind: 'init';
+  key: PropertyKey;
+  value: BindingPattern;
+  method: false;
+  shorthand: boolean;
+  computed: boolean;
+  optional?: false;
+  parent?: Node;
+}
+
+export interface ArrayPattern extends Span {
+  type: 'ArrayPattern';
+  decorators?: [];
+  elements: Array<BindingPattern | BindingRestElement | null>;
+  optional?: false;
+  typeAnnotation?: null;
+  parent?: Node;
+}
+
+export interface BindingRestElement extends Span {
+  type: 'RestElement';
+  decorators?: [];
+  argument: BindingPattern;
+  optional?: false;
+  typeAnnotation?: null;
+  value?: null;
+  parent?: Node;
+}
+
+export interface Function extends Span {
+  type: FunctionType;
+  id: BindingIdentifier | null;
+  generator: boolean;
+  async: boolean;
+  declare?: boolean;
+  typeParameters?: TSTypeParameterDeclaration | null;
+  params: ParamPattern[];
+  returnType?: TSTypeAnnotation | null;
+  body: FunctionBody | null;
+  expression: false;
+  parent?: Node;
+}
+
+export type ParamPattern = FormalParameter | TSParameterProperty | FormalParameterRest;
+
+export type FunctionType =
+  | 'FunctionDeclaration'
+  | 'FunctionExpression'
+  | 'TSDeclareFunction'
+  | 'TSEmptyBodyFunctionExpression';
+
+export interface FormalParameterRest extends Span {
+  type: 'RestElement';
+  argument: BindingPatternKind;
+  decorators?: [];
+  optional?: boolean;
+  typeAnnotation?: TSTypeAnnotation | null;
+  value?: null;
+}
+
+export type FormalParameter =
+  & ({
+    decorators?: Array<Decorator>;
+  })
+  & BindingPattern;
+
+export interface TSParameterProperty extends Span {
+  type: 'TSParameterProperty';
+  accessibility: TSAccessibility | null;
+  decorators: Array<Decorator>;
+  override: boolean;
+  parameter: FormalParameter;
+  readonly: boolean;
+  static: boolean;
+}
+
+export interface FunctionBody extends Span {
+  type: 'BlockStatement';
+  body: Array<Directive | Statement>;
+  parent?: Node;
+}
+
+export interface ArrowFunctionExpression extends Span {
+  type: 'ArrowFunctionExpression';
+  expression: boolean;
+  async: boolean;
+  typeParameters?: TSTypeParameterDeclaration | null;
+  params: ParamPattern[];
+  returnType?: TSTypeAnnotation | null;
+  body: FunctionBody | Expression;
+  id: null;
+  generator: false;
+  parent?: Node;
+}
+
+export interface YieldExpression extends Span {
+  type: 'YieldExpression';
+  delegate: boolean;
+  argument: Expression | null;
+  parent?: Node;
+}
+
+export interface Class extends Span {
+  type: ClassType;
+  decorators: Array<Decorator>;
+  id: BindingIdentifier | null;
+  typeParameters?: TSTypeParameterDeclaration | null;
+  superClass: Expression | null;
+  superTypeArguments?: TSTypeParameterInstantiation | null;
+  implements?: Array<TSClassImplements>;
+  body: ClassBody;
+  abstract?: boolean;
+  declare?: boolean;
+  parent?: Node;
+}
+
+export type ClassType = 'ClassDeclaration' | 'ClassExpression';
+
+export interface ClassBody extends Span {
+  type: 'ClassBody';
+  body: Array<ClassElement>;
+  parent?: Node;
+}
+
+export type ClassElement = StaticBlock | MethodDefinition | PropertyDefinition | AccessorProperty | TSIndexSignature;
+
+export interface MethodDefinition extends Span {
+  type: MethodDefinitionType;
+  decorators: Array<Decorator>;
+  key: PropertyKey;
+  value: Function;
+  kind: MethodDefinitionKind;
+  computed: boolean;
+  static: boolean;
+  override?: boolean;
+  optional?: boolean;
+  accessibility?: TSAccessibility | null;
+  parent?: Node;
+}
+
+export type MethodDefinitionType = 'MethodDefinition' | 'TSAbstractMethodDefinition';
+
+export interface PropertyDefinition extends Span {
+  type: PropertyDefinitionType;
+  decorators: Array<Decorator>;
+  key: PropertyKey;
+  typeAnnotation?: TSTypeAnnotation | null;
+  value: Expression | null;
+  computed: boolean;
+  static: boolean;
+  declare?: boolean;
+  override?: boolean;
+  optional?: boolean;
+  definite?: boolean;
+  readonly?: boolean;
+  accessibility?: TSAccessibility | null;
+  parent?: Node;
+}
+
+export type PropertyDefinitionType = 'PropertyDefinition' | 'TSAbstractPropertyDefinition';
+
+export type MethodDefinitionKind = 'constructor' | 'method' | 'get' | 'set';
+
+export interface PrivateIdentifier extends Span {
+  type: 'PrivateIdentifier';
+  name: string;
+  parent?: Node;
+}
+
+export interface StaticBlock extends Span {
+  type: 'StaticBlock';
+  body: Array<Statement>;
+  parent?: Node;
+}
+
+export type ModuleDeclaration =
+  | ImportDeclaration
+  | ExportAllDeclaration
+  | ExportDefaultDeclaration
+  | ExportNamedDeclaration
+  | TSExportAssignment
+  | TSNamespaceExportDeclaration;
+
+export type AccessorPropertyType = 'AccessorProperty' | 'TSAbstractAccessorProperty';
+
+export interface AccessorProperty extends Span {
+  type: AccessorPropertyType;
+  decorators: Array<Decorator>;
+  key: PropertyKey;
+  typeAnnotation?: TSTypeAnnotation | null;
+  value: Expression | null;
+  computed: boolean;
+  static: boolean;
+  override?: boolean;
+  definite?: boolean;
+  accessibility?: TSAccessibility | null;
+  declare?: false;
+  optional?: false;
+  readonly?: false;
+  parent?: Node;
+}
+
+export interface ImportExpression extends Span {
+  type: 'ImportExpression';
+  source: Expression;
+  options: Expression | null;
+  phase: ImportPhase | null;
+  parent?: Node;
+}
+
+export interface ImportDeclaration extends Span {
+  type: 'ImportDeclaration';
+  specifiers: Array<ImportDeclarationSpecifier>;
+  source: StringLiteral;
+  phase: ImportPhase | null;
+  attributes: Array<ImportAttribute>;
+  importKind?: ImportOrExportKind;
+  parent?: Node;
+}
+
+export type ImportPhase = 'source' | 'defer';
+
+export type ImportDeclarationSpecifier = ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier;
+
+export interface ImportSpecifier extends Span {
+  type: 'ImportSpecifier';
+  imported: ModuleExportName;
+  local: BindingIdentifier;
+  importKind?: ImportOrExportKind;
+  parent?: Node;
+}
+
+export interface ImportDefaultSpecifier extends Span {
+  type: 'ImportDefaultSpecifier';
+  local: BindingIdentifier;
+  parent?: Node;
+}
+
+export interface ImportNamespaceSpecifier extends Span {
+  type: 'ImportNamespaceSpecifier';
+  local: BindingIdentifier;
+  parent?: Node;
+}
+
+export interface ImportAttribute extends Span {
+  type: 'ImportAttribute';
+  key: ImportAttributeKey;
+  value: StringLiteral;
+  parent?: Node;
+}
+
+export type ImportAttributeKey = IdentifierName | StringLiteral;
+
+export interface ExportNamedDeclaration extends Span {
+  type: 'ExportNamedDeclaration';
+  declaration: Declaration | null;
+  specifiers: Array<ExportSpecifier>;
+  source: StringLiteral | null;
+  exportKind?: ImportOrExportKind;
+  attributes: Array<ImportAttribute>;
+  parent?: Node;
+}
+
+export interface ExportDefaultDeclaration extends Span {
+  type: 'ExportDefaultDeclaration';
+  declaration: ExportDefaultDeclarationKind;
+  exportKind?: 'value';
+  parent?: Node;
+}
+
+export interface ExportAllDeclaration extends Span {
+  type: 'ExportAllDeclaration';
+  exported: ModuleExportName | null;
+  source: StringLiteral;
+  attributes: Array<ImportAttribute>;
+  exportKind?: ImportOrExportKind;
+  parent?: Node;
+}
+
+export interface ExportSpecifier extends Span {
+  type: 'ExportSpecifier';
+  local: ModuleExportName;
+  exported: ModuleExportName;
+  exportKind?: ImportOrExportKind;
+  parent?: Node;
+}
+
+export type ExportDefaultDeclarationKind = Function | Class | TSInterfaceDeclaration | Expression;
+
+export type ModuleExportName = IdentifierName | IdentifierReference | StringLiteral;
+
+export interface V8IntrinsicExpression extends Span {
+  type: 'V8IntrinsicExpression';
+  name: IdentifierName;
+  arguments: Array<Argument>;
+  parent?: Node;
+}
+
+export interface BooleanLiteral extends Span {
+  type: 'Literal';
+  value: boolean;
+  raw: string | null;
+  parent?: Node;
+}
+
+export interface NullLiteral extends Span {
+  type: 'Literal';
+  value: null;
+  raw: 'null' | null;
+  parent?: Node;
+}
+
+export interface NumericLiteral extends Span {
+  type: 'Literal';
+  value: number;
+  raw: string | null;
+  parent?: Node;
+}
+
+export interface StringLiteral extends Span {
+  type: 'Literal';
+  value: string;
+  raw: string | null;
+  parent?: Node;
+}
+
+export interface BigIntLiteral extends Span {
+  type: 'Literal';
+  value: bigint;
+  raw: string | null;
+  bigint: string;
+  parent?: Node;
+}
+
+export interface RegExpLiteral extends Span {
+  type: 'Literal';
+  value: RegExp | null;
+  raw: string | null;
+  regex: { pattern: string; flags: string };
+  parent?: Node;
+}
+
+export interface JSXElement extends Span {
+  type: 'JSXElement';
+  openingElement: JSXOpeningElement;
+  children: Array<JSXChild>;
+  closingElement: JSXClosingElement | null;
+  parent?: Node;
+}
+
+export interface JSXOpeningElement extends Span {
+  type: 'JSXOpeningElement';
+  name: JSXElementName;
+  typeArguments?: TSTypeParameterInstantiation | null;
+  attributes: Array<JSXAttributeItem>;
+  selfClosing: boolean;
+  parent?: Node;
+}
+
+export interface JSXClosingElement extends Span {
+  type: 'JSXClosingElement';
+  name: JSXElementName;
+  parent?: Node;
+}
+
+export interface JSXFragment extends Span {
+  type: 'JSXFragment';
+  openingFragment: JSXOpeningFragment;
+  children: Array<JSXChild>;
+  closingFragment: JSXClosingFragment;
+  parent?: Node;
+}
+
+export interface JSXOpeningFragment extends Span {
+  type: 'JSXOpeningFragment';
+  attributes?: [];
+  selfClosing?: false;
+  parent?: Node;
+}
+
+export interface JSXClosingFragment extends Span {
+  type: 'JSXClosingFragment';
+  parent?: Node;
+}
+
+export type JSXElementName = JSXIdentifier | JSXNamespacedName | JSXMemberExpression;
+
+export interface JSXNamespacedName extends Span {
+  type: 'JSXNamespacedName';
+  namespace: JSXIdentifier;
+  name: JSXIdentifier;
+  parent?: Node;
+}
+
+export interface JSXMemberExpression extends Span {
+  type: 'JSXMemberExpression';
+  object: JSXMemberExpressionObject;
+  property: JSXIdentifier;
+  parent?: Node;
+}
+
+export type JSXMemberExpressionObject = JSXIdentifier | JSXMemberExpression;
+
+export interface JSXExpressionContainer extends Span {
+  type: 'JSXExpressionContainer';
+  expression: JSXExpression;
+  parent?: Node;
+}
+
+export type JSXExpression = JSXEmptyExpression | Expression;
+
+export interface JSXEmptyExpression extends Span {
+  type: 'JSXEmptyExpression';
+  parent?: Node;
+}
+
+export type JSXAttributeItem = JSXAttribute | JSXSpreadAttribute;
+
+export interface JSXAttribute extends Span {
+  type: 'JSXAttribute';
+  name: JSXAttributeName;
+  value: JSXAttributeValue | null;
+  parent?: Node;
+}
+
+export interface JSXSpreadAttribute extends Span {
+  type: 'JSXSpreadAttribute';
+  argument: Expression;
+  parent?: Node;
+}
+
+export type JSXAttributeName = JSXIdentifier | JSXNamespacedName;
+
+export type JSXAttributeValue = StringLiteral | JSXExpressionContainer | JSXElement | JSXFragment;
+
+export interface JSXIdentifier extends Span {
+  type: 'JSXIdentifier';
+  name: string;
+  parent?: Node;
+}
+
+export type JSXChild = JSXText | JSXElement | JSXFragment | JSXExpressionContainer | JSXSpreadChild;
+
+export interface JSXSpreadChild extends Span {
+  type: 'JSXSpreadChild';
+  expression: Expression;
+  parent?: Node;
+}
+
+export interface JSXText extends Span {
+  type: 'JSXText';
+  value: string;
+  raw: string | null;
+  parent?: Node;
+}
+
+export interface TSThisParameter extends Span {
+  type: 'Identifier';
+  decorators: [];
+  name: 'this';
+  optional: false;
+  typeAnnotation: TSTypeAnnotation | null;
+  parent?: Node;
+}
+
+export interface TSEnumDeclaration extends Span {
+  type: 'TSEnumDeclaration';
+  id: BindingIdentifier;
+  body: TSEnumBody;
+  const: boolean;
+  declare: boolean;
+  parent?: Node;
+}
+
+export interface TSEnumBody extends Span {
+  type: 'TSEnumBody';
+  members: Array<TSEnumMember>;
+  parent?: Node;
+}
+
+export interface TSEnumMember extends Span {
+  type: 'TSEnumMember';
+  id: TSEnumMemberName;
+  initializer: Expression | null;
+  computed: boolean;
+  parent?: Node;
+}
+
+export type TSEnumMemberName = IdentifierName | StringLiteral | TemplateLiteral;
+
+export interface TSTypeAnnotation extends Span {
+  type: 'TSTypeAnnotation';
+  typeAnnotation: TSType;
+  parent?: Node;
+}
+
+export interface TSLiteralType extends Span {
+  type: 'TSLiteralType';
+  literal: TSLiteral;
+  parent?: Node;
+}
+
+export type TSLiteral =
+  | BooleanLiteral
+  | NumericLiteral
+  | BigIntLiteral
+  | StringLiteral
+  | TemplateLiteral
+  | UnaryExpression;
+
+export type TSType =
+  | TSAnyKeyword
+  | TSBigIntKeyword
+  | TSBooleanKeyword
+  | TSIntrinsicKeyword
+  | TSNeverKeyword
+  | TSNullKeyword
+  | TSNumberKeyword
+  | TSObjectKeyword
+  | TSStringKeyword
+  | TSSymbolKeyword
+  | TSUndefinedKeyword
+  | TSUnknownKeyword
+  | TSVoidKeyword
+  | TSArrayType
+  | TSConditionalType
+  | TSConstructorType
+  | TSFunctionType
+  | TSImportType
+  | TSIndexedAccessType
+  | TSInferType
+  | TSIntersectionType
+  | TSLiteralType
+  | TSMappedType
+  | TSNamedTupleMember
+  | TSTemplateLiteralType
+  | TSThisType
+  | TSTupleType
+  | TSTypeLiteral
+  | TSTypeOperator
+  | TSTypePredicate
+  | TSTypeQuery
+  | TSTypeReference
+  | TSUnionType
+  | TSParenthesizedType
+  | JSDocNullableType
+  | JSDocNonNullableType
+  | JSDocUnknownType;
+
+export interface TSConditionalType extends Span {
+  type: 'TSConditionalType';
+  checkType: TSType;
+  extendsType: TSType;
+  trueType: TSType;
+  falseType: TSType;
+  parent?: Node;
+}
+
+export interface TSUnionType extends Span {
+  type: 'TSUnionType';
+  types: Array<TSType>;
+  parent?: Node;
+}
+
+export interface TSIntersectionType extends Span {
+  type: 'TSIntersectionType';
+  types: Array<TSType>;
+  parent?: Node;
+}
+
+export interface TSParenthesizedType extends Span {
+  type: 'TSParenthesizedType';
+  typeAnnotation: TSType;
+  parent?: Node;
+}
+
+export interface TSTypeOperator extends Span {
+  type: 'TSTypeOperator';
+  operator: TSTypeOperatorOperator;
+  typeAnnotation: TSType;
+  parent?: Node;
+}
+
+export type TSTypeOperatorOperator = 'keyof' | 'unique' | 'readonly';
+
+export interface TSArrayType extends Span {
+  type: 'TSArrayType';
+  elementType: TSType;
+  parent?: Node;
+}
+
+export interface TSIndexedAccessType extends Span {
+  type: 'TSIndexedAccessType';
+  objectType: TSType;
+  indexType: TSType;
+  parent?: Node;
+}
+
+export interface TSTupleType extends Span {
+  type: 'TSTupleType';
+  elementTypes: Array<TSTupleElement>;
+  parent?: Node;
+}
+
+export interface TSNamedTupleMember extends Span {
+  type: 'TSNamedTupleMember';
+  label: IdentifierName;
+  elementType: TSTupleElement;
+  optional: boolean;
+  parent?: Node;
+}
+
+export interface TSOptionalType extends Span {
+  type: 'TSOptionalType';
+  typeAnnotation: TSType;
+  parent?: Node;
+}
+
+export interface TSRestType extends Span {
+  type: 'TSRestType';
+  typeAnnotation: TSType;
+  parent?: Node;
+}
+
+export type TSTupleElement = TSOptionalType | TSRestType | TSType;
+
+export interface TSAnyKeyword extends Span {
+  type: 'TSAnyKeyword';
+  parent?: Node;
+}
+
+export interface TSStringKeyword extends Span {
+  type: 'TSStringKeyword';
+  parent?: Node;
+}
+
+export interface TSBooleanKeyword extends Span {
+  type: 'TSBooleanKeyword';
+  parent?: Node;
+}
+
+export interface TSNumberKeyword extends Span {
+  type: 'TSNumberKeyword';
+  parent?: Node;
+}
+
+export interface TSNeverKeyword extends Span {
+  type: 'TSNeverKeyword';
+  parent?: Node;
+}
+
+export interface TSIntrinsicKeyword extends Span {
+  type: 'TSIntrinsicKeyword';
+  parent?: Node;
+}
+
+export interface TSUnknownKeyword extends Span {
+  type: 'TSUnknownKeyword';
+  parent?: Node;
+}
+
+export interface TSNullKeyword extends Span {
+  type: 'TSNullKeyword';
+  parent?: Node;
+}
+
+export interface TSUndefinedKeyword extends Span {
+  type: 'TSUndefinedKeyword';
+  parent?: Node;
+}
+
+export interface TSVoidKeyword extends Span {
+  type: 'TSVoidKeyword';
+  parent?: Node;
+}
+
+export interface TSSymbolKeyword extends Span {
+  type: 'TSSymbolKeyword';
+  parent?: Node;
+}
+
+export interface TSThisType extends Span {
+  type: 'TSThisType';
+  parent?: Node;
+}
+
+export interface TSObjectKeyword extends Span {
+  type: 'TSObjectKeyword';
+  parent?: Node;
+}
+
+export interface TSBigIntKeyword extends Span {
+  type: 'TSBigIntKeyword';
+  parent?: Node;
+}
+
+export interface TSTypeReference extends Span {
+  type: 'TSTypeReference';
+  typeName: TSTypeName;
+  typeArguments: TSTypeParameterInstantiation | null;
+  parent?: Node;
+}
+
+export type TSTypeName = IdentifierReference | TSQualifiedName | ThisExpression;
+
+export interface TSQualifiedName extends Span {
+  type: 'TSQualifiedName';
+  left: TSTypeName;
+  right: IdentifierName;
+  parent?: Node;
+}
+
+export interface TSTypeParameterInstantiation extends Span {
+  type: 'TSTypeParameterInstantiation';
+  params: Array<TSType>;
+  parent?: Node;
+}
+
+export interface TSTypeParameter extends Span {
+  type: 'TSTypeParameter';
+  name: BindingIdentifier;
+  constraint: TSType | null;
+  default: TSType | null;
+  in: boolean;
+  out: boolean;
+  const: boolean;
+  parent?: Node;
+}
+
+export interface TSTypeParameterDeclaration extends Span {
+  type: 'TSTypeParameterDeclaration';
+  params: Array<TSTypeParameter>;
+  parent?: Node;
+}
+
+export interface TSTypeAliasDeclaration extends Span {
+  type: 'TSTypeAliasDeclaration';
+  id: BindingIdentifier;
+  typeParameters: TSTypeParameterDeclaration | null;
+  typeAnnotation: TSType;
+  declare: boolean;
+  parent?: Node;
+}
+
+export type TSAccessibility = 'private' | 'protected' | 'public';
+
+export interface TSClassImplements extends Span {
+  type: 'TSClassImplements';
+  expression: IdentifierReference | ThisExpression | MemberExpression;
+  typeArguments: TSTypeParameterInstantiation | null;
+  parent?: Node;
+}
+
+export interface TSInterfaceDeclaration extends Span {
+  type: 'TSInterfaceDeclaration';
+  id: BindingIdentifier;
+  typeParameters: TSTypeParameterDeclaration | null;
+  extends: Array<TSInterfaceHeritage>;
+  body: TSInterfaceBody;
+  declare: boolean;
+  parent?: Node;
+}
+
+export interface TSInterfaceBody extends Span {
+  type: 'TSInterfaceBody';
+  body: Array<TSSignature>;
+  parent?: Node;
+}
+
+export interface TSPropertySignature extends Span {
+  type: 'TSPropertySignature';
+  computed: boolean;
+  optional: boolean;
+  readonly: boolean;
+  key: PropertyKey;
+  typeAnnotation: TSTypeAnnotation | null;
+  accessibility: null;
+  static: false;
+  parent?: Node;
+}
+
+export type TSSignature =
+  | TSIndexSignature
+  | TSPropertySignature
+  | TSCallSignatureDeclaration
+  | TSConstructSignatureDeclaration
+  | TSMethodSignature;
+
+export interface TSIndexSignature extends Span {
+  type: 'TSIndexSignature';
+  parameters: Array<TSIndexSignatureName>;
+  typeAnnotation: TSTypeAnnotation;
+  readonly: boolean;
+  static: boolean;
+  accessibility: null;
+  parent?: Node;
+}
+
+export interface TSCallSignatureDeclaration extends Span {
+  type: 'TSCallSignatureDeclaration';
+  typeParameters: TSTypeParameterDeclaration | null;
+  params: ParamPattern[];
+  returnType: TSTypeAnnotation | null;
+  parent?: Node;
+}
+
+export type TSMethodSignatureKind = 'method' | 'get' | 'set';
+
+export interface TSMethodSignature extends Span {
+  type: 'TSMethodSignature';
+  key: PropertyKey;
+  computed: boolean;
+  optional: boolean;
+  kind: TSMethodSignatureKind;
+  typeParameters: TSTypeParameterDeclaration | null;
+  params: ParamPattern[];
+  returnType: TSTypeAnnotation | null;
+  accessibility: null;
+  readonly: false;
+  static: false;
+  parent?: Node;
+}
+
+export interface TSConstructSignatureDeclaration extends Span {
+  type: 'TSConstructSignatureDeclaration';
+  typeParameters: TSTypeParameterDeclaration | null;
+  params: ParamPattern[];
+  returnType: TSTypeAnnotation | null;
+  parent?: Node;
+}
+
+export interface TSIndexSignatureName extends Span {
+  type: 'Identifier';
+  decorators: [];
+  name: string;
+  optional: false;
+  typeAnnotation: TSTypeAnnotation;
+  parent?: Node;
+}
+
+export interface TSInterfaceHeritage extends Span {
+  type: 'TSInterfaceHeritage';
+  expression: Expression;
+  typeArguments: TSTypeParameterInstantiation | null;
+  parent?: Node;
+}
+
+export interface TSTypePredicate extends Span {
+  type: 'TSTypePredicate';
+  parameterName: TSTypePredicateName;
+  asserts: boolean;
+  typeAnnotation: TSTypeAnnotation | null;
+  parent?: Node;
+}
+
+export type TSTypePredicateName = IdentifierName | TSThisType;
+
+export interface TSModuleDeclaration extends Span {
+  type: 'TSModuleDeclaration';
+  id: BindingIdentifier | StringLiteral | TSQualifiedName;
+  body: TSModuleBlock | null;
+  kind: TSModuleDeclarationKind;
+  declare: boolean;
+  global: boolean;
+  parent?: Node;
+}
+
+export type TSModuleDeclarationKind = 'global' | 'module' | 'namespace';
+
+export interface TSModuleBlock extends Span {
+  type: 'TSModuleBlock';
+  body: Array<Directive | Statement>;
+  parent?: Node;
+}
+
+export interface TSTypeLiteral extends Span {
+  type: 'TSTypeLiteral';
+  members: Array<TSSignature>;
+  parent?: Node;
+}
+
+export interface TSInferType extends Span {
+  type: 'TSInferType';
+  typeParameter: TSTypeParameter;
+  parent?: Node;
+}
+
+export interface TSTypeQuery extends Span {
+  type: 'TSTypeQuery';
+  exprName: TSTypeQueryExprName;
+  typeArguments: TSTypeParameterInstantiation | null;
+  parent?: Node;
+}
+
+export type TSTypeQueryExprName = TSImportType | TSTypeName;
+
+export interface TSImportType extends Span {
+  type: 'TSImportType';
+  argument: TSType;
+  options: ObjectExpression | null;
+  qualifier: TSImportTypeQualifier | null;
+  typeArguments: TSTypeParameterInstantiation | null;
+  parent?: Node;
+}
+
+export type TSImportTypeQualifier = IdentifierName | TSImportTypeQualifiedName;
+
+export interface TSImportTypeQualifiedName extends Span {
+  type: 'TSQualifiedName';
+  left: TSImportTypeQualifier;
+  right: IdentifierName;
+  parent?: Node;
+}
+
+export interface TSFunctionType extends Span {
+  type: 'TSFunctionType';
+  typeParameters: TSTypeParameterDeclaration | null;
+  params: ParamPattern[];
+  returnType: TSTypeAnnotation;
+  parent?: Node;
+}
+
+export interface TSConstructorType extends Span {
+  type: 'TSConstructorType';
+  abstract: boolean;
+  typeParameters: TSTypeParameterDeclaration | null;
+  params: ParamPattern[];
+  returnType: TSTypeAnnotation;
+  parent?: Node;
+}
+
+export interface TSMappedType extends Span {
+  type: 'TSMappedType';
+  key: TSTypeParameter['name'];
+  constraint: TSTypeParameter['constraint'];
+  nameType: TSType | null;
+  typeAnnotation: TSType | null;
+  optional: TSMappedTypeModifierOperator | false;
+  readonly: TSMappedTypeModifierOperator | null;
+  parent?: Node;
+}
+
+export type TSMappedTypeModifierOperator = true | '+' | '-';
+
+export interface TSTemplateLiteralType extends Span {
+  type: 'TSTemplateLiteralType';
+  quasis: Array<TemplateElement>;
+  types: Array<TSType>;
+  parent?: Node;
+}
+
+export interface TSAsExpression extends Span {
+  type: 'TSAsExpression';
+  expression: Expression;
+  typeAnnotation: TSType;
+  parent?: Node;
+}
+
+export interface TSSatisfiesExpression extends Span {
+  type: 'TSSatisfiesExpression';
+  expression: Expression;
+  typeAnnotation: TSType;
+  parent?: Node;
+}
+
+export interface TSTypeAssertion extends Span {
+  type: 'TSTypeAssertion';
+  typeAnnotation: TSType;
+  expression: Expression;
+  parent?: Node;
+}
+
+export interface TSImportEqualsDeclaration extends Span {
+  type: 'TSImportEqualsDeclaration';
+  id: BindingIdentifier;
+  moduleReference: TSModuleReference;
+  importKind: ImportOrExportKind;
+  parent?: Node;
+}
+
+export type TSModuleReference = TSExternalModuleReference | TSTypeName;
+
+export interface TSExternalModuleReference extends Span {
+  type: 'TSExternalModuleReference';
+  expression: StringLiteral;
+  parent?: Node;
+}
+
+export interface TSNonNullExpression extends Span {
+  type: 'TSNonNullExpression';
+  expression: Expression;
+  parent?: Node;
+}
+
+export interface Decorator extends Span {
+  type: 'Decorator';
+  expression: Expression;
+  parent?: Node;
+}
+
+export interface TSExportAssignment extends Span {
+  type: 'TSExportAssignment';
+  expression: Expression;
+  parent?: Node;
+}
+
+export interface TSNamespaceExportDeclaration extends Span {
+  type: 'TSNamespaceExportDeclaration';
+  id: IdentifierName;
+  parent?: Node;
+}
+
+export interface TSInstantiationExpression extends Span {
+  type: 'TSInstantiationExpression';
+  expression: Expression;
+  typeArguments: TSTypeParameterInstantiation;
+  parent?: Node;
+}
+
+export type ImportOrExportKind = 'value' | 'type';
+
+export interface JSDocNullableType extends Span {
+  type: 'TSJSDocNullableType';
+  typeAnnotation: TSType;
+  postfix: boolean;
+  parent?: Node;
+}
+
+export interface JSDocNonNullableType extends Span {
+  type: 'TSJSDocNonNullableType';
+  typeAnnotation: TSType;
+  postfix: boolean;
+  parent?: Node;
+}
+
+export interface JSDocUnknownType extends Span {
+  type: 'TSJSDocUnknownType';
+  parent?: Node;
+}
+
+export type AssignmentOperator =
+  | '='
+  | '+='
+  | '-='
+  | '*='
+  | '/='
+  | '%='
+  | '**='
+  | '<<='
+  | '>>='
+  | '>>>='
+  | '|='
+  | '^='
+  | '&='
+  | '||='
+  | '&&='
+  | '??=';
+
+export type BinaryOperator =
+  | '=='
+  | '!='
+  | '==='
+  | '!=='
+  | '<'
+  | '<='
+  | '>'
+  | '>='
+  | '+'
+  | '-'
+  | '*'
+  | '/'
+  | '%'
+  | '**'
+  | '<<'
+  | '>>'
+  | '>>>'
+  | '|'
+  | '^'
+  | '&'
+  | 'in'
+  | 'instanceof';
+
+export type LogicalOperator = '||' | '&&' | '??';
+
+export type UnaryOperator = '+' | '-' | '!' | '~' | 'typeof' | 'void' | 'delete';
+
+export type UpdateOperator = '++' | '--';
+
+export interface Span {
+  start: number;
+  end: number;
+  range?: [number, number];
+}
+
+export type ModuleKind = 'script' | 'module';
+
+export type Node =
+  | Program
+  | IdentifierName
+  | IdentifierReference
+  | BindingIdentifier
+  | LabelIdentifier
+  | ThisExpression
+  | ArrayExpression
+  | ObjectExpression
+  | ObjectProperty
+  | TemplateLiteral
+  | TaggedTemplateExpression
+  | TemplateElement
+  | ComputedMemberExpression
+  | StaticMemberExpression
+  | PrivateFieldExpression
+  | CallExpression
+  | NewExpression
+  | MetaProperty
+  | SpreadElement
+  | UpdateExpression
+  | UnaryExpression
+  | BinaryExpression
+  | PrivateInExpression
+  | LogicalExpression
+  | ConditionalExpression
+  | AssignmentExpression
+  | ArrayAssignmentTarget
+  | ObjectAssignmentTarget
+  | AssignmentTargetRest
+  | AssignmentTargetWithDefault
+  | AssignmentTargetPropertyIdentifier
+  | AssignmentTargetPropertyProperty
+  | SequenceExpression
+  | Super
+  | AwaitExpression
+  | ChainExpression
+  | ParenthesizedExpression
+  | Directive
+  | Hashbang
+  | BlockStatement
+  | VariableDeclaration
+  | VariableDeclarator
+  | EmptyStatement
+  | ExpressionStatement
+  | IfStatement
+  | DoWhileStatement
+  | WhileStatement
+  | ForStatement
+  | ForInStatement
+  | ForOfStatement
+  | ContinueStatement
+  | BreakStatement
+  | ReturnStatement
+  | WithStatement
+  | SwitchStatement
+  | SwitchCase
+  | LabeledStatement
+  | ThrowStatement
+  | TryStatement
+  | CatchClause
+  | DebuggerStatement
+  | AssignmentPattern
+  | ObjectPattern
+  | BindingProperty
+  | ArrayPattern
+  | BindingRestElement
+  | Function
+  | FunctionBody
+  | ArrowFunctionExpression
+  | YieldExpression
+  | Class
+  | ClassBody
+  | MethodDefinition
+  | PropertyDefinition
+  | PrivateIdentifier
+  | StaticBlock
+  | AccessorProperty
+  | ImportExpression
+  | ImportDeclaration
+  | ImportSpecifier
+  | ImportDefaultSpecifier
+  | ImportNamespaceSpecifier
+  | ImportAttribute
+  | ExportNamedDeclaration
+  | ExportDefaultDeclaration
+  | ExportAllDeclaration
+  | ExportSpecifier
+  | V8IntrinsicExpression
+  | BooleanLiteral
+  | NullLiteral
+  | NumericLiteral
+  | StringLiteral
+  | BigIntLiteral
+  | RegExpLiteral
+  | JSXElement
+  | JSXOpeningElement
+  | JSXClosingElement
+  | JSXFragment
+  | JSXOpeningFragment
+  | JSXClosingFragment
+  | JSXNamespacedName
+  | JSXMemberExpression
+  | JSXExpressionContainer
+  | JSXEmptyExpression
+  | JSXAttribute
+  | JSXSpreadAttribute
+  | JSXIdentifier
+  | JSXSpreadChild
+  | JSXText
+  | TSThisParameter
+  | TSEnumDeclaration
+  | TSEnumBody
+  | TSEnumMember
+  | TSTypeAnnotation
+  | TSLiteralType
+  | TSConditionalType
+  | TSUnionType
+  | TSIntersectionType
+  | TSParenthesizedType
+  | TSTypeOperator
+  | TSArrayType
+  | TSIndexedAccessType
+  | TSTupleType
+  | TSNamedTupleMember
+  | TSOptionalType
+  | TSRestType
+  | TSAnyKeyword
+  | TSStringKeyword
+  | TSBooleanKeyword
+  | TSNumberKeyword
+  | TSNeverKeyword
+  | TSIntrinsicKeyword
+  | TSUnknownKeyword
+  | TSNullKeyword
+  | TSUndefinedKeyword
+  | TSVoidKeyword
+  | TSSymbolKeyword
+  | TSThisType
+  | TSObjectKeyword
+  | TSBigIntKeyword
+  | TSTypeReference
+  | TSQualifiedName
+  | TSTypeParameterInstantiation
+  | TSTypeParameter
+  | TSTypeParameterDeclaration
+  | TSTypeAliasDeclaration
+  | TSClassImplements
+  | TSInterfaceDeclaration
+  | TSInterfaceBody
+  | TSPropertySignature
+  | TSIndexSignature
+  | TSCallSignatureDeclaration
+  | TSMethodSignature
+  | TSConstructSignatureDeclaration
+  | TSIndexSignatureName
+  | TSInterfaceHeritage
+  | TSTypePredicate
+  | TSModuleDeclaration
+  | TSModuleBlock
+  | TSTypeLiteral
+  | TSInferType
+  | TSTypeQuery
+  | TSImportType
+  | TSImportTypeQualifiedName
+  | TSFunctionType
+  | TSConstructorType
+  | TSMappedType
+  | TSTemplateLiteralType
+  | TSAsExpression
+  | TSSatisfiesExpression
+  | TSTypeAssertion
+  | TSImportEqualsDeclaration
+  | TSExternalModuleReference
+  | TSNonNullExpression
+  | Decorator
+  | TSExportAssignment
+  | TSNamespaceExportDeclaration
+  | TSInstantiationExpression
+  | JSDocNullableType
+  | JSDocNonNullableType
+  | JSDocUnknownType
+  | ParamPattern;

--- a/apps/oxlint/src-js/generated/visitor.d.ts
+++ b/apps/oxlint/src-js/generated/visitor.d.ts
@@ -1,0 +1,383 @@
+// Auto-generated code, DO NOT EDIT DIRECTLY!
+// To edit this generated file you have to edit `tasks/ast_tools/src/generators/estree_visit.rs`.
+
+import * as ESTree from './types.d.ts';
+
+export interface VisitorObject {
+  DebuggerStatement?: (node: ESTree.DebuggerStatement) => void;
+  'DebuggerStatement:exit'?: (node: ESTree.DebuggerStatement) => void;
+  EmptyStatement?: (node: ESTree.EmptyStatement) => void;
+  'EmptyStatement:exit'?: (node: ESTree.EmptyStatement) => void;
+  Literal?: (
+    node:
+      | ESTree.BooleanLiteral
+      | ESTree.NullLiteral
+      | ESTree.NumericLiteral
+      | ESTree.StringLiteral
+      | ESTree.BigIntLiteral
+      | ESTree.RegExpLiteral,
+  ) => void;
+  'Literal:exit'?: (
+    node:
+      | ESTree.BooleanLiteral
+      | ESTree.NullLiteral
+      | ESTree.NumericLiteral
+      | ESTree.StringLiteral
+      | ESTree.BigIntLiteral
+      | ESTree.RegExpLiteral,
+  ) => void;
+  PrivateIdentifier?: (node: ESTree.PrivateIdentifier) => void;
+  'PrivateIdentifier:exit'?: (node: ESTree.PrivateIdentifier) => void;
+  Super?: (node: ESTree.Super) => void;
+  'Super:exit'?: (node: ESTree.Super) => void;
+  TemplateElement?: (node: ESTree.TemplateElement) => void;
+  'TemplateElement:exit'?: (node: ESTree.TemplateElement) => void;
+  ThisExpression?: (node: ESTree.ThisExpression) => void;
+  'ThisExpression:exit'?: (node: ESTree.ThisExpression) => void;
+  JSXClosingFragment?: (node: ESTree.JSXClosingFragment) => void;
+  'JSXClosingFragment:exit'?: (node: ESTree.JSXClosingFragment) => void;
+  JSXEmptyExpression?: (node: ESTree.JSXEmptyExpression) => void;
+  'JSXEmptyExpression:exit'?: (node: ESTree.JSXEmptyExpression) => void;
+  JSXIdentifier?: (node: ESTree.JSXIdentifier) => void;
+  'JSXIdentifier:exit'?: (node: ESTree.JSXIdentifier) => void;
+  JSXOpeningFragment?: (node: ESTree.JSXOpeningFragment) => void;
+  'JSXOpeningFragment:exit'?: (node: ESTree.JSXOpeningFragment) => void;
+  JSXText?: (node: ESTree.JSXText) => void;
+  'JSXText:exit'?: (node: ESTree.JSXText) => void;
+  TSAnyKeyword?: (node: ESTree.TSAnyKeyword) => void;
+  'TSAnyKeyword:exit'?: (node: ESTree.TSAnyKeyword) => void;
+  TSBigIntKeyword?: (node: ESTree.TSBigIntKeyword) => void;
+  'TSBigIntKeyword:exit'?: (node: ESTree.TSBigIntKeyword) => void;
+  TSBooleanKeyword?: (node: ESTree.TSBooleanKeyword) => void;
+  'TSBooleanKeyword:exit'?: (node: ESTree.TSBooleanKeyword) => void;
+  TSIntrinsicKeyword?: (node: ESTree.TSIntrinsicKeyword) => void;
+  'TSIntrinsicKeyword:exit'?: (node: ESTree.TSIntrinsicKeyword) => void;
+  TSJSDocUnknownType?: (node: ESTree.JSDocUnknownType) => void;
+  'TSJSDocUnknownType:exit'?: (node: ESTree.JSDocUnknownType) => void;
+  TSNeverKeyword?: (node: ESTree.TSNeverKeyword) => void;
+  'TSNeverKeyword:exit'?: (node: ESTree.TSNeverKeyword) => void;
+  TSNullKeyword?: (node: ESTree.TSNullKeyword) => void;
+  'TSNullKeyword:exit'?: (node: ESTree.TSNullKeyword) => void;
+  TSNumberKeyword?: (node: ESTree.TSNumberKeyword) => void;
+  'TSNumberKeyword:exit'?: (node: ESTree.TSNumberKeyword) => void;
+  TSObjectKeyword?: (node: ESTree.TSObjectKeyword) => void;
+  'TSObjectKeyword:exit'?: (node: ESTree.TSObjectKeyword) => void;
+  TSStringKeyword?: (node: ESTree.TSStringKeyword) => void;
+  'TSStringKeyword:exit'?: (node: ESTree.TSStringKeyword) => void;
+  TSSymbolKeyword?: (node: ESTree.TSSymbolKeyword) => void;
+  'TSSymbolKeyword:exit'?: (node: ESTree.TSSymbolKeyword) => void;
+  TSThisType?: (node: ESTree.TSThisType) => void;
+  'TSThisType:exit'?: (node: ESTree.TSThisType) => void;
+  TSUndefinedKeyword?: (node: ESTree.TSUndefinedKeyword) => void;
+  'TSUndefinedKeyword:exit'?: (node: ESTree.TSUndefinedKeyword) => void;
+  TSUnknownKeyword?: (node: ESTree.TSUnknownKeyword) => void;
+  'TSUnknownKeyword:exit'?: (node: ESTree.TSUnknownKeyword) => void;
+  TSVoidKeyword?: (node: ESTree.TSVoidKeyword) => void;
+  'TSVoidKeyword:exit'?: (node: ESTree.TSVoidKeyword) => void;
+  AccessorProperty?: (node: ESTree.AccessorProperty) => void;
+  'AccessorProperty:exit'?: (node: ESTree.AccessorProperty) => void;
+  ArrayExpression?: (node: ESTree.ArrayExpression) => void;
+  'ArrayExpression:exit'?: (node: ESTree.ArrayExpression) => void;
+  ArrayPattern?: (node: ESTree.ArrayPattern) => void;
+  'ArrayPattern:exit'?: (node: ESTree.ArrayPattern) => void;
+  ArrowFunctionExpression?: (node: ESTree.ArrowFunctionExpression) => void;
+  'ArrowFunctionExpression:exit'?: (node: ESTree.ArrowFunctionExpression) => void;
+  AssignmentExpression?: (node: ESTree.AssignmentExpression) => void;
+  'AssignmentExpression:exit'?: (node: ESTree.AssignmentExpression) => void;
+  AssignmentPattern?: (node: ESTree.AssignmentPattern) => void;
+  'AssignmentPattern:exit'?: (node: ESTree.AssignmentPattern) => void;
+  AwaitExpression?: (node: ESTree.AwaitExpression) => void;
+  'AwaitExpression:exit'?: (node: ESTree.AwaitExpression) => void;
+  BinaryExpression?: (node: ESTree.BinaryExpression) => void;
+  'BinaryExpression:exit'?: (node: ESTree.BinaryExpression) => void;
+  BlockStatement?: (node: ESTree.BlockStatement) => void;
+  'BlockStatement:exit'?: (node: ESTree.BlockStatement) => void;
+  BreakStatement?: (node: ESTree.BreakStatement) => void;
+  'BreakStatement:exit'?: (node: ESTree.BreakStatement) => void;
+  CallExpression?: (node: ESTree.CallExpression) => void;
+  'CallExpression:exit'?: (node: ESTree.CallExpression) => void;
+  CatchClause?: (node: ESTree.CatchClause) => void;
+  'CatchClause:exit'?: (node: ESTree.CatchClause) => void;
+  ChainExpression?: (node: ESTree.ChainExpression) => void;
+  'ChainExpression:exit'?: (node: ESTree.ChainExpression) => void;
+  ClassBody?: (node: ESTree.ClassBody) => void;
+  'ClassBody:exit'?: (node: ESTree.ClassBody) => void;
+  ClassDeclaration?: (node: ESTree.Class) => void;
+  'ClassDeclaration:exit'?: (node: ESTree.Class) => void;
+  ClassExpression?: (node: ESTree.Class) => void;
+  'ClassExpression:exit'?: (node: ESTree.Class) => void;
+  ConditionalExpression?: (node: ESTree.ConditionalExpression) => void;
+  'ConditionalExpression:exit'?: (node: ESTree.ConditionalExpression) => void;
+  ContinueStatement?: (node: ESTree.ContinueStatement) => void;
+  'ContinueStatement:exit'?: (node: ESTree.ContinueStatement) => void;
+  Decorator?: (node: ESTree.Decorator) => void;
+  'Decorator:exit'?: (node: ESTree.Decorator) => void;
+  DoWhileStatement?: (node: ESTree.DoWhileStatement) => void;
+  'DoWhileStatement:exit'?: (node: ESTree.DoWhileStatement) => void;
+  ExportAllDeclaration?: (node: ESTree.ExportAllDeclaration) => void;
+  'ExportAllDeclaration:exit'?: (node: ESTree.ExportAllDeclaration) => void;
+  ExportDefaultDeclaration?: (node: ESTree.ExportDefaultDeclaration) => void;
+  'ExportDefaultDeclaration:exit'?: (node: ESTree.ExportDefaultDeclaration) => void;
+  ExportNamedDeclaration?: (node: ESTree.ExportNamedDeclaration) => void;
+  'ExportNamedDeclaration:exit'?: (node: ESTree.ExportNamedDeclaration) => void;
+  ExportSpecifier?: (node: ESTree.ExportSpecifier) => void;
+  'ExportSpecifier:exit'?: (node: ESTree.ExportSpecifier) => void;
+  ExpressionStatement?: (node: ESTree.ExpressionStatement) => void;
+  'ExpressionStatement:exit'?: (node: ESTree.ExpressionStatement) => void;
+  ForInStatement?: (node: ESTree.ForInStatement) => void;
+  'ForInStatement:exit'?: (node: ESTree.ForInStatement) => void;
+  ForOfStatement?: (node: ESTree.ForOfStatement) => void;
+  'ForOfStatement:exit'?: (node: ESTree.ForOfStatement) => void;
+  ForStatement?: (node: ESTree.ForStatement) => void;
+  'ForStatement:exit'?: (node: ESTree.ForStatement) => void;
+  FunctionDeclaration?: (node: ESTree.Function) => void;
+  'FunctionDeclaration:exit'?: (node: ESTree.Function) => void;
+  FunctionExpression?: (node: ESTree.Function) => void;
+  'FunctionExpression:exit'?: (node: ESTree.Function) => void;
+  Identifier?: (
+    node:
+      | ESTree.IdentifierName
+      | ESTree.IdentifierReference
+      | ESTree.BindingIdentifier
+      | ESTree.LabelIdentifier
+      | ESTree.TSThisParameter
+      | ESTree.TSIndexSignatureName,
+  ) => void;
+  'Identifier:exit'?: (
+    node:
+      | ESTree.IdentifierName
+      | ESTree.IdentifierReference
+      | ESTree.BindingIdentifier
+      | ESTree.LabelIdentifier
+      | ESTree.TSThisParameter
+      | ESTree.TSIndexSignatureName,
+  ) => void;
+  IfStatement?: (node: ESTree.IfStatement) => void;
+  'IfStatement:exit'?: (node: ESTree.IfStatement) => void;
+  ImportAttribute?: (node: ESTree.ImportAttribute) => void;
+  'ImportAttribute:exit'?: (node: ESTree.ImportAttribute) => void;
+  ImportDeclaration?: (node: ESTree.ImportDeclaration) => void;
+  'ImportDeclaration:exit'?: (node: ESTree.ImportDeclaration) => void;
+  ImportDefaultSpecifier?: (node: ESTree.ImportDefaultSpecifier) => void;
+  'ImportDefaultSpecifier:exit'?: (node: ESTree.ImportDefaultSpecifier) => void;
+  ImportExpression?: (node: ESTree.ImportExpression) => void;
+  'ImportExpression:exit'?: (node: ESTree.ImportExpression) => void;
+  ImportNamespaceSpecifier?: (node: ESTree.ImportNamespaceSpecifier) => void;
+  'ImportNamespaceSpecifier:exit'?: (node: ESTree.ImportNamespaceSpecifier) => void;
+  ImportSpecifier?: (node: ESTree.ImportSpecifier) => void;
+  'ImportSpecifier:exit'?: (node: ESTree.ImportSpecifier) => void;
+  LabeledStatement?: (node: ESTree.LabeledStatement) => void;
+  'LabeledStatement:exit'?: (node: ESTree.LabeledStatement) => void;
+  LogicalExpression?: (node: ESTree.LogicalExpression) => void;
+  'LogicalExpression:exit'?: (node: ESTree.LogicalExpression) => void;
+  MemberExpression?: (node: ESTree.MemberExpression) => void;
+  'MemberExpression:exit'?: (node: ESTree.MemberExpression) => void;
+  MetaProperty?: (node: ESTree.MetaProperty) => void;
+  'MetaProperty:exit'?: (node: ESTree.MetaProperty) => void;
+  MethodDefinition?: (node: ESTree.MethodDefinition) => void;
+  'MethodDefinition:exit'?: (node: ESTree.MethodDefinition) => void;
+  NewExpression?: (node: ESTree.NewExpression) => void;
+  'NewExpression:exit'?: (node: ESTree.NewExpression) => void;
+  ObjectExpression?: (node: ESTree.ObjectExpression) => void;
+  'ObjectExpression:exit'?: (node: ESTree.ObjectExpression) => void;
+  ObjectPattern?: (node: ESTree.ObjectPattern) => void;
+  'ObjectPattern:exit'?: (node: ESTree.ObjectPattern) => void;
+  ParenthesizedExpression?: (node: ESTree.ParenthesizedExpression) => void;
+  'ParenthesizedExpression:exit'?: (node: ESTree.ParenthesizedExpression) => void;
+  Program?: (node: ESTree.Program) => void;
+  'Program:exit'?: (node: ESTree.Program) => void;
+  Property?: (
+    node:
+      | ESTree.ObjectProperty
+      | ESTree.AssignmentTargetProperty
+      | ESTree.AssignmentTargetPropertyProperty
+      | ESTree.BindingProperty,
+  ) => void;
+  'Property:exit'?: (
+    node:
+      | ESTree.ObjectProperty
+      | ESTree.AssignmentTargetProperty
+      | ESTree.AssignmentTargetPropertyProperty
+      | ESTree.BindingProperty,
+  ) => void;
+  PropertyDefinition?: (node: ESTree.PropertyDefinition) => void;
+  'PropertyDefinition:exit'?: (node: ESTree.PropertyDefinition) => void;
+  RestElement?: (node: ESTree.AssignmentTargetRest | ESTree.BindingRestElement | ESTree.FormalParameterRest) => void;
+  'RestElement:exit'?: (
+    node: ESTree.AssignmentTargetRest | ESTree.BindingRestElement | ESTree.FormalParameterRest,
+  ) => void;
+  ReturnStatement?: (node: ESTree.ReturnStatement) => void;
+  'ReturnStatement:exit'?: (node: ESTree.ReturnStatement) => void;
+  SequenceExpression?: (node: ESTree.SequenceExpression) => void;
+  'SequenceExpression:exit'?: (node: ESTree.SequenceExpression) => void;
+  SpreadElement?: (node: ESTree.SpreadElement) => void;
+  'SpreadElement:exit'?: (node: ESTree.SpreadElement) => void;
+  StaticBlock?: (node: ESTree.StaticBlock) => void;
+  'StaticBlock:exit'?: (node: ESTree.StaticBlock) => void;
+  SwitchCase?: (node: ESTree.SwitchCase) => void;
+  'SwitchCase:exit'?: (node: ESTree.SwitchCase) => void;
+  SwitchStatement?: (node: ESTree.SwitchStatement) => void;
+  'SwitchStatement:exit'?: (node: ESTree.SwitchStatement) => void;
+  TaggedTemplateExpression?: (node: ESTree.TaggedTemplateExpression) => void;
+  'TaggedTemplateExpression:exit'?: (node: ESTree.TaggedTemplateExpression) => void;
+  TemplateLiteral?: (node: ESTree.TemplateLiteral) => void;
+  'TemplateLiteral:exit'?: (node: ESTree.TemplateLiteral) => void;
+  ThrowStatement?: (node: ESTree.ThrowStatement) => void;
+  'ThrowStatement:exit'?: (node: ESTree.ThrowStatement) => void;
+  TryStatement?: (node: ESTree.TryStatement) => void;
+  'TryStatement:exit'?: (node: ESTree.TryStatement) => void;
+  UnaryExpression?: (node: ESTree.UnaryExpression) => void;
+  'UnaryExpression:exit'?: (node: ESTree.UnaryExpression) => void;
+  UpdateExpression?: (node: ESTree.UpdateExpression) => void;
+  'UpdateExpression:exit'?: (node: ESTree.UpdateExpression) => void;
+  V8IntrinsicExpression?: (node: ESTree.V8IntrinsicExpression) => void;
+  'V8IntrinsicExpression:exit'?: (node: ESTree.V8IntrinsicExpression) => void;
+  VariableDeclaration?: (node: ESTree.VariableDeclaration) => void;
+  'VariableDeclaration:exit'?: (node: ESTree.VariableDeclaration) => void;
+  VariableDeclarator?: (node: ESTree.VariableDeclarator) => void;
+  'VariableDeclarator:exit'?: (node: ESTree.VariableDeclarator) => void;
+  WhileStatement?: (node: ESTree.WhileStatement) => void;
+  'WhileStatement:exit'?: (node: ESTree.WhileStatement) => void;
+  WithStatement?: (node: ESTree.WithStatement) => void;
+  'WithStatement:exit'?: (node: ESTree.WithStatement) => void;
+  YieldExpression?: (node: ESTree.YieldExpression) => void;
+  'YieldExpression:exit'?: (node: ESTree.YieldExpression) => void;
+  JSXAttribute?: (node: ESTree.JSXAttribute) => void;
+  'JSXAttribute:exit'?: (node: ESTree.JSXAttribute) => void;
+  JSXClosingElement?: (node: ESTree.JSXClosingElement) => void;
+  'JSXClosingElement:exit'?: (node: ESTree.JSXClosingElement) => void;
+  JSXElement?: (node: ESTree.JSXElement) => void;
+  'JSXElement:exit'?: (node: ESTree.JSXElement) => void;
+  JSXExpressionContainer?: (node: ESTree.JSXExpressionContainer) => void;
+  'JSXExpressionContainer:exit'?: (node: ESTree.JSXExpressionContainer) => void;
+  JSXFragment?: (node: ESTree.JSXFragment) => void;
+  'JSXFragment:exit'?: (node: ESTree.JSXFragment) => void;
+  JSXMemberExpression?: (node: ESTree.JSXMemberExpression) => void;
+  'JSXMemberExpression:exit'?: (node: ESTree.JSXMemberExpression) => void;
+  JSXNamespacedName?: (node: ESTree.JSXNamespacedName) => void;
+  'JSXNamespacedName:exit'?: (node: ESTree.JSXNamespacedName) => void;
+  JSXOpeningElement?: (node: ESTree.JSXOpeningElement) => void;
+  'JSXOpeningElement:exit'?: (node: ESTree.JSXOpeningElement) => void;
+  JSXSpreadAttribute?: (node: ESTree.JSXSpreadAttribute) => void;
+  'JSXSpreadAttribute:exit'?: (node: ESTree.JSXSpreadAttribute) => void;
+  JSXSpreadChild?: (node: ESTree.JSXSpreadChild) => void;
+  'JSXSpreadChild:exit'?: (node: ESTree.JSXSpreadChild) => void;
+  TSAbstractAccessorProperty?: (node: ESTree.AccessorProperty) => void;
+  'TSAbstractAccessorProperty:exit'?: (node: ESTree.AccessorProperty) => void;
+  TSAbstractMethodDefinition?: (node: ESTree.MethodDefinition) => void;
+  'TSAbstractMethodDefinition:exit'?: (node: ESTree.MethodDefinition) => void;
+  TSAbstractPropertyDefinition?: (node: ESTree.PropertyDefinition) => void;
+  'TSAbstractPropertyDefinition:exit'?: (node: ESTree.PropertyDefinition) => void;
+  TSArrayType?: (node: ESTree.TSArrayType) => void;
+  'TSArrayType:exit'?: (node: ESTree.TSArrayType) => void;
+  TSAsExpression?: (node: ESTree.TSAsExpression) => void;
+  'TSAsExpression:exit'?: (node: ESTree.TSAsExpression) => void;
+  TSCallSignatureDeclaration?: (node: ESTree.TSCallSignatureDeclaration) => void;
+  'TSCallSignatureDeclaration:exit'?: (node: ESTree.TSCallSignatureDeclaration) => void;
+  TSClassImplements?: (node: ESTree.TSClassImplements) => void;
+  'TSClassImplements:exit'?: (node: ESTree.TSClassImplements) => void;
+  TSConditionalType?: (node: ESTree.TSConditionalType) => void;
+  'TSConditionalType:exit'?: (node: ESTree.TSConditionalType) => void;
+  TSConstructSignatureDeclaration?: (node: ESTree.TSConstructSignatureDeclaration) => void;
+  'TSConstructSignatureDeclaration:exit'?: (node: ESTree.TSConstructSignatureDeclaration) => void;
+  TSConstructorType?: (node: ESTree.TSConstructorType) => void;
+  'TSConstructorType:exit'?: (node: ESTree.TSConstructorType) => void;
+  TSDeclareFunction?: (node: ESTree.Function) => void;
+  'TSDeclareFunction:exit'?: (node: ESTree.Function) => void;
+  TSEmptyBodyFunctionExpression?: (node: ESTree.Function) => void;
+  'TSEmptyBodyFunctionExpression:exit'?: (node: ESTree.Function) => void;
+  TSEnumBody?: (node: ESTree.TSEnumBody) => void;
+  'TSEnumBody:exit'?: (node: ESTree.TSEnumBody) => void;
+  TSEnumDeclaration?: (node: ESTree.TSEnumDeclaration) => void;
+  'TSEnumDeclaration:exit'?: (node: ESTree.TSEnumDeclaration) => void;
+  TSEnumMember?: (node: ESTree.TSEnumMember) => void;
+  'TSEnumMember:exit'?: (node: ESTree.TSEnumMember) => void;
+  TSExportAssignment?: (node: ESTree.TSExportAssignment) => void;
+  'TSExportAssignment:exit'?: (node: ESTree.TSExportAssignment) => void;
+  TSExternalModuleReference?: (node: ESTree.TSExternalModuleReference) => void;
+  'TSExternalModuleReference:exit'?: (node: ESTree.TSExternalModuleReference) => void;
+  TSFunctionType?: (node: ESTree.TSFunctionType) => void;
+  'TSFunctionType:exit'?: (node: ESTree.TSFunctionType) => void;
+  TSImportEqualsDeclaration?: (node: ESTree.TSImportEqualsDeclaration) => void;
+  'TSImportEqualsDeclaration:exit'?: (node: ESTree.TSImportEqualsDeclaration) => void;
+  TSImportType?: (node: ESTree.TSImportType) => void;
+  'TSImportType:exit'?: (node: ESTree.TSImportType) => void;
+  TSIndexSignature?: (node: ESTree.TSIndexSignature) => void;
+  'TSIndexSignature:exit'?: (node: ESTree.TSIndexSignature) => void;
+  TSIndexedAccessType?: (node: ESTree.TSIndexedAccessType) => void;
+  'TSIndexedAccessType:exit'?: (node: ESTree.TSIndexedAccessType) => void;
+  TSInferType?: (node: ESTree.TSInferType) => void;
+  'TSInferType:exit'?: (node: ESTree.TSInferType) => void;
+  TSInstantiationExpression?: (node: ESTree.TSInstantiationExpression) => void;
+  'TSInstantiationExpression:exit'?: (node: ESTree.TSInstantiationExpression) => void;
+  TSInterfaceBody?: (node: ESTree.TSInterfaceBody) => void;
+  'TSInterfaceBody:exit'?: (node: ESTree.TSInterfaceBody) => void;
+  TSInterfaceDeclaration?: (node: ESTree.TSInterfaceDeclaration) => void;
+  'TSInterfaceDeclaration:exit'?: (node: ESTree.TSInterfaceDeclaration) => void;
+  TSInterfaceHeritage?: (node: ESTree.TSInterfaceHeritage) => void;
+  'TSInterfaceHeritage:exit'?: (node: ESTree.TSInterfaceHeritage) => void;
+  TSIntersectionType?: (node: ESTree.TSIntersectionType) => void;
+  'TSIntersectionType:exit'?: (node: ESTree.TSIntersectionType) => void;
+  TSJSDocNonNullableType?: (node: ESTree.JSDocNonNullableType) => void;
+  'TSJSDocNonNullableType:exit'?: (node: ESTree.JSDocNonNullableType) => void;
+  TSJSDocNullableType?: (node: ESTree.JSDocNullableType) => void;
+  'TSJSDocNullableType:exit'?: (node: ESTree.JSDocNullableType) => void;
+  TSLiteralType?: (node: ESTree.TSLiteralType) => void;
+  'TSLiteralType:exit'?: (node: ESTree.TSLiteralType) => void;
+  TSMappedType?: (node: ESTree.TSMappedType) => void;
+  'TSMappedType:exit'?: (node: ESTree.TSMappedType) => void;
+  TSMethodSignature?: (node: ESTree.TSMethodSignature) => void;
+  'TSMethodSignature:exit'?: (node: ESTree.TSMethodSignature) => void;
+  TSModuleBlock?: (node: ESTree.TSModuleBlock) => void;
+  'TSModuleBlock:exit'?: (node: ESTree.TSModuleBlock) => void;
+  TSModuleDeclaration?: (node: ESTree.TSModuleDeclaration) => void;
+  'TSModuleDeclaration:exit'?: (node: ESTree.TSModuleDeclaration) => void;
+  TSNamedTupleMember?: (node: ESTree.TSNamedTupleMember) => void;
+  'TSNamedTupleMember:exit'?: (node: ESTree.TSNamedTupleMember) => void;
+  TSNamespaceExportDeclaration?: (node: ESTree.TSNamespaceExportDeclaration) => void;
+  'TSNamespaceExportDeclaration:exit'?: (node: ESTree.TSNamespaceExportDeclaration) => void;
+  TSNonNullExpression?: (node: ESTree.TSNonNullExpression) => void;
+  'TSNonNullExpression:exit'?: (node: ESTree.TSNonNullExpression) => void;
+  TSOptionalType?: (node: ESTree.TSOptionalType) => void;
+  'TSOptionalType:exit'?: (node: ESTree.TSOptionalType) => void;
+  TSParameterProperty?: (node: ESTree.TSParameterProperty) => void;
+  'TSParameterProperty:exit'?: (node: ESTree.TSParameterProperty) => void;
+  TSParenthesizedType?: (node: ESTree.TSParenthesizedType) => void;
+  'TSParenthesizedType:exit'?: (node: ESTree.TSParenthesizedType) => void;
+  TSPropertySignature?: (node: ESTree.TSPropertySignature) => void;
+  'TSPropertySignature:exit'?: (node: ESTree.TSPropertySignature) => void;
+  TSQualifiedName?: (node: ESTree.TSQualifiedName) => void;
+  'TSQualifiedName:exit'?: (node: ESTree.TSQualifiedName) => void;
+  TSRestType?: (node: ESTree.TSRestType) => void;
+  'TSRestType:exit'?: (node: ESTree.TSRestType) => void;
+  TSSatisfiesExpression?: (node: ESTree.TSSatisfiesExpression) => void;
+  'TSSatisfiesExpression:exit'?: (node: ESTree.TSSatisfiesExpression) => void;
+  TSTemplateLiteralType?: (node: ESTree.TSTemplateLiteralType) => void;
+  'TSTemplateLiteralType:exit'?: (node: ESTree.TSTemplateLiteralType) => void;
+  TSTupleType?: (node: ESTree.TSTupleType) => void;
+  'TSTupleType:exit'?: (node: ESTree.TSTupleType) => void;
+  TSTypeAliasDeclaration?: (node: ESTree.TSTypeAliasDeclaration) => void;
+  'TSTypeAliasDeclaration:exit'?: (node: ESTree.TSTypeAliasDeclaration) => void;
+  TSTypeAnnotation?: (node: ESTree.TSTypeAnnotation) => void;
+  'TSTypeAnnotation:exit'?: (node: ESTree.TSTypeAnnotation) => void;
+  TSTypeAssertion?: (node: ESTree.TSTypeAssertion) => void;
+  'TSTypeAssertion:exit'?: (node: ESTree.TSTypeAssertion) => void;
+  TSTypeLiteral?: (node: ESTree.TSTypeLiteral) => void;
+  'TSTypeLiteral:exit'?: (node: ESTree.TSTypeLiteral) => void;
+  TSTypeOperator?: (node: ESTree.TSTypeOperator) => void;
+  'TSTypeOperator:exit'?: (node: ESTree.TSTypeOperator) => void;
+  TSTypeParameter?: (node: ESTree.TSTypeParameter) => void;
+  'TSTypeParameter:exit'?: (node: ESTree.TSTypeParameter) => void;
+  TSTypeParameterDeclaration?: (node: ESTree.TSTypeParameterDeclaration) => void;
+  'TSTypeParameterDeclaration:exit'?: (node: ESTree.TSTypeParameterDeclaration) => void;
+  TSTypeParameterInstantiation?: (node: ESTree.TSTypeParameterInstantiation) => void;
+  'TSTypeParameterInstantiation:exit'?: (node: ESTree.TSTypeParameterInstantiation) => void;
+  TSTypePredicate?: (node: ESTree.TSTypePredicate) => void;
+  'TSTypePredicate:exit'?: (node: ESTree.TSTypePredicate) => void;
+  TSTypeQuery?: (node: ESTree.TSTypeQuery) => void;
+  'TSTypeQuery:exit'?: (node: ESTree.TSTypeQuery) => void;
+  TSTypeReference?: (node: ESTree.TSTypeReference) => void;
+  'TSTypeReference:exit'?: (node: ESTree.TSTypeReference) => void;
+  TSUnionType?: (node: ESTree.TSUnionType) => void;
+  'TSUnionType:exit'?: (node: ESTree.TSUnionType) => void;
+}

--- a/apps/oxlint/src-js/index.ts
+++ b/apps/oxlint/src-js/index.ts
@@ -2,6 +2,7 @@ import type { Context } from './plugins/context.ts';
 import type { CreateOnceRule, Plugin, Rule } from './plugins/load.ts';
 import type { BeforeHook, Visitor, VisitorWithHooks } from './plugins/types.ts';
 
+export type * as ESTree from './generated/types.d.ts';
 export type { Context, Diagnostic, DiagnosticBase, DiagnosticWithLoc, DiagnosticWithNode } from './plugins/context.ts';
 export type { Fix, Fixer, FixFn } from './plugins/fix.ts';
 export type { CreateOnceRule, CreateRule, Plugin, Rule } from './plugins/load.ts';

--- a/apps/oxlint/src-js/plugins/scope.ts
+++ b/apps/oxlint/src-js/plugins/scope.ts
@@ -1,4 +1,4 @@
-import type * as ESTree from '@oxc-project/types';
+import type * as ESTree from '../generated/types.d.ts';
 
 import type { Node } from './types.ts';
 

--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -10,7 +10,7 @@ import {
 import { deserializeProgramOnly } from '../../dist/generated/deserialize/ts_range_parent_no_parens.js';
 import { getLineColumnFromOffset, getOffsetFromLineColumn, initLines, lines, resetLines } from './location.js';
 
-import type { Program } from '@oxc-project/types';
+import type { Program } from '../generated/types.d.ts';
 import type { Scope, ScopeManager, Variable } from './scope.ts';
 import type { BufferWithArrays, Comment, Node, NodeOrToken, Token } from './types.ts';
 

--- a/apps/oxlint/src-js/plugins/types.ts
+++ b/apps/oxlint/src-js/plugins/types.ts
@@ -6,7 +6,7 @@ export interface Visitor {
 }
 */
 
-import type { VisitorObject as Visitor } from '../../dist/generated/visit/visitor.d.ts';
+import type { VisitorObject as Visitor } from '../generated/visitor.d.ts';
 export type { Visitor };
 
 // Hook function that runs before traversal.

--- a/apps/oxlint/test/fixtures/sourceCode/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode/plugin.ts
@@ -1,7 +1,8 @@
 import assert from 'node:assert';
 
-import type { Program } from '@oxc-project/types';
-import type { Node, Plugin, Rule } from '../../../dist/index.js';
+import type { ESTree, Node, Plugin, Rule } from '../../../dist/index.js';
+
+type Program = ESTree.Program;
 
 const SPAN: Node = { start: 0, end: 0, range: [0, 0] };
 

--- a/apps/oxlint/test/fixtures/sourceCode_late_access/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode_late_access/plugin.ts
@@ -1,7 +1,8 @@
 import assert from 'node:assert';
 
-import type { Program } from '@oxc-project/types';
-import type { Node, Plugin, Rule } from '../../../dist/index.js';
+import type { ESTree, Node, Plugin, Rule } from '../../../dist/index.js';
+
+type Program = ESTree.Program;
 
 const SPAN: Node = { start: 0, end: 0, range: [0, 0] };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,10 +52,6 @@ importers:
         version: 3.2.4(@types/node@24.5.2)(@vitest/browser@3.2.4)(jiti@2.6.0)
 
   apps/oxlint:
-    dependencies:
-      '@oxc-project/types':
-        specifier: workspace:^
-        version: link:../../npm/oxc-types
     devDependencies:
       eslint:
         specifier: ^9.36.0
@@ -187,19 +183,6 @@ importers:
       degit:
         specifier: 2.8.4
         version: 2.8.4
-
-  tasks/mcp:
-    dependencies:
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.17.2
-        version: 1.18.2
-    devDependencies:
-      '@types/node':
-        specifier: ^24.0.0
-        version: 24.5.2
-      typescript:
-        specifier: 'catalog:'
-        version: 5.9.2
 
   tasks/transform_conformance:
     dependencies:
@@ -928,10 +911,6 @@ packages:
   '@loaderkit/resolve@1.0.4':
     resolution: {integrity: sha512-rJzYKVcV4dxJv+vW6jlvagF8zvGxHJ2+HTr1e2qOejfmGhAApgJHl8Aog4mMszxceTRiKTTbnpgmTO1bEZHV/A==}
 
-  '@modelcontextprotocol/sdk@1.18.2':
-    resolution: {integrity: sha512-beedclIvFcCnPrYgHsylqiYJVJ/CI47Vyc4tY8no1/Li/O8U4BTlJfy6ZwxkYwx+Mx10nrgwSVrA7VBbhh4slg==}
-    engines: {node: '>=18'}
-
   '@napi-rs/cli@3.2.0':
     resolution: {integrity: sha512-heyXt/9OBPv/WrTFW2+PxIMzH6MCeqP9ZsvOg0LN6pLngBnszcxFsdhCAh5I6sddzQsvru53zj59GUzvmpWk8Q==}
     engines: {node: '>= 16'}
@@ -1452,6 +1431,9 @@ packages:
   '@oxc-project/types@0.92.0':
     resolution: {integrity: sha512-PDLfCbwgXjGdTBxzcuDOUxJYNBl6P8dOp3eDKWw54dYvqONan9rwGDRQU0zrkdEMiItfXQQUOI17uOcMX5Zm7A==}
 
+  '@oxc-project/types@0.93.0':
+    resolution: {integrity: sha512-yNtwmWZIBtJsMr5TEfoZFDxIWV6OdScOpza/f5YxbqUMJk+j6QX3Cf3jgZShGEFYWQJ5j9mJ6jM0tZHu2J9Yrg==}
+
   '@oxlint-tsgolint/darwin-arm64@0.2.0':
     resolution: {integrity: sha512-ayJO9SmiJ15oV3+svIw8bqun0ySdjiD7L+ddwNB4vOAgUX/rdX1KTBnDb/ZEk6MOFBnFgbbiEiLRJLlGtuFYVQ==}
     cpu: [arm64]
@@ -1546,8 +1528,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@rolldown/binding-android-arm64@1.0.0-beta.41':
+    resolution: {integrity: sha512-Edflndd9lU7JVhVIvJlZhdCj5DkhYDJPIRn4Dx0RUdfc8asP9xHOI5gMd8MesDDx+BJpdIT/uAmVTearteU/mQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@rolldown/binding-darwin-arm64@1.0.0-beta.40':
     resolution: {integrity: sha512-5O6d0y2tBQTL+ecQY3qXIwSnF1/Zik8q7LZMKeyF+VJ9l194d0IdMhl2zUF0cqWbYHuF4Pnxplk4OhurPQ/Z9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.41':
+    resolution: {integrity: sha512-XGCzqfjdk7550PlyZRTBKbypXrB7ATtXhw/+bjtxnklLQs0mKP/XkQVOKyn9qGKSlvH8I56JLYryVxl0PCvSNw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -1558,8 +1552,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rolldown/binding-darwin-x64@1.0.0-beta.41':
+    resolution: {integrity: sha512-Ho6lIwGJed98zub7n0xcRKuEtnZgbxevAmO4x3zn3C3N4GVXZD5xvCvTVxSMoeBJwTcIYzkVDRTIhylQNsTgLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
   '@rolldown/binding-freebsd-x64@1.0.0-beta.40':
     resolution: {integrity: sha512-2fdpEpKT+wwP0vig9dqxu+toTeWmVSjo3psJQVDeLJ51rO+GXcCJ1IkCXjhMKVEevNtZS7B8T8Z2vvmRV9MAdA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.41':
+    resolution: {integrity: sha512-ijAZETywvL+gACjbT4zBnCp5ez1JhTRs6OxRN4J+D6AzDRbU2zb01Esl51RP5/8ZOlvB37xxsRQ3X4YRVyYb3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -1570,8 +1576,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.41':
+    resolution: {integrity: sha512-EgIOZt7UildXKFEFvaiLNBXm+4ggQyGe3E5Z1QP9uRcJJs9omihOnm897FwOBQdCuMvI49iBgjFrkhH+wMJ2MA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.40':
     resolution: {integrity: sha512-ng00gfr9BhA2NPAOU5RWAlTiL+JcwAD+L+4yUD1sbBy6tgHdLiNBOvKtHISIF9RM9/eQeS0tAiWOYZGIH9JMew==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.41':
+    resolution: {integrity: sha512-F8bUwJq8v/JAU8HSwgF4dztoqJ+FjdyjuvX4//3+Fbe2we9UktFeZ27U4lRMXF1vxWtdV4ey6oCSqI7yUrSEeg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -1584,8 +1603,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.41':
+    resolution: {integrity: sha512-MioXcCIX/wB1pBnBoJx8q4OGucUAfC1+/X1ilKFsjDK05VwbLZGRgOVD5OJJpUQPK86DhQciNBrfOKDiatxNmg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.40':
     resolution: {integrity: sha512-+wi08S7wT5iLPHRZb0USrS6n+T6m+yY++dePYedE5uvKIpWCJJioFTaRtWjpm0V6dVNLcq2OukrvfdlGtH9Wgg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.41':
+    resolution: {integrity: sha512-m66M61fizvRCwt5pOEiZQMiwBL9/y0bwU/+Kc4Ce/Pef6YfoEkR28y+DzN9rMdjo8Z28NXjsDPq9nH4mXnAP0g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -1598,8 +1631,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.41':
+    resolution: {integrity: sha512-yRxlSfBvWnnfrdtJfvi9lg8xfG5mPuyoSHm0X01oiE8ArmLRvoJGHUTJydCYz+wbK2esbq5J4B4Tq9WAsOlP1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.40':
     resolution: {integrity: sha512-vJwoDehtt+yqj2zacq1AqNc2uE/oh7mnRGqAUbuldV6pgvU01OSQUJ7Zu+35hTopnjFoDNN6mIezkYlGAv5RFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-beta.41':
+    resolution: {integrity: sha512-PHVxYhBpi8UViS3/hcvQQb9RFqCtvFmFU1PvUoTRiUdBtgHA6fONNHU4x796lgzNlVSD3DO/MZNk1s5/ozSMQg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -1609,8 +1655,19 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.41':
+    resolution: {integrity: sha512-OAfcO37ME6GGWmj9qTaDT7jY4rM0T2z0/8ujdQIJQ2x2nl+ztO32EIwURfmXOK0U1tzkyuaKYvE34Pug/ucXlQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.40':
     resolution: {integrity: sha512-0ZtO6yN8XjVoFfN4HDWQj4nDu3ndMybr7jIM00DJqOmc+yFhly7rdOy7fNR9Sky3leCpBtsXfepVqRmVpYKPVA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.41':
+    resolution: {integrity: sha512-NIYGuCcuXaq5BC4Q3upbiMBvmZsTsEPG9k/8QKQdmrch+ocSy5Jv9tdpdmXJyighKqm182nh/zBt+tSJkYoNlg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -1621,14 +1678,29 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.41':
+    resolution: {integrity: sha512-kANdsDbE5FkEOb5NrCGBJBCaZ2Sabp3D7d4PRqMYJqyLljwh9mDyYyYSv5+QNvdAmifj+f3lviNEUUuUZPEFPw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@rolldown/binding-win32-x64-msvc@1.0.0-beta.40':
     resolution: {integrity: sha512-UguA4ltbAk+nbwHRxqaUP/etpTbR0HjyNlsu4Zjbh/ytNbFsbw8CA4tEBkwDyjgI5NIPea6xY11zpl7R2/ddVA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.41':
+    resolution: {integrity: sha512-UlpxKmFdik0Y2VjZrgUCgoYArZJiZllXgIipdBRV1hw6uK45UbQabSTW6Kp6enuOu7vouYWftwhuxfpE8J2JAg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@rolldown/pluginutils@1.0.0-beta.40':
     resolution: {integrity: sha512-s3GeJKSQOwBlzdUrj4ISjJj5SfSh+aqn0wjOar4Bx95iV1ETI7F6S/5hLcfAxZ9kXDcyrAkxPlqmd1ZITttf+w==}
+
+  '@rolldown/pluginutils@1.0.0-beta.41':
+    resolution: {integrity: sha512-ycMEPrS3StOIeb87BT3/+bu+blEtyvwQ4zmo2IcJQy0Rd1DAAhKksA0iUZ3MYSpJtjlPhg0Eo6mvVS6ggPhRbw==}
 
   '@rollup/rollup-android-arm-eabi@4.52.3':
     resolution: {integrity: sha512-h6cqHGZ6VdnwliFG1NXvMPTy/9PS3h8oLh7ImwR+kl+oYnQizgjxsONmmPSb2C66RksfkfIxEVtDSEcJiO0tqw==}
@@ -1986,10 +2058,6 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
-  accepts@2.0.0:
-    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
-    engines: {node: '>= 0.6'}
-
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2036,6 +2104,10 @@ packages:
 
   ansis@4.1.0:
     resolution: {integrity: sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w==}
+    engines: {node: '>=14'}
+
+  ansis@4.2.0:
+    resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
 
   anymatch@3.1.3:
@@ -2099,10 +2171,6 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  body-parser@2.2.0:
-    resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
-    engines: {node: '>=18'}
-
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -2139,10 +2207,6 @@ packages:
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
-
-  bytes@3.1.2:
-    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
-    engines: {node: '>= 0.8'}
 
   c8@9.1.0:
     resolution: {integrity: sha512-mBWcT5iqNir1zIkzSPyI3NCR9EZCVI3WUD+AVO17MVWTSFNyUueXE82qTeampNtTr+ilN/5Ua3j24LgbCKjDVg==}
@@ -2265,31 +2329,11 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  content-disposition@1.0.0:
-    resolution: {integrity: sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==}
-    engines: {node: '>= 0.6'}
-
-  content-type@1.0.5:
-    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
-    engines: {node: '>= 0.6'}
-
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  cookie-signature@1.2.2:
-    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
-    engines: {node: '>=6.6.0'}
-
-  cookie@0.7.2:
-    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
-    engines: {node: '>= 0.6'}
-
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
-
-  cors@2.8.5:
-    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
-    engines: {node: '>= 0.10'}
 
   cross-env@10.0.0:
     resolution: {integrity: sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==}
@@ -2367,10 +2411,6 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
-  depd@2.0.0:
-    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
-    engines: {node: '>= 0.8'}
-
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -2426,9 +2466,6 @@ packages:
     resolution: {integrity: sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ==}
     engines: {ecmascript: '>= es5', node: '>=4'}
 
-  ee-first@1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
-
   electron-to-chromium@1.5.224:
     resolution: {integrity: sha512-kWAoUu/bwzvnhpdZSIc6KUyvkI1rbRXMT0Eq8pKReyOyaPZcctMli+EgvcN1PAvwVc7Tdo4Fxi2PsLNDU05mdg==}
 
@@ -2452,10 +2489,6 @@ packages:
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
-
-  encodeurl@2.0.0:
-    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
-    engines: {node: '>= 0.8'}
 
   encoding-sniffer@0.2.1:
     resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
@@ -2509,9 +2542,6 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
-
-  escape-html@1.0.3:
-    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -2567,18 +2597,6 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  etag@1.8.1:
-    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
-    engines: {node: '>= 0.6'}
-
-  eventsource-parser@3.0.6:
-    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
-    engines: {node: '>=18.0.0'}
-
-  eventsource@3.0.7:
-    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
-    engines: {node: '>=18.0.0'}
-
   execa@9.6.0:
     resolution: {integrity: sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw==}
     engines: {node: ^18.19.0 || >=20.5.0}
@@ -2590,16 +2608,6 @@ packages:
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
-
-  express-rate-limit@7.5.1:
-    resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
-    engines: {node: '>= 16'}
-    peerDependencies:
-      express: '>= 4.11'
-
-  express@5.1.0:
-    resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
-    engines: {node: '>= 18'}
 
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
@@ -2650,10 +2658,6 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
-  finalhandler@2.1.0:
-    resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
-    engines: {node: '>= 0.8'}
-
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -2693,14 +2697,6 @@ packages:
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
-
-  forwarded@0.2.0:
-    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
-    engines: {node: '>= 0.6'}
-
-  fresh@2.0.0:
-    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
-    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -2835,10 +2831,6 @@ packages:
   htmlparser2@10.0.0:
     resolution: {integrity: sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==}
 
-  http-errors@2.0.0:
-    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
-    engines: {node: '>= 0.8'}
-
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -2895,10 +2887,6 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
-  ipaddr.js@1.9.1:
-    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
-    engines: {node: '>= 0.10'}
-
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
@@ -2948,9 +2936,6 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
-
-  is-promise@4.0.0:
-    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-stream@4.0.1:
     resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
@@ -3165,14 +3150,6 @@ packages:
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
-  media-typer@1.1.0:
-    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
-    engines: {node: '>= 0.8'}
-
-  merge-descriptors@2.0.0:
-    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
-    engines: {node: '>=18'}
-
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -3185,16 +3162,8 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
-  mime-db@1.54.0:
-    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
-    engines: {node: '>= 0.6'}
-
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
-
-  mime-types@3.0.1:
-    resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
     engines: {node: '>= 0.6'}
 
   mime@1.6.0:
@@ -3269,10 +3238,6 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  negotiator@1.0.0:
-    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
-    engines: {node: '>= 0.6'}
-
   node-abi@3.77.0:
     resolution: {integrity: sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==}
     engines: {node: '>=10'}
@@ -3306,10 +3271,6 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
-  object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
-
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -3317,10 +3278,6 @@ packages:
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
-
-  on-finished@2.4.1:
-    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
-    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -3413,10 +3370,6 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
-  parseurl@1.3.3:
-    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
-    engines: {node: '>= 0.8'}
-
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -3445,9 +3398,6 @@ packages:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
     engines: {node: 20 || >=22}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
-
   path-type@6.0.0:
     resolution: {integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==}
     engines: {node: '>=18'}
@@ -3472,10 +3422,6 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
-
-  pkce-challenge@5.0.0:
-    resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==}
-    engines: {node: '>=16.20.0'}
 
   playwright-core@1.55.1:
     resolution: {integrity: sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==}
@@ -3518,10 +3464,6 @@ packages:
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
-  proxy-addr@2.0.7:
-    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
-    engines: {node: '>= 0.10'}
-
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -3553,14 +3495,6 @@ packages:
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
-
-  range-parser@1.2.1:
-    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
-    engines: {node: '>= 0.6'}
-
-  raw-body@3.0.1:
-    resolution: {integrity: sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==}
-    engines: {node: '>= 0.10'}
 
   rc-config-loader@4.1.3:
     resolution: {integrity: sha512-kD7FqML7l800i6pS6pvLyIE2ncbk9Du8Q0gp/4hMPhJU6ZxApkoLcGD8ZeqgiAlfwZ6BlETq6qqe+12DUL207w==}
@@ -3645,14 +3579,15 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  rolldown@1.0.0-beta.41:
+    resolution: {integrity: sha512-U+NPR0Bkg3wm61dteD2L4nAM1U9dtaqVrpDXwC36IKRHpEO/Ubpid4Nijpa2imPchcVNHfxVFwSSMJdwdGFUbg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rollup@4.52.3:
     resolution: {integrity: sha512-RIDh866U8agLgiIcdpB+COKnlCreHJLfIhWC3LVflku5YHfpnsIKigRZeFfMfCc4dVcqNVfQQ5gO/afOck064A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
-
-  router@2.2.0:
-    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
-    engines: {node: '>= 18'}
 
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
@@ -3695,22 +3630,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  send@1.2.0:
-    resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
-    engines: {node: '>= 18'}
-
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
-  serve-static@2.2.0:
-    resolution: {integrity: sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==}
-    engines: {node: '>= 18'}
-
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
-
-  setprototypeof@1.2.0:
-    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3786,14 +3710,6 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
-
-  statuses@2.0.1:
-    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
-    engines: {node: '>= 0.8'}
-
-  statuses@2.0.2:
-    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
-    engines: {node: '>= 0.8'}
 
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
@@ -3929,10 +3845,6 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  toidentifier@1.0.1:
-    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
-    engines: {node: '>=0.6'}
-
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -3984,10 +3896,6 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
-  type-is@2.0.1:
-    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
-    engines: {node: '>= 0.6'}
-
   typed-rest-client@1.8.11:
     resolution: {integrity: sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==}
 
@@ -4032,10 +3940,6 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
-  unpipe@1.0.0:
-    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
-    engines: {node: '>= 0.8'}
-
   update-browserslist-db@1.1.3:
     resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
     hasBin: true
@@ -4065,10 +3969,6 @@ packages:
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
-  vary@1.1.2:
-    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
-    engines: {node: '>= 0.8'}
 
   version-range@4.15.0:
     resolution: {integrity: sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==}
@@ -4272,14 +4172,6 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
-
-  zod-to-json-schema@3.24.6:
-    resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
-    peerDependencies:
-      zod: ^3.24.1
-
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
@@ -5001,23 +4893,6 @@ snapshots:
     dependencies:
       '@braidai/lang': 1.1.2
 
-  '@modelcontextprotocol/sdk@1.18.2':
-    dependencies:
-      ajv: 6.12.6
-      content-type: 1.0.5
-      cors: 2.8.5
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.6
-      express: 5.1.0
-      express-rate-limit: 7.5.1(express@5.1.0)
-      pkce-challenge: 5.0.0
-      raw-body: 3.0.1
-      zod: 3.25.76
-      zod-to-json-schema: 3.24.6(zod@3.25.76)
-    transitivePeerDependencies:
-      - supports-color
-
   '@napi-rs/cli@3.2.0(@emnapi/runtime@1.5.0)(@types/node@24.5.2)(emnapi@1.5.0)':
     dependencies:
       '@inquirer/prompts': 7.8.6(@types/node@24.5.2)
@@ -5412,6 +5287,8 @@ snapshots:
 
   '@oxc-project/types@0.92.0': {}
 
+  '@oxc-project/types@0.93.0': {}
+
   '@oxlint-tsgolint/darwin-arm64@0.2.0':
     optional: true
 
@@ -5468,31 +5345,61 @@ snapshots:
   '@rolldown/binding-android-arm64@1.0.0-beta.40':
     optional: true
 
+  '@rolldown/binding-android-arm64@1.0.0-beta.41':
+    optional: true
+
   '@rolldown/binding-darwin-arm64@1.0.0-beta.40':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.41':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.0-beta.40':
     optional: true
 
+  '@rolldown/binding-darwin-x64@1.0.0-beta.41':
+    optional: true
+
   '@rolldown/binding-freebsd-x64@1.0.0-beta.40':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.41':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.40':
     optional: true
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.41':
+    optional: true
+
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.40':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.41':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.40':
     optional: true
 
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.41':
+    optional: true
+
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.40':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.41':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.40':
     optional: true
 
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.41':
+    optional: true
+
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.40':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-beta.41':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-beta.40':
@@ -5500,16 +5407,32 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.0.5
     optional: true
 
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.41':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.0.5
+    optional: true
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.40':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.41':
     optional: true
 
   '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.40':
     optional: true
 
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.41':
+    optional: true
+
   '@rolldown/binding-win32-x64-msvc@1.0.0-beta.40':
     optional: true
 
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.41':
+    optional: true
+
   '@rolldown/pluginutils@1.0.0-beta.40': {}
+
+  '@rolldown/pluginutils@1.0.0-beta.41': {}
 
   '@rollup/rollup-android-arm-eabi@4.52.3':
     optional: true
@@ -5904,11 +5827,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  accepts@2.0.0:
-    dependencies:
-      mime-types: 3.0.1
-      negotiator: 1.0.0
-
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -5948,6 +5866,8 @@ snapshots:
   ansi-styles@6.2.3: {}
 
   ansis@4.1.0: {}
+
+  ansis@4.2.0: {}
 
   anymatch@3.1.3:
     dependencies:
@@ -6012,20 +5932,6 @@ snapshots:
       readable-stream: 3.6.2
     optional: true
 
-  body-parser@2.2.0:
-    dependencies:
-      bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 4.4.3(supports-color@8.1.1)
-      http-errors: 2.0.0
-      iconv-lite: 0.6.3
-      on-finished: 2.4.1
-      qs: 6.14.0
-      raw-body: 3.0.1
-      type-is: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   boolbase@1.0.0: {}
 
   boundary@2.0.0: {}
@@ -6066,8 +5972,6 @@ snapshots:
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
-
-  bytes@3.1.2: {}
 
   c8@9.1.0:
     dependencies:
@@ -6204,24 +6108,9 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  content-disposition@1.0.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
-  content-type@1.0.5: {}
-
   convert-source-map@2.0.0: {}
 
-  cookie-signature@1.2.2: {}
-
-  cookie@0.7.2: {}
-
   core-util-is@1.0.3: {}
-
-  cors@2.8.5:
-    dependencies:
-      object-assign: 4.1.1
-      vary: 1.1.2
 
   cross-env@10.0.0:
     dependencies:
@@ -6291,8 +6180,6 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
-  depd@2.0.0: {}
-
   dequal@2.0.3: {}
 
   detect-libc@2.1.1:
@@ -6340,8 +6227,6 @@ snapshots:
     dependencies:
       version-range: 4.15.0
 
-  ee-first@1.1.1: {}
-
   electron-to-chromium@1.5.224: {}
 
   emnapi@1.5.0: {}
@@ -6353,8 +6238,6 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   empathic@2.0.0: {}
-
-  encodeurl@2.0.0: {}
 
   encoding-sniffer@0.2.1:
     dependencies:
@@ -6426,8 +6309,6 @@ snapshots:
       '@esbuild/win32-x64': 0.25.10
 
   escalade@3.2.0: {}
-
-  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -6506,14 +6387,6 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  etag@1.8.1: {}
-
-  eventsource-parser@3.0.6: {}
-
-  eventsource@3.0.7:
-    dependencies:
-      eventsource-parser: 3.0.6
-
   execa@9.6.0:
     dependencies:
       '@sindresorhus/merge-streams': 4.0.0
@@ -6533,42 +6406,6 @@ snapshots:
     optional: true
 
   expect-type@1.2.2: {}
-
-  express-rate-limit@7.5.1(express@5.1.0):
-    dependencies:
-      express: 5.1.0
-
-  express@5.1.0:
-    dependencies:
-      accepts: 2.0.0
-      body-parser: 2.2.0
-      content-disposition: 1.0.0
-      content-type: 1.0.5
-      cookie: 0.7.2
-      cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@8.1.1)
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      finalhandler: 2.1.0
-      fresh: 2.0.0
-      http-errors: 2.0.0
-      merge-descriptors: 2.0.0
-      mime-types: 3.0.1
-      on-finished: 2.4.1
-      once: 1.4.0
-      parseurl: 1.3.3
-      proxy-addr: 2.0.7
-      qs: 6.14.0
-      range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.0
-      serve-static: 2.2.0
-      statuses: 2.0.2
-      type-is: 2.0.1
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
 
   fast-content-type-parse@3.0.0: {}
 
@@ -6614,17 +6451,6 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@2.1.0:
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -6664,10 +6490,6 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
-
-  forwarded@0.2.0: {}
-
-  fresh@2.0.0: {}
 
   fs-constants@1.0.0:
     optional: true
@@ -6816,14 +6638,6 @@ snapshots:
       domutils: 3.2.2
       entities: 6.0.1
 
-  http-errors@2.0.0:
-    dependencies:
-      depd: 2.0.0
-      inherits: 2.0.4
-      setprototypeof: 1.2.0
-      statuses: 2.0.1
-      toidentifier: 1.0.1
-
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -6876,8 +6690,6 @@ snapshots:
   ini@1.3.8:
     optional: true
 
-  ipaddr.js@1.9.1: {}
-
   is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.3.0
@@ -6911,8 +6723,6 @@ snapshots:
   is-plain-obj@2.1.0: {}
 
   is-plain-obj@4.1.0: {}
-
-  is-promise@4.0.0: {}
 
   is-stream@4.0.1: {}
 
@@ -7125,10 +6935,6 @@ snapshots:
 
   mdurl@2.0.0: {}
 
-  media-typer@1.1.0: {}
-
-  merge-descriptors@2.0.0: {}
-
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
@@ -7138,15 +6944,9 @@ snapshots:
 
   mime-db@1.52.0: {}
 
-  mime-db@1.54.0: {}
-
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
-
-  mime-types@3.0.1:
-    dependencies:
-      mime-db: 1.54.0
 
   mime@1.6.0: {}
 
@@ -7219,8 +7019,6 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  negotiator@1.0.0: {}
-
   node-abi@3.77.0:
     dependencies:
       semver: 7.7.2
@@ -7255,15 +7053,9 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  object-assign@4.1.1: {}
-
   object-inspect@1.13.4: {}
 
   object-keys@1.1.1: {}
-
-  on-finished@2.4.1:
-    dependencies:
-      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -7389,8 +7181,6 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
-  parseurl@1.3.3: {}
-
   path-exists@4.0.0: {}
 
   path-exists@5.0.0: {}
@@ -7411,8 +7201,6 @@ snapshots:
       lru-cache: 11.2.2
       minipass: 7.1.2
 
-  path-to-regexp@8.3.0: {}
-
   path-type@6.0.0: {}
 
   pathe@2.0.3: {}
@@ -7426,8 +7214,6 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
-
-  pkce-challenge@5.0.0: {}
 
   playwright-core@1.55.1: {}
 
@@ -7477,11 +7263,6 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
-  proxy-addr@2.0.7:
-    dependencies:
-      forwarded: 0.2.0
-      ipaddr.js: 1.9.1
-
   proxy-from-env@1.1.0: {}
 
   publint@0.3.13:
@@ -7512,15 +7293,6 @@ snapshots:
   randombytes@2.1.0:
     dependencies:
       safe-buffer: 5.2.1
-
-  range-parser@1.2.1: {}
-
-  raw-body@3.0.1:
-    dependencies:
-      bytes: 3.1.2
-      http-errors: 2.0.0
-      iconv-lite: 0.7.0
-      unpipe: 1.0.0
 
   rc-config-loader@4.1.3:
     dependencies:
@@ -7593,7 +7365,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.16.9(rolldown@1.0.0-beta.40)(typescript@5.9.2):
+  rolldown-plugin-dts@0.16.9(rolldown@1.0.0-beta.41)(typescript@5.9.2):
     dependencies:
       '@babel/generator': 7.28.3
       '@babel/parser': 7.28.4
@@ -7604,7 +7376,7 @@ snapshots:
       dts-resolver: 2.1.2
       get-tsconfig: 4.10.1
       magic-string: 0.30.19
-      rolldown: 1.0.0-beta.40
+      rolldown: 1.0.0-beta.41
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -7631,6 +7403,27 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.40
       '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.40
       '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.40
+
+  rolldown@1.0.0-beta.41:
+    dependencies:
+      '@oxc-project/types': 0.93.0
+      '@rolldown/pluginutils': 1.0.0-beta.41
+      ansis: 4.2.0
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-beta.41
+      '@rolldown/binding-darwin-arm64': 1.0.0-beta.41
+      '@rolldown/binding-darwin-x64': 1.0.0-beta.41
+      '@rolldown/binding-freebsd-x64': 1.0.0-beta.41
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.41
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.41
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.41
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.41
+      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.41
+      '@rolldown/binding-openharmony-arm64': 1.0.0-beta.41
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.41
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.41
+      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.41
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.41
 
   rollup@4.52.3:
     dependencies:
@@ -7659,16 +7452,6 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.52.3
       '@rollup/rollup-win32-x64-msvc': 4.52.3
       fsevents: 2.3.3
-
-  router@2.2.0:
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      depd: 2.0.0
-      is-promise: 4.0.0
-      parseurl: 1.3.3
-      path-to-regexp: 8.3.0
-    transitivePeerDependencies:
-      - supports-color
 
   run-applescript@7.1.0: {}
 
@@ -7706,38 +7489,11 @@ snapshots:
 
   semver@7.7.2: {}
 
-  send@1.2.0:
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 2.0.0
-      http-errors: 2.0.0
-      mime-types: 3.0.1
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
 
-  serve-static@2.2.0:
-    dependencies:
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      parseurl: 1.3.3
-      send: 1.2.0
-    transitivePeerDependencies:
-      - supports-color
-
   setimmediate@1.0.5: {}
-
-  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -7822,10 +7578,6 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
-
-  statuses@2.0.1: {}
-
-  statuses@2.0.2: {}
 
   std-env@3.9.0: {}
 
@@ -7965,8 +7717,6 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  toidentifier@1.0.1: {}
-
   totalist@3.0.1: {}
 
   tree-kill@1.2.2: {}
@@ -7980,8 +7730,8 @@ snapshots:
       diff: 8.0.2
       empathic: 2.0.0
       hookable: 5.5.3
-      rolldown: 1.0.0-beta.40
-      rolldown-plugin-dts: 0.16.9(rolldown@1.0.0-beta.40)(typescript@5.9.2)
+      rolldown: 1.0.0-beta.41
+      rolldown-plugin-dts: 0.16.9(rolldown@1.0.0-beta.41)(typescript@5.9.2)
       semver: 7.7.2
       tinyexec: 1.0.1
       tinyglobby: 0.2.15
@@ -8014,12 +7764,6 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-fest@4.41.0: {}
-
-  type-is@2.0.1:
-    dependencies:
-      content-type: 1.0.5
-      media-typer: 1.1.0
-      mime-types: 3.0.1
 
   typed-rest-client@1.8.11:
     dependencies:
@@ -8054,8 +7798,6 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unpipe@1.0.0: {}
-
   update-browserslist-db@1.1.3(browserslist@4.26.2):
     dependencies:
       browserslist: 4.26.2
@@ -8084,8 +7826,6 @@ snapshots:
       spdx-expression-parse: 3.0.1
 
   validate-npm-package-name@5.0.1: {}
-
-  vary@1.1.2: {}
 
   version-range@4.15.0: {}
 
@@ -8279,9 +8019,3 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   yoctocolors@2.1.2: {}
-
-  zod-to-json-schema@3.24.6(zod@3.25.76):
-    dependencies:
-      zod: 3.25.76
-
-  zod@3.25.76: {}


### PR DESCRIPTION
Export AST types directly from `oxlint` package, instead of depending on `@oxc-project/types`. This enables altering the types to reflect that `range` field is always present on AST node in Oxlint's AST (#14354).