### PR TITLE
fix(linter): `vue/no_required_prop_with_default` called `Option::unwrap()` on a `None` value

### DIFF
--- a/crates/oxc_linter/src/rules/vue/no_required_prop_with_default.rs
+++ b/crates/oxc_linter/src/rules/vue/no_required_prop_with_default.rs
@@ -278,7 +278,10 @@ fn handle_type_argument(ctx: &LintContext, ts_type: &TSType, key_hash: &FxHashSe
             if !reference.is_type() {
                 return;
             }
-            let reference_node = ctx.symbol_declaration(reference.symbol_id().unwrap());
+            let Some(symbol_id) = reference.symbol_id() else {
+                return;
+            };
+            let reference_node = ctx.symbol_declaration(symbol_id);
             let AstKind::TSInterfaceDeclaration(interface_decl) = reference_node.kind() else {
                 return;
             };
@@ -618,6 +621,20 @@ fn test() {
                         required: false
                     }
                     })
+                </script>
+                ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "   <script lang='ts'>
+                export interface ComponentProps {
+                    name?: string;
+                }
+                </script>
+                <script setup lang='ts'>
+                    const {name='Hello'} = defineProps<ComponentProps>()
                 </script>
                 ",
             None,


### PR DESCRIPTION
closes https://github.com/oxc-project/oxc/issues/14490

https://play.vuejs.org/#eNp9UsFOwzAM/ZUol4I0bUJwGt0QoEnAASbgmEvVeV1G6kSJOypV/XecTB2bBMspsZ+f37PTyXvnxrsG5FTmofTakTAFVrOMQjZXCK2znoRGAr8uShCPtnYWAWnprQuiUyj4YFHD3VQE8hqrW4W9wnyyp2OSgTgANe6EPtaWFgOJLlLMsicwxma9mIkVrDVC6pKfNp1fXJ7Q84OgdqYgSJT55mredUmT6Pt8ws+IP8LIkaTAfde6Gm+DRTafjChZcidtwL850qxLyelgUcmCpX2/pBj5BkZDvNxA+fVHfBvaGFNy6SGA34GShxwVvgLapxcfr9Dy/ZCs7aoxjD6TfIdgTRM17mEPDa5Y9hEuqX3muXninXyGRUuAYTAVhUZkn/BK8g+IQ/7P+q/c6/FNquMdy/4HKWbA0A==