### PR TITLE
feat(linter/plugins): support interpolation in normal diagnostic `message`

### DIFF
--- a/apps/oxlint/test/e2e.test.ts
+++ b/apps/oxlint/test/e2e.test.ts
@@ -49,6 +49,10 @@ describe('oxlint CLI', () => {
     await testFixture('basic_custom_plugin');
   });
 
+  it('should support message placeholder interpolation', async () => {
+    await testFixture('message_interpolation');
+  });
+
   it('should support messageId', async () => {
     await testFixture('message_id_plugin');
   });

--- a/apps/oxlint/test/fixtures/message_interpolation/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/message_interpolation/.oxlintrc.json
@@ -1,0 +1,9 @@
+{
+  "jsPlugins": ["./plugin.ts"],
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    "interpolation-test/no-var": "error"
+  }
+}

--- a/apps/oxlint/test/fixtures/message_interpolation/files/index.js
+++ b/apps/oxlint/test/fixtures/message_interpolation/files/index.js
@@ -1,0 +1,7 @@
+var testWithNoData = {};
+var testWithName = {};
+var testWithNameNoData = {};
+var testWithMultiple = {};
+var testWithMultipleNoData = {};
+var testWithMissingData = {};
+var testWithSpaces = {};

--- a/apps/oxlint/test/fixtures/message_interpolation/output.snap.md
+++ b/apps/oxlint/test/fixtures/message_interpolation/output.snap.md
@@ -1,0 +1,68 @@
+# Exit code
+1
+
+# stdout
+```
+  x interpolation-test(no-var): Variables should not use var
+   ,-[files/index.js:1:1]
+ 1 | var testWithNoData = {};
+   : ^^^^^^^^^^^^^^^^^^^^^^^^
+ 2 | var testWithName = {};
+   `----
+
+  x interpolation-test(no-var): Variable `testWithName` should not use var
+   ,-[files/index.js:2:1]
+ 1 | var testWithNoData = {};
+ 2 | var testWithName = {};
+   : ^^^^^^^^^^^^^^^^^^^^^^
+ 3 | var testWithNameNoData = {};
+   `----
+
+  x interpolation-test(no-var): Variable `{{name}}` should not use var
+   ,-[files/index.js:3:1]
+ 2 | var testWithName = {};
+ 3 | var testWithNameNoData = {};
+   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 4 | var testWithMultiple = {};
+   `----
+
+  x interpolation-test(no-var): Variable `testWithMultiple` of type `string` should not use var
+   ,-[files/index.js:4:1]
+ 3 | var testWithNameNoData = {};
+ 4 | var testWithMultiple = {};
+   : ^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 5 | var testWithMultipleNoData = {};
+   `----
+
+  x interpolation-test(no-var): Variable `{{name}}` of type `{{type}}` should not use var
+   ,-[files/index.js:5:1]
+ 4 | var testWithMultiple = {};
+ 5 | var testWithMultipleNoData = {};
+   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 6 | var testWithMissingData = {};
+   `----
+
+  x interpolation-test(no-var): Value is `example` and name is `{{name}}`
+   ,-[files/index.js:6:1]
+ 5 | var testWithMultipleNoData = {};
+ 6 | var testWithMissingData = {};
+   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 7 | var testWithSpaces = {};
+   `----
+
+  x interpolation-test(no-var): Value with spaces is `hello` and name is `world`
+   ,-[files/index.js:7:1]
+ 6 | var testWithMissingData = {};
+ 7 | var testWithSpaces = {};
+   : ^^^^^^^^^^^^^^^^^^^^^^^^
+   `----
+
+Found 0 warnings and 7 errors.
+Finished in Xms on 1 file using X threads.
+```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/message_interpolation/plugin.ts
+++ b/apps/oxlint/test/fixtures/message_interpolation/plugin.ts
@@ -1,0 +1,85 @@
+import type { Plugin } from '../../../dist/index.js';
+
+const plugin: Plugin = {
+  meta: {
+    name: 'interpolation-test',
+  },
+  rules: {
+    'no-var': {
+      create(context) {
+        return {
+          VariableDeclaration(node) {
+            if (node.kind === 'var') {
+              const declarations = node.declarations;
+              if (declarations.length > 0) {
+                const firstDeclaration = declarations[0];
+                if (firstDeclaration.id.type === 'Identifier') {
+                  const name = firstDeclaration.id.name;
+
+                  if (name === 'testWithNoData') {
+                    // Test with no placeholders, no data
+                    context.report({
+                      message: 'Variables should not use var',
+                      node,
+                    });
+                  } else if (name === 'testWithName') {
+                    // Test with single placeholder
+                    context.report({
+                      message: 'Variable `{{name}}` should not use var',
+                      node,
+                      data: { name },
+                    });
+                  } else if (name === 'testWithNameNoData') {
+                    // Test with single placeholder, but no data
+                    context.report({
+                      message: 'Variable `{{name}}` should not use var',
+                      node,
+                    });
+                  } else if (name === 'testWithMultiple') {
+                    // Test with multiple placeholders
+                    context.report({
+                      message: 'Variable `{{name}}` of type `{{type}}` should not use var',
+                      node,
+                      data: {
+                        name,
+                        type: 'string',
+                      },
+                    });
+                  } else if (name === 'testWithMultipleNoData') {
+                    // Test with multiple placeholders, but no data
+                    context.report({
+                      message: 'Variable `{{name}}` of type `{{type}}` should not use var',
+                      node,
+                    });
+                  } else if (name === 'testWithMissingData') {
+                    // Test missing data - placeholder should remain
+                    context.report({
+                      message: 'Value is `{{value}}` and name is `{{name}}`',
+                      node,
+                      data: {
+                        value: 'example',
+                        // name is missing
+                      },
+                    });
+                  } else if (name === 'testWithSpaces') {
+                    // Test whitespace in placeholders
+                    context.report({
+                      message: 'Value with spaces is `{{ value }}` and name is `{{  name  }}`',
+                      node,
+                      data: {
+                        value: 'hello',
+                        name: 'world',
+                      },
+                    });
+                  }
+                }
+              }
+            }
+          },
+        };
+      },
+    },
+  },
+};
+
+export default plugin;


### PR DESCRIPTION
Extend support for placeholder interpolation to normal `message` (without `messageId`).

```js
context.report({
  message: 'Do not use {{ type }}',
  data: { type: node.type },
  node,
});
```
