### PR TITLE
fix(mangler): avoid reusing same mangled names in the outer class

### DIFF
--- a/crates/oxc_minifier/tests/mangler/mod.rs
+++ b/crates/oxc_minifier/tests/mangler/mod.rs
@@ -125,6 +125,7 @@ fn private_member_mangling() {
         // Test same names across different classes should reuse mangled names
         "class A { #field = 1; #method() { return this.#field; } } class B { #field = 2; #method() { return this.#field; } }",
         "class A { #field = 1; #method() { return this.#field; } } class B { #field2 = 2; #method2() { return this.#field2; } }",
+        "class Outer { #shared = 1; #getInner() { return class { #method() { return this.#shared; } }; } }",
     ];
 
     let mut snapshot = String::new();

--- a/crates/oxc_minifier/tests/mangler/snapshots/private_member_mangling.snap
+++ b/crates/oxc_minifier/tests/mangler/snapshots/private_member_mangling.snap
@@ -52,9 +52,9 @@ class Outer {
 	#e = 1;
 	inner() {
 		return class e {
-			#e = 2;
+			#t = 2;
 			get() {
-				return this.#e;
+				return this.#t;
 			}
 		};
 	}
@@ -78,9 +78,9 @@ class Outer {
 	#e = 1;
 	getInner() {
 		return class {
-			#e = 2;
+			#t = 2;
 			method() {
-				return this.#e;
+				return this.#t;
 			}
 		};
 	}
@@ -120,5 +120,17 @@ class B {
 	#e = 2;
 	#t() {
 		return this.#e;
+	}
+}
+
+class Outer { #shared = 1; #getInner() { return class { #method() { return this.#shared; } }; } }
+class Outer {
+	#e = 1;
+	#t() {
+		return class {
+			#n() {
+				return this.#e;
+			}
+		};
 	}
 }


### PR DESCRIPTION
```js
class Outer {
	#shared = 1;
	#getInner() {
		return class {
			#method() {
				return this.#shared;
			}
		};
	}
}
```
was transformed to
```js
class Outer {
	#e = 1;
	#t() {
		return class {
			#e() {
				return this.#e;
			}
		};
	}
}
```
. This is wrong because `this.#e` points the #e method in the inner class rather than the #e in the outer class.
This PR fixes that by avoiding reusing the name used in the outer class.