### PR TITLE
feat(language_server): autodetect root `.oxfmtrc.json`

### DIFF
--- a/crates/oxc_language_server/fixtures/formatter/root_config/.oxfmtrc.json
+++ b/crates/oxc_language_server/fixtures/formatter/root_config/.oxfmtrc.json
@@ -1,0 +1,3 @@
+{
+  "semicolons": "as-needed"
+}

--- a/crates/oxc_language_server/fixtures/formatter/root_config/semicolons-as-needed.ts
+++ b/crates/oxc_language_server/fixtures/formatter/root_config/semicolons-as-needed.ts
@@ -1,0 +1,2 @@
+// semicolon is on character 8-9, which will be removed
+debugger;

--- a/crates/oxc_language_server/src/formatter/server_formatter.rs
+++ b/crates/oxc_language_server/src/formatter/server_formatter.rs
@@ -1,20 +1,28 @@
+use std::path::Path;
+
+use log::warn;
 use oxc_allocator::Allocator;
 use oxc_data_structures::rope::{Rope, get_line_column};
-use oxc_formatter::{FormatOptions, Formatter, get_supported_source_type};
+use oxc_formatter::{FormatOptions, Formatter, Oxfmtrc, get_supported_source_type};
 use oxc_parser::{ParseOptions, Parser};
 use tower_lsp_server::{
     UriExt,
     lsp_types::{Position, Range, TextEdit, Uri},
 };
 
-pub struct ServerFormatter;
+use crate::FORMAT_CONFIG_FILE;
+
+pub struct ServerFormatter {
+    options: FormatOptions,
+}
 
 impl ServerFormatter {
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(root_uri: &Uri) -> Self {
+        let root_path = root_uri.to_file_path().unwrap();
+
+        Self { options: Self::get_format_options(&root_path) }
     }
 
-    #[expect(clippy::unused_self)]
     pub fn run_single(&self, uri: &Uri, content: Option<String>) -> Option<Vec<TextEdit>> {
         let path = uri.to_file_path()?;
         let source_type = get_supported_source_type(&path)?;
@@ -46,8 +54,7 @@ impl ServerFormatter {
             return None;
         }
 
-        let options = FormatOptions::default();
-        let code = Formatter::new(&allocator, options).build(&ret.program);
+        let code = Formatter::new(&allocator, self.options.clone()).build(&ret.program);
 
         // nothing has changed
         if code == source_text {
@@ -66,6 +73,33 @@ impl ServerFormatter {
             ),
             replacement.to_string(),
         )])
+    }
+
+    fn get_format_options(root_path: &Path) -> FormatOptions {
+        let config_path = FORMAT_CONFIG_FILE;
+        let config = root_path.join(config_path); // normalize_path when supporting `oxc.fmt.configPath`
+        let oxfmtrc = if config.try_exists().is_ok_and(|exists| exists) {
+            if let Ok(oxfmtrc) = Oxfmtrc::from_file(&config) {
+                oxfmtrc
+            } else {
+                warn!("Failed to initialize oxfmtrc config: {}", config.to_string_lossy());
+                Oxfmtrc::default()
+            }
+        } else {
+            warn!(
+                "Config file not found: {}, fallback to default config",
+                config.to_string_lossy()
+            );
+            Oxfmtrc::default()
+        };
+
+        match oxfmtrc.into_format_options() {
+            Ok(options) => options,
+            Err(err) => {
+                warn!("Failed to parse oxfmtrc config: {err}, fallback to default config");
+                FormatOptions::default()
+            }
+        }
     }
 }
 
@@ -200,5 +234,11 @@ mod tests {
     fn test_formatter() {
         Tester::new("fixtures/formatter/basic", Some(FormatOptions { experimental: true }))
             .format_and_snapshot_single_file("basic.ts");
+    }
+
+    #[test]
+    fn test_root_config_detection() {
+        Tester::new("fixtures/formatter/root_config", Some(FormatOptions { experimental: true }))
+            .format_and_snapshot_single_file("semicolons-as-needed.ts");
     }
 }

--- a/crates/oxc_language_server/src/linter/config_walker.rs
+++ b/crates/oxc_language_server/src/linter/config_walker.rs
@@ -6,7 +6,7 @@ use std::{
 
 use ignore::DirEntry;
 
-use crate::OXC_CONFIG_FILE;
+use crate::LINT_CONFIG_FILE;
 
 pub struct ConfigWalker {
     inner: ignore::WalkParallel,
@@ -56,7 +56,7 @@ impl WalkCollector {
         }
         let Some(file_name) = entry.path().file_name() else { return false };
 
-        file_name == OXC_CONFIG_FILE
+        file_name == LINT_CONFIG_FILE
     }
 }
 

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -21,7 +21,7 @@ use crate::linter::{
     options::{LintOptions as LSPLintOptions, Run},
     tsgo_linter::TsgoLinter,
 };
-use crate::{ConcurrentHashMap, OXC_CONFIG_FILE};
+use crate::{ConcurrentHashMap, LINT_CONFIG_FILE};
 
 use super::config_walker::ConfigWalker;
 
@@ -90,7 +90,7 @@ impl ServerLinter {
         let mut nested_ignore_patterns = Vec::new();
         let (nested_configs, mut extended_paths) =
             Self::create_nested_configs(&root_path, options, &mut nested_ignore_patterns);
-        let config_path = options.config_path.as_ref().map_or(OXC_CONFIG_FILE, |v| v);
+        let config_path = options.config_path.as_ref().map_or(LINT_CONFIG_FILE, |v| v);
         let config = normalize_path(root_path.join(config_path));
         let oxlintrc = if config.try_exists().is_ok_and(|exists| exists) {
             if let Ok(oxlintrc) = Oxlintrc::from_file(&config) {

--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -17,7 +17,8 @@ use crate::backend::Backend;
 
 type ConcurrentHashMap<K, V> = papaya::HashMap<K, V, FxBuildHasher>;
 
-const OXC_CONFIG_FILE: &str = ".oxlintrc.json";
+const LINT_CONFIG_FILE: &str = ".oxlintrc.json";
+const FORMAT_CONFIG_FILE: &str = ".oxfmtrc.json";
 
 #[tokio::main]
 async fn main() {

--- a/crates/oxc_language_server/src/snapshots/fixtures_formatter_root_config@semicolons-as-needed.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_formatter_root_config@semicolons-as-needed.ts.snap
@@ -1,0 +1,16 @@
+---
+source: crates/oxc_language_server/src/formatter/tester.rs
+---
+========================================
+File: fixtures/formatter/root_config/semicolons-as-needed.ts
+========================================
+Range: Range {
+    start: Position {
+        line: 1,
+        character: 8,
+    },
+    end: Position {
+        line: 1,
+        character: 9,
+    },
+}

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -71,7 +71,7 @@ impl WorkspaceWorker {
         *self.server_linter.write().await = Some(ServerLinter::new(&self.root_uri, &options.lint));
         if options.format.experimental {
             debug!("experimental formatter enabled");
-            *self.server_formatter.write().await = Some(ServerFormatter::new());
+            *self.server_formatter.write().await = Some(ServerFormatter::new(&self.root_uri));
         }
     }
 
@@ -341,7 +341,7 @@ impl WorkspaceWorker {
         if current_option.format.experimental != changed_options.format.experimental {
             if changed_options.format.experimental {
                 debug!("experimental formatter enabled");
-                *self.server_formatter.write().await = Some(ServerFormatter::new());
+                *self.server_formatter.write().await = Some(ServerFormatter::new(&self.root_uri));
                 formatting = true;
             } else {
                 debug!("experimental formatter disabled");


### PR DESCRIPTION
> This PR implements autodetection of the root .oxfmtrc.json configuration file for the language server's formatter functionality. The language server can now automatically discover and use formatter configuration files located at the workspace root.

It does not support a custom config path, the next PR in this stack will implement it.
When a user does change the content of `.oxfmtrc.json`, he needs to restart the server at the moment.
Need to improve the file watcher implementation, created another stack with tests for current implementation.