### PR TITLE
refactor(language_server): use `FxHashSet` for `ServerLinter::extended_paths`

### DIFF
--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use ignore::gitignore::Gitignore;
 use log::{debug, warn};
 use oxc_linter::{AllowWarnDeny, LintIgnoreMatcher};
-use rustc_hash::{FxBuildHasher, FxHashMap};
+use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use tokio::sync::Mutex;
 use tower_lsp_server::lsp_types::Uri;
 
@@ -40,7 +40,7 @@ pub struct ServerLinter {
     gitignore_glob: Vec<Gitignore>,
     lint_on_run: Run,
     diagnostics: ServerLinterDiagnostics,
-    pub extended_paths: Vec<PathBuf>,
+    pub extended_paths: FxHashSet<PathBuf>,
 }
 
 #[derive(Debug, Default)]
@@ -189,8 +189,8 @@ impl ServerLinter {
         root_path: &Path,
         options: &LSPLintOptions,
         nested_ignore_patterns: &mut Vec<(Vec<String>, PathBuf)>,
-    ) -> (ConcurrentHashMap<PathBuf, Config>, Vec<PathBuf>) {
-        let mut extended_paths = Vec::new();
+    ) -> (ConcurrentHashMap<PathBuf, Config>, FxHashSet<PathBuf>) {
+        let mut extended_paths = FxHashSet::default();
         // nested config is disabled, no need to search for configs
         if !options.use_nested_configs() {
             return (ConcurrentHashMap::default(), extended_paths);

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -516,9 +516,8 @@ mod test_init_watchers {
         let tester = Tester::new("fixtures/watcher/linter_extends", &Options::default());
         let watchers = tester.init_watchers();
 
-        // The root `.oxlintrc.json` extends `./lint.json -> 2 watchers
-        // The nested configs are enabled, so it finds `.oxlintrc.json` a second time -> 3 watchers
-        assert_eq!(watchers.len(), 3);
+        // The `.oxlintrc.json` extends `./lint.json -> 2 watchers
+        assert_eq!(watchers.len(), 2);
 
         // nested configs pattern
         assert_eq!(
@@ -529,19 +528,9 @@ mod test_init_watchers {
             })
         );
 
-        // nested config extends
+        // extends of root config
         assert_eq!(
             watchers[1].glob_pattern,
-            GlobPattern::Relative(RelativePattern {
-                base_uri: OneOf::Right(tester.worker.get_root_uri().clone()),
-                pattern: "lint.json".to_string(),
-            })
-        );
-
-        // base config extends
-        // TODO: filter duplicates
-        assert_eq!(
-            watchers[2].glob_pattern,
             GlobPattern::Relative(RelativePattern {
                 base_uri: OneOf::Right(tester.worker.get_root_uri().clone()),
                 pattern: "lint.json".to_string(),


### PR DESCRIPTION
Fixes duplicate entries in `extended_paths`, found by the tests in #14516.