### PR TITLE
perf(linter): refactor `no-invalid-fetch-options` to be more easily analyzed

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2416,7 +2416,8 @@ impl RuleRunner for crate::rules::unicorn::no_instanceof_builtins::NoInstanceofB
 }
 
 impl RuleRunner for crate::rules::unicorn::no_invalid_fetch_options::NoInvalidFetchOptions {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::NewExpression]));
 }
 
 impl RuleRunner

--- a/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
@@ -59,29 +59,30 @@ declare_oxc_lint!(
 
 impl Rule for NoInvalidFetchOptions {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let arg = match node.kind() {
+        match node.kind() {
             AstKind::CallExpression(call_expr) => {
                 if !call_expr.callee.is_specific_id("fetch") || call_expr.arguments.len() < 2 {
                     return;
                 }
 
-                &call_expr.arguments[1]
+                if let Argument::ObjectExpression(expr) = &call_expr.arguments[1]
+                    && let Some((method_name, body_span)) = is_invalid_fetch_options(expr, ctx)
+                {
+                    ctx.diagnostic(no_invalid_fetch_options_diagnostic(body_span, &method_name));
+                }
             }
             AstKind::NewExpression(new_expr) => {
                 if !is_new_expression(new_expr, &["Request"], Some(2), None) {
                     return;
                 }
 
-                &new_expr.arguments[1]
+                if let Argument::ObjectExpression(expr) = &new_expr.arguments[1]
+                    && let Some((method_name, body_span)) = is_invalid_fetch_options(expr, ctx)
+                {
+                    ctx.diagnostic(no_invalid_fetch_options_diagnostic(body_span, &method_name));
+                }
             }
-            _ => return,
-        };
-
-        let Argument::ObjectExpression(expr) = arg else { return };
-        let result = is_invalid_fetch_options(expr, ctx);
-
-        if let Some((method_name, body_span)) = result {
-            ctx.diagnostic(no_invalid_fetch_options_diagnostic(body_span, &method_name));
+            _ => {}
         }
     }
 }


### PR DESCRIPTION
Updating the code style here so that the linter codegen can more easily analyze this rule's node types.

+1% perf gain on the radix UI benchmark file.