### PR TITLE
feat(language_server): watch for `fmt.configPath` file content change

### DIFF
--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -327,7 +327,7 @@ impl LanguageServer for Backend {
                 continue;
             };
 
-            let (diagnostics, watcher, formatter_activated) =
+            let (diagnostics, watchers, formatter_activated) =
                 worker.did_change_configuration(&option.options).await;
 
             if formatter_activated && self.capabilities.get().is_some_and(|c| c.dynamic_formatting)
@@ -344,7 +344,7 @@ impl LanguageServer for Backend {
                 }
             }
 
-            if let Some(watcher) = watcher
+            if let Some(watchers) = watchers
                 && self.capabilities.get().is_some_and(|capabilities| capabilities.dynamic_watchers)
             {
                 // remove the old watcher
@@ -357,7 +357,7 @@ impl LanguageServer for Backend {
                     id: format!("watcher-{}", worker.get_root_uri().as_str()),
                     method: "workspace/didChangeWatchedFiles".to_string(),
                     register_options: Some(json!(DidChangeWatchedFilesRegistrationOptions {
-                        watchers: vec![watcher]
+                        watchers
                     })),
                 });
             }


### PR DESCRIPTION
The server now sends a request to the client, to watch for `.oxfmtrc.json` or custom configurable `fmt.configPath` file content changes.
The client will send a `workspace/didChangeWatchedFiles` notification to the server.

The client can also send `workspace/didChangeConfiguration`, for now the server will restart both tools.
This will be optimized by looking at which tool is responsible for the file in https://github.com/oxc-project/oxc/pull/14645