### PR TITLE
fix(language_server): add whitespace for `// oxlint-disable-next-line` fix

### DIFF
--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_astro@debugger.astro.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_astro@debugger.astro.snap
@@ -101,7 +101,7 @@ fixed: Multiple(
             message: Some(
                 "Disable no-debugger for this line",
             ),
-            code: "// oxlint-disable-next-line no-debugger\n",
+            code: "  // oxlint-disable-next-line no-debugger\n",
             range: Range {
                 start: Position {
                     line: 10,
@@ -165,7 +165,7 @@ fixed: Multiple(
             message: Some(
                 "Disable no-debugger for this line",
             ),
-            code: "// oxlint-disable-next-line no-debugger\n",
+            code: "  // oxlint-disable-next-line no-debugger\n",
             range: Range {
                 start: Position {
                     line: 14,
@@ -229,7 +229,7 @@ fixed: Multiple(
             message: Some(
                 "Disable no-debugger for this line",
             ),
-            code: "// oxlint-disable-next-line no-debugger\n",
+            code: "  // oxlint-disable-next-line no-debugger\n",
             range: Range {
                 start: Position {
                     line: 18,

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_issue_9958@issue.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_issue_9958@issue.ts.snap
@@ -21,7 +21,7 @@ fixed: Multiple(
             message: Some(
                 "Disable no-extra-boolean-cast for this line",
             ),
-            code: "// oxlint-disable-next-line no-extra-boolean-cast\n",
+            code: "  // oxlint-disable-next-line no-extra-boolean-cast\n",
             range: Range {
                 start: Position {
                     line: 3,
@@ -72,7 +72,7 @@ fixed: Multiple(
             message: Some(
                 "Disable no-non-null-asserted-optional-chain for this line",
             ),
-            code: "// oxlint-disable-next-line no-non-null-asserted-optional-chain\n",
+            code: "  // oxlint-disable-next-line no-non-null-asserted-optional-chain\n",
             range: Range {
                 start: Position {
                     line: 11,

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_svelte@debugger.svelte.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_svelte@debugger.svelte.snap
@@ -21,7 +21,7 @@ fixed: Multiple(
             message: Some(
                 "Disable no-unassigned-vars for this line",
             ),
-            code: "// oxlint-disable-next-line no-unassigned-vars\n",
+            code: "\t// oxlint-disable-next-line no-unassigned-vars\n",
             range: Range {
                 start: Position {
                     line: 3,
@@ -69,7 +69,7 @@ fixed: Multiple(
             message: Some(
                 "Disable no-unassigned-vars for this line",
             ),
-            code: "// oxlint-disable-next-line no-unassigned-vars\n",
+            code: "\t// oxlint-disable-next-line no-unassigned-vars\n",
             range: Range {
                 start: Position {
                     line: 4,
@@ -133,7 +133,7 @@ fixed: Multiple(
             message: Some(
                 "Disable no-debugger for this line",
             ),
-            code: "// oxlint-disable-next-line no-debugger\n",
+            code: "\t// oxlint-disable-next-line no-debugger\n",
             range: Range {
                 start: Position {
                     line: 1,

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_unused_disabled_directives@test.js.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_unused_disabled_directives@test.js.snap
@@ -85,7 +85,7 @@ fixed: Multiple(
             message: Some(
                 "Disable no-debugger for this line",
             ),
-            code: "// oxlint-disable-next-line no-debugger\n",
+            code: "  // oxlint-disable-next-line no-debugger\n",
             range: Range {
                 start: Position {
                     line: 2,

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_vue@debugger.vue.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_vue@debugger.vue.snap
@@ -37,15 +37,15 @@ fixed: Multiple(
             message: Some(
                 "Disable no-debugger for this line",
             ),
-            code: "// oxlint-disable-next-line no-debugger\n",
+            code: "\n// oxlint-disable-next-line no-debugger\n",
             range: Range {
                 start: Position {
                     line: 4,
-                    character: 0,
+                    character: 8,
                 },
                 end: Position {
                     line: 4,
-                    character: 0,
+                    character: 8,
                 },
             },
         },
@@ -101,7 +101,7 @@ fixed: Multiple(
             message: Some(
                 "Disable no-debugger for this line",
             ),
-            code: "// oxlint-disable-next-line no-debugger\n",
+            code: "    // oxlint-disable-next-line no-debugger\n",
             range: Range {
                 start: Position {
                     line: 8,


### PR DESCRIPTION
Now the comment is aligned with the indent of the line:
![whitespace-disable-next-line](https://github.com/user-attachments/assets/5ff6c485-4608-4d71-8f79-f8b9f5b07f04)

