### PR TITLE
feat(linter/no-duplicate-imports): support `allowSeparateTypeImports` option

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
@@ -39,6 +39,7 @@ fn no_duplicate_exports_diagnostic(
 #[derive(Debug, Default, Clone)]
 pub struct NoDuplicateImports {
     include_exports: bool,
+    allow_separate_type_imports: bool,
 }
 
 declare_oxc_lint!(
@@ -105,6 +106,25 @@ declare_oxc_lint!(
     /// // cannot be written differently
     /// export * from 'module';
     /// ```
+    ///
+    /// #### allowSeparateTypeImports
+    ///
+    /// `{ type: boolean, default: false }`
+    ///
+    /// When `true`, imports with only type specifiers (inline types or type imports) are
+    /// considered separate from imports with value specifiers, so they can be imported from the
+    /// same module on separate import statements.
+    ///
+    /// Examples of **correct** code when `allowSeparateTypeImports` is set to `true`:
+    /// ```js
+    /// import { foo } from "module";
+    /// import type { Bar } from "module";
+    /// ```
+    ///
+    /// ```js
+    /// import { type Foo } from "module";
+    /// import type { Bar } from "module";
+    /// ```
     NoDuplicateImports,
     eslint,
     style,
@@ -134,12 +154,16 @@ impl Rule for NoDuplicateImports {
                 .and_then(|v| v.get("includeExports"))
                 .and_then(serde_json::Value::as_bool)
                 .unwrap_or(false),
+            allow_separate_type_imports: value
+                .and_then(|v| v.get("allowSeparateTypeImports"))
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false),
         }
     }
 
     fn run_once(&self, ctx: &LintContext) {
         let module_record = ctx.module_record();
-        let mut import_map: FxHashMap<&CompactStr, Vec<(ImportType, Span, ModuleType)>> =
+        let mut import_map: FxHashMap<&CompactStr, Vec<(ImportType, Span, ModuleType, bool)>> =
             FxHashMap::default();
         let mut previous_span: Option<Span> = None;
         let mut side_effect_import_map: FxHashMap<&CompactStr, Vec<Span>> = FxHashMap::default();
@@ -147,6 +171,13 @@ impl Rule for NoDuplicateImports {
         for entry in &module_record.import_entries {
             let source = &entry.module_request.name;
             let span = entry.module_request.span;
+
+            let requested_module_is_type_import = module_record.requested_modules
+                [&entry.module_request.name]
+                .iter()
+                .find(|requested_module| requested_module.span == entry.module_request.span)
+                .unwrap()
+                .is_type;
 
             let import_type = match &entry.import_name {
                 ImportImportName::Name(_) => ImportType::Named,
@@ -158,7 +189,13 @@ impl Rule for NoDuplicateImports {
                 previous_span = Some(span);
 
                 if let Some(existing) = import_map.get(source)
-                    && can_merge_imports(&import_type, existing)
+                    && can_merge_imports(
+                        &import_type,
+                        existing,
+                        self.allow_separate_type_imports,
+                        requested_module_is_type_import,
+                        entry.is_type,
+                    )
                 {
                     ctx.diagnostic(no_duplicate_imports_diagnostic(
                         source,
@@ -169,7 +206,12 @@ impl Rule for NoDuplicateImports {
                 }
             }
 
-            import_map.entry(source).or_default().push((import_type, span, ModuleType::Import));
+            import_map.entry(source).or_default().push((
+                import_type,
+                span,
+                ModuleType::Import,
+                requested_module_is_type_import,
+            ));
         }
 
         if module_record.import_entries.is_empty() {
@@ -205,7 +247,9 @@ impl Rule for NoDuplicateImports {
 
                 if entry.import_name.is_all_but_default() {
                     if let Some(existing) = import_map.get(source)
-                        && existing.iter().any(|(t, _, _)| matches!(t, ImportType::AllButDefault))
+                        && existing
+                            .iter()
+                            .any(|(t, _, _, _)| matches!(t, ImportType::AllButDefault))
                     {
                         ctx.diagnostic(no_duplicate_exports_diagnostic(
                             source,
@@ -226,13 +270,14 @@ impl Rule for NoDuplicateImports {
                         ImportType::AllButDefault,
                         span,
                         ModuleType::Export,
+                        false,
                     ));
                     continue;
                 }
                 if let Some(existing) = import_map.get(source)
                     && existing
                         .iter()
-                        .any(|(t, _, _)| matches!(t, ImportType::Named | ImportType::SideEffect))
+                        .any(|(t, _, _, _)| matches!(t, ImportType::Named | ImportType::SideEffect))
                 {
                     ctx.diagnostic(no_duplicate_exports_diagnostic(
                         source,
@@ -246,6 +291,7 @@ impl Rule for NoDuplicateImports {
                     ImportType::SideEffect,
                     span,
                     ModuleType::Export,
+                    entry.is_type,
                 ));
             }
 
@@ -256,9 +302,25 @@ impl Rule for NoDuplicateImports {
                 let source = &module_request.name;
                 let span = entry.span;
 
+                // Check if this export is from a statement-level type export (export type)
+                let requested_module = module_record.requested_modules[source]
+                    .iter()
+                    .find(|rm| rm.span == module_request.span)
+                    .unwrap();
+                let is_statement_type_export = requested_module.is_type;
+
+                if let Some(existing) = side_effect_import_map.get(source) {
+                    ctx.diagnostic(no_duplicate_exports_diagnostic(
+                        source,
+                        span,
+                        *existing.first().unwrap(),
+                    ));
+                    continue;
+                }
+
                 if let Some(existing) = import_map.get(source) {
                     if entry.import_name == ExportImportName::All {
-                        if existing.iter().any(|(t, _, _)| {
+                        if existing.iter().any(|(t, _, _, _)| {
                             matches!(t, ImportType::Default | ImportType::Namespace)
                         }) {
                             ctx.diagnostic(no_duplicate_exports_diagnostic(
@@ -271,7 +333,74 @@ impl Rule for NoDuplicateImports {
                         continue;
                     }
 
-                    if existing.iter().any(|(t, import_span, module_type)| {
+                    // Special case: type export with type imports (default + named)
+                    // This applies regardless of allowSeparateTypeImports
+                    if entry.is_type {
+                        let all_existing_are_type =
+                            existing.iter().all(|(_, _, _, is_stmt_type)| *is_stmt_type);
+                        if all_existing_are_type {
+                            let has_default = existing
+                                .iter()
+                                .any(|(t, _, _, _)| matches!(t, ImportType::Default));
+                            // Export is named, cannot merge with default type import
+                            if has_default {
+                                import_map.entry(source).or_default().push((
+                                    ImportType::Named,
+                                    span,
+                                    ModuleType::Export,
+                                    entry.is_type,
+                                ));
+                                continue;
+                            }
+                        }
+                    }
+
+                    // Handle allowSeparateTypeImports for exports
+                    if self.allow_separate_type_imports {
+                        let imports_only = existing
+                            .iter()
+                            .filter(|(_, _, module_type, _)| *module_type == ModuleType::Import)
+                            .collect::<Vec<_>>();
+
+                        if !imports_only.is_empty() {
+                            // Only consider statement-level type exports/imports
+                            // Inline type specifiers (export { type Foo }) are treated as value exports
+                            if is_statement_type_export && entry.is_type {
+                                // Statement-level type export: check if there are value imports
+                                let has_value_imports = imports_only
+                                    .iter()
+                                    .any(|(_, _, _, is_stmt_type)| !is_stmt_type);
+                                if has_value_imports {
+                                    // Don't report, allow separation from value imports
+                                    import_map.entry(source).or_default().push((
+                                        ImportType::Named,
+                                        span,
+                                        ModuleType::Export,
+                                        is_statement_type_export,
+                                    ));
+                                    continue;
+                                }
+                            } else if !is_statement_type_export {
+                                // Value/inline type export: check if there are only statement-level type imports
+                                let all_imports_are_statement_type = imports_only
+                                    .iter()
+                                    .all(|(_, _, _, is_stmt_type)| *is_stmt_type);
+
+                                if all_imports_are_statement_type {
+                                    // Don't report, allow separation from statement-level type imports
+                                    import_map.entry(source).or_default().push((
+                                        ImportType::Named,
+                                        span,
+                                        ModuleType::Export,
+                                        is_statement_type_export,
+                                    ));
+                                    continue;
+                                }
+                            }
+                        }
+                    }
+
+                    if existing.iter().any(|(t, import_span, module_type, _)| {
                         // import { a } from 'foo'; export { a as t };
                         if matches!(t, ImportType::Named) && module_request.span != *import_span {
                             return true;
@@ -296,6 +425,7 @@ impl Rule for NoDuplicateImports {
                     ImportType::Named,
                     span,
                     ModuleType::Export,
+                    is_statement_type_export,
                 ));
             }
         }
@@ -304,7 +434,10 @@ impl Rule for NoDuplicateImports {
 
 fn can_merge_imports(
     current_type: &ImportType,
-    existing: &[(ImportType, Span, ModuleType)],
+    existing: &[(ImportType, Span, ModuleType, bool)],
+    allow_separate_type_imports: bool,
+    is_current_statement_type_import: bool,
+    is_current_specifier_type: bool,
 ) -> bool {
     if *current_type == ImportType::AllButDefault {
         return false;
@@ -314,9 +447,48 @@ fn can_merge_imports(
         return !existing.is_empty();
     }
 
-    let namespace = existing.iter().find(|(t, _, _)| matches!(t, ImportType::Namespace));
-    let named = existing.iter().find(|(t, _, _)| matches!(t, ImportType::Named));
-    let default = existing.iter().find(|(t, _, _)| matches!(t, ImportType::Default));
+    // Special case: both are type imports (statement-level)
+    // Check if one is default and one is named (cannot be merged per ESLint)
+    let all_existing_are_type = existing.iter().all(|(_, _, _, is_stmt_type)| *is_stmt_type);
+    if is_current_statement_type_import && is_current_specifier_type && all_existing_are_type {
+        let current_is_default = matches!(current_type, ImportType::Default);
+        let current_is_named = matches!(current_type, ImportType::Named);
+        let has_default = existing.iter().any(|(t, _, _, _)| matches!(t, ImportType::Default));
+        let has_named = existing.iter().any(|(t, _, _, _)| matches!(t, ImportType::Named));
+
+        // Cannot merge if one is default and the other is named
+        if (current_is_default && has_named) || (current_is_named && has_default) {
+            return false;
+        }
+    }
+
+    // Handle allowSeparateTypeImports option
+    if allow_separate_type_imports {
+        let has_value_statement_imports =
+            existing.iter().any(|(_, _, _, is_stmt_type)| !is_stmt_type);
+        let has_type_statement_imports =
+            existing.iter().any(|(_, _, _, is_stmt_type)| *is_stmt_type);
+
+        // If current is a statement-level type import (import type)
+        if is_current_statement_type_import {
+            // Don't merge with value/mixed statements (allow separation)
+            // But DO merge with other statement-level type imports (report as duplicate)
+            if has_value_statement_imports && !has_type_statement_imports {
+                return false;
+            }
+            // If there are other type imports, continue to check if they can be merged
+        } else {
+            // Current is a value or mixed import (not statement-level type)
+            // Don't merge with statement-level type imports (allow separation)
+            if has_type_statement_imports {
+                return false;
+            }
+        }
+    }
+
+    let namespace = existing.iter().find(|(t, _, _, _)| matches!(t, ImportType::Namespace));
+    let named = existing.iter().find(|(t, _, _, _)| matches!(t, ImportType::Named));
+    let default = existing.iter().find(|(t, _, _, _)| matches!(t, ImportType::Default));
 
     let has_namespace = namespace.is_some();
     let has_named = named.is_some();
@@ -326,15 +498,15 @@ fn can_merge_imports(
         ImportType::Named => {
             has_named
                 || (has_default
-                    && !namespace.is_some_and(|(_, namespace_span, _)| {
+                    && !namespace.is_some_and(|(_, namespace_span, _, _)| {
                         default.unwrap().1 == *namespace_span
                     }))
         }
         ImportType::Namespace => {
             if has_named
                 && has_default
-                && let Some((_, named_span, _)) = named
-                && let Some((_, default_span, _)) = default
+                && let Some((_, named_span, _, _)) = named
+                && let Some((_, default_span, _, _)) = default
                 && named_span == default_span
             {
                 return false;
@@ -354,7 +526,7 @@ fn test() {
     let pass = vec![
         (
             r#"import os from "os";
-    		import fs from "fs";"#,
+			import fs from "fs";"#,
             None,
         ),
         (r#"import { merge } from "lodash-es";"#, None),
@@ -363,180 +535,404 @@ fn test() {
         (r#"import "foo""#, None),
         (
             r#"import os from "os";
-        export { something } from "os";"#,
+			export { something } from "os";"#,
             None,
         ),
         (
             r#"import * as bar from "os";
-        import { baz } from "os";"#,
+			import { baz } from "os";"#,
             None,
         ),
         (
             r#"import foo, * as bar from "os";
-        import { baz } from "os";"#,
+			import { baz } from "os";"#,
             None,
         ),
         (
             r#"import foo, { bar } from "os";
-        import * as baz from "os";"#,
+			import * as baz from "os";"#,
             None,
         ),
         (
             r#"import os from "os";
-        export { hello } from "hello";"#,
+			export { hello } from "hello";"#,
             Some(serde_json::json!([{ "includeExports": true }])),
         ),
         (
             r#"import os from "os";
-        export * from "hello";"#,
+			export * from "hello";"#,
             Some(serde_json::json!([{ "includeExports": true }])),
         ),
         (
             r#"import os from "os";
-        export { hello as hi } from "hello";"#,
+			export { hello as hi } from "hello";"#,
             Some(serde_json::json!([{ "includeExports": true }])),
         ),
         (
             r#"import os from "os";
-        export default function(){};"#,
+			export default function(){};"#,
             Some(serde_json::json!([{ "includeExports": true }])),
         ),
         (
             r#"import { merge } from "lodash-es";
-        export { merge as lodashMerge }"#,
+			export { merge as lodashMerge }"#,
             Some(serde_json::json!([{ "includeExports": true }])),
         ),
         (
             r#"export { something } from "os";
-        export * as os from "os";"#,
+			export * as os from "os";"#,
             Some(serde_json::json!([{ "includeExports": true }])),
         ),
         (
             r#"import { something } from "os";
-        export * as os from "os";"#,
+			export * as os from "os";"#,
             Some(serde_json::json!([{ "includeExports": true }])),
         ),
         (
             r#"import * as os from "os";
-        export { something } from "os";"#,
+			export { something } from "os";"#,
             Some(serde_json::json!([{ "includeExports": true }])),
         ),
         (
             r#"import os from "os";
-        export * from "os";"#,
+			export * from "os";"#,
             Some(serde_json::json!([{ "includeExports": true }])),
         ),
         (
             r#"export { something } from "os";
-        export * from "os";"#,
+			export * from "os";"#,
             Some(serde_json::json!([{ "includeExports": true }])),
         ),
         (
-            "
-                import { a } from 'f';
-                export { b as r };
-            ",
+            r#"import type { Os } from "os";
+			import type { Fs } from "fs";"#,
+            None,
+        ),
+        (
+            r#"import { type Os } from "os";
+			import type { Fs } from "fs";"#,
+            None,
+        ),
+        (r#"import type { Merge } from "lodash-es";"#, None),
+        (r#"import _, { type Merge } from "lodash-es";"#, None),
+        (r#"import type * as Foobar from "async";"#, None),
+        (
+            r#"import type Os from "os";
+			export type { Something } from "os";"#,
+            None,
+        ),
+        (
+            r#"import type Os from "os";
+			export { type Something } from "os";"#,
+            None,
+        ),
+        (
+            r#"import type * as Bar from "os";
+			import { type Baz } from "os";"#,
+            None,
+        ),
+        (
+            r#"import foo, * as bar from "os";
+			import { type Baz } from "os";"#,
+            None,
+        ),
+        (
+            r#"import foo, { type bar } from "os";
+			import type * as Baz from "os";"#,
+            None,
+        ),
+        (
+            r#"import type { Merge } from "lodash-es";
+			import type _ from "lodash-es";"#,
+            None,
+        ),
+        (
+            r#"import type Os from "os";
+			export { type Hello } from "hello";"#,
             Some(serde_json::json!([{ "includeExports": true }])),
+        ),
+        (
+            r#"import type Os from "os";
+			export type * from "hello";"#,
+            Some(serde_json::json!([{ "includeExports": true }])),
+        ),
+        (
+            r#"import type Os from "os";
+			export { type Hello as Hi } from "hello";"#,
+            Some(serde_json::json!([{ "includeExports": true }])),
+        ),
+        (
+            r#"import type Os from "os";
+			export default function(){};"#,
+            Some(serde_json::json!([{ "includeExports": true }])),
+        ),
+        (
+            r#"import { type Merge } from "lodash-es";
+			export { Merge as lodashMerge }"#,
+            Some(serde_json::json!([{ "includeExports": true }])),
+        ),
+        (
+            r#"export type { Something } from "os";
+			export * as os from "os";"#,
+            Some(serde_json::json!([{ "includeExports": true }])),
+        ),
+        (
+            r#"import { type Something } from "os";
+			export * as os from "os";"#,
+            Some(serde_json::json!([{ "includeExports": true }])),
+        ),
+        (
+            r#"import type * as Os from "os";
+			export { something } from "os";"#,
+            Some(serde_json::json!([{ "includeExports": true }])),
+        ),
+        (
+            r#"import type Os from "os";
+			export * from "os";"#,
+            Some(serde_json::json!([{ "includeExports": true }])),
+        ),
+        (
+            r#"import type Os from "os";
+			export type { Something } from "os";"#,
+            Some(serde_json::json!([{ "includeExports": true }])),
+        ),
+        (
+            r#"export type { Something } from "os";
+			export * from "os";"#,
+            Some(serde_json::json!([{ "includeExports": true }])),
+        ),
+        (
+            r#"import { foo, type Bar } from "module";"#,
+            Some(serde_json::json!([{ "allowSeparateTypeImports": true }])),
+        ),
+        (
+            r#"import { foo } from "module";
+			import type { Bar } from "module";"#,
+            Some(serde_json::json!([{ "allowSeparateTypeImports": true }])),
+        ),
+        (
+            r#"import { type Foo } from "module";
+			import type { Bar } from "module";"#,
+            Some(serde_json::json!([{ "allowSeparateTypeImports": true }])),
+        ),
+        (
+            r#"import { foo, type Bar } from "module";
+			export { type Baz } from "module2";"#,
+            Some(serde_json::json!([{ "allowSeparateTypeImports": true, "includeExports": true }])),
+        ),
+        (
+            r#"import type { Foo } from "module";
+			export { bar, type Baz } from "module";"#,
+            Some(serde_json::json!([{ "allowSeparateTypeImports": true, "includeExports": true }])),
+        ),
+        (
+            r#"import { type Foo } from "module";
+			export type { Bar } from "module";"#,
+            Some(serde_json::json!([{ "allowSeparateTypeImports": true, "includeExports": true }])),
+        ),
+        (
+            r#"import type * as Foo from "module";
+			export { type Bar } from "module";"#,
+            Some(serde_json::json!([{ "allowSeparateTypeImports": true, "includeExports": true }])),
+        ),
+        (
+            r#"import { type Foo } from "module";
+			export type * as Bar from "module";"#,
+            Some(serde_json::json!([{ "allowSeparateTypeImports": true, "includeExports": true }])),
         ),
     ];
 
     let fail = vec![
         (
-            "
-                export { a } from 'foo';
-                import { f } from 'foo';
-            ",
-            Some(serde_json::json!([{ "includeExports": true }])),
-        ),
-        (
             r#"import "fs";
-        import "fs""#,
+			import "fs""#,
             None,
         ),
         (
             r#"import { merge } from "lodash-es";
-        import { find } from "lodash-es";"#,
+			import { find } from "lodash-es";"#,
             None,
         ),
         (
             r#"import { merge } from "lodash-es";
-          import _ from "lodash-es";"#,
+			import _ from "lodash-es";"#,
             None,
         ),
         (
             r#"import os from "os";
-          import { something } from "os";
-          import * as foobar from "os";"#,
+			import { something } from "os";
+			import * as foobar from "os";"#,
             None,
         ),
         (
             r#"import * as modns from "lodash-es";
-          import { merge } from "lodash-es";
-          import { baz } from "lodash-es";"#,
+			import { merge } from "lodash-es";
+			import { baz } from "lodash-es";"#,
             None,
         ),
         (
             r#"export { os } from "os";
-          export { something } from "os";"#,
+			export { something } from "os";"#,
             Some(serde_json::json!([{ "includeExports": true }])),
         ),
         (
             r#"import os from "os";
-          export { os as foobar } from "os";
-          export { something } from "os";"#,
+			export { os as foobar } from "os";
+			export { something } from "os";"#,
             Some(serde_json::json!([{ "includeExports": true }])),
         ),
         (
             r#"import os from "os";
-          export { something } from "os";"#,
+			export { something } from "os";"#,
             Some(serde_json::json!([{ "includeExports": true }])),
         ),
         (
             r#"import os from "os";
-        export * as os from "os";"#,
+			export * as os from "os";"#,
             Some(serde_json::json!([{ "includeExports": true }])),
         ),
         (
             r#"export * as os from "os";
-        import os from "os";"#,
+			import os from "os";"#,
             Some(serde_json::json!([{ "includeExports": true }])),
         ),
         (
             r#"import * as modns from "mod";
-        export * as  modns from "mod";"#,
+			export * as  modns from "mod";"#,
             Some(serde_json::json!([{ "includeExports": true }])),
         ),
         (
             r#"export * from "os";
-        export * from "os";"#,
+			export * from "os";"#,
             Some(serde_json::json!([{ "includeExports": true }])),
         ),
         (
             r#"import "os";
-        export * from "os";"#,
+			export * from "os";"#,
             Some(serde_json::json!([{ "includeExports": true }])),
         ),
         (
-            // Verifies that the error for the second line appears only once in the test snapshot.
-            // https://github.com/oxc-project/oxc/pull/11320#issuecomment-2912286528
-            r#"import type { PriorityDialogCustomClassNames, WeightDialogCustomClassNames } from "./HostEditDialogs";
-            import { PriorityDialog, WeightDialog } from "./HostEditDialogs";"#,
+            r#"import "fs";
+			import "fs""#,
             None,
         ),
         (
-            "
-                import b from 'foo';
-                import { a } from 'foo';
-            ",
+            r#"import { type Merge } from "lodash-es";
+			import { type Find } from "lodash-es";"#,
             None,
         ),
         (
-            "
-                import * as bar from 'foo';
-                import b from 'foo';
-                import { a } from 'foo';
-            ",
+            r#"import { type Merge } from "lodash-es";
+			import type { Find } from "lodash-es";"#,
             None,
+        ),
+        (
+            r#"import type { Merge } from "lodash-es";
+			import type { Find } from "lodash-es";"#,
+            None,
+        ),
+        (
+            r#"import type Os from "os";
+			import type { Something } from "os";
+			import type * as Foobar from "os";"#,
+            None,
+        ),
+        (
+            r#"import type * as Modns from "lodash-es";
+			import type { Merge } from "lodash-es";
+			import type { Baz } from "lodash-es";"#,
+            None,
+        ),
+        (
+            r#"import { type Foo } from "module";
+			export type { Bar } from "module";"#,
+            Some(serde_json::json!([{ "includeExports": true }])),
+        ),
+        (
+            r#"export { os } from "os";
+			export type { Something } from "os";"#,
+            Some(serde_json::json!([{ "includeExports": true }])),
+        ),
+        (
+            r#"export type { Os } from "os";
+			export type { Something } from "os";"#,
+            Some(serde_json::json!([{ "includeExports": true }])),
+        ),
+        (
+            r#"import type { Os } from "os";
+			export type { Os as Foobar } from "os";
+			export type { Something } from "os";"#,
+            Some(serde_json::json!([{ "includeExports": true }])),
+        ),
+        (
+            r#"import type { Os } from "os";
+			export type { Something } from "os";"#,
+            Some(serde_json::json!([{ "includeExports": true }])),
+        ),
+        (
+            r#"import type Os from "os";
+			export type * as Os from "os";"#,
+            Some(serde_json::json!([{ "includeExports": true }])),
+        ),
+        (
+            r#"import type * as Modns from "mod";
+			export type * as Modns from "mod";"#,
+            Some(serde_json::json!([{ "includeExports": true }])),
+        ),
+        (
+            r#"export type * from "os";
+			export type * from "os";"#,
+            Some(serde_json::json!([{ "includeExports": true }])),
+        ),
+        (
+            r#"import "os";
+			export type { Os } from "os";"#,
+            Some(serde_json::json!([{ "includeExports": true }])),
+        ),
+        (
+            "import { someValue } from 'module';
+			import { anotherValue } from 'module';",
+            Some(serde_json::json!([{ "allowSeparateTypeImports": true }])),
+        ),
+        (
+            r#"import type { Merge } from "lodash-es";
+			import type { Find } from "lodash-es";"#,
+            Some(serde_json::json!([{ "allowSeparateTypeImports": true }])),
+        ),
+        (
+            "import { someValue, type Foo } from 'module';
+			import type { SomeType } from 'module';
+			import type { AnotherType } from 'module';",
+            Some(serde_json::json!([{ "allowSeparateTypeImports": true }])),
+        ),
+        (
+            "import { type Foo } from 'module';
+			import { type Bar } from 'module';",
+            Some(serde_json::json!([{ "allowSeparateTypeImports": true }])),
+        ),
+        (
+            r#"export type { Foo } from "module";
+			export type { Bar } from "module";"#,
+            Some(serde_json::json!([{ "allowSeparateTypeImports": true, "includeExports": true }])),
+        ),
+        (
+            r#"import { type Foo } from "module";
+			export { type Bar } from "module";
+			export { type Baz } from "module";"#,
+            Some(serde_json::json!([{ "allowSeparateTypeImports": true, "includeExports": true }])),
+        ),
+        (
+            r#"import { type Foo } from "module";
+			export { type Bar } from "module";
+			export { regular } from "module";"#,
+            Some(serde_json::json!([{ "allowSeparateTypeImports": true, "includeExports": true }])),
+        ),
+        (
+            r#"import { type Foo } from "module";
+			import { regular } from "module";
+			export { type Bar } from "module";
+			export { regular as other } from "module";"#,
+            Some(serde_json::json!([{ "allowSeparateTypeImports": true, "includeExports": true }])),
         ),
     ];
 

--- a/crates/oxc_linter/src/snapshots/eslint_no_duplicate_imports.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_duplicate_imports.snap
@@ -1,27 +1,14 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-duplicate-imports): 'foo' export is duplicated
-   ╭─[no_duplicate_imports.tsx:2:26]
- 1 │ 
- 2 │                 export { a } from 'foo';
-   ·                          ┬
-   ·                          ╰── This export is duplicated
- 3 │                 import { f } from 'foo';
-   ·                                   ──┬──
-   ·                                     ╰── Can be merged with this
- 4 │             
-   ╰────
-  help: Merge the duplicated exports into a single export statement
-
   ⚠ eslint(no-duplicate-imports): 'fs' import is duplicated
    ╭─[no_duplicate_imports.tsx:1:8]
  1 │ import "fs";
    ·        ──┬─
    ·          ╰── Can be merged with this import
- 2 │         import "fs"
-   ·                ──┬─
-   ·                  ╰── This import is duplicated
+ 2 │             import "fs"
+   ·                    ──┬─
+   ·                      ╰── This import is duplicated
    ╰────
   help: Merge the duplicated import into a single import statement
 
@@ -30,9 +17,9 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import { merge } from "lodash-es";
    ·                       ─────┬─────
    ·                            ╰── Can be merged with this import
- 2 │         import { find } from "lodash-es";
-   ·                              ─────┬─────
-   ·                                   ╰── This import is duplicated
+ 2 │             import { find } from "lodash-es";
+   ·                                  ─────┬─────
+   ·                                       ╰── This import is duplicated
    ╰────
   help: Merge the duplicated import into a single import statement
 
@@ -41,9 +28,9 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import { merge } from "lodash-es";
    ·                       ─────┬─────
    ·                            ╰── Can be merged with this import
- 2 │           import _ from "lodash-es";
-   ·                         ─────┬─────
-   ·                              ╰── This import is duplicated
+ 2 │             import _ from "lodash-es";
+   ·                           ─────┬─────
+   ·                                ╰── This import is duplicated
    ╰────
   help: Merge the duplicated import into a single import statement
 
@@ -52,22 +39,22 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import os from "os";
    ·                ──┬─
    ·                  ╰── Can be merged with this import
- 2 │           import { something } from "os";
+ 2 │             import { something } from "os";
+   ·                                       ──┬─
+   ·                                         ╰── This import is duplicated
+ 3 │             import * as foobar from "os";
+   ╰────
+  help: Merge the duplicated import into a single import statement
+
+  ⚠ eslint(no-duplicate-imports): 'os' import is duplicated
+   ╭─[no_duplicate_imports.tsx:1:16]
+ 1 │ import os from "os";
+   ·                ──┬─
+   ·                  ╰── Can be merged with this import
+ 2 │             import { something } from "os";
+ 3 │             import * as foobar from "os";
    ·                                     ──┬─
    ·                                       ╰── This import is duplicated
- 3 │           import * as foobar from "os";
-   ╰────
-  help: Merge the duplicated import into a single import statement
-
-  ⚠ eslint(no-duplicate-imports): 'os' import is duplicated
-   ╭─[no_duplicate_imports.tsx:1:16]
- 1 │ import os from "os";
-   ·                ──┬─
-   ·                  ╰── Can be merged with this import
- 2 │           import { something } from "os";
- 3 │           import * as foobar from "os";
-   ·                                   ──┬─
-   ·                                     ╰── This import is duplicated
    ╰────
   help: Merge the duplicated import into a single import statement
 
@@ -76,10 +63,10 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import * as modns from "lodash-es";
    ·                        ─────┬─────
    ·                             ╰── Can be merged with this import
- 2 │           import { merge } from "lodash-es";
- 3 │           import { baz } from "lodash-es";
-   ·                               ─────┬─────
-   ·                                    ╰── This import is duplicated
+ 2 │             import { merge } from "lodash-es";
+ 3 │             import { baz } from "lodash-es";
+   ·                                 ─────┬─────
+   ·                                      ╰── This import is duplicated
    ╰────
   help: Merge the duplicated import into a single import statement
 
@@ -88,21 +75,9 @@ source: crates/oxc_linter/src/tester.rs
  1 │ export { os } from "os";
    ·          ─┬
    ·           ╰── Can be merged with this
- 2 │           export { something } from "os";
-   ·                    ────┬────
-   ·                        ╰── This export is duplicated
-   ╰────
-  help: Merge the duplicated exports into a single export statement
-
-  ⚠ eslint(no-duplicate-imports): 'os' export is duplicated
-   ╭─[no_duplicate_imports.tsx:1:16]
- 1 │ import os from "os";
-   ·                ──┬─
-   ·                  ╰── Can be merged with this
- 2 │           export { os as foobar } from "os";
-   ·                    ──────┬─────
+ 2 │             export { something } from "os";
+   ·                      ────┬────
    ·                          ╰── This export is duplicated
- 3 │           export { something } from "os";
    ╰────
   help: Merge the duplicated exports into a single export statement
 
@@ -111,10 +86,10 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import os from "os";
    ·                ──┬─
    ·                  ╰── Can be merged with this
- 2 │           export { os as foobar } from "os";
- 3 │           export { something } from "os";
-   ·                    ────┬────
-   ·                        ╰── This export is duplicated
+ 2 │             export { os as foobar } from "os";
+   ·                      ──────┬─────
+   ·                            ╰── This export is duplicated
+ 3 │             export { something } from "os";
    ╰────
   help: Merge the duplicated exports into a single export statement
 
@@ -123,9 +98,10 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import os from "os";
    ·                ──┬─
    ·                  ╰── Can be merged with this
- 2 │           export { something } from "os";
-   ·                    ────┬────
-   ·                        ╰── This export is duplicated
+ 2 │             export { os as foobar } from "os";
+ 3 │             export { something } from "os";
+   ·                      ────┬────
+   ·                          ╰── This export is duplicated
    ╰────
   help: Merge the duplicated exports into a single export statement
 
@@ -134,9 +110,20 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import os from "os";
    ·                ──┬─
    ·                  ╰── Can be merged with this
- 2 │         export * as os from "os";
-   ·         ────────────┬────────────
-   ·                     ╰── This export is duplicated
+ 2 │             export { something } from "os";
+   ·                      ────┬────
+   ·                          ╰── This export is duplicated
+   ╰────
+  help: Merge the duplicated exports into a single export statement
+
+  ⚠ eslint(no-duplicate-imports): 'os' export is duplicated
+   ╭─[no_duplicate_imports.tsx:1:16]
+ 1 │ import os from "os";
+   ·                ──┬─
+   ·                  ╰── Can be merged with this
+ 2 │             export * as os from "os";
+   ·             ────────────┬────────────
+   ·                         ╰── This export is duplicated
    ╰────
   help: Merge the duplicated exports into a single export statement
 
@@ -145,9 +132,9 @@ source: crates/oxc_linter/src/tester.rs
  1 │ export * as os from "os";
    · ────────────┬────────────
    ·             ╰── This export is duplicated
- 2 │         import os from "os";
-   ·                        ──┬─
-   ·                          ╰── Can be merged with this
+ 2 │             import os from "os";
+   ·                            ──┬─
+   ·                              ╰── Can be merged with this
    ╰────
   help: Merge the duplicated exports into a single export statement
 
@@ -156,9 +143,9 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import * as modns from "mod";
    ·                        ──┬──
    ·                          ╰── Can be merged with this
- 2 │         export * as  modns from "mod";
-   ·         ───────────────┬──────────────
-   ·                        ╰── This export is duplicated
+ 2 │             export * as  modns from "mod";
+   ·             ───────────────┬──────────────
+   ·                            ╰── This export is duplicated
    ╰────
   help: Merge the duplicated exports into a single export statement
 
@@ -167,9 +154,9 @@ source: crates/oxc_linter/src/tester.rs
  1 │ export * from "os";
    · ─────────┬─────────
    ·          ╰── Can be merged with this
- 2 │         export * from "os";
-   ·         ─────────┬─────────
-   ·                  ╰── This export is duplicated
+ 2 │             export * from "os";
+   ·             ─────────┬─────────
+   ·                      ╰── This export is duplicated
    ╰────
   help: Merge the duplicated exports into a single export statement
 
@@ -178,45 +165,330 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import "os";
    ·        ──┬─
    ·          ╰── Can be merged with this
- 2 │         export * from "os";
-   ·         ─────────┬─────────
-   ·                  ╰── This export is duplicated
+ 2 │             export * from "os";
+   ·             ─────────┬─────────
+   ·                      ╰── This export is duplicated
    ╰────
   help: Merge the duplicated exports into a single export statement
 
-  ⚠ eslint(no-duplicate-imports): './HostEditDialogs' import is duplicated
-   ╭─[no_duplicate_imports.tsx:1:83]
- 1 │ import type { PriorityDialogCustomClassNames, WeightDialogCustomClassNames } from "./HostEditDialogs";
-   ·                                                                                   ─────────┬─────────
-   ·                                                                                            ╰── Can be merged with this import
- 2 │             import { PriorityDialog, WeightDialog } from "./HostEditDialogs";
-   ·                                                          ─────────┬─────────
-   ·                                                                   ╰── This import is duplicated
+  ⚠ eslint(no-duplicate-imports): 'fs' import is duplicated
+   ╭─[no_duplicate_imports.tsx:1:8]
+ 1 │ import "fs";
+   ·        ──┬─
+   ·          ╰── Can be merged with this import
+ 2 │             import "fs"
+   ·                    ──┬─
+   ·                      ╰── This import is duplicated
    ╰────
   help: Merge the duplicated import into a single import statement
 
-  ⚠ eslint(no-duplicate-imports): 'foo' import is duplicated
-   ╭─[no_duplicate_imports.tsx:2:31]
- 1 │ 
- 2 │                 import b from 'foo';
-   ·                               ──┬──
+  ⚠ eslint(no-duplicate-imports): 'lodash-es' import is duplicated
+   ╭─[no_duplicate_imports.tsx:1:28]
+ 1 │ import { type Merge } from "lodash-es";
+   ·                            ─────┬─────
    ·                                 ╰── Can be merged with this import
- 3 │                 import { a } from 'foo';
-   ·                                   ──┬──
-   ·                                     ╰── This import is duplicated
- 4 │             
+ 2 │             import { type Find } from "lodash-es";
+   ·                                       ─────┬─────
+   ·                                            ╰── This import is duplicated
    ╰────
   help: Merge the duplicated import into a single import statement
 
-  ⚠ eslint(no-duplicate-imports): 'foo' import is duplicated
-   ╭─[no_duplicate_imports.tsx:2:38]
- 1 │ 
- 2 │                 import * as bar from 'foo';
-   ·                                      ──┬──
-   ·                                        ╰── Can be merged with this import
- 3 │                 import b from 'foo';
-   ·                               ──┬──
-   ·                                 ╰── This import is duplicated
- 4 │                 import { a } from 'foo';
+  ⚠ eslint(no-duplicate-imports): 'lodash-es' import is duplicated
+   ╭─[no_duplicate_imports.tsx:1:28]
+ 1 │ import { type Merge } from "lodash-es";
+   ·                            ─────┬─────
+   ·                                 ╰── Can be merged with this import
+ 2 │             import type { Find } from "lodash-es";
+   ·                                       ─────┬─────
+   ·                                            ╰── This import is duplicated
    ╰────
   help: Merge the duplicated import into a single import statement
+
+  ⚠ eslint(no-duplicate-imports): 'lodash-es' import is duplicated
+   ╭─[no_duplicate_imports.tsx:1:28]
+ 1 │ import type { Merge } from "lodash-es";
+   ·                            ─────┬─────
+   ·                                 ╰── Can be merged with this import
+ 2 │             import type { Find } from "lodash-es";
+   ·                                       ─────┬─────
+   ·                                            ╰── This import is duplicated
+   ╰────
+  help: Merge the duplicated import into a single import statement
+
+  ⚠ eslint(no-duplicate-imports): 'os' import is duplicated
+   ╭─[no_duplicate_imports.tsx:1:21]
+ 1 │ import type Os from "os";
+   ·                     ──┬─
+   ·                       ╰── Can be merged with this import
+ 2 │             import type { Something } from "os";
+ 3 │             import type * as Foobar from "os";
+   ·                                          ──┬─
+   ·                                            ╰── This import is duplicated
+   ╰────
+  help: Merge the duplicated import into a single import statement
+
+  ⚠ eslint(no-duplicate-imports): 'lodash-es' import is duplicated
+   ╭─[no_duplicate_imports.tsx:1:29]
+ 1 │ import type * as Modns from "lodash-es";
+   ·                             ─────┬─────
+   ·                                  ╰── Can be merged with this import
+ 2 │             import type { Merge } from "lodash-es";
+ 3 │             import type { Baz } from "lodash-es";
+   ·                                      ─────┬─────
+   ·                                           ╰── This import is duplicated
+   ╰────
+  help: Merge the duplicated import into a single import statement
+
+  ⚠ eslint(no-duplicate-imports): 'module' export is duplicated
+   ╭─[no_duplicate_imports.tsx:1:26]
+ 1 │ import { type Foo } from "module";
+   ·                          ────┬───
+   ·                              ╰── Can be merged with this
+ 2 │             export type { Bar } from "module";
+   ·                           ─┬─
+   ·                            ╰── This export is duplicated
+   ╰────
+  help: Merge the duplicated exports into a single export statement
+
+  ⚠ eslint(no-duplicate-imports): 'os' export is duplicated
+   ╭─[no_duplicate_imports.tsx:1:10]
+ 1 │ export { os } from "os";
+   ·          ─┬
+   ·           ╰── Can be merged with this
+ 2 │             export type { Something } from "os";
+   ·                           ────┬────
+   ·                               ╰── This export is duplicated
+   ╰────
+  help: Merge the duplicated exports into a single export statement
+
+  ⚠ eslint(no-duplicate-imports): 'os' export is duplicated
+   ╭─[no_duplicate_imports.tsx:1:15]
+ 1 │ export type { Os } from "os";
+   ·               ─┬
+   ·                ╰── Can be merged with this
+ 2 │             export type { Something } from "os";
+   ·                           ────┬────
+   ·                               ╰── This export is duplicated
+   ╰────
+  help: Merge the duplicated exports into a single export statement
+
+  ⚠ eslint(no-duplicate-imports): 'os' export is duplicated
+   ╭─[no_duplicate_imports.tsx:1:25]
+ 1 │ import type { Os } from "os";
+   ·                         ──┬─
+   ·                           ╰── Can be merged with this
+ 2 │             export type { Os as Foobar } from "os";
+   ·                           ──────┬─────
+   ·                                 ╰── This export is duplicated
+ 3 │             export type { Something } from "os";
+   ╰────
+  help: Merge the duplicated exports into a single export statement
+
+  ⚠ eslint(no-duplicate-imports): 'os' export is duplicated
+   ╭─[no_duplicate_imports.tsx:1:25]
+ 1 │ import type { Os } from "os";
+   ·                         ──┬─
+   ·                           ╰── Can be merged with this
+ 2 │             export type { Os as Foobar } from "os";
+ 3 │             export type { Something } from "os";
+   ·                           ────┬────
+   ·                               ╰── This export is duplicated
+   ╰────
+  help: Merge the duplicated exports into a single export statement
+
+  ⚠ eslint(no-duplicate-imports): 'os' export is duplicated
+   ╭─[no_duplicate_imports.tsx:1:25]
+ 1 │ import type { Os } from "os";
+   ·                         ──┬─
+   ·                           ╰── Can be merged with this
+ 2 │             export type { Something } from "os";
+   ·                           ────┬────
+   ·                               ╰── This export is duplicated
+   ╰────
+  help: Merge the duplicated exports into a single export statement
+
+  ⚠ eslint(no-duplicate-imports): 'os' export is duplicated
+   ╭─[no_duplicate_imports.tsx:1:21]
+ 1 │ import type Os from "os";
+   ·                     ──┬─
+   ·                       ╰── Can be merged with this
+ 2 │             export type * as Os from "os";
+   ·             ───────────────┬──────────────
+   ·                            ╰── This export is duplicated
+   ╰────
+  help: Merge the duplicated exports into a single export statement
+
+  ⚠ eslint(no-duplicate-imports): 'mod' export is duplicated
+   ╭─[no_duplicate_imports.tsx:1:29]
+ 1 │ import type * as Modns from "mod";
+   ·                             ──┬──
+   ·                               ╰── Can be merged with this
+ 2 │             export type * as Modns from "mod";
+   ·             ─────────────────┬────────────────
+   ·                              ╰── This export is duplicated
+   ╰────
+  help: Merge the duplicated exports into a single export statement
+
+  ⚠ eslint(no-duplicate-imports): 'os' export is duplicated
+   ╭─[no_duplicate_imports.tsx:1:1]
+ 1 │ export type * from "os";
+   · ────────────┬───────────
+   ·             ╰── Can be merged with this
+ 2 │             export type * from "os";
+   ·             ────────────┬───────────
+   ·                         ╰── This export is duplicated
+   ╰────
+  help: Merge the duplicated exports into a single export statement
+
+  ⚠ eslint(no-duplicate-imports): 'os' export is duplicated
+   ╭─[no_duplicate_imports.tsx:1:8]
+ 1 │ import "os";
+   ·        ──┬─
+   ·          ╰── Can be merged with this
+ 2 │             export type { Os } from "os";
+   ·                           ─┬
+   ·                            ╰── This export is duplicated
+   ╰────
+  help: Merge the duplicated exports into a single export statement
+
+  ⚠ eslint(no-duplicate-imports): 'module' import is duplicated
+   ╭─[no_duplicate_imports.tsx:1:27]
+ 1 │ import { someValue } from 'module';
+   ·                           ────┬───
+   ·                               ╰── Can be merged with this import
+ 2 │             import { anotherValue } from 'module';
+   ·                                          ────┬───
+   ·                                              ╰── This import is duplicated
+   ╰────
+  help: Merge the duplicated import into a single import statement
+
+  ⚠ eslint(no-duplicate-imports): 'lodash-es' import is duplicated
+   ╭─[no_duplicate_imports.tsx:1:28]
+ 1 │ import type { Merge } from "lodash-es";
+   ·                            ─────┬─────
+   ·                                 ╰── Can be merged with this import
+ 2 │             import type { Find } from "lodash-es";
+   ·                                       ─────┬─────
+   ·                                            ╰── This import is duplicated
+   ╰────
+  help: Merge the duplicated import into a single import statement
+
+  ⚠ eslint(no-duplicate-imports): 'module' import is duplicated
+   ╭─[no_duplicate_imports.tsx:1:37]
+ 1 │ import { someValue, type Foo } from 'module';
+   ·                                     ────┬───
+   ·                                         ╰── Can be merged with this import
+ 2 │             import type { SomeType } from 'module';
+ 3 │             import type { AnotherType } from 'module';
+   ·                                              ────┬───
+   ·                                                  ╰── This import is duplicated
+   ╰────
+  help: Merge the duplicated import into a single import statement
+
+  ⚠ eslint(no-duplicate-imports): 'module' import is duplicated
+   ╭─[no_duplicate_imports.tsx:1:26]
+ 1 │ import { type Foo } from 'module';
+   ·                          ────┬───
+   ·                              ╰── Can be merged with this import
+ 2 │             import { type Bar } from 'module';
+   ·                                      ────┬───
+   ·                                          ╰── This import is duplicated
+   ╰────
+  help: Merge the duplicated import into a single import statement
+
+  ⚠ eslint(no-duplicate-imports): 'module' export is duplicated
+   ╭─[no_duplicate_imports.tsx:1:15]
+ 1 │ export type { Foo } from "module";
+   ·               ─┬─
+   ·                ╰── Can be merged with this
+ 2 │             export type { Bar } from "module";
+   ·                           ─┬─
+   ·                            ╰── This export is duplicated
+   ╰────
+  help: Merge the duplicated exports into a single export statement
+
+  ⚠ eslint(no-duplicate-imports): 'module' export is duplicated
+   ╭─[no_duplicate_imports.tsx:1:26]
+ 1 │ import { type Foo } from "module";
+   ·                          ────┬───
+   ·                              ╰── Can be merged with this
+ 2 │             export { type Bar } from "module";
+   ·                      ────┬───
+   ·                          ╰── This export is duplicated
+ 3 │             export { type Baz } from "module";
+   ╰────
+  help: Merge the duplicated exports into a single export statement
+
+  ⚠ eslint(no-duplicate-imports): 'module' export is duplicated
+   ╭─[no_duplicate_imports.tsx:1:26]
+ 1 │ import { type Foo } from "module";
+   ·                          ────┬───
+   ·                              ╰── Can be merged with this
+ 2 │             export { type Bar } from "module";
+ 3 │             export { type Baz } from "module";
+   ·                      ────┬───
+   ·                          ╰── This export is duplicated
+   ╰────
+  help: Merge the duplicated exports into a single export statement
+
+  ⚠ eslint(no-duplicate-imports): 'module' export is duplicated
+   ╭─[no_duplicate_imports.tsx:1:26]
+ 1 │ import { type Foo } from "module";
+   ·                          ────┬───
+   ·                              ╰── Can be merged with this
+ 2 │             export { type Bar } from "module";
+   ·                      ────┬───
+   ·                          ╰── This export is duplicated
+ 3 │             export { regular } from "module";
+   ╰────
+  help: Merge the duplicated exports into a single export statement
+
+  ⚠ eslint(no-duplicate-imports): 'module' export is duplicated
+   ╭─[no_duplicate_imports.tsx:1:26]
+ 1 │ import { type Foo } from "module";
+   ·                          ────┬───
+   ·                              ╰── Can be merged with this
+ 2 │             export { type Bar } from "module";
+ 3 │             export { regular } from "module";
+   ·                      ───┬───
+   ·                         ╰── This export is duplicated
+   ╰────
+  help: Merge the duplicated exports into a single export statement
+
+  ⚠ eslint(no-duplicate-imports): 'module' import is duplicated
+   ╭─[no_duplicate_imports.tsx:1:26]
+ 1 │ import { type Foo } from "module";
+   ·                          ────┬───
+   ·                              ╰── Can be merged with this import
+ 2 │             import { regular } from "module";
+   ·                                     ────┬───
+   ·                                         ╰── This import is duplicated
+ 3 │             export { type Bar } from "module";
+   ╰────
+  help: Merge the duplicated import into a single import statement
+
+  ⚠ eslint(no-duplicate-imports): 'module' export is duplicated
+   ╭─[no_duplicate_imports.tsx:1:26]
+ 1 │ import { type Foo } from "module";
+   ·                          ────┬───
+   ·                              ╰── Can be merged with this
+ 2 │             import { regular } from "module";
+ 3 │             export { type Bar } from "module";
+   ·                      ────┬───
+   ·                          ╰── This export is duplicated
+ 4 │             export { regular as other } from "module";
+   ╰────
+  help: Merge the duplicated exports into a single export statement
+
+  ⚠ eslint(no-duplicate-imports): 'module' export is duplicated
+   ╭─[no_duplicate_imports.tsx:1:26]
+ 1 │ import { type Foo } from "module";
+   ·                          ────┬───
+   ·                              ╰── Can be merged with this
+ 2 │             import { regular } from "module";
+ 3 │             export { type Bar } from "module";
+ 4 │             export { regular as other } from "module";
+   ·                      ────────┬───────
+   ·                              ╰── This export is duplicated
+   ╰────
+  help: Merge the duplicated exports into a single export statement


### PR DESCRIPTION
fixes #11987