### PR TITLE
refactor(linter): simplify built-in lint plugin checks

### DIFF
--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -346,7 +346,10 @@ impl ConfigStoreBuilder {
 
             RULES
                 .iter()
-                .filter(|rule| builtin_plugins.contains(LintPlugins::from(rule.plugin_name())))
+                .filter(|rule| {
+                    LintPlugins::try_from(rule.plugin_name())
+                        .is_ok_and(|plugin_flag| builtin_plugins.contains(plugin_flag))
+                })
                 .cloned()
                 .collect()
         }
@@ -396,7 +399,10 @@ impl ConfigStoreBuilder {
         let mut rules: Vec<_> = self
             .rules
             .into_iter()
-            .filter(|(r, _)| plugins.contains(r.plugin_name().into()))
+            .filter(|(r, _)| {
+                LintPlugins::try_from(r.plugin_name())
+                    .is_ok_and(|plugin_name| plugins.contains(plugin_name))
+            })
             .collect();
         rules.sort_unstable_by_key(|(r, _)| r.id());
 
@@ -457,7 +463,8 @@ impl ConfigStoreBuilder {
                 // NOTE: this logic means there's no way to disable ESLint
                 // correctness rules. I think that's fine for now.
                 rule.category() == RuleCategory::Correctness
-                    && plugins.contains(LintPlugins::from(rule.plugin_name()))
+                    && LintPlugins::try_from(rule.plugin_name())
+                        .is_ok_and(|plugin_flag| plugins.contains(plugin_flag))
             })
             .map(|rule| (rule.clone(), AllowWarnDeny::Warn))
             .collect()
@@ -535,7 +542,7 @@ impl ConfigStoreBuilder {
 
         match result {
             PluginLoadResult::Success { name, offset, rule_names } => {
-                if name != "eslint" && LintPlugins::from(name.as_str()) == LintPlugins::empty() {
+                if LintPlugins::try_from(name.as_str()).is_err() {
                     external_plugin_store.register_plugin(plugin_path, name, offset, rule_names);
                     Ok(())
                 } else {
@@ -650,11 +657,12 @@ mod test {
         for (rule, severity) in &builder.rules {
             assert_eq!(rule.category(), RuleCategory::Correctness);
             assert_eq!(*severity, AllowWarnDeny::Warn);
-            let plugin = rule.plugin_name();
+            let plugin_name = rule.plugin_name();
+            let plugin = LintPlugins::try_from(plugin_name);
             let name = rule.name();
             assert!(
-                builder.plugins().contains(plugin.into()),
-                "{plugin}/{name} is in the default rule set but its plugin is not enabled"
+                plugin.is_ok_and(|plugin| builder.plugins().contains(plugin)),
+                "{plugin_name}/{name} is in the default rule set but its plugin is not enabled"
             );
         }
     }
@@ -683,11 +691,12 @@ mod test {
             assert_eq!(rule.category(), RuleCategory::Correctness);
             assert_eq!(*severity, AllowWarnDeny::Deny);
 
-            let plugin = rule.plugin_name();
+            let plugin_name = rule.plugin_name();
+            let plugin = LintPlugins::try_from(plugin_name);
             let name = rule.name();
             assert!(
-                builder.plugins().contains(plugin.into()),
-                "{plugin}/{name} is in the default rule set but its plugin is not enabled"
+                plugin.is_ok_and(|plugin| builder.plugins().contains(plugin)),
+                "{plugin_name}/{name} is in the default rule set but its plugin is not enabled"
             );
         }
     }
@@ -792,8 +801,8 @@ mod test {
             let name = rule.name();
             let plugin = rule.plugin_name();
             assert_ne!(
-                LintPlugins::from(plugin),
-                LintPlugins::TYPESCRIPT,
+                LintPlugins::try_from(plugin),
+                Ok(LintPlugins::TYPESCRIPT),
                 "{plugin}/{name} is in the rules list after typescript plugin has been disabled"
             );
         }

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -167,13 +167,19 @@ impl Config {
         let mut rules = self
             .base_rules
             .iter()
-            .filter(|(rule, _)| plugins.contains(LintPlugins::from(rule.plugin_name())))
+            .filter(|(rule, _)| {
+                LintPlugins::try_from(rule.plugin_name())
+                    .is_ok_and(|plugin| plugins.contains(plugin))
+            })
             .cloned()
             .collect::<FxHashMap<_, _>>();
 
         let all_rules = RULES
             .iter()
-            .filter(|rule| plugins.contains(LintPlugins::from(rule.plugin_name())))
+            .filter(|rule| {
+                LintPlugins::try_from(rule.plugin_name())
+                    .is_ok_and(|plugin| plugins.contains(plugin))
+            })
             .cloned()
             .collect::<Vec<_>>();
 
@@ -194,7 +200,8 @@ impl Config {
 
                 if !unconfigured_plugins.is_empty() {
                     for (rule, severity) in all_rules.iter().filter_map(|rule| {
-                        let rule_plugin = LintPlugins::from(rule.plugin_name());
+                        let rule_plugin = LintPlugins::try_from(rule.plugin_name())
+                            .unwrap_or(LintPlugins::empty());
                         // Only apply categories to rules from unconfigured plugins
                         if unconfigured_plugins.contains(rule_plugin) {
                             self.categories

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -86,8 +86,7 @@ impl OxlintRules {
                 let config = rule_config.config.clone().unwrap_or_default();
                 let severity = rule_config.severity;
 
-                // TODO(camc314): remove the `plugin_name == "eslint"`
-                if plugin_name == "eslint" || !LintPlugins::from(plugin_name).is_empty() {
+                if LintPlugins::try_from(plugin_name).is_ok() {
                     let rule = rules_map.get(&plugin_name).copied().or_else(|| {
                         all_rules
                             .iter()

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -518,7 +518,12 @@ impl Tester {
                         )
                         .unwrap()
                     })
-                    .with_builtin_plugins(self.plugins | LintPlugins::from(self.plugin_name))
+                    .with_builtin_plugins(
+                        self.plugins
+                            | LintPlugins::try_from(self.plugin_name).unwrap_or_else(|()| {
+                                panic!("invalid plugin name: {}", self.plugin_name)
+                            }),
+                    )
                     .with_rule(rule, AllowWarnDeny::Warn)
                     .build(&external_plugin_store)
                     .unwrap(),

--- a/tasks/website/src/linter/rules/doc_page.rs
+++ b/tasks/website/src/linter/rules/doc_page.rs
@@ -172,8 +172,7 @@ fn rule_source(rule: &RuleTableRow) -> String {
 /// - Example: `eslint` => true
 /// - Example: `jest` => false
 fn is_default_plugin(plugin: &str) -> bool {
-    let plugin = LintPlugins::from(plugin);
-    LintPlugins::default().contains(plugin)
+    LintPlugins::try_from(plugin).is_ok_and(|plugin| LintPlugins::default().contains(plugin))
 }
 
 /// Returns the normalized plugin name.
@@ -181,7 +180,7 @@ fn is_default_plugin(plugin: &str) -> bool {
 /// - Example: `eslint` -> `eslint`
 /// - Example: `jsx_a11y` -> `jsx-a11y`
 fn get_normalized_plugin_name(plugin: &str) -> &str {
-    LintPlugins::from(plugin).into()
+    LintPlugins::try_from(plugin).unwrap_or(LintPlugins::empty()).into()
 }
 
 fn how_to_use(rule: &RuleTableRow) -> String {


### PR DESCRIPTION
Instead of checking that `plugin != "eslint"`, we can update `LintPlugins::from` to be `LintPlugins::try_from`, which allows for us to represent the default ESLint plugin. If it's any built-in plugin, this will return `Ok(LintPlugins::SomePlugin)`. If it's not a builtin, it will return `Err`. Previously, we had to check if it was empty and if it was not `eslint` plugin (since it was always empty by definition).