### PR TITLE
fix(formatter): missing parenthesis for `ComputedMemberExpression` when its parent is an `NewExpression`

### DIFF
--- a/crates/oxc_formatter/src/parentheses/expression.rs
+++ b/crates/oxc_formatter/src/parentheses/expression.rs
@@ -249,7 +249,8 @@ impl<'a> NeedsParentheses<'a> for AstNode<'a, MemberExpression<'a>> {
 
 impl<'a> NeedsParentheses<'a> for AstNode<'a, ComputedMemberExpression<'a>> {
     fn needs_parentheses(&self, f: &Formatter<'_, 'a>) -> bool {
-        false
+        matches!(self.parent, AstNodes::NewExpression(_))
+            && (!self.optional || member_chain_callee_needs_parens(&self.expression))
     }
 }
 
@@ -797,7 +798,7 @@ impl<'a> NeedsParentheses<'a> for AstNode<'a, TSNonNullExpression<'a>> {
         let parent = self.parent;
         is_class_extends(self.span, parent)
             || (matches!(parent, AstNodes::NewExpression(_))
-                && member_chain_callee_needs_parens(self.expression()))
+                && member_chain_callee_needs_parens(&self.expression))
     }
 }
 

--- a/crates/oxc_formatter/tests/fixtures/js/computed-members/parenthesis.js
+++ b/crates/oxc_formatter/tests/fixtures/js/computed-members/parenthesis.js
@@ -1,0 +1,2 @@
+new (get(win))[ty](xxx);
+new (get(win))[ty][ty](xxx);

--- a/crates/oxc_formatter/tests/fixtures/js/computed-members/parenthesis.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/computed-members/parenthesis.js.snap
@@ -1,0 +1,12 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+new (get(win))[ty](xxx);
+new (get(win))[ty][ty](xxx);
+
+==================== Output ====================
+new (get(win)[ty])(xxx);
+new (get(win)[ty][ty])(xxx);
+
+===================== End =====================


### PR DESCRIPTION
* close #14453