### PR TITLE
refactor(linter/plugins): allow nullish values as `message` or `messageId`

### DIFF
--- a/apps/oxlint/src-js/index.ts
+++ b/apps/oxlint/src-js/index.ts
@@ -3,14 +3,7 @@ import type { CreateOnceRule, Plugin, Rule } from './plugins/load.ts';
 import type { BeforeHook, Visitor, VisitorWithHooks } from './plugins/types.ts';
 
 export type * as ESTree from './generated/types.d.ts';
-export type {
-  Context,
-  Diagnostic,
-  DiagnosticBase,
-  DiagnosticWithLoc,
-  DiagnosticWithMessageId,
-  DiagnosticWithNode,
-} from './plugins/context.ts';
+export type { Context, Diagnostic, DiagnosticBase, DiagnosticWithLoc, DiagnosticWithNode } from './plugins/context.ts';
 export type { Fix, Fixer, FixFn } from './plugins/fix.ts';
 export type { CreateOnceRule, CreateRule, Plugin, Rule } from './plugins/load.ts';
 export type {


### PR DESCRIPTION
It makes the types a bit shit, but so far we accept `null` or `undefined` for all properties, and treat them the same as the property being absent. Extend this convention to `message` and `messageId` properties.

Also split out getting the message from a diagnostic into a separate function, to make this pattern simpler via early return.