### PR TITLE
feat(napi/minify): expose join_vars, sequences, and max_iterations options

### DIFF
--- a/napi/minify/index.d.ts
+++ b/napi/minify/index.d.ts
@@ -45,6 +45,22 @@ export interface CompressOptions {
   unused?: true | false | 'keep_assign'
   /** Keep function / class names. */
   keepNames?: CompressOptionsKeepNames
+  /**
+   * Join consecutive var, let and const statements.
+   *
+   * @default true
+   */
+  joinVars?: boolean
+  /**
+   * Join consecutive simple statements using the comma operator.
+   *
+   * `a; b` -> `a, b`
+   *
+   * @default true
+   */
+  sequences?: boolean
+  /** Limit the maximum number of iterations for debugging purpose. */
+  passes?: number
 }
 
 export interface CompressOptionsKeepNames {

--- a/napi/minify/src/options.rs
+++ b/napi/minify/src/options.rs
@@ -38,6 +38,21 @@ pub struct CompressOptions {
 
     /// Keep function / class names.
     pub keep_names: Option<CompressOptionsKeepNames>,
+
+    /// Join consecutive var, let and const statements.
+    ///
+    /// @default true
+    pub join_vars: Option<bool>,
+
+    /// Join consecutive simple statements using the comma operator.
+    ///
+    /// `a; b` -> `a, b`
+    ///
+    /// @default true
+    pub sequences: Option<bool>,
+
+    /// Limit the maximum number of iterations for debugging purpose.
+    pub passes: Option<u8>,
 }
 
 impl TryFrom<&CompressOptions> for oxc_minifier::CompressOptions {
@@ -52,14 +67,13 @@ impl TryFrom<&CompressOptions> for oxc_minifier::CompressOptions {
             },
             drop_console: o.drop_console.unwrap_or(default.drop_console),
             drop_debugger: o.drop_debugger.unwrap_or(default.drop_debugger),
-            // TODO
-            join_vars: true,
-            sequences: true,
+            join_vars: o.join_vars.unwrap_or(true),
+            sequences: o.sequences.unwrap_or(true),
             // TODO
             unused: oxc_minifier::CompressOptionsUnused::Keep,
             keep_names: o.keep_names.as_ref().map(Into::into).unwrap_or_default(),
             treeshake: TreeShakeOptions::default(),
-            max_iterations: None,
+            max_iterations: o.passes,
         })
     }
 }


### PR DESCRIPTION
related to https://github.com/rolldown/rolldown/issues/6477

I use `passes` instead of `max_iterations` since `passes` is commonly used in the Javascript community, 
see 
- terser: https://github.com/terser/terser#:~:text=passes%20(default%3A%201)%20%2D%2D%20The%20maximum%20number%20of%20times%20to%20run%20compress.%20In%20some%20cases%20more%20than%20one%20pass%20leads%20to%20further%20compressed%20code.%20Keep%20in%20mind%20more%20passes%20will%20take%20more%20time.
- swc: 
<img width="626" height="828" alt="image" src="https://github.com/user-attachments/assets/aabc2e10-59a1-43ab-b9e0-52ab35522f85" />
