### PR TITLE
refactor(linter/plugins): remove default value from `Context` constructor

### DIFF
--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -110,9 +110,9 @@ export class Context {
    * @class
    * @param fullRuleName - Rule name, in form `<plugin>/<rule>`
    * @param isFixable - Whether the rule can provide fixes
-   * @param messages - Message templates for messageId support
+   * @param messages - Message templates for `messageId` support (or `null` if none)
    */
-  constructor(fullRuleName: string, isFixable: boolean, messages: Record<string, string> | null = null) {
+  constructor(fullRuleName: string, isFixable: boolean, messages: Record<string, string> | null) {
     this.#internal = {
       id: fullRuleName,
       filePath: '',


### PR DESCRIPTION
It's not necessary. We should always be passing in `null` anyway if no `messages` object.