### PR TITLE
test(napi/parser): increase timeout on slow test

### DIFF
--- a/napi/parser/test/parse-raw.test.ts
+++ b/napi/parser/test/parse-raw.test.ts
@@ -225,7 +225,8 @@ describe.concurrent('fixtures', () => {
   it.each(benchFixturePaths)('%s', path => runCaseInWorker(TEST_TYPE_FIXTURE, path));
 });
 
-describeRangeParent.concurrent('range & parent fixtures', () => {
+// `antd.js` test sometimes takes longer than 5 seconds on CI, so increase timeout to 10 seconds
+describeRangeParent.concurrent('range & parent fixtures', { timeout: 10_000 }, () => {
   // oxlint-disable-next-line jest/expect-expect
   it.each(benchFixturePaths)('%s', path => runCaseInWorker(TEST_TYPE_FIXTURE | TEST_TYPE_RANGE_PARENT, path));
 });


### PR DESCRIPTION
1 raw transfer test sometimes takes longer than 5 secs on CI. Increase the timeout.