### PR TITLE
refactor(napi/parser, linter/plugins): minify walker code

### DIFF
--- a/apps/oxlint/src-js/generated/walk.js
+++ b/apps/oxlint/src-js/generated/walk.js
@@ -2,18 +2,14 @@
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/estree_visit.rs`.
 
 export { walkProgram };
-
 const { isArray } = Array;
 
 function walkNode(node, visitors) {
   if (node == null) return;
   if (isArray(node)) {
-    const len = node.length;
-    for (let i = 0; i < len; i++) {
-      walkNode(node[i], visitors);
-    }
-  } else {
-    switch (node.type) {
+    let len = node.length;
+    for (let i = 0; i < len; i++) walkNode(node[i], visitors);
+  } else {switch (node.type) {
       case 'DebuggerStatement':
         walkDebuggerStatement(node, visitors);
         break;
@@ -509,336 +505,320 @@ function walkNode(node, visitors) {
       case 'TSUnionType':
         walkTSUnionType(node, visitors);
         break;
-    }
-  }
+    }}
 }
 
 function walkDebuggerStatement(node, visitors) {
-  const visit = visitors[0];
-  if (visit !== null) visit(node);
+  let visit = visitors[0];
+  visit !== null && visit(node);
 }
 
 function walkEmptyStatement(node, visitors) {
-  const visit = visitors[1];
-  if (visit !== null) visit(node);
+  let visit = visitors[1];
+  visit !== null && visit(node);
 }
 
 function walkLiteral(node, visitors) {
-  const visit = visitors[2];
-  if (visit !== null) visit(node);
+  let visit = visitors[2];
+  visit !== null && visit(node);
 }
 
 function walkPrivateIdentifier(node, visitors) {
-  const visit = visitors[3];
-  if (visit !== null) visit(node);
+  let visit = visitors[3];
+  visit !== null && visit(node);
 }
 
 function walkSuper(node, visitors) {
-  const visit = visitors[4];
-  if (visit !== null) visit(node);
+  let visit = visitors[4];
+  visit !== null && visit(node);
 }
 
 function walkTemplateElement(node, visitors) {
-  const visit = visitors[5];
-  if (visit !== null) visit(node);
+  let visit = visitors[5];
+  visit !== null && visit(node);
 }
 
 function walkThisExpression(node, visitors) {
-  const visit = visitors[6];
-  if (visit !== null) visit(node);
+  let visit = visitors[6];
+  visit !== null && visit(node);
 }
 
 function walkJSXClosingFragment(node, visitors) {
-  const visit = visitors[7];
-  if (visit !== null) visit(node);
+  let visit = visitors[7];
+  visit !== null && visit(node);
 }
 
 function walkJSXEmptyExpression(node, visitors) {
-  const visit = visitors[8];
-  if (visit !== null) visit(node);
+  let visit = visitors[8];
+  visit !== null && visit(node);
 }
 
 function walkJSXIdentifier(node, visitors) {
-  const visit = visitors[9];
-  if (visit !== null) visit(node);
+  let visit = visitors[9];
+  visit !== null && visit(node);
 }
 
 function walkJSXOpeningFragment(node, visitors) {
-  const visit = visitors[10];
-  if (visit !== null) visit(node);
+  let visit = visitors[10];
+  visit !== null && visit(node);
 }
 
 function walkJSXText(node, visitors) {
-  const visit = visitors[11];
-  if (visit !== null) visit(node);
+  let visit = visitors[11];
+  visit !== null && visit(node);
 }
 
 function walkTSAnyKeyword(node, visitors) {
-  const visit = visitors[12];
-  if (visit !== null) visit(node);
+  let visit = visitors[12];
+  visit !== null && visit(node);
 }
 
 function walkTSBigIntKeyword(node, visitors) {
-  const visit = visitors[13];
-  if (visit !== null) visit(node);
+  let visit = visitors[13];
+  visit !== null && visit(node);
 }
 
 function walkTSBooleanKeyword(node, visitors) {
-  const visit = visitors[14];
-  if (visit !== null) visit(node);
+  let visit = visitors[14];
+  visit !== null && visit(node);
 }
 
 function walkTSIntrinsicKeyword(node, visitors) {
-  const visit = visitors[15];
-  if (visit !== null) visit(node);
+  let visit = visitors[15];
+  visit !== null && visit(node);
 }
 
 function walkTSJSDocUnknownType(node, visitors) {
-  const visit = visitors[16];
-  if (visit !== null) visit(node);
+  let visit = visitors[16];
+  visit !== null && visit(node);
 }
 
 function walkTSNeverKeyword(node, visitors) {
-  const visit = visitors[17];
-  if (visit !== null) visit(node);
+  let visit = visitors[17];
+  visit !== null && visit(node);
 }
 
 function walkTSNullKeyword(node, visitors) {
-  const visit = visitors[18];
-  if (visit !== null) visit(node);
+  let visit = visitors[18];
+  visit !== null && visit(node);
 }
 
 function walkTSNumberKeyword(node, visitors) {
-  const visit = visitors[19];
-  if (visit !== null) visit(node);
+  let visit = visitors[19];
+  visit !== null && visit(node);
 }
 
 function walkTSObjectKeyword(node, visitors) {
-  const visit = visitors[20];
-  if (visit !== null) visit(node);
+  let visit = visitors[20];
+  visit !== null && visit(node);
 }
 
 function walkTSStringKeyword(node, visitors) {
-  const visit = visitors[21];
-  if (visit !== null) visit(node);
+  let visit = visitors[21];
+  visit !== null && visit(node);
 }
 
 function walkTSSymbolKeyword(node, visitors) {
-  const visit = visitors[22];
-  if (visit !== null) visit(node);
+  let visit = visitors[22];
+  visit !== null && visit(node);
 }
 
 function walkTSThisType(node, visitors) {
-  const visit = visitors[23];
-  if (visit !== null) visit(node);
+  let visit = visitors[23];
+  visit !== null && visit(node);
 }
 
 function walkTSUndefinedKeyword(node, visitors) {
-  const visit = visitors[24];
-  if (visit !== null) visit(node);
+  let visit = visitors[24];
+  visit !== null && visit(node);
 }
 
 function walkTSUnknownKeyword(node, visitors) {
-  const visit = visitors[25];
-  if (visit !== null) visit(node);
+  let visit = visitors[25];
+  visit !== null && visit(node);
 }
 
 function walkTSVoidKeyword(node, visitors) {
-  const visit = visitors[26];
-  if (visit !== null) visit(node);
+  let visit = visitors[26];
+  visit !== null && visit(node);
 }
 
 function walkAccessorProperty(node, visitors) {
-  const enterExit = visitors[27];
-  let exit = null;
+  let enterExit = visitors[27], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.key, visitors);
   walkNode(node.typeAnnotation, visitors);
   walkNode(node.value, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkArrayExpression(node, visitors) {
-  const enterExit = visitors[28];
-  let exit = null;
+  let enterExit = visitors[28], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.elements, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkArrayPattern(node, visitors) {
-  const enterExit = visitors[29];
-  let exit = null;
+  let enterExit = visitors[29], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.elements, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkArrowFunctionExpression(node, visitors) {
-  const enterExit = visitors[30];
-  let exit = null;
+  let enterExit = visitors[30], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeParameters, visitors);
   walkNode(node.params, visitors);
   walkNode(node.returnType, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkAssignmentExpression(node, visitors) {
-  const enterExit = visitors[31];
-  let exit = null;
+  let enterExit = visitors[31], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.left, visitors);
   walkNode(node.right, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkAssignmentPattern(node, visitors) {
-  const enterExit = visitors[32];
-  let exit = null;
+  let enterExit = visitors[32], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.left, visitors);
   walkNode(node.right, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkAwaitExpression(node, visitors) {
-  const enterExit = visitors[33];
-  let exit = null;
+  let enterExit = visitors[33], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.argument, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkBinaryExpression(node, visitors) {
-  const enterExit = visitors[34];
-  let exit = null;
+  let enterExit = visitors[34], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.left, visitors);
   walkNode(node.right, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkBlockStatement(node, visitors) {
-  const enterExit = visitors[35];
-  let exit = null;
+  let enterExit = visitors[35], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkBreakStatement(node, visitors) {
-  const enterExit = visitors[36];
-  let exit = null;
+  let enterExit = visitors[36], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.label, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkCallExpression(node, visitors) {
-  const enterExit = visitors[37];
-  let exit = null;
+  let enterExit = visitors[37], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.callee, visitors);
   walkNode(node.typeArguments, visitors);
   walkNode(node.arguments, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkCatchClause(node, visitors) {
-  const enterExit = visitors[38];
-  let exit = null;
+  let enterExit = visitors[38], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.param, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkChainExpression(node, visitors) {
-  const enterExit = visitors[39];
-  let exit = null;
+  let enterExit = visitors[39], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkClassBody(node, visitors) {
-  const enterExit = visitors[40];
-  let exit = null;
+  let enterExit = visitors[40], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkClassDeclaration(node, visitors) {
-  const enterExit = visitors[41];
-  let exit = null;
+  let enterExit = visitors[41], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.id, visitors);
@@ -847,16 +827,15 @@ function walkClassDeclaration(node, visitors) {
   walkNode(node.superTypeArguments, visitors);
   walkNode(node.implements, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkClassExpression(node, visitors) {
-  const enterExit = visitors[42];
-  let exit = null;
+  let enterExit = visitors[42], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.id, visitors);
@@ -865,1596 +844,1474 @@ function walkClassExpression(node, visitors) {
   walkNode(node.superTypeArguments, visitors);
   walkNode(node.implements, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkConditionalExpression(node, visitors) {
-  const enterExit = visitors[43];
-  let exit = null;
+  let enterExit = visitors[43], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.test, visitors);
   walkNode(node.consequent, visitors);
   walkNode(node.alternate, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkContinueStatement(node, visitors) {
-  const enterExit = visitors[44];
-  let exit = null;
+  let enterExit = visitors[44], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.label, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkDecorator(node, visitors) {
-  const enterExit = visitors[45];
-  let exit = null;
+  let enterExit = visitors[45], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkDoWhileStatement(node, visitors) {
-  const enterExit = visitors[46];
-  let exit = null;
+  let enterExit = visitors[46], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.body, visitors);
   walkNode(node.test, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkExportAllDeclaration(node, visitors) {
-  const enterExit = visitors[47];
-  let exit = null;
+  let enterExit = visitors[47], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.exported, visitors);
   walkNode(node.source, visitors);
   walkNode(node.attributes, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkExportDefaultDeclaration(node, visitors) {
-  const enterExit = visitors[48];
-  let exit = null;
+  let enterExit = visitors[48], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.declaration, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkExportNamedDeclaration(node, visitors) {
-  const enterExit = visitors[49];
-  let exit = null;
+  let enterExit = visitors[49], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.declaration, visitors);
   walkNode(node.specifiers, visitors);
   walkNode(node.source, visitors);
   walkNode(node.attributes, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkExportSpecifier(node, visitors) {
-  const enterExit = visitors[50];
-  let exit = null;
+  let enterExit = visitors[50], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.local, visitors);
   walkNode(node.exported, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkExpressionStatement(node, visitors) {
-  const enterExit = visitors[51];
-  let exit = null;
+  let enterExit = visitors[51], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkForInStatement(node, visitors) {
-  const enterExit = visitors[52];
-  let exit = null;
+  let enterExit = visitors[52], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.left, visitors);
   walkNode(node.right, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkForOfStatement(node, visitors) {
-  const enterExit = visitors[53];
-  let exit = null;
+  let enterExit = visitors[53], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.left, visitors);
   walkNode(node.right, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkForStatement(node, visitors) {
-  const enterExit = visitors[54];
-  let exit = null;
+  let enterExit = visitors[54], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.init, visitors);
   walkNode(node.test, visitors);
   walkNode(node.update, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkFunctionDeclaration(node, visitors) {
-  const enterExit = visitors[55];
-  let exit = null;
+  let enterExit = visitors[55], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.id, visitors);
   walkNode(node.typeParameters, visitors);
   walkNode(node.params, visitors);
   walkNode(node.returnType, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkFunctionExpression(node, visitors) {
-  const enterExit = visitors[56];
-  let exit = null;
+  let enterExit = visitors[56], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.id, visitors);
   walkNode(node.typeParameters, visitors);
   walkNode(node.params, visitors);
   walkNode(node.returnType, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkIdentifier(node, visitors) {
-  const enterExit = visitors[57];
-  let exit = null;
+  let enterExit = visitors[57], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkIfStatement(node, visitors) {
-  const enterExit = visitors[58];
-  let exit = null;
+  let enterExit = visitors[58], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.test, visitors);
   walkNode(node.consequent, visitors);
   walkNode(node.alternate, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkImportAttribute(node, visitors) {
-  const enterExit = visitors[59];
-  let exit = null;
+  let enterExit = visitors[59], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.key, visitors);
   walkNode(node.value, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkImportDeclaration(node, visitors) {
-  const enterExit = visitors[60];
-  let exit = null;
+  let enterExit = visitors[60], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.specifiers, visitors);
   walkNode(node.source, visitors);
   walkNode(node.attributes, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkImportDefaultSpecifier(node, visitors) {
-  const enterExit = visitors[61];
-  let exit = null;
+  let enterExit = visitors[61], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.local, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkImportExpression(node, visitors) {
-  const enterExit = visitors[62];
-  let exit = null;
+  let enterExit = visitors[62], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.source, visitors);
   walkNode(node.options, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkImportNamespaceSpecifier(node, visitors) {
-  const enterExit = visitors[63];
-  let exit = null;
+  let enterExit = visitors[63], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.local, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkImportSpecifier(node, visitors) {
-  const enterExit = visitors[64];
-  let exit = null;
+  let enterExit = visitors[64], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.imported, visitors);
   walkNode(node.local, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkLabeledStatement(node, visitors) {
-  const enterExit = visitors[65];
-  let exit = null;
+  let enterExit = visitors[65], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.label, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkLogicalExpression(node, visitors) {
-  const enterExit = visitors[66];
-  let exit = null;
+  let enterExit = visitors[66], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.left, visitors);
   walkNode(node.right, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkMemberExpression(node, visitors) {
-  const enterExit = visitors[67];
-  let exit = null;
+  let enterExit = visitors[67], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.object, visitors);
   walkNode(node.property, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkMetaProperty(node, visitors) {
-  const enterExit = visitors[68];
-  let exit = null;
+  let enterExit = visitors[68], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.meta, visitors);
   walkNode(node.property, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkMethodDefinition(node, visitors) {
-  const enterExit = visitors[69];
-  let exit = null;
+  let enterExit = visitors[69], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.key, visitors);
   walkNode(node.value, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkNewExpression(node, visitors) {
-  const enterExit = visitors[70];
-  let exit = null;
+  let enterExit = visitors[70], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.callee, visitors);
   walkNode(node.typeArguments, visitors);
   walkNode(node.arguments, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkObjectExpression(node, visitors) {
-  const enterExit = visitors[71];
-  let exit = null;
+  let enterExit = visitors[71], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.properties, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkObjectPattern(node, visitors) {
-  const enterExit = visitors[72];
-  let exit = null;
+  let enterExit = visitors[72], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.properties, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkParenthesizedExpression(node, visitors) {
-  const enterExit = visitors[73];
-  let exit = null;
+  let enterExit = visitors[73], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkProgram(node, visitors) {
-  const enterExit = visitors[74];
-  let exit = null;
+  let enterExit = visitors[74], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkProperty(node, visitors) {
-  const enterExit = visitors[75];
-  let exit = null;
+  let enterExit = visitors[75], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.key, visitors);
   walkNode(node.value, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkPropertyDefinition(node, visitors) {
-  const enterExit = visitors[76];
-  let exit = null;
+  let enterExit = visitors[76], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.key, visitors);
   walkNode(node.typeAnnotation, visitors);
   walkNode(node.value, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkRestElement(node, visitors) {
-  const enterExit = visitors[77];
-  let exit = null;
+  let enterExit = visitors[77], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.argument, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkReturnStatement(node, visitors) {
-  const enterExit = visitors[78];
-  let exit = null;
+  let enterExit = visitors[78], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.argument, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkSequenceExpression(node, visitors) {
-  const enterExit = visitors[79];
-  let exit = null;
+  let enterExit = visitors[79], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expressions, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkSpreadElement(node, visitors) {
-  const enterExit = visitors[80];
-  let exit = null;
+  let enterExit = visitors[80], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.argument, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkStaticBlock(node, visitors) {
-  const enterExit = visitors[81];
-  let exit = null;
+  let enterExit = visitors[81], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkSwitchCase(node, visitors) {
-  const enterExit = visitors[82];
-  let exit = null;
+  let enterExit = visitors[82], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.test, visitors);
   walkNode(node.consequent, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkSwitchStatement(node, visitors) {
-  const enterExit = visitors[83];
-  let exit = null;
+  let enterExit = visitors[83], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.discriminant, visitors);
   walkNode(node.cases, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTaggedTemplateExpression(node, visitors) {
-  const enterExit = visitors[84];
-  let exit = null;
+  let enterExit = visitors[84], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.tag, visitors);
   walkNode(node.typeArguments, visitors);
   walkNode(node.quasi, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTemplateLiteral(node, visitors) {
-  const enterExit = visitors[85];
-  let exit = null;
+  let enterExit = visitors[85], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.quasis, visitors);
   walkNode(node.expressions, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkThrowStatement(node, visitors) {
-  const enterExit = visitors[86];
-  let exit = null;
+  let enterExit = visitors[86], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.argument, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTryStatement(node, visitors) {
-  const enterExit = visitors[87];
-  let exit = null;
+  let enterExit = visitors[87], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.block, visitors);
   walkNode(node.handler, visitors);
   walkNode(node.finalizer, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkUnaryExpression(node, visitors) {
-  const enterExit = visitors[88];
-  let exit = null;
+  let enterExit = visitors[88], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.argument, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkUpdateExpression(node, visitors) {
-  const enterExit = visitors[89];
-  let exit = null;
+  let enterExit = visitors[89], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.argument, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkV8IntrinsicExpression(node, visitors) {
-  const enterExit = visitors[90];
-  let exit = null;
+  let enterExit = visitors[90], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.name, visitors);
   walkNode(node.arguments, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkVariableDeclaration(node, visitors) {
-  const enterExit = visitors[91];
-  let exit = null;
+  let enterExit = visitors[91], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.declarations, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkVariableDeclarator(node, visitors) {
-  const enterExit = visitors[92];
-  let exit = null;
+  let enterExit = visitors[92], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.id, visitors);
   walkNode(node.init, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkWhileStatement(node, visitors) {
-  const enterExit = visitors[93];
-  let exit = null;
+  let enterExit = visitors[93], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.test, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkWithStatement(node, visitors) {
-  const enterExit = visitors[94];
-  let exit = null;
+  let enterExit = visitors[94], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.object, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkYieldExpression(node, visitors) {
-  const enterExit = visitors[95];
-  let exit = null;
+  let enterExit = visitors[95], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.argument, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkJSXAttribute(node, visitors) {
-  const enterExit = visitors[96];
-  let exit = null;
+  let enterExit = visitors[96], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.name, visitors);
   walkNode(node.value, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkJSXClosingElement(node, visitors) {
-  const enterExit = visitors[97];
-  let exit = null;
+  let enterExit = visitors[97], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.name, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkJSXElement(node, visitors) {
-  const enterExit = visitors[98];
-  let exit = null;
+  let enterExit = visitors[98], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.openingElement, visitors);
   walkNode(node.children, visitors);
   walkNode(node.closingElement, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkJSXExpressionContainer(node, visitors) {
-  const enterExit = visitors[99];
-  let exit = null;
+  let enterExit = visitors[99], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkJSXFragment(node, visitors) {
-  const enterExit = visitors[100];
-  let exit = null;
+  let enterExit = visitors[100], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.openingFragment, visitors);
   walkNode(node.children, visitors);
   walkNode(node.closingFragment, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkJSXMemberExpression(node, visitors) {
-  const enterExit = visitors[101];
-  let exit = null;
+  let enterExit = visitors[101], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.object, visitors);
   walkNode(node.property, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkJSXNamespacedName(node, visitors) {
-  const enterExit = visitors[102];
-  let exit = null;
+  let enterExit = visitors[102], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.namespace, visitors);
   walkNode(node.name, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkJSXOpeningElement(node, visitors) {
-  const enterExit = visitors[103];
-  let exit = null;
+  let enterExit = visitors[103], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.name, visitors);
   walkNode(node.typeArguments, visitors);
   walkNode(node.attributes, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkJSXSpreadAttribute(node, visitors) {
-  const enterExit = visitors[104];
-  let exit = null;
+  let enterExit = visitors[104], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.argument, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkJSXSpreadChild(node, visitors) {
-  const enterExit = visitors[105];
-  let exit = null;
+  let enterExit = visitors[105], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSAbstractAccessorProperty(node, visitors) {
-  const enterExit = visitors[106];
-  let exit = null;
+  let enterExit = visitors[106], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.key, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSAbstractMethodDefinition(node, visitors) {
-  const enterExit = visitors[107];
-  let exit = null;
+  let enterExit = visitors[107], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.key, visitors);
   walkNode(node.value, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSAbstractPropertyDefinition(node, visitors) {
-  const enterExit = visitors[108];
-  let exit = null;
+  let enterExit = visitors[108], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.key, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSArrayType(node, visitors) {
-  const enterExit = visitors[109];
-  let exit = null;
+  let enterExit = visitors[109], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.elementType, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSAsExpression(node, visitors) {
-  const enterExit = visitors[110];
-  let exit = null;
+  let enterExit = visitors[110], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSCallSignatureDeclaration(node, visitors) {
-  const enterExit = visitors[111];
-  let exit = null;
+  let enterExit = visitors[111], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeParameters, visitors);
   walkNode(node.params, visitors);
   walkNode(node.returnType, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSClassImplements(node, visitors) {
-  const enterExit = visitors[112];
-  let exit = null;
+  let enterExit = visitors[112], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
   walkNode(node.typeArguments, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSConditionalType(node, visitors) {
-  const enterExit = visitors[113];
-  let exit = null;
+  let enterExit = visitors[113], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.checkType, visitors);
   walkNode(node.extendsType, visitors);
   walkNode(node.trueType, visitors);
   walkNode(node.falseType, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSConstructSignatureDeclaration(node, visitors) {
-  const enterExit = visitors[114];
-  let exit = null;
+  let enterExit = visitors[114], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeParameters, visitors);
   walkNode(node.params, visitors);
   walkNode(node.returnType, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSConstructorType(node, visitors) {
-  const enterExit = visitors[115];
-  let exit = null;
+  let enterExit = visitors[115], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeParameters, visitors);
   walkNode(node.params, visitors);
   walkNode(node.returnType, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSDeclareFunction(node, visitors) {
-  const enterExit = visitors[116];
-  let exit = null;
+  let enterExit = visitors[116], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.id, visitors);
   walkNode(node.typeParameters, visitors);
   walkNode(node.params, visitors);
   walkNode(node.returnType, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSEmptyBodyFunctionExpression(node, visitors) {
-  const enterExit = visitors[117];
-  let exit = null;
+  let enterExit = visitors[117], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.id, visitors);
   walkNode(node.typeParameters, visitors);
   walkNode(node.params, visitors);
   walkNode(node.returnType, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSEnumBody(node, visitors) {
-  const enterExit = visitors[118];
-  let exit = null;
+  let enterExit = visitors[118], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.members, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSEnumDeclaration(node, visitors) {
-  const enterExit = visitors[119];
-  let exit = null;
+  let enterExit = visitors[119], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.id, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSEnumMember(node, visitors) {
-  const enterExit = visitors[120];
-  let exit = null;
+  let enterExit = visitors[120], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.id, visitors);
   walkNode(node.initializer, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSExportAssignment(node, visitors) {
-  const enterExit = visitors[121];
-  let exit = null;
+  let enterExit = visitors[121], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSExternalModuleReference(node, visitors) {
-  const enterExit = visitors[122];
-  let exit = null;
+  let enterExit = visitors[122], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSFunctionType(node, visitors) {
-  const enterExit = visitors[123];
-  let exit = null;
+  let enterExit = visitors[123], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeParameters, visitors);
   walkNode(node.params, visitors);
   walkNode(node.returnType, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSImportEqualsDeclaration(node, visitors) {
-  const enterExit = visitors[124];
-  let exit = null;
+  let enterExit = visitors[124], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.id, visitors);
   walkNode(node.moduleReference, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSImportType(node, visitors) {
-  const enterExit = visitors[125];
-  let exit = null;
+  let enterExit = visitors[125], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.argument, visitors);
   walkNode(node.options, visitors);
   walkNode(node.qualifier, visitors);
   walkNode(node.typeArguments, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSIndexSignature(node, visitors) {
-  const enterExit = visitors[126];
-  let exit = null;
+  let enterExit = visitors[126], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.parameters, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSIndexedAccessType(node, visitors) {
-  const enterExit = visitors[127];
-  let exit = null;
+  let enterExit = visitors[127], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.objectType, visitors);
   walkNode(node.indexType, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSInferType(node, visitors) {
-  const enterExit = visitors[128];
-  let exit = null;
+  let enterExit = visitors[128], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeParameter, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSInstantiationExpression(node, visitors) {
-  const enterExit = visitors[129];
-  let exit = null;
+  let enterExit = visitors[129], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
   walkNode(node.typeArguments, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSInterfaceBody(node, visitors) {
-  const enterExit = visitors[130];
-  let exit = null;
+  let enterExit = visitors[130], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSInterfaceDeclaration(node, visitors) {
-  const enterExit = visitors[131];
-  let exit = null;
+  let enterExit = visitors[131], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.id, visitors);
   walkNode(node.typeParameters, visitors);
   walkNode(node.extends, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSInterfaceHeritage(node, visitors) {
-  const enterExit = visitors[132];
-  let exit = null;
+  let enterExit = visitors[132], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
   walkNode(node.typeArguments, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSIntersectionType(node, visitors) {
-  const enterExit = visitors[133];
-  let exit = null;
+  let enterExit = visitors[133], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.types, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSJSDocNonNullableType(node, visitors) {
-  const enterExit = visitors[134];
-  let exit = null;
+  let enterExit = visitors[134], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSJSDocNullableType(node, visitors) {
-  const enterExit = visitors[135];
-  let exit = null;
+  let enterExit = visitors[135], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSLiteralType(node, visitors) {
-  const enterExit = visitors[136];
-  let exit = null;
+  let enterExit = visitors[136], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.literal, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSMappedType(node, visitors) {
-  const enterExit = visitors[137];
-  let exit = null;
+  let enterExit = visitors[137], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.key, visitors);
   walkNode(node.constraint, visitors);
   walkNode(node.nameType, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSMethodSignature(node, visitors) {
-  const enterExit = visitors[138];
-  let exit = null;
+  let enterExit = visitors[138], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.key, visitors);
   walkNode(node.typeParameters, visitors);
   walkNode(node.params, visitors);
   walkNode(node.returnType, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSModuleBlock(node, visitors) {
-  const enterExit = visitors[139];
-  let exit = null;
+  let enterExit = visitors[139], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSModuleDeclaration(node, visitors) {
-  const enterExit = visitors[140];
-  let exit = null;
+  let enterExit = visitors[140], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.id, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSNamedTupleMember(node, visitors) {
-  const enterExit = visitors[141];
-  let exit = null;
+  let enterExit = visitors[141], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.label, visitors);
   walkNode(node.elementType, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSNamespaceExportDeclaration(node, visitors) {
-  const enterExit = visitors[142];
-  let exit = null;
+  let enterExit = visitors[142], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.id, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSNonNullExpression(node, visitors) {
-  const enterExit = visitors[143];
-  let exit = null;
+  let enterExit = visitors[143], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSOptionalType(node, visitors) {
-  const enterExit = visitors[144];
-  let exit = null;
+  let enterExit = visitors[144], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSParameterProperty(node, visitors) {
-  const enterExit = visitors[145];
-  let exit = null;
+  let enterExit = visitors[145], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.parameter, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSParenthesizedType(node, visitors) {
-  const enterExit = visitors[146];
-  let exit = null;
+  let enterExit = visitors[146], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSPropertySignature(node, visitors) {
-  const enterExit = visitors[147];
-  let exit = null;
+  let enterExit = visitors[147], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.key, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSQualifiedName(node, visitors) {
-  const enterExit = visitors[148];
-  let exit = null;
+  let enterExit = visitors[148], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.left, visitors);
   walkNode(node.right, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSRestType(node, visitors) {
-  const enterExit = visitors[149];
-  let exit = null;
+  let enterExit = visitors[149], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSSatisfiesExpression(node, visitors) {
-  const enterExit = visitors[150];
-  let exit = null;
+  let enterExit = visitors[150], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTemplateLiteralType(node, visitors) {
-  const enterExit = visitors[151];
-  let exit = null;
+  let enterExit = visitors[151], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.quasis, visitors);
   walkNode(node.types, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTupleType(node, visitors) {
-  const enterExit = visitors[152];
-  let exit = null;
+  let enterExit = visitors[152], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.elementTypes, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTypeAliasDeclaration(node, visitors) {
-  const enterExit = visitors[153];
-  let exit = null;
+  let enterExit = visitors[153], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.id, visitors);
   walkNode(node.typeParameters, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTypeAnnotation(node, visitors) {
-  const enterExit = visitors[154];
-  let exit = null;
+  let enterExit = visitors[154], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTypeAssertion(node, visitors) {
-  const enterExit = visitors[155];
-  let exit = null;
+  let enterExit = visitors[155], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeAnnotation, visitors);
   walkNode(node.expression, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTypeLiteral(node, visitors) {
-  const enterExit = visitors[156];
-  let exit = null;
+  let enterExit = visitors[156], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.members, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTypeOperator(node, visitors) {
-  const enterExit = visitors[157];
-  let exit = null;
+  let enterExit = visitors[157], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTypeParameter(node, visitors) {
-  const enterExit = visitors[158];
-  let exit = null;
+  let enterExit = visitors[158], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.name, visitors);
   walkNode(node.constraint, visitors);
   walkNode(node.default, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTypeParameterDeclaration(node, visitors) {
-  const enterExit = visitors[159];
-  let exit = null;
+  let enterExit = visitors[159], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.params, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTypeParameterInstantiation(node, visitors) {
-  const enterExit = visitors[160];
-  let exit = null;
+  let enterExit = visitors[160], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.params, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTypePredicate(node, visitors) {
-  const enterExit = visitors[161];
-  let exit = null;
+  let enterExit = visitors[161], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.parameterName, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTypeQuery(node, visitors) {
-  const enterExit = visitors[162];
-  let exit = null;
+  let enterExit = visitors[162], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.exprName, visitors);
   walkNode(node.typeArguments, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTypeReference(node, visitors) {
-  const enterExit = visitors[163];
-  let exit = null;
+  let enterExit = visitors[163], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeName, visitors);
   walkNode(node.typeArguments, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSUnionType(node, visitors) {
-  const enterExit = visitors[164];
-  let exit = null;
+  let enterExit = visitors[164], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.types, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }

--- a/napi/parser/generated/visit/walk.js
+++ b/napi/parser/generated/visit/walk.js
@@ -2,18 +2,14 @@
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/estree_visit.rs`.
 
 export { walkProgram };
-
 const { isArray } = Array;
 
 function walkNode(node, visitors) {
   if (node == null) return;
   if (isArray(node)) {
-    const len = node.length;
-    for (let i = 0; i < len; i++) {
-      walkNode(node[i], visitors);
-    }
-  } else {
-    switch (node.type) {
+    let len = node.length;
+    for (let i = 0; i < len; i++) walkNode(node[i], visitors);
+  } else {switch (node.type) {
       case 'DebuggerStatement':
         walkDebuggerStatement(node, visitors);
         break;
@@ -509,336 +505,320 @@ function walkNode(node, visitors) {
       case 'TSUnionType':
         walkTSUnionType(node, visitors);
         break;
-    }
-  }
+    }}
 }
 
 function walkDebuggerStatement(node, visitors) {
-  const visit = visitors[0];
-  if (visit !== null) visit(node);
+  let visit = visitors[0];
+  visit !== null && visit(node);
 }
 
 function walkEmptyStatement(node, visitors) {
-  const visit = visitors[1];
-  if (visit !== null) visit(node);
+  let visit = visitors[1];
+  visit !== null && visit(node);
 }
 
 function walkLiteral(node, visitors) {
-  const visit = visitors[2];
-  if (visit !== null) visit(node);
+  let visit = visitors[2];
+  visit !== null && visit(node);
 }
 
 function walkPrivateIdentifier(node, visitors) {
-  const visit = visitors[3];
-  if (visit !== null) visit(node);
+  let visit = visitors[3];
+  visit !== null && visit(node);
 }
 
 function walkSuper(node, visitors) {
-  const visit = visitors[4];
-  if (visit !== null) visit(node);
+  let visit = visitors[4];
+  visit !== null && visit(node);
 }
 
 function walkTemplateElement(node, visitors) {
-  const visit = visitors[5];
-  if (visit !== null) visit(node);
+  let visit = visitors[5];
+  visit !== null && visit(node);
 }
 
 function walkThisExpression(node, visitors) {
-  const visit = visitors[6];
-  if (visit !== null) visit(node);
+  let visit = visitors[6];
+  visit !== null && visit(node);
 }
 
 function walkJSXClosingFragment(node, visitors) {
-  const visit = visitors[7];
-  if (visit !== null) visit(node);
+  let visit = visitors[7];
+  visit !== null && visit(node);
 }
 
 function walkJSXEmptyExpression(node, visitors) {
-  const visit = visitors[8];
-  if (visit !== null) visit(node);
+  let visit = visitors[8];
+  visit !== null && visit(node);
 }
 
 function walkJSXIdentifier(node, visitors) {
-  const visit = visitors[9];
-  if (visit !== null) visit(node);
+  let visit = visitors[9];
+  visit !== null && visit(node);
 }
 
 function walkJSXOpeningFragment(node, visitors) {
-  const visit = visitors[10];
-  if (visit !== null) visit(node);
+  let visit = visitors[10];
+  visit !== null && visit(node);
 }
 
 function walkJSXText(node, visitors) {
-  const visit = visitors[11];
-  if (visit !== null) visit(node);
+  let visit = visitors[11];
+  visit !== null && visit(node);
 }
 
 function walkTSAnyKeyword(node, visitors) {
-  const visit = visitors[12];
-  if (visit !== null) visit(node);
+  let visit = visitors[12];
+  visit !== null && visit(node);
 }
 
 function walkTSBigIntKeyword(node, visitors) {
-  const visit = visitors[13];
-  if (visit !== null) visit(node);
+  let visit = visitors[13];
+  visit !== null && visit(node);
 }
 
 function walkTSBooleanKeyword(node, visitors) {
-  const visit = visitors[14];
-  if (visit !== null) visit(node);
+  let visit = visitors[14];
+  visit !== null && visit(node);
 }
 
 function walkTSIntrinsicKeyword(node, visitors) {
-  const visit = visitors[15];
-  if (visit !== null) visit(node);
+  let visit = visitors[15];
+  visit !== null && visit(node);
 }
 
 function walkTSJSDocUnknownType(node, visitors) {
-  const visit = visitors[16];
-  if (visit !== null) visit(node);
+  let visit = visitors[16];
+  visit !== null && visit(node);
 }
 
 function walkTSNeverKeyword(node, visitors) {
-  const visit = visitors[17];
-  if (visit !== null) visit(node);
+  let visit = visitors[17];
+  visit !== null && visit(node);
 }
 
 function walkTSNullKeyword(node, visitors) {
-  const visit = visitors[18];
-  if (visit !== null) visit(node);
+  let visit = visitors[18];
+  visit !== null && visit(node);
 }
 
 function walkTSNumberKeyword(node, visitors) {
-  const visit = visitors[19];
-  if (visit !== null) visit(node);
+  let visit = visitors[19];
+  visit !== null && visit(node);
 }
 
 function walkTSObjectKeyword(node, visitors) {
-  const visit = visitors[20];
-  if (visit !== null) visit(node);
+  let visit = visitors[20];
+  visit !== null && visit(node);
 }
 
 function walkTSStringKeyword(node, visitors) {
-  const visit = visitors[21];
-  if (visit !== null) visit(node);
+  let visit = visitors[21];
+  visit !== null && visit(node);
 }
 
 function walkTSSymbolKeyword(node, visitors) {
-  const visit = visitors[22];
-  if (visit !== null) visit(node);
+  let visit = visitors[22];
+  visit !== null && visit(node);
 }
 
 function walkTSThisType(node, visitors) {
-  const visit = visitors[23];
-  if (visit !== null) visit(node);
+  let visit = visitors[23];
+  visit !== null && visit(node);
 }
 
 function walkTSUndefinedKeyword(node, visitors) {
-  const visit = visitors[24];
-  if (visit !== null) visit(node);
+  let visit = visitors[24];
+  visit !== null && visit(node);
 }
 
 function walkTSUnknownKeyword(node, visitors) {
-  const visit = visitors[25];
-  if (visit !== null) visit(node);
+  let visit = visitors[25];
+  visit !== null && visit(node);
 }
 
 function walkTSVoidKeyword(node, visitors) {
-  const visit = visitors[26];
-  if (visit !== null) visit(node);
+  let visit = visitors[26];
+  visit !== null && visit(node);
 }
 
 function walkAccessorProperty(node, visitors) {
-  const enterExit = visitors[27];
-  let exit = null;
+  let enterExit = visitors[27], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.key, visitors);
   walkNode(node.typeAnnotation, visitors);
   walkNode(node.value, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkArrayExpression(node, visitors) {
-  const enterExit = visitors[28];
-  let exit = null;
+  let enterExit = visitors[28], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.elements, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkArrayPattern(node, visitors) {
-  const enterExit = visitors[29];
-  let exit = null;
+  let enterExit = visitors[29], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.elements, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkArrowFunctionExpression(node, visitors) {
-  const enterExit = visitors[30];
-  let exit = null;
+  let enterExit = visitors[30], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeParameters, visitors);
   walkNode(node.params, visitors);
   walkNode(node.returnType, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkAssignmentExpression(node, visitors) {
-  const enterExit = visitors[31];
-  let exit = null;
+  let enterExit = visitors[31], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.left, visitors);
   walkNode(node.right, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkAssignmentPattern(node, visitors) {
-  const enterExit = visitors[32];
-  let exit = null;
+  let enterExit = visitors[32], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.left, visitors);
   walkNode(node.right, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkAwaitExpression(node, visitors) {
-  const enterExit = visitors[33];
-  let exit = null;
+  let enterExit = visitors[33], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.argument, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkBinaryExpression(node, visitors) {
-  const enterExit = visitors[34];
-  let exit = null;
+  let enterExit = visitors[34], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.left, visitors);
   walkNode(node.right, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkBlockStatement(node, visitors) {
-  const enterExit = visitors[35];
-  let exit = null;
+  let enterExit = visitors[35], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkBreakStatement(node, visitors) {
-  const enterExit = visitors[36];
-  let exit = null;
+  let enterExit = visitors[36], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.label, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkCallExpression(node, visitors) {
-  const enterExit = visitors[37];
-  let exit = null;
+  let enterExit = visitors[37], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.callee, visitors);
   walkNode(node.typeArguments, visitors);
   walkNode(node.arguments, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkCatchClause(node, visitors) {
-  const enterExit = visitors[38];
-  let exit = null;
+  let enterExit = visitors[38], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.param, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkChainExpression(node, visitors) {
-  const enterExit = visitors[39];
-  let exit = null;
+  let enterExit = visitors[39], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkClassBody(node, visitors) {
-  const enterExit = visitors[40];
-  let exit = null;
+  let enterExit = visitors[40], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkClassDeclaration(node, visitors) {
-  const enterExit = visitors[41];
-  let exit = null;
+  let enterExit = visitors[41], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.id, visitors);
@@ -847,16 +827,15 @@ function walkClassDeclaration(node, visitors) {
   walkNode(node.superTypeArguments, visitors);
   walkNode(node.implements, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkClassExpression(node, visitors) {
-  const enterExit = visitors[42];
-  let exit = null;
+  let enterExit = visitors[42], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.id, visitors);
@@ -865,1596 +844,1474 @@ function walkClassExpression(node, visitors) {
   walkNode(node.superTypeArguments, visitors);
   walkNode(node.implements, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkConditionalExpression(node, visitors) {
-  const enterExit = visitors[43];
-  let exit = null;
+  let enterExit = visitors[43], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.test, visitors);
   walkNode(node.consequent, visitors);
   walkNode(node.alternate, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkContinueStatement(node, visitors) {
-  const enterExit = visitors[44];
-  let exit = null;
+  let enterExit = visitors[44], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.label, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkDecorator(node, visitors) {
-  const enterExit = visitors[45];
-  let exit = null;
+  let enterExit = visitors[45], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkDoWhileStatement(node, visitors) {
-  const enterExit = visitors[46];
-  let exit = null;
+  let enterExit = visitors[46], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.body, visitors);
   walkNode(node.test, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkExportAllDeclaration(node, visitors) {
-  const enterExit = visitors[47];
-  let exit = null;
+  let enterExit = visitors[47], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.exported, visitors);
   walkNode(node.source, visitors);
   walkNode(node.attributes, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkExportDefaultDeclaration(node, visitors) {
-  const enterExit = visitors[48];
-  let exit = null;
+  let enterExit = visitors[48], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.declaration, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkExportNamedDeclaration(node, visitors) {
-  const enterExit = visitors[49];
-  let exit = null;
+  let enterExit = visitors[49], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.declaration, visitors);
   walkNode(node.specifiers, visitors);
   walkNode(node.source, visitors);
   walkNode(node.attributes, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkExportSpecifier(node, visitors) {
-  const enterExit = visitors[50];
-  let exit = null;
+  let enterExit = visitors[50], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.local, visitors);
   walkNode(node.exported, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkExpressionStatement(node, visitors) {
-  const enterExit = visitors[51];
-  let exit = null;
+  let enterExit = visitors[51], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkForInStatement(node, visitors) {
-  const enterExit = visitors[52];
-  let exit = null;
+  let enterExit = visitors[52], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.left, visitors);
   walkNode(node.right, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkForOfStatement(node, visitors) {
-  const enterExit = visitors[53];
-  let exit = null;
+  let enterExit = visitors[53], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.left, visitors);
   walkNode(node.right, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkForStatement(node, visitors) {
-  const enterExit = visitors[54];
-  let exit = null;
+  let enterExit = visitors[54], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.init, visitors);
   walkNode(node.test, visitors);
   walkNode(node.update, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkFunctionDeclaration(node, visitors) {
-  const enterExit = visitors[55];
-  let exit = null;
+  let enterExit = visitors[55], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.id, visitors);
   walkNode(node.typeParameters, visitors);
   walkNode(node.params, visitors);
   walkNode(node.returnType, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkFunctionExpression(node, visitors) {
-  const enterExit = visitors[56];
-  let exit = null;
+  let enterExit = visitors[56], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.id, visitors);
   walkNode(node.typeParameters, visitors);
   walkNode(node.params, visitors);
   walkNode(node.returnType, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkIdentifier(node, visitors) {
-  const enterExit = visitors[57];
-  let exit = null;
+  let enterExit = visitors[57], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkIfStatement(node, visitors) {
-  const enterExit = visitors[58];
-  let exit = null;
+  let enterExit = visitors[58], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.test, visitors);
   walkNode(node.consequent, visitors);
   walkNode(node.alternate, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkImportAttribute(node, visitors) {
-  const enterExit = visitors[59];
-  let exit = null;
+  let enterExit = visitors[59], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.key, visitors);
   walkNode(node.value, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkImportDeclaration(node, visitors) {
-  const enterExit = visitors[60];
-  let exit = null;
+  let enterExit = visitors[60], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.specifiers, visitors);
   walkNode(node.source, visitors);
   walkNode(node.attributes, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkImportDefaultSpecifier(node, visitors) {
-  const enterExit = visitors[61];
-  let exit = null;
+  let enterExit = visitors[61], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.local, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkImportExpression(node, visitors) {
-  const enterExit = visitors[62];
-  let exit = null;
+  let enterExit = visitors[62], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.source, visitors);
   walkNode(node.options, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkImportNamespaceSpecifier(node, visitors) {
-  const enterExit = visitors[63];
-  let exit = null;
+  let enterExit = visitors[63], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.local, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkImportSpecifier(node, visitors) {
-  const enterExit = visitors[64];
-  let exit = null;
+  let enterExit = visitors[64], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.imported, visitors);
   walkNode(node.local, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkLabeledStatement(node, visitors) {
-  const enterExit = visitors[65];
-  let exit = null;
+  let enterExit = visitors[65], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.label, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkLogicalExpression(node, visitors) {
-  const enterExit = visitors[66];
-  let exit = null;
+  let enterExit = visitors[66], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.left, visitors);
   walkNode(node.right, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkMemberExpression(node, visitors) {
-  const enterExit = visitors[67];
-  let exit = null;
+  let enterExit = visitors[67], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.object, visitors);
   walkNode(node.property, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkMetaProperty(node, visitors) {
-  const enterExit = visitors[68];
-  let exit = null;
+  let enterExit = visitors[68], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.meta, visitors);
   walkNode(node.property, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkMethodDefinition(node, visitors) {
-  const enterExit = visitors[69];
-  let exit = null;
+  let enterExit = visitors[69], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.key, visitors);
   walkNode(node.value, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkNewExpression(node, visitors) {
-  const enterExit = visitors[70];
-  let exit = null;
+  let enterExit = visitors[70], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.callee, visitors);
   walkNode(node.typeArguments, visitors);
   walkNode(node.arguments, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkObjectExpression(node, visitors) {
-  const enterExit = visitors[71];
-  let exit = null;
+  let enterExit = visitors[71], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.properties, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkObjectPattern(node, visitors) {
-  const enterExit = visitors[72];
-  let exit = null;
+  let enterExit = visitors[72], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.properties, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkParenthesizedExpression(node, visitors) {
-  const enterExit = visitors[73];
-  let exit = null;
+  let enterExit = visitors[73], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkProgram(node, visitors) {
-  const enterExit = visitors[74];
-  let exit = null;
+  let enterExit = visitors[74], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkProperty(node, visitors) {
-  const enterExit = visitors[75];
-  let exit = null;
+  let enterExit = visitors[75], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.key, visitors);
   walkNode(node.value, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkPropertyDefinition(node, visitors) {
-  const enterExit = visitors[76];
-  let exit = null;
+  let enterExit = visitors[76], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.key, visitors);
   walkNode(node.typeAnnotation, visitors);
   walkNode(node.value, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkRestElement(node, visitors) {
-  const enterExit = visitors[77];
-  let exit = null;
+  let enterExit = visitors[77], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.argument, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkReturnStatement(node, visitors) {
-  const enterExit = visitors[78];
-  let exit = null;
+  let enterExit = visitors[78], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.argument, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkSequenceExpression(node, visitors) {
-  const enterExit = visitors[79];
-  let exit = null;
+  let enterExit = visitors[79], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expressions, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkSpreadElement(node, visitors) {
-  const enterExit = visitors[80];
-  let exit = null;
+  let enterExit = visitors[80], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.argument, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkStaticBlock(node, visitors) {
-  const enterExit = visitors[81];
-  let exit = null;
+  let enterExit = visitors[81], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkSwitchCase(node, visitors) {
-  const enterExit = visitors[82];
-  let exit = null;
+  let enterExit = visitors[82], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.test, visitors);
   walkNode(node.consequent, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkSwitchStatement(node, visitors) {
-  const enterExit = visitors[83];
-  let exit = null;
+  let enterExit = visitors[83], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.discriminant, visitors);
   walkNode(node.cases, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTaggedTemplateExpression(node, visitors) {
-  const enterExit = visitors[84];
-  let exit = null;
+  let enterExit = visitors[84], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.tag, visitors);
   walkNode(node.typeArguments, visitors);
   walkNode(node.quasi, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTemplateLiteral(node, visitors) {
-  const enterExit = visitors[85];
-  let exit = null;
+  let enterExit = visitors[85], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.quasis, visitors);
   walkNode(node.expressions, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkThrowStatement(node, visitors) {
-  const enterExit = visitors[86];
-  let exit = null;
+  let enterExit = visitors[86], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.argument, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTryStatement(node, visitors) {
-  const enterExit = visitors[87];
-  let exit = null;
+  let enterExit = visitors[87], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.block, visitors);
   walkNode(node.handler, visitors);
   walkNode(node.finalizer, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkUnaryExpression(node, visitors) {
-  const enterExit = visitors[88];
-  let exit = null;
+  let enterExit = visitors[88], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.argument, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkUpdateExpression(node, visitors) {
-  const enterExit = visitors[89];
-  let exit = null;
+  let enterExit = visitors[89], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.argument, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkV8IntrinsicExpression(node, visitors) {
-  const enterExit = visitors[90];
-  let exit = null;
+  let enterExit = visitors[90], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.name, visitors);
   walkNode(node.arguments, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkVariableDeclaration(node, visitors) {
-  const enterExit = visitors[91];
-  let exit = null;
+  let enterExit = visitors[91], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.declarations, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkVariableDeclarator(node, visitors) {
-  const enterExit = visitors[92];
-  let exit = null;
+  let enterExit = visitors[92], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.id, visitors);
   walkNode(node.init, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkWhileStatement(node, visitors) {
-  const enterExit = visitors[93];
-  let exit = null;
+  let enterExit = visitors[93], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.test, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkWithStatement(node, visitors) {
-  const enterExit = visitors[94];
-  let exit = null;
+  let enterExit = visitors[94], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.object, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkYieldExpression(node, visitors) {
-  const enterExit = visitors[95];
-  let exit = null;
+  let enterExit = visitors[95], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.argument, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkJSXAttribute(node, visitors) {
-  const enterExit = visitors[96];
-  let exit = null;
+  let enterExit = visitors[96], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.name, visitors);
   walkNode(node.value, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkJSXClosingElement(node, visitors) {
-  const enterExit = visitors[97];
-  let exit = null;
+  let enterExit = visitors[97], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.name, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkJSXElement(node, visitors) {
-  const enterExit = visitors[98];
-  let exit = null;
+  let enterExit = visitors[98], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.openingElement, visitors);
   walkNode(node.children, visitors);
   walkNode(node.closingElement, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkJSXExpressionContainer(node, visitors) {
-  const enterExit = visitors[99];
-  let exit = null;
+  let enterExit = visitors[99], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkJSXFragment(node, visitors) {
-  const enterExit = visitors[100];
-  let exit = null;
+  let enterExit = visitors[100], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.openingFragment, visitors);
   walkNode(node.children, visitors);
   walkNode(node.closingFragment, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkJSXMemberExpression(node, visitors) {
-  const enterExit = visitors[101];
-  let exit = null;
+  let enterExit = visitors[101], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.object, visitors);
   walkNode(node.property, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkJSXNamespacedName(node, visitors) {
-  const enterExit = visitors[102];
-  let exit = null;
+  let enterExit = visitors[102], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.namespace, visitors);
   walkNode(node.name, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkJSXOpeningElement(node, visitors) {
-  const enterExit = visitors[103];
-  let exit = null;
+  let enterExit = visitors[103], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.name, visitors);
   walkNode(node.typeArguments, visitors);
   walkNode(node.attributes, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkJSXSpreadAttribute(node, visitors) {
-  const enterExit = visitors[104];
-  let exit = null;
+  let enterExit = visitors[104], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.argument, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkJSXSpreadChild(node, visitors) {
-  const enterExit = visitors[105];
-  let exit = null;
+  let enterExit = visitors[105], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSAbstractAccessorProperty(node, visitors) {
-  const enterExit = visitors[106];
-  let exit = null;
+  let enterExit = visitors[106], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.key, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSAbstractMethodDefinition(node, visitors) {
-  const enterExit = visitors[107];
-  let exit = null;
+  let enterExit = visitors[107], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.key, visitors);
   walkNode(node.value, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSAbstractPropertyDefinition(node, visitors) {
-  const enterExit = visitors[108];
-  let exit = null;
+  let enterExit = visitors[108], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.key, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSArrayType(node, visitors) {
-  const enterExit = visitors[109];
-  let exit = null;
+  let enterExit = visitors[109], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.elementType, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSAsExpression(node, visitors) {
-  const enterExit = visitors[110];
-  let exit = null;
+  let enterExit = visitors[110], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSCallSignatureDeclaration(node, visitors) {
-  const enterExit = visitors[111];
-  let exit = null;
+  let enterExit = visitors[111], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeParameters, visitors);
   walkNode(node.params, visitors);
   walkNode(node.returnType, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSClassImplements(node, visitors) {
-  const enterExit = visitors[112];
-  let exit = null;
+  let enterExit = visitors[112], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
   walkNode(node.typeArguments, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSConditionalType(node, visitors) {
-  const enterExit = visitors[113];
-  let exit = null;
+  let enterExit = visitors[113], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.checkType, visitors);
   walkNode(node.extendsType, visitors);
   walkNode(node.trueType, visitors);
   walkNode(node.falseType, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSConstructSignatureDeclaration(node, visitors) {
-  const enterExit = visitors[114];
-  let exit = null;
+  let enterExit = visitors[114], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeParameters, visitors);
   walkNode(node.params, visitors);
   walkNode(node.returnType, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSConstructorType(node, visitors) {
-  const enterExit = visitors[115];
-  let exit = null;
+  let enterExit = visitors[115], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeParameters, visitors);
   walkNode(node.params, visitors);
   walkNode(node.returnType, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSDeclareFunction(node, visitors) {
-  const enterExit = visitors[116];
-  let exit = null;
+  let enterExit = visitors[116], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.id, visitors);
   walkNode(node.typeParameters, visitors);
   walkNode(node.params, visitors);
   walkNode(node.returnType, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSEmptyBodyFunctionExpression(node, visitors) {
-  const enterExit = visitors[117];
-  let exit = null;
+  let enterExit = visitors[117], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.id, visitors);
   walkNode(node.typeParameters, visitors);
   walkNode(node.params, visitors);
   walkNode(node.returnType, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSEnumBody(node, visitors) {
-  const enterExit = visitors[118];
-  let exit = null;
+  let enterExit = visitors[118], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.members, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSEnumDeclaration(node, visitors) {
-  const enterExit = visitors[119];
-  let exit = null;
+  let enterExit = visitors[119], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.id, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSEnumMember(node, visitors) {
-  const enterExit = visitors[120];
-  let exit = null;
+  let enterExit = visitors[120], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.id, visitors);
   walkNode(node.initializer, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSExportAssignment(node, visitors) {
-  const enterExit = visitors[121];
-  let exit = null;
+  let enterExit = visitors[121], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSExternalModuleReference(node, visitors) {
-  const enterExit = visitors[122];
-  let exit = null;
+  let enterExit = visitors[122], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSFunctionType(node, visitors) {
-  const enterExit = visitors[123];
-  let exit = null;
+  let enterExit = visitors[123], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeParameters, visitors);
   walkNode(node.params, visitors);
   walkNode(node.returnType, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSImportEqualsDeclaration(node, visitors) {
-  const enterExit = visitors[124];
-  let exit = null;
+  let enterExit = visitors[124], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.id, visitors);
   walkNode(node.moduleReference, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSImportType(node, visitors) {
-  const enterExit = visitors[125];
-  let exit = null;
+  let enterExit = visitors[125], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.argument, visitors);
   walkNode(node.options, visitors);
   walkNode(node.qualifier, visitors);
   walkNode(node.typeArguments, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSIndexSignature(node, visitors) {
-  const enterExit = visitors[126];
-  let exit = null;
+  let enterExit = visitors[126], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.parameters, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSIndexedAccessType(node, visitors) {
-  const enterExit = visitors[127];
-  let exit = null;
+  let enterExit = visitors[127], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.objectType, visitors);
   walkNode(node.indexType, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSInferType(node, visitors) {
-  const enterExit = visitors[128];
-  let exit = null;
+  let enterExit = visitors[128], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeParameter, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSInstantiationExpression(node, visitors) {
-  const enterExit = visitors[129];
-  let exit = null;
+  let enterExit = visitors[129], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
   walkNode(node.typeArguments, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSInterfaceBody(node, visitors) {
-  const enterExit = visitors[130];
-  let exit = null;
+  let enterExit = visitors[130], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSInterfaceDeclaration(node, visitors) {
-  const enterExit = visitors[131];
-  let exit = null;
+  let enterExit = visitors[131], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.id, visitors);
   walkNode(node.typeParameters, visitors);
   walkNode(node.extends, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSInterfaceHeritage(node, visitors) {
-  const enterExit = visitors[132];
-  let exit = null;
+  let enterExit = visitors[132], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
   walkNode(node.typeArguments, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSIntersectionType(node, visitors) {
-  const enterExit = visitors[133];
-  let exit = null;
+  let enterExit = visitors[133], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.types, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSJSDocNonNullableType(node, visitors) {
-  const enterExit = visitors[134];
-  let exit = null;
+  let enterExit = visitors[134], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSJSDocNullableType(node, visitors) {
-  const enterExit = visitors[135];
-  let exit = null;
+  let enterExit = visitors[135], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSLiteralType(node, visitors) {
-  const enterExit = visitors[136];
-  let exit = null;
+  let enterExit = visitors[136], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.literal, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSMappedType(node, visitors) {
-  const enterExit = visitors[137];
-  let exit = null;
+  let enterExit = visitors[137], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.key, visitors);
   walkNode(node.constraint, visitors);
   walkNode(node.nameType, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSMethodSignature(node, visitors) {
-  const enterExit = visitors[138];
-  let exit = null;
+  let enterExit = visitors[138], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.key, visitors);
   walkNode(node.typeParameters, visitors);
   walkNode(node.params, visitors);
   walkNode(node.returnType, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSModuleBlock(node, visitors) {
-  const enterExit = visitors[139];
-  let exit = null;
+  let enterExit = visitors[139], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSModuleDeclaration(node, visitors) {
-  const enterExit = visitors[140];
-  let exit = null;
+  let enterExit = visitors[140], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.id, visitors);
   walkNode(node.body, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSNamedTupleMember(node, visitors) {
-  const enterExit = visitors[141];
-  let exit = null;
+  let enterExit = visitors[141], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.label, visitors);
   walkNode(node.elementType, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSNamespaceExportDeclaration(node, visitors) {
-  const enterExit = visitors[142];
-  let exit = null;
+  let enterExit = visitors[142], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.id, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSNonNullExpression(node, visitors) {
-  const enterExit = visitors[143];
-  let exit = null;
+  let enterExit = visitors[143], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSOptionalType(node, visitors) {
-  const enterExit = visitors[144];
-  let exit = null;
+  let enterExit = visitors[144], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSParameterProperty(node, visitors) {
-  const enterExit = visitors[145];
-  let exit = null;
+  let enterExit = visitors[145], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.decorators, visitors);
   walkNode(node.parameter, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSParenthesizedType(node, visitors) {
-  const enterExit = visitors[146];
-  let exit = null;
+  let enterExit = visitors[146], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSPropertySignature(node, visitors) {
-  const enterExit = visitors[147];
-  let exit = null;
+  let enterExit = visitors[147], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.key, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSQualifiedName(node, visitors) {
-  const enterExit = visitors[148];
-  let exit = null;
+  let enterExit = visitors[148], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.left, visitors);
   walkNode(node.right, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSRestType(node, visitors) {
-  const enterExit = visitors[149];
-  let exit = null;
+  let enterExit = visitors[149], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSSatisfiesExpression(node, visitors) {
-  const enterExit = visitors[150];
-  let exit = null;
+  let enterExit = visitors[150], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.expression, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTemplateLiteralType(node, visitors) {
-  const enterExit = visitors[151];
-  let exit = null;
+  let enterExit = visitors[151], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.quasis, visitors);
   walkNode(node.types, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTupleType(node, visitors) {
-  const enterExit = visitors[152];
-  let exit = null;
+  let enterExit = visitors[152], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.elementTypes, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTypeAliasDeclaration(node, visitors) {
-  const enterExit = visitors[153];
-  let exit = null;
+  let enterExit = visitors[153], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.id, visitors);
   walkNode(node.typeParameters, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTypeAnnotation(node, visitors) {
-  const enterExit = visitors[154];
-  let exit = null;
+  let enterExit = visitors[154], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTypeAssertion(node, visitors) {
-  const enterExit = visitors[155];
-  let exit = null;
+  let enterExit = visitors[155], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeAnnotation, visitors);
   walkNode(node.expression, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTypeLiteral(node, visitors) {
-  const enterExit = visitors[156];
-  let exit = null;
+  let enterExit = visitors[156], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.members, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTypeOperator(node, visitors) {
-  const enterExit = visitors[157];
-  let exit = null;
+  let enterExit = visitors[157], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTypeParameter(node, visitors) {
-  const enterExit = visitors[158];
-  let exit = null;
+  let enterExit = visitors[158], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.name, visitors);
   walkNode(node.constraint, visitors);
   walkNode(node.default, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTypeParameterDeclaration(node, visitors) {
-  const enterExit = visitors[159];
-  let exit = null;
+  let enterExit = visitors[159], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.params, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTypeParameterInstantiation(node, visitors) {
-  const enterExit = visitors[160];
-  let exit = null;
+  let enterExit = visitors[160], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.params, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTypePredicate(node, visitors) {
-  const enterExit = visitors[161];
-  let exit = null;
+  let enterExit = visitors[161], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.parameterName, visitors);
   walkNode(node.typeAnnotation, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTypeQuery(node, visitors) {
-  const enterExit = visitors[162];
-  let exit = null;
+  let enterExit = visitors[162], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.exprName, visitors);
   walkNode(node.typeArguments, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSTypeReference(node, visitors) {
-  const enterExit = visitors[163];
-  let exit = null;
+  let enterExit = visitors[163], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.typeName, visitors);
   walkNode(node.typeArguments, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }
 
 function walkTSUnionType(node, visitors) {
-  const enterExit = visitors[164];
-  let exit = null;
+  let enterExit = visitors[164], exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
-    if (enter !== null) enter(node);
+    enter !== null && enter(node);
   }
   walkNode(node.types, visitors);
-  if (exit !== null) exit(node);
+  exit !== null && exit(node);
 }

--- a/tasks/ast_tools/src/generators/estree_visit.rs
+++ b/tasks/ast_tools/src/generators/estree_visit.rs
@@ -9,11 +9,15 @@ use std::{
 
 use serde::Deserialize;
 
+use oxc_allocator::Allocator;
 use oxc_index::{IndexVec, define_index_type};
 
 use crate::{
     Codegen, Generator, NAPI_PARSER_PACKAGE_PATH, OXLINT_APP_PATH,
-    output::Output,
+    output::{
+        Output,
+        javascript::{parse_js, print_minified},
+    },
     schema::Schema,
     utils::{string, write_it},
 };
@@ -319,6 +323,11 @@ fn generate(codegen: &Codegen) -> Codes {
 
         {walk_fns}
     ");
+
+    // Minify walker code
+    let allocator = Allocator::new();
+    let mut program = parse_js(&walk, &allocator);
+    let walk = print_minified(&mut program, &allocator);
 
     visitor_keys.push_str("});");
 


### PR DESCRIPTION
Run minifier on generated AST walker code. Mainly the purpose is to prepare the way for generating a different variant of the walker for linter which tracks ancestors while walking (pre-requisite for supporting selectors DSL).