### PR TITLE
feat(oxfmt): Provide JSON schema for `.oxfmtrc.json`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2098,7 +2098,9 @@ name = "oxc_formatter"
 version = "0.4.0"
 dependencies = [
  "cow-utils",
+ "insta",
  "json-strip-comments",
+ "oxc-schemars",
  "oxc_allocator 0.94.0",
  "oxc_ast 0.94.0",
  "oxc_data_structures 0.94.0",
@@ -2106,6 +2108,7 @@ dependencies = [
  "oxc_span 0.94.0",
  "oxc_syntax 0.94.0",
  "pico-args",
+ "project-root",
  "rustc-hash",
  "serde",
  "serde_json",

--- a/crates/oxc_formatter/Cargo.toml
+++ b/crates/oxc_formatter/Cargo.toml
@@ -29,10 +29,13 @@ oxc_syntax = { workspace = true }
 cow-utils = { workspace = true }
 json-strip-comments = { workspace = true }
 rustc-hash = { workspace = true }
+schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 unicode-width = "0.2"
 
 [dev-dependencies]
+insta = { workspace = true }
 oxc_parser = { workspace = true }
 pico-args = { workspace = true }
+project-root = { workspace = true }

--- a/crates/oxc_formatter/src/service/oxfmtrc.rs
+++ b/crates/oxc_formatter/src/service/oxfmtrc.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -8,7 +9,7 @@ use crate::{
     Semicolons, SortImports, SortOrder, TrailingCommas,
 };
 
-#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default)]
 pub struct Oxfmtrc {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -45,7 +46,7 @@ pub struct Oxfmtrc {
     pub experimental_sort_imports: Option<SortImportsConfig>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default)]
 pub struct SortImportsConfig {
     #[serde(default)]

--- a/crates/oxc_formatter/tests/schema.rs
+++ b/crates/oxc_formatter/tests/schema.rs
@@ -1,0 +1,20 @@
+use std::fs;
+
+use oxc_formatter::Oxfmtrc;
+use project_root::get_project_root;
+
+// NOTE: This test generates the JSON schema for the `.oxfmtrc.json` configuration file
+
+#[test]
+fn test_schema_json() {
+    let path = get_project_root().unwrap().join("npm/oxfmt/configuration_schema.json");
+    let schema = schemars::schema_for!(Oxfmtrc);
+    let json = serde_json::to_string_pretty(&schema).unwrap();
+    let existing_json = fs::read_to_string(&path).unwrap_or_default();
+    if existing_json.trim() != json.trim() {
+        std::fs::write(&path, &json).unwrap();
+    }
+    insta::with_settings!({ prepend_module_to_snapshot => false }, {
+        insta::assert_snapshot!(json);
+    });
+}

--- a/crates/oxc_formatter/tests/snapshots/schema_json.snap
+++ b/crates/oxc_formatter/tests/snapshots/schema_json.snap
@@ -1,0 +1,142 @@
+---
+source: crates/oxc_formatter/tests/schema.rs
+expression: json
+---
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Oxfmtrc",
+  "type": "object",
+  "properties": {
+    "arrowParentheses": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "attributePosition": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "bracketSameLine": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "bracketSpacing": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "expand": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "experimentalOperatorPosition": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "experimentalSortImports": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SortImportsConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "indentStyle": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "indentWidth": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint8",
+      "minimum": 0.0
+    },
+    "jsxQuoteStyle": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "lineEnding": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "lineWidth": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint16",
+      "minimum": 0.0
+    },
+    "quoteProperties": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "quoteStyle": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "semicolons": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "trailingCommas": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "definitions": {
+    "SortImportsConfig": {
+      "type": "object",
+      "properties": {
+        "ignoreCase": {
+          "default": true,
+          "type": "boolean"
+        },
+        "order": {
+          "default": "asc",
+          "type": "string"
+        },
+        "partitionByComment": {
+          "default": false,
+          "type": "boolean"
+        },
+        "partitionByNewline": {
+          "default": false,
+          "type": "boolean"
+        },
+        "sortSideEffects": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Oxfmtrc",
+  "type": "object",
+  "properties": {
+    "arrowParentheses": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "attributePosition": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "bracketSameLine": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "bracketSpacing": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "expand": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "experimentalOperatorPosition": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "experimentalSortImports": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SortImportsConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "indentStyle": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "indentWidth": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint8",
+      "minimum": 0.0
+    },
+    "jsxQuoteStyle": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "lineEnding": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "lineWidth": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint16",
+      "minimum": 0.0
+    },
+    "quoteProperties": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "quoteStyle": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "semicolons": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "trailingCommas": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "definitions": {
+    "SortImportsConfig": {
+      "type": "object",
+      "properties": {
+        "ignoreCase": {
+          "default": true,
+          "type": "boolean"
+        },
+        "order": {
+          "default": "asc",
+          "type": "string"
+        },
+        "partitionByComment": {
+          "default": false,
+          "type": "boolean"
+        },
+        "partitionByNewline": {
+          "default": false,
+          "type": "boolean"
+        },
+        "sortSideEffects": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/npm/oxfmt/package.json
+++ b/npm/oxfmt/package.json
@@ -24,6 +24,7 @@
   },
   "files": [
     "bin/oxfmt",
+    "configuration_schema.json",
     "README.md"
   ]
 }


### PR DESCRIPTION
It's the same approach as `oxlint`.

It uses the `schemars::JsonSchema`, generating a snapshot and `configuration_schema.json`.