### PR TITLE
fix(oxlint): ignore fixtures dir for vitest

### DIFF
--- a/apps/oxlint/vitest.config.ts
+++ b/apps/oxlint/vitest.config.ts
@@ -1,3 +1,7 @@
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
 
-export default defineConfig({});
+export default defineConfig({
+  test: {
+    exclude: [...configDefaults.exclude, 'fixtures/**'],
+  },
+});


### PR DESCRIPTION
not sure why, but I was getting this error:

```
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Suites 4 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL  fixtures/overrides_with_plugin/index.test.ts [ fixtures/overrides_with_plugin/index.test.ts ]
ReferenceError: describe is not defined
 ❯ fixtures/overrides_with_plugin/index.test.ts:1:1
      1| describe("", () => {
       | ^
      2|   // ^ jest/no-valid-title error as explicitly set in the `.test.ts` override
      3| 

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/4]⎯

 FAIL  fixtures/eslintrc_vitest_replace/foo.test.js [ fixtures/eslintrc_vitest_replace/foo.test.js ]
ReferenceError: test is not defined
 ❯ fixtures/eslintrc_vitest_replace/foo.test.js:1:1
      1| test.skip('foo', () => {
       | ^
      2|   // ...
      3| })

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/4]⎯

 FAIL  fixtures/issue_10394/foo.test.ts [ fixtures/issue_10394/foo.test.ts ]
ReferenceError: describe is not defined
 ❯ fixtures/issue_10394/foo.test.ts:1:1
      1| describe("", () => {
       | ^
      2|   //
      3| });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/4]⎯

 FAIL  fixtures/config_ignore_patterns/ignore_directory/tests/main.spec.js [ fixtures/config_ignore_patterns/ignore_directory/tests/main.spec.js ]
Error: No test suite found in file /Users/cameron/github/Boshen/oxc/apps/oxlint/fixtures/config_ignore_patterns/ignore_directory/tests/main.spec.js
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/4]⎯


 Test Files  4 failed | 3 passed (7)
      Tests  61 passed (61)
   Start at  16:31:02
   Duration  2.88s
```