### PR TITLE
refactor(oxlint): use `vitest`s built in file snapshot comparison

### DIFF
--- a/apps/oxlint/test/utils.ts
+++ b/apps/oxlint/test/utils.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs/promises';
 import { join as pathJoin } from 'node:path';
 
 import { execa } from 'execa';
@@ -52,17 +51,7 @@ export async function testFixtureWithCommand(options: TestFixtureOptions): Promi
     }
   }
 
-  let expectedSnapshot = null;
-  try {
-    expectedSnapshot = await fs.readFile(snapshotPath, 'utf8');
-  } catch (err) {
-    if (err?.code !== 'ENOENT') throw err;
-  }
-
-  if (snapshot !== expectedSnapshot) {
-    await fs.writeFile(snapshotPath, snapshot);
-    if (expectedSnapshot !== null) expect(snapshot).toBe(expectedSnapshot);
-  }
+  await expect(snapshot).toMatchFileSnapshot(snapshotPath);
 }
 
 /**


### PR DESCRIPTION
not sure if there was a reason this had a manual impl, but vitest's implementation should handle the line ending proglems (i think)