### PR TITLE
fix(oxlint): resolve tsdown deprecation warning

### DIFF
--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -6,7 +6,7 @@ const commonConfig: UserConfig = {
   target: 'node20',
   outDir: 'dist',
   clean: true,
-  bundle: true,
+  unbundle: false,
   external: [
     // External native bindings
     './oxlint.*.node',


### PR DESCRIPTION
I currently see the following warning when bundling with tsdown

```
oxlint@1.20.0 build-js D:\a\oxc\oxc\apps\oxlint
  > node scripts/build.js
  Modifying bindings.js...
  Building with tsdown...
  ℹ tsdown v0.15.5 powered by rolldown v1.0.0-beta.41
  ℹ Using tsdown config: D:\a\oxc\oxc\apps\oxlint\tsdown.config.ts
   WARN  `bundle` option is deprecated. Use `unbundle` instead.
   WARN  `bundle` option is deprecated. Use `unbundle` instead.
```