### PR TITLE
test(napi/parser): fix and clarify exclude tests logic

### DIFF
--- a/napi/parser/vitest.config.ts
+++ b/napi/parser/vitest.config.ts
@@ -1,24 +1,25 @@
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
 
 const { env, platform } = process;
 const isEnabled = envValue => envValue === 'true' || envValue === '1';
-const exclude = new Set<string>();
-if (!isEnabled(env.RUN_LAZY_TESTS)) {
-  exclude.add('lazy-deserialization.test.ts');
-  if (!isEnabled(env.RUN_RAW_TESTS) && !isEnabled(env.RUN_RAW_RANGE_TESTS)) exclude.add('parse-raw.test.ts');
-}
-// TinyPool doesn't seem to work on Windows with Vitest
+
+const runLazyTests = isEnabled(env.RUN_LAZY_TESTS);
+let runRawTests = runLazyTests || isEnabled(env.RUN_RAW_TESTS) || isEnabled(env.RUN_RAW_RANGE_TESTS);
+
+// Raw tests use `tinypool`, which doesn't seem to work on Windows with Vitest
 // Ref: https://github.com/vitest-dev/vitest/issues/8201
-if (platform === 'win32') {
-  exclude.add('parse-raw.test.ts');
-}
+if (platform === 'win32') runRawTests = false;
+
+const exclude = [...configDefaults.exclude];
+if (!runRawTests) exclude.push('parse-raw.test.ts');
+if (!runLazyTests) exclude.push('lazy-deserialization.test.ts');
 
 export default defineConfig({
   test: {
     diff: {
       expand: false,
     },
-    exclude: [...exclude],
+    exclude,
   },
   plugins: [
     // Enable Codspeed plugin in CI only


### PR DESCRIPTION
Fix a bug in Vitest config for `napi/parser` package. When providing `exclude` property, should extend the default to prevent Vitest searching `node_modules` for test files ([docs](https://vitest.dev/config/)).

Also refactor to clarify the logic of which tests are skipped depending on different `env` vars.
