### PR TITLE
chore(ci): remove invalid option from `dorny/paths-filter`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,6 @@ jobs:
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
-          predicate-quantifier: "every"
           filters: |
             src:
               - '!crates/oxc_linter/**'


### PR DESCRIPTION
CI logs currently have this warning:

```
Warning: Unexpected input(s) 'predicate-quantifier', valid inputs are ['token', 'working-directory', 'ref', 'base', 'filters', 'list-files', 'initial-fetch-depth']
```