### PR TITLE
fix(oxc_formatter): Fix arrow_parentheses: 'avoid' > 'as-needed'

### DIFF
--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -596,8 +596,7 @@ impl FromStr for ArrowParentheses {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            // Prettier calls it `avoid`, but Biome calls it `AsNeeded`
-            "avoid" => Ok(Self::AsNeeded),
+            "as-needed" => Ok(Self::AsNeeded),
             "always" => Ok(Self::Always),
             _ => Err(
                 "Value not supported for Arrow parentheses. Supported values are 'as-needed' and 'always'.",

--- a/tasks/prettier_conformance/src/spec.rs
+++ b/tasks/prettier_conformance/src/spec.rs
@@ -187,8 +187,11 @@ impl VisitMut<'_> for SpecParser {
                                 }
                                 "arrowParens" => {
                                     // TODO: change `unwrap_or_default` to `unwrap`
-                                    options.arrow_parentheses =
-                                        ArrowParentheses::from_str(s).unwrap_or_default();
+                                    options.arrow_parentheses = ArrowParentheses::from_str(
+                                        // Prettier uses "avoid", but we use "as-needed"
+                                        if s == "avoid" { "as-needed" } else { s },
+                                    )
+                                    .unwrap_or_default();
                                 }
                                 "experimentalOperatorPosition" => {
                                     // TODO: change `unwrap_or_default` to `unwrap`


### PR DESCRIPTION
Instead of Prettier's term, use that match our code.