### PR TITLE
fix(package.json): fix quotes for windows compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "private": true,
   "packageManager": "pnpm@10.18.0",
   "scripts": {
-    "build": "pnpm --workspace-concurrency=1 --filter './napi/*' --filter './apps/*' build",
-    "build-dev": "pnpm --workspace-concurrency=1 --filter './napi/*' --filter './apps/*' build-dev",
-    "build-test": "pnpm --workspace-concurrency=1 --filter './napi/*' --filter './apps/*' build-test",
-    "test": "pnpm --workspace-concurrency=1 --filter './napi/*' --filter './apps/*' test",
+    "build": "pnpm --workspace-concurrency=1 --filter \"./napi/*\" --filter \"./apps/*\" build",
+    "build-dev": "pnpm --workspace-concurrency=1 --filter \"./napi/*\" --filter \"./apps/*\" build-dev",
+    "build-test": "pnpm --workspace-concurrency=1 --filter \"./napi/*\" --filter \"./apps/*\" build-test",
+    "test": "pnpm --workspace-concurrency=1 --filter \"./napi/*\" --filter \"./apps/*\" test",
     "lint": "oxlint -c oxlintrc.json --type-aware --deny-warnings"
   },
   "devDependencies": {


### PR DESCRIPTION
single quotes appear not to work on windows:

```
info: downloading component 'rust-std' for 'wasm32-wasip1-threads'
info: installing component 'rust-std' for 'wasm32-wasip1-threads'
> oxc@ build-test D:\a\oxc\oxc
> pnpm --workspace-concurrency=1 --filter './napi/*' --filter './apps/*' build-test
No projects matched the filters in "D:\a\oxc\oxc"
> oxc@ test D:\a\oxc\oxc
> pnpm --workspace-concurrency=1 --filter './napi/*' --filter './apps/*' test
No projects matched the filters in "D:\a\oxc\oxc"
```