### PR TITLE
fix(linter): promise/prefer-await-to-then strict option not reading from config

### DIFF
--- a/crates/oxc_linter/src/snapshots/promise_prefer_await_to_then.snap
+++ b/crates/oxc_linter/src/snapshots/promise_prefer_await_to_then.snap
@@ -78,3 +78,9 @@ source: crates/oxc_linter/src/tester.rs
  1 │ async function foo() { thing().then() }
    ·                                ────
    ╰────
+
+  ⚠ eslint-plugin-promise(prefer-await-to-then): Prefer await to then()/catch()/finally()
+   ╭─[prefer_await_to_then.tsx:1:37]
+ 1 │ async function hi() { await thing().then(x => {}) }
+   ·                                     ────
+   ╰────


### PR DESCRIPTION
fixes #14324