### PR TITLE
refactor(linter): remove lifetime of `Message`

### DIFF
--- a/crates/oxc_language_server/src/linter/error_with_position.rs
+++ b/crates/oxc_language_server/src/linter/error_with_position.rs
@@ -35,7 +35,7 @@ pub enum PossibleFixContent {
 // we assume that the fix offset will not exceed 2GB in either direction
 #[expect(clippy::cast_possible_truncation)]
 pub fn message_to_lsp_diagnostic(
-    message: &Message<'_>,
+    message: &Message,
     uri: &Uri,
     source_text: &str,
     rope: &Rope,
@@ -134,7 +134,7 @@ pub fn message_to_lsp_diagnostic(
     DiagnosticReport { diagnostic, fixed_content }
 }
 
-fn fix_to_fixed_content(fix: &Fix<'_>, rope: &Rope, source_text: &str) -> FixedContent {
+fn fix_to_fixed_content(fix: &Fix, rope: &Rope, source_text: &str) -> FixedContent {
     let start_position = offset_to_position(rope, fix.span.start, source_text);
     let end_position = offset_to_position(rope, fix.span.end, source_text);
 

--- a/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
+++ b/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
@@ -145,7 +145,7 @@ impl IsolatedLintHandler {
         &self,
         directives: &DisableDirectives,
         severity: AllowWarnDeny,
-    ) -> Vec<Message<'_>> {
+    ) -> Vec<Message> {
         let diagnostics = create_unused_directives_diagnostics(directives, severity);
         diagnostics
             .into_iter()

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -132,7 +132,7 @@ pub struct ContextHost<'a> {
     /// Diagnostics reported by the linter.
     ///
     /// Contains diagnostics for all rules across a single file.
-    diagnostics: RefCell<Vec<Message<'a>>>,
+    diagnostics: RefCell<Vec<Message>>,
     /// Whether or not to apply code fixes during linting. Defaults to
     /// [`FixKind::None`] (no fixing).
     ///
@@ -241,7 +241,7 @@ impl<'a> ContextHost<'a> {
     /// Add a diagnostic message to the end of the list of diagnostics. Can be used
     /// by any rule to report issues.
     #[inline]
-    pub(crate) fn push_diagnostic(&self, mut diagnostic: Message<'a>) {
+    pub(crate) fn push_diagnostic(&self, mut diagnostic: Message) {
         if self.current_sub_host().source_text_offset != 0 {
             diagnostic.move_offset(self.current_sub_host().source_text_offset);
         }
@@ -249,7 +249,7 @@ impl<'a> ContextHost<'a> {
     }
 
     // Append a list of diagnostics. Only used in report_unused_directives.
-    fn append_diagnostics(&self, mut diagnostics: Vec<Message<'a>>) {
+    fn append_diagnostics(&self, mut diagnostics: Vec<Message>) {
         if self.current_sub_host().source_text_offset != 0 {
             let offset = self.current_sub_host().source_text_offset;
             for diagnostic in &mut diagnostics {
@@ -345,7 +345,7 @@ impl<'a> ContextHost<'a> {
     }
 
     /// Take ownership of all diagnostics collected during linting.
-    pub fn take_diagnostics(&self) -> Vec<Message<'a>> {
+    pub fn take_diagnostics(&self) -> Vec<Message> {
         // NOTE: diagnostics are only ever borrowed here and in push_diagnostic, append_diagnostics.
         // The latter drops the reference as soon as the function returns, so
         // this should never panic.
@@ -368,7 +368,7 @@ impl<'a> ContextHost<'a> {
     }
 
     #[cfg(debug_assertions)]
-    pub fn get_diagnostics(&self, cb: impl FnOnce(&mut Vec<Message<'a>>)) {
+    pub fn get_diagnostics(&self, cb: impl FnOnce(&mut Vec<Message>)) {
         cb(self.diagnostics.borrow_mut().as_mut());
     }
 
@@ -450,7 +450,7 @@ impl<'a> ContextHost<'a> {
     }
 }
 
-impl<'a> From<ContextHost<'a>> for Vec<Message<'a>> {
+impl<'a> From<ContextHost<'a>> for Vec<Message> {
     fn from(ctx_host: ContextHost<'a>) -> Self {
         ctx_host.diagnostics.into_inner()
     }

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -222,7 +222,7 @@ impl<'a> LintContext<'a> {
 
     /// Add a diagnostic message to the list of diagnostics. Outputs a diagnostic with the current rule
     /// name, severity, and a link to the rule's documentation URL.
-    fn add_diagnostic(&self, mut message: Message<'a>) {
+    fn add_diagnostic(&self, mut message: Message) {
         if self.parent.disable_directives().contains(self.current_rule_name, message.span()) {
             return;
         }
@@ -272,7 +272,7 @@ impl<'a> LintContext<'a> {
     #[inline]
     pub fn diagnostic_with_fix<C, F>(&self, diagnostic: OxcDiagnostic, fix: F)
     where
-        C: Into<RuleFix<'a>>,
+        C: Into<RuleFix>,
         F: FnOnce(RuleFixer<'_, 'a>) -> C,
     {
         self.diagnostic_with_fix_of_kind(diagnostic, FixKind::SafeFix, fix);
@@ -293,7 +293,7 @@ impl<'a> LintContext<'a> {
     #[inline]
     pub fn diagnostic_with_suggestion<C, F>(&self, diagnostic: OxcDiagnostic, fix: F)
     where
-        C: Into<RuleFix<'a>>,
+        C: Into<RuleFix>,
         F: FnOnce(RuleFixer<'_, 'a>) -> C,
     {
         self.diagnostic_with_fix_of_kind(diagnostic, FixKind::Suggestion, fix);
@@ -314,7 +314,7 @@ impl<'a> LintContext<'a> {
     #[inline]
     pub fn diagnostic_with_dangerous_suggestion<C, F>(&self, diagnostic: OxcDiagnostic, fix: F)
     where
-        C: Into<RuleFix<'a>>,
+        C: Into<RuleFix>,
         F: FnOnce(RuleFixer<'_, 'a>) -> C,
     {
         self.diagnostic_with_fix_of_kind(diagnostic, FixKind::DangerousSuggestion, fix);
@@ -342,7 +342,7 @@ impl<'a> LintContext<'a> {
     #[inline]
     pub fn diagnostic_with_dangerous_fix<C, F>(&self, diagnostic: OxcDiagnostic, fix: F)
     where
-        C: Into<RuleFix<'a>>,
+        C: Into<RuleFix>,
         F: FnOnce(RuleFixer<'_, 'a>) -> C,
     {
         self.diagnostic_with_fix_of_kind(diagnostic, FixKind::DangerousFix, fix);
@@ -360,7 +360,7 @@ impl<'a> LintContext<'a> {
         fix_kind: FixKind,
         fix: F,
     ) where
-        C: Into<RuleFix<'a>>,
+        C: Into<RuleFix>,
         F: FnOnce(RuleFixer<'_, 'a>) -> C,
     {
         let (diagnostic, fix) = self.create_fix(fix_kind, fix, diagnostic);
@@ -386,11 +386,11 @@ impl<'a> LintContext<'a> {
         fix_one: (FixKind, F1),
         fix_two: (FixKind, F2),
     ) where
-        C: Into<RuleFix<'a>>,
+        C: Into<RuleFix>,
         F1: FnOnce(RuleFixer<'_, 'a>) -> C,
         F2: FnOnce(RuleFixer<'_, 'a>) -> C,
     {
-        let fixes_result: Vec<Fix<'a>> = vec![
+        let fixes_result: Vec<Fix> = vec![
             self.create_fix(fix_one.0, fix_one.1, diagnostic.clone()).1,
             self.create_fix(fix_two.0, fix_two.1, diagnostic.clone()).1,
         ]
@@ -417,13 +417,13 @@ impl<'a> LintContext<'a> {
         fix_kind: FixKind,
         fix: F,
         diagnostic: OxcDiagnostic,
-    ) -> (OxcDiagnostic, Option<Fix<'a>>)
+    ) -> (OxcDiagnostic, Option<Fix>)
     where
-        C: Into<RuleFix<'a>>,
+        C: Into<RuleFix>,
         F: FnOnce(RuleFixer<'_, 'a>) -> C,
     {
         let fixer = RuleFixer::new(fix_kind, self);
-        let rule_fix: RuleFix<'a> = fix(fixer).into();
+        let rule_fix: RuleFix = fix(fixer).into();
         #[cfg(debug_assertions)]
         debug_assert!(
             self.current_rule_fix_capabilities.supports_fix(fix_kind),

--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -40,7 +40,7 @@ pub struct RuleCommentRule {
 
 impl RuleCommentRule {
     #[expect(clippy::cast_possible_truncation)] // for `as u32`
-    pub fn create_fix<'a>(&self, source_text: &'a str, comment_span: Span) -> Fix<'a> {
+    pub fn create_fix(&self, source_text: &str, comment_span: Span) -> Fix {
         let before_source =
             &source_text[comment_span.start as usize..self.name_span.start as usize];
 

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -146,7 +146,7 @@ impl Linter {
         path: &Path,
         context_sub_hosts: Vec<ContextSubHost<'a>>,
         allocator: &'a Allocator,
-    ) -> Vec<Message<'a>> {
+    ) -> Vec<Message> {
         self.run_with_disable_directives(path, context_sub_hosts, allocator).0
     }
 
@@ -159,7 +159,7 @@ impl Linter {
         path: &Path,
         context_sub_hosts: Vec<ContextSubHost<'a>>,
         allocator: &'a Allocator,
-    ) -> (Vec<Message<'a>>, Option<DisableDirectives>) {
+    ) -> (Vec<Message>, Option<DisableDirectives>) {
         let ResolvedLinterState { rules, config, external_rules } = self.config.resolve(path);
 
         let mut ctx_host = Rc::new(ContextHost::new(path, context_sub_hosts, self.options, config));

--- a/crates/oxc_linter/src/rules/eslint/curly.rs
+++ b/crates/oxc_linter/src/rules/eslint/curly.rs
@@ -424,7 +424,7 @@ fn apply_rule_fix<'a>(
     body: &Statement<'a>,
     should_have_braces: bool,
     ctx: &LintContext<'a>,
-) -> RuleFix<'a> {
+) -> RuleFix {
     let source = ctx.source_range(body.span());
 
     let fixed = if should_have_braces {

--- a/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
+++ b/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
@@ -296,9 +296,9 @@ fn get_operator_span(binary_expr: &BinaryExpression, operator: &str, ctx: &LintC
 
 fn apply_rule_fix<'a>(
     fixer: &RuleFixer<'_, 'a>,
-    binary_expr: &BinaryExpression,
-    preferred_operator_with_padding: &'a str,
-) -> RuleFix<'a> {
+    binary_expr: &'a BinaryExpression,
+    preferred_operator_with_padding: &'static str,
+) -> RuleFix {
     let span = Span::new(binary_expr.left.span().end, binary_expr.right.span().start);
 
     fixer.replace(span, preferred_operator_with_padding)

--- a/crates/oxc_linter/src/rules/eslint/for_direction.rs
+++ b/crates/oxc_linter/src/rules/eslint/for_direction.rs
@@ -202,7 +202,7 @@ fn get_fixer_replace_span(update: &Expression) -> Span {
     }
 }
 
-fn apply_rule_fix<'a>(fixer: &RuleFixer<'_, 'a>, update: &Expression) -> RuleFix<'a> {
+fn apply_rule_fix(fixer: &RuleFixer<'_, '_>, update: &Expression) -> RuleFix {
     let span = get_fixer_replace_span(update);
     let replacement = get_fixer_replace_operator(update);
 

--- a/crates/oxc_linter/src/rules/eslint/func_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/func_names.rs
@@ -431,12 +431,12 @@ fn can_safely_apply_fix(func: &Function, name: &str, ctx: &LintContext) -> bool 
     })
 }
 
-fn apply_rule_fix<'a>(
-    fixer: &RuleFixer<'_, 'a>,
+fn apply_rule_fix(
+    fixer: &RuleFixer<'_, '_>,
     is_safe_fix: bool,
     replace_span: Span,
     function_name: Option<String>,
-) -> RuleFix<'a> {
+) -> RuleFix {
     if is_safe_fix && let Some(name) = function_name {
         return fixer.insert_text_after(&replace_span, format!(" {name}"));
     }

--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -156,7 +156,7 @@ fn remove_console<'c, 'a: 'c>(
     fixer: RuleFixer<'c, 'a>,
     ctx: &'c LintContext<'a>,
     node: &AstNode<'a>,
-) -> RuleFix<'a> {
+) -> RuleFix {
     let mut node_to_delete = node;
     for parent in ctx.nodes().ancestors(node.id()) {
         match parent.kind() {

--- a/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
@@ -104,7 +104,7 @@ fn remove_new_operator<'a>(
     fixer: RuleFixer<'_, 'a>,
     expr: &NewExpression<'a>,
     name: &'a str,
-) -> RuleFix<'a> {
+) -> RuleFix {
     debug_assert!(expr.callee.is_identifier_reference());
     let remove_new_fix = fixer.delete_range(Span::new(expr.span.start, expr.callee.span().start));
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_imports.rs
@@ -11,7 +11,7 @@ impl NoUnusedVars {
         fixer: RuleFixer<'_, 'a>,
         symbol: &Symbol<'_, 'a>,
         import: &ImportDeclaration<'a>,
-    ) -> RuleFix<'a> {
+    ) -> RuleFix {
         let specifiers = import
                 .specifiers
                 .as_ref()

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_symbol.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_symbol.rs
@@ -12,7 +12,7 @@ impl<'s, 'a> Symbol<'s, 'a> {
         fixer: RuleFixer<'_, 'a>,
         list: &[T],
         own: &T,
-    ) -> RuleFix<'a>
+    ) -> RuleFix
     where
         T: GetSpan,
         Symbol<'s, 'a>: PartialEq<T>,
@@ -52,8 +52,8 @@ impl<'s, 'a> Symbol<'s, 'a> {
         fixer.delete(&delete_range)
     }
 
-    pub(super) fn rename(&self, new_name: &CompactStr) -> RuleFix<'a> {
-        let mut fixes: Vec<Fix<'a>> = vec![];
+    pub(super) fn rename(&self, new_name: &CompactStr) -> RuleFix {
+        let mut fixes: Vec<Fix> = vec![];
         let decl_span = self.span();
         fixes.push(Fix::new(new_name.clone(), decl_span));
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_vars.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_vars.rs
@@ -30,7 +30,7 @@ impl NoUnusedVars {
         symbol: &Symbol<'_, 'a>,
         decl: &VariableDeclarator<'a>,
         decl_id: NodeId,
-    ) -> RuleFix<'a> {
+    ) -> RuleFix {
         if decl.init.as_ref().is_some_and(|init| is_skipped_init(symbol, init)) {
             return fixer.noop();
         }

--- a/crates/oxc_linter/src/rules/jest/prefer_lowercase_title/mod.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_lowercase_title/mod.rs
@@ -298,7 +298,7 @@ impl PreferLowercaseTitle {
         let replacement_len = replacement.len() as u32;
 
         ctx.diagnostic_with_fix(prefer_lowercase_title_diagnostic(literal, span), |fixer| {
-            fixer.replace(Span::sized(span.start + 1, replacement_len), replacement)
+            fixer.replace(Span::sized(span.start + 1, replacement_len), replacement.into_owned())
         });
     }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_has_content.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_has_content.rs
@@ -98,7 +98,7 @@ impl Rule for AnchorHasContent {
     }
 }
 
-fn remove_hidden_attributes<'a>(element: &JSXElement<'a>) -> RuleFix<'a> {
+fn remove_hidden_attributes(element: &JSXElement<'_>) -> RuleFix {
     element
         .opening_element
         .attributes

--- a/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
@@ -469,7 +469,7 @@ fn get_map_callback<'a, 'b>(call_expr: &'b CallExpression<'a>) -> Option<&'b Exp
 fn fix_spread_to_object_assign<'a>(
     fixer: RuleFixer<'_, 'a>,
     obj: &ObjectExpression<'a>,
-) -> RuleFix<'a> {
+) -> RuleFix {
     use oxc_allocator::{Allocator, CloneIn};
     use oxc_ast::AstBuilder;
     use oxc_codegen::CodegenOptions;

--- a/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
@@ -1524,7 +1524,7 @@ mod fix {
         fixer: RuleFixer<'c, 'a>,
         names: &[Name<'a>],
         deps: &ArrayExpression<'a>,
-    ) -> RuleFix<'a> {
+    ) -> RuleFix {
         let mut codegen = fixer.codegen();
 
         let alloc = Allocator::default();
@@ -1548,7 +1548,7 @@ mod fix {
         fixer: RuleFixer<'c, 'a>,
         dependency: &Dependency,
         deps: &ArrayExpression<'a>,
-    ) -> RuleFix<'a> {
+    ) -> RuleFix {
         let mut codegen = fixer.codegen();
 
         let alloc = Allocator::default();

--- a/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
@@ -575,13 +575,13 @@ fn report_unnecessary_curly<'a>(
                 let mut fix = fixer.codegen();
                 fix.print_str(template_lit.single_quasi().unwrap().as_str());
 
-                fixer.replace(container.span, fix)
+                fixer.replace(container.span, fix.into_source_text())
             }
             JSXExpression::StringLiteral(string_literal) => {
                 let mut fix = fixer.codegen();
                 fix.print_str(string_literal.value.as_str());
 
-                fixer.replace(container.span, fix)
+                fixer.replace(container.span, fix.into_source_text())
             }
             _ => {
                 let mut fix = fixer.new_fix_with_capacity(2);
@@ -608,7 +608,7 @@ fn report_unnecessary_curly_for_attribute_value<'a>(
             JSXExpression::TemplateLiteral(template_lit) => template_lit.single_quasi().unwrap(),
             JSXExpression::StringLiteral(string_lit) => string_lit.value,
             JSXExpression::JSXElement(el) => {
-                return fixer.replace(container.span, ctx.source_range(el.span));
+                return fixer.replace(container.span, ctx.source_range(el.span).to_owned());
             }
             _ => unreachable!(),
         };
@@ -625,7 +625,7 @@ fn report_unnecessary_curly_for_attribute_value<'a>(
             None,
         ));
 
-        fixer.replace(container.span, fix)
+        fixer.replace(container.span, fix.into_source_text())
     });
 }
 
@@ -658,7 +658,7 @@ fn report_missing_curly_for_string_attribute_value(
         let mut fix = fixer.new_fix_with_capacity(3);
         fix.push(fixer.insert_text_before(&span, "{"));
         fix.push(fixer.insert_text_after(&span, "}"));
-        fix.push(fixer.replace(span, replace));
+        fix.push(fixer.replace(span, replace.into_source_text()));
         fix.with_message("add the missing curly braces")
     });
 }
@@ -695,7 +695,7 @@ fn report_missing_curly_for_text_node(ctx: &LintContext, span: Span, string_valu
                 text,
                 None,
             ));
-            fix.push(fixer.replace(span_from_first_char, replace));
+            fix.push(fixer.replace(span_from_first_char, replace.into_source_text()));
             fix.push(fixer.insert_text_before(&span_from_first_char, "{"));
             fix.push(fixer.insert_text_after(&span_from_first_char, "}"));
         }

--- a/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
@@ -159,7 +159,7 @@ fn fix_fragment_element<'a>(
     elem: &JSXElement,
     ctx: &LintContext<'a>,
     fixer: RuleFixer<'_, 'a>,
-) -> RuleFix<'a> {
+) -> RuleFix {
     let replacement = if let Some(closing_elem) = &elem.closing_element {
         trim_like_react(
             Span::new(elem.opening_element.span.end, closing_elem.span.start)
@@ -169,20 +169,21 @@ fn fix_fragment_element<'a>(
         ""
     };
 
-    fixer.replace(elem.span(), trim_like_react(replacement))
+    fixer.replace(elem.span(), trim_like_react(replacement).to_owned())
 }
 
 fn fix_jsx_fragment<'a>(
     elem: &JSXFragment,
     ctx: &LintContext<'a>,
     fixer: RuleFixer<'_, 'a>,
-) -> RuleFix<'a> {
+) -> RuleFix {
     fixer.replace(
         elem.span(),
         trim_like_react(
             Span::new(elem.opening_fragment.span.end, elem.closing_fragment.span.start)
                 .source_text(ctx.source_text()),
-        ),
+        )
+        .to_owned(),
     )
 }
 

--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spread_multi.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spread_multi.rs
@@ -109,7 +109,7 @@ impl Rule for JsxPropsNoSpreadMulti {
                             .rev()
                             .skip(1)
                             .map(|span| Fix::delete(*span))
-                            .collect::<RuleFix<'a>>()
+                            .collect::<RuleFix>()
                             .with_message(REMOVE_DUPLICATE_SPREAD)
                     },
                 );

--- a/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
@@ -187,7 +187,8 @@ impl Rule for BanTsComment {
                                     |fixer| {
                                         fixer.replace(
                                             comm.content_span(),
-                                            raw.cow_replace("@ts-ignore", "@ts-expect-error"),
+                                            raw.cow_replace("@ts-ignore", "@ts-expect-error")
+                                                .into_owned(),
                                         )
                                     },
                                 );

--- a/crates/oxc_linter/src/rules/typescript/no_wrapper_object_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_wrapper_object_types.rs
@@ -91,7 +91,7 @@ impl Rule for NoWrapperObjectTypes {
 
             if can_fix {
                 ctx.diagnostic_with_fix(no_wrapper_object_types(ident_span), |fixer| {
-                    fixer.replace(ident_span, ident_name.cow_to_ascii_lowercase())
+                    fixer.replace(ident_span, ident_name.cow_to_ascii_lowercase().to_string())
                 });
             } else {
                 ctx.diagnostic(no_wrapper_object_types(ident_span));

--- a/crates/oxc_linter/src/rules/unicorn/no_await_expression_member.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_await_expression_member.rs
@@ -118,7 +118,7 @@ impl Rule for NoAwaitExpressionMember {
                     }
                     // (await b())[0] => await b()
                     // (await b()).a => await b()
-                    rule_fixes.push(fixer.replace(member_expr.span(), inner_text));
+                    rule_fixes.push(fixer.replace(member_expr.span(), inner_text.to_owned()));
                     rule_fixes.with_message("Assign the result of the await expression to a variable, then access the member from that variable.")
                 },
             );

--- a/crates/oxc_linter/src/rules/unicorn/no_console_spaces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_console_spaces.rs
@@ -140,7 +140,7 @@ fn report_diagnostic<'a>(
         } else {
             Cow::Borrowed(literal_raw.trim())
         };
-        fixer.replace(span, content)
+        fixer.replace(span, content.to_string())
     });
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/no_null.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_null.rs
@@ -237,15 +237,15 @@ impl Rule for NoNull {
     }
 }
 
-fn fix_null<'a>(fixer: RuleFixer<'_, 'a>, null: &NullLiteral) -> RuleFix<'a> {
+fn fix_null(fixer: RuleFixer<'_, '_>, null: &NullLiteral) -> RuleFix {
     fixer.replace(null.span, "undefined")
 }
 
-fn try_fix_case<'a>(
-    fixer: RuleFixer<'_, 'a>,
+fn try_fix_case(
+    fixer: RuleFixer<'_, '_>,
     null: &NullLiteral,
-    switch: &SwitchStatement<'a>,
-) -> RuleFix<'a> {
+    switch: &SwitchStatement<'_>,
+) -> RuleFix {
     let also_has_undefined = switch
         .cases
         .iter()

--- a/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs
@@ -111,7 +111,7 @@ impl Rule for NoSinglePromiseInPromiseMethods {
                 let call_span = call_expr.span;
 
                 if is_directly_in_await {
-                    fixer.replace(call_span, elem_text)
+                    fixer.replace(call_span, elem_text.to_owned())
                 } else {
                     fixer.replace(call_span, format!("Promise.resolve({elem_text})"))
                 }

--- a/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
@@ -1,7 +1,7 @@
 use oxc_ast::{AstKind, ast::Expression};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{GetSpan, Span};
+use oxc_span::Span;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -71,7 +71,7 @@ impl Rule for NoUnnecessaryAwait {
             } else {
                 ctx.diagnostic_with_fix(
                     no_unnecessary_await_diagnostic(Span::sized(expr.span.start, 5)),
-                    |fixer| fixer.replace(expr.span, fixer.source_range(expr.argument.span())),
+                    |fixer| fixer.replace_with(expr, &expr.argument),
                 );
             }
         }

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
@@ -284,7 +284,7 @@ fn generate_fix<'a>(
     fixer: RuleFixer<'_, 'a>,
     ctx: &LintContext<'a>,
     node: &AstNode<'a>,
-) -> RuleFix<'a> {
+) -> RuleFix {
     if call_expr.arguments.len() > 1 {
         return fixer.noop();
     }

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
@@ -224,7 +224,7 @@ fn check_useless_spread_in_list<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -
                         ""
                     };
 
-                    fixer.replace(spread_elem.span(), replacer)
+                    fixer.replace(spread_elem.span(), replacer.to_owned())
                 });
                 true
             }
@@ -291,7 +291,7 @@ fn diagnose_array_in_array_spread<'a>(
                     }
                 }
                 codegen.print_ascii_byte(b']');
-                fixer.replace(outer_array.span, codegen)
+                fixer.replace(outer_array.span, codegen.into_source_text())
             });
         }
     }
@@ -452,8 +452,8 @@ fn fix_by_removing_array_spread<'a, S: GetSpan>(
     fixer: RuleFixer<'_, 'a>,
     iterable: &S,
     spread: &SpreadElement<'a>,
-) -> RuleFix<'a> {
-    fixer.replace(iterable.span(), fixer.source_range(spread.argument.span()))
+) -> RuleFix {
+    fixer.replace_with(iterable, &spread.argument)
 }
 
 /// Creates a fix that replaces `{...spread}` with `spread`, when `spread` is an
@@ -465,7 +465,7 @@ fn fix_by_removing_array_spread<'a, S: GetSpan>(
 fn fix_by_removing_object_spread<'a>(
     fixer: RuleFixer<'_, 'a>,
     spread: &SpreadElement<'a>,
-) -> RuleFix<'a> {
+) -> RuleFix {
     // get contents inside object brackets
     // e.g. `...{ a, b, }` -> ` a, b, `
     let replacement_span = &spread.argument.span().shrink(1);

--- a/crates/oxc_linter/src/rules/unicorn/prefer_at.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_at.rs
@@ -545,12 +545,12 @@ fn extract_length_minus_pattern<'a>(expr: &'a Expression<'a>) -> Option<(&'a Exp
 }
 
 // Unified fix creation
-fn create_at_fix<'a>(
-    fixer: &RuleFixer<'_, 'a>,
+fn create_at_fix(
+    fixer: &RuleFixer<'_, '_>,
     object_span: Span,
     full_span: Span,
     index: i64,
-) -> RuleFix<'a> {
+) -> RuleFix {
     let new_code = format!("{}.at({})", fixer.source_range(object_span), index);
     fixer.replace(full_span, new_code)
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_class_fields.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_class_fields.rs
@@ -143,7 +143,7 @@ impl Rule for PreferClassFields {
                 if let Some(value) = &prop.value {
                     let mut codegen = fixer.codegen();
                     codegen.print_expression(&assign.right);
-                    fix.push(fixer.replace(value.span(), codegen));
+                    fix.push(fixer.replace(value.span(), codegen.into_source_text()));
                 }
 
                 fix.with_message("Replace `this` assignment with class field declaration")
@@ -162,7 +162,7 @@ impl Rule for PreferClassFields {
                 let mut codegen = fixer.codegen();
                 codegen.print_str(" = ");
                 codegen.print_expression(&assign.right);
-                fix.push(fixer.insert_text_after(&prop.key, codegen));
+                fix.push(fixer.insert_text_after(&prop.key, codegen.into_source_text()));
             } else {
                 let indent =
                     ctx.source_range(constructor.span).lines().next().map_or("\t", |line| {
@@ -176,7 +176,7 @@ impl Rule for PreferClassFields {
                 codegen.print_str(" = ");
                 codegen.print_expression(&assign.right);
                 codegen.print_str(";\n");
-                fix.push(fixer.insert_text_before(&**constructor, codegen));
+                fix.push(fixer.insert_text_before(&**constructor, codegen.into_source_text()));
             }
 
             fix.with_message("Replace `this` assignment with class field declaration")

--- a/crates/oxc_linter/src/rules/unicorn/prefer_classlist_toggle.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_classlist_toggle.rs
@@ -345,7 +345,7 @@ fn fix_if_statement<'a>(
     add_call: &CallExpression<'a>,
     is_add_first: bool,
     ctx: &LintContext<'a>,
-) -> RuleFix<'a> {
+) -> RuleFix {
     let Some(member_expr) = add_call.callee.get_member_expr() else {
         return fixer.noop();
     };
@@ -372,7 +372,7 @@ fn fix_conditional_expression<'a>(
     add_call: &CallExpression<'a>,
     is_add_first: bool,
     ctx: &LintContext<'a>,
-) -> RuleFix<'a> {
+) -> RuleFix {
     let Some(member_expr) = add_call.callee.get_member_expr() else {
         return fixer.noop();
     };
@@ -398,7 +398,7 @@ fn fix_computed_member_call<'a>(
     test: &Expression<'a>,
     is_add_first: bool,
     ctx: &LintContext<'a>,
-) -> RuleFix<'a> {
+) -> RuleFix {
     let Some(member_expr) = call_expr.callee.get_member_expr() else {
         return fixer.noop();
     };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
@@ -4,7 +4,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{GetSpan, Span};
+use oxc_span::Span;
 
 use crate::{AstNode, ast_util::outermost_paren_parent, context::LintContext, rule::Rule};
 
@@ -157,16 +157,8 @@ impl Rule for PreferRegexpTest {
             let mut fix = fixer.new_fix_with_capacity(3);
 
             fix.push(fixer.replace(span, "test"));
-
-            fix.push(fixer.replace(
-                call_expr.arguments[0].span(),
-                fixer.source_range(member_expr.object().span()),
-            ));
-
-            fix.push(fixer.replace(
-                member_expr.object().span(),
-                fixer.source_range(call_expr.arguments[0].span()),
-            ));
+            fix.push(fixer.replace_with(&call_expr.arguments[0], member_expr.object()));
+            fix.push(fixer.replace_with(member_expr.object(), &call_expr.arguments[0]));
 
             fix.with_message("Replace with `RegExp.test()`")
         });

--- a/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
@@ -251,7 +251,7 @@ fn report_with_spread_fixer(
         codegen.print_str("[...");
         codegen.print_expression(expr_to_spread);
         codegen.print_str("]");
-        fixer.replace(span, codegen)
+        fixer.replace(span, codegen.into_source_text())
     });
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
@@ -103,7 +103,7 @@ fn do_fix<'a>(
     fixer: RuleFixer<'_, 'a>,
     err_kind: ErrorKind,
     call_expr: &CallExpression<'a>,
-) -> RuleFix<'a> {
+) -> RuleFix {
     let Some(target_span) = can_replace(call_expr) else { return fixer.noop() };
     let (argument, method) = match err_kind {
         ErrorKind::StartsWith(arg) => {
@@ -120,7 +120,7 @@ fn do_fix<'a>(
     content.print_str(&format!(r"{}.{}(", fixer.source_range(target_span), method));
     content.print_expression(&ast.expression_string_literal(SPAN, ast.atom(&argument), None));
     content.print_str(r")");
-    fixer.replace(call_expr.span, content)
+    fixer.replace(call_expr.span, content.into_source_text())
 }
 
 fn can_replace(call_expr: &CallExpression) -> Option<Span> {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_structured_clone.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_structured_clone.rs
@@ -155,16 +155,16 @@ impl Rule for PreferStructuredClone {
     }
 }
 
-fn replace_with_structured_clone<'a>(
-    fixer: RuleFixer<'_, 'a>,
+fn replace_with_structured_clone(
+    fixer: RuleFixer<'_, '_>,
     call_expr: &CallExpression<'_>,
     first_argument: &Expression<'_>,
-) -> RuleFix<'a> {
+) -> RuleFix {
     let mut codegen = fixer.codegen();
     codegen.print_str("structuredClone(");
     codegen.print_expression(first_argument);
     codegen.print_str(")");
-    fixer.replace(call_expr.span, codegen)
+    fixer.replace(call_expr.span, codegen.into_source_text())
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/unicorn/require_module_specifiers.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_module_specifiers.rs
@@ -125,7 +125,7 @@ fn find_empty_braces_in_export(
     find_empty_braces_in_text(export_text, export_decl.span)
 }
 
-fn fix_import<'a>(fixer: RuleFixer<'_, 'a>, import_decl: &ImportDeclaration<'a>) -> RuleFix<'a> {
+fn fix_import<'a>(fixer: RuleFixer<'_, 'a>, import_decl: &ImportDeclaration<'a>) -> RuleFix {
     let import_text = fixer.source_range(import_decl.span);
 
     let Some(comma_pos) = import_text.find(',') else {
@@ -141,10 +141,7 @@ fn fix_import<'a>(fixer: RuleFixer<'_, 'a>, import_decl: &ImportDeclaration<'a>)
     fixer.replace(import_decl.span, format!("{default_part} {from_part}"))
 }
 
-fn fix_export<'a>(
-    fixer: RuleFixer<'_, 'a>,
-    export_decl: &ExportNamedDeclaration<'a>,
-) -> RuleFix<'a> {
+fn fix_export<'a>(fixer: RuleFixer<'_, 'a>, export_decl: &ExportNamedDeclaration<'a>) -> RuleFix {
     if export_decl.source.is_some() {
         return fixer.noop();
     }

--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -130,7 +130,7 @@ impl Rule for SwitchCaseBraces {
                             |fixer| {
                                 fixer.replace(
                                     block_stmt.span,
-                                    fixer.source_range(block_stmt.span.shrink(1)),
+                                    fixer.source_range(block_stmt.span.shrink(1)).to_owned(),
                                 )
                             },
                         );

--- a/crates/oxc_linter/src/service/mod.rs
+++ b/crates/oxc_linter/src/service/mod.rs
@@ -96,21 +96,18 @@ impl LintService {
     }
 
     #[cfg(feature = "language_server")]
-    pub fn run_source<'a>(
-        &mut self,
-        allocator: &'a mut oxc_allocator::Allocator,
-    ) -> Vec<crate::Message<'a>> {
+    pub fn run_source(&mut self, allocator: &mut oxc_allocator::Allocator) -> Vec<crate::Message> {
         self.runtime.run_source(allocator)
     }
 
     /// For tests
     #[cfg(test)]
-    pub(crate) fn run_test_source<'a>(
+    pub(crate) fn run_test_source(
         &mut self,
-        allocator: &'a mut oxc_allocator::Allocator,
+        allocator: &mut oxc_allocator::Allocator,
         check_syntax_errors: bool,
         tx_error: &DiagnosticSender,
-    ) -> Vec<crate::Message<'a>> {
+    ) -> Vec<crate::Message> {
         self.runtime.run_test_source(allocator, check_syntax_errors, tx_error)
     }
 }

--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -292,7 +292,7 @@ impl TsGoLintState {
         &self,
         path: &Arc<OsStr>,
         source_text: String,
-    ) -> Result<Vec<Message<'_>>, String> {
+    ) -> Result<Vec<Message>, String> {
         let mut resolved_configs: FxHashMap<PathBuf, ResolvedLinterState> = FxHashMap::default();
 
         let json_input = self.json_input(std::slice::from_ref(path), &mut resolved_configs);
@@ -332,7 +332,7 @@ impl TsGoLintState {
             // Stream diagnostics as they are emitted, rather than waiting for all output
             let stdout = child.stdout.take().expect("Failed to open tsgolint stdout");
 
-            let stdout_handler = std::thread::spawn(move || -> Result<Vec<Message<'_>>, String> {
+            let stdout_handler = std::thread::spawn(move || -> Result<Vec<Message>, String> {
                 let msg_iter = TsGoLintMessageStream::new(stdout);
 
                 let mut result = vec![];
@@ -554,7 +554,7 @@ impl From<TsGoLintDiagnostic> for OxcDiagnostic {
 }
 
 #[cfg(feature = "language_server")]
-impl Message<'_> {
+impl Message {
     /// Converts a `TsGoLintDiagnostic` into a `Message` with possible fixes.
     fn from_tsgo_lint_diagnostic(mut val: TsGoLintDiagnostic, source_text: &str) -> Self {
         use std::{borrow::Cow, mem};


### PR DESCRIPTION
closes https://github.com/oxc-project/oxc/issues/14563

Some fixes are references to the `source_text`, removed that reference to hold its own fix source text.
So the language server / tester does not need to clone the `Message` into the own allocator.

Tried to use `.to_owned()` where possible, some needed `.to_string()`, or `into_source_text()` (for codegen).