### PR TITLE
feat(language_server): support `fmt.configPath` configuration

### DIFF
--- a/crates/oxc_language_server/README.md
+++ b/crates/oxc_language_server/README.md
@@ -28,6 +28,7 @@ These options can be passed with [initialize](#initialize), [workspace/didChange
 | `typeAware`               | `true` \| `false`              | `false`    | Enables type-aware linting                                                                                                                             |
 | `flags`                   | `Map<string, string>`          | `<empty>`  | Special oxc language server flags, currently only one flag key is supported: `disable_nested_config`                                                   |
 | `fmt.experimental`        | `true` \| `false`              | `false`    | Enables experimental formatting with `oxc_formatter`                                                                                                   |
+| `fmt.configPath`          | `<string>` \| `null`           | `null`     | Path to a oxfmt configuration file, when `null` is passed, the server will use `.oxfmtrc.json` and the workspace root                                  |
 
 ## Supported LSP Specifications from Server
 
@@ -47,7 +48,8 @@ The client can pass the workspace options like following:
       "unusedDisableDirectives": "allow",
       "typeAware": false,
       "flags": {},
-      "fmt.experimental": false
+      "fmt.experimental": false,
+      "fmt.configPath": null
     }
   }]
 }
@@ -84,7 +86,8 @@ The client can pass the workspace options like following:
       "unusedDisableDirectives": "allow",
       "typeAware": false,
       "flags": {},
-      "fmt.experimental": false
+      "fmt.experimental": false,
+      "fmt.configPath": null
     }
   }]
 }
@@ -178,6 +181,7 @@ The client can return a response like:
   "unusedDisableDirectives": "allow",
   "typeAware": false,
   "flags": {},
-  "fmt.experimental": false
+  "fmt.experimental": false,
+  "fmt.configPath": null
 }]
 ```

--- a/crates/oxc_language_server/fixtures/formatter/custom_config_path/format.json
+++ b/crates/oxc_language_server/fixtures/formatter/custom_config_path/format.json
@@ -1,0 +1,3 @@
+{
+  "semicolons": "as-needed"
+}

--- a/crates/oxc_language_server/fixtures/formatter/custom_config_path/semicolons-as-needed.ts
+++ b/crates/oxc_language_server/fixtures/formatter/custom_config_path/semicolons-as-needed.ts
@@ -1,0 +1,2 @@
+// semicolon is on character 8-9, which will be removed
+debugger;

--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -11,6 +11,7 @@ mod linter;
 mod options;
 #[cfg(test)]
 mod tester;
+mod utils;
 mod worker;
 
 use crate::backend::Backend;

--- a/crates/oxc_language_server/src/snapshots/fixtures_formatter_custom_config_path@semicolons-as-needed.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_formatter_custom_config_path@semicolons-as-needed.ts.snap
@@ -1,0 +1,16 @@
+---
+source: crates/oxc_language_server/src/formatter/tester.rs
+---
+========================================
+File: fixtures/formatter/custom_config_path/semicolons-as-needed.ts
+========================================
+Range: Range {
+    start: Position {
+        line: 1,
+        character: 8,
+    },
+    end: Position {
+        line: 1,
+        character: 9,
+    },
+}

--- a/crates/oxc_language_server/src/utils.rs
+++ b/crates/oxc_language_server/src/utils.rs
@@ -1,0 +1,41 @@
+use std::path::{Component, Path, PathBuf};
+
+/// Normalize a path by removing `.` and resolving `..` components,
+/// without touching the filesystem.
+pub fn normalize_path<P: AsRef<Path>>(path: P) -> PathBuf {
+    let mut result = PathBuf::new();
+
+    for component in path.as_ref().components() {
+        match component {
+            Component::ParentDir => {
+                result.pop();
+            }
+            Component::CurDir => {
+                // Skip current directory component
+            }
+            Component::Normal(c) => {
+                result.push(c);
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                result.push(component.as_os_str());
+            }
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod test {
+    use std::path::Path;
+
+    use crate::utils::normalize_path;
+
+    #[test]
+    fn test_normalize_path() {
+        assert_eq!(
+            normalize_path(Path::new("/root/directory/./.oxlintrc.json")),
+            Path::new("/root/directory/.oxlintrc.json")
+        );
+    }
+}


### PR DESCRIPTION
> This PR adds support for the `fmt.configPath` configuration to the language server, allowing users to specify a custom path to the oxfmt configuration file instead of using the default `.oxfmtrc.json` in the workspace root.