### PR TITLE
fix(language_server): ignore JS plugins

### DIFF
--- a/crates/oxc_language_server/fixtures/linter/js_plugins/.oxlintrc.json
+++ b/crates/oxc_language_server/fixtures/linter/js_plugins/.oxlintrc.json
@@ -1,0 +1,7 @@
+{
+  "jsPlugins": ["./plugin.js"],
+  "rules": {
+    "js-plugin/no-debugger": "error",
+    "no-unused-vars": "off"
+  }
+}

--- a/crates/oxc_language_server/fixtures/linter/js_plugins/index.js
+++ b/crates/oxc_language_server/fixtures/linter/js_plugins/index.js
@@ -1,0 +1,3 @@
+debugger;
+
+let x;

--- a/crates/oxc_language_server/fixtures/linter/js_plugins/plugin.js
+++ b/crates/oxc_language_server/fixtures/linter/js_plugins/plugin.js
@@ -1,0 +1,21 @@
+const plugin = {
+  meta: {
+    name: 'js-plugin',
+  },
+  rules: {
+    'no-debugger': {
+      create(context) {
+        return {
+          DebuggerStatement(debuggerStatement) {
+            context.report({
+              message: 'Unexpected Debugger Statement',
+              node: debuggerStatement,
+            });
+          },
+        };
+      },
+    },
+  },
+};
+
+export default plugin;

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -109,7 +109,7 @@ impl ServerLinter {
 
         let base_patterns = oxlintrc.ignore_patterns.clone();
 
-        let mut external_plugin_store = ExternalPluginStore::default();
+        let mut external_plugin_store = ExternalPluginStore::new(false);
         let config_builder =
             ConfigStoreBuilder::from_oxlintrc(false, oxlintrc, None, &mut external_plugin_store)
                 .unwrap_or_default();
@@ -211,7 +211,7 @@ impl ServerLinter {
             };
             // Collect ignore patterns and their root
             nested_ignore_patterns.push((oxlintrc.ignore_patterns.clone(), dir_path.to_path_buf()));
-            let mut external_plugin_store = ExternalPluginStore::default();
+            let mut external_plugin_store = ExternalPluginStore::new(false);
             let Ok(config_store_builder) = ConfigStoreBuilder::from_oxlintrc(
                 false,
                 oxlintrc,
@@ -668,5 +668,14 @@ mod test {
             Some(LintOptions { type_aware: true, run: Run::OnSave, ..Default::default() }),
         );
         tester.test_and_snapshot_single_file("no-floating-promises/index.ts");
+    }
+
+    #[test]
+    fn test_ignore_js_plugins() {
+        let tester = Tester::new(
+            "fixtures/linter/js_plugins",
+            Some(LintOptions { run: Run::OnSave, ..Default::default() }),
+        );
+        tester.test_and_snapshot_single_file("index.js");
     }
 }

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_js_plugins@index.js.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_js_plugins@index.js.snap
@@ -1,0 +1,69 @@
+---
+source: crates/oxc_language_server/src/tester.rs
+---
+########## 
+file: fixtures/linter/js_plugins/index.js
+----------
+
+code: "eslint(no-debugger)"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
+message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"
+range: Range { start: Position { line: 0, character: 0 }, end: Position { line: 0, character: 9 } }
+related_information[0].message: ""
+related_information[0].location.uri: "file://<variable>/fixtures/linter/js_plugins/index.js"
+related_information[0].location.range: Range { start: Position { line: 0, character: 0 }, end: Position { line: 0, character: 9 } }
+severity: Some(Warning)
+source: Some("oxc")
+tags: None
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Remove the debugger statement",
+            ),
+            code: "",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 9,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this line",
+            ),
+            code: "// oxlint-disable-next-line no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-debugger for this file",
+            ),
+            code: "// oxlint-disable no-debugger\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -159,7 +159,10 @@ impl ConfigStoreBuilder {
             }
         }
 
-        if !external_plugins.is_empty() {
+        // If external plugins are not enabled (language server), then skip loading JS plugins.
+        // This is so that a project can use JS plugins via `oxlint` CLI, and language server
+        // will just silently ignore them - rather than crashing.
+        if !external_plugins.is_empty() && external_plugin_store.is_enabled() {
             let Some(external_linter) = external_linter else {
                 #[expect(clippy::missing_panics_doc, reason = "infallible")]
                 let plugin_specifier = external_plugins.iter().next().unwrap().clone();
@@ -613,7 +616,7 @@ impl Display for ConfigBuilderError {
             ConfigBuilderError::NoExternalLinterConfigured { plugin_specifier } => {
                 write!(
                     f,
-                    "`jsPlugins` config contains '{plugin_specifier}'. JS plugins are not supported in the language server, or on 32-bit or big-endian platforms at present.",
+                    "`jsPlugins` config contains '{plugin_specifier}'. JS plugins are not supported on 32-bit or big-endian platforms at present.",
                 )?;
                 Ok(())
             }

--- a/crates/oxc_linter/src/config/overrides.rs
+++ b/crates/oxc_linter/src/config/overrides.rs
@@ -94,6 +94,9 @@ pub struct OxlintOverride {
     pub plugins: Option<LintPlugins>,
 
     /// JS plugins for this override.
+    ///
+    /// Note: JS plugins are experimental and not subject to semver.
+    /// They are not supported in language server at present.
     #[serde(rename = "jsPlugins")]
     pub external_plugins: Option<FxHashSet<String>>,
 

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -65,6 +65,9 @@ use super::{
 pub struct Oxlintrc {
     pub plugins: Option<LintPlugins>,
     /// JS plugins.
+    ///
+    /// Note: JS plugins are experimental and not subject to semver.
+    /// They are not supported in language server at present.
     #[serde(rename = "jsPlugins")]
     pub external_plugins: Option<FxHashSet<String>>,
     pub categories: OxlintCategories,

--- a/crates/oxc_linter/src/external_plugin_store.rs
+++ b/crates/oxc_linter/src/external_plugin_store.rs
@@ -12,16 +12,40 @@ define_index_type! {
     pub struct ExternalRuleId = u32;
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct ExternalPluginStore {
     registered_plugin_paths: FxHashSet<String>,
 
     plugins: IndexVec<ExternalPluginId, ExternalPlugin>,
     plugin_names: FxHashMap<String, ExternalPluginId>,
     rules: IndexVec<ExternalRuleId, ExternalRule>,
+
+    // `true` for `oxlint`, `false` for language server
+    is_enabled: bool,
+}
+
+impl Default for ExternalPluginStore {
+    fn default() -> Self {
+        Self::new(true)
+    }
 }
 
 impl ExternalPluginStore {
+    pub fn new(is_enabled: bool) -> Self {
+        Self {
+            registered_plugin_paths: FxHashSet::default(),
+            plugins: IndexVec::default(),
+            plugin_names: FxHashMap::default(),
+            rules: IndexVec::default(),
+            is_enabled,
+        }
+    }
+
+    /// Returns `true` if external plugins are enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.is_enabled
+    }
+
     /// Returns `true` if no external plugins have been loaded.
     pub fn is_empty(&self) -> bool {
         self.plugins.is_empty()

--- a/crates/oxc_linter/src/snapshots/schema_json.snap
+++ b/crates/oxc_linter/src/snapshots/schema_json.snap
@@ -52,7 +52,7 @@ expression: json
       }
     },
     "jsPlugins": {
-      "description": "JS plugins.",
+      "description": "JS plugins.\n\nNote: JS plugins are experimental and not subject to semver.\nThey are not supported in language server at present.",
       "default": null,
       "type": [
         "array",
@@ -444,7 +444,7 @@ expression: json
           ]
         },
         "jsPlugins": {
-          "description": "JS plugins for this override.",
+          "description": "JS plugins for this override.\n\nNote: JS plugins are experimental and not subject to semver.\nThey are not supported in language server at present.",
           "type": [
             "array",
             "null"

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -48,7 +48,7 @@
       }
     },
     "jsPlugins": {
-      "description": "JS plugins.",
+      "description": "JS plugins.\n\nNote: JS plugins are experimental and not subject to semver.\nThey are not supported in language server at present.",
       "default": null,
       "type": [
         "array",
@@ -440,7 +440,7 @@
           ]
         },
         "jsPlugins": {
-          "description": "JS plugins for this override.",
+          "description": "JS plugins for this override.\n\nNote: JS plugins are experimental and not subject to semver.\nThey are not supported in language server at present.",
           "type": [
             "array",
             "null"

--- a/tasks/website/src/linter/snapshots/schema_markdown.snap
+++ b/tasks/website/src/linter/snapshots/schema_markdown.snap
@@ -201,6 +201,9 @@ default: `null`
 
 JS plugins.
 
+Note: JS plugins are experimental and not subject to semver.
+They are not supported in language server at present.
+
 
 ## overrides
 
@@ -232,6 +235,9 @@ type: `string[]`
 
 
 JS plugins for this override.
+
+Note: JS plugins are experimental and not subject to semver.
+They are not supported in language server at present.
 
 
 #### overrides[n].rules


### PR DESCRIPTION
Previously we produced an error when JS plugins are defined in config but no `ExternalLinter` is present. That's the desired behavior in `oxlint` CLI, because it happens when user is running Oxlint on an unsupported platform (32-bit, or big-endian).

But it's *not* what we want to happen in language server. Language server does not yet support JS plugins, but user may want to use them in their project (via `oxlint` CLI), and language server should not fail with a "JS plugins are not supported" error on any file in such a project.

This PR prevents that by adding an `is_enabled` field to `ExternalPluginStore`. By default, `is_enabled = true`, but language server sets it to `false`. When `false`, JS plugins are silently ignored, rather than producing an error.

Note: A better solution would be to pass around `Option<ExternalPluginStore>` instead of `ExternalPluginStore` having an `is_enabled` flag. But JS plugin support will be added to the language server pretty soon, at which point we'll need to revert this change. `is_enabled` flag approach will produce less churn when we do that.