### PR TITLE
test(linter/plugins): clarify tests for message placeholders

### DIFF
--- a/apps/oxlint/test/fixtures/message_id_interpolation/files/index.js
+++ b/apps/oxlint/test/fixtures/message_id_interpolation/files/index.js
@@ -1,5 +1,7 @@
 var testWithNoData = {};
 var testWithName = {};
+var testWithNameNoData = {};
 var testWithMultiple = {};
+var testWithMultipleNoData = {};
 var testWithMissingData = {};
 var testWithSpaces = {};

--- a/apps/oxlint/test/fixtures/message_id_interpolation/output.snap.md
+++ b/apps/oxlint/test/fixtures/message_id_interpolation/output.snap.md
@@ -3,45 +3,61 @@
 
 # stdout
 ```
-  x interpolation-test(no-var): Variable {{name}} should not use var
+  x interpolation-test(no-var): Variables should not use var
    ,-[files/index.js:1:1]
  1 | var testWithNoData = {};
    : ^^^^^^^^^^^^^^^^^^^^^^^^
  2 | var testWithName = {};
    `----
 
-  x interpolation-test(no-var): Variable testWithName of type string should not use var
+  x interpolation-test(no-var): Variable `testWithName` should not use var
    ,-[files/index.js:2:1]
  1 | var testWithNoData = {};
  2 | var testWithName = {};
    : ^^^^^^^^^^^^^^^^^^^^^^
- 3 | var testWithMultiple = {};
+ 3 | var testWithNameNoData = {};
    `----
 
-  x interpolation-test(no-var): Variable testWithMultiple of type number should not use var
+  x interpolation-test(no-var): Variable `{{name}}` should not use var
    ,-[files/index.js:3:1]
  2 | var testWithName = {};
- 3 | var testWithMultiple = {};
-   : ^^^^^^^^^^^^^^^^^^^^^^^^^^
- 4 | var testWithMissingData = {};
+ 3 | var testWithNameNoData = {};
+   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 4 | var testWithMultiple = {};
    `----
 
-  x interpolation-test(no-var): Value is example and name is {{name}}
+  x interpolation-test(no-var): Variable `testWithMultiple` of type `string` should not use var
    ,-[files/index.js:4:1]
- 3 | var testWithMultiple = {};
- 4 | var testWithMissingData = {};
-   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- 5 | var testWithSpaces = {};
+ 3 | var testWithNameNoData = {};
+ 4 | var testWithMultiple = {};
+   : ^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 5 | var testWithMultipleNoData = {};
    `----
 
-  x interpolation-test(no-var): Value with spaces: hello and name: world
+  x interpolation-test(no-var): Variable `{{name}}` of type `{{type}}` should not use var
    ,-[files/index.js:5:1]
- 4 | var testWithMissingData = {};
- 5 | var testWithSpaces = {};
+ 4 | var testWithMultiple = {};
+ 5 | var testWithMultipleNoData = {};
+   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 6 | var testWithMissingData = {};
+   `----
+
+  x interpolation-test(no-var): Value is `example` and name is `{{name}}`
+   ,-[files/index.js:6:1]
+ 5 | var testWithMultipleNoData = {};
+ 6 | var testWithMissingData = {};
+   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 7 | var testWithSpaces = {};
+   `----
+
+  x interpolation-test(no-var): Value with spaces is `hello` and name is `world`
+   ,-[files/index.js:7:1]
+ 6 | var testWithMissingData = {};
+ 7 | var testWithSpaces = {};
    : ^^^^^^^^^^^^^^^^^^^^^^^^
    `----
 
-Found 0 warnings and 5 errors.
+Found 0 warnings and 7 errors.
 Finished in Xms on 1 file using X threads.
 ```
 

--- a/apps/oxlint/test/fixtures/message_id_interpolation/plugin.ts
+++ b/apps/oxlint/test/fixtures/message_id_interpolation/plugin.ts
@@ -9,11 +9,11 @@ const plugin: Plugin = {
       meta: {
         messages: {
           noData: 'Variables should not use var',
-          withName: 'Variable {{name}} should not use var',
-          withMultiple: 'Variable {{name}} of type {{type}} should not use var',
+          withName: 'Variable `{{name}}` should not use var',
+          withMultiple: 'Variable `{{name}}` of type `{{type}}` should not use var',
           // edge cases
-          missingData: 'Value is {{value}} and name is {{name}}',
-          withSpaces: 'Value with spaces: {{ value }} and name: {{  name  }}',
+          missingData: 'Value is `{{value}}` and name is `{{name}}`',
+          withSpaces: 'Value with spaces is `{{ value }}` and name is `{{  name  }}`',
         },
       },
       create(context) {
@@ -26,14 +26,27 @@ const plugin: Plugin = {
                 if (firstDeclaration.id.type === 'Identifier') {
                   const name = firstDeclaration.id.name;
 
-                  // Test with single placeholder
                   if (name === 'testWithNoData') {
+                    // Test with no placeholders, no data
+                    context.report({
+                      messageId: 'noData',
+                      node,
+                    });
+                  } else if (name === 'testWithName') {
+                    // Test with single placeholder
+                    context.report({
+                      messageId: 'withName',
+                      node,
+                      data: { name },
+                    });
+                  } else if (name === 'testWithNameNoData') {
+                    // Test with single placeholder, but no data
                     context.report({
                       messageId: 'withName',
                       node,
                     });
-                  } // Test with multiple placeholders
-                  else if (name === 'testWithName') {
+                  } else if (name === 'testWithMultiple') {
+                    // Test with multiple placeholders
                     context.report({
                       messageId: 'withMultiple',
                       node,
@@ -42,15 +55,11 @@ const plugin: Plugin = {
                         type: 'string',
                       },
                     });
-                  } // Test without data
-                  else if (name === 'testWithMultiple') {
+                  } else if (name === 'testWithMultipleNoData') {
+                    // Test with multiple placeholders, but no data
                     context.report({
                       messageId: 'withMultiple',
                       node,
-                      data: {
-                        name,
-                        type: 'number',
-                      },
                     });
                   } else if (name === 'testWithMissingData') {
                     // Test missing data - placeholder should remain


### PR DESCRIPTION
Follow-on after #14416. Clarify the tests for message interpolation. There were some mismatches between names used in the tests and what they did, which made it a little tricky to verify them.