### PR TITLE
release(oxfmt): v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_formatter"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cow-utils",
  "oxc_allocator 0.94.0",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "oxfmt"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bpaf",
  "cow-utils",

--- a/apps/oxfmt/CHANGELOG.md
+++ b/apps/oxfmt/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.3.0] - 2025-09-19
 
 ### 🐛 Bug Fixes

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxfmt"
-version = "0.3.0"
+version = "0.4.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_formatter/CHANGELOG.md
+++ b/crates/oxc_formatter/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.4.0] - 2025-10-09
+
+### 🚀 Features
+
+- 142e7ac formatter/sort-imports: Implement options.ignoreCase: bool (#14367) (leaysgur)
+- 5c8bd31 formatter/sort-imports: Implement options.sortSideEffects: bool (#14293) (leaysgur)
+- 593c416 formatter/sort-imports: Add options.order: asc|desc (#14292) (leaysgur)
+- f1a1f89 formatter/sort-imports: Implement basic sorting with tests (#14291) (leaysgur)
+- f75b8f7 formatter/sort-imports: Wrap `ImportDeclaration` with `JsLabels` (#14109) (leaysgur)
+- 6be4ae5 formatter/sort-imports: Experimental sort-imports base (#14105) (leaysgur)
+- cb29117 formatter: Correct printing parameters with `return_type` for function-like node (#14084) (Dunqing)
+- 90fd46f formatter: Normalize key of `TSPropertySignature` (#14083) (Dunqing)
+- 6cfce80 formatter: Implement formatting for `TSTypeAliasDeclaration` (#14040) (Dunqing)
+- 3097b60 formatter: Implement formatting for `TSMappedType` (#14025) (Dunqing)
+- cd620bd formatter: Correct printing for `Class` (#14024) (Dunqing)
+- 03244f1 formatter: Correct printing for `TSConditionalType` (#14023) (Dunqing)
+- f6dc981 formatter: Implement formatting for `TSTupletype` (#14019) (Dunqing)
+- 10a41ab formatter: Export doc() API to inspect IR in example (#14068) (leaysgur)
+- 06a1df6 formatter: Implement formatting for `TSTypeParameters` and `TSTypeParameterInstantiation` (#13919) (Dunqing)
+- 9b46dd7 formatter: Implement formatting for `TSTypeAssertion` (#13911) (Dunqing)
+- 5710b13 formatter: Implement formatting for `TSIntersectiontype` (#13910) (Dunqing)
+- 2d18144 formatter: Implement formatting for `TSUnionType` (#13893) (Dunqing)
+- 0f15ed3 formatter: Implement formatting for `TSAsExpression` and `TSSatisfiesExpression` (#13892) (Dunqing)
+
+### 🐛 Bug Fixes
+
+- ad5c18a formatter: Correct parentheses in `TSIntersectionType` (#14098) (Noel Kim (김민혁))
+- 7c09b20 formatter: Print comments incorrectly if the node is without following a node (#14110) (Dunqing)
+- ed33fad formatter: Merge the right side of `LogicalExpression` if it's a `LogicalExpression` and both have the same `operator` (#14097) (Dunqing)
+- 1b0519c formatter: Correct printing comments within the type annotation of ArrayPattern and `ObjectPattern` (#14077) (Dunqing)
+- e299ab0 formatter: Correct printing comments around decorators (#14076) (Dunqing)
+- 7d11047 formatter: Correct a bunch of implementations for TypeScript (#14069) (Dunqing)
+- 57cbf84 formatter: Correct preserving parentheses for `TSXXXType` nodes (#14022) (Dunqing)
+- 134f255 formatter: Missing parenthesis for `NewExpression` whose callee is a `TSNonNullExpression` with `TaggedTemplateExpression` (#14021) (Dunqing)
+- 1e9ce4e formatter: Skip the parent node if it is a `TSNonNullExpression` or `AstNodes::ChainExpression` for `StaticMemberExpression` (#14020) (Dunqing)
+- 3ce0775 formatter: Missing semicolon for `declare` function (#13928) (Dunqing)
+
+### 🚜 Refactor
+
+- 70bd141 formatter: Improve formatting of `Function` and `ArrowFunctionExpression` with types (#14070) (Dunqing)
+
+
 ## [0.3.0] - 2025-09-19
 
 ### 🚀 Features

--- a/crates/oxc_formatter/Cargo.toml
+++ b/crates/oxc_formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_formatter"
-version = "0.3.0"
+version = "0.4.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/npm/oxfmt/CHANGELOG.md
+++ b/npm/oxfmt/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.4.0] - 2025-10-09
+
+### 🐛 Bug Fixes
+
+- 59dc17e oxfmt: Change bin script to ESM (#14263) (Boshen)
+
+### 🚜 Refactor
+
+- 226deee oxfmt: Rename build script to `.js` (#14046) (overlookmotel)
+
+
 ## [0.3.0] - 2025-09-19
 
 ### 🚀 Features

--- a/npm/oxfmt/package.json
+++ b/npm/oxfmt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxfmt",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "description": "Formatter for the JavaScript Oxidation Compiler",
   "keywords": [],


### PR DESCRIPTION
## [0.4.0] - 2025-10-09

### 🚀 Features

- 142e7ac formatter/sort-imports: Implement options.ignoreCase: bool (#14367) (leaysgur)
- 5c8bd31 formatter/sort-imports: Implement options.sortSideEffects: bool (#14293) (leaysgur)
- 593c416 formatter/sort-imports: Add options.order: asc|desc (#14292) (leaysgur)
- f1a1f89 formatter/sort-imports: Implement basic sorting with tests (#14291) (leaysgur)
- f75b8f7 formatter/sort-imports: Wrap `ImportDeclaration` with `JsLabels` (#14109) (leaysgur)
- 6be4ae5 formatter/sort-imports: Experimental sort-imports base (#14105) (leaysgur)
- cb29117 formatter: Correct printing parameters with `return_type` for function-like node (#14084) (Dunqing)
- 90fd46f formatter: Normalize key of `TSPropertySignature` (#14083) (Dunqing)
- 6cfce80 formatter: Implement formatting for `TSTypeAliasDeclaration` (#14040) (Dunqing)
- 3097b60 formatter: Implement formatting for `TSMappedType` (#14025) (Dunqing)
- cd620bd formatter: Correct printing for `Class` (#14024) (Dunqing)
- 03244f1 formatter: Correct printing for `TSConditionalType` (#14023) (Dunqing)
- f6dc981 formatter: Implement formatting for `TSTupletype` (#14019) (Dunqing)
- 10a41ab formatter: Export doc() API to inspect IR in example (#14068) (leaysgur)
- 06a1df6 formatter: Implement formatting for `TSTypeParameters` and `TSTypeParameterInstantiation` (#13919) (Dunqing)
- 9b46dd7 formatter: Implement formatting for `TSTypeAssertion` (#13911) (Dunqing)
- 5710b13 formatter: Implement formatting for `TSIntersectiontype` (#13910) (Dunqing)
- 2d18144 formatter: Implement formatting for `TSUnionType` (#13893) (Dunqing)
- 0f15ed3 formatter: Implement formatting for `TSAsExpression` and `TSSatisfiesExpression` (#13892) (Dunqing)

### 🐛 Bug Fixes

- 59dc17e oxfmt: Change bin script to ESM (#14263) (Boshen)
- ad5c18a formatter: Correct parentheses in `TSIntersectionType` (#14098) (Noel Kim (김민혁))
- 7c09b20 formatter: Print comments incorrectly if the node is without following a node (#14110) (Dunqing)
- ed33fad formatter: Merge the right side of `LogicalExpression` if it's a `LogicalExpression` and both have the same `operator` (#14097) (Dunqing)
- 1b0519c formatter: Correct printing comments within the type annotation of ArrayPattern and `ObjectPattern` (#14077) (Dunqing)
- e299ab0 formatter: Correct printing comments around decorators (#14076) (Dunqing)
- 7d11047 formatter: Correct a bunch of implementations for TypeScript (#14069) (Dunqing)
- 57cbf84 formatter: Correct preserving parentheses for `TSXXXType` nodes (#14022) (Dunqing)
- 134f255 formatter: Missing parenthesis for `NewExpression` whose callee is a `TSNonNullExpression` with `TaggedTemplateExpression` (#14021) (Dunqing)
- 1e9ce4e formatter: Skip the parent node if it is a `TSNonNullExpression` or `AstNodes::ChainExpression` for `StaticMemberExpression` (#14020) (Dunqing)
- 3ce0775 formatter: Missing semicolon for `declare` function (#13928) (Dunqing)

### 🚜 Refactor

- 70bd141 formatter: Improve formatting of `Function` and `ArrowFunctionExpression` with types (#14070) (Dunqing)
- 226deee oxfmt: Rename build script to `.js` (#14046) (overlookmotel)