### PR TITLE
perf(linter): refactor rules to take advantage of node type skipping

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -270,7 +270,8 @@ impl RuleRunner for crate::rules::eslint::no_empty_function::NoEmptyFunction {
 }
 
 impl RuleRunner for crate::rules::eslint::no_empty_pattern::NoEmptyPattern {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ArrayPattern, AstType::ObjectPattern]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_empty_static_block::NoEmptyStaticBlock {
@@ -288,7 +289,8 @@ impl RuleRunner for crate::rules::eslint::no_eval::NoEval {
 }
 
 impl RuleRunner for crate::rules::eslint::no_ex_assign::NoExAssign {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CatchParameter]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_extend_native::NoExtendNative {
@@ -305,7 +307,8 @@ impl RuleRunner for crate::rules::eslint::no_extra_boolean_cast::NoExtraBooleanC
 }
 
 impl RuleRunner for crate::rules::eslint::no_extra_label::NoExtraLabel {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BreakStatement, AstType::ContinueStatement]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_fallthrough::NoFallthrough {
@@ -314,7 +317,8 @@ impl RuleRunner for crate::rules::eslint::no_fallthrough::NoFallthrough {
 }
 
 impl RuleRunner for crate::rules::eslint::no_func_assign::NoFuncAssign {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Function]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_global_assign::NoGlobalAssign {
@@ -322,11 +326,13 @@ impl RuleRunner for crate::rules::eslint::no_global_assign::NoGlobalAssign {
 }
 
 impl RuleRunner for crate::rules::eslint::no_import_assign::NoImportAssign {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ImportDeclaration]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_inner_declarations::NoInnerDeclarations {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Function, AstType::VariableDeclaration]));
 }
 
 impl RuleRunner for crate::rules::eslint::no_invalid_regexp::NoInvalidRegexp {

--- a/crates/oxc_linter/src/rules/eslint/no_empty_pattern.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_pattern.rs
@@ -76,12 +76,19 @@ declare_oxc_lint!(
 
 impl Rule for NoEmptyPattern {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let (pattern_type, span) = match node.kind() {
-            AstKind::ArrayPattern(array) if array.is_empty() => ("array", array.span),
-            AstKind::ObjectPattern(object) if object.is_empty() => ("object", object.span),
-            _ => return,
-        };
-        ctx.diagnostic(no_empty_pattern_diagnostic(pattern_type, span));
+        match node.kind() {
+            AstKind::ArrayPattern(array) => {
+                if array.is_empty() {
+                    ctx.diagnostic(no_empty_pattern_diagnostic("array", array.span));
+                }
+            }
+            AstKind::ObjectPattern(object) => {
+                if object.is_empty() {
+                    ctx.diagnostic(no_empty_pattern_diagnostic("object", object.span));
+                }
+            }
+            _ => {}
+        }
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_extra_label.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extra_label.rs
@@ -90,15 +90,18 @@ declare_oxc_lint!(
 
 impl Rule for NoExtraLabel {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if let AstKind::BreakStatement(break_stmt) = node.kind()
-            && let Some(label) = &break_stmt.label
-        {
-            report_label_if_extra(label, node, ctx);
-        }
-        if let AstKind::ContinueStatement(cont_stmt) = node.kind()
-            && let Some(label) = &cont_stmt.label
-        {
-            report_label_if_extra(label, node, ctx);
+        match node.kind() {
+            AstKind::BreakStatement(break_stmt) => {
+                if let Some(label) = &break_stmt.label {
+                    report_label_if_extra(label, node, ctx);
+                }
+            }
+            AstKind::ContinueStatement(cont_stmt) => {
+                if let Some(label) = &cont_stmt.label {
+                    report_label_if_extra(label, node, ctx);
+                }
+            }
+            _ => {}
         }
     }
 }

--- a/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
@@ -1,7 +1,7 @@
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::SymbolId;
+use oxc_semantic::AstNode;
 use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
@@ -67,14 +67,17 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoFuncAssign {
-    fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
-        let symbol_table = ctx.scoping();
-        let decl = symbol_table.symbol_declaration(symbol_id);
-        if let AstKind::Function(_) = ctx.nodes().kind(decl) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        if let AstKind::Function(func) = node.kind() {
+            let (func_name, symbol_id) = match &func.id {
+                Some(id) => (id.name.as_str(), id.symbol_id()),
+                None => return,
+            };
+            let symbol_table = ctx.scoping();
             for reference in symbol_table.get_resolved_references(symbol_id) {
                 if reference.is_write() {
                     ctx.diagnostic(no_func_assign_diagnostic(
-                        symbol_table.symbol_name(symbol_id),
+                        func_name,
                         ctx.semantic().reference_span(reference),
                     ));
                 }


### PR DESCRIPTION
Updating rules to take advantage of the node type skipping so that they don't need to be run on every file. I forgot to split this out, so this is a composite PR of several rules, which I'll try to avoid in the future.

Some symbol-based rules have been refactored to search for the node type first and then look for symbols based on that. For example, if there are no imports in the file, we can skip `no-import-assign` instead of looping over all symbols and looking for an import.