### PR TITLE
fix(linter/plugins): fix error messages

### DIFF
--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -256,12 +256,12 @@ function getMessage(diagnostic: Diagnostic, internal: InternalContext): string {
 function resolveMessageFromMessageId(messageId: string, internal: InternalContext): string {
   const { messages } = internal;
   if (messages === null) {
-    throw new Error(`Cannot use messageId '${messageId}' - rule does not define any messages in meta.messages`);
+    throw new Error(`Cannot use messageId '${messageId}' - rule does not define any messages in \`meta.messages\``);
   }
 
   if (!hasOwn(messages, messageId)) {
     throw new Error(
-      `Unknown messageId '${messageId}'. Available messages: ${
+      `Unknown messageId '${messageId}'. Available \`messageIds\`: ${
         ObjectKeys(messages).map((msg) => `'${msg}'`).join(', ')
       }`,
     );

--- a/apps/oxlint/test/fixtures/message_id_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/message_id_error/output.snap.md
@@ -5,7 +5,7 @@
 ```
   x Error running JS plugin.
   | File path: <root>/apps/oxlint/test/fixtures/message_id_error/files/index.js
-  | Error: Unknown messageId 'unknownMessage'. Available messages: 'validMessage'
+  | Error: Unknown messageId 'unknownMessage'. Available `messageIds`: 'validMessage'
   |     at DebuggerStatement (<root>/apps/oxlint/test/fixtures/message_id_error/plugin.ts:18:21)
 
 Found 0 warnings and 1 error.


### PR DESCRIPTION
Fix a typo in 1 error message, and add quotes to another, following formatting convention used elsewhere.