### PR TITLE
fix(tsgolint): pipe tsgolints stderr

### DIFF
--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::BTreeSet,
     ffi::OsStr,
-    io::{ErrorKind, Read, Write},
+    io::{ErrorKind, Read, Write, stderr},
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
@@ -87,7 +87,8 @@ impl TsGoLintState {
             let mut cmd = std::process::Command::new(&self.executable_path);
             cmd.arg("headless")
                 .stdin(std::process::Stdio::piped())
-                .stdout(std::process::Stdio::piped());
+                .stdout(std::process::Stdio::piped())
+                .stderr(stderr());
 
             if let Ok(trace_file) = std::env::var("OXLINT_TSGOLINT_TRACE") {
                 cmd.arg(format!("-trace={trace_file}"));


### PR DESCRIPTION
Since we converted oxlint to a napi package, go's debug logging broke. 

It is unclear to me exactly why this broke, but this PR explicitly passes `stderr()`​ to the stderr handler of the child process which fixes ths issue.



If anyone has any better ideas/solutions, please let me know.



This blocks debugging/investigating https://github.com/oxc-project/tsgolint/issues/288