### PR TITLE
fix(napi/minify): handle boolean values for `compress.unused` option

### DIFF
--- a/napi/minify/index.d.ts
+++ b/napi/minify/index.d.ts
@@ -38,11 +38,12 @@ export interface CompressOptions {
    */
   dropDebugger?: boolean
   /**
-   * Drop unreferenced functions and variables.
+   * Pass `true` to drop unreferenced functions and variables.
    *
-   * Simple direct variable assignments do not count as references unless set to "keep_assign".
+   * Simple direct variable assignments do not count as references unless set to `keep_assign`.
+   * @default true
    */
-  unused?: true | false | 'keep_assign'
+  unused?: boolean | 'keep_assign'
   /** Keep function / class names. */
   keepNames?: CompressOptionsKeepNames
   /**

--- a/napi/minify/src/options.rs
+++ b/napi/minify/src/options.rs
@@ -73,10 +73,11 @@ impl TryFrom<&CompressOptions> for oxc_minifier::CompressOptions {
             unused: match &o.unused {
                 Some(Either::A(true)) => oxc_minifier::CompressOptionsUnused::Remove,
                 Some(Either::A(false)) => oxc_minifier::CompressOptionsUnused::Keep,
-                Some(Either::B(s)) if s == "keep_assign" => {
-                    oxc_minifier::CompressOptionsUnused::KeepAssign
-                }
-                None | Some(Either::B(_)) => default.unused,
+                Some(Either::B(s)) => match s.as_str() {
+                    "keep_assign" => oxc_minifier::CompressOptionsUnused::KeepAssign,
+                    _ => return Err(format!("Invalid unused option: `{s}`.")),
+                },
+                None => default.unused,
             },
             keep_names: o.keep_names.as_ref().map(Into::into).unwrap_or_default(),
             treeshake: TreeShakeOptions::default(),


### PR DESCRIPTION
fixes https://github.com/oxc-project/oxc/issues/14512

Fixes the `compress.unused` option implemented in PR #11796 to properly accept boolean values from the napi binding.