### PR TITLE
fix(transformer/legacy-decorator): correct generating metadata for getter/setter methods

### DIFF
--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -999,7 +999,11 @@ impl<'a> LegacyDecorator<'a, '_> {
                     decorations.push(ArrayExpressionElement::from(metadata));
                 }
             } else if let Some(metadata) = self.metadata.pop_method_metadata() {
-                decorations.extend(metadata.map(ArrayExpressionElement::from));
+                decorations.push(ArrayExpressionElement::from(metadata.r#type));
+                decorations.push(ArrayExpressionElement::from(metadata.param_types));
+                if let Some(return_type) = metadata.return_type {
+                    decorations.push(ArrayExpressionElement::from(return_type));
+                }
             }
         }
 

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -8672,7 +8672,7 @@ rebuilt        : [ReferenceId(13)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataElidedImport.ts
 Symbol reference IDs mismatch for "Observable":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(8), ReferenceId(9)]
+after transform: SymbolId(0): [ReferenceId(2), ReferenceId(4), ReferenceId(5)]
 rebuilt        : SymbolId(0): [ReferenceId(12), ReferenceId(13)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataElidedImportOnDeclare.ts
@@ -8727,22 +8727,22 @@ Reference symbol mismatch for "decorator":
 after transform: SymbolId(0) "decorator"
 rebuilt        : <None>
 Reference flags mismatch for "Promise":
-after transform: ReferenceId(26): ReferenceFlags(Read | Type)
+after transform: ReferenceId(30): ReferenceFlags(Read | Type)
 rebuilt        : ReferenceId(28): ReferenceFlags(Read)
 Reference flags mismatch for "Promise":
-after transform: ReferenceId(27): ReferenceFlags(Read | Type)
+after transform: ReferenceId(31): ReferenceFlags(Read | Type)
 rebuilt        : ReferenceId(29): ReferenceFlags(Read)
 Reference flags mismatch for "Promise":
-after transform: ReferenceId(32): ReferenceFlags(Read | Type)
+after transform: ReferenceId(25): ReferenceFlags(Read | Type)
 rebuilt        : ReferenceId(34): ReferenceFlags(Read)
 Reference flags mismatch for "Promise":
-after transform: ReferenceId(33): ReferenceFlags(Read | Type)
+after transform: ReferenceId(26): ReferenceFlags(Read | Type)
 rebuilt        : ReferenceId(35): ReferenceFlags(Read)
 Unresolved references mismatch:
 after transform: ["Function", "MethodDecorator", "Object", "Promise", "require"]
 rebuilt        : ["Function", "Object", "Promise", "decorator", "require"]
 Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(11), ReferenceId(19), ReferenceId(26), ReferenceId(27), ReferenceId(32), ReferenceId(33)]
+after transform: [ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(17), ReferenceId(25), ReferenceId(26), ReferenceId(30), ReferenceId(31)]
 rebuilt        : [ReferenceId(12), ReferenceId(20), ReferenceId(28), ReferenceId(29), ReferenceId(34), ReferenceId(35)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataRestParameterWithImportedType.ts
@@ -8864,7 +8864,7 @@ rebuilt        : ["Object", "database"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorReferenceOnOtherProperty.ts
 Symbol reference IDs mismatch for "Yoha":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(5), ReferenceId(6)]
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(4), ReferenceId(5)]
 rebuilt        : SymbolId(0): [ReferenceId(8), ReferenceId(9)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorReferences.ts
@@ -35962,8 +35962,8 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "TypedPropertyDescriptor", "require"]
-rebuilt        : ["Function", "dec", "require"]
+after transform: ["TypedPropertyDescriptor", "require"]
+rebuilt        : ["dec", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor2.ts
 Bindings mismatch:
@@ -35976,8 +35976,8 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "TypedPropertyDescriptor", "require"]
-rebuilt        : ["Function", "dec", "require"]
+after transform: ["TypedPropertyDescriptor", "require"]
+rebuilt        : ["dec", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor4.ts
 Bindings mismatch:
@@ -35990,8 +35990,8 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "Number", "TypedPropertyDescriptor", "require"]
-rebuilt        : ["Function", "Number", "dec", "require"]
+after transform: ["Number", "TypedPropertyDescriptor", "require"]
+rebuilt        : ["Number", "dec", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor5.ts
 Bindings mismatch:
@@ -36004,8 +36004,8 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "Number", "TypedPropertyDescriptor", "require"]
-rebuilt        : ["Function", "Number", "dec", "require"]
+after transform: ["Number", "TypedPropertyDescriptor", "require"]
+rebuilt        : ["Number", "dec", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor8.ts
 Bindings mismatch:
@@ -36033,8 +36033,8 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "Number", "TypedPropertyDescriptor", "require"]
-rebuilt        : ["Function", "Number", "dec", "require"]
+after transform: ["Number", "TypedPropertyDescriptor", "require"]
+rebuilt        : ["Number", "dec", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor3.ts
 Unresolved references mismatch:
@@ -38551,8 +38551,8 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "TypedPropertyDescriptor"]
-rebuilt        : ["Function", "dec"]
+after transform: ["TypedPropertyDescriptor"]
+rebuilt        : ["dec"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass1.es6.ts
 Bindings mismatch:
@@ -39372,10 +39372,10 @@ Bindings mismatch:
 after transform: ScopeId(0): ["C", "_decorate", "_decorateMetadata", "_method", "_method2", "dec", "method3"]
 rebuilt        : ScopeId(0): ["C", "_decorate", "_decorateMetadata", "_method", "_method2", "method3"]
 Reference flags mismatch for "_method":
-after transform: ReferenceId(39): ReferenceFlags(Read | Write)
+after transform: ReferenceId(31): ReferenceFlags(Read | Write)
 rebuilt        : ReferenceId(2): ReferenceFlags(Write)
 Reference flags mismatch for "_method2":
-after transform: ReferenceId(48): ReferenceFlags(Read | Write)
+after transform: ReferenceId(39): ReferenceFlags(Read | Write)
 rebuilt        : ReferenceId(4): ReferenceFlags(Write)
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
@@ -39396,8 +39396,8 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "Object", "require"]
-rebuilt        : ["Function", "Object", "dec", "require"]
+after transform: ["Object", "require"]
+rebuilt        : ["Object", "dec", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/accessors/esDecorators-classDeclaration-accessors-nonStaticPrivate.ts
 Bindings mismatch:
@@ -39410,18 +39410,18 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "Object", "WeakSet", "require"]
-rebuilt        : ["Function", "Object", "WeakSet", "dec", "require"]
+after transform: ["Object", "WeakSet", "require"]
+rebuilt        : ["Object", "WeakSet", "dec", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/accessors/esDecorators-classDeclaration-accessors-static.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["C", "_decorate", "_decorateMetadata", "_method", "_method2", "dec", "method3"]
 rebuilt        : ScopeId(0): ["C", "_decorate", "_decorateMetadata", "_method", "_method2", "method3"]
 Reference flags mismatch for "_method":
-after transform: ReferenceId(39): ReferenceFlags(Read | Write)
+after transform: ReferenceId(31): ReferenceFlags(Read | Write)
 rebuilt        : ReferenceId(2): ReferenceFlags(Write)
 Reference flags mismatch for "_method2":
-after transform: ReferenceId(48): ReferenceFlags(Read | Write)
+after transform: ReferenceId(39): ReferenceFlags(Read | Write)
 rebuilt        : ReferenceId(4): ReferenceFlags(Write)
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
@@ -39442,8 +39442,8 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "Object", "require"]
-rebuilt        : ["Function", "Object", "dec", "require"]
+after transform: ["Object", "require"]
+rebuilt        : ["Object", "dec", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/accessors/esDecorators-classDeclaration-accessors-staticPrivate.ts
 Bindings mismatch:
@@ -39453,13 +39453,13 @@ Symbol span mismatch for "D":
 after transform: SymbolId(3): Span { start: 137, end: 138 }
 rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "D":
-after transform: SymbolId(3): [ReferenceId(23), ReferenceId(25)]
-rebuilt        : SymbolId(9): [ReferenceId(20), ReferenceId(30), ReferenceId(33)]
+after transform: SymbolId(3): [ReferenceId(20), ReferenceId(22)]
+rebuilt        : SymbolId(9): [ReferenceId(17), ReferenceId(27), ReferenceId(30)]
 Symbol span mismatch for "D":
 after transform: SymbolId(14): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(10): Span { start: 137, end: 138 }
 Symbol reference IDs mismatch for "D":
-after transform: SymbolId(14): [ReferenceId(28)]
+after transform: SymbolId(14): [ReferenceId(25)]
 rebuilt        : SymbolId(10): []
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
@@ -39474,8 +39474,8 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "Object", "require"]
-rebuilt        : ["Function", "Object", "dec", "require"]
+after transform: ["Object", "require"]
+rebuilt        : ["Object", "dec", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.1.ts
 Bindings mismatch:
@@ -40482,7 +40482,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["_C", "_decorateMetadata", "_defineProperty", "_get_x", "_method", "_set_x", "_y", "dec"]
 rebuilt        : ScopeId(0): ["_C", "_decorateMetadata", "_defineProperty", "_get_x", "_method", "_set_x", "_y"]
 Symbol reference IDs mismatch for "_decorateMetadata":
-after transform: SymbolId(10): [ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(32), ReferenceId(34), ReferenceId(35), ReferenceId(37), ReferenceId(39), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(49), ReferenceId(51), ReferenceId(52), ReferenceId(54), ReferenceId(56)]
+after transform: SymbolId(10): [ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(31), ReferenceId(32), ReferenceId(34), ReferenceId(36), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(45), ReferenceId(46), ReferenceId(48), ReferenceId(50)]
 rebuilt        : SymbolId(1): []
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 41d96516
 
-Passed: 188/316
+Passed: 188/317
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -544,7 +544,7 @@ x Output mismatch
 x Output mismatch
 
 
-# legacy-decorators (6/85)
+# legacy-decorators (6/86)
 * oxc/class-without-name-with-decorated_class/input.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["dec"]
@@ -698,6 +698,29 @@ Symbol reference IDs mismatch for "ComputedEnum":
 after transform: SymbolId(25): [ReferenceId(19), ReferenceId(72)]
 rebuilt        : SymbolId(15): [ReferenceId(52)]
 
+* oxc/metadata/getter-setter-method/input.ts
+Bindings mismatch:
+after transform: ScopeId(0): ["Getter", "Setter", "dec"]
+rebuilt        : ScopeId(0): ["Getter", "Setter"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
+Reference symbol mismatch for "dec":
+after transform: SymbolId(0) "dec"
+rebuilt        : <None>
+Reference symbol mismatch for "dec":
+after transform: SymbolId(0) "dec"
+rebuilt        : <None>
+Reference symbol mismatch for "dec":
+after transform: SymbolId(0) "dec"
+rebuilt        : <None>
+Reference symbol mismatch for "dec":
+after transform: SymbolId(0) "dec"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: ["Function", "Number", "PropertyDescriptor", "String", "babelHelpers"]
+rebuilt        : ["Function", "Number", "String", "babelHelpers", "dec"]
+
 * oxc/metadata/imports/input.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Cls", "Foo", "Zoo", "_ref", "dec"]
@@ -809,7 +832,7 @@ Reference symbol mismatch for "Cls2":
 after transform: SymbolId(2) "Cls2"
 rebuilt        : SymbolId(2) "Cls2"
 Unresolved reference IDs mismatch for "babelHelpers":
-after transform: [ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(16), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(22), ReferenceId(24)]
+after transform: [ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(22), ReferenceId(24)]
 rebuilt        : [ReferenceId(0), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(9), ReferenceId(12), ReferenceId(14), ReferenceId(16)]
 
 * oxc/metadata/this/input.ts

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/getter-setter-method/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/getter-setter-method/input.ts
@@ -1,0 +1,27 @@
+declare function dec(
+	target: any,
+	propertyKey: string,
+	descriptor: PropertyDescriptor,
+): void;
+
+class Getter {
+	@dec
+	get address(): string {
+		return "test";
+	}
+
+	@dec
+	regularMethod(): string {
+		return "test";
+	}
+}
+
+class Setter {
+	@dec
+	set address(value: number) {}
+
+	@dec
+	regularMethod(): string {
+		return "test";
+	}
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/getter-setter-method/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/getter-setter-method/output.js
@@ -1,0 +1,39 @@
+class Getter {
+  get address() {
+    return "test";
+  }
+  regularMethod() {
+    return "test";
+  }
+}
+
+babelHelpers.decorate([
+  dec,
+  babelHelpers.decorateMetadata("design:type", String),
+  babelHelpers.decorateMetadata("design:paramtypes", [])
+], Getter.prototype, "address", null);
+babelHelpers.decorate([
+  dec,
+  babelHelpers.decorateMetadata("design:type", Function),
+  babelHelpers.decorateMetadata("design:paramtypes", []),
+  babelHelpers.decorateMetadata("design:returntype", String)
+], Getter.prototype, "regularMethod", null);
+
+class Setter {
+  set address(value) {}
+  regularMethod() {
+    return "test";
+  }
+}
+
+babelHelpers.decorate([
+  dec,
+  babelHelpers.decorateMetadata("design:type", Number),
+  babelHelpers.decorateMetadata("design:paramtypes", [Number])
+], Setter.prototype, "address", null);
+babelHelpers.decorate([
+  dec,
+  babelHelpers.decorateMetadata("design:type", Function),
+  babelHelpers.decorateMetadata("design:paramtypes", []),
+  babelHelpers.decorateMetadata("design:returntype", String)
+], Setter.prototype, "regularMethod", null);


### PR DESCRIPTION
* Fixes: #14493

Getter and setter methods should not have `design:returntype` metadata according to TypeScript's `emitDecoratorMetadata` behavior. They should only have `design:type` and `design:paramtypes`.

**And `design:type` is different for the getter and setter:**

Getter: `design:type` is the same as the return type of method.
Setter: `design:type` is the same as the type of the first parameter of the method
