### PR TITLE
ci(napi): remove redundant step from workflow + add comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,9 +171,6 @@ jobs:
     name: Test NAPI
     runs-on: ubuntu-latest
     steps:
-      - name: Enable long paths on Windows
-        if: matrix.os == 'windows-latest'
-        run: git config --system core.longpaths true
       - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter

--- a/apps/oxlint/test/eslint-compat.test.ts
+++ b/apps/oxlint/test/eslint-compat.test.ts
@@ -17,6 +17,7 @@ async function testFixture(fixtureName: string): Promise<void> {
   });
 }
 
+// These tests take longer than 5 seconds on CI, so increase timeout to 10 seconds
 describe('ESLint compatibility', { timeout: 10_000 }, () => {
   it('`definePlugin` should work', async () => {
     await testFixture('definePlugin');


### PR DESCRIPTION
Follow-on after #14383. Remove redundant lines from workflow + add a comment about why longer timeout on ESLint compat tests.