### PR TITLE
refactor(linter/language_server): `oxc_linter::Runtime::run_source` returns `Message`

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -89,7 +89,7 @@ use crate::{
 #[cfg(feature = "language_server")]
 pub use crate::lsp::{
     FixWithPosition, MessageWithPosition, PossibleFixesWithPosition, SpanPositionMessage,
-    oxc_diagnostic_to_message_with_position,
+    message_to_message_with_position, oxc_diagnostic_to_message_with_position,
 };
 
 #[cfg(target_pointer_width = "64")]

--- a/crates/oxc_linter/src/lsp.rs
+++ b/crates/oxc_linter/src/lsp.rs
@@ -199,7 +199,13 @@ fn add_ignore_fixes<'a>(
         new_fixes.push(disable_for_this_section(rule_name, section_offset, rope, source_text));
     }
 
-    PossibleFixesWithPosition::Multiple(new_fixes)
+    if new_fixes.is_empty() {
+        PossibleFixesWithPosition::None
+    } else if new_fixes.len() == 1 {
+        PossibleFixesWithPosition::Single(new_fixes.remove(0))
+    } else {
+        PossibleFixesWithPosition::Multiple(new_fixes)
+    }
 }
 
 fn disable_for_this_line<'a>(

--- a/crates/oxc_linter/src/service/mod.rs
+++ b/crates/oxc_linter/src/service/mod.rs
@@ -99,7 +99,7 @@ impl LintService {
     pub fn run_source<'a>(
         &mut self,
         allocator: &'a mut oxc_allocator::Allocator,
-    ) -> Vec<crate::MessageWithPosition<'a>> {
+    ) -> Vec<crate::Message<'a>> {
         self.runtime.run_source(allocator)
     }
 


### PR DESCRIPTION
Because `oxc_linter::fixer::Message` has now `section_offset` and thanks to https://github.com/oxc-project/oxc/pull/12647 in combination with https://github.com/oxc-project/oxc/pull/12724, the server has everything to calculate what it needs, 
all relevant code can be moved to the language_server crate. 

Next steps are to simplify the transformation to `DiagnosticReport` noticed by https://github.com/oxc-project/oxc/issues/14563