### PR TITLE
fix(linter): use `pathToFileURL` for importing plugins to ensure correct URL format

### DIFF
--- a/apps/oxlint/src-js/plugins/load.ts
+++ b/apps/oxlint/src-js/plugins/load.ts
@@ -1,3 +1,5 @@
+import { pathToFileURL } from 'node:url';
+
 import { Context } from './context.js';
 import { getErrorMessage } from './utils.js';
 
@@ -100,7 +102,7 @@ async function loadPluginImpl(path: string): Promise<PluginDetails> {
     throw new Error('This plugin has already been registered. This is a bug in Oxlint. Please report it.');
   }
 
-  const { default: plugin } = (await import(path)) as { default: Plugin };
+  const { default: plugin } = (await import(pathToFileURL(path).href)) as { default: Plugin };
 
   registeredPluginPaths.add(path);
 


### PR DESCRIPTION
writing a test for this is too hard

fixes https://github.com/oxc-project/oxc/issues/14375