### PR TITLE
chore(ci): fix windows test

### DIFF
--- a/crates/oxc_formatter/build.rs
+++ b/crates/oxc_formatter/build.rs
@@ -3,7 +3,7 @@ use std::{
     env,
     fs::{self, File},
     io::Write,
-    path::{Path, PathBuf},
+    path::{MAIN_SEPARATOR, Path, PathBuf},
 };
 
 use oxc_span::SourceType;
@@ -108,6 +108,7 @@ fn is_test_file(path: &Path) -> bool {
     }
 }
 
+#[expect(clippy::disallowed_methods)]
 fn generate_test_function(
     f: &mut File,
     relative_path: &Path,
@@ -123,7 +124,7 @@ fn generate_test_function(
         f,
         "{}    let path = std::path::Path::new(\"tests/fixtures/{}\");",
         indent,
-        relative_path.display()
+        relative_path.display().to_string().replace(MAIN_SEPARATOR, "/")
     )?;
     writeln!(f, "{indent}    test_file(path);")?;
     writeln!(f, "{indent}}}")?;

--- a/crates/oxc_formatter/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter/tests/fixtures/mod.rs
@@ -187,7 +187,7 @@ fn generate_snapshot(path: &Path, source_text: &str) -> String {
         }
 
         let options = parse_format_options(&option_json);
-        let formatted = format_source(source_text, source_type, options);
+        let formatted = normalize_newlines(format_source(source_text, source_type, options));
         snapshot.push_str(&formatted);
         snapshot.push('\n');
     }
@@ -199,7 +199,7 @@ fn generate_snapshot(path: &Path, source_text: &str) -> String {
 
 /// Helper function to run a test for a single file
 fn test_file(path: &Path) {
-    let source_text = fs::read_to_string(path).unwrap();
+    let source_text = normalize_newlines(fs::read_to_string(path).unwrap());
     let snapshot = generate_snapshot(path, &source_text);
     let snapshot_path = current_dir().unwrap().join(path.parent().unwrap());
     let snapshot_name = path.file_name().unwrap().to_str().unwrap();
@@ -213,6 +213,15 @@ fn test_file(path: &Path) {
     }, {
         insta::assert_snapshot!(snapshot_name, snapshot);
     });
+}
+
+#[expect(clippy::disallowed_methods)]
+fn normalize_newlines(text: String) -> String {
+    if !text.contains('\r') {
+        return text;
+    }
+
+    text.replace("\r\n", "\n")
 }
 
 // Include auto-generated test functions from build.rs


### PR DESCRIPTION
CI on main seems to be failing since snapshot based tests were introduced.

This PR includes two fixes:
- handling of backslashed paths when generating test code
- normalization of crlf which, were counted as two line breaks by snapshot comparison

Looks like windows test job doen't run on pull requests or feature branches, it only runs on main. You can review its status on my fork's main workflow run: https://github.com/lilnasy/oxc/actions/runs/18458898920.