### PR TITLE
fix(linter/plugins): make `range` field non-optional on AST types

### DIFF
--- a/apps/oxlint/src-js/generated/types.d.ts
+++ b/apps/oxlint/src-js/generated/types.d.ts
@@ -1704,7 +1704,7 @@ export type UpdateOperator = '++' | '--';
 export interface Span {
   start: number;
   end: number;
-  range?: [number, number];
+  range: [number, number];
 }
 
 export type ModuleKind = 'script' | 'module';

--- a/apps/oxlint/src-js/index.ts
+++ b/apps/oxlint/src-js/index.ts
@@ -25,6 +25,7 @@ export type {
   Node,
   NodeOrToken,
   Range,
+  Ranged,
   RuleMeta,
   Token,
   Visitor,

--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -4,7 +4,7 @@ import { SOURCE_CODE } from './source_code.js';
 
 import type { Fix, FixFn } from './fix.ts';
 import type { SourceCode } from './source_code.ts';
-import type { Location, Node } from './types.ts';
+import type { Location, Ranged } from './types.ts';
 
 const { hasOwn } = Object;
 
@@ -17,7 +17,7 @@ export interface DiagnosticBase {
 }
 
 export interface DiagnosticWithNode extends DiagnosticBase {
-  node: Node;
+  node: Ranged;
 }
 
 export interface DiagnosticWithLoc extends DiagnosticBase {

--- a/apps/oxlint/src-js/plugins/fix.ts
+++ b/apps/oxlint/src-js/plugins/fix.ts
@@ -1,7 +1,7 @@
 import { assertIs } from './utils.js';
 
 import type { Diagnostic, InternalContext } from './context.ts';
-import type { NodeOrToken, Range } from './types.ts';
+import type { Range, Ranged } from './types.ts';
 
 const { prototype: ArrayPrototype, from: ArrayFrom } = Array,
   { getPrototypeOf, hasOwn, prototype: ObjectPrototype } = Object,
@@ -23,7 +23,7 @@ export type Fix = { range: Range; text: string };
 // Fixer is stateless, so reuse a single object for all fixes.
 // Freeze the object to prevent user mutating it.
 const FIXER = Object.freeze({
-  insertTextBefore(nodeOrToken: NodeOrToken, text: string): Fix {
+  insertTextBefore(nodeOrToken: Ranged, text: string): Fix {
     const start = nodeOrToken.range[0];
     return { range: [start, start], text };
   },
@@ -31,7 +31,7 @@ const FIXER = Object.freeze({
     const start = range[0];
     return { range: [start, start], text };
   },
-  insertTextAfter(nodeOrToken: NodeOrToken, text: string): Fix {
+  insertTextAfter(nodeOrToken: Ranged, text: string): Fix {
     const end = nodeOrToken.range[1];
     return { range: [end, end], text };
   },
@@ -39,13 +39,13 @@ const FIXER = Object.freeze({
     const end = range[1];
     return { range: [end, end], text };
   },
-  remove(nodeOrToken: NodeOrToken): Fix {
+  remove(nodeOrToken: Ranged): Fix {
     return { range: nodeOrToken.range, text: '' };
   },
   removeRange(range: Range): Fix {
     return { range, text: '' };
   },
-  replaceText(nodeOrToken: NodeOrToken, text: string): Fix {
+  replaceText(nodeOrToken: Ranged, text: string): Fix {
     return { range: nodeOrToken.range, text };
   },
   replaceTextRange(range: Range, text: string): Fix {

--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -12,7 +12,7 @@ import { getLineColumnFromOffset, getOffsetFromLineColumn, initLines, lines, res
 
 import type { Program } from '../generated/types.d.ts';
 import type { Scope, ScopeManager, Variable } from './scope.ts';
-import type { BufferWithArrays, Comment, Node, NodeOrToken, Token } from './types.ts';
+import type { BufferWithArrays, Comment, Node, NodeOrToken, Ranged, Token } from './types.ts';
 
 const require = createRequire(import.meta.url);
 
@@ -139,7 +139,7 @@ export const SOURCE_CODE = Object.freeze({
    * @returns Source text representing the AST node.
    */
   getText(
-    node?: Node | null | undefined,
+    node?: Ranged | null | undefined,
     beforeCount?: number | null | undefined,
     afterCount?: number | null | undefined,
   ): string {

--- a/apps/oxlint/src-js/plugins/types.ts
+++ b/apps/oxlint/src-js/plugins/types.ts
@@ -25,15 +25,15 @@ export interface VisitorWithHooks extends Visitor {
 // Visit function for a specific AST node type.
 export type VisitFn = (node: Node) => void;
 
+// Interface for any type which has `range` field
+export interface Ranged {
+  range: Range;
+}
+
 // Internal interface for any type which has location properties.
-interface Spanned {
+interface Spanned extends Ranged {
   start: number;
   end: number;
-  // This property should not be optional - all AST nodes do have a `range` field.
-  // But ESTree types have `range` field as optional, so to allow AST nodes to be passed
-  // to methods which take `Node`, we have to make it optional here too.
-  // TODO: Fix this
-  range?: Range;
   loc?: Location;
 }
 

--- a/apps/oxlint/test/compile-visitor.test.ts
+++ b/apps/oxlint/test/compile-visitor.test.ts
@@ -15,10 +15,12 @@ import {
   initCompiledVisitor,
 } from '../src-js/plugins/visitor.js';
 
-import type { EnterExit, VisitFn } from '../src-js/plugins/types.ts';
+import type { EnterExit, Node, VisitFn } from '../src-js/plugins/types.ts';
 
 const PROGRAM_TYPE_ID = NODE_TYPE_IDS_MAP.get('Program'),
   EMPTY_STMT_TYPE_ID = NODE_TYPE_IDS_MAP.get('EmptyStatement');
+
+const SPAN: Node = { start: 0, end: 0, range: [0, 0] };
 
 describe('compile visitor', () => {
   beforeEach(initCompiledVisitor);
@@ -97,7 +99,7 @@ describe('compile visitor', () => {
         addVisitorToCompiled({ EmptyStatement: enter, 'EmptyStatement:exit': exit });
         expect(finalizeCompiledVisitor()).toBe(true);
 
-        const node = { type: 'EmptyStatement', start: 0, end: 0 };
+        const node = { type: 'EmptyStatement', ...SPAN };
         (compiledVisitor[EMPTY_STMT_TYPE_ID] as VisitFn)(node);
         expect(enter).toHaveBeenCalledWith(node);
         expect(exit).toHaveBeenCalledWith(node);
@@ -110,7 +112,7 @@ describe('compile visitor', () => {
         addVisitorToCompiled({ 'EmptyStatement:exit': exit, EmptyStatement: enter });
         expect(finalizeCompiledVisitor()).toBe(true);
 
-        const node = { type: 'EmptyStatement', start: 0, end: 0 };
+        const node = { type: 'EmptyStatement', ...SPAN };
         (compiledVisitor[EMPTY_STMT_TYPE_ID] as VisitFn)(node);
         expect(enter).toHaveBeenCalledWith(node);
         expect(exit).toHaveBeenCalledWith(node);
@@ -158,7 +160,7 @@ describe('compile visitor', () => {
 
         expect(finalizeCompiledVisitor()).toBe(true);
 
-        const node = { type: 'EmptyStatement', start: 0, end: 0 };
+        const node = { type: 'EmptyStatement', ...SPAN };
         (compiledVisitor[EMPTY_STMT_TYPE_ID] as VisitFn)(node);
         expect(enter1).toHaveBeenCalledWith(node);
         expect(exit1).toHaveBeenCalledWith(node);
@@ -180,7 +182,7 @@ describe('compile visitor', () => {
 
         expect(finalizeCompiledVisitor()).toBe(true);
 
-        const node = { type: 'EmptyStatement', start: 0, end: 0 };
+        const node = { type: 'EmptyStatement', ...SPAN };
         (compiledVisitor[EMPTY_STMT_TYPE_ID] as VisitFn)(node);
         expect(enter1).toHaveBeenCalledWith(node);
         expect(exit1).toHaveBeenCalledWith(node);
@@ -202,7 +204,7 @@ describe('compile visitor', () => {
 
         expect(finalizeCompiledVisitor()).toBe(true);
 
-        const node = { type: 'EmptyStatement', start: 0, end: 0 };
+        const node = { type: 'EmptyStatement', ...SPAN };
         (compiledVisitor[EMPTY_STMT_TYPE_ID] as VisitFn)(node);
         expect(enter1).toHaveBeenCalledWith(node);
         expect(exit1).toHaveBeenCalledWith(node);
@@ -224,7 +226,7 @@ describe('compile visitor', () => {
 
         expect(finalizeCompiledVisitor()).toBe(true);
 
-        const node = { type: 'EmptyStatement', start: 0, end: 0 };
+        const node = { type: 'EmptyStatement', ...SPAN };
         (compiledVisitor[EMPTY_STMT_TYPE_ID] as VisitFn)(node);
         expect(enter1).toHaveBeenCalledWith(node);
         expect(exit1).toHaveBeenCalledWith(node);
@@ -250,12 +252,12 @@ describe('compile visitor', () => {
 
         const enterExit = compiledVisitor[PROGRAM_TYPE_ID] as EnterExit;
 
-        const enterNode = { type: 'Program', start: 0, end: 0 };
+        const enterNode = { type: 'Program', ...SPAN };
         enterExit.enter(enterNode);
         expect(enter1).toHaveBeenCalledWith(enterNode);
         expect(enter2).toHaveBeenCalledWith(enterNode);
 
-        const exitNode = { type: 'Program', start: 0, end: 0 };
+        const exitNode = { type: 'Program', ...SPAN };
         enterExit.exit(exitNode);
         expect(exit1).toHaveBeenCalledWith(exitNode);
         expect(exit2).toHaveBeenCalledWith(exitNode);
@@ -274,12 +276,12 @@ describe('compile visitor', () => {
 
         const enterExit = compiledVisitor[PROGRAM_TYPE_ID] as EnterExit;
 
-        const enterNode = { type: 'Program', start: 0, end: 0 };
+        const enterNode = { type: 'Program', ...SPAN };
         enterExit.enter(enterNode);
         expect(enter1).toHaveBeenCalledWith(enterNode);
         expect(enter2).toHaveBeenCalledWith(enterNode);
 
-        const exitNode = { type: 'Program', start: 0, end: 0 };
+        const exitNode = { type: 'Program', ...SPAN };
         enterExit.exit(exitNode);
         expect(exit1).toHaveBeenCalledWith(exitNode);
         expect(exit2).toHaveBeenCalledWith(exitNode);
@@ -298,12 +300,12 @@ describe('compile visitor', () => {
 
         const enterExit = compiledVisitor[PROGRAM_TYPE_ID] as EnterExit;
 
-        const enterNode = { type: 'Program', start: 0, end: 0 };
+        const enterNode = { type: 'Program', ...SPAN };
         enterExit.enter(enterNode);
         expect(enter1).toHaveBeenCalledWith(enterNode);
         expect(enter2).toHaveBeenCalledWith(enterNode);
 
-        const exitNode = { type: 'Program', start: 0, end: 0 };
+        const exitNode = { type: 'Program', ...SPAN };
         enterExit.exit(exitNode);
         expect(exit1).toHaveBeenCalledWith(exitNode);
         expect(exit2).toHaveBeenCalledWith(exitNode);
@@ -322,12 +324,12 @@ describe('compile visitor', () => {
 
         const enterExit = compiledVisitor[PROGRAM_TYPE_ID] as EnterExit;
 
-        const enterNode = { type: 'Program', start: 0, end: 0 };
+        const enterNode = { type: 'Program', ...SPAN };
         enterExit.enter(enterNode);
         expect(enter1).toHaveBeenCalledWith(enterNode);
         expect(enter2).toHaveBeenCalledWith(enterNode);
 
-        const exitNode = { type: 'Program', start: 0, end: 0 };
+        const exitNode = { type: 'Program', ...SPAN };
         enterExit.exit(exitNode);
         expect(exit1).toHaveBeenCalledWith(exitNode);
         expect(exit2).toHaveBeenCalledWith(exitNode);
@@ -361,7 +363,7 @@ describe('compile visitor', () => {
 
       expect(finalizeCompiledVisitor()).toBe(true);
 
-      const node = { type: 'EmptyStatement', start: 0, end: 0 };
+      const node = { type: 'EmptyStatement', ...SPAN };
       (compiledVisitor[EMPTY_STMT_TYPE_ID] as VisitFn)(node);
 
       expect(enter1).toHaveBeenCalledWith(node);

--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -27,14 +27,15 @@ impl Generator for TypescriptGenerator {
     fn generate_many(&self, schema: &Schema, codegen: &Codegen) -> Vec<Output> {
         let code = generate_ts_type_defs(schema, codegen);
 
+        // In Oxlint AST, `range` field is not optional
+        #[expect(clippy::disallowed_methods)]
+        let oxlint_code = code.replace("range?: [number, number];", "range: [number, number];");
+
         vec![
-            Output::Javascript {
-                path: TYPESCRIPT_DEFINITIONS_PATH.to_string(),
-                code: code.clone(),
-            },
+            Output::Javascript { path: TYPESCRIPT_DEFINITIONS_PATH.to_string(), code },
             Output::Javascript {
                 path: format!("{OXLINT_APP_PATH}/src-js/generated/types.d.ts"),
-                code,
+                code: oxlint_code,
             },
         ]
     }


### PR DESCRIPTION
Alter AST types exported from `oxlint` to make the `range` field non-optional - it's always present on AST nodes in Oxlint's AST.