### PR TITLE
release(crates): v0.94.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1655,22 +1655,22 @@ checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
 name = "oxc"
-version = "0.93.0"
+version = "0.94.0"
 dependencies = [
- "oxc_allocator 0.93.0",
- "oxc_ast 0.93.0",
- "oxc_ast_visit 0.93.0",
+ "oxc_allocator 0.94.0",
+ "oxc_ast 0.94.0",
+ "oxc_ast_visit 0.94.0",
  "oxc_cfg",
- "oxc_codegen 0.93.0",
- "oxc_diagnostics 0.93.0",
+ "oxc_codegen 0.94.0",
+ "oxc_diagnostics 0.94.0",
  "oxc_isolated_declarations",
- "oxc_mangler 0.93.0",
- "oxc_minifier 0.93.0",
- "oxc_parser 0.93.0",
- "oxc_regular_expression 0.93.0",
- "oxc_semantic 0.93.0",
- "oxc_span 0.93.0",
- "oxc_syntax 0.93.0",
+ "oxc_mangler 0.94.0",
+ "oxc_minifier 0.94.0",
+ "oxc_parser 0.94.0",
+ "oxc_regular_expression 0.94.0",
+ "oxc_semantic 0.94.0",
+ "oxc_span 0.94.0",
+ "oxc_syntax 0.94.0",
  "oxc_transformer",
  "oxc_transformer_plugins",
 ]
@@ -1733,34 +1733,36 @@ dependencies = [
 [[package]]
 name = "oxc_allocator"
 version = "0.93.0"
-dependencies = [
- "allocator-api2",
- "bumpalo",
- "hashbrown 0.16.0",
- "oxc_ast_macros 0.93.0",
- "oxc_data_structures 0.93.0",
- "oxc_estree 0.93.0",
- "rustc-hash",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "oxc_allocator"
-version = "0.93.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "014a6bc98da00c997b35db73a7aced63d9e148ddcfe1a6bd759e87b903d95757"
 dependencies = [
  "allocator-api2",
  "bumpalo",
  "hashbrown 0.16.0",
- "oxc_data_structures 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_data_structures 0.93.0",
  "rustc-hash",
+]
+
+[[package]]
+name = "oxc_allocator"
+version = "0.94.0"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.16.0",
+ "oxc_ast_macros 0.94.0",
+ "oxc_data_structures 0.94.0",
+ "oxc_estree 0.94.0",
+ "rustc-hash",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "oxc_ast"
 version = "0.93.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f88ca3bb0ed59cebad6883e7a09e16e19fd1dbec7fcd7659c5e696456f3ea37"
 dependencies = [
  "bitflags 2.9.4",
  "oxc_allocator 0.93.0",
@@ -1775,24 +1777,24 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.93.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f88ca3bb0ed59cebad6883e7a09e16e19fd1dbec7fcd7659c5e696456f3ea37"
+version = "0.94.0"
 dependencies = [
  "bitflags 2.9.4",
- "oxc_allocator 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast_macros 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_diagnostics 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_estree 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_regular_expression 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.94.0",
+ "oxc_ast_macros 0.94.0",
+ "oxc_data_structures 0.94.0",
+ "oxc_diagnostics 0.94.0",
+ "oxc_estree 0.94.0",
+ "oxc_regular_expression 0.94.0",
+ "oxc_span 0.94.0",
+ "oxc_syntax 0.94.0",
 ]
 
 [[package]]
 name = "oxc_ast_macros"
 version = "0.93.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf7bc9985027ebc3b8daaa4bcdeeafe8d027fb6f3ffed3dfc496a851d7b3ffe"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1802,9 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.93.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf7bc9985027ebc3b8daaa4bcdeeafe8d027fb6f3ffed3dfc496a851d7b3ffe"
+version = "0.94.0"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1823,16 +1823,16 @@ dependencies = [
  "indexmap",
  "itertools",
  "lazy-regex",
- "oxc_allocator 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast_visit 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_codegen 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.93.0",
+ "oxc_allocator 0.93.0",
+ "oxc_ast 0.93.0",
+ "oxc_ast_visit 0.93.0",
+ "oxc_codegen 0.93.0",
+ "oxc_data_structures 0.94.0",
  "oxc_index 4.1.0",
- "oxc_minifier 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_parser 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_minifier 0.93.0",
+ "oxc_parser 0.93.0",
+ "oxc_span 0.93.0",
+ "oxc_syntax 0.93.0",
  "phf",
  "phf_codegen",
  "prettyplease",
@@ -1848,6 +1848,8 @@ dependencies = [
 [[package]]
 name = "oxc_ast_visit"
 version = "0.93.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2750ee1156a0700d483c2b148dac6d45fbbdbbc44dfae973ab36fc8d92811259"
 dependencies = [
  "oxc_allocator 0.93.0",
  "oxc_ast 0.93.0",
@@ -1857,14 +1859,12 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.93.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2750ee1156a0700d483c2b148dac6d45fbbdbbc44dfae973ab36fc8d92811259"
+version = "0.94.0"
 dependencies = [
- "oxc_allocator 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.94.0",
+ "oxc_ast 0.94.0",
+ "oxc_span 0.94.0",
+ "oxc_syntax 0.94.0",
 ]
 
 [[package]]
@@ -1872,18 +1872,18 @@ name = "oxc_benchmark"
 version = "0.0.0"
 dependencies = [
  "criterion2",
- "oxc_allocator 0.93.0",
- "oxc_ast 0.93.0",
- "oxc_ast_visit 0.93.0",
- "oxc_codegen 0.93.0",
+ "oxc_allocator 0.94.0",
+ "oxc_ast 0.94.0",
+ "oxc_ast_visit 0.94.0",
+ "oxc_codegen 0.94.0",
  "oxc_formatter",
  "oxc_isolated_declarations",
  "oxc_linter",
- "oxc_mangler 0.93.0",
- "oxc_minifier 0.93.0",
- "oxc_parser 0.93.0",
- "oxc_semantic 0.93.0",
- "oxc_span 0.93.0",
+ "oxc_mangler 0.94.0",
+ "oxc_minifier 0.94.0",
+ "oxc_parser 0.94.0",
+ "oxc_semantic 0.94.0",
+ "oxc_span 0.94.0",
  "oxc_tasks_common",
  "oxc_transformer",
  "rustc-hash",
@@ -1893,35 +1893,13 @@ dependencies = [
 
 [[package]]
 name = "oxc_cfg"
-version = "0.93.0"
+version = "0.94.0"
 dependencies = [
  "bitflags 2.9.4",
  "itertools",
  "oxc_index 4.1.0",
- "oxc_syntax 0.93.0",
+ "oxc_syntax 0.94.0",
  "petgraph",
- "rustc-hash",
-]
-
-[[package]]
-name = "oxc_codegen"
-version = "0.93.0"
-dependencies = [
- "bitflags 2.9.4",
- "cow-utils",
- "dragonbox_ecma",
- "insta",
- "itoa",
- "oxc_allocator 0.93.0",
- "oxc_ast 0.93.0",
- "oxc_data_structures 0.93.0",
- "oxc_index 4.1.0",
- "oxc_parser 0.93.0",
- "oxc_semantic 0.93.0",
- "oxc_sourcemap",
- "oxc_span 0.93.0",
- "oxc_syntax 0.93.0",
- "pico-args",
  "rustc-hash",
 ]
 
@@ -1936,26 +1914,37 @@ dependencies = [
  "dragonbox_ecma",
  "itoa",
  "nonmax",
- "oxc_allocator 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.93.0",
+ "oxc_ast 0.93.0",
+ "oxc_data_structures 0.93.0",
  "oxc_index 3.1.0",
- "oxc_semantic 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_semantic 0.93.0",
  "oxc_sourcemap",
- "oxc_span 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_span 0.93.0",
+ "oxc_syntax 0.93.0",
  "rustc-hash",
 ]
 
 [[package]]
-name = "oxc_compat"
-version = "0.93.0"
+name = "oxc_codegen"
+version = "0.94.0"
 dependencies = [
+ "bitflags 2.9.4",
  "cow-utils",
- "oxc-browserslist",
- "oxc_syntax 0.93.0",
+ "dragonbox_ecma",
+ "insta",
+ "itoa",
+ "oxc_allocator 0.94.0",
+ "oxc_ast 0.94.0",
+ "oxc_data_structures 0.94.0",
+ "oxc_index 4.1.0",
+ "oxc_parser 0.94.0",
+ "oxc_semantic 0.94.0",
+ "oxc_sourcemap",
+ "oxc_span 0.94.0",
+ "oxc_syntax 0.94.0",
+ "pico-args",
  "rustc-hash",
- "serde",
 ]
 
 [[package]]
@@ -1966,7 +1955,18 @@ checksum = "b89f5747d9992cd94d82feb2f2fbac94c60fdcada607904708c7f856b2215270"
 dependencies = [
  "cow-utils",
  "oxc-browserslist",
- "oxc_syntax 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_syntax 0.93.0",
+ "rustc-hash",
+ "serde",
+]
+
+[[package]]
+name = "oxc_compat"
+version = "0.94.0"
+dependencies = [
+ "cow-utils",
+ "oxc-browserslist",
+ "oxc_syntax 0.94.0",
  "rustc-hash",
  "serde",
 ]
@@ -2015,23 +2015,14 @@ dependencies = [
 [[package]]
 name = "oxc_data_structures"
 version = "0.93.0"
-dependencies = [
- "ropey",
-]
-
-[[package]]
-name = "oxc_data_structures"
-version = "0.93.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45904e6b2cf3e05e586a526f4668dac3ab3cb1a88f8ef065503d1336e85e64d2"
 
 [[package]]
-name = "oxc_diagnostics"
-version = "0.93.0"
+name = "oxc_data_structures"
+version = "0.94.0"
 dependencies = [
- "cow-utils",
- "oxc-miette",
- "percent-encoding",
+ "ropey",
 ]
 
 [[package]]
@@ -2046,16 +2037,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "oxc_ecmascript"
-version = "0.93.0"
+name = "oxc_diagnostics"
+version = "0.94.0"
 dependencies = [
  "cow-utils",
- "num-bigint",
- "num-traits",
- "oxc_allocator 0.93.0",
- "oxc_ast 0.93.0",
- "oxc_span 0.93.0",
- "oxc_syntax 0.93.0",
+ "oxc-miette",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -2067,19 +2054,23 @@ dependencies = [
  "cow-utils",
  "num-bigint",
  "num-traits",
- "oxc_allocator 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.93.0",
+ "oxc_ast 0.93.0",
+ "oxc_span 0.93.0",
+ "oxc_syntax 0.93.0",
 ]
 
 [[package]]
-name = "oxc_estree"
-version = "0.93.0"
+name = "oxc_ecmascript"
+version = "0.94.0"
 dependencies = [
- "dragonbox_ecma",
- "itoa",
- "oxc_data_structures 0.93.0",
+ "cow-utils",
+ "num-bigint",
+ "num-traits",
+ "oxc_allocator 0.94.0",
+ "oxc_ast 0.94.0",
+ "oxc_span 0.94.0",
+ "oxc_syntax 0.94.0",
 ]
 
 [[package]]
@@ -2090,7 +2081,16 @@ checksum = "a8f909b432bafad7fe98609e2fd00b6b046c143fda4246a4e7bb7e41b47cf65e"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
- "oxc_data_structures 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_data_structures 0.93.0",
+]
+
+[[package]]
+name = "oxc_estree"
+version = "0.94.0"
+dependencies = [
+ "dragonbox_ecma",
+ "itoa",
+ "oxc_data_structures 0.94.0",
 ]
 
 [[package]]
@@ -2098,12 +2098,12 @@ name = "oxc_formatter"
 version = "0.3.0"
 dependencies = [
  "cow-utils",
- "oxc_allocator 0.93.0",
- "oxc_ast 0.93.0",
- "oxc_data_structures 0.93.0",
- "oxc_parser 0.93.0",
- "oxc_span 0.93.0",
- "oxc_syntax 0.93.0",
+ "oxc_allocator 0.94.0",
+ "oxc_ast 0.94.0",
+ "oxc_data_structures 0.94.0",
+ "oxc_parser 0.94.0",
+ "oxc_span 0.94.0",
+ "oxc_syntax 0.94.0",
  "pico-args",
  "rustc-hash",
  "unicode-width",
@@ -2130,19 +2130,19 @@ dependencies = [
 
 [[package]]
 name = "oxc_isolated_declarations"
-version = "0.93.0"
+version = "0.94.0"
 dependencies = [
  "bitflags 2.9.4",
  "insta",
- "oxc_allocator 0.93.0",
- "oxc_ast 0.93.0",
- "oxc_ast_visit 0.93.0",
- "oxc_codegen 0.93.0",
- "oxc_diagnostics 0.93.0",
- "oxc_ecmascript 0.93.0",
- "oxc_parser 0.93.0",
- "oxc_span 0.93.0",
- "oxc_syntax 0.93.0",
+ "oxc_allocator 0.94.0",
+ "oxc_ast 0.94.0",
+ "oxc_ast_visit 0.94.0",
+ "oxc_codegen 0.94.0",
+ "oxc_diagnostics 0.94.0",
+ "oxc_ecmascript 0.94.0",
+ "oxc_parser 0.94.0",
+ "oxc_span 0.94.0",
+ "oxc_syntax 0.94.0",
  "rustc-hash",
 ]
 
@@ -2155,12 +2155,12 @@ dependencies = [
  "ignore",
  "insta",
  "log",
- "oxc_allocator 0.93.0",
- "oxc_data_structures 0.93.0",
- "oxc_diagnostics 0.93.0",
+ "oxc_allocator 0.94.0",
+ "oxc_data_structures 0.94.0",
+ "oxc_diagnostics 0.94.0",
  "oxc_formatter",
  "oxc_linter",
- "oxc_parser 0.93.0",
+ "oxc_parser 0.94.0",
  "papaya",
  "rustc-hash",
  "serde",
@@ -2190,23 +2190,23 @@ dependencies = [
  "markdown",
  "memchr",
  "oxc-schemars",
- "oxc_allocator 0.93.0",
- "oxc_ast 0.93.0",
- "oxc_ast_macros 0.93.0",
- "oxc_ast_visit 0.93.0",
+ "oxc_allocator 0.94.0",
+ "oxc_ast 0.94.0",
+ "oxc_ast_macros 0.94.0",
+ "oxc_ast_visit 0.94.0",
  "oxc_cfg",
- "oxc_codegen 0.93.0",
- "oxc_data_structures 0.93.0",
- "oxc_diagnostics 0.93.0",
- "oxc_ecmascript 0.93.0",
+ "oxc_codegen 0.94.0",
+ "oxc_data_structures 0.94.0",
+ "oxc_diagnostics 0.94.0",
+ "oxc_ecmascript 0.94.0",
  "oxc_index 4.1.0",
  "oxc_macros",
- "oxc_parser 0.93.0",
- "oxc_regular_expression 0.93.0",
+ "oxc_parser 0.94.0",
+ "oxc_regular_expression 0.94.0",
  "oxc_resolver",
- "oxc_semantic 0.93.0",
- "oxc_span 0.93.0",
- "oxc_syntax 0.93.0",
+ "oxc_semantic 0.94.0",
+ "oxc_span 0.94.0",
+ "oxc_syntax 0.94.0",
  "papaya",
  "phf",
  "project-root",
@@ -2244,42 +2244,42 @@ dependencies = [
 [[package]]
 name = "oxc_mangler"
 version = "0.93.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0adb9be10b606c70ea6adbe634b5f02f8126929c07638c37c000e2e0ecdad73f"
 dependencies = [
  "itertools",
  "oxc_allocator 0.93.0",
  "oxc_ast 0.93.0",
  "oxc_data_structures 0.93.0",
- "oxc_index 4.1.0",
- "oxc_parser 0.93.0",
+ "oxc_index 3.1.0",
  "oxc_semantic 0.93.0",
  "oxc_span 0.93.0",
- "oxc_syntax 0.93.0",
  "rustc-hash",
 ]
 
 [[package]]
 name = "oxc_mangler"
-version = "0.93.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0adb9be10b606c70ea6adbe634b5f02f8126929c07638c37c000e2e0ecdad73f"
+version = "0.94.0"
 dependencies = [
  "itertools",
- "oxc_allocator 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_index 3.1.0",
- "oxc_semantic 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.94.0",
+ "oxc_ast 0.94.0",
+ "oxc_data_structures 0.94.0",
+ "oxc_index 4.1.0",
+ "oxc_parser 0.94.0",
+ "oxc_semantic 0.94.0",
+ "oxc_span 0.94.0",
+ "oxc_syntax 0.94.0",
  "rustc-hash",
 ]
 
 [[package]]
 name = "oxc_minifier"
 version = "0.93.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30f8c01fdd37594aed27f8fb020c6ef2e2e8eef8bdbfa386b307a900a09b7882"
 dependencies = [
  "cow-utils",
- "insta",
- "javascript-globals",
  "oxc_allocator 0.93.0",
  "oxc_ast 0.93.0",
  "oxc_ast_visit 0.93.0",
@@ -2291,55 +2291,55 @@ dependencies = [
  "oxc_parser 0.93.0",
  "oxc_regular_expression 0.93.0",
  "oxc_semantic 0.93.0",
- "oxc_sourcemap",
  "oxc_span 0.93.0",
  "oxc_syntax 0.93.0",
  "oxc_traverse 0.93.0",
- "pico-args",
  "rustc-hash",
 ]
 
 [[package]]
 name = "oxc_minifier"
-version = "0.93.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30f8c01fdd37594aed27f8fb020c6ef2e2e8eef8bdbfa386b307a900a09b7882"
+version = "0.94.0"
 dependencies = [
  "cow-utils",
- "oxc_allocator 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast_visit 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_codegen 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_compat 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ecmascript 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_mangler 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_parser 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_regular_expression 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_semantic 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_traverse 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "insta",
+ "javascript-globals",
+ "oxc_allocator 0.94.0",
+ "oxc_ast 0.94.0",
+ "oxc_ast_visit 0.94.0",
+ "oxc_codegen 0.94.0",
+ "oxc_compat 0.94.0",
+ "oxc_data_structures 0.94.0",
+ "oxc_ecmascript 0.94.0",
+ "oxc_mangler 0.94.0",
+ "oxc_parser 0.94.0",
+ "oxc_regular_expression 0.94.0",
+ "oxc_semantic 0.94.0",
+ "oxc_sourcemap",
+ "oxc_span 0.94.0",
+ "oxc_syntax 0.94.0",
+ "oxc_traverse 0.94.0",
+ "pico-args",
  "rustc-hash",
 ]
 
 [[package]]
 name = "oxc_minify_napi"
-version = "0.93.0"
+version = "0.94.0"
 dependencies = [
  "mimalloc-safe",
  "napi",
  "napi-build",
  "napi-derive",
- "oxc_allocator 0.93.0",
- "oxc_codegen 0.93.0",
- "oxc_compat 0.93.0",
- "oxc_diagnostics 0.93.0",
- "oxc_minifier 0.93.0",
+ "oxc_allocator 0.94.0",
+ "oxc_codegen 0.94.0",
+ "oxc_compat 0.94.0",
+ "oxc_diagnostics 0.94.0",
+ "oxc_minifier 0.94.0",
  "oxc_napi",
- "oxc_parser 0.93.0",
+ "oxc_parser 0.94.0",
  "oxc_sourcemap",
- "oxc_span 0.93.0",
+ "oxc_span 0.94.0",
 ]
 
 [[package]]
@@ -2349,12 +2349,12 @@ dependencies = [
  "cow-utils",
  "flate2",
  "humansize",
- "oxc_allocator 0.93.0",
- "oxc_codegen 0.93.0",
- "oxc_minifier 0.93.0",
- "oxc_parser 0.93.0",
- "oxc_semantic 0.93.0",
- "oxc_span 0.93.0",
+ "oxc_allocator 0.94.0",
+ "oxc_codegen 0.94.0",
+ "oxc_minifier 0.94.0",
+ "oxc_parser 0.94.0",
+ "oxc_semantic 0.94.0",
+ "oxc_span 0.94.0",
  "oxc_tasks_common",
  "oxc_transformer_plugins",
  "pico-args",
@@ -2364,39 +2364,16 @@ dependencies = [
 
 [[package]]
 name = "oxc_napi"
-version = "0.93.0"
+version = "0.94.0"
 dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
- "oxc_ast 0.93.0",
- "oxc_ast_visit 0.93.0",
- "oxc_diagnostics 0.93.0",
- "oxc_span 0.93.0",
- "oxc_syntax 0.93.0",
-]
-
-[[package]]
-name = "oxc_parser"
-version = "0.93.0"
-dependencies = [
- "bitflags 2.9.4",
- "cow-utils",
- "memchr",
- "num-bigint",
- "num-traits",
- "oxc_allocator 0.93.0",
- "oxc_ast 0.93.0",
- "oxc_ast_visit 0.93.0",
- "oxc_data_structures 0.93.0",
- "oxc_diagnostics 0.93.0",
- "oxc_ecmascript 0.93.0",
- "oxc_regular_expression 0.93.0",
- "oxc_span 0.93.0",
- "oxc_syntax 0.93.0",
- "pico-args",
- "rustc-hash",
- "seq-macro",
+ "oxc_ast 0.94.0",
+ "oxc_ast_visit 0.94.0",
+ "oxc_diagnostics 0.94.0",
+ "oxc_span 0.94.0",
+ "oxc_syntax 0.94.0",
 ]
 
 [[package]]
@@ -2410,29 +2387,52 @@ dependencies = [
  "memchr",
  "num-bigint",
  "num-traits",
- "oxc_allocator 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_diagnostics 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ecmascript 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_regular_expression 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.93.0",
+ "oxc_ast 0.93.0",
+ "oxc_data_structures 0.93.0",
+ "oxc_diagnostics 0.93.0",
+ "oxc_ecmascript 0.93.0",
+ "oxc_regular_expression 0.93.0",
+ "oxc_span 0.93.0",
+ "oxc_syntax 0.93.0",
+ "rustc-hash",
+ "seq-macro",
+]
+
+[[package]]
+name = "oxc_parser"
+version = "0.94.0"
+dependencies = [
+ "bitflags 2.9.4",
+ "cow-utils",
+ "memchr",
+ "num-bigint",
+ "num-traits",
+ "oxc_allocator 0.94.0",
+ "oxc_ast 0.94.0",
+ "oxc_ast_visit 0.94.0",
+ "oxc_data_structures 0.94.0",
+ "oxc_diagnostics 0.94.0",
+ "oxc_ecmascript 0.94.0",
+ "oxc_regular_expression 0.94.0",
+ "oxc_span 0.94.0",
+ "oxc_syntax 0.94.0",
+ "pico-args",
  "rustc-hash",
  "seq-macro",
 ]
 
 [[package]]
 name = "oxc_parser_napi"
-version = "0.93.0"
+version = "0.94.0"
 dependencies = [
  "mimalloc-safe",
  "napi",
  "napi-build",
  "napi-derive",
  "oxc",
- "oxc_ast_macros 0.93.0",
- "oxc_estree 0.93.0",
+ "oxc_ast_macros 0.94.0",
+ "oxc_estree 0.94.0",
  "oxc_napi",
  "rustc-hash",
 ]
@@ -2459,12 +2459,12 @@ name = "oxc_prettier_conformance"
 version = "0.0.0"
 dependencies = [
  "cow-utils",
- "oxc_allocator 0.93.0",
- "oxc_ast 0.93.0",
- "oxc_ast_visit 0.93.0",
+ "oxc_allocator 0.94.0",
+ "oxc_ast 0.94.0",
+ "oxc_ast_visit 0.94.0",
  "oxc_formatter",
- "oxc_parser 0.93.0",
- "oxc_span 0.93.0",
+ "oxc_parser 0.94.0",
+ "oxc_span 0.94.0",
  "oxc_tasks_common",
  "pico-args",
  "rustc-hash",
@@ -2475,6 +2475,8 @@ dependencies = [
 [[package]]
 name = "oxc_regular_expression"
 version = "0.93.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e783f03017ed46d9d50aed65de775fdcc57914d0a997300ea5816e1ed5d583"
 dependencies = [
  "bitflags 2.9.4",
  "oxc_allocator 0.93.0",
@@ -2488,15 +2490,13 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.93.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93e783f03017ed46d9d50aed65de775fdcc57914d0a997300ea5816e1ed5d583"
+version = "0.94.0"
 dependencies = [
  "bitflags 2.9.4",
- "oxc_allocator 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast_macros 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_diagnostics 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.94.0",
+ "oxc_ast_macros 0.94.0",
+ "oxc_diagnostics 0.94.0",
+ "oxc_span 0.94.0",
  "phf",
  "rustc-hash",
  "unicode-id-start",
@@ -2539,45 +2539,45 @@ dependencies = [
 [[package]]
 name = "oxc_semantic"
 version = "0.93.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f4bac78c59d63b90a5b39702ae259adfdb84fc69d61490c43c6547ab3bb3823"
 dependencies = [
- "insta",
  "itertools",
  "oxc_allocator 0.93.0",
  "oxc_ast 0.93.0",
  "oxc_ast_visit 0.93.0",
- "oxc_cfg",
  "oxc_data_structures 0.93.0",
  "oxc_diagnostics 0.93.0",
  "oxc_ecmascript 0.93.0",
- "oxc_index 4.1.0",
- "oxc_parser 0.93.0",
+ "oxc_index 3.1.0",
  "oxc_span 0.93.0",
  "oxc_syntax 0.93.0",
  "phf",
  "rustc-hash",
  "self_cell",
- "serde_json",
 ]
 
 [[package]]
 name = "oxc_semantic"
-version = "0.93.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f4bac78c59d63b90a5b39702ae259adfdb84fc69d61490c43c6547ab3bb3823"
+version = "0.94.0"
 dependencies = [
+ "insta",
  "itertools",
- "oxc_allocator 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast_visit 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_diagnostics 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ecmascript 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_index 3.1.0",
- "oxc_span 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.94.0",
+ "oxc_ast 0.94.0",
+ "oxc_ast_visit 0.94.0",
+ "oxc_cfg",
+ "oxc_data_structures 0.94.0",
+ "oxc_diagnostics 0.94.0",
+ "oxc_ecmascript 0.94.0",
+ "oxc_index 4.1.0",
+ "oxc_parser 0.94.0",
+ "oxc_span 0.94.0",
+ "oxc_syntax 0.94.0",
  "phf",
  "rustc-hash",
  "self_cell",
+ "serde_json",
 ]
 
 [[package]]
@@ -2598,10 +2598,11 @@ dependencies = [
 [[package]]
 name = "oxc_span"
 version = "0.93.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b10b09752e1043e988081be2aabcc2abb948da5339adf66623c84fe959fd6f"
 dependencies = [
  "compact_str",
  "oxc-miette",
- "oxc-schemars",
  "oxc_allocator 0.93.0",
  "oxc_ast_macros 0.93.0",
  "oxc_estree 0.93.0",
@@ -2610,35 +2611,15 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.93.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b10b09752e1043e988081be2aabcc2abb948da5339adf66623c84fe959fd6f"
+version = "0.94.0"
 dependencies = [
  "compact_str",
  "oxc-miette",
- "oxc_allocator 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast_macros 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_estree 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc-schemars",
+ "oxc_allocator 0.94.0",
+ "oxc_ast_macros 0.94.0",
+ "oxc_estree 0.94.0",
  "serde",
-]
-
-[[package]]
-name = "oxc_syntax"
-version = "0.93.0"
-dependencies = [
- "bitflags 2.9.4",
- "cow-utils",
- "dragonbox_ecma",
- "nonmax",
- "oxc_allocator 0.93.0",
- "oxc_ast_macros 0.93.0",
- "oxc_data_structures 0.93.0",
- "oxc_estree 0.93.0",
- "oxc_index 4.1.0",
- "oxc_span 0.93.0",
- "phf",
- "serde",
- "unicode-id-start",
 ]
 
 [[package]]
@@ -2651,12 +2632,31 @@ dependencies = [
  "cow-utils",
  "dragonbox_ecma",
  "nonmax",
- "oxc_allocator 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast_macros 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_estree 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.93.0",
+ "oxc_ast_macros 0.93.0",
+ "oxc_data_structures 0.93.0",
+ "oxc_estree 0.93.0",
  "oxc_index 3.1.0",
- "oxc_span 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_span 0.93.0",
+ "phf",
+ "serde",
+ "unicode-id-start",
+]
+
+[[package]]
+name = "oxc_syntax"
+version = "0.94.0"
+dependencies = [
+ "bitflags 2.9.4",
+ "cow-utils",
+ "dragonbox_ecma",
+ "nonmax",
+ "oxc_allocator 0.94.0",
+ "oxc_ast_macros 0.94.0",
+ "oxc_data_structures 0.94.0",
+ "oxc_estree 0.94.0",
+ "oxc_index 4.1.0",
+ "oxc_span 0.94.0",
  "phf",
  "serde",
  "unicode-id-start",
@@ -2667,7 +2667,7 @@ name = "oxc_tasks_common"
 version = "0.0.0"
 dependencies = [
  "console 0.16.1",
- "oxc_span 0.93.0",
+ "oxc_span 0.94.0",
  "project-root",
  "similar",
  "ureq",
@@ -2678,13 +2678,13 @@ name = "oxc_tasks_transform_checker"
 version = "0.0.0"
 dependencies = [
  "indexmap",
- "oxc_allocator 0.93.0",
- "oxc_ast 0.93.0",
- "oxc_ast_visit 0.93.0",
- "oxc_diagnostics 0.93.0",
- "oxc_semantic 0.93.0",
- "oxc_span 0.93.0",
- "oxc_syntax 0.93.0",
+ "oxc_allocator 0.94.0",
+ "oxc_ast 0.94.0",
+ "oxc_ast_visit 0.94.0",
+ "oxc_diagnostics 0.94.0",
+ "oxc_semantic 0.94.0",
+ "oxc_span 0.94.0",
+ "oxc_syntax 0.94.0",
  "rustc-hash",
 ]
 
@@ -2694,10 +2694,10 @@ version = "0.0.0"
 dependencies = [
  "humansize",
  "mimalloc-safe",
- "oxc_allocator 0.93.0",
- "oxc_minifier 0.93.0",
- "oxc_parser 0.93.0",
- "oxc_semantic 0.93.0",
+ "oxc_allocator 0.94.0",
+ "oxc_minifier 0.94.0",
+ "oxc_parser 0.94.0",
+ "oxc_semantic 0.94.0",
  "oxc_tasks_common",
  "oxc_transformer",
 ]
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_transform_napi"
-version = "0.93.0"
+version = "0.94.0"
 dependencies = [
  "mimalloc-safe",
  "napi",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer"
-version = "0.93.0"
+version = "0.94.0"
 dependencies = [
  "base64",
  "compact_str",
@@ -2740,20 +2740,20 @@ dependencies = [
  "insta",
  "itoa",
  "memchr",
- "oxc_allocator 0.93.0",
- "oxc_ast 0.93.0",
- "oxc_ast_visit 0.93.0",
- "oxc_codegen 0.93.0",
- "oxc_compat 0.93.0",
- "oxc_data_structures 0.93.0",
- "oxc_diagnostics 0.93.0",
- "oxc_ecmascript 0.93.0",
- "oxc_parser 0.93.0",
- "oxc_regular_expression 0.93.0",
- "oxc_semantic 0.93.0",
- "oxc_span 0.93.0",
- "oxc_syntax 0.93.0",
- "oxc_traverse 0.93.0",
+ "oxc_allocator 0.94.0",
+ "oxc_ast 0.94.0",
+ "oxc_ast_visit 0.94.0",
+ "oxc_codegen 0.94.0",
+ "oxc_compat 0.94.0",
+ "oxc_data_structures 0.94.0",
+ "oxc_diagnostics 0.94.0",
+ "oxc_ecmascript 0.94.0",
+ "oxc_parser 0.94.0",
+ "oxc_regular_expression 0.94.0",
+ "oxc_semantic 0.94.0",
+ "oxc_span 0.94.0",
+ "oxc_syntax 0.94.0",
+ "oxc_traverse 0.94.0",
  "pico-args",
  "rustc-hash",
  "serde",
@@ -2763,26 +2763,26 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer_plugins"
-version = "0.93.0"
+version = "0.94.0"
 dependencies = [
  "cow-utils",
  "insta",
  "itoa",
- "oxc_allocator 0.93.0",
- "oxc_ast 0.93.0",
- "oxc_ast_visit 0.93.0",
- "oxc_codegen 0.93.0",
- "oxc_diagnostics 0.93.0",
- "oxc_ecmascript 0.93.0",
- "oxc_minifier 0.93.0",
- "oxc_parser 0.93.0",
- "oxc_semantic 0.93.0",
+ "oxc_allocator 0.94.0",
+ "oxc_ast 0.94.0",
+ "oxc_ast_visit 0.94.0",
+ "oxc_codegen 0.94.0",
+ "oxc_diagnostics 0.94.0",
+ "oxc_ecmascript 0.94.0",
+ "oxc_minifier 0.94.0",
+ "oxc_parser 0.94.0",
+ "oxc_semantic 0.94.0",
  "oxc_sourcemap",
- "oxc_span 0.93.0",
- "oxc_syntax 0.93.0",
+ "oxc_span 0.94.0",
+ "oxc_syntax 0.94.0",
  "oxc_tasks_common",
  "oxc_transformer",
- "oxc_traverse 0.93.0",
+ "oxc_traverse 0.94.0",
  "pico-args",
  "rustc-hash",
  "similar",
@@ -2791,6 +2791,8 @@ dependencies = [
 [[package]]
 name = "oxc_traverse"
 version = "0.93.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa44f53e667d15f5aa8421c0461415501ca402095befd7a7c40cd729826e6e76"
 dependencies = [
  "itoa",
  "oxc_allocator 0.93.0",
@@ -2806,19 +2808,17 @@ dependencies = [
 
 [[package]]
 name = "oxc_traverse"
-version = "0.93.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa44f53e667d15f5aa8421c0461415501ca402095befd7a7c40cd729826e6e76"
+version = "0.94.0"
 dependencies = [
  "itoa",
- "oxc_allocator 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast_visit 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ecmascript 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_semantic 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.93.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.94.0",
+ "oxc_ast 0.94.0",
+ "oxc_ast_visit 0.94.0",
+ "oxc_data_structures 0.94.0",
+ "oxc_ecmascript 0.94.0",
+ "oxc_semantic 0.94.0",
+ "oxc_span 0.94.0",
+ "oxc_syntax 0.94.0",
  "rustc-hash",
 ]
 
@@ -2833,11 +2833,11 @@ dependencies = [
  "lazy-regex",
  "mimalloc-safe",
  "oxc-miette",
- "oxc_allocator 0.93.0",
- "oxc_diagnostics 0.93.0",
+ "oxc_allocator 0.94.0",
+ "oxc_diagnostics 0.94.0",
  "oxc_formatter",
- "oxc_parser 0.93.0",
- "oxc_span 0.93.0",
+ "oxc_parser 0.94.0",
+ "oxc_span 0.94.0",
  "rayon",
  "tracing-subscriber",
 ]
@@ -2856,10 +2856,10 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "oxc-miette",
- "oxc_allocator 0.93.0",
- "oxc_diagnostics 0.93.0",
+ "oxc_allocator 0.94.0",
+ "oxc_diagnostics 0.94.0",
  "oxc_linter",
- "oxc_span 0.93.0",
+ "oxc_span 0.94.0",
  "rayon",
  "rustc-hash",
  "serde",
@@ -3186,11 +3186,11 @@ dependencies = [
  "convert_case",
  "handlebars",
  "lazy-regex",
- "oxc_allocator 0.93.0",
- "oxc_ast 0.93.0",
- "oxc_ast_visit 0.93.0",
- "oxc_parser 0.93.0",
- "oxc_span 0.93.0",
+ "oxc_allocator 0.94.0",
+ "oxc_ast 0.94.0",
+ "oxc_ast_visit 0.94.0",
+ "oxc_parser 0.94.0",
+ "oxc_span 0.94.0",
  "oxc_tasks_common",
  "rustc-hash",
  "serde",
@@ -4082,11 +4082,11 @@ dependencies = [
  "itertools",
  "markdown",
  "oxc-schemars",
- "oxc_allocator 0.93.0",
- "oxc_diagnostics 0.93.0",
+ "oxc_allocator 0.94.0",
+ "oxc_diagnostics 0.94.0",
  "oxc_linter",
- "oxc_parser 0.93.0",
- "oxc_span 0.93.0",
+ "oxc_parser 0.94.0",
+ "oxc_span 0.94.0",
  "oxlint",
  "pico-args",
  "project-root",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,33 +103,33 @@ multiple_crate_versions = "allow"
 
 [workspace.dependencies]
 # publish = true
-oxc = { version = "0.93.0", path = "crates/oxc" }
-oxc_allocator = { version = "0.93.0", path = "crates/oxc_allocator" }
-oxc_ast = { version = "0.93.0", path = "crates/oxc_ast" }
-oxc_ast_macros = { version = "0.93.0", path = "crates/oxc_ast_macros" }
-oxc_ast_visit = { version = "0.93.0", path = "crates/oxc_ast_visit" }
-oxc_cfg = { version = "0.93.0", path = "crates/oxc_cfg" }
-oxc_codegen = { version = "0.93.0", path = "crates/oxc_codegen" }
-oxc_compat = { version = "0.93.0", path = "crates/oxc_compat" }
-oxc_data_structures = { version = "0.93.0", path = "crates/oxc_data_structures" }
-oxc_diagnostics = { version = "0.93.0", path = "crates/oxc_diagnostics" }
-oxc_ecmascript = { version = "0.93.0", path = "crates/oxc_ecmascript" }
-oxc_estree = { version = "0.93.0", path = "crates/oxc_estree" }
-oxc_isolated_declarations = { version = "0.93.0", path = "crates/oxc_isolated_declarations" }
-oxc_mangler = { version = "0.93.0", path = "crates/oxc_mangler" }
-oxc_minifier = { version = "0.93.0", path = "crates/oxc_minifier" }
-oxc_minify_napi = { version = "0.93.0", path = "napi/minify" }
-oxc_napi = { version = "0.93.0", path = "crates/oxc_napi" }
-oxc_parser = { version = "0.93.0", path = "crates/oxc_parser", features = ["regular_expression"] }
-oxc_parser_napi = { version = "0.93.0", path = "napi/parser" }
-oxc_regular_expression = { version = "0.93.0", path = "crates/oxc_regular_expression" }
-oxc_semantic = { version = "0.93.0", path = "crates/oxc_semantic" }
-oxc_span = { version = "0.93.0", path = "crates/oxc_span" }
-oxc_syntax = { version = "0.93.0", path = "crates/oxc_syntax" }
-oxc_transform_napi = { version = "0.93.0", path = "napi/transform" }
-oxc_transformer = { version = "0.93.0", path = "crates/oxc_transformer" }
-oxc_transformer_plugins = { version = "0.93.0", path = "crates/oxc_transformer_plugins" }
-oxc_traverse = { version = "0.93.0", path = "crates/oxc_traverse" }
+oxc = { version = "0.94.0", path = "crates/oxc" }
+oxc_allocator = { version = "0.94.0", path = "crates/oxc_allocator" }
+oxc_ast = { version = "0.94.0", path = "crates/oxc_ast" }
+oxc_ast_macros = { version = "0.94.0", path = "crates/oxc_ast_macros" }
+oxc_ast_visit = { version = "0.94.0", path = "crates/oxc_ast_visit" }
+oxc_cfg = { version = "0.94.0", path = "crates/oxc_cfg" }
+oxc_codegen = { version = "0.94.0", path = "crates/oxc_codegen" }
+oxc_compat = { version = "0.94.0", path = "crates/oxc_compat" }
+oxc_data_structures = { version = "0.94.0", path = "crates/oxc_data_structures" }
+oxc_diagnostics = { version = "0.94.0", path = "crates/oxc_diagnostics" }
+oxc_ecmascript = { version = "0.94.0", path = "crates/oxc_ecmascript" }
+oxc_estree = { version = "0.94.0", path = "crates/oxc_estree" }
+oxc_isolated_declarations = { version = "0.94.0", path = "crates/oxc_isolated_declarations" }
+oxc_mangler = { version = "0.94.0", path = "crates/oxc_mangler" }
+oxc_minifier = { version = "0.94.0", path = "crates/oxc_minifier" }
+oxc_minify_napi = { version = "0.94.0", path = "napi/minify" }
+oxc_napi = { version = "0.94.0", path = "crates/oxc_napi" }
+oxc_parser = { version = "0.94.0", path = "crates/oxc_parser", features = ["regular_expression"] }
+oxc_parser_napi = { version = "0.94.0", path = "napi/parser" }
+oxc_regular_expression = { version = "0.94.0", path = "crates/oxc_regular_expression" }
+oxc_semantic = { version = "0.94.0", path = "crates/oxc_semantic" }
+oxc_span = { version = "0.94.0", path = "crates/oxc_span" }
+oxc_syntax = { version = "0.94.0", path = "crates/oxc_syntax" }
+oxc_transform_napi = { version = "0.94.0", path = "napi/transform" }
+oxc_transformer = { version = "0.94.0", path = "crates/oxc_transformer" }
+oxc_transformer_plugins = { version = "0.94.0", path = "crates/oxc_transformer_plugins" }
+oxc_traverse = { version = "0.94.0", path = "crates/oxc_traverse" }
 
 # publish = false
 oxc_formatter = { path = "crates/oxc_formatter" }

--- a/crates/oxc/CHANGELOG.md
+++ b/crates/oxc/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.94.0] - 2025-10-06
+
+### 🐛 Bug Fixes
+
+- 013e053 napi/transform: Fix define plugin not applying DCE correctly (#14264) (Boshen)
+
+
 ## [0.93.0] - 2025-09-28
 
 ### 🚀 Features

--- a/crates/oxc/Cargo.toml
+++ b/crates/oxc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_allocator/CHANGELOG.md
+++ b/crates/oxc_allocator/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.94.0] - 2025-10-06
+
+### 🚀 Features
+
+- f37b211 allocator: Add `HashSet` (#14212) (sapphi-red)
+- 7a1c339 allocator: Add `HashMap::from_iter_in` (#14211) (sapphi-red)
+
+### 📚 Documentation
+
+- 0c14e50 allocator/hashmap: Add comments to `HashMap::from_iter_in` (#14329) (overlookmotel)
+
+
 ## [0.93.0] - 2025-09-28
 
 ### 🚜 Refactor

--- a/crates/oxc_allocator/Cargo.toml
+++ b/crates/oxc_allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_allocator"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ast/CHANGELOG.md
+++ b/crates/oxc_ast/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.94.0] - 2025-10-06
+
+### 🚀 Features
+
+- 7e4d04f napi/parser: Add option to add `parent` prop to AST nodes with raw transfer (#14344) (overlookmotel)
+- 6374065 napi/parser: Raw transfer support `range` field (#14319) (overlookmotel)
+
+### 🐛 Bug Fixes
+
+- a11bc9f napi/parser, linter/plugins: Add `range` field to `TemplateElement` (#14339) (overlookmotel)
+
+### 🚜 Refactor
+
+- 34e1c0b napi/parser: Use minifier to generate JS/TS raw transfer deserializers from single source (#14312) (overlookmotel)
+
+### ⚡ Performance
+
+- e75d42d napi/parser, linter/plugins: Remove runtime `preserveParens` option from raw transfer deserializers (#14338) (overlookmotel)
+
+
 ## [0.93.0] - 2025-09-28
 
 ### 🚜 Refactor

--- a/crates/oxc_ast/Cargo.toml
+++ b/crates/oxc_ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ast"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ast_macros/CHANGELOG.md
+++ b/crates/oxc_ast_macros/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.91.0] - 2025-09-22
 
 ### 💼 Other

--- a/crates/oxc_ast_macros/Cargo.toml
+++ b/crates/oxc_ast_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ast_macros"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ast_visit/CHANGELOG.md
+++ b/crates/oxc_ast_visit/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.91.0] - 2025-09-22
 
 ### 🚀 Features

--- a/crates/oxc_ast_visit/Cargo.toml
+++ b/crates/oxc_ast_visit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ast_visit"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_cfg/CHANGELOG.md
+++ b/crates/oxc_cfg/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.94.0] - 2025-10-06
+
+### 🚀 Features
+
+- 3656908 rust: Oxc-index-vec v4.0 (#14254) (Boshen)
+
+
 
 
 ## [0.91.0] - 2025-09-22

--- a/crates/oxc_cfg/Cargo.toml
+++ b/crates/oxc_cfg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_cfg"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_codegen/CHANGELOG.md
+++ b/crates/oxc_codegen/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.94.0] - 2025-10-06
+
+### 🚀 Features
+
+- 3656908 rust: Oxc-index-vec v4.0 (#14254) (Boshen)
+
+### 🐛 Bug Fixes
+
+- fc519c8 mangler: Mangle private class members in subsequent classes correctly (#14361) (sapphi-red)
+- b83ffe5 mangler: Mangle private class members used in nested classes properly (#14218) (sapphi-red)
+
+
 ## [0.93.0] - 2025-09-28
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_codegen"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_compat/CHANGELOG.md
+++ b/crates/oxc_compat/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.94.0] - 2025-10-06
+
+### 🚀 Features
+
+- 588acd5 transformer: Add ES2026 target for explicit resource management (#14330) (Boshen)
+
+
 
 
 ## [0.91.0] - 2025-09-22

--- a/crates/oxc_compat/Cargo.toml
+++ b/crates/oxc_compat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_compat"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_data_structures/CHANGELOG.md
+++ b/crates/oxc_data_structures/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.93.0] - 2025-09-28
 
 ### 🚀 Features

--- a/crates/oxc_data_structures/Cargo.toml
+++ b/crates/oxc_data_structures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_data_structures"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_diagnostics/CHANGELOG.md
+++ b/crates/oxc_diagnostics/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.93.0] - 2025-09-28
 
 ### ⚡ Performance

--- a/crates/oxc_diagnostics/Cargo.toml
+++ b/crates/oxc_diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_diagnostics"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ecmascript/CHANGELOG.md
+++ b/crates/oxc_ecmascript/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.91.0] - 2025-09-22
 
 ### 💼 Other

--- a/crates/oxc_ecmascript/Cargo.toml
+++ b/crates/oxc_ecmascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ecmascript"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_estree/CHANGELOG.md
+++ b/crates/oxc_estree/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.91.0] - 2025-09-22
 
 ### 💼 Other

--- a/crates/oxc_estree/Cargo.toml
+++ b/crates/oxc_estree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_estree"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_isolated_declarations/CHANGELOG.md
+++ b/crates/oxc_isolated_declarations/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.91.0] - 2025-09-22
 
 ### 💼 Other

--- a/crates/oxc_isolated_declarations/Cargo.toml
+++ b/crates/oxc_isolated_declarations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_isolated_declarations"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_mangler/CHANGELOG.md
+++ b/crates/oxc_mangler/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.94.0] - 2025-10-06
+
+### 🚀 Features
+
+- 3656908 rust: Oxc-index-vec v4.0 (#14254) (Boshen)
+
+### 🐛 Bug Fixes
+
+- c257b41 mangler: Avoid reusing same mangled names in the outer class (#14362) (sapphi-red)
+- fc519c8 mangler: Mangle private class members in subsequent classes correctly (#14361) (sapphi-red)
+- 5d3114c mangler: Allow using typescript keywords as variable names (#14315) (sapphi-red)
+
+
 ## [0.93.0] - 2025-09-28
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_mangler/Cargo.toml
+++ b/crates/oxc_mangler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_mangler"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_minifier/CHANGELOG.md
+++ b/crates/oxc_minifier/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.94.0] - 2025-10-06
+
+### 🚀 Features
+
+- 6123684 minifier: Inline single-use variable past read-only variables (#14184) (sapphi-red)
+
+### 🐛 Bug Fixes
+
+- c257b41 mangler: Avoid reusing same mangled names in the outer class (#14362) (sapphi-red)
+- fc519c8 mangler: Mangle private class members in subsequent classes correctly (#14361) (sapphi-red)
+- 6b2daa8 minifier: Don't inline single use variable in conditional logical expressions (#14185) (sapphi-red)
+- e4e963b minifier: Remove `continue` in the end of for-in / for-of (#14186) (sapphi-red)
+- 353c001 minifier: Keep private class members used in nested classes (#14217) (sapphi-red)
+- b83ffe5 mangler: Mangle private class members used in nested classes properly (#14218) (sapphi-red)
+
+### 🚜 Refactor
+
+- 11dd63b minifier: Use `oxc_ast::NONE` (#14322) (sapphi-red)
+
+
 ## [0.93.0] - 2025-09-28
 
 ### 🚀 Features

--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_minifier"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_napi/CHANGELOG.md
+++ b/crates/oxc_napi/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.91.0] - 2025-09-22
 
 ### 💼 Other

--- a/crates/oxc_napi/Cargo.toml
+++ b/crates/oxc_napi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_napi"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_parser/CHANGELOG.md
+++ b/crates/oxc_parser/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.94.0] - 2025-10-06
+
+### 🐛 Bug Fixes
+
+- 81a28d4 parser: Forbid abstract class members with implementation in parser instead of semantic (#14325) (Ulrich Stark)
+
+### 🚜 Refactor
+
+- feca94e parser: Split `check_method_definition` by method kind (#14364) (Ulrich Stark)
+
+### ⚡ Performance
+
+- 653aa8a parser: Cleanup and optimize re-lexing angle tokens (#14208) (Ulrich Stark)
+- ff3c240 parser: Cleanup and optimize parsing jsx (#14234) (Ulrich Stark)
+- e6118fa parser: Optimize expect() to reduce branch misprediction (#14242) (Boshen)
+
+
 ## [0.93.0] - 2025-09-28
 
 ### ⚡ Performance

--- a/crates/oxc_parser/Cargo.toml
+++ b/crates/oxc_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_parser"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_regular_expression/CHANGELOG.md
+++ b/crates/oxc_regular_expression/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.91.0] - 2025-09-22
 
 ### 💼 Other

--- a/crates/oxc_regular_expression/Cargo.toml
+++ b/crates/oxc_regular_expression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_regular_expression"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_semantic/CHANGELOG.md
+++ b/crates/oxc_semantic/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.94.0] - 2025-10-06
+
+### 🚀 Features
+
+- 3656908 rust: Oxc-index-vec v4.0 (#14254) (Boshen)
+
+### 🐛 Bug Fixes
+
+- 81a28d4 parser: Forbid abstract class members with implementation in parser instead of semantic (#14325) (Ulrich Stark)
+
+
 ## [0.93.0] - 2025-09-28
 
 ### 🚀 Features

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_semantic"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_span/CHANGELOG.md
+++ b/crates/oxc_span/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.91.0] - 2025-09-22
 
 ### 💼 Other

--- a/crates/oxc_span/Cargo.toml
+++ b/crates/oxc_span/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_span"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_syntax/CHANGELOG.md
+++ b/crates/oxc_syntax/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.94.0] - 2025-10-06
+
+### 🚀 Features
+
+- 588acd5 transformer: Add ES2026 target for explicit resource management (#14330) (Boshen)
+- 6374065 napi/parser: Raw transfer support `range` field (#14319) (overlookmotel)
+- 3656908 rust: Oxc-index-vec v4.0 (#14254) (Boshen)
+
+
 ## [0.93.0] - 2025-09-28
 
 ### 🚜 Refactor

--- a/crates/oxc_syntax/Cargo.toml
+++ b/crates/oxc_syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_syntax"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_transformer/CHANGELOG.md
+++ b/crates/oxc_transformer/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.94.0] - 2025-10-06
+
+### 🚀 Features
+
+- 588acd5 transformer: Add ES2026 target for explicit resource management (#14330) (Boshen)
+
+
 
 
 ## [0.91.0] - 2025-09-22

--- a/crates/oxc_transformer/Cargo.toml
+++ b/crates/oxc_transformer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_transformer"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_transformer_plugins/CHANGELOG.md
+++ b/crates/oxc_transformer_plugins/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.91.0] - 2025-09-22
 
 ### 💼 Other

--- a/crates/oxc_transformer_plugins/Cargo.toml
+++ b/crates/oxc_transformer_plugins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_transformer_plugins"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_traverse/CHANGELOG.md
+++ b/crates/oxc_traverse/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.91.0] - 2025-09-22
 
 ### 💼 Other

--- a/crates/oxc_traverse/Cargo.toml
+++ b/crates/oxc_traverse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_traverse"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/minify/CHANGELOG.md
+++ b/napi/minify/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
+
 ## [0.92.0] - 2025-09-24
 
 ### 🐛 Bug Fixes

--- a/napi/minify/Cargo.toml
+++ b/napi/minify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_minify_napi"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/minify/index.js
+++ b/napi/minify/index.js
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-android-arm64')
         const bindingPackageVersion = require('@oxc-minify/binding-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-android-arm-eabi')
         const bindingPackageVersion = require('@oxc-minify/binding-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -117,8 +117,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-win32-x64-msvc')
         const bindingPackageVersion = require('@oxc-minify/binding-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -133,8 +133,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-win32-ia32-msvc')
         const bindingPackageVersion = require('@oxc-minify/binding-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -149,8 +149,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-win32-arm64-msvc')
         const bindingPackageVersion = require('@oxc-minify/binding-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -168,8 +168,8 @@ function requireNative() {
     try {
       const binding = require('@oxc-minify/binding-darwin-universal')
       const bindingPackageVersion = require('@oxc-minify/binding-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -184,8 +184,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-darwin-x64')
         const bindingPackageVersion = require('@oxc-minify/binding-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -200,8 +200,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-darwin-arm64')
         const bindingPackageVersion = require('@oxc-minify/binding-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -220,8 +220,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-freebsd-x64')
         const bindingPackageVersion = require('@oxc-minify/binding-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -236,8 +236,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-freebsd-arm64')
         const bindingPackageVersion = require('@oxc-minify/binding-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -257,8 +257,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-x64-musl')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -273,8 +273,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-x64-gnu')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-arm64-musl')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -307,8 +307,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-arm64-gnu')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-arm-musleabihf')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -341,8 +341,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-loong64-musl')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -375,8 +375,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-loong64-gnu')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-riscv64-musl')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -409,8 +409,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-riscv64-gnu')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -426,8 +426,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-linux-ppc64-gnu')
         const bindingPackageVersion = require('@oxc-minify/binding-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -442,8 +442,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-linux-s390x-gnu')
         const bindingPackageVersion = require('@oxc-minify/binding-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -462,8 +462,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-openharmony-arm64')
         const bindingPackageVersion = require('@oxc-minify/binding-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -478,8 +478,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-openharmony-x64')
         const bindingPackageVersion = require('@oxc-minify/binding-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -494,8 +494,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-openharmony-arm')
         const bindingPackageVersion = require('@oxc-minify/binding-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/napi/minify/package.json
+++ b/napi/minify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-minify",
-  "version": "0.93.0",
+  "version": "0.94.0",
   "type": "module",
   "main": "index.js",
   "browser": "browser.js",

--- a/napi/parser/CHANGELOG.md
+++ b/napi/parser/CHANGELOG.md
@@ -4,6 +4,60 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.94.0] - 2025-10-06
+
+### 🚀 Features
+
+- a2914fe linter/plugins: Add `loc` field getter to all AST nodes (#14355) (overlookmotel)
+- c8de6fe linter/plugins: Add `parent` field to AST nodes (#14345) (overlookmotel)
+- 7e4d04f napi/parser: Add option to add `parent` prop to AST nodes with raw transfer (#14344) (overlookmotel)
+- 6374065 napi/parser: Raw transfer support `range` field (#14319) (overlookmotel)
+
+### 🐛 Bug Fixes
+
+- a11bc9f napi/parser, linter/plugins: Add `range` field to `TemplateElement` (#14339) (overlookmotel)
+- c65e782 napi/parser: Fix JSDoc comments (#14318) (overlookmotel)
+
+### 🚜 Refactor
+
+- 1489376 napi/parser, linter/plugins: Minify walker code (#14376) (overlookmotel)
+- c8eeeb5 linter/plugins: Remove build-time dependency on `napi/parser` (#14374) (overlookmotel)
+- 073167a napi/parser: Simplify raw transfer deserializer codegen (#14313) (overlookmotel)
+- 34e1c0b napi/parser: Use minifier to generate JS/TS raw transfer deserializers from single source (#14312) (overlookmotel)
+- a98757a napi/parser: Minify syntax in raw transfer deserializers (#14308) (overlookmotel)
+
+### ⚡ Performance
+
+- e75d42d napi/parser, linter/plugins: Remove runtime `preserveParens` option from raw transfer deserializers (#14338) (overlookmotel)
+
+
+## [0.94.0] - 2025-10-06
+
+### 🚀 Features
+
+- a2914fe linter/plugins: Add `loc` field getter to all AST nodes (#14355) (overlookmotel)
+- c8de6fe linter/plugins: Add `parent` field to AST nodes (#14345) (overlookmotel)
+- 7e4d04f napi/parser: Add option to add `parent` prop to AST nodes with raw transfer (#14344) (overlookmotel)
+- 6374065 napi/parser: Raw transfer support `range` field (#14319) (overlookmotel)
+
+### 🐛 Bug Fixes
+
+- a11bc9f napi/parser, linter/plugins: Add `range` field to `TemplateElement` (#14339) (overlookmotel)
+- c65e782 napi/parser: Fix JSDoc comments (#14318) (overlookmotel)
+
+### 🚜 Refactor
+
+- 1489376 napi/parser, linter/plugins: Minify walker code (#14376) (overlookmotel)
+- c8eeeb5 linter/plugins: Remove build-time dependency on `napi/parser` (#14374) (overlookmotel)
+- 073167a napi/parser: Simplify raw transfer deserializer codegen (#14313) (overlookmotel)
+- 34e1c0b napi/parser: Use minifier to generate JS/TS raw transfer deserializers from single source (#14312) (overlookmotel)
+- a98757a napi/parser: Minify syntax in raw transfer deserializers (#14308) (overlookmotel)
+
+### ⚡ Performance
+
+- e75d42d napi/parser, linter/plugins: Remove runtime `preserveParens` option from raw transfer deserializers (#14338) (overlookmotel)
+
+
 ## [0.93.0] - 2025-09-28
 
 ### 🚜 Refactor

--- a/napi/parser/Cargo.toml
+++ b/napi/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_parser_napi"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-parser",
-  "version": "0.93.0",
+  "version": "0.94.0",
   "type": "module",
   "main": "src-js/index.js",
   "browser": "src-js/wasm.js",

--- a/napi/parser/src-js/bindings.js
+++ b/napi/parser/src-js/bindings.js
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-android-arm64')
         const bindingPackageVersion = require('@oxc-parser/binding-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-android-arm-eabi')
         const bindingPackageVersion = require('@oxc-parser/binding-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -117,8 +117,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-win32-x64-msvc')
         const bindingPackageVersion = require('@oxc-parser/binding-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -133,8 +133,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-win32-ia32-msvc')
         const bindingPackageVersion = require('@oxc-parser/binding-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -149,8 +149,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-win32-arm64-msvc')
         const bindingPackageVersion = require('@oxc-parser/binding-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -168,8 +168,8 @@ function requireNative() {
     try {
       const binding = require('@oxc-parser/binding-darwin-universal')
       const bindingPackageVersion = require('@oxc-parser/binding-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -184,8 +184,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-darwin-x64')
         const bindingPackageVersion = require('@oxc-parser/binding-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -200,8 +200,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-darwin-arm64')
         const bindingPackageVersion = require('@oxc-parser/binding-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -220,8 +220,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-freebsd-x64')
         const bindingPackageVersion = require('@oxc-parser/binding-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -236,8 +236,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-freebsd-arm64')
         const bindingPackageVersion = require('@oxc-parser/binding-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -257,8 +257,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-x64-musl')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -273,8 +273,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-x64-gnu')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-arm64-musl')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -307,8 +307,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-arm64-gnu')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-arm-musleabihf')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -341,8 +341,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-loong64-musl')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -375,8 +375,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-loong64-gnu')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-riscv64-musl')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -409,8 +409,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-riscv64-gnu')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -426,8 +426,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-linux-ppc64-gnu')
         const bindingPackageVersion = require('@oxc-parser/binding-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -442,8 +442,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-linux-s390x-gnu')
         const bindingPackageVersion = require('@oxc-parser/binding-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -462,8 +462,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-openharmony-arm64')
         const bindingPackageVersion = require('@oxc-parser/binding-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -478,8 +478,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-openharmony-x64')
         const bindingPackageVersion = require('@oxc-parser/binding-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -494,8 +494,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-openharmony-arm')
         const bindingPackageVersion = require('@oxc-parser/binding-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/napi/transform/CHANGELOG.md
+++ b/napi/transform/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.94.0] - 2025-10-06
+
+### 🚀 Features
+
+- 588acd5 transformer: Add ES2026 target for explicit resource management (#14330) (Boshen)
+
+### 🐛 Bug Fixes
+
+- 013e053 napi/transform: Fix define plugin not applying DCE correctly (#14264) (Boshen)
+
+
+## [0.94.0] - 2025-10-06
+
+### 🚀 Features
+
+- 588acd5 transformer: Add ES2026 target for explicit resource management (#14330) (Boshen)
+
+### 🐛 Bug Fixes
+
+- 013e053 napi/transform: Fix define plugin not applying DCE correctly (#14264) (Boshen)
+
+
 
 
 ## [0.92.0] - 2025-09-24

--- a/napi/transform/Cargo.toml
+++ b/napi/transform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_transform_napi"
-version = "0.93.0"
+version = "0.94.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/transform/index.js
+++ b/napi/transform/index.js
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-android-arm64')
         const bindingPackageVersion = require('@oxc-transform/binding-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-android-arm-eabi')
         const bindingPackageVersion = require('@oxc-transform/binding-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -117,8 +117,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-win32-x64-msvc')
         const bindingPackageVersion = require('@oxc-transform/binding-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -133,8 +133,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-win32-ia32-msvc')
         const bindingPackageVersion = require('@oxc-transform/binding-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -149,8 +149,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-win32-arm64-msvc')
         const bindingPackageVersion = require('@oxc-transform/binding-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -168,8 +168,8 @@ function requireNative() {
     try {
       const binding = require('@oxc-transform/binding-darwin-universal')
       const bindingPackageVersion = require('@oxc-transform/binding-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -184,8 +184,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-darwin-x64')
         const bindingPackageVersion = require('@oxc-transform/binding-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -200,8 +200,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-darwin-arm64')
         const bindingPackageVersion = require('@oxc-transform/binding-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -220,8 +220,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-freebsd-x64')
         const bindingPackageVersion = require('@oxc-transform/binding-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -236,8 +236,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-freebsd-arm64')
         const bindingPackageVersion = require('@oxc-transform/binding-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -257,8 +257,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-x64-musl')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -273,8 +273,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-x64-gnu')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-arm64-musl')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -307,8 +307,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-arm64-gnu')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-arm-musleabihf')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -341,8 +341,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-loong64-musl')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -375,8 +375,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-loong64-gnu')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-riscv64-musl')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -409,8 +409,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-riscv64-gnu')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -426,8 +426,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-linux-ppc64-gnu')
         const bindingPackageVersion = require('@oxc-transform/binding-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -442,8 +442,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-linux-s390x-gnu')
         const bindingPackageVersion = require('@oxc-transform/binding-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -462,8 +462,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-openharmony-arm64')
         const bindingPackageVersion = require('@oxc-transform/binding-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -478,8 +478,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-openharmony-x64')
         const bindingPackageVersion = require('@oxc-transform/binding-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -494,8 +494,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-openharmony-arm')
         const bindingPackageVersion = require('@oxc-transform/binding-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.93.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.93.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.94.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.94.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/napi/transform/package.json
+++ b/napi/transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-transform",
-  "version": "0.93.0",
+  "version": "0.94.0",
   "type": "module",
   "main": "index.js",
   "browser": "browser.js",

--- a/npm/oxc-types/CHANGELOG.md
+++ b/npm/oxc-types/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.94.0] - 2025-10-06
+
+### 🚀 Features
+
+- 7e4d04f napi/parser: Add option to add `parent` prop to AST nodes with raw transfer (#14344) (overlookmotel)
+
+
 
 
 ## [0.91.0] - 2025-09-22

--- a/npm/oxc-types/package.json
+++ b/npm/oxc-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxc-project/types",
-  "version": "0.93.0",
+  "version": "0.94.0",
   "description": "Types for Oxc AST nodes",
   "type": "module",
   "keywords": [

--- a/npm/runtime/CHANGELOG.md
+++ b/npm/runtime/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.91.0] - 2025-09-22
 
 ### 🚀 Features

--- a/npm/runtime/package.json
+++ b/npm/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxc-project/runtime",
-  "version": "0.93.0",
+  "version": "0.94.0",
   "description": "Oxc's modular runtime helpers",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## [0.94.0] - 2025-10-06

### 🚀 Features

- a2914fe linter/plugins: Add `loc` field getter to all AST nodes (#14355) (overlookmotel)
- 588acd5 transformer: Add ES2026 target for explicit resource management (#14330) (Boshen)
- c8de6fe linter/plugins: Add `parent` field to AST nodes (#14345) (overlookmotel)
- 7e4d04f napi/parser: Add option to add `parent` prop to AST nodes with raw transfer (#14344) (overlookmotel)
- 6374065 napi/parser: Raw transfer support `range` field (#14319) (overlookmotel)
- f37b211 allocator: Add `HashSet` (#14212) (sapphi-red)
- 7a1c339 allocator: Add `HashMap::from_iter_in` (#14211) (sapphi-red)
- 3656908 rust: Oxc-index-vec v4.0 (#14254) (Boshen)
- 6123684 minifier: Inline single-use variable past read-only variables (#14184) (sapphi-red)

### 🐛 Bug Fixes

- c257b41 mangler: Avoid reusing same mangled names in the outer class (#14362) (sapphi-red)
- fc519c8 mangler: Mangle private class members in subsequent classes correctly (#14361) (sapphi-red)
- 81a28d4 parser: Forbid abstract class members with implementation in parser instead of semantic (#14325) (Ulrich Stark)
- a11bc9f napi/parser, linter/plugins: Add `range` field to `TemplateElement` (#14339) (overlookmotel)
- c65e782 napi/parser: Fix JSDoc comments (#14318) (overlookmotel)
- 5d3114c mangler: Allow using typescript keywords as variable names (#14315) (sapphi-red)
- 6b2daa8 minifier: Don't inline single use variable in conditional logical expressions (#14185) (sapphi-red)
- e4e963b minifier: Remove `continue` in the end of for-in / for-of (#14186) (sapphi-red)
- 353c001 minifier: Keep private class members used in nested classes (#14217) (sapphi-red)
- b83ffe5 mangler: Mangle private class members used in nested classes properly (#14218) (sapphi-red)
- 013e053 napi/transform: Fix define plugin not applying DCE correctly (#14264) (Boshen)

### 🚜 Refactor

- feca94e parser: Split `check_method_definition` by method kind (#14364) (Ulrich Stark)
- 1489376 napi/parser, linter/plugins: Minify walker code (#14376) (overlookmotel)
- c8eeeb5 linter/plugins: Remove build-time dependency on `napi/parser` (#14374) (overlookmotel)
- 073167a napi/parser: Simplify raw transfer deserializer codegen (#14313) (overlookmotel)
- 34e1c0b napi/parser: Use minifier to generate JS/TS raw transfer deserializers from single source (#14312) (overlookmotel)
- a98757a napi/parser: Minify syntax in raw transfer deserializers (#14308) (overlookmotel)
- 11dd63b minifier: Use `oxc_ast::NONE` (#14322) (sapphi-red)

### 📚 Documentation

- 0c14e50 allocator/hashmap: Add comments to `HashMap::from_iter_in` (#14329) (overlookmotel)

### ⚡ Performance

- e75d42d napi/parser, linter/plugins: Remove runtime `preserveParens` option from raw transfer deserializers (#14338) (overlookmotel)
- 653aa8a parser: Cleanup and optimize re-lexing angle tokens (#14208) (Ulrich Stark)
- ff3c240 parser: Cleanup and optimize parsing jsx (#14234) (Ulrich Stark)
- e6118fa parser: Optimize expect() to reduce branch misprediction (#14242) (Boshen)