### PR TITLE
refactor(formatter): improve printing comments for special nodes

### DIFF
--- a/crates/oxc_formatter/src/utils/member_chain/chain_member.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/chain_member.rs
@@ -7,7 +7,7 @@ use crate::{
         prelude::*,
         trivia::{FormatLeadingComments, FormatTrailingComments},
     },
-    generated::ast_nodes::AstNode,
+    generated::ast_nodes::{AstNode, AstNodes},
     write,
 };
 use oxc_ast::{AstKind, ast::*};
@@ -77,15 +77,20 @@ impl<'a> Format<'a> for ChainMember<'a, '_> {
                         member.property()
                     ]
                 )?;
-                member.format_trailing_comments(f)
-            }
 
+                // `A.b /* comment */ (c)` -> `A.b(/* comment */ c)`
+                if !matches!(member.parent, AstNodes::CallExpression(call) if call.type_arguments.is_none())
+                {
+                    member.format_trailing_comments(f)?;
+                }
+
+                Ok(())
+            }
             Self::TSNonNullExpression(e) => {
                 e.format_leading_comments(f)?;
                 write!(f, ["!"])?;
                 e.format_trailing_comments(f)
             }
-
             Self::CallExpression { expression, position } => match *position {
                 CallExpressionPosition::Start => write!(f, expression),
                 CallExpressionPosition::Middle => {

--- a/crates/oxc_formatter/src/write/export_declarations.rs
+++ b/crates/oxc_formatter/src/write/export_declarations.rs
@@ -12,7 +12,10 @@ use crate::{
     },
     generated::ast_nodes::{AstNode, AstNodes},
     write,
-    write::semicolon::OptionalSemicolon,
+    write::{
+        import_declaration::format_import_and_export_source_with_clause,
+        semicolon::OptionalSemicolon,
+    },
 };
 
 use super::FormatWrite;
@@ -78,7 +81,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ExportAllDeclaration<'a>> {
         if let Some(name) = &self.exported() {
             write!(f, ["as", space(), name, space()])?;
         }
-        write!(f, ["from", space(), self.source(), self.with_clause(), OptionalSemicolon])
+        write!(f, ["from", space()]);
+
+        format_import_and_export_source_with_clause(self.source(), self.with_clause(), f)?;
+        write!(f, [OptionalSemicolon])
     }
 }
 
@@ -88,7 +94,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ExportNamedDeclaration<'a>> {
         let export_kind = self.export_kind();
         let specifiers = self.specifiers();
         let source = self.source();
-        let with_clause = self.with_clause();
 
         if let Some(decl) = declaration {
             format_export_keyword_with_class_decorators(
@@ -147,12 +152,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ExportNamedDeclaration<'a>> {
             }
             write!(f, "}")?;
 
+            let with_clause = self.with_clause();
             if let Some(source) = source {
-                write!(f, [space(), "from", space(), source])?;
-            }
-
-            if let Some(with_clause) = with_clause {
-                write!(f, [space(), with_clause])?;
+                write!(f, [space(), "from", space()])?;
+                format_import_and_export_source_with_clause(source, with_clause, f)?;
             }
         }
 

--- a/crates/oxc_formatter/src/write/mod.rs
+++ b/crates/oxc_formatter/src/write/mod.rs
@@ -226,7 +226,12 @@ impl<'a> FormatWrite<'a> for AstNode<'a, CallExpression<'a>> {
             MemberChain::from_call_expression(self, f).fmt(f)
         } else {
             let format_inner = format_with(|f| {
-                write!(f, [callee, optional.then_some("?."), type_arguments, arguments])
+                if self.type_arguments.is_some() {
+                    write!(f, [callee]);
+                } else {
+                    write!(f, [FormatNodeWithoutTrailingComments(callee)]);
+                }
+                write!(f, [optional.then_some("?."), type_arguments, arguments])
             });
             if matches!(callee.as_ref(), Expression::CallExpression(_)) {
                 write!(f, [group(&format_inner)])
@@ -239,7 +244,13 @@ impl<'a> FormatWrite<'a> for AstNode<'a, CallExpression<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, NewExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, ["new", space(), self.callee(), self.type_arguments(), self.arguments()])
+        write!(f, ["new", space()]);
+        if self.type_arguments.is_some() {
+            write!(f, [self.callee()]);
+        } else {
+            write!(f, [FormatNodeWithoutTrailingComments(self.callee())]);
+        }
+        write!(f, [self.type_arguments(), self.arguments()])
     }
 }
 
@@ -593,17 +604,67 @@ impl<'a> FormatWrite<'a> for AstNode<'a, DoWhileStatement<'a>> {
     }
 }
 
+/// Formats comments that appear before empty statements in control structures.
+///
+/// Example:
+/// ```js
+/// // Input:
+/// for (init;;) /* comment */ ;
+/// for (init;;update) /* comment */ ;
+/// for (init of iterable) /* comment */ ;
+/// for (init in iterable) /* comment */ ;
+/// while (test) /* comment */ ;
+/// if (test) /* comment */ ;
+///
+/// // Output:
+/// for (init /* comment */;; );
+/// for (init; ; update /* comment */);
+/// for (init of iterable /* comment */) ;
+/// for (init in iterable /* comment */) ;
+/// while (test /* comment */) ;
+/// if (test /* comment */) ;
+/// ```
+///
+/// This ensures compatibility with [Prettier's comment handling for empty statements](https://github.com/prettier/prettier/blob/7584432401a47a26943dd7a9ca9a8e032ead7285/src/language-js/comments/printer-methods.js#L15).
+struct FormatCommentForEmptyStatement<'a, 'b>(&'b AstNode<'a, Statement<'a>>);
+impl<'a> Format<'a> for FormatCommentForEmptyStatement<'a, '_> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        if let AstNodes::EmptyStatement(empty) = self.0.as_ast_nodes() {
+            let comments = f.context().comments().comments_before(empty.span.start);
+            FormatTrailingComments::Comments(comments).fmt(f)?;
+            empty.format_trailing_comments(f)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+struct FormatTestOfIfAndWhileStatement<'a, 'b>(&'b AstNode<'a, Expression<'a>>);
+impl<'a> Format<'a> for FormatTestOfIfAndWhileStatement<'a, '_> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        write!(f, FormatNodeWithoutTrailingComments(self.0))?;
+        let comments = f.context().comments().comments_before_character(self.0.span().end, b')');
+        if !comments.is_empty() {
+            write!(f, [space(), FormatTrailingComments::Comments(comments)])?;
+        }
+        Ok(())
+    }
+}
 impl<'a> FormatWrite<'a> for AstNode<'a, WhileStatement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let body = self.body();
         write!(
             f,
             group(&format_args!(
                 "while",
                 space(),
                 "(",
-                group(&soft_block_indent(self.test())),
+                group(&soft_block_indent(&format_args!(
+                    FormatTestOfIfAndWhileStatement(self.test()),
+                    FormatCommentForEmptyStatement(self.body())
+                ))),
                 ")",
-                FormatStatementBody::new(self.body())
+                FormatStatementBody::new(body)
             ))
         )
     }
@@ -642,12 +703,16 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForStatement<'a>> {
                     "(",
                     group(&soft_block_indent(&format_args!(
                         init,
+                        (test.is_none() && update.is_none())
+                            .then_some(FormatCommentForEmptyStatement(body)),
                         ";",
                         soft_line_break_or_space(),
                         test,
+                        (update.is_none()).then_some(FormatCommentForEmptyStatement(body)),
                         ";",
                         soft_line_break_or_space(),
-                        update
+                        update,
+                        FormatCommentForEmptyStatement(body)
                     ))),
                     ")",
                     format_body
@@ -661,6 +726,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForStatement<'a>> {
 impl<'a> FormatWrite<'a> for AstNode<'a, ForInStatement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let comments = f.context().comments().own_line_comments_before(self.right.span().start);
+        let body = self.body();
         write!(
             f,
             [
@@ -674,8 +740,9 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForInStatement<'a>> {
                     "in",
                     space(),
                     self.right(),
+                    FormatCommentForEmptyStatement(body),
                     ")",
-                    FormatStatementBody::new(self.body())
+                    FormatStatementBody::new(body)
                 ))
             ]
         )
@@ -705,6 +772,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForOfStatement<'a>> {
                     "of",
                     space(),
                     right,
+                    FormatCommentForEmptyStatement(body),
                     ")",
                     FormatStatementBody::new(body)
                 ]
@@ -719,13 +787,17 @@ impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
         let test = self.test();
         let consequent = self.consequent();
         let alternate = self.alternate();
+
         write!(
             f,
             group(&format_args!(
                 "if",
                 space(),
                 "(",
-                group(&soft_block_indent(&test)),
+                group(&soft_block_indent(&format_args!(
+                    FormatTestOfIfAndWhileStatement(test),
+                    FormatCommentForEmptyStatement(consequent)
+                ))),
                 ")",
                 FormatStatementBody::new(consequent),
             ))
@@ -738,9 +810,9 @@ impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
             let has_dangling_comments = has_line_comment
                 || comments.last().is_some_and(|last_comment| {
                     // Ensure the comments are placed before the else keyword or on a new line
-                    let gap_str =
-                        f.source_text().slice_range(last_comment.span.end, alternate_start);
-                    gap_str.contains("else")
+                    f.source_text()
+                        .slice_range(last_comment.span.end, alternate_start)
+                        .contains("else")
                         || f.source_text()
                             .contains_newline_between(last_comment.span.end, alternate_start)
                 });
@@ -804,6 +876,14 @@ impl<'a> FormatWrite<'a> for AstNode<'a, BreakStatement<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, WithStatement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        let format_comment_for_empty_body = format_with(|f| {
+            if let Statement::EmptyStatement(empty) = &self.body {
+                let comments = f.context().comments().comments_before(empty.span.start);
+                FormatTrailingComments::Comments(comments).fmt(f)?;
+            }
+            Ok(())
+        });
+
         write!(
             f,
             group(&format_args!(

--- a/crates/oxc_formatter/src/write/utils/statement_body.rs
+++ b/crates/oxc_formatter/src/write/utils/statement_body.rs
@@ -1,12 +1,17 @@
 use oxc_ast::ast::Statement;
+use oxc_span::GetSpan;
 
 use crate::{
     format_args,
     formatter::{
         Buffer, Format, FormatResult, Formatter,
-        prelude::{indent, soft_line_break_or_space, space},
+        prelude::{
+            format_once, group, indent, soft_line_break_or_space, soft_line_indent_or_space, space,
+        },
+        trivia::FormatTrailingComments,
     },
     generated::ast_nodes::{AstNode, AstNodes},
+    utils::format_node_without_trailing_comments::FormatNodeWithoutTrailingComments,
     write,
     write::FormatWrite,
 };
@@ -41,7 +46,37 @@ impl<'a> Format<'a> for FormatStatementBody<'a, '_> {
         } else if self.force_space {
             write!(f, [space(), self.body])
         } else {
-            write!(f, [indent(&format_args!(soft_line_break_or_space(), &self.body))])
+            write!(
+                f,
+                [indent(&format_args!(
+                    &soft_line_break_or_space(),
+                    &format_once(|f| {
+                        // ```js
+                        // if (condition)
+                        //     statement; // comment1
+                        // // comment2
+                        // else {}
+                        // ```
+                        // The following logic is to ensure that `comment1` is printed as a trailing comment of the
+                        // statement, and leave `comment2` to be printed in the IfStatement's alternate.
+
+                        let body_span = self.body.span();
+                        let is_consequent_of_if_statement_parent = matches!(
+                            self.body.parent,
+                            AstNodes::IfStatement(if_stmt)
+                            if if_stmt.consequent.span() == body_span && if_stmt.alternate.is_some()
+                        );
+                        if is_consequent_of_if_statement_parent {
+                            write!(f, FormatNodeWithoutTrailingComments(self.body))?;
+                            let comments =
+                                f.context().comments().end_of_line_comments_after(body_span.end);
+                            FormatTrailingComments::Comments(comments).fmt(f)
+                        } else {
+                            write!(f, self.body)
+                        }
+                    })
+                ))]
+            )
         }
     }
 }

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -28,7 +28,7 @@ ts compatibility: 533/573 (93.02%)
 | typescript/conditional-types/parentheses.ts | 💥✨ | 15.22% |
 | typescript/conformance/types/functions/functionOverloadErrorsSyntax.ts | 💥 | 0.00% |
 | typescript/decorators-ts/angular.ts | 💥 | 87.50% |
-| typescript/definite/without-annotation.ts | 💥 | 83.33% |
+| typescript/definite/without-annotation.ts | 💥 | 91.67% |
 | typescript/enum/computed-members.ts | 💥 | 0.00% |
 | typescript/interface/ignore.ts | 💥✨ | 40.09% |
 | typescript/intersection/intersection-parens.ts | 💥💥 | 86.17% |


### PR DESCRIPTION
Remove `SiblingNode` usages. It used to check comments for special nodes based on [Prettier's](https://github.com/prettier/prettier/blob/7584432401a47a26943dd7a9ca9a8e032ead7285/src/language-js/comments/handle-comments.js#L861) behavior, but we have moved all of the logic to the comments printing side, so `SiblingNode` becomes unnecessary; it will be removed in the next PR.

