### PR TITLE
feat(linter/plugins): support selectors DSL

### DIFF
--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -36,7 +36,10 @@
     "dist"
   ],
   "devDependencies": {
+    "@types/esquery": "^1.5.4",
+    "@types/estree": "^1.0.8",
     "eslint": "^9.36.0",
+    "esquery": "^1.6.0",
     "execa": "^9.6.0",
     "jiti": "^2.6.0",
     "tsdown": "^0.15.5",

--- a/apps/oxlint/src-js/generated/type_ids.ts
+++ b/apps/oxlint/src-js/generated/type_ids.ts
@@ -174,3 +174,4 @@ export const NODE_TYPE_IDS_MAP = new Map([
 
 export const NODE_TYPES_COUNT = 165;
 export const LEAF_NODE_TYPES_COUNT = 27;
+export const FUNCTION_NODE_TYPE_IDS = [30, 55, 56];

--- a/apps/oxlint/src-js/generated/visitor.d.ts
+++ b/apps/oxlint/src-js/generated/visitor.d.ts
@@ -380,4 +380,5 @@ export interface VisitorObject {
   'TSTypeReference:exit'?: (node: ESTree.TSTypeReference) => void;
   TSUnionType?: (node: ESTree.TSUnionType) => void;
   'TSUnionType:exit'?: (node: ESTree.TSUnionType) => void;
+  [key: string]: (node: ESTree.Node) => void;
 }

--- a/apps/oxlint/src-js/plugins/selector.ts
+++ b/apps/oxlint/src-js/plugins/selector.ts
@@ -1,0 +1,203 @@
+import esquery from 'esquery';
+import visitorKeys from '../generated/keys.js';
+import { FUNCTION_NODE_TYPE_IDS, NODE_TYPE_IDS_MAP } from '../generated/type_ids.js';
+// @ts-expect-error we need to generate `.d.ts` file for this module
+import { ancestors } from '../generated/walk.js';
+
+import type { ESQueryOptions, Selector as EsquerySelector } from 'esquery';
+import type { Node as EsqueryNode } from 'estree';
+import type { Node, VisitFn } from './types.ts';
+
+const ObjectKeys = Object.keys;
+
+const { matches: esqueryMatches, parse: esqueryParse } = esquery;
+
+type NodeTypeId = number;
+
+// Options to call `esquery.matches` with.
+const ESQUERY_OPTIONS: ESQueryOptions = {
+  nodeTypeKey: 'type',
+  visitorKeys,
+  fallback: (node: EsqueryNode) => ObjectKeys(node).filter(filterKey),
+  matchClass: (_className: unknown, _node: EsqueryNode, _ancestors: EsqueryNode[]) => false, // TODO: Is this right?
+};
+const filterKey = (key: string) => key !== 'parent' && key !== 'range' && key !== 'loc';
+
+// Parsed selector.
+interface Selector {
+  // Array of IDs of types this selector matches, or `null` if selector matches all types.
+  typeIds: NodeTypeId[] | null;
+  // `esquery` selector object for this selector.
+  esquerySelector: EsquerySelector;
+  // `true` if selector applies matching beyond just filtering on node type.
+  // * `FunctionExpression > Identifier` is complex.
+  // * `:matches(FunctionExpression, FunctionDeclaration)` is not complex.
+  // Primarily this exists to make simple `:matches` faster.
+  isComplex: boolean;
+  // Number of attributes in selector. Used for calculating selector's specificity.
+  attributeCount: number;
+  // Number of identifiers in selector. Used for calculating selector's specificity.
+  identifierCount: number;
+}
+
+// Cache of parsed `Selector`s.
+const cache: Map<string, Selector> = new Map([]);
+
+const EMPTY_TYPE_IDS_ARRAY: NodeTypeId[] = [];
+
+/**
+ * Parse a selector string and return a `Selector` object which represents it.
+ *
+ * @param key - Selector string e.g. `Program > VariableDeclaration`
+ * @returns `Selector` object
+ */
+export function parseSelector(key: string): Selector {
+  // Used cached object if we've parsed this key before
+  let selector = cache.get(key);
+  if (selector !== void 0) return selector;
+
+  // Parse with `esquery` and analyse
+  const esquerySelector = esqueryParse(key);
+
+  selector = {
+    typeIds: null,
+    esquerySelector,
+    isComplex: false,
+    attributeCount: 0,
+    identifierCount: 0,
+  };
+  selector.typeIds = analyzeSelector(esquerySelector, selector);
+
+  // Store in cache for next time
+  cache.set(key, selector);
+
+  return selector;
+}
+
+/**
+ * Analyse an `EsquerySelector` to determine:
+ *
+ * 1. What node types it matches on.
+ * 2. Whether it is "simple" or "complex" - "simple" matches a subset of node types without further conditions.
+ * 3. It's specificity (number of identifiers and attributes).
+ *
+ * This function traverses the `EsquerySelector` and calls itself recursively.
+ * It returns an array of node type IDs which the selector may match.
+ *
+ * @param esquerySelector - `EsquerySelector` to analyse.
+ * @param selector - `Selector` which has its `isSimple`, `attributeCount`, and `identifierCount` updated.
+ * @returns Array of node type IDs the selector matches, or `null` if it matches all nodes.
+ */
+function analyzeSelector(esquerySelector: EsquerySelector, selector: Selector): NodeTypeId[] | null {
+  switch (esquerySelector.type) {
+    case 'identifier': {
+      selector.identifierCount++;
+
+      const typeId = NODE_TYPE_IDS_MAP.get(esquerySelector.value);
+      // If the type is invalid, just treat this selector as not matching any types.
+      // But still increment `identifierCount`.
+      // This matches ESLint's behavior.
+      return typeId === void 0 ? EMPTY_TYPE_IDS_ARRAY : [typeId];
+    }
+
+    case 'not':
+      for (let i = 0, childSelectors = esquerySelector.selectors, len = childSelectors.length; i < len; i++) {
+        analyzeSelector(childSelectors[i], selector);
+      }
+      selector.isComplex = true;
+      return null;
+
+    case 'matches': {
+      // OR matcher. Matches a node if any of child selectors matches it.
+      let nodeTypes: NodeTypeId[] | null = [];
+      for (let i = 0, childSelectors = esquerySelector.selectors, len = childSelectors.length; i < len; i++) {
+        const childNodeTypes = analyzeSelector(childSelectors[i], selector);
+        if (childNodeTypes === null) {
+          nodeTypes = null;
+        } else if (nodeTypes !== null) {
+          nodeTypes.push(...childNodeTypes);
+        }
+      }
+      if (nodeTypes === null) return null;
+      // De-duplicate
+      // TODO: Faster way to do this? Sort and then dedupe manually?
+      return [...new Set(nodeTypes)];
+    }
+
+    case 'compound': {
+      // AND matcher. Only matches a node if all child selectors match it.
+      const childSelectors = esquerySelector.selectors,
+        len = childSelectors.length;
+      // TODO: Can `childSelectors` have 0 length?
+      if (len === 0) return [];
+
+      let nodeTypes: NodeTypeId[] | null = null;
+      for (let i = 0; i < len; i++) {
+        const childNodeTypes = analyzeSelector(childSelectors[i], selector);
+
+        // If child selector matches all types, does not narrow the types the selector matches
+        if (childNodeTypes === null) continue;
+
+        if (nodeTypes === null) {
+          // First child selector which matches specific types
+          nodeTypes = childNodeTypes;
+        } else {
+          // Selector only matches intersection of all child selectors.
+          // TODO: Could make this faster if `analyzeSelector` always returned an ordered array.
+          nodeTypes = childNodeTypes.filter(nodeType => nodeTypes.includes(nodeType));
+        }
+      }
+      return nodeTypes;
+    }
+
+    case 'attribute':
+    case 'field':
+    case 'nth-child':
+    case 'nth-last-child':
+      selector.isComplex = true;
+      selector.attributeCount++;
+      return null;
+
+    case 'child':
+    case 'descendant':
+    case 'sibling':
+    case 'adjacent':
+      selector.isComplex = true;
+      analyzeSelector(esquerySelector.left, selector);
+      return analyzeSelector(esquerySelector.right, selector);
+
+    case 'class':
+      // TODO: Should TS function types be included in `FUNCTION_NODE_TYPE_IDS`?
+      // This TODO comment is from ESLint's implementation. Not sure what it means!
+      // TODO: Abstract into JSLanguage somehow.
+      if (esquerySelector.name === 'function') return FUNCTION_NODE_TYPE_IDS;
+      selector.isComplex = true;
+      return null;
+
+    case 'wildcard':
+      return null;
+
+    default:
+      selector.isComplex = true;
+      return null;
+  }
+}
+
+/**
+ * Wrap a visit function so it's only called if the provided `EsquerySelector` matches the AST node.
+ *
+ * IMPORTANT: Selector matching will only be correct if `ancestors` from `generated/walk.js`
+ * contains the ancestors of the AST node passed to the returned visit function.
+ * Therefore, the returned visit function can only be called during AST traversal.
+ *
+ * @params visitFn - Visit function to wrap
+ * @params esquerySelector - `EsquerySelector` object
+ * @returns Wrapped visit function
+ */
+export function wrapVisitFnWithSelectorMatch(visitFn: VisitFn, esquerySelector: EsquerySelector): VisitFn {
+  return (node: Node) => {
+    if (esqueryMatches(node as unknown as EsqueryNode, esquerySelector, ancestors, ESQUERY_OPTIONS)) {
+      visitFn(node);
+    }
+  };
+}

--- a/apps/oxlint/test/compile-visitor.test.ts
+++ b/apps/oxlint/test/compile-visitor.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { NODE_TYPE_IDS_MAP } from '../src-js/generated/type_ids.js';
+import { LEAF_NODE_TYPES_COUNT, NODE_TYPE_IDS_MAP } from '../src-js/generated/type_ids.js';
 import {
   addVisitorToCompiled,
   compiledVisitor,
@@ -10,7 +10,12 @@ import {
 import type { EnterExit, Node, VisitFn } from '../src-js/plugins/types.ts';
 
 const PROGRAM_TYPE_ID = NODE_TYPE_IDS_MAP.get('Program'),
-  EMPTY_STMT_TYPE_ID = NODE_TYPE_IDS_MAP.get('EmptyStatement');
+  EMPTY_STMT_TYPE_ID = NODE_TYPE_IDS_MAP.get('EmptyStatement'),
+  IDENTIFIER_TYPE_ID = NODE_TYPE_IDS_MAP.get('Identifier'),
+  JSX_IDENTIFIER_TYPE_ID = NODE_TYPE_IDS_MAP.get('JSXIdentifier'),
+  FUNC_DECL_TYPE_ID = NODE_TYPE_IDS_MAP.get('FunctionDeclaration'),
+  FUNC_EXPR_TYPE_ID = NODE_TYPE_IDS_MAP.get('FunctionExpression'),
+  ARROW_FUNC_TYPE_ID = NODE_TYPE_IDS_MAP.get('ArrowFunctionExpression');
 
 const SPAN: Node = {
   start: 0,
@@ -37,12 +42,6 @@ describe('compile visitor', () => {
     // oxlint-enable typescript-eslint/no-confusing-void-expression
   });
 
-  it('throws if unknown visitor key', () => {
-    // @ts-expect-error
-    expect(() => addVisitorToCompiled({ Foo() {} }))
-      .toThrow(new Error("Unknown node type 'Foo' in visitor object"));
-  });
-
   it('throws if visitor property is not a function', () => {
     const expectedErr = new TypeError("'Program' property of visitor object is not a function");
     // oxlint-disable typescript-eslint/no-confusing-void-expression
@@ -51,6 +50,11 @@ describe('compile visitor', () => {
     expect(() => addVisitorToCompiled({ Program: true } as any)).toThrow(expectedErr);
     expect(() => addVisitorToCompiled({ Program: {} } as any)).toThrow(expectedErr);
     // oxlint-enable typescript-eslint/no-confusing-void-expression
+  });
+
+  it('accepts unknown visitor key', () => {
+    addVisitorToCompiled({ Foo() {} });
+    addVisitorToCompiled({ 'Foo:exit'() {} });
   });
 
   describe('registers enter visitor', () => {
@@ -389,6 +393,253 @@ describe('compile visitor', () => {
       expect(enter6).toHaveBeenCalledWith(node);
       expect(exit6).toHaveBeenCalledWith(node);
       expect(enter6).toHaveBeenCalledBefore(exit6);
+    });
+  });
+
+  describe('selectors', () => {
+    it('`*` adds visitor function for all node types', () => {
+      const enter = vi.fn(() => {});
+      const exit = vi.fn(() => {});
+      addVisitorToCompiled({ '*': enter, '*:exit': exit });
+
+      expect(finalizeCompiledVisitor()).toBe(true);
+
+      for (const [typeName, typeId] of NODE_TYPE_IDS_MAP) {
+        if (typeId < LEAF_NODE_TYPES_COUNT) {
+          const node = { type: typeName, ...SPAN };
+          (compiledVisitor[typeId] as VisitFn)(node);
+          expect(enter).toHaveBeenCalledWith(node);
+          expect(exit).toHaveBeenCalledWith(node);
+        } else {
+          const enterExit = compiledVisitor[typeId] as EnterExit;
+          expect(enterExit.enter).toBe(enter);
+          expect(enterExit.exit).toBe(exit);
+        }
+      }
+    });
+
+    it('`:matches` adds visitor function for all specified node types', () => {
+      const enter = vi.fn(() => {});
+      const exit = vi.fn(() => {});
+      // List `EmptyStatement` twice to ensure it's deduped
+      addVisitorToCompiled({
+        ':matches(Program, EmptyStatement, EmptyStatement)': enter,
+        ':matches(Program, EmptyStatement, EmptyStatement):exit': exit,
+      });
+
+      expect(finalizeCompiledVisitor()).toBe(true);
+
+      const enterExit = compiledVisitor[PROGRAM_TYPE_ID] as EnterExit;
+      expect(enterExit.enter).toBe(enter);
+      expect(enterExit.exit).toBe(exit);
+
+      const node = { type: 'EmptyStatement', ...SPAN };
+      (compiledVisitor[EMPTY_STMT_TYPE_ID] as VisitFn)(node);
+      expect(enter).toHaveBeenCalledWith(node);
+      expect(exit).toHaveBeenCalledWith(node);
+
+      for (const typeId of NODE_TYPE_IDS_MAP.values()) {
+        if ([PROGRAM_TYPE_ID, EMPTY_STMT_TYPE_ID].includes(typeId)) continue;
+        expect(compiledVisitor[typeId]).toBeNull();
+      }
+    });
+
+    it('`:matches` with attributes adds visitor function for all specified node types', () => {
+      const enter = vi.fn(() => {});
+      const exit = vi.fn(() => {});
+      addVisitorToCompiled({
+        ':matches(Program[type], EmptyStatement)': enter,
+        ':matches(Program, EmptyStatement[type]):exit': exit,
+      });
+
+      expect(finalizeCompiledVisitor()).toBe(true);
+
+      const enterExit = compiledVisitor[PROGRAM_TYPE_ID] as EnterExit;
+      expect(enterExit.enter).not.toBe(enter);
+      expect(enterExit.exit).not.toBe(exit);
+
+      const enterNode = { type: 'Program', ...SPAN };
+      enterExit.enter(enterNode);
+      expect(enter).toHaveBeenCalledWith(enterNode);
+
+      const exitNode = { type: 'Program', ...SPAN };
+      enterExit.exit(exitNode);
+      expect(exit).toHaveBeenCalledWith(exitNode);
+
+      const node = { type: 'EmptyStatement', ...SPAN };
+      (compiledVisitor[EMPTY_STMT_TYPE_ID] as VisitFn)(node);
+      expect(enter).toHaveBeenCalledWith(node);
+      expect(exit).toHaveBeenCalledWith(node);
+
+      for (const typeId of NODE_TYPE_IDS_MAP.values()) {
+        if ([PROGRAM_TYPE_ID, EMPTY_STMT_TYPE_ID].includes(typeId)) continue;
+        expect(compiledVisitor[typeId]).toBeNull();
+      }
+    });
+
+    it('attributes adds visitor function for all node types, but filtered', () => {
+      const enter = vi.fn(() => {});
+      const exit = vi.fn(() => {});
+      addVisitorToCompiled({
+        '[name=foo]': enter,
+        '[name=foo]:exit': exit,
+      });
+
+      expect(finalizeCompiledVisitor()).toBe(true);
+
+      for (const typeId of NODE_TYPE_IDS_MAP.values()) {
+        if (typeId < LEAF_NODE_TYPES_COUNT) {
+          expect(compiledVisitor[typeId]).toBeTypeOf('function');
+        } else {
+          const enterExit = compiledVisitor[typeId] as EnterExit;
+          expect(enterExit.enter).toBeTypeOf('function');
+          expect(enterExit.exit).toBeTypeOf('function');
+          expect(enterExit.enter).not.toBe(enter);
+          expect(enterExit.exit).not.toBe(exit);
+        }
+      }
+
+      const program = { type: 'Program', ...SPAN };
+      const programEnterExit = compiledVisitor[PROGRAM_TYPE_ID] as EnterExit;
+      programEnterExit.enter(program);
+      programEnterExit.exit(program);
+      expect(enter).not.toHaveBeenCalled();
+      expect(exit).not.toHaveBeenCalled();
+
+      const identEnterExit = compiledVisitor[IDENTIFIER_TYPE_ID] as EnterExit;
+      const jsxIdentVisit = compiledVisitor[JSX_IDENTIFIER_TYPE_ID] as VisitFn;
+
+      let ident = { type: 'Identifier', name: 'bar', ...SPAN };
+      identEnterExit.enter(ident);
+      identEnterExit.exit(ident);
+      expect(enter).not.toHaveBeenCalled();
+      expect(exit).not.toHaveBeenCalled();
+
+      ident = { type: 'JSXIdentifier', name: 'qux', ...SPAN };
+      jsxIdentVisit(ident);
+      expect(enter).not.toHaveBeenCalled();
+      expect(exit).not.toHaveBeenCalled();
+
+      ident = { type: 'Identifier', name: 'foo', ...SPAN };
+      identEnterExit.enter(ident);
+      expect(enter).toHaveBeenCalledWith(ident);
+      ident = { type: 'Identifier', name: 'foo', ...SPAN };
+      identEnterExit.exit(ident);
+      expect(exit).toHaveBeenCalledWith(ident);
+
+      ident = { type: 'JSXIdentifier', name: 'foo', ...SPAN };
+      jsxIdentVisit(ident);
+      expect(enter).toHaveBeenCalledWith(ident);
+      expect(exit).toHaveBeenCalledWith(ident);
+    });
+
+    it('identifier with attribute adds visitor function for only specified node types, and filtered', () => {
+      const enter = vi.fn(() => {});
+      const exit = vi.fn(() => {});
+      addVisitorToCompiled({
+        'Identifier[name=foo]': enter,
+        'Identifier[name=foo]:exit': exit,
+      });
+
+      expect(finalizeCompiledVisitor()).toBe(true);
+
+      const identEnterExit = compiledVisitor[IDENTIFIER_TYPE_ID] as EnterExit;
+      expect(identEnterExit.enter).toBeTypeOf('function');
+      expect(identEnterExit.exit).toBeTypeOf('function');
+      expect(identEnterExit.enter).not.toBe(enter);
+      expect(identEnterExit.exit).not.toBe(exit);
+
+      for (const typeId of NODE_TYPE_IDS_MAP.values()) {
+        if (typeId === IDENTIFIER_TYPE_ID) continue;
+        expect(compiledVisitor[typeId]).toBeNull();
+      }
+
+      let ident = { type: 'Identifier', name: 'bar', ...SPAN };
+      identEnterExit.enter(ident);
+      identEnterExit.exit(ident);
+      expect(enter).not.toHaveBeenCalled();
+      expect(exit).not.toHaveBeenCalled();
+
+      ident = { type: 'Identifier', name: 'foo', ...SPAN };
+      identEnterExit.enter(ident);
+      expect(enter).toHaveBeenCalledWith(ident);
+      ident = { type: 'Identifier', name: 'foo', ...SPAN };
+      identEnterExit.exit(ident);
+      expect(exit).toHaveBeenCalledWith(ident);
+    });
+
+    it('combined', () => {
+      const enter1 = vi.fn(() => {});
+      const exit1 = vi.fn(() => {});
+      addVisitorToCompiled({
+        'FunctionDeclaration[name=foo]': enter1,
+        'FunctionDeclaration[name=foo]:exit': exit1,
+      });
+      const enter2 = vi.fn(() => {});
+      const exit2 = vi.fn(() => {});
+      addVisitorToCompiled({
+        ':function': enter2,
+        ':function:exit': exit2,
+      });
+
+      expect(finalizeCompiledVisitor()).toBe(true);
+
+      const funcDeclEnterExit = compiledVisitor[FUNC_DECL_TYPE_ID] as EnterExit;
+      expect(funcDeclEnterExit.enter).toBeTypeOf('function');
+      expect(funcDeclEnterExit.exit).toBeTypeOf('function');
+      expect(funcDeclEnterExit.enter).not.toBe(enter1);
+      expect(funcDeclEnterExit.enter).not.toBe(enter2);
+      expect(funcDeclEnterExit.exit).not.toBe(exit1);
+      expect(funcDeclEnterExit.exit).not.toBe(exit2);
+
+      const funcExprEnterExit = compiledVisitor[FUNC_EXPR_TYPE_ID] as EnterExit;
+      expect(funcExprEnterExit.enter).toBe(enter2);
+      expect(funcExprEnterExit.exit).toBe(exit2);
+
+      const arrowFuncEnterExit = compiledVisitor[ARROW_FUNC_TYPE_ID] as EnterExit;
+      expect(arrowFuncEnterExit.enter).toBe(enter2);
+      expect(arrowFuncEnterExit.exit).toBe(exit2);
+
+      for (const typeId of NODE_TYPE_IDS_MAP.values()) {
+        if ([FUNC_DECL_TYPE_ID, FUNC_EXPR_TYPE_ID, ARROW_FUNC_TYPE_ID].includes(typeId)) continue;
+        expect(compiledVisitor[typeId]).toBeNull();
+      }
+
+      let arrowExpr = { type: 'ArrowFunctionExpression', ...SPAN };
+      arrowFuncEnterExit.enter(arrowExpr);
+      expect(enter2).toHaveBeenCalledWith(arrowExpr);
+      arrowExpr = { type: 'ArrowFunctionExpression', ...SPAN };
+      arrowFuncEnterExit.exit(arrowExpr);
+      expect(exit2).toHaveBeenCalledWith(arrowExpr);
+      expect(enter1).not.toHaveBeenCalled();
+      expect(exit1).not.toHaveBeenCalled();
+
+      let funcExpr = { type: 'FunctionExpression', name: 'foo', ...SPAN };
+      funcExprEnterExit.enter(funcExpr);
+      expect(enter2).toHaveBeenCalledWith(funcExpr);
+      funcExpr = { type: 'FunctionExpression', name: 'foo', ...SPAN };
+      funcExprEnterExit.exit(funcExpr);
+      expect(exit2).toHaveBeenCalledWith(funcExpr);
+      expect(enter1).not.toHaveBeenCalled();
+      expect(exit1).not.toHaveBeenCalled();
+
+      let funcDecl = { type: 'FunctionDeclaration', name: 'bar', ...SPAN };
+      funcDeclEnterExit.enter(funcDecl);
+      expect(enter2).toHaveBeenCalledWith(funcDecl);
+      funcDecl = { type: 'FunctionDeclaration', name: 'bar', ...SPAN };
+      funcDeclEnterExit.exit(funcDecl);
+      expect(exit2).toHaveBeenCalledWith(funcDecl);
+      expect(enter1).not.toHaveBeenCalled();
+      expect(exit1).not.toHaveBeenCalled();
+
+      funcDecl = { type: 'FunctionDeclaration', name: 'foo', ...SPAN };
+      funcDeclEnterExit.enter(funcDecl);
+      expect(enter1).toHaveBeenCalledWith(funcDecl);
+      expect(enter2).toHaveBeenCalledWith(funcDecl);
+      funcDecl = { type: 'FunctionDeclaration', name: 'foo', ...SPAN };
+      funcDeclEnterExit.exit(funcDecl);
+      expect(exit1).toHaveBeenCalledWith(funcDecl);
+      expect(exit2).toHaveBeenCalledWith(funcDecl);
     });
   });
 

--- a/apps/oxlint/test/e2e.test.ts
+++ b/apps/oxlint/test/e2e.test.ts
@@ -159,6 +159,10 @@ describe('oxlint CLI', () => {
     await testFixture('sourceCode_late_access_after_only');
   });
 
+  it('should support selectors', async () => {
+    await testFixture('selector');
+  });
+
   it('should support `createOnce`', async () => {
     await testFixture('createOnce');
   });

--- a/apps/oxlint/test/fixtures/selector/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/selector/.oxlintrc.json
@@ -1,0 +1,9 @@
+{
+  "jsPlugins": ["./plugin.ts"],
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    "selectors/check": "error"
+  }
+}

--- a/apps/oxlint/test/fixtures/selector/files/index.js
+++ b/apps/oxlint/test/fixtures/selector/files/index.js
@@ -1,0 +1,6 @@
+const obj = { a: [b, c], ...d };
+
+function foo() {}
+function bar() {}
+
+(() => {});

--- a/apps/oxlint/test/fixtures/selector/output.snap.md
+++ b/apps/oxlint/test/fixtures/selector/output.snap.md
@@ -1,0 +1,131 @@
+# Exit code
+1
+
+# stdout
+```
+  x selectors(check):
+  | *: Program
+  | :not(Identifier): Program
+  | *: VariableDeclaration
+  | :not(Identifier): VariableDeclaration
+  | *: VariableDeclarator
+  | :not(Identifier): VariableDeclarator
+  | *: Identifier(obj)
+  | Identifier: Identifier(obj)
+  | :matches(Identifier, FunctionDeclaration): Identifier(obj)
+  | *:exit: Identifier(obj)
+  | *: ObjectExpression
+  | :not(Identifier): ObjectExpression
+  | *: Property
+  | :not(Identifier): Property
+  | *: Identifier(a)
+  | Identifier: Identifier(a)
+  | Identifier[name=a]: Identifier(a)
+  | :matches(Identifier, FunctionDeclaration): Identifier(a)
+  | :matches(Identifier[name=a], FunctionDeclaration[id.name=foo]): Identifier(a)
+  | Property > Identifier: Identifier(a)
+  | ObjectExpression > Property > Identifier: Identifier(a)
+  | ObjectExpression > Property > Identifier[name=a]: Identifier(a)
+  | ObjectExpression Identifier: Identifier(a)
+  | *:exit: Identifier(a)
+  | *: ArrayExpression
+  | :not(Identifier): ArrayExpression
+  | ObjectExpression ArrayExpression: ArrayExpression
+  | *: Identifier(b)
+  | Identifier: Identifier(b)
+  | :matches(Identifier, FunctionDeclaration): Identifier(b)
+  | ArrayExpression > Identifier: Identifier(b)
+  | Program > VariableDeclaration > VariableDeclarator > ObjectExpression > Property > ArrayExpression > Identifier: Identifier(b)
+  | ObjectExpression Identifier: Identifier(b)
+  | ArrayExpression Identifier: Identifier(b)
+  | ArrayExpression Identifier[name=b]: Identifier(b)
+  | *:exit: Identifier(b)
+  | *: Identifier(c)
+  | Identifier: Identifier(c)
+  | :matches(Identifier, FunctionDeclaration): Identifier(c)
+  | ArrayExpression > Identifier: Identifier(c)
+  | ArrayExpression > Identifier[name=c]: Identifier(c)
+  | Program > VariableDeclaration > VariableDeclarator > ObjectExpression > Property > ArrayExpression > Identifier: Identifier(c)
+  | ObjectExpression Identifier: Identifier(c)
+  | ArrayExpression Identifier: Identifier(c)
+  | Identifier ~ Identifier: Identifier(c)
+  | *:exit: Identifier(c)
+  | *:exit: ArrayExpression
+  | *:exit: Property
+  | *: SpreadElement
+  | :not(Identifier): SpreadElement
+  | Property ~ [type]: SpreadElement
+  | :matches(ObjectExpression > SpreadElement, FunctionDeclaration): SpreadElement
+  | :matches(ObjectExpression > SpreadElement, FunctionDeclaration[id.name=bar]): SpreadElement
+  | *: Identifier(d)
+  | Identifier: Identifier(d)
+  | Identifier[name=d]: Identifier(d)
+  | :matches(Identifier, FunctionDeclaration): Identifier(d)
+  | ObjectExpression Identifier: Identifier(d)
+  | *:exit: Identifier(d)
+  | *:exit: SpreadElement
+  | *:exit: ObjectExpression
+  | *:exit: VariableDeclarator
+  | *:exit: VariableDeclaration
+  | *: FunctionDeclaration(foo)
+  | :matches(Identifier, FunctionDeclaration): FunctionDeclaration(foo)
+  | :matches(Identifier[name=a], FunctionDeclaration[id.name=foo]): FunctionDeclaration(foo)
+  | :not(Identifier): FunctionDeclaration(foo)
+  | :function: FunctionDeclaration(foo)
+  | Program > FunctionDeclaration: FunctionDeclaration(foo)
+  | VariableDeclaration ~ FunctionDeclaration: FunctionDeclaration(foo)
+  | VariableDeclaration + FunctionDeclaration: FunctionDeclaration(foo)
+  | :matches(ObjectExpression > SpreadElement, FunctionDeclaration): FunctionDeclaration(foo)
+  | *: Identifier(foo)
+  | Identifier: Identifier(foo)
+  | :matches(Identifier, FunctionDeclaration): Identifier(foo)
+  | *:exit: Identifier(foo)
+  | *: BlockStatement
+  | :not(Identifier): BlockStatement
+  | *:exit: BlockStatement
+  | *:exit: FunctionDeclaration(foo)
+  | *: FunctionDeclaration(bar)
+  | :matches(Identifier, FunctionDeclaration): FunctionDeclaration(bar)
+  | :not(Identifier): FunctionDeclaration(bar)
+  | :function: FunctionDeclaration(bar)
+  | Program > FunctionDeclaration: FunctionDeclaration(bar)
+  | VariableDeclaration ~ FunctionDeclaration: FunctionDeclaration(bar)
+  | :matches(ObjectExpression > SpreadElement, FunctionDeclaration): FunctionDeclaration(bar)
+  | :matches(ObjectExpression > SpreadElement, FunctionDeclaration[id.name=bar]): FunctionDeclaration(bar)
+  | *: Identifier(bar)
+  | Identifier: Identifier(bar)
+  | :matches(Identifier, FunctionDeclaration): Identifier(bar)
+  | *:exit: Identifier(bar)
+  | *: BlockStatement
+  | :not(Identifier): BlockStatement
+  | *:exit: BlockStatement
+  | *:exit: FunctionDeclaration(bar)
+  | *: ExpressionStatement
+  | :not(Identifier): ExpressionStatement
+  | *: ArrowFunctionExpression
+  | :not(Identifier): ArrowFunctionExpression
+  | :function: ArrowFunctionExpression
+  | *: BlockStatement
+  | :not(Identifier): BlockStatement
+  | *:exit: BlockStatement
+  | *:exit: ArrowFunctionExpression
+  | *:exit: ExpressionStatement
+  | *:exit: Program
+   ,-[files/index.js:1:1]
+ 1 | ,-> const obj = { a: [b, c], ...d };
+ 2 | |   
+ 3 | |   function foo() {}
+ 4 | |   function bar() {}
+ 5 | |   
+ 6 | `-> (() => {});
+   `----
+
+Found 0 warnings and 1 error.
+Finished in Xms on 1 file using X threads.
+```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/selector/plugin.ts
+++ b/apps/oxlint/test/fixtures/selector/plugin.ts
@@ -1,0 +1,85 @@
+import type { ESTree, Plugin, Visitor } from '../../../dist/index.js';
+
+const plugin: Plugin = {
+  meta: {
+    name: 'selectors',
+  },
+  rules: {
+    check: {
+      create(context) {
+        const keys = [
+          // Wildcard
+          '*',
+          // Node type
+          'Identifier',
+          // Attributes
+          'Identifier[name=a]',
+          'Identifier[name=d]',
+          // :matches
+          ':matches(Identifier, FunctionDeclaration)',
+          ':matches(Identifier[name=a], FunctionDeclaration[id.name=foo])',
+          // :not
+          ':not(Identifier)',
+          // class
+          ':function',
+          // Child
+          'Property > Identifier',
+          'ObjectExpression > Identifier', // does not match
+          'ObjectExpression > Property > Identifier',
+          'ObjectExpression > Property > Identifier[name=a]',
+          'ObjectExpression > Property > Identifier[name=b]', // does not match
+          'ArrayExpression > Identifier',
+          'ArrayExpression > Identifier[name=c]',
+          'Program > VariableDeclaration > VariableDeclarator > ObjectExpression > Property > ArrayExpression > Identifier',
+          'Program > FunctionDeclaration',
+          // Descendent
+          'ObjectExpression Identifier',
+          'ObjectExpression ArrayExpression',
+          'ArrayExpression Identifier',
+          'ArrayExpression Identifier[name=b]',
+          // Sibling
+          'Identifier ~ Identifier',
+          'Property ~ [type]',
+          'VariableDeclaration ~ FunctionDeclaration',
+          'VariableDeclaration + FunctionDeclaration',
+          // Combination
+          ':matches(ObjectExpression > SpreadElement, FunctionDeclaration)',
+          ':matches(ObjectExpression > SpreadElement, FunctionDeclaration[id.name=bar])',
+          // Wildcard
+          '*:exit',
+        ];
+
+        const visitor: Visitor = {};
+        const visits: { key: string; node: ESTree.Node }[] = [];
+
+        for (const key of keys) {
+          visitor[key] = (node) => {
+            visits.push({ key, node });
+          };
+        }
+
+        visitor['Program:exit'] = (program) => {
+          const visitLog = visits.map(({ key, node }) => {
+            const { type } = node;
+            let nodeDescription = type;
+            if (type === 'Identifier') {
+              nodeDescription += `(${node.name})`;
+            } else if (type === 'FunctionDeclaration') {
+              nodeDescription += `(${node.id.name})`;
+            }
+            return `${key}: ${nodeDescription}`;
+          }).join('\n');
+
+          context.report({
+            message: `\n${visitLog}`,
+            node: program,
+          });
+        };
+
+        return visitor;
+      },
+    },
+  },
+};
+
+export default plugin;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,9 +53,18 @@ importers:
 
   apps/oxlint:
     devDependencies:
+      '@types/esquery':
+        specifier: ^1.5.4
+        version: 1.5.4
+      '@types/estree':
+        specifier: ^1.0.8
+        version: 1.0.8
       eslint:
         specifier: ^9.36.0
         version: 9.36.0(jiti@2.6.0)
+      esquery:
+        specifier: ^1.6.0
+        version: 1.6.0
       execa:
         specifier: ^9.6.0
         version: 9.6.0
@@ -1813,6 +1822,9 @@ packages:
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/esquery@1.5.4':
+    resolution: {integrity: sha512-yYO4Q8H+KJHKW1rEeSzHxcZi90durqYgWVfnh5K6ZADVBjBv2e1NEveYX5yT2bffgN7RqzH3k9930m+i2yBoMA==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -5466,6 +5478,10 @@ snapshots:
       '@types/deep-eql': 4.0.2
 
   '@types/deep-eql@4.0.2': {}
+
+  '@types/esquery@1.5.4':
+    dependencies:
+      '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
 


### PR DESCRIPTION
Implement support for selectors DSL in Oxlint JS plugins.

The implementation is based on ESLint's implementation. Like ESLint, it uses [esquery](https://www.npmjs.com/package/esquery) as the underlying selector parser and matcher.

One detail is not implemented. ESLint ensures that visit functions are called in order of their "specificity" with the most specific called first. This implementation just calls them in the order they're defined. This is a shortcoming and will need to be fixed in future, but I imagine that in practice visitation order makes no difference for the vast majority of rules.

I've made what I hope are some optimizations versus ESLint's version. Notably:

1. Making simple selectors which unconditionally visit a subset of nodes (e.g. `:matches(FunctionDeclaration, FunctionExpression)` bypass the selector match process - as it'd always return `true` anyway.
2. Faster implementations of union and intersection.
