### PR TITLE
perf(linter): only run rule run functions if implemented

### DIFF
--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -100,6 +100,24 @@ pub enum RuleRunFunctionsImplemented {
     RunOnJestNode,
 }
 
+impl RuleRunFunctionsImplemented {
+    pub fn is_run_implemented(self) -> bool {
+        matches!(self, Self::Run | Self::Unknown)
+    }
+
+    pub fn is_run_once_implemented(self) -> bool {
+        matches!(self, Self::RunOnce | Self::Unknown)
+    }
+
+    pub fn is_run_on_symbol_implemented(self) -> bool {
+        matches!(self, Self::RunOnSymbol | Self::Unknown)
+    }
+
+    pub fn is_run_on_jest_node_implemented(self) -> bool {
+        matches!(self, Self::RunOnJestNode | Self::Unknown)
+    }
+}
+
 pub trait RuleMeta {
     const NAME: &'static str;
 


### PR DESCRIPTION
Optimizes the native linter runtime by skipping rule run functions which are known to be no-ops. If we don't know anything about the rule functions implemented, we run all of them by default.