### PR TITLE
fix(ast): skip `source_text` and `comments` fields in `ContentEq` for `Program`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -50,9 +50,11 @@ use super::{macros::inherit_variants, *};
 pub struct Program<'a> {
     pub span: Span,
     pub source_type: SourceType,
+    #[content_eq(skip)]
     #[estree(skip)]
     pub source_text: &'a str,
     /// Sorted comments
+    #[content_eq(skip)]
     #[estree(skip)]
     pub comments: Vec<'a, Comment>,
     pub hashbang: Option<Hashbang<'a>>,

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -14,8 +14,6 @@ use crate::ast::ts::*;
 impl ContentEq for Program<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.source_type, &other.source_type)
-            && ContentEq::content_eq(&self.source_text, &other.source_text)
-            && ContentEq::content_eq(&self.comments, &other.comments)
             && ContentEq::content_eq(&self.hashbang, &other.hashbang)
             && ContentEq::content_eq(&self.directives, &other.directives)
             && ContentEq::content_eq(&self.body, &other.body)


### PR DESCRIPTION
`source_text` is not semantically meaningful, and comments is *mostly* not either. Exclude both from `ContentEq` comparison for `Program`.