### PR TITLE
chore(tasks/lint_rules): add unsupported promise/no-native

### DIFF
--- a/tasks/lint_rules/src/oxlint-rules.mjs
+++ b/tasks/lint_rules/src/oxlint-rules.mjs
@@ -51,6 +51,7 @@ const NOT_SUPPORTED_RULE_NAMES = new Set([
   'eslint/no-new-symbol', // Deprecated as of ESLint v9, but for a while disable manually
   'eslint/no-undef-init', // #6456 unicorn/no-useless-undefined covers this case
   'import/no-unresolved', // Will always contain false positives due to module resolution complexity,
+  'promise/no-native', // handled by eslint/no-undef
   'react/jsx-equals-spacing', // stylistic rule
   'react/jsx-curly-spacing', // stylistic rule
   'react/jsx-indent', // stylistic rule


### PR DESCRIPTION
Related: #4655 

This rule is handled by `eslint/no-undef` (ref: https://github.com/oxc-project/oxc/pull/13233#pullrequestreview-3136701058)