### PR TITLE
fix(formatter): missing parenthesis for `PrivateInExpression` when its parent is an `UnaryExpression`

### DIFF
--- a/crates/oxc_formatter/src/parentheses/expression.rs
+++ b/crates/oxc_formatter/src/parentheses/expression.rs
@@ -416,6 +416,7 @@ impl<'a> NeedsParentheses<'a> for AstNode<'a, PrivateInExpression<'a>> {
         }
 
         is_class_extends(self.span, self.parent)
+            || matches!(self.parent, AstNodes::UnaryExpression(_))
     }
 }
 

--- a/crates/oxc_formatter/tests/fixtures/js/private-fields/parenthesis.js
+++ b/crates/oxc_formatter/tests/fixtures/js/private-fields/parenthesis.js
@@ -1,0 +1,8 @@
+class F {
+  #target = null
+  next () {
+    !(#target in this);
+    -(#target in this);
+    +(#target in this);
+  }
+}

--- a/crates/oxc_formatter/tests/fixtures/js/private-fields/parenthesis.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/private-fields/parenthesis.js.snap
@@ -1,0 +1,24 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+class F {
+  #target = null
+  next () {
+    !(#target in this);
+    -(#target in this);
+    +(#target in this);
+  }
+}
+
+==================== Output ====================
+class F {
+  #target = null;
+  next() {
+    !(#target in this);
+    -(#target in this);
+    +(#target in this);
+  }
+}
+
+===================== End =====================


### PR DESCRIPTION
*close: #14437 