### PR TITLE
test(napi/parser): increase timeout flag for fixture tests

### DIFF
--- a/napi/parser/test/parse-raw.test.ts
+++ b/napi/parser/test/parse-raw.test.ts
@@ -220,7 +220,7 @@ describe.concurrent('edge cases', () => {
 });
 
 // Test raw transfer output matches standard (via JSON) output for some large files
-describe.concurrent('fixtures', () => {
+describe.concurrent('fixtures', { timeout: 10_000 }, () => {
   // oxlint-disable-next-line jest/expect-expect
   it.each(benchFixturePaths)('%s', path => runCaseInWorker(TEST_TYPE_FIXTURE, path));
 });


### PR DESCRIPTION
I am still seeing this failure on some PRs

```
2025-10-07T17:20:30.0133725Z [31m   [31m×[31m fixtures[2m > [22mtarget/antd.js[39m[33m 5032[2mms[22m[39m
2025-10-07T17:20:30.0133896Z [31m     → Test timed out in 5000ms.
2025-10-07T17:20:30.0134434Z If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".[39m
```