### PR TITLE
fix(oxfmt): Normalize path delimiter on Windows

### DIFF
--- a/apps/oxfmt/tests/snapshots/tests__fixtures__config_file_--check --config .__fmt.json --check --config .__fmt.jsonc --check --config NOT_EXISTS.json@oxfmt.snap
+++ b/apps/oxfmt/tests/snapshots/tests__fixtures__config_file_--check --config .__fmt.json --check --config .__fmt.jsonc --check --config NOT_EXISTS.json@oxfmt.snap
@@ -32,7 +32,7 @@ arguments: --check --config NOT_EXISTS.json
 working directory: tests/fixtures/config_file
 ----------
 Failed to load configuration file.
-Failed to read config <cwd>/tests/fixtures/config_file/NOT_EXISTS.json: No such file or directory (os error 2)
+Failed to read config <cwd>/tests/fixtures/config_file/NOT_EXISTS.json: File not found
 ----------
 CLI result: InvalidOptionConfig
 ----------

--- a/apps/oxfmt/tests/tester.rs
+++ b/apps/oxfmt/tests/tester.rs
@@ -79,14 +79,15 @@ impl Tester {
         let regex = Regex::new(r"\d+(?:\.\d+)?s|\d+ms").unwrap();
         let output_string = regex.replace_all(output_string, "<variable>ms").into_owned();
 
+        // Normalize all backslashes to forward slashes first (for Windows paths)
+        let output_string = output_string.cow_replace('\\', "/").to_string();
+
         // do not output the current working directory, each machine has a different one
-        let current_cwd_string = current_cwd.to_str().unwrap();
-        let current_cwd_string = current_cwd_string.cow_replace('\\', "/").to_string(); // for windows
+        let current_cwd_string = current_cwd.to_str().unwrap().cow_replace('\\', "/").to_string();
         let output_string = output_string.cow_replace(&current_cwd_string, "<cwd>");
 
         // Also replace the test cwd path
-        let test_cwd_string = self.cwd.to_str().unwrap();
-        let test_cwd_string = test_cwd_string.cow_replace('\\', "/").to_string(); // for windows
+        let test_cwd_string = self.cwd.to_str().unwrap().cow_replace('\\', "/").to_string();
         let output_string = output_string.cow_replace(&test_cwd_string, "<cwd>");
 
         let full_args_list =

--- a/crates/oxc_formatter/src/service/oxfmtrc.rs
+++ b/crates/oxc_formatter/src/service/oxfmtrc.rs
@@ -87,7 +87,8 @@ impl Oxfmtrc {
     pub fn from_file(path: &Path) -> Result<Self, String> {
         // TODO: Use `simdutf8` like `oxc_linter`?
         let mut string = std::fs::read_to_string(path)
-            .map_err(|err| format!("Failed to read config {}: {err}", path.display()))?;
+            // Do not include OS error, it differs between platforms
+            .map_err(|_| format!("Failed to read config {}: File not found", path.display()))?;
 
         // JSONC support - strip comments
         json_strip_comments::strip(&mut string)


### PR DESCRIPTION
Fixes CI fails on `main` branch. 🙇🏻 