### PR TITLE
refactor(formatter): remove `SiblingNode`

### DIFF
--- a/crates/oxc_formatter/src/formatter/trivia.rs
+++ b/crates/oxc_formatter/src/formatter/trivia.rs
@@ -63,7 +63,7 @@ use oxc_ast::{
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::comment_node;
 
-use crate::{generated::ast_nodes::SiblingNode, write};
+use crate::write;
 
 use super::{Argument, Arguments, GroupId, SourceText, SyntaxToken, prelude::*};
 
@@ -161,23 +161,23 @@ impl<'a> Format<'a> for FormatLeadingComments<'a> {
 }
 
 /// Formats the trailing comments of `node`.
-pub const fn format_trailing_comments<'a, 'b>(
-    enclosing_node: &'b SiblingNode<'a>,
-    preceding_node: &'b SiblingNode<'a>,
-    following_node: Option<&'b SiblingNode<'a>>,
-) -> FormatTrailingComments<'a, 'b> {
-    FormatTrailingComments::Node((enclosing_node, preceding_node, following_node))
+pub const fn format_trailing_comments<'a>(
+    enclosing_span: Span,
+    preceding_span: Span,
+    following_span: Option<Span>,
+) -> FormatTrailingComments<'a> {
+    FormatTrailingComments::Node((enclosing_span, preceding_span, following_span))
 }
 
 /// Formats the trailing comments of `node`
 #[derive(Debug, Clone, Copy)]
-pub enum FormatTrailingComments<'a, 'b> {
-    // (enclosing_node, preceding_node, following_node)
-    Node((&'b SiblingNode<'a>, &'b SiblingNode<'a>, Option<&'b SiblingNode<'a>>)),
+pub enum FormatTrailingComments<'a> {
+    // (enclosing_span, preceding_span, following_span)
+    Node((Span, Span, Option<Span>)),
     Comments(&'a [Comment]),
 }
 
-impl<'a> Format<'a> for FormatTrailingComments<'a, '_> {
+impl<'a> Format<'a> for FormatTrailingComments<'a> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         fn format_trailing_comments_impl<'a>(
             comments: impl IntoIterator<Item = &'a Comment>,
@@ -256,11 +256,11 @@ impl<'a> Format<'a> for FormatTrailingComments<'a, '_> {
         }
 
         match self {
-            Self::Node((enclosing_node, preceding_node, following_node)) => {
+            Self::Node((enclosing_span, preceding_span, following_span)) => {
                 let comments = f.context().comments().get_trailing_comments(
-                    enclosing_node,
-                    preceding_node,
-                    *following_node,
+                    *enclosing_span,
+                    *preceding_span,
+                    *following_span,
                 );
 
                 format_trailing_comments_impl(comments, f)

--- a/crates/oxc_formatter/src/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/generated/ast_nodes.rs
@@ -1,7 +1,7 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/formatter/ast_nodes.rs`.
 
-#![expect(clippy::elidable_lifetime_names, clippy::match_same_arms)]
+#![expect(clippy::elidable_lifetime_names)]
 use std::{fmt, mem::transmute, ops::Deref};
 
 use oxc_allocator::{Allocator, Box, Vec};
@@ -215,2120 +215,6 @@ pub enum AstNodes<'a> {
     JSDocNonNullableType(&'a AstNode<'a, JSDocNonNullableType<'a>>),
     JSDocUnknownType(&'a AstNode<'a, JSDocUnknownType>),
 }
-
-#[derive(Debug, Copy, Clone)]
-pub enum SiblingNode<'a> {
-    Program(&'a Program<'a>),
-    IdentifierName(&'a IdentifierName<'a>),
-    IdentifierReference(&'a IdentifierReference<'a>),
-    BindingIdentifier(&'a BindingIdentifier<'a>),
-    LabelIdentifier(&'a LabelIdentifier<'a>),
-    ThisExpression(&'a ThisExpression),
-    ArrayExpression(&'a ArrayExpression<'a>),
-    Elision(&'a Elision),
-    ObjectExpression(&'a ObjectExpression<'a>),
-    ObjectProperty(&'a ObjectProperty<'a>),
-    TemplateLiteral(&'a TemplateLiteral<'a>),
-    TaggedTemplateExpression(&'a TaggedTemplateExpression<'a>),
-    TemplateElement(&'a TemplateElement<'a>),
-    ComputedMemberExpression(&'a ComputedMemberExpression<'a>),
-    StaticMemberExpression(&'a StaticMemberExpression<'a>),
-    PrivateFieldExpression(&'a PrivateFieldExpression<'a>),
-    CallExpression(&'a CallExpression<'a>),
-    NewExpression(&'a NewExpression<'a>),
-    MetaProperty(&'a MetaProperty<'a>),
-    SpreadElement(&'a SpreadElement<'a>),
-    UpdateExpression(&'a UpdateExpression<'a>),
-    UnaryExpression(&'a UnaryExpression<'a>),
-    BinaryExpression(&'a BinaryExpression<'a>),
-    PrivateInExpression(&'a PrivateInExpression<'a>),
-    LogicalExpression(&'a LogicalExpression<'a>),
-    ConditionalExpression(&'a ConditionalExpression<'a>),
-    AssignmentExpression(&'a AssignmentExpression<'a>),
-    ArrayAssignmentTarget(&'a ArrayAssignmentTarget<'a>),
-    ObjectAssignmentTarget(&'a ObjectAssignmentTarget<'a>),
-    AssignmentTargetRest(&'a AssignmentTargetRest<'a>),
-    AssignmentTargetWithDefault(&'a AssignmentTargetWithDefault<'a>),
-    AssignmentTargetPropertyIdentifier(&'a AssignmentTargetPropertyIdentifier<'a>),
-    AssignmentTargetPropertyProperty(&'a AssignmentTargetPropertyProperty<'a>),
-    SequenceExpression(&'a SequenceExpression<'a>),
-    Super(&'a Super),
-    AwaitExpression(&'a AwaitExpression<'a>),
-    ChainExpression(&'a ChainExpression<'a>),
-    ParenthesizedExpression(&'a ParenthesizedExpression<'a>),
-    Directive(&'a Directive<'a>),
-    Hashbang(&'a Hashbang<'a>),
-    BlockStatement(&'a BlockStatement<'a>),
-    VariableDeclaration(&'a VariableDeclaration<'a>),
-    VariableDeclarator(&'a VariableDeclarator<'a>),
-    EmptyStatement(&'a EmptyStatement),
-    ExpressionStatement(&'a ExpressionStatement<'a>),
-    IfStatement(&'a IfStatement<'a>),
-    DoWhileStatement(&'a DoWhileStatement<'a>),
-    WhileStatement(&'a WhileStatement<'a>),
-    ForStatement(&'a ForStatement<'a>),
-    ForInStatement(&'a ForInStatement<'a>),
-    ForOfStatement(&'a ForOfStatement<'a>),
-    ContinueStatement(&'a ContinueStatement<'a>),
-    BreakStatement(&'a BreakStatement<'a>),
-    ReturnStatement(&'a ReturnStatement<'a>),
-    WithStatement(&'a WithStatement<'a>),
-    SwitchStatement(&'a SwitchStatement<'a>),
-    SwitchCase(&'a SwitchCase<'a>),
-    LabeledStatement(&'a LabeledStatement<'a>),
-    ThrowStatement(&'a ThrowStatement<'a>),
-    TryStatement(&'a TryStatement<'a>),
-    CatchClause(&'a CatchClause<'a>),
-    CatchParameter(&'a CatchParameter<'a>),
-    DebuggerStatement(&'a DebuggerStatement),
-    BindingPattern(&'a BindingPattern<'a>),
-    AssignmentPattern(&'a AssignmentPattern<'a>),
-    ObjectPattern(&'a ObjectPattern<'a>),
-    BindingProperty(&'a BindingProperty<'a>),
-    ArrayPattern(&'a ArrayPattern<'a>),
-    BindingRestElement(&'a BindingRestElement<'a>),
-    Function(&'a Function<'a>),
-    FormalParameters(&'a FormalParameters<'a>),
-    FormalParameter(&'a FormalParameter<'a>),
-    FunctionBody(&'a FunctionBody<'a>),
-    ArrowFunctionExpression(&'a ArrowFunctionExpression<'a>),
-    YieldExpression(&'a YieldExpression<'a>),
-    Class(&'a Class<'a>),
-    ClassBody(&'a ClassBody<'a>),
-    MethodDefinition(&'a MethodDefinition<'a>),
-    PropertyDefinition(&'a PropertyDefinition<'a>),
-    PrivateIdentifier(&'a PrivateIdentifier<'a>),
-    StaticBlock(&'a StaticBlock<'a>),
-    AccessorProperty(&'a AccessorProperty<'a>),
-    ImportExpression(&'a ImportExpression<'a>),
-    ImportDeclaration(&'a ImportDeclaration<'a>),
-    ImportSpecifier(&'a ImportSpecifier<'a>),
-    ImportDefaultSpecifier(&'a ImportDefaultSpecifier<'a>),
-    ImportNamespaceSpecifier(&'a ImportNamespaceSpecifier<'a>),
-    WithClause(&'a WithClause<'a>),
-    ImportAttribute(&'a ImportAttribute<'a>),
-    ExportNamedDeclaration(&'a ExportNamedDeclaration<'a>),
-    ExportDefaultDeclaration(&'a ExportDefaultDeclaration<'a>),
-    ExportAllDeclaration(&'a ExportAllDeclaration<'a>),
-    ExportSpecifier(&'a ExportSpecifier<'a>),
-    V8IntrinsicExpression(&'a V8IntrinsicExpression<'a>),
-    BooleanLiteral(&'a BooleanLiteral),
-    NullLiteral(&'a NullLiteral),
-    NumericLiteral(&'a NumericLiteral<'a>),
-    StringLiteral(&'a StringLiteral<'a>),
-    BigIntLiteral(&'a BigIntLiteral<'a>),
-    RegExpLiteral(&'a RegExpLiteral<'a>),
-    JSXElement(&'a JSXElement<'a>),
-    JSXOpeningElement(&'a JSXOpeningElement<'a>),
-    JSXClosingElement(&'a JSXClosingElement<'a>),
-    JSXFragment(&'a JSXFragment<'a>),
-    JSXOpeningFragment(&'a JSXOpeningFragment),
-    JSXClosingFragment(&'a JSXClosingFragment),
-    JSXNamespacedName(&'a JSXNamespacedName<'a>),
-    JSXMemberExpression(&'a JSXMemberExpression<'a>),
-    JSXExpressionContainer(&'a JSXExpressionContainer<'a>),
-    JSXEmptyExpression(&'a JSXEmptyExpression),
-    JSXAttribute(&'a JSXAttribute<'a>),
-    JSXSpreadAttribute(&'a JSXSpreadAttribute<'a>),
-    JSXIdentifier(&'a JSXIdentifier<'a>),
-    JSXSpreadChild(&'a JSXSpreadChild<'a>),
-    JSXText(&'a JSXText<'a>),
-    TSThisParameter(&'a TSThisParameter<'a>),
-    TSEnumDeclaration(&'a TSEnumDeclaration<'a>),
-    TSEnumBody(&'a TSEnumBody<'a>),
-    TSEnumMember(&'a TSEnumMember<'a>),
-    TSTypeAnnotation(&'a TSTypeAnnotation<'a>),
-    TSLiteralType(&'a TSLiteralType<'a>),
-    TSConditionalType(&'a TSConditionalType<'a>),
-    TSUnionType(&'a TSUnionType<'a>),
-    TSIntersectionType(&'a TSIntersectionType<'a>),
-    TSParenthesizedType(&'a TSParenthesizedType<'a>),
-    TSTypeOperator(&'a TSTypeOperator<'a>),
-    TSArrayType(&'a TSArrayType<'a>),
-    TSIndexedAccessType(&'a TSIndexedAccessType<'a>),
-    TSTupleType(&'a TSTupleType<'a>),
-    TSNamedTupleMember(&'a TSNamedTupleMember<'a>),
-    TSOptionalType(&'a TSOptionalType<'a>),
-    TSRestType(&'a TSRestType<'a>),
-    TSAnyKeyword(&'a TSAnyKeyword),
-    TSStringKeyword(&'a TSStringKeyword),
-    TSBooleanKeyword(&'a TSBooleanKeyword),
-    TSNumberKeyword(&'a TSNumberKeyword),
-    TSNeverKeyword(&'a TSNeverKeyword),
-    TSIntrinsicKeyword(&'a TSIntrinsicKeyword),
-    TSUnknownKeyword(&'a TSUnknownKeyword),
-    TSNullKeyword(&'a TSNullKeyword),
-    TSUndefinedKeyword(&'a TSUndefinedKeyword),
-    TSVoidKeyword(&'a TSVoidKeyword),
-    TSSymbolKeyword(&'a TSSymbolKeyword),
-    TSThisType(&'a TSThisType),
-    TSObjectKeyword(&'a TSObjectKeyword),
-    TSBigIntKeyword(&'a TSBigIntKeyword),
-    TSTypeReference(&'a TSTypeReference<'a>),
-    TSQualifiedName(&'a TSQualifiedName<'a>),
-    TSTypeParameterInstantiation(&'a TSTypeParameterInstantiation<'a>),
-    TSTypeParameter(&'a TSTypeParameter<'a>),
-    TSTypeParameterDeclaration(&'a TSTypeParameterDeclaration<'a>),
-    TSTypeAliasDeclaration(&'a TSTypeAliasDeclaration<'a>),
-    TSClassImplements(&'a TSClassImplements<'a>),
-    TSInterfaceDeclaration(&'a TSInterfaceDeclaration<'a>),
-    TSInterfaceBody(&'a TSInterfaceBody<'a>),
-    TSPropertySignature(&'a TSPropertySignature<'a>),
-    TSIndexSignature(&'a TSIndexSignature<'a>),
-    TSCallSignatureDeclaration(&'a TSCallSignatureDeclaration<'a>),
-    TSMethodSignature(&'a TSMethodSignature<'a>),
-    TSConstructSignatureDeclaration(&'a TSConstructSignatureDeclaration<'a>),
-    TSIndexSignatureName(&'a TSIndexSignatureName<'a>),
-    TSInterfaceHeritage(&'a TSInterfaceHeritage<'a>),
-    TSTypePredicate(&'a TSTypePredicate<'a>),
-    TSModuleDeclaration(&'a TSModuleDeclaration<'a>),
-    TSModuleBlock(&'a TSModuleBlock<'a>),
-    TSTypeLiteral(&'a TSTypeLiteral<'a>),
-    TSInferType(&'a TSInferType<'a>),
-    TSTypeQuery(&'a TSTypeQuery<'a>),
-    TSImportType(&'a TSImportType<'a>),
-    TSImportTypeQualifiedName(&'a TSImportTypeQualifiedName<'a>),
-    TSFunctionType(&'a TSFunctionType<'a>),
-    TSConstructorType(&'a TSConstructorType<'a>),
-    TSMappedType(&'a TSMappedType<'a>),
-    TSTemplateLiteralType(&'a TSTemplateLiteralType<'a>),
-    TSAsExpression(&'a TSAsExpression<'a>),
-    TSSatisfiesExpression(&'a TSSatisfiesExpression<'a>),
-    TSTypeAssertion(&'a TSTypeAssertion<'a>),
-    TSImportEqualsDeclaration(&'a TSImportEqualsDeclaration<'a>),
-    TSExternalModuleReference(&'a TSExternalModuleReference<'a>),
-    TSNonNullExpression(&'a TSNonNullExpression<'a>),
-    Decorator(&'a Decorator<'a>),
-    TSExportAssignment(&'a TSExportAssignment<'a>),
-    TSNamespaceExportDeclaration(&'a TSNamespaceExportDeclaration<'a>),
-    TSInstantiationExpression(&'a TSInstantiationExpression<'a>),
-    JSDocNullableType(&'a JSDocNullableType<'a>),
-    JSDocNonNullableType(&'a JSDocNonNullableType<'a>),
-    JSDocUnknownType(&'a JSDocUnknownType),
-}
-
-impl<'a> From<&'a Program<'a>> for SiblingNode<'a> {
-    fn from(node: &'a Program<'a>) -> Self {
-        SiblingNode::Program(node)
-    }
-}
-
-impl<'a> From<&'a IdentifierName<'a>> for SiblingNode<'a> {
-    fn from(node: &'a IdentifierName<'a>) -> Self {
-        SiblingNode::IdentifierName(node)
-    }
-}
-
-impl<'a> From<&'a IdentifierReference<'a>> for SiblingNode<'a> {
-    fn from(node: &'a IdentifierReference<'a>) -> Self {
-        SiblingNode::IdentifierReference(node)
-    }
-}
-
-impl<'a> From<&'a BindingIdentifier<'a>> for SiblingNode<'a> {
-    fn from(node: &'a BindingIdentifier<'a>) -> Self {
-        SiblingNode::BindingIdentifier(node)
-    }
-}
-
-impl<'a> From<&'a LabelIdentifier<'a>> for SiblingNode<'a> {
-    fn from(node: &'a LabelIdentifier<'a>) -> Self {
-        SiblingNode::LabelIdentifier(node)
-    }
-}
-
-impl<'a> From<&'a ThisExpression> for SiblingNode<'a> {
-    fn from(node: &'a ThisExpression) -> Self {
-        SiblingNode::ThisExpression(node)
-    }
-}
-
-impl<'a> From<&'a ArrayExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ArrayExpression<'a>) -> Self {
-        SiblingNode::ArrayExpression(node)
-    }
-}
-
-impl<'a> From<&'a Elision> for SiblingNode<'a> {
-    fn from(node: &'a Elision) -> Self {
-        SiblingNode::Elision(node)
-    }
-}
-
-impl<'a> From<&'a ObjectExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ObjectExpression<'a>) -> Self {
-        SiblingNode::ObjectExpression(node)
-    }
-}
-
-impl<'a> From<&'a ObjectProperty<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ObjectProperty<'a>) -> Self {
-        SiblingNode::ObjectProperty(node)
-    }
-}
-
-impl<'a> From<&'a TemplateLiteral<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TemplateLiteral<'a>) -> Self {
-        SiblingNode::TemplateLiteral(node)
-    }
-}
-
-impl<'a> From<&'a TaggedTemplateExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TaggedTemplateExpression<'a>) -> Self {
-        SiblingNode::TaggedTemplateExpression(node)
-    }
-}
-
-impl<'a> From<&'a TemplateElement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TemplateElement<'a>) -> Self {
-        SiblingNode::TemplateElement(node)
-    }
-}
-
-impl<'a> From<&'a ComputedMemberExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ComputedMemberExpression<'a>) -> Self {
-        SiblingNode::ComputedMemberExpression(node)
-    }
-}
-
-impl<'a> From<&'a StaticMemberExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a StaticMemberExpression<'a>) -> Self {
-        SiblingNode::StaticMemberExpression(node)
-    }
-}
-
-impl<'a> From<&'a PrivateFieldExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a PrivateFieldExpression<'a>) -> Self {
-        SiblingNode::PrivateFieldExpression(node)
-    }
-}
-
-impl<'a> From<&'a CallExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a CallExpression<'a>) -> Self {
-        SiblingNode::CallExpression(node)
-    }
-}
-
-impl<'a> From<&'a NewExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a NewExpression<'a>) -> Self {
-        SiblingNode::NewExpression(node)
-    }
-}
-
-impl<'a> From<&'a MetaProperty<'a>> for SiblingNode<'a> {
-    fn from(node: &'a MetaProperty<'a>) -> Self {
-        SiblingNode::MetaProperty(node)
-    }
-}
-
-impl<'a> From<&'a SpreadElement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a SpreadElement<'a>) -> Self {
-        SiblingNode::SpreadElement(node)
-    }
-}
-
-impl<'a> From<&'a UpdateExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a UpdateExpression<'a>) -> Self {
-        SiblingNode::UpdateExpression(node)
-    }
-}
-
-impl<'a> From<&'a UnaryExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a UnaryExpression<'a>) -> Self {
-        SiblingNode::UnaryExpression(node)
-    }
-}
-
-impl<'a> From<&'a BinaryExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a BinaryExpression<'a>) -> Self {
-        SiblingNode::BinaryExpression(node)
-    }
-}
-
-impl<'a> From<&'a PrivateInExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a PrivateInExpression<'a>) -> Self {
-        SiblingNode::PrivateInExpression(node)
-    }
-}
-
-impl<'a> From<&'a LogicalExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a LogicalExpression<'a>) -> Self {
-        SiblingNode::LogicalExpression(node)
-    }
-}
-
-impl<'a> From<&'a ConditionalExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ConditionalExpression<'a>) -> Self {
-        SiblingNode::ConditionalExpression(node)
-    }
-}
-
-impl<'a> From<&'a AssignmentExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a AssignmentExpression<'a>) -> Self {
-        SiblingNode::AssignmentExpression(node)
-    }
-}
-
-impl<'a> From<&'a ArrayAssignmentTarget<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ArrayAssignmentTarget<'a>) -> Self {
-        SiblingNode::ArrayAssignmentTarget(node)
-    }
-}
-
-impl<'a> From<&'a ObjectAssignmentTarget<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ObjectAssignmentTarget<'a>) -> Self {
-        SiblingNode::ObjectAssignmentTarget(node)
-    }
-}
-
-impl<'a> From<&'a AssignmentTargetRest<'a>> for SiblingNode<'a> {
-    fn from(node: &'a AssignmentTargetRest<'a>) -> Self {
-        SiblingNode::AssignmentTargetRest(node)
-    }
-}
-
-impl<'a> From<&'a AssignmentTargetWithDefault<'a>> for SiblingNode<'a> {
-    fn from(node: &'a AssignmentTargetWithDefault<'a>) -> Self {
-        SiblingNode::AssignmentTargetWithDefault(node)
-    }
-}
-
-impl<'a> From<&'a AssignmentTargetPropertyIdentifier<'a>> for SiblingNode<'a> {
-    fn from(node: &'a AssignmentTargetPropertyIdentifier<'a>) -> Self {
-        SiblingNode::AssignmentTargetPropertyIdentifier(node)
-    }
-}
-
-impl<'a> From<&'a AssignmentTargetPropertyProperty<'a>> for SiblingNode<'a> {
-    fn from(node: &'a AssignmentTargetPropertyProperty<'a>) -> Self {
-        SiblingNode::AssignmentTargetPropertyProperty(node)
-    }
-}
-
-impl<'a> From<&'a SequenceExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a SequenceExpression<'a>) -> Self {
-        SiblingNode::SequenceExpression(node)
-    }
-}
-
-impl<'a> From<&'a Super> for SiblingNode<'a> {
-    fn from(node: &'a Super) -> Self {
-        SiblingNode::Super(node)
-    }
-}
-
-impl<'a> From<&'a AwaitExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a AwaitExpression<'a>) -> Self {
-        SiblingNode::AwaitExpression(node)
-    }
-}
-
-impl<'a> From<&'a ChainExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ChainExpression<'a>) -> Self {
-        SiblingNode::ChainExpression(node)
-    }
-}
-
-impl<'a> From<&'a ParenthesizedExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ParenthesizedExpression<'a>) -> Self {
-        SiblingNode::ParenthesizedExpression(node)
-    }
-}
-
-impl<'a> From<&'a Directive<'a>> for SiblingNode<'a> {
-    fn from(node: &'a Directive<'a>) -> Self {
-        SiblingNode::Directive(node)
-    }
-}
-
-impl<'a> From<&'a Hashbang<'a>> for SiblingNode<'a> {
-    fn from(node: &'a Hashbang<'a>) -> Self {
-        SiblingNode::Hashbang(node)
-    }
-}
-
-impl<'a> From<&'a BlockStatement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a BlockStatement<'a>) -> Self {
-        SiblingNode::BlockStatement(node)
-    }
-}
-
-impl<'a> From<&'a VariableDeclaration<'a>> for SiblingNode<'a> {
-    fn from(node: &'a VariableDeclaration<'a>) -> Self {
-        SiblingNode::VariableDeclaration(node)
-    }
-}
-
-impl<'a> From<&'a VariableDeclarator<'a>> for SiblingNode<'a> {
-    fn from(node: &'a VariableDeclarator<'a>) -> Self {
-        SiblingNode::VariableDeclarator(node)
-    }
-}
-
-impl<'a> From<&'a EmptyStatement> for SiblingNode<'a> {
-    fn from(node: &'a EmptyStatement) -> Self {
-        SiblingNode::EmptyStatement(node)
-    }
-}
-
-impl<'a> From<&'a ExpressionStatement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ExpressionStatement<'a>) -> Self {
-        SiblingNode::ExpressionStatement(node)
-    }
-}
-
-impl<'a> From<&'a IfStatement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a IfStatement<'a>) -> Self {
-        SiblingNode::IfStatement(node)
-    }
-}
-
-impl<'a> From<&'a DoWhileStatement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a DoWhileStatement<'a>) -> Self {
-        SiblingNode::DoWhileStatement(node)
-    }
-}
-
-impl<'a> From<&'a WhileStatement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a WhileStatement<'a>) -> Self {
-        SiblingNode::WhileStatement(node)
-    }
-}
-
-impl<'a> From<&'a ForStatement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ForStatement<'a>) -> Self {
-        SiblingNode::ForStatement(node)
-    }
-}
-
-impl<'a> From<&'a ForInStatement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ForInStatement<'a>) -> Self {
-        SiblingNode::ForInStatement(node)
-    }
-}
-
-impl<'a> From<&'a ForOfStatement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ForOfStatement<'a>) -> Self {
-        SiblingNode::ForOfStatement(node)
-    }
-}
-
-impl<'a> From<&'a ContinueStatement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ContinueStatement<'a>) -> Self {
-        SiblingNode::ContinueStatement(node)
-    }
-}
-
-impl<'a> From<&'a BreakStatement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a BreakStatement<'a>) -> Self {
-        SiblingNode::BreakStatement(node)
-    }
-}
-
-impl<'a> From<&'a ReturnStatement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ReturnStatement<'a>) -> Self {
-        SiblingNode::ReturnStatement(node)
-    }
-}
-
-impl<'a> From<&'a WithStatement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a WithStatement<'a>) -> Self {
-        SiblingNode::WithStatement(node)
-    }
-}
-
-impl<'a> From<&'a SwitchStatement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a SwitchStatement<'a>) -> Self {
-        SiblingNode::SwitchStatement(node)
-    }
-}
-
-impl<'a> From<&'a SwitchCase<'a>> for SiblingNode<'a> {
-    fn from(node: &'a SwitchCase<'a>) -> Self {
-        SiblingNode::SwitchCase(node)
-    }
-}
-
-impl<'a> From<&'a LabeledStatement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a LabeledStatement<'a>) -> Self {
-        SiblingNode::LabeledStatement(node)
-    }
-}
-
-impl<'a> From<&'a ThrowStatement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ThrowStatement<'a>) -> Self {
-        SiblingNode::ThrowStatement(node)
-    }
-}
-
-impl<'a> From<&'a TryStatement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TryStatement<'a>) -> Self {
-        SiblingNode::TryStatement(node)
-    }
-}
-
-impl<'a> From<&'a CatchClause<'a>> for SiblingNode<'a> {
-    fn from(node: &'a CatchClause<'a>) -> Self {
-        SiblingNode::CatchClause(node)
-    }
-}
-
-impl<'a> From<&'a CatchParameter<'a>> for SiblingNode<'a> {
-    fn from(node: &'a CatchParameter<'a>) -> Self {
-        SiblingNode::CatchParameter(node)
-    }
-}
-
-impl<'a> From<&'a DebuggerStatement> for SiblingNode<'a> {
-    fn from(node: &'a DebuggerStatement) -> Self {
-        SiblingNode::DebuggerStatement(node)
-    }
-}
-
-impl<'a> From<&'a BindingPattern<'a>> for SiblingNode<'a> {
-    fn from(node: &'a BindingPattern<'a>) -> Self {
-        SiblingNode::BindingPattern(node)
-    }
-}
-
-impl<'a> From<&'a AssignmentPattern<'a>> for SiblingNode<'a> {
-    fn from(node: &'a AssignmentPattern<'a>) -> Self {
-        SiblingNode::AssignmentPattern(node)
-    }
-}
-
-impl<'a> From<&'a ObjectPattern<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ObjectPattern<'a>) -> Self {
-        SiblingNode::ObjectPattern(node)
-    }
-}
-
-impl<'a> From<&'a BindingProperty<'a>> for SiblingNode<'a> {
-    fn from(node: &'a BindingProperty<'a>) -> Self {
-        SiblingNode::BindingProperty(node)
-    }
-}
-
-impl<'a> From<&'a ArrayPattern<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ArrayPattern<'a>) -> Self {
-        SiblingNode::ArrayPattern(node)
-    }
-}
-
-impl<'a> From<&'a BindingRestElement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a BindingRestElement<'a>) -> Self {
-        SiblingNode::BindingRestElement(node)
-    }
-}
-
-impl<'a> From<&'a Function<'a>> for SiblingNode<'a> {
-    fn from(node: &'a Function<'a>) -> Self {
-        SiblingNode::Function(node)
-    }
-}
-
-impl<'a> From<&'a FormalParameters<'a>> for SiblingNode<'a> {
-    fn from(node: &'a FormalParameters<'a>) -> Self {
-        SiblingNode::FormalParameters(node)
-    }
-}
-
-impl<'a> From<&'a FormalParameter<'a>> for SiblingNode<'a> {
-    fn from(node: &'a FormalParameter<'a>) -> Self {
-        SiblingNode::FormalParameter(node)
-    }
-}
-
-impl<'a> From<&'a FunctionBody<'a>> for SiblingNode<'a> {
-    fn from(node: &'a FunctionBody<'a>) -> Self {
-        SiblingNode::FunctionBody(node)
-    }
-}
-
-impl<'a> From<&'a ArrowFunctionExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ArrowFunctionExpression<'a>) -> Self {
-        SiblingNode::ArrowFunctionExpression(node)
-    }
-}
-
-impl<'a> From<&'a YieldExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a YieldExpression<'a>) -> Self {
-        SiblingNode::YieldExpression(node)
-    }
-}
-
-impl<'a> From<&'a Class<'a>> for SiblingNode<'a> {
-    fn from(node: &'a Class<'a>) -> Self {
-        SiblingNode::Class(node)
-    }
-}
-
-impl<'a> From<&'a ClassBody<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ClassBody<'a>) -> Self {
-        SiblingNode::ClassBody(node)
-    }
-}
-
-impl<'a> From<&'a MethodDefinition<'a>> for SiblingNode<'a> {
-    fn from(node: &'a MethodDefinition<'a>) -> Self {
-        SiblingNode::MethodDefinition(node)
-    }
-}
-
-impl<'a> From<&'a PropertyDefinition<'a>> for SiblingNode<'a> {
-    fn from(node: &'a PropertyDefinition<'a>) -> Self {
-        SiblingNode::PropertyDefinition(node)
-    }
-}
-
-impl<'a> From<&'a PrivateIdentifier<'a>> for SiblingNode<'a> {
-    fn from(node: &'a PrivateIdentifier<'a>) -> Self {
-        SiblingNode::PrivateIdentifier(node)
-    }
-}
-
-impl<'a> From<&'a StaticBlock<'a>> for SiblingNode<'a> {
-    fn from(node: &'a StaticBlock<'a>) -> Self {
-        SiblingNode::StaticBlock(node)
-    }
-}
-
-impl<'a> From<&'a AccessorProperty<'a>> for SiblingNode<'a> {
-    fn from(node: &'a AccessorProperty<'a>) -> Self {
-        SiblingNode::AccessorProperty(node)
-    }
-}
-
-impl<'a> From<&'a ImportExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ImportExpression<'a>) -> Self {
-        SiblingNode::ImportExpression(node)
-    }
-}
-
-impl<'a> From<&'a ImportDeclaration<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ImportDeclaration<'a>) -> Self {
-        SiblingNode::ImportDeclaration(node)
-    }
-}
-
-impl<'a> From<&'a ImportSpecifier<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ImportSpecifier<'a>) -> Self {
-        SiblingNode::ImportSpecifier(node)
-    }
-}
-
-impl<'a> From<&'a ImportDefaultSpecifier<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ImportDefaultSpecifier<'a>) -> Self {
-        SiblingNode::ImportDefaultSpecifier(node)
-    }
-}
-
-impl<'a> From<&'a ImportNamespaceSpecifier<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ImportNamespaceSpecifier<'a>) -> Self {
-        SiblingNode::ImportNamespaceSpecifier(node)
-    }
-}
-
-impl<'a> From<&'a WithClause<'a>> for SiblingNode<'a> {
-    fn from(node: &'a WithClause<'a>) -> Self {
-        SiblingNode::WithClause(node)
-    }
-}
-
-impl<'a> From<&'a ImportAttribute<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ImportAttribute<'a>) -> Self {
-        SiblingNode::ImportAttribute(node)
-    }
-}
-
-impl<'a> From<&'a ExportNamedDeclaration<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ExportNamedDeclaration<'a>) -> Self {
-        SiblingNode::ExportNamedDeclaration(node)
-    }
-}
-
-impl<'a> From<&'a ExportDefaultDeclaration<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ExportDefaultDeclaration<'a>) -> Self {
-        SiblingNode::ExportDefaultDeclaration(node)
-    }
-}
-
-impl<'a> From<&'a ExportAllDeclaration<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ExportAllDeclaration<'a>) -> Self {
-        SiblingNode::ExportAllDeclaration(node)
-    }
-}
-
-impl<'a> From<&'a ExportSpecifier<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ExportSpecifier<'a>) -> Self {
-        SiblingNode::ExportSpecifier(node)
-    }
-}
-
-impl<'a> From<&'a V8IntrinsicExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a V8IntrinsicExpression<'a>) -> Self {
-        SiblingNode::V8IntrinsicExpression(node)
-    }
-}
-
-impl<'a> From<&'a BooleanLiteral> for SiblingNode<'a> {
-    fn from(node: &'a BooleanLiteral) -> Self {
-        SiblingNode::BooleanLiteral(node)
-    }
-}
-
-impl<'a> From<&'a NullLiteral> for SiblingNode<'a> {
-    fn from(node: &'a NullLiteral) -> Self {
-        SiblingNode::NullLiteral(node)
-    }
-}
-
-impl<'a> From<&'a NumericLiteral<'a>> for SiblingNode<'a> {
-    fn from(node: &'a NumericLiteral<'a>) -> Self {
-        SiblingNode::NumericLiteral(node)
-    }
-}
-
-impl<'a> From<&'a StringLiteral<'a>> for SiblingNode<'a> {
-    fn from(node: &'a StringLiteral<'a>) -> Self {
-        SiblingNode::StringLiteral(node)
-    }
-}
-
-impl<'a> From<&'a BigIntLiteral<'a>> for SiblingNode<'a> {
-    fn from(node: &'a BigIntLiteral<'a>) -> Self {
-        SiblingNode::BigIntLiteral(node)
-    }
-}
-
-impl<'a> From<&'a RegExpLiteral<'a>> for SiblingNode<'a> {
-    fn from(node: &'a RegExpLiteral<'a>) -> Self {
-        SiblingNode::RegExpLiteral(node)
-    }
-}
-
-impl<'a> From<&'a JSXElement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a JSXElement<'a>) -> Self {
-        SiblingNode::JSXElement(node)
-    }
-}
-
-impl<'a> From<&'a JSXOpeningElement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a JSXOpeningElement<'a>) -> Self {
-        SiblingNode::JSXOpeningElement(node)
-    }
-}
-
-impl<'a> From<&'a JSXClosingElement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a JSXClosingElement<'a>) -> Self {
-        SiblingNode::JSXClosingElement(node)
-    }
-}
-
-impl<'a> From<&'a JSXFragment<'a>> for SiblingNode<'a> {
-    fn from(node: &'a JSXFragment<'a>) -> Self {
-        SiblingNode::JSXFragment(node)
-    }
-}
-
-impl<'a> From<&'a JSXOpeningFragment> for SiblingNode<'a> {
-    fn from(node: &'a JSXOpeningFragment) -> Self {
-        SiblingNode::JSXOpeningFragment(node)
-    }
-}
-
-impl<'a> From<&'a JSXClosingFragment> for SiblingNode<'a> {
-    fn from(node: &'a JSXClosingFragment) -> Self {
-        SiblingNode::JSXClosingFragment(node)
-    }
-}
-
-impl<'a> From<&'a JSXNamespacedName<'a>> for SiblingNode<'a> {
-    fn from(node: &'a JSXNamespacedName<'a>) -> Self {
-        SiblingNode::JSXNamespacedName(node)
-    }
-}
-
-impl<'a> From<&'a JSXMemberExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a JSXMemberExpression<'a>) -> Self {
-        SiblingNode::JSXMemberExpression(node)
-    }
-}
-
-impl<'a> From<&'a JSXExpressionContainer<'a>> for SiblingNode<'a> {
-    fn from(node: &'a JSXExpressionContainer<'a>) -> Self {
-        SiblingNode::JSXExpressionContainer(node)
-    }
-}
-
-impl<'a> From<&'a JSXEmptyExpression> for SiblingNode<'a> {
-    fn from(node: &'a JSXEmptyExpression) -> Self {
-        SiblingNode::JSXEmptyExpression(node)
-    }
-}
-
-impl<'a> From<&'a JSXAttribute<'a>> for SiblingNode<'a> {
-    fn from(node: &'a JSXAttribute<'a>) -> Self {
-        SiblingNode::JSXAttribute(node)
-    }
-}
-
-impl<'a> From<&'a JSXSpreadAttribute<'a>> for SiblingNode<'a> {
-    fn from(node: &'a JSXSpreadAttribute<'a>) -> Self {
-        SiblingNode::JSXSpreadAttribute(node)
-    }
-}
-
-impl<'a> From<&'a JSXIdentifier<'a>> for SiblingNode<'a> {
-    fn from(node: &'a JSXIdentifier<'a>) -> Self {
-        SiblingNode::JSXIdentifier(node)
-    }
-}
-
-impl<'a> From<&'a JSXSpreadChild<'a>> for SiblingNode<'a> {
-    fn from(node: &'a JSXSpreadChild<'a>) -> Self {
-        SiblingNode::JSXSpreadChild(node)
-    }
-}
-
-impl<'a> From<&'a JSXText<'a>> for SiblingNode<'a> {
-    fn from(node: &'a JSXText<'a>) -> Self {
-        SiblingNode::JSXText(node)
-    }
-}
-
-impl<'a> From<&'a TSThisParameter<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSThisParameter<'a>) -> Self {
-        SiblingNode::TSThisParameter(node)
-    }
-}
-
-impl<'a> From<&'a TSEnumDeclaration<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSEnumDeclaration<'a>) -> Self {
-        SiblingNode::TSEnumDeclaration(node)
-    }
-}
-
-impl<'a> From<&'a TSEnumBody<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSEnumBody<'a>) -> Self {
-        SiblingNode::TSEnumBody(node)
-    }
-}
-
-impl<'a> From<&'a TSEnumMember<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSEnumMember<'a>) -> Self {
-        SiblingNode::TSEnumMember(node)
-    }
-}
-
-impl<'a> From<&'a TSTypeAnnotation<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSTypeAnnotation<'a>) -> Self {
-        SiblingNode::TSTypeAnnotation(node)
-    }
-}
-
-impl<'a> From<&'a TSLiteralType<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSLiteralType<'a>) -> Self {
-        SiblingNode::TSLiteralType(node)
-    }
-}
-
-impl<'a> From<&'a TSConditionalType<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSConditionalType<'a>) -> Self {
-        SiblingNode::TSConditionalType(node)
-    }
-}
-
-impl<'a> From<&'a TSUnionType<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSUnionType<'a>) -> Self {
-        SiblingNode::TSUnionType(node)
-    }
-}
-
-impl<'a> From<&'a TSIntersectionType<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSIntersectionType<'a>) -> Self {
-        SiblingNode::TSIntersectionType(node)
-    }
-}
-
-impl<'a> From<&'a TSParenthesizedType<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSParenthesizedType<'a>) -> Self {
-        SiblingNode::TSParenthesizedType(node)
-    }
-}
-
-impl<'a> From<&'a TSTypeOperator<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSTypeOperator<'a>) -> Self {
-        SiblingNode::TSTypeOperator(node)
-    }
-}
-
-impl<'a> From<&'a TSArrayType<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSArrayType<'a>) -> Self {
-        SiblingNode::TSArrayType(node)
-    }
-}
-
-impl<'a> From<&'a TSIndexedAccessType<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSIndexedAccessType<'a>) -> Self {
-        SiblingNode::TSIndexedAccessType(node)
-    }
-}
-
-impl<'a> From<&'a TSTupleType<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSTupleType<'a>) -> Self {
-        SiblingNode::TSTupleType(node)
-    }
-}
-
-impl<'a> From<&'a TSNamedTupleMember<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSNamedTupleMember<'a>) -> Self {
-        SiblingNode::TSNamedTupleMember(node)
-    }
-}
-
-impl<'a> From<&'a TSOptionalType<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSOptionalType<'a>) -> Self {
-        SiblingNode::TSOptionalType(node)
-    }
-}
-
-impl<'a> From<&'a TSRestType<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSRestType<'a>) -> Self {
-        SiblingNode::TSRestType(node)
-    }
-}
-
-impl<'a> From<&'a TSAnyKeyword> for SiblingNode<'a> {
-    fn from(node: &'a TSAnyKeyword) -> Self {
-        SiblingNode::TSAnyKeyword(node)
-    }
-}
-
-impl<'a> From<&'a TSStringKeyword> for SiblingNode<'a> {
-    fn from(node: &'a TSStringKeyword) -> Self {
-        SiblingNode::TSStringKeyword(node)
-    }
-}
-
-impl<'a> From<&'a TSBooleanKeyword> for SiblingNode<'a> {
-    fn from(node: &'a TSBooleanKeyword) -> Self {
-        SiblingNode::TSBooleanKeyword(node)
-    }
-}
-
-impl<'a> From<&'a TSNumberKeyword> for SiblingNode<'a> {
-    fn from(node: &'a TSNumberKeyword) -> Self {
-        SiblingNode::TSNumberKeyword(node)
-    }
-}
-
-impl<'a> From<&'a TSNeverKeyword> for SiblingNode<'a> {
-    fn from(node: &'a TSNeverKeyword) -> Self {
-        SiblingNode::TSNeverKeyword(node)
-    }
-}
-
-impl<'a> From<&'a TSIntrinsicKeyword> for SiblingNode<'a> {
-    fn from(node: &'a TSIntrinsicKeyword) -> Self {
-        SiblingNode::TSIntrinsicKeyword(node)
-    }
-}
-
-impl<'a> From<&'a TSUnknownKeyword> for SiblingNode<'a> {
-    fn from(node: &'a TSUnknownKeyword) -> Self {
-        SiblingNode::TSUnknownKeyword(node)
-    }
-}
-
-impl<'a> From<&'a TSNullKeyword> for SiblingNode<'a> {
-    fn from(node: &'a TSNullKeyword) -> Self {
-        SiblingNode::TSNullKeyword(node)
-    }
-}
-
-impl<'a> From<&'a TSUndefinedKeyword> for SiblingNode<'a> {
-    fn from(node: &'a TSUndefinedKeyword) -> Self {
-        SiblingNode::TSUndefinedKeyword(node)
-    }
-}
-
-impl<'a> From<&'a TSVoidKeyword> for SiblingNode<'a> {
-    fn from(node: &'a TSVoidKeyword) -> Self {
-        SiblingNode::TSVoidKeyword(node)
-    }
-}
-
-impl<'a> From<&'a TSSymbolKeyword> for SiblingNode<'a> {
-    fn from(node: &'a TSSymbolKeyword) -> Self {
-        SiblingNode::TSSymbolKeyword(node)
-    }
-}
-
-impl<'a> From<&'a TSThisType> for SiblingNode<'a> {
-    fn from(node: &'a TSThisType) -> Self {
-        SiblingNode::TSThisType(node)
-    }
-}
-
-impl<'a> From<&'a TSObjectKeyword> for SiblingNode<'a> {
-    fn from(node: &'a TSObjectKeyword) -> Self {
-        SiblingNode::TSObjectKeyword(node)
-    }
-}
-
-impl<'a> From<&'a TSBigIntKeyword> for SiblingNode<'a> {
-    fn from(node: &'a TSBigIntKeyword) -> Self {
-        SiblingNode::TSBigIntKeyword(node)
-    }
-}
-
-impl<'a> From<&'a TSTypeReference<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSTypeReference<'a>) -> Self {
-        SiblingNode::TSTypeReference(node)
-    }
-}
-
-impl<'a> From<&'a TSQualifiedName<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSQualifiedName<'a>) -> Self {
-        SiblingNode::TSQualifiedName(node)
-    }
-}
-
-impl<'a> From<&'a TSTypeParameterInstantiation<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSTypeParameterInstantiation<'a>) -> Self {
-        SiblingNode::TSTypeParameterInstantiation(node)
-    }
-}
-
-impl<'a> From<&'a TSTypeParameter<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSTypeParameter<'a>) -> Self {
-        SiblingNode::TSTypeParameter(node)
-    }
-}
-
-impl<'a> From<&'a TSTypeParameterDeclaration<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSTypeParameterDeclaration<'a>) -> Self {
-        SiblingNode::TSTypeParameterDeclaration(node)
-    }
-}
-
-impl<'a> From<&'a TSTypeAliasDeclaration<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSTypeAliasDeclaration<'a>) -> Self {
-        SiblingNode::TSTypeAliasDeclaration(node)
-    }
-}
-
-impl<'a> From<&'a TSClassImplements<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSClassImplements<'a>) -> Self {
-        SiblingNode::TSClassImplements(node)
-    }
-}
-
-impl<'a> From<&'a TSInterfaceDeclaration<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSInterfaceDeclaration<'a>) -> Self {
-        SiblingNode::TSInterfaceDeclaration(node)
-    }
-}
-
-impl<'a> From<&'a TSInterfaceBody<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSInterfaceBody<'a>) -> Self {
-        SiblingNode::TSInterfaceBody(node)
-    }
-}
-
-impl<'a> From<&'a TSPropertySignature<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSPropertySignature<'a>) -> Self {
-        SiblingNode::TSPropertySignature(node)
-    }
-}
-
-impl<'a> From<&'a TSIndexSignature<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSIndexSignature<'a>) -> Self {
-        SiblingNode::TSIndexSignature(node)
-    }
-}
-
-impl<'a> From<&'a TSCallSignatureDeclaration<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSCallSignatureDeclaration<'a>) -> Self {
-        SiblingNode::TSCallSignatureDeclaration(node)
-    }
-}
-
-impl<'a> From<&'a TSMethodSignature<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSMethodSignature<'a>) -> Self {
-        SiblingNode::TSMethodSignature(node)
-    }
-}
-
-impl<'a> From<&'a TSConstructSignatureDeclaration<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSConstructSignatureDeclaration<'a>) -> Self {
-        SiblingNode::TSConstructSignatureDeclaration(node)
-    }
-}
-
-impl<'a> From<&'a TSIndexSignatureName<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSIndexSignatureName<'a>) -> Self {
-        SiblingNode::TSIndexSignatureName(node)
-    }
-}
-
-impl<'a> From<&'a TSInterfaceHeritage<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSInterfaceHeritage<'a>) -> Self {
-        SiblingNode::TSInterfaceHeritage(node)
-    }
-}
-
-impl<'a> From<&'a TSTypePredicate<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSTypePredicate<'a>) -> Self {
-        SiblingNode::TSTypePredicate(node)
-    }
-}
-
-impl<'a> From<&'a TSModuleDeclaration<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSModuleDeclaration<'a>) -> Self {
-        SiblingNode::TSModuleDeclaration(node)
-    }
-}
-
-impl<'a> From<&'a TSModuleBlock<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSModuleBlock<'a>) -> Self {
-        SiblingNode::TSModuleBlock(node)
-    }
-}
-
-impl<'a> From<&'a TSTypeLiteral<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSTypeLiteral<'a>) -> Self {
-        SiblingNode::TSTypeLiteral(node)
-    }
-}
-
-impl<'a> From<&'a TSInferType<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSInferType<'a>) -> Self {
-        SiblingNode::TSInferType(node)
-    }
-}
-
-impl<'a> From<&'a TSTypeQuery<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSTypeQuery<'a>) -> Self {
-        SiblingNode::TSTypeQuery(node)
-    }
-}
-
-impl<'a> From<&'a TSImportType<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSImportType<'a>) -> Self {
-        SiblingNode::TSImportType(node)
-    }
-}
-
-impl<'a> From<&'a TSImportTypeQualifiedName<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSImportTypeQualifiedName<'a>) -> Self {
-        SiblingNode::TSImportTypeQualifiedName(node)
-    }
-}
-
-impl<'a> From<&'a TSFunctionType<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSFunctionType<'a>) -> Self {
-        SiblingNode::TSFunctionType(node)
-    }
-}
-
-impl<'a> From<&'a TSConstructorType<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSConstructorType<'a>) -> Self {
-        SiblingNode::TSConstructorType(node)
-    }
-}
-
-impl<'a> From<&'a TSMappedType<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSMappedType<'a>) -> Self {
-        SiblingNode::TSMappedType(node)
-    }
-}
-
-impl<'a> From<&'a TSTemplateLiteralType<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSTemplateLiteralType<'a>) -> Self {
-        SiblingNode::TSTemplateLiteralType(node)
-    }
-}
-
-impl<'a> From<&'a TSAsExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSAsExpression<'a>) -> Self {
-        SiblingNode::TSAsExpression(node)
-    }
-}
-
-impl<'a> From<&'a TSSatisfiesExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSSatisfiesExpression<'a>) -> Self {
-        SiblingNode::TSSatisfiesExpression(node)
-    }
-}
-
-impl<'a> From<&'a TSTypeAssertion<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSTypeAssertion<'a>) -> Self {
-        SiblingNode::TSTypeAssertion(node)
-    }
-}
-
-impl<'a> From<&'a TSImportEqualsDeclaration<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSImportEqualsDeclaration<'a>) -> Self {
-        SiblingNode::TSImportEqualsDeclaration(node)
-    }
-}
-
-impl<'a> From<&'a TSExternalModuleReference<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSExternalModuleReference<'a>) -> Self {
-        SiblingNode::TSExternalModuleReference(node)
-    }
-}
-
-impl<'a> From<&'a TSNonNullExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSNonNullExpression<'a>) -> Self {
-        SiblingNode::TSNonNullExpression(node)
-    }
-}
-
-impl<'a> From<&'a Decorator<'a>> for SiblingNode<'a> {
-    fn from(node: &'a Decorator<'a>) -> Self {
-        SiblingNode::Decorator(node)
-    }
-}
-
-impl<'a> From<&'a TSExportAssignment<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSExportAssignment<'a>) -> Self {
-        SiblingNode::TSExportAssignment(node)
-    }
-}
-
-impl<'a> From<&'a TSNamespaceExportDeclaration<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSNamespaceExportDeclaration<'a>) -> Self {
-        SiblingNode::TSNamespaceExportDeclaration(node)
-    }
-}
-
-impl<'a> From<&'a TSInstantiationExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSInstantiationExpression<'a>) -> Self {
-        SiblingNode::TSInstantiationExpression(node)
-    }
-}
-
-impl<'a> From<&'a JSDocNullableType<'a>> for SiblingNode<'a> {
-    fn from(node: &'a JSDocNullableType<'a>) -> Self {
-        SiblingNode::JSDocNullableType(node)
-    }
-}
-
-impl<'a> From<&'a JSDocNonNullableType<'a>> for SiblingNode<'a> {
-    fn from(node: &'a JSDocNonNullableType<'a>) -> Self {
-        SiblingNode::JSDocNonNullableType(node)
-    }
-}
-
-impl<'a> From<&'a JSDocUnknownType> for SiblingNode<'a> {
-    fn from(node: &'a JSDocUnknownType) -> Self {
-        SiblingNode::JSDocUnknownType(node)
-    }
-}
-
-impl<'a> From<&'a Expression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a Expression<'a>) -> Self {
-        match node {
-            Expression::BooleanLiteral(inner) => SiblingNode::BooleanLiteral(inner),
-            Expression::NullLiteral(inner) => SiblingNode::NullLiteral(inner),
-            Expression::NumericLiteral(inner) => SiblingNode::NumericLiteral(inner),
-            Expression::BigIntLiteral(inner) => SiblingNode::BigIntLiteral(inner),
-            Expression::RegExpLiteral(inner) => SiblingNode::RegExpLiteral(inner),
-            Expression::StringLiteral(inner) => SiblingNode::StringLiteral(inner),
-            Expression::TemplateLiteral(inner) => SiblingNode::TemplateLiteral(inner),
-            Expression::Identifier(inner) => SiblingNode::IdentifierReference(inner),
-            Expression::MetaProperty(inner) => SiblingNode::MetaProperty(inner),
-            Expression::Super(inner) => SiblingNode::Super(inner),
-            Expression::ArrayExpression(inner) => SiblingNode::ArrayExpression(inner),
-            Expression::ArrowFunctionExpression(inner) => {
-                SiblingNode::ArrowFunctionExpression(inner)
-            }
-            Expression::AssignmentExpression(inner) => SiblingNode::AssignmentExpression(inner),
-            Expression::AwaitExpression(inner) => SiblingNode::AwaitExpression(inner),
-            Expression::BinaryExpression(inner) => SiblingNode::BinaryExpression(inner),
-            Expression::CallExpression(inner) => SiblingNode::CallExpression(inner),
-            Expression::ChainExpression(inner) => SiblingNode::ChainExpression(inner),
-            Expression::ClassExpression(inner) => SiblingNode::Class(inner),
-            Expression::ConditionalExpression(inner) => SiblingNode::ConditionalExpression(inner),
-            Expression::FunctionExpression(inner) => SiblingNode::Function(inner),
-            Expression::ImportExpression(inner) => SiblingNode::ImportExpression(inner),
-            Expression::LogicalExpression(inner) => SiblingNode::LogicalExpression(inner),
-            Expression::NewExpression(inner) => SiblingNode::NewExpression(inner),
-            Expression::ObjectExpression(inner) => SiblingNode::ObjectExpression(inner),
-            Expression::ParenthesizedExpression(inner) => {
-                SiblingNode::ParenthesizedExpression(inner)
-            }
-            Expression::SequenceExpression(inner) => SiblingNode::SequenceExpression(inner),
-            Expression::TaggedTemplateExpression(inner) => {
-                SiblingNode::TaggedTemplateExpression(inner)
-            }
-            Expression::ThisExpression(inner) => SiblingNode::ThisExpression(inner),
-            Expression::UnaryExpression(inner) => SiblingNode::UnaryExpression(inner),
-            Expression::UpdateExpression(inner) => SiblingNode::UpdateExpression(inner),
-            Expression::YieldExpression(inner) => SiblingNode::YieldExpression(inner),
-            Expression::PrivateInExpression(inner) => SiblingNode::PrivateInExpression(inner),
-            Expression::JSXElement(inner) => SiblingNode::JSXElement(inner),
-            Expression::JSXFragment(inner) => SiblingNode::JSXFragment(inner),
-            Expression::TSAsExpression(inner) => SiblingNode::TSAsExpression(inner),
-            Expression::TSSatisfiesExpression(inner) => SiblingNode::TSSatisfiesExpression(inner),
-            Expression::TSTypeAssertion(inner) => SiblingNode::TSTypeAssertion(inner),
-            Expression::TSNonNullExpression(inner) => SiblingNode::TSNonNullExpression(inner),
-            Expression::TSInstantiationExpression(inner) => {
-                SiblingNode::TSInstantiationExpression(inner)
-            }
-            Expression::V8IntrinsicExpression(inner) => SiblingNode::V8IntrinsicExpression(inner),
-            it @ match_member_expression!(Expression) => {
-                SiblingNode::from(it.to_member_expression())
-            }
-        }
-    }
-}
-
-impl<'a> From<&'a ArrayExpressionElement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ArrayExpressionElement<'a>) -> Self {
-        match node {
-            ArrayExpressionElement::SpreadElement(inner) => SiblingNode::SpreadElement(inner),
-            ArrayExpressionElement::Elision(inner) => SiblingNode::Elision(inner),
-            it @ match_expression!(ArrayExpressionElement) => SiblingNode::from(it.to_expression()),
-        }
-    }
-}
-
-impl<'a> From<&'a ObjectPropertyKind<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ObjectPropertyKind<'a>) -> Self {
-        match node {
-            ObjectPropertyKind::ObjectProperty(inner) => SiblingNode::ObjectProperty(inner),
-            ObjectPropertyKind::SpreadProperty(inner) => SiblingNode::SpreadElement(inner),
-        }
-    }
-}
-
-impl<'a> From<&'a PropertyKey<'a>> for SiblingNode<'a> {
-    fn from(node: &'a PropertyKey<'a>) -> Self {
-        match node {
-            PropertyKey::StaticIdentifier(inner) => SiblingNode::IdentifierName(inner),
-            PropertyKey::PrivateIdentifier(inner) => SiblingNode::PrivateIdentifier(inner),
-            it @ match_expression!(PropertyKey) => SiblingNode::from(it.to_expression()),
-        }
-    }
-}
-
-impl<'a> From<&'a MemberExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a MemberExpression<'a>) -> Self {
-        match node {
-            MemberExpression::ComputedMemberExpression(inner) => {
-                SiblingNode::ComputedMemberExpression(inner)
-            }
-            MemberExpression::StaticMemberExpression(inner) => {
-                SiblingNode::StaticMemberExpression(inner)
-            }
-            MemberExpression::PrivateFieldExpression(inner) => {
-                SiblingNode::PrivateFieldExpression(inner)
-            }
-        }
-    }
-}
-
-impl<'a> From<&'a Argument<'a>> for SiblingNode<'a> {
-    fn from(node: &'a Argument<'a>) -> Self {
-        match node {
-            Argument::SpreadElement(inner) => SiblingNode::SpreadElement(inner),
-            it @ match_expression!(Argument) => SiblingNode::from(it.to_expression()),
-        }
-    }
-}
-
-impl<'a> From<&'a AssignmentTarget<'a>> for SiblingNode<'a> {
-    fn from(node: &'a AssignmentTarget<'a>) -> Self {
-        match node {
-            it @ match_simple_assignment_target!(AssignmentTarget) => {
-                SiblingNode::from(it.to_simple_assignment_target())
-            }
-            it @ match_assignment_target_pattern!(AssignmentTarget) => {
-                SiblingNode::from(it.to_assignment_target_pattern())
-            }
-        }
-    }
-}
-
-impl<'a> From<&'a SimpleAssignmentTarget<'a>> for SiblingNode<'a> {
-    fn from(node: &'a SimpleAssignmentTarget<'a>) -> Self {
-        match node {
-            SimpleAssignmentTarget::AssignmentTargetIdentifier(inner) => {
-                SiblingNode::IdentifierReference(inner)
-            }
-            SimpleAssignmentTarget::TSAsExpression(inner) => SiblingNode::TSAsExpression(inner),
-            SimpleAssignmentTarget::TSSatisfiesExpression(inner) => {
-                SiblingNode::TSSatisfiesExpression(inner)
-            }
-            SimpleAssignmentTarget::TSNonNullExpression(inner) => {
-                SiblingNode::TSNonNullExpression(inner)
-            }
-            SimpleAssignmentTarget::TSTypeAssertion(inner) => SiblingNode::TSTypeAssertion(inner),
-            it @ match_member_expression!(SimpleAssignmentTarget) => {
-                SiblingNode::from(it.to_member_expression())
-            }
-        }
-    }
-}
-
-impl<'a> From<&'a AssignmentTargetPattern<'a>> for SiblingNode<'a> {
-    fn from(node: &'a AssignmentTargetPattern<'a>) -> Self {
-        match node {
-            AssignmentTargetPattern::ArrayAssignmentTarget(inner) => {
-                SiblingNode::ArrayAssignmentTarget(inner)
-            }
-            AssignmentTargetPattern::ObjectAssignmentTarget(inner) => {
-                SiblingNode::ObjectAssignmentTarget(inner)
-            }
-        }
-    }
-}
-
-impl<'a> From<&'a AssignmentTargetMaybeDefault<'a>> for SiblingNode<'a> {
-    fn from(node: &'a AssignmentTargetMaybeDefault<'a>) -> Self {
-        match node {
-            AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(inner) => {
-                SiblingNode::AssignmentTargetWithDefault(inner)
-            }
-            it @ match_assignment_target!(AssignmentTargetMaybeDefault) => {
-                SiblingNode::from(it.to_assignment_target())
-            }
-        }
-    }
-}
-
-impl<'a> From<&'a AssignmentTargetProperty<'a>> for SiblingNode<'a> {
-    fn from(node: &'a AssignmentTargetProperty<'a>) -> Self {
-        match node {
-            AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(inner) => {
-                SiblingNode::AssignmentTargetPropertyIdentifier(inner)
-            }
-            AssignmentTargetProperty::AssignmentTargetPropertyProperty(inner) => {
-                SiblingNode::AssignmentTargetPropertyProperty(inner)
-            }
-        }
-    }
-}
-
-impl<'a> From<&'a ChainElement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ChainElement<'a>) -> Self {
-        match node {
-            ChainElement::CallExpression(inner) => SiblingNode::CallExpression(inner),
-            ChainElement::TSNonNullExpression(inner) => SiblingNode::TSNonNullExpression(inner),
-            it @ match_member_expression!(ChainElement) => {
-                SiblingNode::from(it.to_member_expression())
-            }
-        }
-    }
-}
-
-impl<'a> From<&'a Statement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a Statement<'a>) -> Self {
-        match node {
-            Statement::BlockStatement(inner) => SiblingNode::BlockStatement(inner),
-            Statement::BreakStatement(inner) => SiblingNode::BreakStatement(inner),
-            Statement::ContinueStatement(inner) => SiblingNode::ContinueStatement(inner),
-            Statement::DebuggerStatement(inner) => SiblingNode::DebuggerStatement(inner),
-            Statement::DoWhileStatement(inner) => SiblingNode::DoWhileStatement(inner),
-            Statement::EmptyStatement(inner) => SiblingNode::EmptyStatement(inner),
-            Statement::ExpressionStatement(inner) => SiblingNode::ExpressionStatement(inner),
-            Statement::ForInStatement(inner) => SiblingNode::ForInStatement(inner),
-            Statement::ForOfStatement(inner) => SiblingNode::ForOfStatement(inner),
-            Statement::ForStatement(inner) => SiblingNode::ForStatement(inner),
-            Statement::IfStatement(inner) => SiblingNode::IfStatement(inner),
-            Statement::LabeledStatement(inner) => SiblingNode::LabeledStatement(inner),
-            Statement::ReturnStatement(inner) => SiblingNode::ReturnStatement(inner),
-            Statement::SwitchStatement(inner) => SiblingNode::SwitchStatement(inner),
-            Statement::ThrowStatement(inner) => SiblingNode::ThrowStatement(inner),
-            Statement::TryStatement(inner) => SiblingNode::TryStatement(inner),
-            Statement::WhileStatement(inner) => SiblingNode::WhileStatement(inner),
-            Statement::WithStatement(inner) => SiblingNode::WithStatement(inner),
-            it @ match_declaration!(Statement) => SiblingNode::from(it.to_declaration()),
-            it @ match_module_declaration!(Statement) => {
-                SiblingNode::from(it.to_module_declaration())
-            }
-        }
-    }
-}
-
-impl<'a> From<&'a Declaration<'a>> for SiblingNode<'a> {
-    fn from(node: &'a Declaration<'a>) -> Self {
-        match node {
-            Declaration::VariableDeclaration(inner) => SiblingNode::VariableDeclaration(inner),
-            Declaration::FunctionDeclaration(inner) => SiblingNode::Function(inner),
-            Declaration::ClassDeclaration(inner) => SiblingNode::Class(inner),
-            Declaration::TSTypeAliasDeclaration(inner) => {
-                SiblingNode::TSTypeAliasDeclaration(inner)
-            }
-            Declaration::TSInterfaceDeclaration(inner) => {
-                SiblingNode::TSInterfaceDeclaration(inner)
-            }
-            Declaration::TSEnumDeclaration(inner) => SiblingNode::TSEnumDeclaration(inner),
-            Declaration::TSModuleDeclaration(inner) => SiblingNode::TSModuleDeclaration(inner),
-            Declaration::TSImportEqualsDeclaration(inner) => {
-                SiblingNode::TSImportEqualsDeclaration(inner)
-            }
-        }
-    }
-}
-
-impl<'a> From<&'a ForStatementInit<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ForStatementInit<'a>) -> Self {
-        match node {
-            ForStatementInit::VariableDeclaration(inner) => SiblingNode::VariableDeclaration(inner),
-            it @ match_expression!(ForStatementInit) => SiblingNode::from(it.to_expression()),
-        }
-    }
-}
-
-impl<'a> From<&'a ForStatementLeft<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ForStatementLeft<'a>) -> Self {
-        match node {
-            ForStatementLeft::VariableDeclaration(inner) => SiblingNode::VariableDeclaration(inner),
-            it @ match_assignment_target!(ForStatementLeft) => {
-                SiblingNode::from(it.to_assignment_target())
-            }
-        }
-    }
-}
-
-impl<'a> From<&'a BindingPatternKind<'a>> for SiblingNode<'a> {
-    fn from(node: &'a BindingPatternKind<'a>) -> Self {
-        match node {
-            BindingPatternKind::BindingIdentifier(inner) => SiblingNode::BindingIdentifier(inner),
-            BindingPatternKind::ObjectPattern(inner) => SiblingNode::ObjectPattern(inner),
-            BindingPatternKind::ArrayPattern(inner) => SiblingNode::ArrayPattern(inner),
-            BindingPatternKind::AssignmentPattern(inner) => SiblingNode::AssignmentPattern(inner),
-        }
-    }
-}
-
-impl<'a> From<&'a ClassElement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ClassElement<'a>) -> Self {
-        match node {
-            ClassElement::StaticBlock(inner) => SiblingNode::StaticBlock(inner),
-            ClassElement::MethodDefinition(inner) => SiblingNode::MethodDefinition(inner),
-            ClassElement::PropertyDefinition(inner) => SiblingNode::PropertyDefinition(inner),
-            ClassElement::AccessorProperty(inner) => SiblingNode::AccessorProperty(inner),
-            ClassElement::TSIndexSignature(inner) => SiblingNode::TSIndexSignature(inner),
-        }
-    }
-}
-
-impl<'a> From<&'a ModuleDeclaration<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ModuleDeclaration<'a>) -> Self {
-        match node {
-            ModuleDeclaration::ImportDeclaration(inner) => SiblingNode::ImportDeclaration(inner),
-            ModuleDeclaration::ExportAllDeclaration(inner) => {
-                SiblingNode::ExportAllDeclaration(inner)
-            }
-            ModuleDeclaration::ExportDefaultDeclaration(inner) => {
-                SiblingNode::ExportDefaultDeclaration(inner)
-            }
-            ModuleDeclaration::ExportNamedDeclaration(inner) => {
-                SiblingNode::ExportNamedDeclaration(inner)
-            }
-            ModuleDeclaration::TSExportAssignment(inner) => SiblingNode::TSExportAssignment(inner),
-            ModuleDeclaration::TSNamespaceExportDeclaration(inner) => {
-                SiblingNode::TSNamespaceExportDeclaration(inner)
-            }
-        }
-    }
-}
-
-impl<'a> From<&'a ImportDeclarationSpecifier<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ImportDeclarationSpecifier<'a>) -> Self {
-        match node {
-            ImportDeclarationSpecifier::ImportSpecifier(inner) => {
-                SiblingNode::ImportSpecifier(inner)
-            }
-            ImportDeclarationSpecifier::ImportDefaultSpecifier(inner) => {
-                SiblingNode::ImportDefaultSpecifier(inner)
-            }
-            ImportDeclarationSpecifier::ImportNamespaceSpecifier(inner) => {
-                SiblingNode::ImportNamespaceSpecifier(inner)
-            }
-        }
-    }
-}
-
-impl<'a> From<&'a ImportAttributeKey<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ImportAttributeKey<'a>) -> Self {
-        match node {
-            ImportAttributeKey::Identifier(inner) => SiblingNode::IdentifierName(inner),
-            ImportAttributeKey::StringLiteral(inner) => SiblingNode::StringLiteral(inner),
-        }
-    }
-}
-
-impl<'a> From<&'a ExportDefaultDeclarationKind<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ExportDefaultDeclarationKind<'a>) -> Self {
-        match node {
-            ExportDefaultDeclarationKind::FunctionDeclaration(inner) => {
-                SiblingNode::Function(inner)
-            }
-            ExportDefaultDeclarationKind::ClassDeclaration(inner) => SiblingNode::Class(inner),
-            ExportDefaultDeclarationKind::TSInterfaceDeclaration(inner) => {
-                SiblingNode::TSInterfaceDeclaration(inner)
-            }
-            it @ match_expression!(ExportDefaultDeclarationKind) => {
-                SiblingNode::from(it.to_expression())
-            }
-        }
-    }
-}
-
-impl<'a> From<&'a ModuleExportName<'a>> for SiblingNode<'a> {
-    fn from(node: &'a ModuleExportName<'a>) -> Self {
-        match node {
-            ModuleExportName::IdentifierName(inner) => SiblingNode::IdentifierName(inner),
-            ModuleExportName::IdentifierReference(inner) => SiblingNode::IdentifierReference(inner),
-            ModuleExportName::StringLiteral(inner) => SiblingNode::StringLiteral(inner),
-        }
-    }
-}
-
-impl<'a> From<&'a JSXElementName<'a>> for SiblingNode<'a> {
-    fn from(node: &'a JSXElementName<'a>) -> Self {
-        match node {
-            JSXElementName::Identifier(inner) => SiblingNode::JSXIdentifier(inner),
-            JSXElementName::IdentifierReference(inner) => SiblingNode::IdentifierReference(inner),
-            JSXElementName::NamespacedName(inner) => SiblingNode::JSXNamespacedName(inner),
-            JSXElementName::MemberExpression(inner) => SiblingNode::JSXMemberExpression(inner),
-            JSXElementName::ThisExpression(inner) => SiblingNode::ThisExpression(inner),
-        }
-    }
-}
-
-impl<'a> From<&'a JSXMemberExpressionObject<'a>> for SiblingNode<'a> {
-    fn from(node: &'a JSXMemberExpressionObject<'a>) -> Self {
-        match node {
-            JSXMemberExpressionObject::IdentifierReference(inner) => {
-                SiblingNode::IdentifierReference(inner)
-            }
-            JSXMemberExpressionObject::MemberExpression(inner) => {
-                SiblingNode::JSXMemberExpression(inner)
-            }
-            JSXMemberExpressionObject::ThisExpression(inner) => SiblingNode::ThisExpression(inner),
-        }
-    }
-}
-
-impl<'a> From<&'a JSXExpression<'a>> for SiblingNode<'a> {
-    fn from(node: &'a JSXExpression<'a>) -> Self {
-        match node {
-            JSXExpression::EmptyExpression(inner) => SiblingNode::JSXEmptyExpression(inner),
-            it @ match_expression!(JSXExpression) => SiblingNode::from(it.to_expression()),
-        }
-    }
-}
-
-impl<'a> From<&'a JSXAttributeItem<'a>> for SiblingNode<'a> {
-    fn from(node: &'a JSXAttributeItem<'a>) -> Self {
-        match node {
-            JSXAttributeItem::Attribute(inner) => SiblingNode::JSXAttribute(inner),
-            JSXAttributeItem::SpreadAttribute(inner) => SiblingNode::JSXSpreadAttribute(inner),
-        }
-    }
-}
-
-impl<'a> From<&'a JSXAttributeName<'a>> for SiblingNode<'a> {
-    fn from(node: &'a JSXAttributeName<'a>) -> Self {
-        match node {
-            JSXAttributeName::Identifier(inner) => SiblingNode::JSXIdentifier(inner),
-            JSXAttributeName::NamespacedName(inner) => SiblingNode::JSXNamespacedName(inner),
-        }
-    }
-}
-
-impl<'a> From<&'a JSXAttributeValue<'a>> for SiblingNode<'a> {
-    fn from(node: &'a JSXAttributeValue<'a>) -> Self {
-        match node {
-            JSXAttributeValue::StringLiteral(inner) => SiblingNode::StringLiteral(inner),
-            JSXAttributeValue::ExpressionContainer(inner) => {
-                SiblingNode::JSXExpressionContainer(inner)
-            }
-            JSXAttributeValue::Element(inner) => SiblingNode::JSXElement(inner),
-            JSXAttributeValue::Fragment(inner) => SiblingNode::JSXFragment(inner),
-        }
-    }
-}
-
-impl<'a> From<&'a JSXChild<'a>> for SiblingNode<'a> {
-    fn from(node: &'a JSXChild<'a>) -> Self {
-        match node {
-            JSXChild::Text(inner) => SiblingNode::JSXText(inner),
-            JSXChild::Element(inner) => SiblingNode::JSXElement(inner),
-            JSXChild::Fragment(inner) => SiblingNode::JSXFragment(inner),
-            JSXChild::ExpressionContainer(inner) => SiblingNode::JSXExpressionContainer(inner),
-            JSXChild::Spread(inner) => SiblingNode::JSXSpreadChild(inner),
-        }
-    }
-}
-
-impl<'a> From<&'a TSEnumMemberName<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSEnumMemberName<'a>) -> Self {
-        match node {
-            TSEnumMemberName::Identifier(inner) => SiblingNode::IdentifierName(inner),
-            TSEnumMemberName::String(inner) => SiblingNode::StringLiteral(inner),
-            TSEnumMemberName::ComputedString(inner) => SiblingNode::StringLiteral(inner),
-            TSEnumMemberName::ComputedTemplateString(inner) => SiblingNode::TemplateLiteral(inner),
-        }
-    }
-}
-
-impl<'a> From<&'a TSLiteral<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSLiteral<'a>) -> Self {
-        match node {
-            TSLiteral::BooleanLiteral(inner) => SiblingNode::BooleanLiteral(inner),
-            TSLiteral::NumericLiteral(inner) => SiblingNode::NumericLiteral(inner),
-            TSLiteral::BigIntLiteral(inner) => SiblingNode::BigIntLiteral(inner),
-            TSLiteral::StringLiteral(inner) => SiblingNode::StringLiteral(inner),
-            TSLiteral::TemplateLiteral(inner) => SiblingNode::TemplateLiteral(inner),
-            TSLiteral::UnaryExpression(inner) => SiblingNode::UnaryExpression(inner),
-        }
-    }
-}
-
-impl<'a> From<&'a TSType<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSType<'a>) -> Self {
-        match node {
-            TSType::TSAnyKeyword(inner) => SiblingNode::TSAnyKeyword(inner),
-            TSType::TSBigIntKeyword(inner) => SiblingNode::TSBigIntKeyword(inner),
-            TSType::TSBooleanKeyword(inner) => SiblingNode::TSBooleanKeyword(inner),
-            TSType::TSIntrinsicKeyword(inner) => SiblingNode::TSIntrinsicKeyword(inner),
-            TSType::TSNeverKeyword(inner) => SiblingNode::TSNeverKeyword(inner),
-            TSType::TSNullKeyword(inner) => SiblingNode::TSNullKeyword(inner),
-            TSType::TSNumberKeyword(inner) => SiblingNode::TSNumberKeyword(inner),
-            TSType::TSObjectKeyword(inner) => SiblingNode::TSObjectKeyword(inner),
-            TSType::TSStringKeyword(inner) => SiblingNode::TSStringKeyword(inner),
-            TSType::TSSymbolKeyword(inner) => SiblingNode::TSSymbolKeyword(inner),
-            TSType::TSUndefinedKeyword(inner) => SiblingNode::TSUndefinedKeyword(inner),
-            TSType::TSUnknownKeyword(inner) => SiblingNode::TSUnknownKeyword(inner),
-            TSType::TSVoidKeyword(inner) => SiblingNode::TSVoidKeyword(inner),
-            TSType::TSArrayType(inner) => SiblingNode::TSArrayType(inner),
-            TSType::TSConditionalType(inner) => SiblingNode::TSConditionalType(inner),
-            TSType::TSConstructorType(inner) => SiblingNode::TSConstructorType(inner),
-            TSType::TSFunctionType(inner) => SiblingNode::TSFunctionType(inner),
-            TSType::TSImportType(inner) => SiblingNode::TSImportType(inner),
-            TSType::TSIndexedAccessType(inner) => SiblingNode::TSIndexedAccessType(inner),
-            TSType::TSInferType(inner) => SiblingNode::TSInferType(inner),
-            TSType::TSIntersectionType(inner) => SiblingNode::TSIntersectionType(inner),
-            TSType::TSLiteralType(inner) => SiblingNode::TSLiteralType(inner),
-            TSType::TSMappedType(inner) => SiblingNode::TSMappedType(inner),
-            TSType::TSNamedTupleMember(inner) => SiblingNode::TSNamedTupleMember(inner),
-            TSType::TSTemplateLiteralType(inner) => SiblingNode::TSTemplateLiteralType(inner),
-            TSType::TSThisType(inner) => SiblingNode::TSThisType(inner),
-            TSType::TSTupleType(inner) => SiblingNode::TSTupleType(inner),
-            TSType::TSTypeLiteral(inner) => SiblingNode::TSTypeLiteral(inner),
-            TSType::TSTypeOperatorType(inner) => SiblingNode::TSTypeOperator(inner),
-            TSType::TSTypePredicate(inner) => SiblingNode::TSTypePredicate(inner),
-            TSType::TSTypeQuery(inner) => SiblingNode::TSTypeQuery(inner),
-            TSType::TSTypeReference(inner) => SiblingNode::TSTypeReference(inner),
-            TSType::TSUnionType(inner) => SiblingNode::TSUnionType(inner),
-            TSType::TSParenthesizedType(inner) => SiblingNode::TSParenthesizedType(inner),
-            TSType::JSDocNullableType(inner) => SiblingNode::JSDocNullableType(inner),
-            TSType::JSDocNonNullableType(inner) => SiblingNode::JSDocNonNullableType(inner),
-            TSType::JSDocUnknownType(inner) => SiblingNode::JSDocUnknownType(inner),
-        }
-    }
-}
-
-impl<'a> From<&'a TSTupleElement<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSTupleElement<'a>) -> Self {
-        match node {
-            TSTupleElement::TSOptionalType(inner) => SiblingNode::TSOptionalType(inner),
-            TSTupleElement::TSRestType(inner) => SiblingNode::TSRestType(inner),
-            it @ match_ts_type!(TSTupleElement) => SiblingNode::from(it.to_ts_type()),
-        }
-    }
-}
-
-impl<'a> From<&'a TSTypeName<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSTypeName<'a>) -> Self {
-        match node {
-            TSTypeName::IdentifierReference(inner) => SiblingNode::IdentifierReference(inner),
-            TSTypeName::QualifiedName(inner) => SiblingNode::TSQualifiedName(inner),
-            TSTypeName::ThisExpression(inner) => SiblingNode::ThisExpression(inner),
-        }
-    }
-}
-
-impl<'a> From<&'a TSSignature<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSSignature<'a>) -> Self {
-        match node {
-            TSSignature::TSIndexSignature(inner) => SiblingNode::TSIndexSignature(inner),
-            TSSignature::TSPropertySignature(inner) => SiblingNode::TSPropertySignature(inner),
-            TSSignature::TSCallSignatureDeclaration(inner) => {
-                SiblingNode::TSCallSignatureDeclaration(inner)
-            }
-            TSSignature::TSConstructSignatureDeclaration(inner) => {
-                SiblingNode::TSConstructSignatureDeclaration(inner)
-            }
-            TSSignature::TSMethodSignature(inner) => SiblingNode::TSMethodSignature(inner),
-        }
-    }
-}
-
-impl<'a> From<&'a TSTypePredicateName<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSTypePredicateName<'a>) -> Self {
-        match node {
-            TSTypePredicateName::Identifier(inner) => SiblingNode::IdentifierName(inner),
-            TSTypePredicateName::This(inner) => SiblingNode::TSThisType(inner),
-        }
-    }
-}
-
-impl<'a> From<&'a TSModuleDeclarationName<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSModuleDeclarationName<'a>) -> Self {
-        match node {
-            TSModuleDeclarationName::Identifier(inner) => SiblingNode::BindingIdentifier(inner),
-            TSModuleDeclarationName::StringLiteral(inner) => SiblingNode::StringLiteral(inner),
-        }
-    }
-}
-
-impl<'a> From<&'a TSModuleDeclarationBody<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSModuleDeclarationBody<'a>) -> Self {
-        match node {
-            TSModuleDeclarationBody::TSModuleDeclaration(inner) => {
-                SiblingNode::TSModuleDeclaration(inner)
-            }
-            TSModuleDeclarationBody::TSModuleBlock(inner) => SiblingNode::TSModuleBlock(inner),
-        }
-    }
-}
-
-impl<'a> From<&'a TSTypeQueryExprName<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSTypeQueryExprName<'a>) -> Self {
-        match node {
-            TSTypeQueryExprName::TSImportType(inner) => SiblingNode::TSImportType(inner),
-            it @ match_ts_type_name!(TSTypeQueryExprName) => {
-                SiblingNode::from(it.to_ts_type_name())
-            }
-        }
-    }
-}
-
-impl<'a> From<&'a TSImportTypeQualifier<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSImportTypeQualifier<'a>) -> Self {
-        match node {
-            TSImportTypeQualifier::Identifier(inner) => SiblingNode::IdentifierName(inner),
-            TSImportTypeQualifier::QualifiedName(inner) => {
-                SiblingNode::TSImportTypeQualifiedName(inner)
-            }
-        }
-    }
-}
-
-impl<'a> From<&'a TSModuleReference<'a>> for SiblingNode<'a> {
-    fn from(node: &'a TSModuleReference<'a>) -> Self {
-        match node {
-            TSModuleReference::ExternalModuleReference(inner) => {
-                SiblingNode::TSExternalModuleReference(inner)
-            }
-            it @ match_ts_type_name!(TSModuleReference) => SiblingNode::from(it.to_ts_type_name()),
-        }
-    }
-}
-
-impl SiblingNode<'_> {
-    pub fn span(&self) -> oxc_span::Span {
-        match self {
-            Self::Program(n) => n.span(),
-            Self::IdentifierName(n) => n.span(),
-            Self::IdentifierReference(n) => n.span(),
-            Self::BindingIdentifier(n) => n.span(),
-            Self::LabelIdentifier(n) => n.span(),
-            Self::ThisExpression(n) => n.span(),
-            Self::ArrayExpression(n) => n.span(),
-            Self::Elision(n) => n.span(),
-            Self::ObjectExpression(n) => n.span(),
-            Self::ObjectProperty(n) => n.span(),
-            Self::TemplateLiteral(n) => n.span(),
-            Self::TaggedTemplateExpression(n) => n.span(),
-            Self::TemplateElement(n) => n.span(),
-            Self::ComputedMemberExpression(n) => n.span(),
-            Self::StaticMemberExpression(n) => n.span(),
-            Self::PrivateFieldExpression(n) => n.span(),
-            Self::CallExpression(n) => n.span(),
-            Self::NewExpression(n) => n.span(),
-            Self::MetaProperty(n) => n.span(),
-            Self::SpreadElement(n) => n.span(),
-            Self::UpdateExpression(n) => n.span(),
-            Self::UnaryExpression(n) => n.span(),
-            Self::BinaryExpression(n) => n.span(),
-            Self::PrivateInExpression(n) => n.span(),
-            Self::LogicalExpression(n) => n.span(),
-            Self::ConditionalExpression(n) => n.span(),
-            Self::AssignmentExpression(n) => n.span(),
-            Self::ArrayAssignmentTarget(n) => n.span(),
-            Self::ObjectAssignmentTarget(n) => n.span(),
-            Self::AssignmentTargetRest(n) => n.span(),
-            Self::AssignmentTargetWithDefault(n) => n.span(),
-            Self::AssignmentTargetPropertyIdentifier(n) => n.span(),
-            Self::AssignmentTargetPropertyProperty(n) => n.span(),
-            Self::SequenceExpression(n) => n.span(),
-            Self::Super(n) => n.span(),
-            Self::AwaitExpression(n) => n.span(),
-            Self::ChainExpression(n) => n.span(),
-            Self::ParenthesizedExpression(n) => n.span(),
-            Self::Directive(n) => n.span(),
-            Self::Hashbang(n) => n.span(),
-            Self::BlockStatement(n) => n.span(),
-            Self::VariableDeclaration(n) => n.span(),
-            Self::VariableDeclarator(n) => n.span(),
-            Self::EmptyStatement(n) => n.span(),
-            Self::ExpressionStatement(n) => n.span(),
-            Self::IfStatement(n) => n.span(),
-            Self::DoWhileStatement(n) => n.span(),
-            Self::WhileStatement(n) => n.span(),
-            Self::ForStatement(n) => n.span(),
-            Self::ForInStatement(n) => n.span(),
-            Self::ForOfStatement(n) => n.span(),
-            Self::ContinueStatement(n) => n.span(),
-            Self::BreakStatement(n) => n.span(),
-            Self::ReturnStatement(n) => n.span(),
-            Self::WithStatement(n) => n.span(),
-            Self::SwitchStatement(n) => n.span(),
-            Self::SwitchCase(n) => n.span(),
-            Self::LabeledStatement(n) => n.span(),
-            Self::ThrowStatement(n) => n.span(),
-            Self::TryStatement(n) => n.span(),
-            Self::CatchClause(n) => n.span(),
-            Self::CatchParameter(n) => n.span(),
-            Self::DebuggerStatement(n) => n.span(),
-            Self::BindingPattern(n) => n.span(),
-            Self::AssignmentPattern(n) => n.span(),
-            Self::ObjectPattern(n) => n.span(),
-            Self::BindingProperty(n) => n.span(),
-            Self::ArrayPattern(n) => n.span(),
-            Self::BindingRestElement(n) => n.span(),
-            Self::Function(n) => n.span(),
-            Self::FormalParameters(n) => n.span(),
-            Self::FormalParameter(n) => n.span(),
-            Self::FunctionBody(n) => n.span(),
-            Self::ArrowFunctionExpression(n) => n.span(),
-            Self::YieldExpression(n) => n.span(),
-            Self::Class(n) => n.span(),
-            Self::ClassBody(n) => n.span(),
-            Self::MethodDefinition(n) => n.span(),
-            Self::PropertyDefinition(n) => n.span(),
-            Self::PrivateIdentifier(n) => n.span(),
-            Self::StaticBlock(n) => n.span(),
-            Self::AccessorProperty(n) => n.span(),
-            Self::ImportExpression(n) => n.span(),
-            Self::ImportDeclaration(n) => n.span(),
-            Self::ImportSpecifier(n) => n.span(),
-            Self::ImportDefaultSpecifier(n) => n.span(),
-            Self::ImportNamespaceSpecifier(n) => n.span(),
-            Self::WithClause(n) => n.span(),
-            Self::ImportAttribute(n) => n.span(),
-            Self::ExportNamedDeclaration(n) => n.span(),
-            Self::ExportDefaultDeclaration(n) => n.span(),
-            Self::ExportAllDeclaration(n) => n.span(),
-            Self::ExportSpecifier(n) => n.span(),
-            Self::V8IntrinsicExpression(n) => n.span(),
-            Self::BooleanLiteral(n) => n.span(),
-            Self::NullLiteral(n) => n.span(),
-            Self::NumericLiteral(n) => n.span(),
-            Self::StringLiteral(n) => n.span(),
-            Self::BigIntLiteral(n) => n.span(),
-            Self::RegExpLiteral(n) => n.span(),
-            Self::JSXElement(n) => n.span(),
-            Self::JSXOpeningElement(n) => n.span(),
-            Self::JSXClosingElement(n) => n.span(),
-            Self::JSXFragment(n) => n.span(),
-            Self::JSXOpeningFragment(n) => n.span(),
-            Self::JSXClosingFragment(n) => n.span(),
-            Self::JSXNamespacedName(n) => n.span(),
-            Self::JSXMemberExpression(n) => n.span(),
-            Self::JSXExpressionContainer(n) => n.span(),
-            Self::JSXEmptyExpression(n) => n.span(),
-            Self::JSXAttribute(n) => n.span(),
-            Self::JSXSpreadAttribute(n) => n.span(),
-            Self::JSXIdentifier(n) => n.span(),
-            Self::JSXSpreadChild(n) => n.span(),
-            Self::JSXText(n) => n.span(),
-            Self::TSThisParameter(n) => n.span(),
-            Self::TSEnumDeclaration(n) => n.span(),
-            Self::TSEnumBody(n) => n.span(),
-            Self::TSEnumMember(n) => n.span(),
-            Self::TSTypeAnnotation(n) => n.span(),
-            Self::TSLiteralType(n) => n.span(),
-            Self::TSConditionalType(n) => n.span(),
-            Self::TSUnionType(n) => n.span(),
-            Self::TSIntersectionType(n) => n.span(),
-            Self::TSParenthesizedType(n) => n.span(),
-            Self::TSTypeOperator(n) => n.span(),
-            Self::TSArrayType(n) => n.span(),
-            Self::TSIndexedAccessType(n) => n.span(),
-            Self::TSTupleType(n) => n.span(),
-            Self::TSNamedTupleMember(n) => n.span(),
-            Self::TSOptionalType(n) => n.span(),
-            Self::TSRestType(n) => n.span(),
-            Self::TSAnyKeyword(n) => n.span(),
-            Self::TSStringKeyword(n) => n.span(),
-            Self::TSBooleanKeyword(n) => n.span(),
-            Self::TSNumberKeyword(n) => n.span(),
-            Self::TSNeverKeyword(n) => n.span(),
-            Self::TSIntrinsicKeyword(n) => n.span(),
-            Self::TSUnknownKeyword(n) => n.span(),
-            Self::TSNullKeyword(n) => n.span(),
-            Self::TSUndefinedKeyword(n) => n.span(),
-            Self::TSVoidKeyword(n) => n.span(),
-            Self::TSSymbolKeyword(n) => n.span(),
-            Self::TSThisType(n) => n.span(),
-            Self::TSObjectKeyword(n) => n.span(),
-            Self::TSBigIntKeyword(n) => n.span(),
-            Self::TSTypeReference(n) => n.span(),
-            Self::TSQualifiedName(n) => n.span(),
-            Self::TSTypeParameterInstantiation(n) => n.span(),
-            Self::TSTypeParameter(n) => n.span(),
-            Self::TSTypeParameterDeclaration(n) => n.span(),
-            Self::TSTypeAliasDeclaration(n) => n.span(),
-            Self::TSClassImplements(n) => n.span(),
-            Self::TSInterfaceDeclaration(n) => n.span(),
-            Self::TSInterfaceBody(n) => n.span(),
-            Self::TSPropertySignature(n) => n.span(),
-            Self::TSIndexSignature(n) => n.span(),
-            Self::TSCallSignatureDeclaration(n) => n.span(),
-            Self::TSMethodSignature(n) => n.span(),
-            Self::TSConstructSignatureDeclaration(n) => n.span(),
-            Self::TSIndexSignatureName(n) => n.span(),
-            Self::TSInterfaceHeritage(n) => n.span(),
-            Self::TSTypePredicate(n) => n.span(),
-            Self::TSModuleDeclaration(n) => n.span(),
-            Self::TSModuleBlock(n) => n.span(),
-            Self::TSTypeLiteral(n) => n.span(),
-            Self::TSInferType(n) => n.span(),
-            Self::TSTypeQuery(n) => n.span(),
-            Self::TSImportType(n) => n.span(),
-            Self::TSImportTypeQualifiedName(n) => n.span(),
-            Self::TSFunctionType(n) => n.span(),
-            Self::TSConstructorType(n) => n.span(),
-            Self::TSMappedType(n) => n.span(),
-            Self::TSTemplateLiteralType(n) => n.span(),
-            Self::TSAsExpression(n) => n.span(),
-            Self::TSSatisfiesExpression(n) => n.span(),
-            Self::TSTypeAssertion(n) => n.span(),
-            Self::TSImportEqualsDeclaration(n) => n.span(),
-            Self::TSExternalModuleReference(n) => n.span(),
-            Self::TSNonNullExpression(n) => n.span(),
-            Self::Decorator(n) => n.span(),
-            Self::TSExportAssignment(n) => n.span(),
-            Self::TSNamespaceExportDeclaration(n) => n.span(),
-            Self::TSInstantiationExpression(n) => n.span(),
-            Self::JSDocNullableType(n) => n.span(),
-            Self::JSDocNonNullableType(n) => n.span(),
-            Self::JSDocUnknownType(n) => n.span(),
-        }
-    }
-}
 impl<'a> AstNodes<'a> {
     #[inline]
     pub fn span(&self) -> Span {
@@ -2354,7 +240,7 @@ impl<'a> AstNodes<'a> {
             Self::NewExpression(n) => n.span(),
             Self::MetaProperty(n) => n.span(),
             Self::SpreadElement(n) => n.span(),
-            Self::Argument(n) => n.span(),
+            Self::Argument(n) => n.parent.span(),
             Self::UpdateExpression(n) => n.span(),
             Self::UnaryExpression(n) => n.span(),
             Self::BinaryExpression(n) => n.span(),
@@ -2717,199 +603,6 @@ impl<'a> AstNodes<'a> {
         }
     }
     #[inline]
-    pub fn as_sibling_node(&self) -> SiblingNode<'a> {
-        match self {
-            Self::Dummy() => panic!("Should never be called on a dummy node"),
-            Self::Program(n) => SiblingNode::from(n.inner),
-            Self::IdentifierName(n) => SiblingNode::from(n.inner),
-            Self::IdentifierReference(n) => SiblingNode::from(n.inner),
-            Self::BindingIdentifier(n) => SiblingNode::from(n.inner),
-            Self::LabelIdentifier(n) => SiblingNode::from(n.inner),
-            Self::ThisExpression(n) => SiblingNode::from(n.inner),
-            Self::ArrayExpression(n) => SiblingNode::from(n.inner),
-            Self::Elision(n) => SiblingNode::from(n.inner),
-            Self::ObjectExpression(n) => SiblingNode::from(n.inner),
-            Self::ObjectProperty(n) => SiblingNode::from(n.inner),
-            Self::TemplateLiteral(n) => SiblingNode::from(n.inner),
-            Self::TaggedTemplateExpression(n) => SiblingNode::from(n.inner),
-            Self::TemplateElement(n) => SiblingNode::from(n.inner),
-            Self::ComputedMemberExpression(n) => SiblingNode::from(n.inner),
-            Self::StaticMemberExpression(n) => SiblingNode::from(n.inner),
-            Self::PrivateFieldExpression(n) => SiblingNode::from(n.inner),
-            Self::CallExpression(n) => SiblingNode::from(n.inner),
-            Self::NewExpression(n) => SiblingNode::from(n.inner),
-            Self::MetaProperty(n) => SiblingNode::from(n.inner),
-            Self::SpreadElement(n) => SiblingNode::from(n.inner),
-            Self::Argument(n) => n.parent.as_sibling_node(),
-            Self::UpdateExpression(n) => SiblingNode::from(n.inner),
-            Self::UnaryExpression(n) => SiblingNode::from(n.inner),
-            Self::BinaryExpression(n) => SiblingNode::from(n.inner),
-            Self::PrivateInExpression(n) => SiblingNode::from(n.inner),
-            Self::LogicalExpression(n) => SiblingNode::from(n.inner),
-            Self::ConditionalExpression(n) => SiblingNode::from(n.inner),
-            Self::AssignmentExpression(n) => SiblingNode::from(n.inner),
-            Self::ArrayAssignmentTarget(n) => SiblingNode::from(n.inner),
-            Self::ObjectAssignmentTarget(n) => SiblingNode::from(n.inner),
-            Self::AssignmentTargetRest(n) => SiblingNode::from(n.inner),
-            Self::AssignmentTargetWithDefault(n) => SiblingNode::from(n.inner),
-            Self::AssignmentTargetPropertyIdentifier(n) => SiblingNode::from(n.inner),
-            Self::AssignmentTargetPropertyProperty(n) => SiblingNode::from(n.inner),
-            Self::SequenceExpression(n) => SiblingNode::from(n.inner),
-            Self::Super(n) => SiblingNode::from(n.inner),
-            Self::AwaitExpression(n) => SiblingNode::from(n.inner),
-            Self::ChainExpression(n) => SiblingNode::from(n.inner),
-            Self::ParenthesizedExpression(n) => SiblingNode::from(n.inner),
-            Self::Directive(n) => SiblingNode::from(n.inner),
-            Self::Hashbang(n) => SiblingNode::from(n.inner),
-            Self::BlockStatement(n) => SiblingNode::from(n.inner),
-            Self::VariableDeclaration(n) => SiblingNode::from(n.inner),
-            Self::VariableDeclarator(n) => SiblingNode::from(n.inner),
-            Self::EmptyStatement(n) => SiblingNode::from(n.inner),
-            Self::ExpressionStatement(n) => SiblingNode::from(n.inner),
-            Self::IfStatement(n) => SiblingNode::from(n.inner),
-            Self::DoWhileStatement(n) => SiblingNode::from(n.inner),
-            Self::WhileStatement(n) => SiblingNode::from(n.inner),
-            Self::ForStatement(n) => SiblingNode::from(n.inner),
-            Self::ForInStatement(n) => SiblingNode::from(n.inner),
-            Self::ForOfStatement(n) => SiblingNode::from(n.inner),
-            Self::ContinueStatement(n) => SiblingNode::from(n.inner),
-            Self::BreakStatement(n) => SiblingNode::from(n.inner),
-            Self::ReturnStatement(n) => SiblingNode::from(n.inner),
-            Self::WithStatement(n) => SiblingNode::from(n.inner),
-            Self::SwitchStatement(n) => SiblingNode::from(n.inner),
-            Self::SwitchCase(n) => SiblingNode::from(n.inner),
-            Self::LabeledStatement(n) => SiblingNode::from(n.inner),
-            Self::ThrowStatement(n) => SiblingNode::from(n.inner),
-            Self::TryStatement(n) => SiblingNode::from(n.inner),
-            Self::CatchClause(n) => SiblingNode::from(n.inner),
-            Self::CatchParameter(n) => SiblingNode::from(n.inner),
-            Self::DebuggerStatement(n) => SiblingNode::from(n.inner),
-            Self::AssignmentPattern(n) => SiblingNode::from(n.inner),
-            Self::ObjectPattern(n) => SiblingNode::from(n.inner),
-            Self::BindingProperty(n) => SiblingNode::from(n.inner),
-            Self::ArrayPattern(n) => SiblingNode::from(n.inner),
-            Self::BindingRestElement(n) => SiblingNode::from(n.inner),
-            Self::Function(n) => SiblingNode::from(n.inner),
-            Self::FormalParameters(n) => SiblingNode::from(n.inner),
-            Self::FormalParameter(n) => SiblingNode::from(n.inner),
-            Self::FunctionBody(n) => SiblingNode::from(n.inner),
-            Self::ArrowFunctionExpression(n) => SiblingNode::from(n.inner),
-            Self::YieldExpression(n) => SiblingNode::from(n.inner),
-            Self::Class(n) => SiblingNode::from(n.inner),
-            Self::ClassBody(n) => SiblingNode::from(n.inner),
-            Self::MethodDefinition(n) => SiblingNode::from(n.inner),
-            Self::PropertyDefinition(n) => SiblingNode::from(n.inner),
-            Self::PrivateIdentifier(n) => SiblingNode::from(n.inner),
-            Self::StaticBlock(n) => SiblingNode::from(n.inner),
-            Self::AccessorProperty(n) => SiblingNode::from(n.inner),
-            Self::ImportExpression(n) => SiblingNode::from(n.inner),
-            Self::ImportDeclaration(n) => SiblingNode::from(n.inner),
-            Self::ImportSpecifier(n) => SiblingNode::from(n.inner),
-            Self::ImportDefaultSpecifier(n) => SiblingNode::from(n.inner),
-            Self::ImportNamespaceSpecifier(n) => SiblingNode::from(n.inner),
-            Self::WithClause(n) => SiblingNode::from(n.inner),
-            Self::ImportAttribute(n) => SiblingNode::from(n.inner),
-            Self::ExportNamedDeclaration(n) => SiblingNode::from(n.inner),
-            Self::ExportDefaultDeclaration(n) => SiblingNode::from(n.inner),
-            Self::ExportAllDeclaration(n) => SiblingNode::from(n.inner),
-            Self::ExportSpecifier(n) => SiblingNode::from(n.inner),
-            Self::V8IntrinsicExpression(n) => SiblingNode::from(n.inner),
-            Self::BooleanLiteral(n) => SiblingNode::from(n.inner),
-            Self::NullLiteral(n) => SiblingNode::from(n.inner),
-            Self::NumericLiteral(n) => SiblingNode::from(n.inner),
-            Self::StringLiteral(n) => SiblingNode::from(n.inner),
-            Self::BigIntLiteral(n) => SiblingNode::from(n.inner),
-            Self::RegExpLiteral(n) => SiblingNode::from(n.inner),
-            Self::JSXElement(n) => SiblingNode::from(n.inner),
-            Self::JSXOpeningElement(n) => SiblingNode::from(n.inner),
-            Self::JSXClosingElement(n) => SiblingNode::from(n.inner),
-            Self::JSXFragment(n) => SiblingNode::from(n.inner),
-            Self::JSXOpeningFragment(n) => SiblingNode::from(n.inner),
-            Self::JSXClosingFragment(n) => SiblingNode::from(n.inner),
-            Self::JSXNamespacedName(n) => SiblingNode::from(n.inner),
-            Self::JSXMemberExpression(n) => SiblingNode::from(n.inner),
-            Self::JSXExpressionContainer(n) => SiblingNode::from(n.inner),
-            Self::JSXEmptyExpression(n) => SiblingNode::from(n.inner),
-            Self::JSXAttribute(n) => SiblingNode::from(n.inner),
-            Self::JSXSpreadAttribute(n) => SiblingNode::from(n.inner),
-            Self::JSXIdentifier(n) => SiblingNode::from(n.inner),
-            Self::JSXSpreadChild(n) => SiblingNode::from(n.inner),
-            Self::JSXText(n) => SiblingNode::from(n.inner),
-            Self::TSThisParameter(n) => SiblingNode::from(n.inner),
-            Self::TSEnumDeclaration(n) => SiblingNode::from(n.inner),
-            Self::TSEnumBody(n) => SiblingNode::from(n.inner),
-            Self::TSEnumMember(n) => SiblingNode::from(n.inner),
-            Self::TSTypeAnnotation(n) => SiblingNode::from(n.inner),
-            Self::TSLiteralType(n) => SiblingNode::from(n.inner),
-            Self::TSConditionalType(n) => SiblingNode::from(n.inner),
-            Self::TSUnionType(n) => SiblingNode::from(n.inner),
-            Self::TSIntersectionType(n) => SiblingNode::from(n.inner),
-            Self::TSParenthesizedType(n) => SiblingNode::from(n.inner),
-            Self::TSTypeOperator(n) => SiblingNode::from(n.inner),
-            Self::TSArrayType(n) => SiblingNode::from(n.inner),
-            Self::TSIndexedAccessType(n) => SiblingNode::from(n.inner),
-            Self::TSTupleType(n) => SiblingNode::from(n.inner),
-            Self::TSNamedTupleMember(n) => SiblingNode::from(n.inner),
-            Self::TSOptionalType(n) => SiblingNode::from(n.inner),
-            Self::TSRestType(n) => SiblingNode::from(n.inner),
-            Self::TSAnyKeyword(n) => SiblingNode::from(n.inner),
-            Self::TSStringKeyword(n) => SiblingNode::from(n.inner),
-            Self::TSBooleanKeyword(n) => SiblingNode::from(n.inner),
-            Self::TSNumberKeyword(n) => SiblingNode::from(n.inner),
-            Self::TSNeverKeyword(n) => SiblingNode::from(n.inner),
-            Self::TSIntrinsicKeyword(n) => SiblingNode::from(n.inner),
-            Self::TSUnknownKeyword(n) => SiblingNode::from(n.inner),
-            Self::TSNullKeyword(n) => SiblingNode::from(n.inner),
-            Self::TSUndefinedKeyword(n) => SiblingNode::from(n.inner),
-            Self::TSVoidKeyword(n) => SiblingNode::from(n.inner),
-            Self::TSSymbolKeyword(n) => SiblingNode::from(n.inner),
-            Self::TSThisType(n) => SiblingNode::from(n.inner),
-            Self::TSObjectKeyword(n) => SiblingNode::from(n.inner),
-            Self::TSBigIntKeyword(n) => SiblingNode::from(n.inner),
-            Self::TSTypeReference(n) => SiblingNode::from(n.inner),
-            Self::TSQualifiedName(n) => SiblingNode::from(n.inner),
-            Self::TSTypeParameterInstantiation(n) => SiblingNode::from(n.inner),
-            Self::TSTypeParameter(n) => SiblingNode::from(n.inner),
-            Self::TSTypeParameterDeclaration(n) => SiblingNode::from(n.inner),
-            Self::TSTypeAliasDeclaration(n) => SiblingNode::from(n.inner),
-            Self::TSClassImplements(n) => SiblingNode::from(n.inner),
-            Self::TSInterfaceDeclaration(n) => SiblingNode::from(n.inner),
-            Self::TSInterfaceBody(n) => SiblingNode::from(n.inner),
-            Self::TSPropertySignature(n) => SiblingNode::from(n.inner),
-            Self::TSIndexSignature(n) => SiblingNode::from(n.inner),
-            Self::TSCallSignatureDeclaration(n) => SiblingNode::from(n.inner),
-            Self::TSMethodSignature(n) => SiblingNode::from(n.inner),
-            Self::TSConstructSignatureDeclaration(n) => SiblingNode::from(n.inner),
-            Self::TSIndexSignatureName(n) => SiblingNode::from(n.inner),
-            Self::TSInterfaceHeritage(n) => SiblingNode::from(n.inner),
-            Self::TSTypePredicate(n) => SiblingNode::from(n.inner),
-            Self::TSModuleDeclaration(n) => SiblingNode::from(n.inner),
-            Self::TSModuleBlock(n) => SiblingNode::from(n.inner),
-            Self::TSTypeLiteral(n) => SiblingNode::from(n.inner),
-            Self::TSInferType(n) => SiblingNode::from(n.inner),
-            Self::TSTypeQuery(n) => SiblingNode::from(n.inner),
-            Self::TSImportType(n) => SiblingNode::from(n.inner),
-            Self::TSImportTypeQualifiedName(n) => SiblingNode::from(n.inner),
-            Self::TSFunctionType(n) => SiblingNode::from(n.inner),
-            Self::TSConstructorType(n) => SiblingNode::from(n.inner),
-            Self::TSMappedType(n) => SiblingNode::from(n.inner),
-            Self::TSTemplateLiteralType(n) => SiblingNode::from(n.inner),
-            Self::TSAsExpression(n) => SiblingNode::from(n.inner),
-            Self::TSSatisfiesExpression(n) => SiblingNode::from(n.inner),
-            Self::TSTypeAssertion(n) => SiblingNode::from(n.inner),
-            Self::TSImportEqualsDeclaration(n) => SiblingNode::from(n.inner),
-            Self::TSExternalModuleReference(n) => SiblingNode::from(n.inner),
-            Self::TSNonNullExpression(n) => SiblingNode::from(n.inner),
-            Self::Decorator(n) => SiblingNode::from(n.inner),
-            Self::TSExportAssignment(n) => SiblingNode::from(n.inner),
-            Self::TSNamespaceExportDeclaration(n) => SiblingNode::from(n.inner),
-            Self::TSInstantiationExpression(n) => SiblingNode::from(n.inner),
-            Self::JSDocNullableType(n) => SiblingNode::from(n.inner),
-            Self::JSDocNonNullableType(n) => SiblingNode::from(n.inner),
-            Self::JSDocUnknownType(n) => SiblingNode::from(n.inner),
-        }
-    }
-    #[inline]
     pub fn debug_name(&self) -> &'static str {
         match self {
             Self::Dummy() => "Dummy",
@@ -3108,7 +801,7 @@ pub struct AstNode<'a, T> {
     pub(super) inner: &'a T,
     pub parent: &'a AstNodes<'a>,
     pub(super) allocator: &'a Allocator,
-    pub(super) following_node: Option<SiblingNode<'a>>,
+    pub(super) following_span: Option<Span>,
 }
 impl<T: GetSpan> GetSpan for &AstNode<'_, T> {
     fn span(&self) -> Span {
@@ -3140,7 +833,7 @@ impl<'a, T> AsRef<T> for AstNode<'a, T> {
 
 impl<'a> AstNode<'a, Program<'a>> {
     pub fn new(inner: &'a Program<'a>, parent: &'a AstNodes<'a>, allocator: &'a Allocator) -> Self {
-        AstNode { inner, parent, allocator, following_node: None }
+        AstNode { inner, parent, allocator, following_span: None }
     }
 }
 
@@ -3151,7 +844,7 @@ impl<'a, T> AstNode<'a, Option<T>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             }))
             .as_ref()
     }
@@ -3175,51 +868,42 @@ impl<'a> AstNode<'a, Program<'a>> {
 
     #[inline]
     pub fn hashbang(&self) -> Option<&AstNode<'a, Hashbang<'a>>> {
-        let following_node = self
+        let following_span = self
             .inner
             .directives
             .first()
-            .as_ref()
-            .copied()
-            .map(SiblingNode::from)
-            .or_else(|| self.inner.body.first().as_ref().copied().map(SiblingNode::from))
-            .or(self.following_node);
+            .map(GetSpan::span)
+            .or_else(|| self.inner.body.first().map(GetSpan::span))
+            .or(self.following_span);
         self.allocator
             .alloc(self.inner.hashbang.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::Program(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn directives(&self) -> &AstNode<'a, Vec<'a, Directive<'a>>> {
-        let following_node = self
-            .inner
-            .body
-            .first()
-            .as_ref()
-            .copied()
-            .map(SiblingNode::from)
-            .or(self.following_node);
+        let following_span = self.inner.body.first().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.directives,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::Program(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::Program(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -3228,12 +912,7 @@ impl<'a> AstNode<'a, Program<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -3254,21 +933,21 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::NullLiteral(s) => AstNodes::NullLiteral(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             Expression::NumericLiteral(s) => {
                 AstNodes::NumericLiteral(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::BigIntLiteral(s) => {
@@ -3276,7 +955,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::RegExpLiteral(s) => {
@@ -3284,7 +963,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::StringLiteral(s) => {
@@ -3292,7 +971,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::TemplateLiteral(s) => {
@@ -3300,7 +979,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::Identifier(s) => {
@@ -3308,27 +987,27 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::MetaProperty(s) => AstNodes::MetaProperty(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             Expression::Super(s) => AstNodes::Super(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             Expression::ArrayExpression(s) => {
                 AstNodes::ArrayExpression(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::ArrowFunctionExpression(s) => {
@@ -3336,7 +1015,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::AssignmentExpression(s) => {
@@ -3344,7 +1023,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::AwaitExpression(s) => {
@@ -3352,7 +1031,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::BinaryExpression(s) => {
@@ -3360,7 +1039,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::CallExpression(s) => {
@@ -3368,7 +1047,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::ChainExpression(s) => {
@@ -3376,21 +1055,21 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::ClassExpression(s) => AstNodes::Class(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             Expression::ConditionalExpression(s) => {
                 AstNodes::ConditionalExpression(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::FunctionExpression(s) => {
@@ -3398,7 +1077,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::ImportExpression(s) => {
@@ -3406,7 +1085,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::LogicalExpression(s) => {
@@ -3414,7 +1093,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::NewExpression(s) => {
@@ -3422,7 +1101,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::ObjectExpression(s) => {
@@ -3430,7 +1109,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::ParenthesizedExpression(s) => {
@@ -3438,7 +1117,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::SequenceExpression(s) => {
@@ -3446,7 +1125,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::TaggedTemplateExpression(s) => {
@@ -3454,7 +1133,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::ThisExpression(s) => {
@@ -3462,7 +1141,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::UnaryExpression(s) => {
@@ -3470,7 +1149,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::UpdateExpression(s) => {
@@ -3478,7 +1157,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::YieldExpression(s) => {
@@ -3486,7 +1165,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::PrivateInExpression(s) => {
@@ -3494,27 +1173,27 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::JSXElement(s) => AstNodes::JSXElement(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             Expression::JSXFragment(s) => AstNodes::JSXFragment(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             Expression::TSAsExpression(s) => {
                 AstNodes::TSAsExpression(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::TSSatisfiesExpression(s) => {
@@ -3522,7 +1201,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::TSTypeAssertion(s) => {
@@ -3530,7 +1209,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::TSNonNullExpression(s) => {
@@ -3538,7 +1217,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::TSInstantiationExpression(s) => {
@@ -3546,7 +1225,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Expression::V8IntrinsicExpression(s) => {
@@ -3554,7 +1233,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             it @ match_member_expression!(Expression) => {
@@ -3564,7 +1243,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                         inner: it.to_member_expression(),
                         parent,
                         allocator: self.allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .as_ast_nodes();
             }
@@ -3591,12 +1270,7 @@ impl<'a> AstNode<'a, IdentifierName<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -3618,12 +1292,7 @@ impl<'a> AstNode<'a, IdentifierReference<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -3645,12 +1314,7 @@ impl<'a> AstNode<'a, BindingIdentifier<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -3672,12 +1336,7 @@ impl<'a> AstNode<'a, LabelIdentifier<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -3694,12 +1353,7 @@ impl<'a> AstNode<'a, ThisExpression> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -3713,12 +1367,12 @@ impl<'a> GetSpan for AstNode<'a, ThisExpression> {
 impl<'a> AstNode<'a, ArrayExpression<'a>> {
     #[inline]
     pub fn elements(&self) -> &AstNode<'a, Vec<'a, ArrayExpressionElement<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.elements,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ArrayExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -3727,12 +1381,7 @@ impl<'a> AstNode<'a, ArrayExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -3753,7 +1402,7 @@ impl<'a> AstNode<'a, ArrayExpressionElement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             ArrayExpressionElement::Elision(s) => {
@@ -3761,7 +1410,7 @@ impl<'a> AstNode<'a, ArrayExpressionElement<'a>> {
                     inner: s,
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             it @ match_expression!(ArrayExpressionElement) => {
@@ -3771,7 +1420,7 @@ impl<'a> AstNode<'a, ArrayExpressionElement<'a>> {
                         inner: it.to_expression(),
                         parent,
                         allocator: self.allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .as_ast_nodes();
             }
@@ -3793,12 +1442,7 @@ impl<'a> AstNode<'a, Elision> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -3812,12 +1456,12 @@ impl<'a> GetSpan for AstNode<'a, Elision> {
 impl<'a> AstNode<'a, ObjectExpression<'a>> {
     #[inline]
     pub fn properties(&self) -> &AstNode<'a, Vec<'a, ObjectPropertyKind<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.properties,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ObjectExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -3826,12 +1470,7 @@ impl<'a> AstNode<'a, ObjectExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -3852,7 +1491,7 @@ impl<'a> AstNode<'a, ObjectPropertyKind<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             ObjectPropertyKind::SpreadProperty(s) => {
@@ -3860,7 +1499,7 @@ impl<'a> AstNode<'a, ObjectPropertyKind<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
         };
@@ -3883,23 +1522,23 @@ impl<'a> AstNode<'a, ObjectProperty<'a>> {
 
     #[inline]
     pub fn key(&self) -> &AstNode<'a, PropertyKey<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.value));
+        let following_span = Some(self.inner.value.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ObjectProperty(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn value(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator.alloc(AstNode {
             inner: &self.inner.value,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ObjectProperty(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -3923,12 +1562,7 @@ impl<'a> AstNode<'a, ObjectProperty<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -3949,7 +1583,7 @@ impl<'a> AstNode<'a, PropertyKey<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             PropertyKey::PrivateIdentifier(s) => {
@@ -3957,7 +1591,7 @@ impl<'a> AstNode<'a, PropertyKey<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             it @ match_expression!(PropertyKey) => {
@@ -3967,7 +1601,7 @@ impl<'a> AstNode<'a, PropertyKey<'a>> {
                         inner: it.to_expression(),
                         parent,
                         allocator: self.allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .as_ast_nodes();
             }
@@ -3986,30 +1620,24 @@ impl<'a> GetSpan for AstNode<'a, PropertyKey<'a>> {
 impl<'a> AstNode<'a, TemplateLiteral<'a>> {
     #[inline]
     pub fn quasis(&self) -> &AstNode<'a, Vec<'a, TemplateElement<'a>>> {
-        let following_node = self
-            .inner
-            .expressions
-            .first()
-            .as_ref()
-            .copied()
-            .map(SiblingNode::from)
-            .or(self.following_node);
+        let following_span =
+            self.inner.expressions.first().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.quasis,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TemplateLiteral(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn expressions(&self) -> &AstNode<'a, Vec<'a, Expression<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expressions,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TemplateLiteral(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -4018,12 +1646,7 @@ impl<'a> AstNode<'a, TemplateLiteral<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -4037,42 +1660,42 @@ impl<'a> GetSpan for AstNode<'a, TemplateLiteral<'a>> {
 impl<'a> AstNode<'a, TaggedTemplateExpression<'a>> {
     #[inline]
     pub fn tag(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = self
+        let following_span = self
             .inner
             .type_arguments
             .as_deref()
-            .map(SiblingNode::from)
-            .or_else(|| Some(SiblingNode::from(&self.inner.quasi)));
+            .map(GetSpan::span)
+            .or_else(|| Some(self.inner.quasi.span()));
         self.allocator.alloc(AstNode {
             inner: &self.inner.tag,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TaggedTemplateExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
-        let following_node = Some(SiblingNode::from(&self.inner.quasi));
+        let following_span = Some(self.inner.quasi.span());
         self.allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent:
                     self.allocator.alloc(AstNodes::TaggedTemplateExpression(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn quasi(&self) -> &AstNode<'a, TemplateLiteral<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.quasi,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TaggedTemplateExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -4081,12 +1704,7 @@ impl<'a> AstNode<'a, TaggedTemplateExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -4118,12 +1736,7 @@ impl<'a> AstNode<'a, TemplateElement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -4144,7 +1757,7 @@ impl<'a> AstNode<'a, MemberExpression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             MemberExpression::StaticMemberExpression(s) => {
@@ -4152,7 +1765,7 @@ impl<'a> AstNode<'a, MemberExpression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             MemberExpression::PrivateFieldExpression(s) => {
@@ -4160,7 +1773,7 @@ impl<'a> AstNode<'a, MemberExpression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
         };
@@ -4178,23 +1791,23 @@ impl<'a> GetSpan for AstNode<'a, MemberExpression<'a>> {
 impl<'a> AstNode<'a, ComputedMemberExpression<'a>> {
     #[inline]
     pub fn object(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.expression));
+        let following_span = Some(self.inner.expression.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.object,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ComputedMemberExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ComputedMemberExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -4208,12 +1821,7 @@ impl<'a> AstNode<'a, ComputedMemberExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -4227,23 +1835,23 @@ impl<'a> GetSpan for AstNode<'a, ComputedMemberExpression<'a>> {
 impl<'a> AstNode<'a, StaticMemberExpression<'a>> {
     #[inline]
     pub fn object(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.property));
+        let following_span = Some(self.inner.property.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.object,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::StaticMemberExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn property(&self) -> &AstNode<'a, IdentifierName<'a>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator.alloc(AstNode {
             inner: &self.inner.property,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::StaticMemberExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -4257,12 +1865,7 @@ impl<'a> AstNode<'a, StaticMemberExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -4276,23 +1879,23 @@ impl<'a> GetSpan for AstNode<'a, StaticMemberExpression<'a>> {
 impl<'a> AstNode<'a, PrivateFieldExpression<'a>> {
     #[inline]
     pub fn object(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.field));
+        let following_span = Some(self.inner.field.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.object,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::PrivateFieldExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn field(&self) -> &AstNode<'a, PrivateIdentifier<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.field,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::PrivateFieldExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -4306,12 +1909,7 @@ impl<'a> AstNode<'a, PrivateFieldExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -4325,49 +1923,43 @@ impl<'a> GetSpan for AstNode<'a, PrivateFieldExpression<'a>> {
 impl<'a> AstNode<'a, CallExpression<'a>> {
     #[inline]
     pub fn callee(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = self
+        let following_span = self
             .inner
             .type_arguments
             .as_deref()
-            .map(SiblingNode::from)
-            .or_else(|| self.inner.arguments.first().as_ref().copied().map(SiblingNode::from))
-            .or(self.following_node);
+            .map(GetSpan::span)
+            .or_else(|| self.inner.arguments.first().map(GetSpan::span))
+            .or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.callee,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::CallExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
-        let following_node = self
-            .inner
-            .arguments
-            .first()
-            .as_ref()
-            .copied()
-            .map(SiblingNode::from)
-            .or(self.following_node);
+        let following_span =
+            self.inner.arguments.first().map(GetSpan::span).or(self.following_span);
         self.allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::CallExpression(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn arguments(&self) -> &AstNode<'a, Vec<'a, Argument<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.arguments,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::CallExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -4386,12 +1978,7 @@ impl<'a> AstNode<'a, CallExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -4405,49 +1992,43 @@ impl<'a> GetSpan for AstNode<'a, CallExpression<'a>> {
 impl<'a> AstNode<'a, NewExpression<'a>> {
     #[inline]
     pub fn callee(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = self
+        let following_span = self
             .inner
             .type_arguments
             .as_deref()
-            .map(SiblingNode::from)
-            .or_else(|| self.inner.arguments.first().as_ref().copied().map(SiblingNode::from))
-            .or(self.following_node);
+            .map(GetSpan::span)
+            .or_else(|| self.inner.arguments.first().map(GetSpan::span))
+            .or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.callee,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::NewExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
-        let following_node = self
-            .inner
-            .arguments
-            .first()
-            .as_ref()
-            .copied()
-            .map(SiblingNode::from)
-            .or(self.following_node);
+        let following_span =
+            self.inner.arguments.first().map(GetSpan::span).or(self.following_span);
         self.allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::NewExpression(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn arguments(&self) -> &AstNode<'a, Vec<'a, Argument<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.arguments,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::NewExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -4461,12 +2042,7 @@ impl<'a> AstNode<'a, NewExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -4480,23 +2056,23 @@ impl<'a> GetSpan for AstNode<'a, NewExpression<'a>> {
 impl<'a> AstNode<'a, MetaProperty<'a>> {
     #[inline]
     pub fn meta(&self) -> &AstNode<'a, IdentifierName<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.property));
+        let following_span = Some(self.inner.property.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.meta,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::MetaProperty(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn property(&self) -> &AstNode<'a, IdentifierName<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.property,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::MetaProperty(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -4505,12 +2081,7 @@ impl<'a> AstNode<'a, MetaProperty<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -4524,12 +2095,12 @@ impl<'a> GetSpan for AstNode<'a, MetaProperty<'a>> {
 impl<'a> AstNode<'a, SpreadElement<'a>> {
     #[inline]
     pub fn argument(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.argument,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::SpreadElement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -4538,12 +2109,7 @@ impl<'a> AstNode<'a, SpreadElement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -4563,7 +2129,7 @@ impl<'a> AstNode<'a, Argument<'a>> {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             it @ match_expression!(Argument) => {
                 return self
@@ -4572,7 +2138,7 @@ impl<'a> AstNode<'a, Argument<'a>> {
                         inner: it.to_expression(),
                         parent,
                         allocator: self.allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .as_ast_nodes();
             }
@@ -4601,12 +2167,12 @@ impl<'a> AstNode<'a, UpdateExpression<'a>> {
 
     #[inline]
     pub fn argument(&self) -> &AstNode<'a, SimpleAssignmentTarget<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.argument,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::UpdateExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -4615,12 +2181,7 @@ impl<'a> AstNode<'a, UpdateExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -4639,12 +2200,12 @@ impl<'a> AstNode<'a, UnaryExpression<'a>> {
 
     #[inline]
     pub fn argument(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.argument,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::UnaryExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -4653,12 +2214,7 @@ impl<'a> AstNode<'a, UnaryExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -4672,12 +2228,12 @@ impl<'a> GetSpan for AstNode<'a, UnaryExpression<'a>> {
 impl<'a> AstNode<'a, BinaryExpression<'a>> {
     #[inline]
     pub fn left(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.right));
+        let following_span = Some(self.inner.right.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::BinaryExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -4688,12 +2244,12 @@ impl<'a> AstNode<'a, BinaryExpression<'a>> {
 
     #[inline]
     pub fn right(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::BinaryExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -4702,12 +2258,7 @@ impl<'a> AstNode<'a, BinaryExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -4721,23 +2272,23 @@ impl<'a> GetSpan for AstNode<'a, BinaryExpression<'a>> {
 impl<'a> AstNode<'a, PrivateInExpression<'a>> {
     #[inline]
     pub fn left(&self) -> &AstNode<'a, PrivateIdentifier<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.right));
+        let following_span = Some(self.inner.right.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::PrivateInExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn right(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::PrivateInExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -4746,12 +2297,7 @@ impl<'a> AstNode<'a, PrivateInExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -4765,12 +2311,12 @@ impl<'a> GetSpan for AstNode<'a, PrivateInExpression<'a>> {
 impl<'a> AstNode<'a, LogicalExpression<'a>> {
     #[inline]
     pub fn left(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.right));
+        let following_span = Some(self.inner.right.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::LogicalExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -4781,12 +2327,12 @@ impl<'a> AstNode<'a, LogicalExpression<'a>> {
 
     #[inline]
     pub fn right(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::LogicalExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -4795,12 +2341,7 @@ impl<'a> AstNode<'a, LogicalExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -4814,34 +2355,34 @@ impl<'a> GetSpan for AstNode<'a, LogicalExpression<'a>> {
 impl<'a> AstNode<'a, ConditionalExpression<'a>> {
     #[inline]
     pub fn test(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.consequent));
+        let following_span = Some(self.inner.consequent.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.test,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ConditionalExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn consequent(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.alternate));
+        let following_span = Some(self.inner.alternate.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.consequent,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ConditionalExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn alternate(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.alternate,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ConditionalExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -4850,12 +2391,7 @@ impl<'a> AstNode<'a, ConditionalExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -4874,23 +2410,23 @@ impl<'a> AstNode<'a, AssignmentExpression<'a>> {
 
     #[inline]
     pub fn left(&self) -> &AstNode<'a, AssignmentTarget<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.right));
+        let following_span = Some(self.inner.right.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::AssignmentExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn right(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::AssignmentExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -4899,12 +2435,7 @@ impl<'a> AstNode<'a, AssignmentExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -4927,7 +2458,7 @@ impl<'a> AstNode<'a, AssignmentTarget<'a>> {
                         inner: it.to_simple_assignment_target(),
                         parent,
                         allocator: self.allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .as_ast_nodes();
             }
@@ -4938,7 +2469,7 @@ impl<'a> AstNode<'a, AssignmentTarget<'a>> {
                         inner: it.to_assignment_target_pattern(),
                         parent,
                         allocator: self.allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .as_ast_nodes();
             }
@@ -4964,7 +2495,7 @@ impl<'a> AstNode<'a, SimpleAssignmentTarget<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             SimpleAssignmentTarget::TSAsExpression(s) => {
@@ -4972,7 +2503,7 @@ impl<'a> AstNode<'a, SimpleAssignmentTarget<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             SimpleAssignmentTarget::TSSatisfiesExpression(s) => {
@@ -4980,7 +2511,7 @@ impl<'a> AstNode<'a, SimpleAssignmentTarget<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             SimpleAssignmentTarget::TSNonNullExpression(s) => {
@@ -4988,7 +2519,7 @@ impl<'a> AstNode<'a, SimpleAssignmentTarget<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             SimpleAssignmentTarget::TSTypeAssertion(s) => {
@@ -4996,7 +2527,7 @@ impl<'a> AstNode<'a, SimpleAssignmentTarget<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             it @ match_member_expression!(SimpleAssignmentTarget) => {
@@ -5006,7 +2537,7 @@ impl<'a> AstNode<'a, SimpleAssignmentTarget<'a>> {
                         inner: it.to_member_expression(),
                         parent,
                         allocator: self.allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .as_ast_nodes();
             }
@@ -5032,7 +2563,7 @@ impl<'a> AstNode<'a, AssignmentTargetPattern<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             AssignmentTargetPattern::ObjectAssignmentTarget(s) => {
@@ -5040,7 +2571,7 @@ impl<'a> AstNode<'a, AssignmentTargetPattern<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
         };
@@ -5058,25 +2589,24 @@ impl<'a> GetSpan for AstNode<'a, AssignmentTargetPattern<'a>> {
 impl<'a> AstNode<'a, ArrayAssignmentTarget<'a>> {
     #[inline]
     pub fn elements(&self) -> &AstNode<'a, Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>> {
-        let following_node =
-            self.inner.rest.as_deref().map(SiblingNode::from).or(self.following_node);
+        let following_span = self.inner.rest.as_deref().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.elements,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ArrayAssignmentTarget(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn rest(&self) -> Option<&AstNode<'a, AssignmentTargetRest<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.rest.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ArrayAssignmentTarget(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -5086,12 +2616,7 @@ impl<'a> AstNode<'a, ArrayAssignmentTarget<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -5105,26 +2630,25 @@ impl<'a> GetSpan for AstNode<'a, ArrayAssignmentTarget<'a>> {
 impl<'a> AstNode<'a, ObjectAssignmentTarget<'a>> {
     #[inline]
     pub fn properties(&self) -> &AstNode<'a, Vec<'a, AssignmentTargetProperty<'a>>> {
-        let following_node =
-            self.inner.rest.as_deref().map(SiblingNode::from).or(self.following_node);
+        let following_span = self.inner.rest.as_deref().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.properties,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ObjectAssignmentTarget(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn rest(&self) -> Option<&AstNode<'a, AssignmentTargetRest<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.rest.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent:
                     self.allocator.alloc(AstNodes::ObjectAssignmentTarget(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -5134,12 +2658,7 @@ impl<'a> AstNode<'a, ObjectAssignmentTarget<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -5153,12 +2672,12 @@ impl<'a> GetSpan for AstNode<'a, ObjectAssignmentTarget<'a>> {
 impl<'a> AstNode<'a, AssignmentTargetRest<'a>> {
     #[inline]
     pub fn target(&self) -> &AstNode<'a, AssignmentTarget<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.target,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::AssignmentTargetRest(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -5167,12 +2686,7 @@ impl<'a> AstNode<'a, AssignmentTargetRest<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -5193,7 +2707,7 @@ impl<'a> AstNode<'a, AssignmentTargetMaybeDefault<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             it @ match_assignment_target!(AssignmentTargetMaybeDefault) => {
@@ -5203,7 +2717,7 @@ impl<'a> AstNode<'a, AssignmentTargetMaybeDefault<'a>> {
                         inner: it.to_assignment_target(),
                         parent,
                         allocator: self.allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .as_ast_nodes();
             }
@@ -5222,27 +2736,27 @@ impl<'a> GetSpan for AstNode<'a, AssignmentTargetMaybeDefault<'a>> {
 impl<'a> AstNode<'a, AssignmentTargetWithDefault<'a>> {
     #[inline]
     pub fn binding(&self) -> &AstNode<'a, AssignmentTarget<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.init));
+        let following_span = Some(self.inner.init.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.binding,
             allocator: self.allocator,
             parent: self
                 .allocator
                 .alloc(AstNodes::AssignmentTargetWithDefault(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn init(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.init,
             allocator: self.allocator,
             parent: self
                 .allocator
                 .alloc(AstNodes::AssignmentTargetWithDefault(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -5251,12 +2765,7 @@ impl<'a> AstNode<'a, AssignmentTargetWithDefault<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -5277,7 +2786,7 @@ impl<'a> AstNode<'a, AssignmentTargetProperty<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             AssignmentTargetProperty::AssignmentTargetPropertyProperty(s) => {
@@ -5285,7 +2794,7 @@ impl<'a> AstNode<'a, AssignmentTargetProperty<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
         };
@@ -5303,21 +2812,20 @@ impl<'a> GetSpan for AstNode<'a, AssignmentTargetProperty<'a>> {
 impl<'a> AstNode<'a, AssignmentTargetPropertyIdentifier<'a>> {
     #[inline]
     pub fn binding(&self) -> &AstNode<'a, IdentifierReference<'a>> {
-        let following_node =
-            self.inner.init.as_ref().map(SiblingNode::from).or(self.following_node);
+        let following_span = self.inner.init.as_ref().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.binding,
             allocator: self.allocator,
             parent: self
                 .allocator
                 .alloc(AstNodes::AssignmentTargetPropertyIdentifier(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn init(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.init.as_ref().map(|inner| {
                 AstNode {
@@ -5326,7 +2834,7 @@ impl<'a> AstNode<'a, AssignmentTargetPropertyIdentifier<'a>> {
                     parent: self
                         .allocator
                         .alloc(AstNodes::AssignmentTargetPropertyIdentifier(transmute_self(self))),
-                    following_node,
+                    following_span,
                 }
             }))
             .as_ref()
@@ -5337,12 +2845,7 @@ impl<'a> AstNode<'a, AssignmentTargetPropertyIdentifier<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -5356,27 +2859,27 @@ impl<'a> GetSpan for AstNode<'a, AssignmentTargetPropertyIdentifier<'a>> {
 impl<'a> AstNode<'a, AssignmentTargetPropertyProperty<'a>> {
     #[inline]
     pub fn name(&self) -> &AstNode<'a, PropertyKey<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.binding));
+        let following_span = Some(self.inner.binding.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.name,
             allocator: self.allocator,
             parent: self
                 .allocator
                 .alloc(AstNodes::AssignmentTargetPropertyProperty(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn binding(&self) -> &AstNode<'a, AssignmentTargetMaybeDefault<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.binding,
             allocator: self.allocator,
             parent: self
                 .allocator
                 .alloc(AstNodes::AssignmentTargetPropertyProperty(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -5390,12 +2893,7 @@ impl<'a> AstNode<'a, AssignmentTargetPropertyProperty<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -5409,12 +2907,12 @@ impl<'a> GetSpan for AstNode<'a, AssignmentTargetPropertyProperty<'a>> {
 impl<'a> AstNode<'a, SequenceExpression<'a>> {
     #[inline]
     pub fn expressions(&self) -> &AstNode<'a, Vec<'a, Expression<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expressions,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::SequenceExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -5423,12 +2921,7 @@ impl<'a> AstNode<'a, SequenceExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -5445,12 +2938,7 @@ impl<'a> AstNode<'a, Super> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -5464,12 +2952,12 @@ impl<'a> GetSpan for AstNode<'a, Super> {
 impl<'a> AstNode<'a, AwaitExpression<'a>> {
     #[inline]
     pub fn argument(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.argument,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::AwaitExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -5478,12 +2966,7 @@ impl<'a> AstNode<'a, AwaitExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -5497,12 +2980,12 @@ impl<'a> GetSpan for AstNode<'a, AwaitExpression<'a>> {
 impl<'a> AstNode<'a, ChainExpression<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, ChainElement<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ChainExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -5511,12 +2994,7 @@ impl<'a> AstNode<'a, ChainExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -5537,7 +3015,7 @@ impl<'a> AstNode<'a, ChainElement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             ChainElement::TSNonNullExpression(s) => {
@@ -5545,7 +3023,7 @@ impl<'a> AstNode<'a, ChainElement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             it @ match_member_expression!(ChainElement) => {
@@ -5555,7 +3033,7 @@ impl<'a> AstNode<'a, ChainElement<'a>> {
                         inner: it.to_member_expression(),
                         parent,
                         allocator: self.allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .as_ast_nodes();
             }
@@ -5574,12 +3052,12 @@ impl<'a> GetSpan for AstNode<'a, ChainElement<'a>> {
 impl<'a> AstNode<'a, ParenthesizedExpression<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ParenthesizedExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -5588,12 +3066,7 @@ impl<'a> AstNode<'a, ParenthesizedExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -5614,7 +3087,7 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Statement::BreakStatement(s) => {
@@ -5622,7 +3095,7 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Statement::ContinueStatement(s) => {
@@ -5630,7 +3103,7 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Statement::DebuggerStatement(s) => {
@@ -5638,7 +3111,7 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Statement::DoWhileStatement(s) => {
@@ -5646,7 +3119,7 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Statement::EmptyStatement(s) => {
@@ -5654,7 +3127,7 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Statement::ExpressionStatement(s) => {
@@ -5662,7 +3135,7 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Statement::ForInStatement(s) => {
@@ -5670,7 +3143,7 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Statement::ForOfStatement(s) => {
@@ -5678,27 +3151,27 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Statement::ForStatement(s) => AstNodes::ForStatement(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             Statement::IfStatement(s) => AstNodes::IfStatement(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             Statement::LabeledStatement(s) => {
                 AstNodes::LabeledStatement(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Statement::ReturnStatement(s) => {
@@ -5706,7 +3179,7 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Statement::SwitchStatement(s) => {
@@ -5714,7 +3187,7 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Statement::ThrowStatement(s) => {
@@ -5722,28 +3195,28 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Statement::TryStatement(s) => AstNodes::TryStatement(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             Statement::WhileStatement(s) => {
                 AstNodes::WhileStatement(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Statement::WithStatement(s) => AstNodes::WithStatement(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             it @ match_declaration!(Statement) => {
                 return self
@@ -5752,7 +3225,7 @@ impl<'a> AstNode<'a, Statement<'a>> {
                         inner: it.to_declaration(),
                         parent,
                         allocator: self.allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .as_ast_nodes();
             }
@@ -5763,7 +3236,7 @@ impl<'a> AstNode<'a, Statement<'a>> {
                         inner: it.to_module_declaration(),
                         parent,
                         allocator: self.allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .as_ast_nodes();
             }
@@ -5782,12 +3255,12 @@ impl<'a> GetSpan for AstNode<'a, Statement<'a>> {
 impl<'a> AstNode<'a, Directive<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, StringLiteral<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::Directive(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -5801,12 +3274,7 @@ impl<'a> AstNode<'a, Directive<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -5828,12 +3296,7 @@ impl<'a> AstNode<'a, Hashbang<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -5847,12 +3310,12 @@ impl<'a> GetSpan for AstNode<'a, Hashbang<'a>> {
 impl<'a> AstNode<'a, BlockStatement<'a>> {
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::BlockStatement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -5861,12 +3324,7 @@ impl<'a> AstNode<'a, BlockStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -5887,7 +3345,7 @@ impl<'a> AstNode<'a, Declaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Declaration::FunctionDeclaration(s) => {
@@ -5895,21 +3353,21 @@ impl<'a> AstNode<'a, Declaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Declaration::ClassDeclaration(s) => AstNodes::Class(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             Declaration::TSTypeAliasDeclaration(s) => {
                 AstNodes::TSTypeAliasDeclaration(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Declaration::TSInterfaceDeclaration(s) => {
@@ -5917,7 +3375,7 @@ impl<'a> AstNode<'a, Declaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Declaration::TSEnumDeclaration(s) => {
@@ -5925,7 +3383,7 @@ impl<'a> AstNode<'a, Declaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Declaration::TSModuleDeclaration(s) => {
@@ -5933,7 +3391,7 @@ impl<'a> AstNode<'a, Declaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             Declaration::TSImportEqualsDeclaration(s) => {
@@ -5941,7 +3399,7 @@ impl<'a> AstNode<'a, Declaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
         };
@@ -5964,12 +3422,12 @@ impl<'a> AstNode<'a, VariableDeclaration<'a>> {
 
     #[inline]
     pub fn declarations(&self) -> &AstNode<'a, Vec<'a, VariableDeclarator<'a>>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator.alloc(AstNode {
             inner: &self.inner.declarations,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::VariableDeclaration(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -5983,12 +3441,7 @@ impl<'a> AstNode<'a, VariableDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -6007,25 +3460,24 @@ impl<'a> AstNode<'a, VariableDeclarator<'a>> {
 
     #[inline]
     pub fn id(&self) -> &AstNode<'a, BindingPattern<'a>> {
-        let following_node =
-            self.inner.init.as_ref().map(SiblingNode::from).or(self.following_node);
+        let following_span = self.inner.init.as_ref().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::VariableDeclarator(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn init(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.init.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::VariableDeclarator(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -6040,12 +3492,7 @@ impl<'a> AstNode<'a, VariableDeclarator<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -6062,12 +3509,7 @@ impl<'a> AstNode<'a, EmptyStatement> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -6081,12 +3523,12 @@ impl<'a> GetSpan for AstNode<'a, EmptyStatement> {
 impl<'a> AstNode<'a, ExpressionStatement<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ExpressionStatement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -6095,12 +3537,7 @@ impl<'a> AstNode<'a, ExpressionStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -6114,35 +3551,35 @@ impl<'a> GetSpan for AstNode<'a, ExpressionStatement<'a>> {
 impl<'a> AstNode<'a, IfStatement<'a>> {
     #[inline]
     pub fn test(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.consequent));
+        let following_span = Some(self.inner.consequent.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.test,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::IfStatement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn consequent(&self) -> &AstNode<'a, Statement<'a>> {
-        let following_node = self.inner.alternate.as_ref().map(SiblingNode::from);
+        let following_span = self.inner.alternate.as_ref().map(GetSpan::span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.consequent,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::IfStatement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn alternate(&self) -> Option<&AstNode<'a, Statement<'a>>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator
             .alloc(self.inner.alternate.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::IfStatement(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -6152,12 +3589,7 @@ impl<'a> AstNode<'a, IfStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -6171,23 +3603,23 @@ impl<'a> GetSpan for AstNode<'a, IfStatement<'a>> {
 impl<'a> AstNode<'a, DoWhileStatement<'a>> {
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Statement<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.test));
+        let following_span = Some(self.inner.test.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::DoWhileStatement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn test(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator.alloc(AstNode {
             inner: &self.inner.test,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::DoWhileStatement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -6196,12 +3628,7 @@ impl<'a> AstNode<'a, DoWhileStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -6215,23 +3642,23 @@ impl<'a> GetSpan for AstNode<'a, DoWhileStatement<'a>> {
 impl<'a> AstNode<'a, WhileStatement<'a>> {
     #[inline]
     pub fn test(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.body));
+        let following_span = Some(self.inner.body.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.test,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::WhileStatement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Statement<'a>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::WhileStatement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -6240,12 +3667,7 @@ impl<'a> AstNode<'a, WhileStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -6259,62 +3681,58 @@ impl<'a> GetSpan for AstNode<'a, WhileStatement<'a>> {
 impl<'a> AstNode<'a, ForStatement<'a>> {
     #[inline]
     pub fn init(&self) -> Option<&AstNode<'a, ForStatementInit<'a>>> {
-        let following_node = self
+        let following_span = self
             .inner
             .test
             .as_ref()
-            .map(SiblingNode::from)
-            .or_else(|| self.inner.update.as_ref().map(SiblingNode::from))
-            .or_else(|| Some(SiblingNode::from(&self.inner.body)));
+            .map(GetSpan::span)
+            .or_else(|| self.inner.update.as_ref().map(GetSpan::span))
+            .or_else(|| Some(self.inner.body.span()));
         self.allocator
             .alloc(self.inner.init.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ForStatement(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn test(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_node = self
-            .inner
-            .update
-            .as_ref()
-            .map(SiblingNode::from)
-            .or_else(|| Some(SiblingNode::from(&self.inner.body)));
+        let following_span =
+            self.inner.update.as_ref().map(GetSpan::span).or_else(|| Some(self.inner.body.span()));
         self.allocator
             .alloc(self.inner.test.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ForStatement(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn update(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_node = Some(SiblingNode::from(&self.inner.body));
+        let following_span = Some(self.inner.body.span());
         self.allocator
             .alloc(self.inner.update.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ForStatement(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Statement<'a>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ForStatement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -6323,12 +3741,7 @@ impl<'a> AstNode<'a, ForStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -6349,7 +3762,7 @@ impl<'a> AstNode<'a, ForStatementInit<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             it @ match_expression!(ForStatementInit) => {
@@ -6359,7 +3772,7 @@ impl<'a> AstNode<'a, ForStatementInit<'a>> {
                         inner: it.to_expression(),
                         parent,
                         allocator: self.allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .as_ast_nodes();
             }
@@ -6378,34 +3791,34 @@ impl<'a> GetSpan for AstNode<'a, ForStatementInit<'a>> {
 impl<'a> AstNode<'a, ForInStatement<'a>> {
     #[inline]
     pub fn left(&self) -> &AstNode<'a, ForStatementLeft<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.right));
+        let following_span = Some(self.inner.right.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ForInStatement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn right(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.body));
+        let following_span = Some(self.inner.body.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ForInStatement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Statement<'a>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ForInStatement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -6414,12 +3827,7 @@ impl<'a> AstNode<'a, ForInStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -6440,7 +3848,7 @@ impl<'a> AstNode<'a, ForStatementLeft<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             it @ match_assignment_target!(ForStatementLeft) => {
@@ -6450,7 +3858,7 @@ impl<'a> AstNode<'a, ForStatementLeft<'a>> {
                         inner: it.to_assignment_target(),
                         parent,
                         allocator: self.allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .as_ast_nodes();
             }
@@ -6474,34 +3882,34 @@ impl<'a> AstNode<'a, ForOfStatement<'a>> {
 
     #[inline]
     pub fn left(&self) -> &AstNode<'a, ForStatementLeft<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.right));
+        let following_span = Some(self.inner.right.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ForOfStatement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn right(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.body));
+        let following_span = Some(self.inner.body.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ForOfStatement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Statement<'a>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ForOfStatement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -6510,12 +3918,7 @@ impl<'a> AstNode<'a, ForOfStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -6529,13 +3932,13 @@ impl<'a> GetSpan for AstNode<'a, ForOfStatement<'a>> {
 impl<'a> AstNode<'a, ContinueStatement<'a>> {
     #[inline]
     pub fn label(&self) -> Option<&AstNode<'a, LabelIdentifier<'a>>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator
             .alloc(self.inner.label.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ContinueStatement(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -6545,12 +3948,7 @@ impl<'a> AstNode<'a, ContinueStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -6564,13 +3962,13 @@ impl<'a> GetSpan for AstNode<'a, ContinueStatement<'a>> {
 impl<'a> AstNode<'a, BreakStatement<'a>> {
     #[inline]
     pub fn label(&self) -> Option<&AstNode<'a, LabelIdentifier<'a>>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator
             .alloc(self.inner.label.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::BreakStatement(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -6580,12 +3978,7 @@ impl<'a> AstNode<'a, BreakStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -6599,13 +3992,13 @@ impl<'a> GetSpan for AstNode<'a, BreakStatement<'a>> {
 impl<'a> AstNode<'a, ReturnStatement<'a>> {
     #[inline]
     pub fn argument(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator
             .alloc(self.inner.argument.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ReturnStatement(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -6615,12 +4008,7 @@ impl<'a> AstNode<'a, ReturnStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -6634,23 +4022,23 @@ impl<'a> GetSpan for AstNode<'a, ReturnStatement<'a>> {
 impl<'a> AstNode<'a, WithStatement<'a>> {
     #[inline]
     pub fn object(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.body));
+        let following_span = Some(self.inner.body.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.object,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::WithStatement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Statement<'a>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::WithStatement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -6659,12 +4047,7 @@ impl<'a> AstNode<'a, WithStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -6678,23 +4061,23 @@ impl<'a> GetSpan for AstNode<'a, WithStatement<'a>> {
 impl<'a> AstNode<'a, SwitchStatement<'a>> {
     #[inline]
     pub fn discriminant(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = self.inner.cases.first().as_ref().copied().map(SiblingNode::from);
+        let following_span = self.inner.cases.first().map(GetSpan::span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.discriminant,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::SwitchStatement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn cases(&self) -> &AstNode<'a, Vec<'a, SwitchCase<'a>>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator.alloc(AstNode {
             inner: &self.inner.cases,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::SwitchStatement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -6703,12 +4086,7 @@ impl<'a> AstNode<'a, SwitchStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -6722,32 +4100,26 @@ impl<'a> GetSpan for AstNode<'a, SwitchStatement<'a>> {
 impl<'a> AstNode<'a, SwitchCase<'a>> {
     #[inline]
     pub fn test(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_node = self
-            .inner
-            .consequent
-            .first()
-            .as_ref()
-            .copied()
-            .map(SiblingNode::from)
-            .or(self.following_node);
+        let following_span =
+            self.inner.consequent.first().map(GetSpan::span).or(self.following_span);
         self.allocator
             .alloc(self.inner.test.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::SwitchCase(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn consequent(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.consequent,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::SwitchCase(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -6756,12 +4128,7 @@ impl<'a> AstNode<'a, SwitchCase<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -6775,23 +4142,23 @@ impl<'a> GetSpan for AstNode<'a, SwitchCase<'a>> {
 impl<'a> AstNode<'a, LabeledStatement<'a>> {
     #[inline]
     pub fn label(&self) -> &AstNode<'a, LabelIdentifier<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.body));
+        let following_span = Some(self.inner.body.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.label,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::LabeledStatement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Statement<'a>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::LabeledStatement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -6800,12 +4167,7 @@ impl<'a> AstNode<'a, LabeledStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -6819,12 +4181,12 @@ impl<'a> GetSpan for AstNode<'a, LabeledStatement<'a>> {
 impl<'a> AstNode<'a, ThrowStatement<'a>> {
     #[inline]
     pub fn argument(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator.alloc(AstNode {
             inner: &self.inner.argument,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ThrowStatement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -6833,12 +4195,7 @@ impl<'a> AstNode<'a, ThrowStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -6852,42 +4209,42 @@ impl<'a> GetSpan for AstNode<'a, ThrowStatement<'a>> {
 impl<'a> AstNode<'a, TryStatement<'a>> {
     #[inline]
     pub fn block(&self) -> &AstNode<'a, BlockStatement<'a>> {
-        let following_node = self
+        let following_span = self
             .inner
             .handler
             .as_deref()
-            .map(SiblingNode::from)
-            .or_else(|| self.inner.finalizer.as_deref().map(SiblingNode::from));
+            .map(GetSpan::span)
+            .or_else(|| self.inner.finalizer.as_deref().map(GetSpan::span));
         self.allocator.alloc(AstNode {
             inner: self.inner.block.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TryStatement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn handler(&self) -> Option<&AstNode<'a, CatchClause<'a>>> {
-        let following_node = self.inner.finalizer.as_deref().map(SiblingNode::from);
+        let following_span = self.inner.finalizer.as_deref().map(GetSpan::span);
         self.allocator
             .alloc(self.inner.handler.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TryStatement(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn finalizer(&self) -> Option<&AstNode<'a, BlockStatement<'a>>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator
             .alloc(self.inner.finalizer.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TryStatement(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -6897,12 +4254,7 @@ impl<'a> AstNode<'a, TryStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -6916,25 +4268,25 @@ impl<'a> GetSpan for AstNode<'a, TryStatement<'a>> {
 impl<'a> AstNode<'a, CatchClause<'a>> {
     #[inline]
     pub fn param(&self) -> Option<&AstNode<'a, CatchParameter<'a>>> {
-        let following_node = Some(SiblingNode::from(self.inner.body.as_ref()));
+        let following_span = Some(self.inner.body.span());
         self.allocator
             .alloc(self.inner.param.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::CatchClause(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, BlockStatement<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: self.inner.body.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::CatchClause(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -6943,12 +4295,7 @@ impl<'a> AstNode<'a, CatchClause<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -6962,12 +4309,12 @@ impl<'a> GetSpan for AstNode<'a, CatchClause<'a>> {
 impl<'a> AstNode<'a, CatchParameter<'a>> {
     #[inline]
     pub fn pattern(&self) -> &AstNode<'a, BindingPattern<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.pattern,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::CatchParameter(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -6976,12 +4323,7 @@ impl<'a> AstNode<'a, CatchParameter<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -6998,12 +4340,7 @@ impl<'a> AstNode<'a, DebuggerStatement> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -7017,25 +4354,25 @@ impl<'a> GetSpan for AstNode<'a, DebuggerStatement> {
 impl<'a> AstNode<'a, BindingPattern<'a>> {
     #[inline]
     pub fn kind(&self) -> &AstNode<'a, BindingPatternKind<'a>> {
-        let following_node =
-            self.inner.type_annotation.as_deref().map(SiblingNode::from).or(self.following_node);
+        let following_span =
+            self.inner.type_annotation.as_deref().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.kind,
             allocator: self.allocator,
             parent: self.parent,
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn type_annotation(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.parent,
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -7050,12 +4387,7 @@ impl<'a> AstNode<'a, BindingPattern<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -7076,7 +4408,7 @@ impl<'a> AstNode<'a, BindingPatternKind<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             BindingPatternKind::ObjectPattern(s) => {
@@ -7084,7 +4416,7 @@ impl<'a> AstNode<'a, BindingPatternKind<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             BindingPatternKind::ArrayPattern(s) => {
@@ -7092,7 +4424,7 @@ impl<'a> AstNode<'a, BindingPatternKind<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             BindingPatternKind::AssignmentPattern(s) => {
@@ -7100,7 +4432,7 @@ impl<'a> AstNode<'a, BindingPatternKind<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
         };
@@ -7118,23 +4450,23 @@ impl<'a> GetSpan for AstNode<'a, BindingPatternKind<'a>> {
 impl<'a> AstNode<'a, AssignmentPattern<'a>> {
     #[inline]
     pub fn left(&self) -> &AstNode<'a, BindingPattern<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.right));
+        let following_span = Some(self.inner.right.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::AssignmentPattern(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn right(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::AssignmentPattern(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -7143,12 +4475,7 @@ impl<'a> AstNode<'a, AssignmentPattern<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -7162,25 +4489,24 @@ impl<'a> GetSpan for AstNode<'a, AssignmentPattern<'a>> {
 impl<'a> AstNode<'a, ObjectPattern<'a>> {
     #[inline]
     pub fn properties(&self) -> &AstNode<'a, Vec<'a, BindingProperty<'a>>> {
-        let following_node =
-            self.inner.rest.as_deref().map(SiblingNode::from).or(self.following_node);
+        let following_span = self.inner.rest.as_deref().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.properties,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ObjectPattern(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn rest(&self) -> Option<&AstNode<'a, BindingRestElement<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.rest.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ObjectPattern(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -7190,12 +4516,7 @@ impl<'a> AstNode<'a, ObjectPattern<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -7209,23 +4530,23 @@ impl<'a> GetSpan for AstNode<'a, ObjectPattern<'a>> {
 impl<'a> AstNode<'a, BindingProperty<'a>> {
     #[inline]
     pub fn key(&self) -> &AstNode<'a, PropertyKey<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.value));
+        let following_span = Some(self.inner.value.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::BindingProperty(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn value(&self) -> &AstNode<'a, BindingPattern<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.value,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::BindingProperty(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -7244,12 +4565,7 @@ impl<'a> AstNode<'a, BindingProperty<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -7263,25 +4579,24 @@ impl<'a> GetSpan for AstNode<'a, BindingProperty<'a>> {
 impl<'a> AstNode<'a, ArrayPattern<'a>> {
     #[inline]
     pub fn elements(&self) -> &AstNode<'a, Vec<'a, Option<BindingPattern<'a>>>> {
-        let following_node =
-            self.inner.rest.as_deref().map(SiblingNode::from).or(self.following_node);
+        let following_span = self.inner.rest.as_deref().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.elements,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ArrayPattern(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn rest(&self) -> Option<&AstNode<'a, BindingRestElement<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.rest.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ArrayPattern(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -7291,12 +4606,7 @@ impl<'a> AstNode<'a, ArrayPattern<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -7310,12 +4620,12 @@ impl<'a> GetSpan for AstNode<'a, ArrayPattern<'a>> {
 impl<'a> AstNode<'a, BindingRestElement<'a>> {
     #[inline]
     pub fn argument(&self) -> &AstNode<'a, BindingPattern<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.argument,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::BindingRestElement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -7324,12 +4634,7 @@ impl<'a> AstNode<'a, BindingRestElement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -7348,19 +4653,19 @@ impl<'a> AstNode<'a, Function<'a>> {
 
     #[inline]
     pub fn id(&self) -> Option<&AstNode<'a, BindingIdentifier<'a>>> {
-        let following_node = self
+        let following_span = self
             .inner
             .type_parameters
             .as_deref()
-            .map(SiblingNode::from)
-            .or_else(|| self.inner.this_param.as_deref().map(SiblingNode::from))
-            .or_else(|| Some(SiblingNode::from(self.inner.params.as_ref())));
+            .map(GetSpan::span)
+            .or_else(|| self.inner.this_param.as_deref().map(GetSpan::span))
+            .or_else(|| Some(self.inner.params.span()));
         self.allocator
             .alloc(self.inner.id.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::Function(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -7382,75 +4687,74 @@ impl<'a> AstNode<'a, Function<'a>> {
 
     #[inline]
     pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
-        let following_node = self
+        let following_span = self
             .inner
             .this_param
             .as_deref()
-            .map(SiblingNode::from)
-            .or_else(|| Some(SiblingNode::from(self.inner.params.as_ref())));
+            .map(GetSpan::span)
+            .or_else(|| Some(self.inner.params.span()));
         self.allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::Function(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn this_param(&self) -> Option<&AstNode<'a, TSThisParameter<'a>>> {
-        let following_node = Some(SiblingNode::from(self.inner.params.as_ref()));
+        let following_span = Some(self.inner.params.span());
         self.allocator
             .alloc(self.inner.this_param.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::Function(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn params(&self) -> &AstNode<'a, FormalParameters<'a>> {
-        let following_node = self
+        let following_span = self
             .inner
             .return_type
             .as_deref()
-            .map(SiblingNode::from)
-            .or_else(|| self.inner.body.as_deref().map(SiblingNode::from))
-            .or(self.following_node);
+            .map(GetSpan::span)
+            .or_else(|| self.inner.body.as_deref().map(GetSpan::span))
+            .or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: self.inner.params.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::Function(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn return_type(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_node =
-            self.inner.body.as_deref().map(SiblingNode::from).or(self.following_node);
+        let following_span = self.inner.body.as_deref().map(GetSpan::span).or(self.following_span);
         self.allocator
             .alloc(self.inner.return_type.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::Function(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn body(&self) -> Option<&AstNode<'a, FunctionBody<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.body.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::Function(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -7470,12 +4774,7 @@ impl<'a> AstNode<'a, Function<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -7494,24 +4793,24 @@ impl<'a> AstNode<'a, FormalParameters<'a>> {
 
     #[inline]
     pub fn items(&self) -> &AstNode<'a, Vec<'a, FormalParameter<'a>>> {
-        let following_node = self.inner.rest.as_deref().map(SiblingNode::from);
+        let following_span = self.inner.rest.as_deref().map(GetSpan::span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.items,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::FormalParameters(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn rest(&self) -> Option<&AstNode<'a, BindingRestElement<'a>>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator
             .alloc(self.inner.rest.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::FormalParameters(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -7521,12 +4820,7 @@ impl<'a> AstNode<'a, FormalParameters<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -7540,23 +4834,23 @@ impl<'a> GetSpan for AstNode<'a, FormalParameters<'a>> {
 impl<'a> AstNode<'a, FormalParameter<'a>> {
     #[inline]
     pub fn decorators(&self) -> &AstNode<'a, Vec<'a, Decorator<'a>>> {
-        let following_node = Some(SiblingNode::from(&self.inner.pattern));
+        let following_span = Some(self.inner.pattern.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.decorators,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::FormalParameter(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn pattern(&self) -> &AstNode<'a, BindingPattern<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.pattern,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::FormalParameter(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -7580,12 +4874,7 @@ impl<'a> AstNode<'a, FormalParameter<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -7599,30 +4888,24 @@ impl<'a> GetSpan for AstNode<'a, FormalParameter<'a>> {
 impl<'a> AstNode<'a, FunctionBody<'a>> {
     #[inline]
     pub fn directives(&self) -> &AstNode<'a, Vec<'a, Directive<'a>>> {
-        let following_node = self
-            .inner
-            .statements
-            .first()
-            .as_ref()
-            .copied()
-            .map(SiblingNode::from)
-            .or(self.following_node);
+        let following_span =
+            self.inner.statements.first().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.directives,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::FunctionBody(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn statements(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.statements,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::FunctionBody(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -7631,12 +4914,7 @@ impl<'a> AstNode<'a, FunctionBody<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -7660,56 +4938,56 @@ impl<'a> AstNode<'a, ArrowFunctionExpression<'a>> {
 
     #[inline]
     pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
-        let following_node = Some(SiblingNode::from(self.inner.params.as_ref()));
+        let following_span = Some(self.inner.params.span());
         self.allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent:
                     self.allocator.alloc(AstNodes::ArrowFunctionExpression(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn params(&self) -> &AstNode<'a, FormalParameters<'a>> {
-        let following_node = self
+        let following_span = self
             .inner
             .return_type
             .as_deref()
-            .map(SiblingNode::from)
-            .or_else(|| Some(SiblingNode::from(self.inner.body.as_ref())));
+            .map(GetSpan::span)
+            .or_else(|| Some(self.inner.body.span()));
         self.allocator.alloc(AstNode {
             inner: self.inner.params.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ArrowFunctionExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn return_type(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_node = Some(SiblingNode::from(self.inner.body.as_ref()));
+        let following_span = Some(self.inner.body.span());
         self.allocator
             .alloc(self.inner.return_type.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent:
                     self.allocator.alloc(AstNodes::ArrowFunctionExpression(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, FunctionBody<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: self.inner.body.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ArrowFunctionExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -7728,12 +5006,7 @@ impl<'a> AstNode<'a, ArrowFunctionExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -7752,13 +5025,13 @@ impl<'a> AstNode<'a, YieldExpression<'a>> {
 
     #[inline]
     pub fn argument(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.argument.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::YieldExpression(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -7768,12 +5041,7 @@ impl<'a> AstNode<'a, YieldExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -7792,123 +5060,121 @@ impl<'a> AstNode<'a, Class<'a>> {
 
     #[inline]
     pub fn decorators(&self) -> &AstNode<'a, Vec<'a, Decorator<'a>>> {
-        let following_node = self
+        let following_span = self
             .inner
             .id
             .as_ref()
-            .map(SiblingNode::from)
-            .or_else(|| self.inner.type_parameters.as_deref().map(SiblingNode::from))
-            .or_else(|| self.inner.super_class.as_ref().map(SiblingNode::from))
-            .or_else(|| self.inner.super_type_arguments.as_deref().map(SiblingNode::from))
-            .or_else(|| self.inner.implements.first().as_ref().copied().map(SiblingNode::from))
-            .or_else(|| Some(SiblingNode::from(self.inner.body.as_ref())));
+            .map(GetSpan::span)
+            .or_else(|| self.inner.type_parameters.as_deref().map(GetSpan::span))
+            .or_else(|| self.inner.super_class.as_ref().map(GetSpan::span))
+            .or_else(|| self.inner.super_type_arguments.as_deref().map(GetSpan::span))
+            .or_else(|| self.inner.implements.first().map(GetSpan::span))
+            .or_else(|| Some(self.inner.body.span()));
         self.allocator.alloc(AstNode {
             inner: &self.inner.decorators,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::Class(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn id(&self) -> Option<&AstNode<'a, BindingIdentifier<'a>>> {
-        let following_node = self
+        let following_span = self
             .inner
             .type_parameters
             .as_deref()
-            .map(SiblingNode::from)
-            .or_else(|| self.inner.super_class.as_ref().map(SiblingNode::from))
-            .or_else(|| self.inner.super_type_arguments.as_deref().map(SiblingNode::from))
-            .or_else(|| self.inner.implements.first().as_ref().copied().map(SiblingNode::from))
-            .or_else(|| Some(SiblingNode::from(self.inner.body.as_ref())));
+            .map(GetSpan::span)
+            .or_else(|| self.inner.super_class.as_ref().map(GetSpan::span))
+            .or_else(|| self.inner.super_type_arguments.as_deref().map(GetSpan::span))
+            .or_else(|| self.inner.implements.first().map(GetSpan::span))
+            .or_else(|| Some(self.inner.body.span()));
         self.allocator
             .alloc(self.inner.id.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::Class(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
-        let following_node = self
+        let following_span = self
             .inner
             .super_class
             .as_ref()
-            .map(SiblingNode::from)
-            .or_else(|| self.inner.super_type_arguments.as_deref().map(SiblingNode::from))
-            .or_else(|| self.inner.implements.first().as_ref().copied().map(SiblingNode::from))
-            .or_else(|| Some(SiblingNode::from(self.inner.body.as_ref())));
+            .map(GetSpan::span)
+            .or_else(|| self.inner.super_type_arguments.as_deref().map(GetSpan::span))
+            .or_else(|| self.inner.implements.first().map(GetSpan::span))
+            .or_else(|| Some(self.inner.body.span()));
         self.allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::Class(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn super_class(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_node = self
+        let following_span = self
             .inner
             .super_type_arguments
             .as_deref()
-            .map(SiblingNode::from)
-            .or_else(|| self.inner.implements.first().as_ref().copied().map(SiblingNode::from))
-            .or_else(|| Some(SiblingNode::from(self.inner.body.as_ref())));
+            .map(GetSpan::span)
+            .or_else(|| self.inner.implements.first().map(GetSpan::span))
+            .or_else(|| Some(self.inner.body.span()));
         self.allocator
             .alloc(self.inner.super_class.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::Class(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn super_type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
-        let following_node = self
+        let following_span = self
             .inner
             .implements
             .first()
-            .as_ref()
-            .copied()
-            .map(SiblingNode::from)
-            .or_else(|| Some(SiblingNode::from(self.inner.body.as_ref())));
+            .map(GetSpan::span)
+            .or_else(|| Some(self.inner.body.span()));
         self.allocator
             .alloc(self.inner.super_type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::Class(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn implements(&self) -> &AstNode<'a, Vec<'a, TSClassImplements<'a>>> {
-        let following_node = Some(SiblingNode::from(self.inner.body.as_ref()));
+        let following_span = Some(self.inner.body.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.implements,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::Class(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, ClassBody<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: self.inner.body.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::Class(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -7927,12 +5193,7 @@ impl<'a> AstNode<'a, Class<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -7946,12 +5207,12 @@ impl<'a> GetSpan for AstNode<'a, Class<'a>> {
 impl<'a> AstNode<'a, ClassBody<'a>> {
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Vec<'a, ClassElement<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ClassBody(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -7960,12 +5221,7 @@ impl<'a> AstNode<'a, ClassBody<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -7985,14 +5241,14 @@ impl<'a> AstNode<'a, ClassElement<'a>> {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             ClassElement::MethodDefinition(s) => {
                 AstNodes::MethodDefinition(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             ClassElement::PropertyDefinition(s) => {
@@ -8000,7 +5256,7 @@ impl<'a> AstNode<'a, ClassElement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             ClassElement::AccessorProperty(s) => {
@@ -8008,7 +5264,7 @@ impl<'a> AstNode<'a, ClassElement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             ClassElement::TSIndexSignature(s) => {
@@ -8016,7 +5272,7 @@ impl<'a> AstNode<'a, ClassElement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
         };
@@ -8039,34 +5295,34 @@ impl<'a> AstNode<'a, MethodDefinition<'a>> {
 
     #[inline]
     pub fn decorators(&self) -> &AstNode<'a, Vec<'a, Decorator<'a>>> {
-        let following_node = Some(SiblingNode::from(&self.inner.key));
+        let following_span = Some(self.inner.key.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.decorators,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::MethodDefinition(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn key(&self) -> &AstNode<'a, PropertyKey<'a>> {
-        let following_node = Some(SiblingNode::from(self.inner.value.as_ref()));
+        let following_span = Some(self.inner.value.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::MethodDefinition(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn value(&self) -> &AstNode<'a, Function<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: self.inner.value.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::MethodDefinition(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -8105,12 +5361,7 @@ impl<'a> AstNode<'a, MethodDefinition<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -8129,55 +5380,54 @@ impl<'a> AstNode<'a, PropertyDefinition<'a>> {
 
     #[inline]
     pub fn decorators(&self) -> &AstNode<'a, Vec<'a, Decorator<'a>>> {
-        let following_node = Some(SiblingNode::from(&self.inner.key));
+        let following_span = Some(self.inner.key.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.decorators,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::PropertyDefinition(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn key(&self) -> &AstNode<'a, PropertyKey<'a>> {
-        let following_node = self
+        let following_span = self
             .inner
             .type_annotation
             .as_deref()
-            .map(SiblingNode::from)
-            .or_else(|| self.inner.value.as_ref().map(SiblingNode::from))
-            .or(self.following_node);
+            .map(GetSpan::span)
+            .or_else(|| self.inner.value.as_ref().map(GetSpan::span))
+            .or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::PropertyDefinition(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn type_annotation(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_node =
-            self.inner.value.as_ref().map(SiblingNode::from).or(self.following_node);
+        let following_span = self.inner.value.as_ref().map(GetSpan::span).or(self.following_span);
         self.allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::PropertyDefinition(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn value(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.value.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::PropertyDefinition(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -8227,12 +5477,7 @@ impl<'a> AstNode<'a, PropertyDefinition<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -8254,12 +5499,7 @@ impl<'a> AstNode<'a, PrivateIdentifier<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -8273,12 +5513,12 @@ impl<'a> GetSpan for AstNode<'a, PrivateIdentifier<'a>> {
 impl<'a> AstNode<'a, StaticBlock<'a>> {
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::StaticBlock(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -8287,12 +5527,7 @@ impl<'a> AstNode<'a, StaticBlock<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -8313,7 +5548,7 @@ impl<'a> AstNode<'a, ModuleDeclaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             ModuleDeclaration::ExportAllDeclaration(s) => {
@@ -8321,7 +5556,7 @@ impl<'a> AstNode<'a, ModuleDeclaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             ModuleDeclaration::ExportDefaultDeclaration(s) => {
@@ -8329,7 +5564,7 @@ impl<'a> AstNode<'a, ModuleDeclaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             ModuleDeclaration::ExportNamedDeclaration(s) => {
@@ -8337,7 +5572,7 @@ impl<'a> AstNode<'a, ModuleDeclaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             ModuleDeclaration::TSExportAssignment(s) => {
@@ -8345,7 +5580,7 @@ impl<'a> AstNode<'a, ModuleDeclaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             ModuleDeclaration::TSNamespaceExportDeclaration(s) => {
@@ -8353,7 +5588,7 @@ impl<'a> AstNode<'a, ModuleDeclaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
         };
@@ -8376,55 +5611,54 @@ impl<'a> AstNode<'a, AccessorProperty<'a>> {
 
     #[inline]
     pub fn decorators(&self) -> &AstNode<'a, Vec<'a, Decorator<'a>>> {
-        let following_node = Some(SiblingNode::from(&self.inner.key));
+        let following_span = Some(self.inner.key.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.decorators,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::AccessorProperty(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn key(&self) -> &AstNode<'a, PropertyKey<'a>> {
-        let following_node = self
+        let following_span = self
             .inner
             .type_annotation
             .as_deref()
-            .map(SiblingNode::from)
-            .or_else(|| self.inner.value.as_ref().map(SiblingNode::from))
-            .or(self.following_node);
+            .map(GetSpan::span)
+            .or_else(|| self.inner.value.as_ref().map(GetSpan::span))
+            .or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::AccessorProperty(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn type_annotation(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_node =
-            self.inner.value.as_ref().map(SiblingNode::from).or(self.following_node);
+        let following_span = self.inner.value.as_ref().map(GetSpan::span).or(self.following_span);
         self.allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::AccessorProperty(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn value(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.value.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::AccessorProperty(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -8459,12 +5693,7 @@ impl<'a> AstNode<'a, AccessorProperty<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -8478,25 +5707,24 @@ impl<'a> GetSpan for AstNode<'a, AccessorProperty<'a>> {
 impl<'a> AstNode<'a, ImportExpression<'a>> {
     #[inline]
     pub fn source(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node =
-            self.inner.options.as_ref().map(SiblingNode::from).or(self.following_node);
+        let following_span = self.inner.options.as_ref().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.source,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ImportExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn options(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.options.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ImportExpression(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -8511,12 +5739,7 @@ impl<'a> AstNode<'a, ImportExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -8530,25 +5753,25 @@ impl<'a> GetSpan for AstNode<'a, ImportExpression<'a>> {
 impl<'a> AstNode<'a, ImportDeclaration<'a>> {
     #[inline]
     pub fn specifiers(&self) -> Option<&AstNode<'a, Vec<'a, ImportDeclarationSpecifier<'a>>>> {
-        let following_node = Some(SiblingNode::from(&self.inner.source));
+        let following_span = Some(self.inner.source.span());
         self.allocator
             .alloc(self.inner.specifiers.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ImportDeclaration(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn source(&self) -> &AstNode<'a, StringLiteral<'a>> {
-        let following_node = self.inner.with_clause.as_deref().map(SiblingNode::from);
+        let following_span = self.inner.with_clause.as_deref().map(GetSpan::span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.source,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ImportDeclaration(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -8559,13 +5782,13 @@ impl<'a> AstNode<'a, ImportDeclaration<'a>> {
 
     #[inline]
     pub fn with_clause(&self) -> Option<&AstNode<'a, WithClause<'a>>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator
             .alloc(self.inner.with_clause.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ImportDeclaration(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -8580,12 +5803,7 @@ impl<'a> AstNode<'a, ImportDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -8606,7 +5824,7 @@ impl<'a> AstNode<'a, ImportDeclarationSpecifier<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             ImportDeclarationSpecifier::ImportDefaultSpecifier(s) => {
@@ -8614,7 +5832,7 @@ impl<'a> AstNode<'a, ImportDeclarationSpecifier<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             ImportDeclarationSpecifier::ImportNamespaceSpecifier(s) => {
@@ -8622,7 +5840,7 @@ impl<'a> AstNode<'a, ImportDeclarationSpecifier<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
         };
@@ -8640,23 +5858,23 @@ impl<'a> GetSpan for AstNode<'a, ImportDeclarationSpecifier<'a>> {
 impl<'a> AstNode<'a, ImportSpecifier<'a>> {
     #[inline]
     pub fn imported(&self) -> &AstNode<'a, ModuleExportName<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.local));
+        let following_span = Some(self.inner.local.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.imported,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ImportSpecifier(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn local(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.local,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ImportSpecifier(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -8670,12 +5888,7 @@ impl<'a> AstNode<'a, ImportSpecifier<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -8689,12 +5902,12 @@ impl<'a> GetSpan for AstNode<'a, ImportSpecifier<'a>> {
 impl<'a> AstNode<'a, ImportDefaultSpecifier<'a>> {
     #[inline]
     pub fn local(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.local,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ImportDefaultSpecifier(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -8703,12 +5916,7 @@ impl<'a> AstNode<'a, ImportDefaultSpecifier<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -8722,12 +5930,12 @@ impl<'a> GetSpan for AstNode<'a, ImportDefaultSpecifier<'a>> {
 impl<'a> AstNode<'a, ImportNamespaceSpecifier<'a>> {
     #[inline]
     pub fn local(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.local,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ImportNamespaceSpecifier(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -8736,12 +5944,7 @@ impl<'a> AstNode<'a, ImportNamespaceSpecifier<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -8760,12 +5963,12 @@ impl<'a> AstNode<'a, WithClause<'a>> {
 
     #[inline]
     pub fn with_entries(&self) -> &AstNode<'a, Vec<'a, ImportAttribute<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.with_entries,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::WithClause(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -8774,12 +5977,7 @@ impl<'a> AstNode<'a, WithClause<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -8793,23 +5991,23 @@ impl<'a> GetSpan for AstNode<'a, WithClause<'a>> {
 impl<'a> AstNode<'a, ImportAttribute<'a>> {
     #[inline]
     pub fn key(&self) -> &AstNode<'a, ImportAttributeKey<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.value));
+        let following_span = Some(self.inner.value.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ImportAttribute(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn value(&self) -> &AstNode<'a, StringLiteral<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.value,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ImportAttribute(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -8818,12 +6016,7 @@ impl<'a> AstNode<'a, ImportAttribute<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -8844,7 +6037,7 @@ impl<'a> AstNode<'a, ImportAttributeKey<'a>> {
                     inner: s,
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             ImportAttributeKey::StringLiteral(s) => {
@@ -8852,7 +6045,7 @@ impl<'a> AstNode<'a, ImportAttributeKey<'a>> {
                     inner: s,
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
         };
@@ -8870,52 +6063,50 @@ impl<'a> GetSpan for AstNode<'a, ImportAttributeKey<'a>> {
 impl<'a> AstNode<'a, ExportNamedDeclaration<'a>> {
     #[inline]
     pub fn declaration(&self) -> Option<&AstNode<'a, Declaration<'a>>> {
-        let following_node = self
+        let following_span = self
             .inner
             .specifiers
             .first()
-            .as_ref()
-            .copied()
-            .map(SiblingNode::from)
-            .or_else(|| self.inner.source.as_ref().map(SiblingNode::from))
-            .or_else(|| self.inner.with_clause.as_deref().map(SiblingNode::from));
+            .map(GetSpan::span)
+            .or_else(|| self.inner.source.as_ref().map(GetSpan::span))
+            .or_else(|| self.inner.with_clause.as_deref().map(GetSpan::span));
         self.allocator
             .alloc(self.inner.declaration.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent:
                     self.allocator.alloc(AstNodes::ExportNamedDeclaration(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn specifiers(&self) -> &AstNode<'a, Vec<'a, ExportSpecifier<'a>>> {
-        let following_node = self
+        let following_span = self
             .inner
             .source
             .as_ref()
-            .map(SiblingNode::from)
-            .or_else(|| self.inner.with_clause.as_deref().map(SiblingNode::from));
+            .map(GetSpan::span)
+            .or_else(|| self.inner.with_clause.as_deref().map(GetSpan::span));
         self.allocator.alloc(AstNode {
             inner: &self.inner.specifiers,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ExportNamedDeclaration(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn source(&self) -> Option<&AstNode<'a, StringLiteral<'a>>> {
-        let following_node = self.inner.with_clause.as_deref().map(SiblingNode::from);
+        let following_span = self.inner.with_clause.as_deref().map(GetSpan::span);
         self.allocator
             .alloc(self.inner.source.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent:
                     self.allocator.alloc(AstNodes::ExportNamedDeclaration(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -8927,14 +6118,14 @@ impl<'a> AstNode<'a, ExportNamedDeclaration<'a>> {
 
     #[inline]
     pub fn with_clause(&self) -> Option<&AstNode<'a, WithClause<'a>>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator
             .alloc(self.inner.with_clause.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent:
                     self.allocator.alloc(AstNodes::ExportNamedDeclaration(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -8944,12 +6135,7 @@ impl<'a> AstNode<'a, ExportNamedDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -8963,12 +6149,12 @@ impl<'a> GetSpan for AstNode<'a, ExportNamedDeclaration<'a>> {
 impl<'a> AstNode<'a, ExportDefaultDeclaration<'a>> {
     #[inline]
     pub fn declaration(&self) -> &AstNode<'a, ExportDefaultDeclarationKind<'a>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator.alloc(AstNode {
             inner: &self.inner.declaration,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ExportDefaultDeclaration(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -8977,12 +6163,7 @@ impl<'a> AstNode<'a, ExportDefaultDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -8996,37 +6177,37 @@ impl<'a> GetSpan for AstNode<'a, ExportDefaultDeclaration<'a>> {
 impl<'a> AstNode<'a, ExportAllDeclaration<'a>> {
     #[inline]
     pub fn exported(&self) -> Option<&AstNode<'a, ModuleExportName<'a>>> {
-        let following_node = Some(SiblingNode::from(&self.inner.source));
+        let following_span = Some(self.inner.source.span());
         self.allocator
             .alloc(self.inner.exported.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ExportAllDeclaration(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn source(&self) -> &AstNode<'a, StringLiteral<'a>> {
-        let following_node = self.inner.with_clause.as_deref().map(SiblingNode::from);
+        let following_span = self.inner.with_clause.as_deref().map(GetSpan::span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.source,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ExportAllDeclaration(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn with_clause(&self) -> Option<&AstNode<'a, WithClause<'a>>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator
             .alloc(self.inner.with_clause.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ExportAllDeclaration(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -9041,12 +6222,7 @@ impl<'a> AstNode<'a, ExportAllDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -9060,23 +6236,23 @@ impl<'a> GetSpan for AstNode<'a, ExportAllDeclaration<'a>> {
 impl<'a> AstNode<'a, ExportSpecifier<'a>> {
     #[inline]
     pub fn local(&self) -> &AstNode<'a, ModuleExportName<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.exported));
+        let following_span = Some(self.inner.exported.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.local,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ExportSpecifier(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn exported(&self) -> &AstNode<'a, ModuleExportName<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.exported,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ExportSpecifier(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -9090,12 +6266,7 @@ impl<'a> AstNode<'a, ExportSpecifier<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -9116,7 +6287,7 @@ impl<'a> AstNode<'a, ExportDefaultDeclarationKind<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             ExportDefaultDeclarationKind::ClassDeclaration(s) => {
@@ -9124,7 +6295,7 @@ impl<'a> AstNode<'a, ExportDefaultDeclarationKind<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             ExportDefaultDeclarationKind::TSInterfaceDeclaration(s) => {
@@ -9132,7 +6303,7 @@ impl<'a> AstNode<'a, ExportDefaultDeclarationKind<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             it @ match_expression!(ExportDefaultDeclarationKind) => {
@@ -9142,7 +6313,7 @@ impl<'a> AstNode<'a, ExportDefaultDeclarationKind<'a>> {
                         inner: it.to_expression(),
                         parent,
                         allocator: self.allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .as_ast_nodes();
             }
@@ -9168,7 +6339,7 @@ impl<'a> AstNode<'a, ModuleExportName<'a>> {
                     inner: s,
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             ModuleExportName::IdentifierReference(s) => {
@@ -9176,7 +6347,7 @@ impl<'a> AstNode<'a, ModuleExportName<'a>> {
                     inner: s,
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             ModuleExportName::StringLiteral(s) => {
@@ -9184,7 +6355,7 @@ impl<'a> AstNode<'a, ModuleExportName<'a>> {
                     inner: s,
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
         };
@@ -9202,30 +6373,24 @@ impl<'a> GetSpan for AstNode<'a, ModuleExportName<'a>> {
 impl<'a> AstNode<'a, V8IntrinsicExpression<'a>> {
     #[inline]
     pub fn name(&self) -> &AstNode<'a, IdentifierName<'a>> {
-        let following_node = self
-            .inner
-            .arguments
-            .first()
-            .as_ref()
-            .copied()
-            .map(SiblingNode::from)
-            .or(self.following_node);
+        let following_span =
+            self.inner.arguments.first().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.name,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::V8IntrinsicExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn arguments(&self) -> &AstNode<'a, Vec<'a, Argument<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.arguments,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::V8IntrinsicExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -9234,12 +6399,7 @@ impl<'a> AstNode<'a, V8IntrinsicExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -9261,12 +6421,7 @@ impl<'a> AstNode<'a, BooleanLiteral> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -9283,12 +6438,7 @@ impl<'a> AstNode<'a, NullLiteral> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -9320,12 +6470,7 @@ impl<'a> AstNode<'a, NumericLiteral<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -9357,12 +6502,7 @@ impl<'a> AstNode<'a, StringLiteral<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -9394,12 +6534,7 @@ impl<'a> AstNode<'a, BigIntLiteral<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -9426,12 +6561,7 @@ impl<'a> AstNode<'a, RegExpLiteral<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -9445,44 +6575,42 @@ impl<'a> GetSpan for AstNode<'a, RegExpLiteral<'a>> {
 impl<'a> AstNode<'a, JSXElement<'a>> {
     #[inline]
     pub fn opening_element(&self) -> &AstNode<'a, JSXOpeningElement<'a>> {
-        let following_node = self
+        let following_span = self
             .inner
             .children
             .first()
-            .as_ref()
-            .copied()
-            .map(SiblingNode::from)
-            .or_else(|| self.inner.closing_element.as_deref().map(SiblingNode::from))
-            .or(self.following_node);
+            .map(GetSpan::span)
+            .or_else(|| self.inner.closing_element.as_deref().map(GetSpan::span))
+            .or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: self.inner.opening_element.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXElement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn children(&self) -> &AstNode<'a, Vec<'a, JSXChild<'a>>> {
-        let following_node =
-            self.inner.closing_element.as_deref().map(SiblingNode::from).or(self.following_node);
+        let following_span =
+            self.inner.closing_element.as_deref().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.children,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXElement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn closing_element(&self) -> Option<&AstNode<'a, JSXClosingElement<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.closing_element.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::JSXElement(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -9492,12 +6620,7 @@ impl<'a> AstNode<'a, JSXElement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -9511,49 +6634,43 @@ impl<'a> GetSpan for AstNode<'a, JSXElement<'a>> {
 impl<'a> AstNode<'a, JSXOpeningElement<'a>> {
     #[inline]
     pub fn name(&self) -> &AstNode<'a, JSXElementName<'a>> {
-        let following_node = self
+        let following_span = self
             .inner
             .type_arguments
             .as_deref()
-            .map(SiblingNode::from)
-            .or_else(|| self.inner.attributes.first().as_ref().copied().map(SiblingNode::from))
-            .or(self.following_node);
+            .map(GetSpan::span)
+            .or_else(|| self.inner.attributes.first().map(GetSpan::span))
+            .or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.name,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXOpeningElement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
-        let following_node = self
-            .inner
-            .attributes
-            .first()
-            .as_ref()
-            .copied()
-            .map(SiblingNode::from)
-            .or(self.following_node);
+        let following_span =
+            self.inner.attributes.first().map(GetSpan::span).or(self.following_span);
         self.allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::JSXOpeningElement(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn attributes(&self) -> &AstNode<'a, Vec<'a, JSXAttributeItem<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.attributes,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXOpeningElement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -9562,12 +6679,7 @@ impl<'a> AstNode<'a, JSXOpeningElement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -9581,12 +6693,12 @@ impl<'a> GetSpan for AstNode<'a, JSXOpeningElement<'a>> {
 impl<'a> AstNode<'a, JSXClosingElement<'a>> {
     #[inline]
     pub fn name(&self) -> &AstNode<'a, JSXElementName<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.name,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXClosingElement(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -9595,12 +6707,7 @@ impl<'a> AstNode<'a, JSXClosingElement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -9614,41 +6721,39 @@ impl<'a> GetSpan for AstNode<'a, JSXClosingElement<'a>> {
 impl<'a> AstNode<'a, JSXFragment<'a>> {
     #[inline]
     pub fn opening_fragment(&self) -> &AstNode<'a, JSXOpeningFragment> {
-        let following_node = self
+        let following_span = self
             .inner
             .children
             .first()
-            .as_ref()
-            .copied()
-            .map(SiblingNode::from)
-            .or_else(|| Some(SiblingNode::from(&self.inner.closing_fragment)));
+            .map(GetSpan::span)
+            .or_else(|| Some(self.inner.closing_fragment.span()));
         self.allocator.alloc(AstNode {
             inner: &self.inner.opening_fragment,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXFragment(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn children(&self) -> &AstNode<'a, Vec<'a, JSXChild<'a>>> {
-        let following_node = Some(SiblingNode::from(&self.inner.closing_fragment));
+        let following_span = Some(self.inner.closing_fragment.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.children,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXFragment(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn closing_fragment(&self) -> &AstNode<'a, JSXClosingFragment> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.closing_fragment,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXFragment(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -9657,12 +6762,7 @@ impl<'a> AstNode<'a, JSXFragment<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -9679,12 +6779,7 @@ impl<'a> AstNode<'a, JSXOpeningFragment> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -9701,12 +6796,7 @@ impl<'a> AstNode<'a, JSXClosingFragment> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -9727,7 +6817,7 @@ impl<'a> AstNode<'a, JSXElementName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             JSXElementName::IdentifierReference(s) => {
@@ -9735,7 +6825,7 @@ impl<'a> AstNode<'a, JSXElementName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             JSXElementName::NamespacedName(s) => {
@@ -9743,7 +6833,7 @@ impl<'a> AstNode<'a, JSXElementName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             JSXElementName::MemberExpression(s) => {
@@ -9751,7 +6841,7 @@ impl<'a> AstNode<'a, JSXElementName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             JSXElementName::ThisExpression(s) => {
@@ -9759,7 +6849,7 @@ impl<'a> AstNode<'a, JSXElementName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
         };
@@ -9777,23 +6867,23 @@ impl<'a> GetSpan for AstNode<'a, JSXElementName<'a>> {
 impl<'a> AstNode<'a, JSXNamespacedName<'a>> {
     #[inline]
     pub fn namespace(&self) -> &AstNode<'a, JSXIdentifier<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.name));
+        let following_span = Some(self.inner.name.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.namespace,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXNamespacedName(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn name(&self) -> &AstNode<'a, JSXIdentifier<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.name,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXNamespacedName(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -9802,12 +6892,7 @@ impl<'a> AstNode<'a, JSXNamespacedName<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -9821,23 +6906,23 @@ impl<'a> GetSpan for AstNode<'a, JSXNamespacedName<'a>> {
 impl<'a> AstNode<'a, JSXMemberExpression<'a>> {
     #[inline]
     pub fn object(&self) -> &AstNode<'a, JSXMemberExpressionObject<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.property));
+        let following_span = Some(self.inner.property.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.object,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXMemberExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn property(&self) -> &AstNode<'a, JSXIdentifier<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.property,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXMemberExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -9846,12 +6931,7 @@ impl<'a> AstNode<'a, JSXMemberExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -9872,7 +6952,7 @@ impl<'a> AstNode<'a, JSXMemberExpressionObject<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             JSXMemberExpressionObject::MemberExpression(s) => {
@@ -9880,7 +6960,7 @@ impl<'a> AstNode<'a, JSXMemberExpressionObject<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             JSXMemberExpressionObject::ThisExpression(s) => {
@@ -9888,7 +6968,7 @@ impl<'a> AstNode<'a, JSXMemberExpressionObject<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
         };
@@ -9906,12 +6986,12 @@ impl<'a> GetSpan for AstNode<'a, JSXMemberExpressionObject<'a>> {
 impl<'a> AstNode<'a, JSXExpressionContainer<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, JSXExpression<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXExpressionContainer(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -9920,12 +7000,7 @@ impl<'a> AstNode<'a, JSXExpressionContainer<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -9946,7 +7021,7 @@ impl<'a> AstNode<'a, JSXExpression<'a>> {
                     inner: s,
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             it @ match_expression!(JSXExpression) => {
@@ -9956,7 +7031,7 @@ impl<'a> AstNode<'a, JSXExpression<'a>> {
                         inner: it.to_expression(),
                         parent,
                         allocator: self.allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .as_ast_nodes();
             }
@@ -9978,12 +7053,7 @@ impl<'a> AstNode<'a, JSXEmptyExpression> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -10004,7 +7074,7 @@ impl<'a> AstNode<'a, JSXAttributeItem<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             JSXAttributeItem::SpreadAttribute(s) => {
@@ -10012,7 +7082,7 @@ impl<'a> AstNode<'a, JSXAttributeItem<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
         };
@@ -10030,25 +7100,24 @@ impl<'a> GetSpan for AstNode<'a, JSXAttributeItem<'a>> {
 impl<'a> AstNode<'a, JSXAttribute<'a>> {
     #[inline]
     pub fn name(&self) -> &AstNode<'a, JSXAttributeName<'a>> {
-        let following_node =
-            self.inner.value.as_ref().map(SiblingNode::from).or(self.following_node);
+        let following_span = self.inner.value.as_ref().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.name,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXAttribute(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn value(&self) -> Option<&AstNode<'a, JSXAttributeValue<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.value.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::JSXAttribute(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -10058,12 +7127,7 @@ impl<'a> AstNode<'a, JSXAttribute<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -10077,12 +7141,12 @@ impl<'a> GetSpan for AstNode<'a, JSXAttribute<'a>> {
 impl<'a> AstNode<'a, JSXSpreadAttribute<'a>> {
     #[inline]
     pub fn argument(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.argument,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXSpreadAttribute(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -10091,12 +7155,7 @@ impl<'a> AstNode<'a, JSXSpreadAttribute<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -10117,7 +7176,7 @@ impl<'a> AstNode<'a, JSXAttributeName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             JSXAttributeName::NamespacedName(s) => {
@@ -10125,7 +7184,7 @@ impl<'a> AstNode<'a, JSXAttributeName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
         };
@@ -10150,7 +7209,7 @@ impl<'a> AstNode<'a, JSXAttributeValue<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             JSXAttributeValue::ExpressionContainer(s) => {
@@ -10158,21 +7217,21 @@ impl<'a> AstNode<'a, JSXAttributeValue<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             JSXAttributeValue::Element(s) => AstNodes::JSXElement(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             JSXAttributeValue::Fragment(s) => {
                 AstNodes::JSXFragment(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
         };
@@ -10198,12 +7257,7 @@ impl<'a> AstNode<'a, JSXIdentifier<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -10223,33 +7277,33 @@ impl<'a> AstNode<'a, JSXChild<'a>> {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             JSXChild::Element(s) => AstNodes::JSXElement(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             JSXChild::Fragment(s) => AstNodes::JSXFragment(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             JSXChild::ExpressionContainer(s) => {
                 AstNodes::JSXExpressionContainer(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             JSXChild::Spread(s) => AstNodes::JSXSpreadChild(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
         };
         self.allocator.alloc(node)
@@ -10266,12 +7320,12 @@ impl<'a> GetSpan for AstNode<'a, JSXChild<'a>> {
 impl<'a> AstNode<'a, JSXSpreadChild<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXSpreadChild(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -10280,12 +7334,7 @@ impl<'a> AstNode<'a, JSXSpreadChild<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -10312,12 +7361,7 @@ impl<'a> AstNode<'a, JSXText<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -10336,13 +7380,13 @@ impl<'a> AstNode<'a, TSThisParameter<'a>> {
 
     #[inline]
     pub fn type_annotation(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSThisParameter(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -10352,12 +7396,7 @@ impl<'a> AstNode<'a, TSThisParameter<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -10371,23 +7410,23 @@ impl<'a> GetSpan for AstNode<'a, TSThisParameter<'a>> {
 impl<'a> AstNode<'a, TSEnumDeclaration<'a>> {
     #[inline]
     pub fn id(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.body));
+        let following_span = Some(self.inner.body.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSEnumDeclaration(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, TSEnumBody<'a>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSEnumDeclaration(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -10406,12 +7445,7 @@ impl<'a> AstNode<'a, TSEnumDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -10425,12 +7459,12 @@ impl<'a> GetSpan for AstNode<'a, TSEnumDeclaration<'a>> {
 impl<'a> AstNode<'a, TSEnumBody<'a>> {
     #[inline]
     pub fn members(&self) -> &AstNode<'a, Vec<'a, TSEnumMember<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.members,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSEnumBody(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -10439,12 +7473,7 @@ impl<'a> AstNode<'a, TSEnumBody<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -10458,25 +7487,25 @@ impl<'a> GetSpan for AstNode<'a, TSEnumBody<'a>> {
 impl<'a> AstNode<'a, TSEnumMember<'a>> {
     #[inline]
     pub fn id(&self) -> &AstNode<'a, TSEnumMemberName<'a>> {
-        let following_node =
-            self.inner.initializer.as_ref().map(SiblingNode::from).or(self.following_node);
+        let following_span =
+            self.inner.initializer.as_ref().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSEnumMember(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn initializer(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.initializer.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSEnumMember(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -10486,12 +7515,7 @@ impl<'a> AstNode<'a, TSEnumMember<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -10512,21 +7536,21 @@ impl<'a> AstNode<'a, TSEnumMemberName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSEnumMemberName::String(s) => AstNodes::StringLiteral(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             TSEnumMemberName::ComputedString(s) => {
                 AstNodes::StringLiteral(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSEnumMemberName::ComputedTemplateString(s) => {
@@ -10534,7 +7558,7 @@ impl<'a> AstNode<'a, TSEnumMemberName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
         };
@@ -10552,12 +7576,12 @@ impl<'a> GetSpan for AstNode<'a, TSEnumMemberName<'a>> {
 impl<'a> AstNode<'a, TSTypeAnnotation<'a>> {
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTypeAnnotation(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -10566,12 +7590,7 @@ impl<'a> AstNode<'a, TSTypeAnnotation<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -10585,12 +7604,12 @@ impl<'a> GetSpan for AstNode<'a, TSTypeAnnotation<'a>> {
 impl<'a> AstNode<'a, TSLiteralType<'a>> {
     #[inline]
     pub fn literal(&self) -> &AstNode<'a, TSLiteral<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.literal,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSLiteralType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -10599,12 +7618,7 @@ impl<'a> AstNode<'a, TSLiteralType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -10625,7 +7639,7 @@ impl<'a> AstNode<'a, TSLiteral<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSLiteral::NumericLiteral(s) => {
@@ -10633,27 +7647,27 @@ impl<'a> AstNode<'a, TSLiteral<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSLiteral::BigIntLiteral(s) => AstNodes::BigIntLiteral(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             TSLiteral::StringLiteral(s) => AstNodes::StringLiteral(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             TSLiteral::TemplateLiteral(s) => {
                 AstNodes::TemplateLiteral(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSLiteral::UnaryExpression(s) => {
@@ -10661,7 +7675,7 @@ impl<'a> AstNode<'a, TSLiteral<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
         };
@@ -10685,14 +7699,14 @@ impl<'a> AstNode<'a, TSType<'a>> {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             TSType::TSBigIntKeyword(s) => {
                 AstNodes::TSBigIntKeyword(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSType::TSBooleanKeyword(s) => {
@@ -10700,7 +7714,7 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSType::TSIntrinsicKeyword(s) => {
@@ -10708,27 +7722,27 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSType::TSNeverKeyword(s) => AstNodes::TSNeverKeyword(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             TSType::TSNullKeyword(s) => AstNodes::TSNullKeyword(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             TSType::TSNumberKeyword(s) => {
                 AstNodes::TSNumberKeyword(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSType::TSObjectKeyword(s) => {
@@ -10736,7 +7750,7 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSType::TSStringKeyword(s) => {
@@ -10744,7 +7758,7 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSType::TSSymbolKeyword(s) => {
@@ -10752,7 +7766,7 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSType::TSUndefinedKeyword(s) => {
@@ -10760,7 +7774,7 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSType::TSUnknownKeyword(s) => {
@@ -10768,27 +7782,27 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSType::TSVoidKeyword(s) => AstNodes::TSVoidKeyword(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             TSType::TSArrayType(s) => AstNodes::TSArrayType(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             TSType::TSConditionalType(s) => {
                 AstNodes::TSConditionalType(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSType::TSConstructorType(s) => {
@@ -10796,61 +7810,61 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSType::TSFunctionType(s) => AstNodes::TSFunctionType(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             TSType::TSImportType(s) => AstNodes::TSImportType(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             TSType::TSIndexedAccessType(s) => {
                 AstNodes::TSIndexedAccessType(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSType::TSInferType(s) => AstNodes::TSInferType(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             TSType::TSIntersectionType(s) => {
                 AstNodes::TSIntersectionType(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSType::TSLiteralType(s) => AstNodes::TSLiteralType(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             TSType::TSMappedType(s) => AstNodes::TSMappedType(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             TSType::TSNamedTupleMember(s) => {
                 AstNodes::TSNamedTupleMember(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSType::TSTemplateLiteralType(s) => {
@@ -10858,33 +7872,33 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSType::TSThisType(s) => AstNodes::TSThisType(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             TSType::TSTupleType(s) => AstNodes::TSTupleType(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             TSType::TSTypeLiteral(s) => AstNodes::TSTypeLiteral(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             TSType::TSTypeOperatorType(s) => {
                 AstNodes::TSTypeOperator(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSType::TSTypePredicate(s) => {
@@ -10892,35 +7906,35 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSType::TSTypeQuery(s) => AstNodes::TSTypeQuery(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             TSType::TSTypeReference(s) => {
                 AstNodes::TSTypeReference(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSType::TSUnionType(s) => AstNodes::TSUnionType(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             TSType::TSParenthesizedType(s) => {
                 AstNodes::TSParenthesizedType(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSType::JSDocNullableType(s) => {
@@ -10928,7 +7942,7 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSType::JSDocNonNullableType(s) => {
@@ -10936,7 +7950,7 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSType::JSDocUnknownType(s) => {
@@ -10944,7 +7958,7 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
         };
@@ -10962,45 +7976,45 @@ impl<'a> GetSpan for AstNode<'a, TSType<'a>> {
 impl<'a> AstNode<'a, TSConditionalType<'a>> {
     #[inline]
     pub fn check_type(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.extends_type));
+        let following_span = Some(self.inner.extends_type.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.check_type,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSConditionalType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn extends_type(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.true_type));
+        let following_span = Some(self.inner.true_type.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.extends_type,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSConditionalType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn true_type(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.false_type));
+        let following_span = Some(self.inner.false_type.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.true_type,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSConditionalType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn false_type(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.false_type,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSConditionalType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -11009,12 +8023,7 @@ impl<'a> AstNode<'a, TSConditionalType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11028,12 +8037,12 @@ impl<'a> GetSpan for AstNode<'a, TSConditionalType<'a>> {
 impl<'a> AstNode<'a, TSUnionType<'a>> {
     #[inline]
     pub fn types(&self) -> &AstNode<'a, Vec<'a, TSType<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.types,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSUnionType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -11042,12 +8051,7 @@ impl<'a> AstNode<'a, TSUnionType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11061,12 +8065,12 @@ impl<'a> GetSpan for AstNode<'a, TSUnionType<'a>> {
 impl<'a> AstNode<'a, TSIntersectionType<'a>> {
     #[inline]
     pub fn types(&self) -> &AstNode<'a, Vec<'a, TSType<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.types,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSIntersectionType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -11075,12 +8079,7 @@ impl<'a> AstNode<'a, TSIntersectionType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11094,12 +8093,12 @@ impl<'a> GetSpan for AstNode<'a, TSIntersectionType<'a>> {
 impl<'a> AstNode<'a, TSParenthesizedType<'a>> {
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSParenthesizedType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -11108,12 +8107,7 @@ impl<'a> AstNode<'a, TSParenthesizedType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11132,12 +8126,12 @@ impl<'a> AstNode<'a, TSTypeOperator<'a>> {
 
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTypeOperator(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -11146,12 +8140,7 @@ impl<'a> AstNode<'a, TSTypeOperator<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11165,12 +8154,12 @@ impl<'a> GetSpan for AstNode<'a, TSTypeOperator<'a>> {
 impl<'a> AstNode<'a, TSArrayType<'a>> {
     #[inline]
     pub fn element_type(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.element_type,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSArrayType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -11179,12 +8168,7 @@ impl<'a> AstNode<'a, TSArrayType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11198,23 +8182,23 @@ impl<'a> GetSpan for AstNode<'a, TSArrayType<'a>> {
 impl<'a> AstNode<'a, TSIndexedAccessType<'a>> {
     #[inline]
     pub fn object_type(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.index_type));
+        let following_span = Some(self.inner.index_type.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.object_type,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSIndexedAccessType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn index_type(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.index_type,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSIndexedAccessType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -11223,12 +8207,7 @@ impl<'a> AstNode<'a, TSIndexedAccessType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11242,12 +8221,12 @@ impl<'a> GetSpan for AstNode<'a, TSIndexedAccessType<'a>> {
 impl<'a> AstNode<'a, TSTupleType<'a>> {
     #[inline]
     pub fn element_types(&self) -> &AstNode<'a, Vec<'a, TSTupleElement<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.element_types,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTupleType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -11256,12 +8235,7 @@ impl<'a> AstNode<'a, TSTupleType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11275,23 +8249,23 @@ impl<'a> GetSpan for AstNode<'a, TSTupleType<'a>> {
 impl<'a> AstNode<'a, TSNamedTupleMember<'a>> {
     #[inline]
     pub fn label(&self) -> &AstNode<'a, IdentifierName<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.element_type));
+        let following_span = Some(self.inner.element_type.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.label,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSNamedTupleMember(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn element_type(&self) -> &AstNode<'a, TSTupleElement<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.element_type,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSNamedTupleMember(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -11305,12 +8279,7 @@ impl<'a> AstNode<'a, TSNamedTupleMember<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11324,12 +8293,12 @@ impl<'a> GetSpan for AstNode<'a, TSNamedTupleMember<'a>> {
 impl<'a> AstNode<'a, TSOptionalType<'a>> {
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSOptionalType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -11338,12 +8307,7 @@ impl<'a> AstNode<'a, TSOptionalType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11357,12 +8321,12 @@ impl<'a> GetSpan for AstNode<'a, TSOptionalType<'a>> {
 impl<'a> AstNode<'a, TSRestType<'a>> {
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSRestType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -11371,12 +8335,7 @@ impl<'a> AstNode<'a, TSRestType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11397,14 +8356,14 @@ impl<'a> AstNode<'a, TSTupleElement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSTupleElement::TSRestType(s) => AstNodes::TSRestType(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
             it @ match_ts_type!(TSTupleElement) => {
                 return self
@@ -11413,7 +8372,7 @@ impl<'a> AstNode<'a, TSTupleElement<'a>> {
                         inner: it.to_ts_type(),
                         parent,
                         allocator: self.allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .as_ast_nodes();
             }
@@ -11435,12 +8394,7 @@ impl<'a> AstNode<'a, TSAnyKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11457,12 +8411,7 @@ impl<'a> AstNode<'a, TSStringKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11479,12 +8428,7 @@ impl<'a> AstNode<'a, TSBooleanKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11501,12 +8445,7 @@ impl<'a> AstNode<'a, TSNumberKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11523,12 +8462,7 @@ impl<'a> AstNode<'a, TSNeverKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11545,12 +8479,7 @@ impl<'a> AstNode<'a, TSIntrinsicKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11567,12 +8496,7 @@ impl<'a> AstNode<'a, TSUnknownKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11589,12 +8513,7 @@ impl<'a> AstNode<'a, TSNullKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11611,12 +8530,7 @@ impl<'a> AstNode<'a, TSUndefinedKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11633,12 +8547,7 @@ impl<'a> AstNode<'a, TSVoidKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11655,12 +8564,7 @@ impl<'a> AstNode<'a, TSSymbolKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11677,12 +8581,7 @@ impl<'a> AstNode<'a, TSThisType> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11699,12 +8598,7 @@ impl<'a> AstNode<'a, TSObjectKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11721,12 +8615,7 @@ impl<'a> AstNode<'a, TSBigIntKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11740,25 +8629,25 @@ impl<'a> GetSpan for AstNode<'a, TSBigIntKeyword> {
 impl<'a> AstNode<'a, TSTypeReference<'a>> {
     #[inline]
     pub fn type_name(&self) -> &AstNode<'a, TSTypeName<'a>> {
-        let following_node =
-            self.inner.type_arguments.as_deref().map(SiblingNode::from).or(self.following_node);
+        let following_span =
+            self.inner.type_arguments.as_deref().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.type_name,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTypeReference(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSTypeReference(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -11768,12 +8657,7 @@ impl<'a> AstNode<'a, TSTypeReference<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11794,7 +8678,7 @@ impl<'a> AstNode<'a, TSTypeName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSTypeName::QualifiedName(s) => {
@@ -11802,7 +8686,7 @@ impl<'a> AstNode<'a, TSTypeName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSTypeName::ThisExpression(s) => {
@@ -11810,7 +8694,7 @@ impl<'a> AstNode<'a, TSTypeName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
         };
@@ -11828,23 +8712,23 @@ impl<'a> GetSpan for AstNode<'a, TSTypeName<'a>> {
 impl<'a> AstNode<'a, TSQualifiedName<'a>> {
     #[inline]
     pub fn left(&self) -> &AstNode<'a, TSTypeName<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.right));
+        let following_span = Some(self.inner.right.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSQualifiedName(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn right(&self) -> &AstNode<'a, IdentifierName<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSQualifiedName(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -11853,12 +8737,7 @@ impl<'a> AstNode<'a, TSQualifiedName<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11872,14 +8751,14 @@ impl<'a> GetSpan for AstNode<'a, TSQualifiedName<'a>> {
 impl<'a> AstNode<'a, TSTypeParameterInstantiation<'a>> {
     #[inline]
     pub fn params(&self) -> &AstNode<'a, Vec<'a, TSType<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.params,
             allocator: self.allocator,
             parent: self
                 .allocator
                 .alloc(AstNodes::TSTypeParameterInstantiation(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -11888,12 +8767,7 @@ impl<'a> AstNode<'a, TSTypeParameterInstantiation<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11907,44 +8781,43 @@ impl<'a> GetSpan for AstNode<'a, TSTypeParameterInstantiation<'a>> {
 impl<'a> AstNode<'a, TSTypeParameter<'a>> {
     #[inline]
     pub fn name(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
-        let following_node = self
+        let following_span = self
             .inner
             .constraint
             .as_ref()
-            .map(SiblingNode::from)
-            .or_else(|| self.inner.default.as_ref().map(SiblingNode::from))
-            .or(self.following_node);
+            .map(GetSpan::span)
+            .or_else(|| self.inner.default.as_ref().map(GetSpan::span))
+            .or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.name,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTypeParameter(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn constraint(&self) -> Option<&AstNode<'a, TSType<'a>>> {
-        let following_node =
-            self.inner.default.as_ref().map(SiblingNode::from).or(self.following_node);
+        let following_span = self.inner.default.as_ref().map(GetSpan::span).or(self.following_span);
         self.allocator
             .alloc(self.inner.constraint.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSTypeParameter(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn default(&self) -> Option<&AstNode<'a, TSType<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.default.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSTypeParameter(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -11969,12 +8842,7 @@ impl<'a> AstNode<'a, TSTypeParameter<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -11988,14 +8856,14 @@ impl<'a> GetSpan for AstNode<'a, TSTypeParameter<'a>> {
 impl<'a> AstNode<'a, TSTypeParameterDeclaration<'a>> {
     #[inline]
     pub fn params(&self) -> &AstNode<'a, Vec<'a, TSTypeParameter<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.params,
             allocator: self.allocator,
             parent: self
                 .allocator
                 .alloc(AstNodes::TSTypeParameterDeclaration(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -12004,12 +8872,7 @@ impl<'a> AstNode<'a, TSTypeParameterDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -12023,42 +8886,42 @@ impl<'a> GetSpan for AstNode<'a, TSTypeParameterDeclaration<'a>> {
 impl<'a> AstNode<'a, TSTypeAliasDeclaration<'a>> {
     #[inline]
     pub fn id(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
-        let following_node = self
+        let following_span = self
             .inner
             .type_parameters
             .as_deref()
-            .map(SiblingNode::from)
-            .or_else(|| Some(SiblingNode::from(&self.inner.type_annotation)));
+            .map(GetSpan::span)
+            .or_else(|| Some(self.inner.type_annotation.span()));
         self.allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTypeAliasDeclaration(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
-        let following_node = Some(SiblingNode::from(&self.inner.type_annotation));
+        let following_span = Some(self.inner.type_annotation.span());
         self.allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent:
                     self.allocator.alloc(AstNodes::TSTypeAliasDeclaration(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTypeAliasDeclaration(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -12072,12 +8935,7 @@ impl<'a> AstNode<'a, TSTypeAliasDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -12091,25 +8949,25 @@ impl<'a> GetSpan for AstNode<'a, TSTypeAliasDeclaration<'a>> {
 impl<'a> AstNode<'a, TSClassImplements<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, TSTypeName<'a>> {
-        let following_node =
-            self.inner.type_arguments.as_deref().map(SiblingNode::from).or(self.following_node);
+        let following_span =
+            self.inner.type_arguments.as_deref().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSClassImplements(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSClassImplements(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -12119,12 +8977,7 @@ impl<'a> AstNode<'a, TSClassImplements<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -12138,61 +8991,55 @@ impl<'a> GetSpan for AstNode<'a, TSClassImplements<'a>> {
 impl<'a> AstNode<'a, TSInterfaceDeclaration<'a>> {
     #[inline]
     pub fn id(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
-        let following_node = self
+        let following_span = self
             .inner
             .type_parameters
             .as_deref()
-            .map(SiblingNode::from)
-            .or_else(|| self.inner.extends.first().as_ref().copied().map(SiblingNode::from))
-            .or_else(|| Some(SiblingNode::from(self.inner.body.as_ref())));
+            .map(GetSpan::span)
+            .or_else(|| self.inner.extends.first().map(GetSpan::span))
+            .or_else(|| Some(self.inner.body.span()));
         self.allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSInterfaceDeclaration(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
-        let following_node = self
-            .inner
-            .extends
-            .first()
-            .as_ref()
-            .copied()
-            .map(SiblingNode::from)
-            .or_else(|| Some(SiblingNode::from(self.inner.body.as_ref())));
+        let following_span =
+            self.inner.extends.first().map(GetSpan::span).or_else(|| Some(self.inner.body.span()));
         self.allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent:
                     self.allocator.alloc(AstNodes::TSInterfaceDeclaration(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn extends(&self) -> &AstNode<'a, Vec<'a, TSInterfaceHeritage<'a>>> {
-        let following_node = Some(SiblingNode::from(self.inner.body.as_ref()));
+        let following_span = Some(self.inner.body.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.extends,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSInterfaceDeclaration(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, TSInterfaceBody<'a>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator.alloc(AstNode {
             inner: self.inner.body.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSInterfaceDeclaration(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -12206,12 +9053,7 @@ impl<'a> AstNode<'a, TSInterfaceDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -12225,12 +9067,12 @@ impl<'a> GetSpan for AstNode<'a, TSInterfaceDeclaration<'a>> {
 impl<'a> AstNode<'a, TSInterfaceBody<'a>> {
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Vec<'a, TSSignature<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSInterfaceBody(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -12239,12 +9081,7 @@ impl<'a> AstNode<'a, TSInterfaceBody<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -12273,25 +9110,25 @@ impl<'a> AstNode<'a, TSPropertySignature<'a>> {
 
     #[inline]
     pub fn key(&self) -> &AstNode<'a, PropertyKey<'a>> {
-        let following_node =
-            self.inner.type_annotation.as_deref().map(SiblingNode::from).or(self.following_node);
+        let following_span =
+            self.inner.type_annotation.as_deref().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSPropertySignature(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn type_annotation(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSPropertySignature(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -12301,12 +9138,7 @@ impl<'a> AstNode<'a, TSPropertySignature<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -12327,7 +9159,7 @@ impl<'a> AstNode<'a, TSSignature<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSSignature::TSPropertySignature(s) => {
@@ -12335,7 +9167,7 @@ impl<'a> AstNode<'a, TSSignature<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSSignature::TSCallSignatureDeclaration(s) => {
@@ -12343,7 +9175,7 @@ impl<'a> AstNode<'a, TSSignature<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSSignature::TSConstructSignatureDeclaration(s) => {
@@ -12351,7 +9183,7 @@ impl<'a> AstNode<'a, TSSignature<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSSignature::TSMethodSignature(s) => {
@@ -12359,7 +9191,7 @@ impl<'a> AstNode<'a, TSSignature<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
         };
@@ -12377,23 +9209,23 @@ impl<'a> GetSpan for AstNode<'a, TSSignature<'a>> {
 impl<'a> AstNode<'a, TSIndexSignature<'a>> {
     #[inline]
     pub fn parameters(&self) -> &AstNode<'a, Vec<'a, TSIndexSignatureName<'a>>> {
-        let following_node = Some(SiblingNode::from(self.inner.type_annotation.as_ref()));
+        let following_span = Some(self.inner.type_annotation.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.parameters,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSIndexSignature(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSTypeAnnotation<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: self.inner.type_annotation.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSIndexSignature(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -12412,12 +9244,7 @@ impl<'a> AstNode<'a, TSIndexSignature<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -12431,12 +9258,12 @@ impl<'a> GetSpan for AstNode<'a, TSIndexSignature<'a>> {
 impl<'a> AstNode<'a, TSCallSignatureDeclaration<'a>> {
     #[inline]
     pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
-        let following_node = self
+        let following_span = self
             .inner
             .this_param
             .as_deref()
-            .map(SiblingNode::from)
-            .or_else(|| Some(SiblingNode::from(self.inner.params.as_ref())));
+            .map(GetSpan::span)
+            .or_else(|| Some(self.inner.params.span()));
         self.allocator
             .alloc(
                 self.inner.type_parameters.as_ref().map(|inner| AstNode {
@@ -12445,7 +9272,7 @@ impl<'a> AstNode<'a, TSCallSignatureDeclaration<'a>> {
                     parent: self
                         .allocator
                         .alloc(AstNodes::TSCallSignatureDeclaration(transmute_self(self))),
-                    following_node,
+                    following_span,
                 }),
             )
             .as_ref()
@@ -12453,7 +9280,7 @@ impl<'a> AstNode<'a, TSCallSignatureDeclaration<'a>> {
 
     #[inline]
     pub fn this_param(&self) -> Option<&AstNode<'a, TSThisParameter<'a>>> {
-        let following_node = Some(SiblingNode::from(self.inner.params.as_ref()));
+        let following_span = Some(self.inner.params.span());
         self.allocator
             .alloc(
                 self.inner.this_param.as_ref().map(|inner| AstNode {
@@ -12462,7 +9289,7 @@ impl<'a> AstNode<'a, TSCallSignatureDeclaration<'a>> {
                     parent: self
                         .allocator
                         .alloc(AstNodes::TSCallSignatureDeclaration(transmute_self(self))),
-                    following_node,
+                    following_span,
                 }),
             )
             .as_ref()
@@ -12470,21 +9297,21 @@ impl<'a> AstNode<'a, TSCallSignatureDeclaration<'a>> {
 
     #[inline]
     pub fn params(&self) -> &AstNode<'a, FormalParameters<'a>> {
-        let following_node =
-            self.inner.return_type.as_deref().map(SiblingNode::from).or(self.following_node);
+        let following_span =
+            self.inner.return_type.as_deref().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: self.inner.params.as_ref(),
             allocator: self.allocator,
             parent: self
                 .allocator
                 .alloc(AstNodes::TSCallSignatureDeclaration(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn return_type(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(
                 self.inner.return_type.as_ref().map(|inner| AstNode {
@@ -12493,7 +9320,7 @@ impl<'a> AstNode<'a, TSCallSignatureDeclaration<'a>> {
                     parent: self
                         .allocator
                         .alloc(AstNodes::TSCallSignatureDeclaration(transmute_self(self))),
-                    following_node,
+                    following_span,
                 }),
             )
             .as_ref()
@@ -12504,12 +9331,7 @@ impl<'a> AstNode<'a, TSCallSignatureDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -12523,18 +9345,18 @@ impl<'a> GetSpan for AstNode<'a, TSCallSignatureDeclaration<'a>> {
 impl<'a> AstNode<'a, TSMethodSignature<'a>> {
     #[inline]
     pub fn key(&self) -> &AstNode<'a, PropertyKey<'a>> {
-        let following_node = self
+        let following_span = self
             .inner
             .type_parameters
             .as_deref()
-            .map(SiblingNode::from)
-            .or_else(|| self.inner.this_param.as_deref().map(SiblingNode::from))
-            .or_else(|| Some(SiblingNode::from(self.inner.params.as_ref())));
+            .map(GetSpan::span)
+            .or_else(|| self.inner.this_param.as_deref().map(GetSpan::span))
+            .or_else(|| Some(self.inner.params.span()));
         self.allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSMethodSignature(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -12555,56 +9377,56 @@ impl<'a> AstNode<'a, TSMethodSignature<'a>> {
 
     #[inline]
     pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
-        let following_node = self
+        let following_span = self
             .inner
             .this_param
             .as_deref()
-            .map(SiblingNode::from)
-            .or_else(|| Some(SiblingNode::from(self.inner.params.as_ref())));
+            .map(GetSpan::span)
+            .or_else(|| Some(self.inner.params.span()));
         self.allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSMethodSignature(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn this_param(&self) -> Option<&AstNode<'a, TSThisParameter<'a>>> {
-        let following_node = Some(SiblingNode::from(self.inner.params.as_ref()));
+        let following_span = Some(self.inner.params.span());
         self.allocator
             .alloc(self.inner.this_param.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSMethodSignature(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn params(&self) -> &AstNode<'a, FormalParameters<'a>> {
-        let following_node =
-            self.inner.return_type.as_deref().map(SiblingNode::from).or(self.following_node);
+        let following_span =
+            self.inner.return_type.as_deref().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: self.inner.params.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSMethodSignature(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn return_type(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.return_type.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSMethodSignature(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -12614,12 +9436,7 @@ impl<'a> AstNode<'a, TSMethodSignature<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -12633,7 +9450,7 @@ impl<'a> GetSpan for AstNode<'a, TSMethodSignature<'a>> {
 impl<'a> AstNode<'a, TSConstructSignatureDeclaration<'a>> {
     #[inline]
     pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
-        let following_node = Some(SiblingNode::from(self.inner.params.as_ref()));
+        let following_span = Some(self.inner.params.span());
         self.allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| {
                 AstNode {
@@ -12642,7 +9459,7 @@ impl<'a> AstNode<'a, TSConstructSignatureDeclaration<'a>> {
                     parent: self
                         .allocator
                         .alloc(AstNodes::TSConstructSignatureDeclaration(transmute_self(self))),
-                    following_node,
+                    following_span,
                 }
             }))
             .as_ref()
@@ -12650,21 +9467,21 @@ impl<'a> AstNode<'a, TSConstructSignatureDeclaration<'a>> {
 
     #[inline]
     pub fn params(&self) -> &AstNode<'a, FormalParameters<'a>> {
-        let following_node =
-            self.inner.return_type.as_deref().map(SiblingNode::from).or(self.following_node);
+        let following_span =
+            self.inner.return_type.as_deref().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: self.inner.params.as_ref(),
             allocator: self.allocator,
             parent: self
                 .allocator
                 .alloc(AstNodes::TSConstructSignatureDeclaration(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn return_type(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.return_type.as_ref().map(|inner| {
                 AstNode {
@@ -12673,7 +9490,7 @@ impl<'a> AstNode<'a, TSConstructSignatureDeclaration<'a>> {
                     parent: self
                         .allocator
                         .alloc(AstNodes::TSConstructSignatureDeclaration(transmute_self(self))),
-                    following_node,
+                    following_span,
                 }
             }))
             .as_ref()
@@ -12684,12 +9501,7 @@ impl<'a> AstNode<'a, TSConstructSignatureDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -12708,12 +9520,12 @@ impl<'a> AstNode<'a, TSIndexSignatureName<'a>> {
 
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSTypeAnnotation<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: self.inner.type_annotation.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSIndexSignatureName(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -12722,12 +9534,7 @@ impl<'a> AstNode<'a, TSIndexSignatureName<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -12741,25 +9548,25 @@ impl<'a> GetSpan for AstNode<'a, TSIndexSignatureName<'a>> {
 impl<'a> AstNode<'a, TSInterfaceHeritage<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node =
-            self.inner.type_arguments.as_deref().map(SiblingNode::from).or(self.following_node);
+        let following_span =
+            self.inner.type_arguments.as_deref().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSInterfaceHeritage(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSInterfaceHeritage(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -12769,12 +9576,7 @@ impl<'a> AstNode<'a, TSInterfaceHeritage<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -12788,13 +9590,13 @@ impl<'a> GetSpan for AstNode<'a, TSInterfaceHeritage<'a>> {
 impl<'a> AstNode<'a, TSTypePredicate<'a>> {
     #[inline]
     pub fn parameter_name(&self) -> &AstNode<'a, TSTypePredicateName<'a>> {
-        let following_node =
-            self.inner.type_annotation.as_deref().map(SiblingNode::from).or(self.following_node);
+        let following_span =
+            self.inner.type_annotation.as_deref().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.parameter_name,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTypePredicate(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -12805,13 +9607,13 @@ impl<'a> AstNode<'a, TSTypePredicate<'a>> {
 
     #[inline]
     pub fn type_annotation(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSTypePredicate(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -12821,12 +9623,7 @@ impl<'a> AstNode<'a, TSTypePredicate<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -12847,14 +9644,14 @@ impl<'a> AstNode<'a, TSTypePredicateName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSTypePredicateName::This(s) => AstNodes::TSThisType(self.allocator.alloc(AstNode {
                 inner: s,
                 parent,
                 allocator: self.allocator,
-                following_node: self.following_node,
+                following_span: self.following_span,
             })),
         };
         self.allocator.alloc(node)
@@ -12871,24 +9668,24 @@ impl<'a> GetSpan for AstNode<'a, TSTypePredicateName<'a>> {
 impl<'a> AstNode<'a, TSModuleDeclaration<'a>> {
     #[inline]
     pub fn id(&self) -> &AstNode<'a, TSModuleDeclarationName<'a>> {
-        let following_node = self.inner.body.as_ref().map(SiblingNode::from);
+        let following_span = self.inner.body.as_ref().map(GetSpan::span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSModuleDeclaration(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn body(&self) -> Option<&AstNode<'a, TSModuleDeclarationBody<'a>>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator
             .alloc(self.inner.body.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSModuleDeclaration(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -12908,12 +9705,7 @@ impl<'a> AstNode<'a, TSModuleDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -12934,7 +9726,7 @@ impl<'a> AstNode<'a, TSModuleDeclarationName<'a>> {
                     inner: s,
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSModuleDeclarationName::StringLiteral(s) => {
@@ -12942,7 +9734,7 @@ impl<'a> AstNode<'a, TSModuleDeclarationName<'a>> {
                     inner: s,
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
         };
@@ -12967,7 +9759,7 @@ impl<'a> AstNode<'a, TSModuleDeclarationBody<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSModuleDeclarationBody::TSModuleBlock(s) => {
@@ -12975,7 +9767,7 @@ impl<'a> AstNode<'a, TSModuleDeclarationBody<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
         };
@@ -12993,30 +9785,23 @@ impl<'a> GetSpan for AstNode<'a, TSModuleDeclarationBody<'a>> {
 impl<'a> AstNode<'a, TSModuleBlock<'a>> {
     #[inline]
     pub fn directives(&self) -> &AstNode<'a, Vec<'a, Directive<'a>>> {
-        let following_node = self
-            .inner
-            .body
-            .first()
-            .as_ref()
-            .copied()
-            .map(SiblingNode::from)
-            .or(self.following_node);
+        let following_span = self.inner.body.first().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.directives,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSModuleBlock(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSModuleBlock(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -13025,12 +9810,7 @@ impl<'a> AstNode<'a, TSModuleBlock<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -13044,12 +9824,12 @@ impl<'a> GetSpan for AstNode<'a, TSModuleBlock<'a>> {
 impl<'a> AstNode<'a, TSTypeLiteral<'a>> {
     #[inline]
     pub fn members(&self) -> &AstNode<'a, Vec<'a, TSSignature<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.members,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTypeLiteral(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -13058,12 +9838,7 @@ impl<'a> AstNode<'a, TSTypeLiteral<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -13077,12 +9852,12 @@ impl<'a> GetSpan for AstNode<'a, TSTypeLiteral<'a>> {
 impl<'a> AstNode<'a, TSInferType<'a>> {
     #[inline]
     pub fn type_parameter(&self) -> &AstNode<'a, TSTypeParameter<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: self.inner.type_parameter.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSInferType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -13091,12 +9866,7 @@ impl<'a> AstNode<'a, TSInferType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -13110,25 +9880,25 @@ impl<'a> GetSpan for AstNode<'a, TSInferType<'a>> {
 impl<'a> AstNode<'a, TSTypeQuery<'a>> {
     #[inline]
     pub fn expr_name(&self) -> &AstNode<'a, TSTypeQueryExprName<'a>> {
-        let following_node =
-            self.inner.type_arguments.as_deref().map(SiblingNode::from).or(self.following_node);
+        let following_span =
+            self.inner.type_arguments.as_deref().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.expr_name,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTypeQuery(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSTypeQuery(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -13138,12 +9908,7 @@ impl<'a> AstNode<'a, TSTypeQuery<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -13164,7 +9929,7 @@ impl<'a> AstNode<'a, TSTypeQueryExprName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             it @ match_ts_type_name!(TSTypeQueryExprName) => {
@@ -13174,7 +9939,7 @@ impl<'a> AstNode<'a, TSTypeQueryExprName<'a>> {
                         inner: it.to_ts_type_name(),
                         parent,
                         allocator: self.allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .as_ast_nodes();
             }
@@ -13193,64 +9958,64 @@ impl<'a> GetSpan for AstNode<'a, TSTypeQueryExprName<'a>> {
 impl<'a> AstNode<'a, TSImportType<'a>> {
     #[inline]
     pub fn argument(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_node = self
+        let following_span = self
             .inner
             .options
             .as_deref()
-            .map(SiblingNode::from)
-            .or_else(|| self.inner.qualifier.as_ref().map(SiblingNode::from))
-            .or_else(|| self.inner.type_arguments.as_deref().map(SiblingNode::from))
-            .or(self.following_node);
+            .map(GetSpan::span)
+            .or_else(|| self.inner.qualifier.as_ref().map(GetSpan::span))
+            .or_else(|| self.inner.type_arguments.as_deref().map(GetSpan::span))
+            .or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.argument,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSImportType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn options(&self) -> Option<&AstNode<'a, ObjectExpression<'a>>> {
-        let following_node = self
+        let following_span = self
             .inner
             .qualifier
             .as_ref()
-            .map(SiblingNode::from)
-            .or_else(|| self.inner.type_arguments.as_deref().map(SiblingNode::from))
-            .or(self.following_node);
+            .map(GetSpan::span)
+            .or_else(|| self.inner.type_arguments.as_deref().map(GetSpan::span))
+            .or(self.following_span);
         self.allocator
             .alloc(self.inner.options.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSImportType(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn qualifier(&self) -> Option<&AstNode<'a, TSImportTypeQualifier<'a>>> {
-        let following_node =
-            self.inner.type_arguments.as_deref().map(SiblingNode::from).or(self.following_node);
+        let following_span =
+            self.inner.type_arguments.as_deref().map(GetSpan::span).or(self.following_span);
         self.allocator
             .alloc(self.inner.qualifier.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSImportType(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSImportType(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -13260,12 +10025,7 @@ impl<'a> AstNode<'a, TSImportType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -13286,7 +10046,7 @@ impl<'a> AstNode<'a, TSImportTypeQualifier<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             TSImportTypeQualifier::QualifiedName(s) => {
@@ -13294,7 +10054,7 @@ impl<'a> AstNode<'a, TSImportTypeQualifier<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
         };
@@ -13312,23 +10072,23 @@ impl<'a> GetSpan for AstNode<'a, TSImportTypeQualifier<'a>> {
 impl<'a> AstNode<'a, TSImportTypeQualifiedName<'a>> {
     #[inline]
     pub fn left(&self) -> &AstNode<'a, TSImportTypeQualifier<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.right));
+        let following_span = Some(self.inner.right.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSImportTypeQualifiedName(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn right(&self) -> &AstNode<'a, IdentifierName<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSImportTypeQualifiedName(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -13337,12 +10097,7 @@ impl<'a> AstNode<'a, TSImportTypeQualifiedName<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -13356,54 +10111,54 @@ impl<'a> GetSpan for AstNode<'a, TSImportTypeQualifiedName<'a>> {
 impl<'a> AstNode<'a, TSFunctionType<'a>> {
     #[inline]
     pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
-        let following_node = self
+        let following_span = self
             .inner
             .this_param
             .as_deref()
-            .map(SiblingNode::from)
-            .or_else(|| Some(SiblingNode::from(self.inner.params.as_ref())));
+            .map(GetSpan::span)
+            .or_else(|| Some(self.inner.params.span()));
         self.allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSFunctionType(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn this_param(&self) -> Option<&AstNode<'a, TSThisParameter<'a>>> {
-        let following_node = Some(SiblingNode::from(self.inner.params.as_ref()));
+        let following_span = Some(self.inner.params.span());
         self.allocator
             .alloc(self.inner.this_param.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSFunctionType(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn params(&self) -> &AstNode<'a, FormalParameters<'a>> {
-        let following_node = Some(SiblingNode::from(self.inner.return_type.as_ref()));
+        let following_span = Some(self.inner.return_type.span());
         self.allocator.alloc(AstNode {
             inner: self.inner.params.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSFunctionType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn return_type(&self) -> &AstNode<'a, TSTypeAnnotation<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: self.inner.return_type.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSFunctionType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -13412,12 +10167,7 @@ impl<'a> AstNode<'a, TSFunctionType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -13436,36 +10186,36 @@ impl<'a> AstNode<'a, TSConstructorType<'a>> {
 
     #[inline]
     pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
-        let following_node = Some(SiblingNode::from(self.inner.params.as_ref()));
+        let following_span = Some(self.inner.params.span());
         self.allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSConstructorType(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn params(&self) -> &AstNode<'a, FormalParameters<'a>> {
-        let following_node = Some(SiblingNode::from(self.inner.return_type.as_ref()));
+        let following_span = Some(self.inner.return_type.span());
         self.allocator.alloc(AstNode {
             inner: self.inner.params.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSConstructorType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn return_type(&self) -> &AstNode<'a, TSTypeAnnotation<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: self.inner.return_type.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSConstructorType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -13474,12 +10224,7 @@ impl<'a> AstNode<'a, TSConstructorType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -13493,44 +10238,44 @@ impl<'a> GetSpan for AstNode<'a, TSConstructorType<'a>> {
 impl<'a> AstNode<'a, TSMappedType<'a>> {
     #[inline]
     pub fn type_parameter(&self) -> &AstNode<'a, TSTypeParameter<'a>> {
-        let following_node = self
+        let following_span = self
             .inner
             .name_type
             .as_ref()
-            .map(SiblingNode::from)
-            .or_else(|| self.inner.type_annotation.as_ref().map(SiblingNode::from))
-            .or(self.following_node);
+            .map(GetSpan::span)
+            .or_else(|| self.inner.type_annotation.as_ref().map(GetSpan::span))
+            .or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: self.inner.type_parameter.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSMappedType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn name_type(&self) -> Option<&AstNode<'a, TSType<'a>>> {
-        let following_node =
-            self.inner.type_annotation.as_ref().map(SiblingNode::from).or(self.following_node);
+        let following_span =
+            self.inner.type_annotation.as_ref().map(GetSpan::span).or(self.following_span);
         self.allocator
             .alloc(self.inner.name_type.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSMappedType(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn type_annotation(&self) -> Option<&AstNode<'a, TSType<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSMappedType(transmute_self(self))),
-                following_node,
+                following_span,
             }))
             .as_ref()
     }
@@ -13550,12 +10295,7 @@ impl<'a> AstNode<'a, TSMappedType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -13569,30 +10309,23 @@ impl<'a> GetSpan for AstNode<'a, TSMappedType<'a>> {
 impl<'a> AstNode<'a, TSTemplateLiteralType<'a>> {
     #[inline]
     pub fn quasis(&self) -> &AstNode<'a, Vec<'a, TemplateElement<'a>>> {
-        let following_node = self
-            .inner
-            .types
-            .first()
-            .as_ref()
-            .copied()
-            .map(SiblingNode::from)
-            .or(self.following_node);
+        let following_span = self.inner.types.first().map(GetSpan::span).or(self.following_span);
         self.allocator.alloc(AstNode {
             inner: &self.inner.quasis,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTemplateLiteralType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn types(&self) -> &AstNode<'a, Vec<'a, TSType<'a>>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.types,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTemplateLiteralType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -13601,12 +10334,7 @@ impl<'a> AstNode<'a, TSTemplateLiteralType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -13620,23 +10348,23 @@ impl<'a> GetSpan for AstNode<'a, TSTemplateLiteralType<'a>> {
 impl<'a> AstNode<'a, TSAsExpression<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.type_annotation));
+        let following_span = Some(self.inner.type_annotation.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSAsExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSAsExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -13645,12 +10373,7 @@ impl<'a> AstNode<'a, TSAsExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -13664,23 +10387,23 @@ impl<'a> GetSpan for AstNode<'a, TSAsExpression<'a>> {
 impl<'a> AstNode<'a, TSSatisfiesExpression<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.type_annotation));
+        let following_span = Some(self.inner.type_annotation.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSSatisfiesExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSSatisfiesExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -13689,12 +10412,7 @@ impl<'a> AstNode<'a, TSSatisfiesExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -13708,23 +10426,23 @@ impl<'a> GetSpan for AstNode<'a, TSSatisfiesExpression<'a>> {
 impl<'a> AstNode<'a, TSTypeAssertion<'a>> {
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.expression));
+        let following_span = Some(self.inner.expression.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTypeAssertion(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTypeAssertion(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -13733,12 +10451,7 @@ impl<'a> AstNode<'a, TSTypeAssertion<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -13752,23 +10465,23 @@ impl<'a> GetSpan for AstNode<'a, TSTypeAssertion<'a>> {
 impl<'a> AstNode<'a, TSImportEqualsDeclaration<'a>> {
     #[inline]
     pub fn id(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
-        let following_node = Some(SiblingNode::from(&self.inner.module_reference));
+        let following_span = Some(self.inner.module_reference.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSImportEqualsDeclaration(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn module_reference(&self) -> &AstNode<'a, TSModuleReference<'a>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator.alloc(AstNode {
             inner: &self.inner.module_reference,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSImportEqualsDeclaration(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -13782,12 +10495,7 @@ impl<'a> AstNode<'a, TSImportEqualsDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -13808,7 +10516,7 @@ impl<'a> AstNode<'a, TSModuleReference<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }))
             }
             it @ match_ts_type_name!(TSModuleReference) => {
@@ -13818,7 +10526,7 @@ impl<'a> AstNode<'a, TSModuleReference<'a>> {
                         inner: it.to_ts_type_name(),
                         parent,
                         allocator: self.allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .as_ast_nodes();
             }
@@ -13837,12 +10545,12 @@ impl<'a> GetSpan for AstNode<'a, TSModuleReference<'a>> {
 impl<'a> AstNode<'a, TSExternalModuleReference<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, StringLiteral<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSExternalModuleReference(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -13851,12 +10559,7 @@ impl<'a> AstNode<'a, TSExternalModuleReference<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -13870,12 +10573,12 @@ impl<'a> GetSpan for AstNode<'a, TSExternalModuleReference<'a>> {
 impl<'a> AstNode<'a, TSNonNullExpression<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSNonNullExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -13884,12 +10587,7 @@ impl<'a> AstNode<'a, TSNonNullExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -13903,12 +10601,12 @@ impl<'a> GetSpan for AstNode<'a, TSNonNullExpression<'a>> {
 impl<'a> AstNode<'a, Decorator<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::Decorator(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -13917,12 +10615,7 @@ impl<'a> AstNode<'a, Decorator<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -13936,12 +10629,12 @@ impl<'a> GetSpan for AstNode<'a, Decorator<'a>> {
 impl<'a> AstNode<'a, TSExportAssignment<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSExportAssignment(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -13950,12 +10643,7 @@ impl<'a> AstNode<'a, TSExportAssignment<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -13969,14 +10657,14 @@ impl<'a> GetSpan for AstNode<'a, TSExportAssignment<'a>> {
 impl<'a> AstNode<'a, TSNamespaceExportDeclaration<'a>> {
     #[inline]
     pub fn id(&self) -> &AstNode<'a, IdentifierName<'a>> {
-        let following_node = None;
+        let following_span = None;
         self.allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
             parent: self
                 .allocator
                 .alloc(AstNodes::TSNamespaceExportDeclaration(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -13985,12 +10673,7 @@ impl<'a> AstNode<'a, TSNamespaceExportDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -14004,23 +10687,23 @@ impl<'a> GetSpan for AstNode<'a, TSNamespaceExportDeclaration<'a>> {
 impl<'a> AstNode<'a, TSInstantiationExpression<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_node = Some(SiblingNode::from(self.inner.type_arguments.as_ref()));
+        let following_span = Some(self.inner.type_arguments.span());
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSInstantiationExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
     #[inline]
     pub fn type_arguments(&self) -> &AstNode<'a, TSTypeParameterInstantiation<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: self.inner.type_arguments.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSInstantiationExpression(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -14029,12 +10712,7 @@ impl<'a> AstNode<'a, TSInstantiationExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -14048,12 +10726,12 @@ impl<'a> GetSpan for AstNode<'a, TSInstantiationExpression<'a>> {
 impl<'a> AstNode<'a, JSDocNullableType<'a>> {
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSDocNullableType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -14067,12 +10745,7 @@ impl<'a> AstNode<'a, JSDocNullableType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -14086,12 +10759,12 @@ impl<'a> GetSpan for AstNode<'a, JSDocNullableType<'a>> {
 impl<'a> AstNode<'a, JSDocNonNullableType<'a>> {
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_node = self.following_node;
+        let following_span = self.following_span;
         self.allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSDocNonNullableType(transmute_self(self))),
-            following_node,
+            following_span,
         })
     }
 
@@ -14105,12 +10778,7 @@ impl<'a> AstNode<'a, JSDocNonNullableType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -14127,12 +10795,7 @@ impl<'a> AstNode<'a, JSDocUnknownType> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(
-            &self.parent.as_sibling_node(),
-            &SiblingNode::from(self.inner),
-            self.following_node.as_ref(),
-        )
-        .fmt(f)
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
     }
 }
 
@@ -14165,7 +10828,7 @@ impl<'a> AstNode<'a, Vec<'a, Expression<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -14176,7 +10839,7 @@ impl<'a> AstNode<'a, Vec<'a, Expression<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -14188,8 +10851,8 @@ impl<'a> Iterator for AstNodeIterator<'a, Expression<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -14223,7 +10886,7 @@ impl<'a> AstNode<'a, Vec<'a, ArrayExpressionElement<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -14234,7 +10897,7 @@ impl<'a> AstNode<'a, Vec<'a, ArrayExpressionElement<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -14246,8 +10909,8 @@ impl<'a> Iterator for AstNodeIterator<'a, ArrayExpressionElement<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -14281,7 +10944,7 @@ impl<'a> AstNode<'a, Vec<'a, ObjectPropertyKind<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -14292,7 +10955,7 @@ impl<'a> AstNode<'a, Vec<'a, ObjectPropertyKind<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -14304,8 +10967,8 @@ impl<'a> Iterator for AstNodeIterator<'a, ObjectPropertyKind<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -14339,7 +11002,7 @@ impl<'a> AstNode<'a, Vec<'a, TemplateElement<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -14350,7 +11013,7 @@ impl<'a> AstNode<'a, Vec<'a, TemplateElement<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -14362,8 +11025,8 @@ impl<'a> Iterator for AstNodeIterator<'a, TemplateElement<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -14397,7 +11060,7 @@ impl<'a> AstNode<'a, Vec<'a, Argument<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -14408,7 +11071,7 @@ impl<'a> AstNode<'a, Vec<'a, Argument<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -14420,8 +11083,8 @@ impl<'a> Iterator for AstNodeIterator<'a, Argument<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -14455,7 +11118,7 @@ impl<'a> AstNode<'a, Vec<'a, AssignmentTargetProperty<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -14466,7 +11129,7 @@ impl<'a> AstNode<'a, Vec<'a, AssignmentTargetProperty<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -14478,8 +11141,8 @@ impl<'a> Iterator for AstNodeIterator<'a, AssignmentTargetProperty<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -14513,7 +11176,7 @@ impl<'a> AstNode<'a, Vec<'a, Statement<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -14524,7 +11187,7 @@ impl<'a> AstNode<'a, Vec<'a, Statement<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -14536,8 +11199,8 @@ impl<'a> Iterator for AstNodeIterator<'a, Statement<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -14571,7 +11234,7 @@ impl<'a> AstNode<'a, Vec<'a, Directive<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -14582,7 +11245,7 @@ impl<'a> AstNode<'a, Vec<'a, Directive<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -14594,8 +11257,8 @@ impl<'a> Iterator for AstNodeIterator<'a, Directive<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -14629,7 +11292,7 @@ impl<'a> AstNode<'a, Vec<'a, VariableDeclarator<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -14640,7 +11303,7 @@ impl<'a> AstNode<'a, Vec<'a, VariableDeclarator<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -14652,8 +11315,8 @@ impl<'a> Iterator for AstNodeIterator<'a, VariableDeclarator<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -14687,7 +11350,7 @@ impl<'a> AstNode<'a, Vec<'a, SwitchCase<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -14698,7 +11361,7 @@ impl<'a> AstNode<'a, Vec<'a, SwitchCase<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -14710,8 +11373,8 @@ impl<'a> Iterator for AstNodeIterator<'a, SwitchCase<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -14745,7 +11408,7 @@ impl<'a> AstNode<'a, Vec<'a, BindingProperty<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -14756,7 +11419,7 @@ impl<'a> AstNode<'a, Vec<'a, BindingProperty<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -14768,8 +11431,8 @@ impl<'a> Iterator for AstNodeIterator<'a, BindingProperty<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -14803,7 +11466,7 @@ impl<'a> AstNode<'a, Vec<'a, FormalParameter<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -14814,7 +11477,7 @@ impl<'a> AstNode<'a, Vec<'a, FormalParameter<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -14826,8 +11489,8 @@ impl<'a> Iterator for AstNodeIterator<'a, FormalParameter<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -14861,7 +11524,7 @@ impl<'a> AstNode<'a, Vec<'a, ClassElement<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -14872,7 +11535,7 @@ impl<'a> AstNode<'a, Vec<'a, ClassElement<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -14884,8 +11547,8 @@ impl<'a> Iterator for AstNodeIterator<'a, ClassElement<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -14919,7 +11582,7 @@ impl<'a> AstNode<'a, Vec<'a, ImportDeclarationSpecifier<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -14930,7 +11593,7 @@ impl<'a> AstNode<'a, Vec<'a, ImportDeclarationSpecifier<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -14942,8 +11605,8 @@ impl<'a> Iterator for AstNodeIterator<'a, ImportDeclarationSpecifier<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -14977,7 +11640,7 @@ impl<'a> AstNode<'a, Vec<'a, ImportAttribute<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -14988,7 +11651,7 @@ impl<'a> AstNode<'a, Vec<'a, ImportAttribute<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -15000,8 +11663,8 @@ impl<'a> Iterator for AstNodeIterator<'a, ImportAttribute<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -15035,7 +11698,7 @@ impl<'a> AstNode<'a, Vec<'a, ExportSpecifier<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -15046,7 +11709,7 @@ impl<'a> AstNode<'a, Vec<'a, ExportSpecifier<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -15058,8 +11721,8 @@ impl<'a> Iterator for AstNodeIterator<'a, ExportSpecifier<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -15093,7 +11756,7 @@ impl<'a> AstNode<'a, Vec<'a, JSXAttributeItem<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -15104,7 +11767,7 @@ impl<'a> AstNode<'a, Vec<'a, JSXAttributeItem<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -15116,8 +11779,8 @@ impl<'a> Iterator for AstNodeIterator<'a, JSXAttributeItem<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -15151,7 +11814,7 @@ impl<'a> AstNode<'a, Vec<'a, JSXChild<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -15162,7 +11825,7 @@ impl<'a> AstNode<'a, Vec<'a, JSXChild<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -15174,8 +11837,8 @@ impl<'a> Iterator for AstNodeIterator<'a, JSXChild<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -15209,7 +11872,7 @@ impl<'a> AstNode<'a, Vec<'a, TSEnumMember<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -15220,7 +11883,7 @@ impl<'a> AstNode<'a, Vec<'a, TSEnumMember<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -15232,8 +11895,8 @@ impl<'a> Iterator for AstNodeIterator<'a, TSEnumMember<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -15267,7 +11930,7 @@ impl<'a> AstNode<'a, Vec<'a, TSType<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -15278,7 +11941,7 @@ impl<'a> AstNode<'a, Vec<'a, TSType<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -15290,8 +11953,8 @@ impl<'a> Iterator for AstNodeIterator<'a, TSType<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -15325,7 +11988,7 @@ impl<'a> AstNode<'a, Vec<'a, TSTupleElement<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -15336,7 +11999,7 @@ impl<'a> AstNode<'a, Vec<'a, TSTupleElement<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -15348,8 +12011,8 @@ impl<'a> Iterator for AstNodeIterator<'a, TSTupleElement<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -15383,7 +12046,7 @@ impl<'a> AstNode<'a, Vec<'a, TSTypeParameter<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -15394,7 +12057,7 @@ impl<'a> AstNode<'a, Vec<'a, TSTypeParameter<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -15406,8 +12069,8 @@ impl<'a> Iterator for AstNodeIterator<'a, TSTypeParameter<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -15441,7 +12104,7 @@ impl<'a> AstNode<'a, Vec<'a, TSClassImplements<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -15452,7 +12115,7 @@ impl<'a> AstNode<'a, Vec<'a, TSClassImplements<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -15464,8 +12127,8 @@ impl<'a> Iterator for AstNodeIterator<'a, TSClassImplements<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -15499,7 +12162,7 @@ impl<'a> AstNode<'a, Vec<'a, TSSignature<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -15510,7 +12173,7 @@ impl<'a> AstNode<'a, Vec<'a, TSSignature<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -15522,8 +12185,8 @@ impl<'a> Iterator for AstNodeIterator<'a, TSSignature<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -15557,7 +12220,7 @@ impl<'a> AstNode<'a, Vec<'a, TSIndexSignatureName<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -15568,7 +12231,7 @@ impl<'a> AstNode<'a, Vec<'a, TSIndexSignatureName<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -15580,8 +12243,8 @@ impl<'a> Iterator for AstNodeIterator<'a, TSIndexSignatureName<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -15615,7 +12278,7 @@ impl<'a> AstNode<'a, Vec<'a, TSInterfaceHeritage<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -15626,7 +12289,7 @@ impl<'a> AstNode<'a, Vec<'a, TSInterfaceHeritage<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -15638,8 +12301,8 @@ impl<'a> Iterator for AstNodeIterator<'a, TSInterfaceHeritage<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -15673,7 +12336,7 @@ impl<'a> AstNode<'a, Vec<'a, Decorator<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: inner_iter.next().map(SiblingNode::from),
+                following_span: inner_iter.next().map(GetSpan::span),
             }))
             .as_ref()
     }
@@ -15684,7 +12347,7 @@ impl<'a> AstNode<'a, Vec<'a, Decorator<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -15696,8 +12359,8 @@ impl<'a> Iterator for AstNodeIterator<'a, Decorator<'a>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self.inner.peek().copied().map(SiblingNode::from);
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                let following_span = self.inner.peek().copied().map(GetSpan::span);
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -15732,9 +12395,9 @@ impl<'a> AstNode<'a, Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>> {
                     inner,
                     parent: self.parent,
                     allocator: self.allocator,
-                    following_node: inner_iter
+                    following_span: inner_iter
                         .next()
-                        .map(|next| next.as_ref().map(SiblingNode::from))
+                        .map(|next| next.as_ref().map(GetSpan::span))
                         .unwrap_or_default(),
                 }
             }))
@@ -15747,7 +12410,7 @@ impl<'a> AstNode<'a, Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -15759,13 +12422,13 @@ impl<'a> Iterator for AstNodeIterator<'a, Option<AssignmentTargetMaybeDefault<'a
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self
+                let following_span = self
                     .inner
                     .peek()
                     .copied()
-                    .map(|next| next.as_ref().map(SiblingNode::from))
+                    .map(|next| next.as_ref().map(GetSpan::span))
                     .unwrap_or_default();
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }
@@ -15800,9 +12463,9 @@ impl<'a> AstNode<'a, Vec<'a, Option<BindingPattern<'a>>>> {
                     inner,
                     parent: self.parent,
                     allocator: self.allocator,
-                    following_node: inner_iter
+                    following_span: inner_iter
                         .next()
-                        .map(|next| next.as_ref().map(SiblingNode::from))
+                        .map(|next| next.as_ref().map(GetSpan::span))
                         .unwrap_or_default(),
                 }
             }))
@@ -15815,7 +12478,7 @@ impl<'a> AstNode<'a, Vec<'a, Option<BindingPattern<'a>>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_node: None,
+                following_span: None,
             }))
             .as_ref()
     }
@@ -15827,13 +12490,13 @@ impl<'a> Iterator for AstNodeIterator<'a, Option<BindingPattern<'a>>> {
         let allocator = self.allocator;
         allocator
             .alloc(self.inner.next().map(|inner| {
-                let following_node = self
+                let following_span = self
                     .inner
                     .peek()
                     .copied()
-                    .map(|next| next.as_ref().map(SiblingNode::from))
+                    .map(|next| next.as_ref().map(GetSpan::span))
                     .unwrap_or_default();
-                AstNode { parent: self.parent, inner, allocator, following_node }
+                AstNode { parent: self.parent, inner, allocator, following_span }
             }))
             .as_ref()
     }

--- a/crates/oxc_formatter/src/generated/format.rs
+++ b/crates/oxc_formatter/src/generated/format.rs
@@ -30,7 +30,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::NullLiteral(inner) => allocator
@@ -38,7 +38,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::NumericLiteral(inner) => allocator
@@ -46,7 +46,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::BigIntLiteral(inner) => allocator
@@ -54,7 +54,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::RegExpLiteral(inner) => allocator
@@ -62,7 +62,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::StringLiteral(inner) => allocator
@@ -70,7 +70,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::TemplateLiteral(inner) => allocator
@@ -78,7 +78,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::Identifier(inner) => allocator
@@ -86,7 +86,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::MetaProperty(inner) => allocator
@@ -94,7 +94,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::Super(inner) => allocator
@@ -102,7 +102,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::ArrayExpression(inner) => allocator
@@ -110,7 +110,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::ArrowFunctionExpression(inner) => allocator
@@ -118,7 +118,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::AssignmentExpression(inner) => allocator
@@ -126,7 +126,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::AwaitExpression(inner) => allocator
@@ -134,7 +134,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::BinaryExpression(inner) => allocator
@@ -142,7 +142,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::CallExpression(inner) => allocator
@@ -150,7 +150,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::ChainExpression(inner) => allocator
@@ -158,7 +158,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::ClassExpression(inner) => allocator
@@ -166,7 +166,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::ConditionalExpression(inner) => allocator
@@ -174,7 +174,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::FunctionExpression(inner) => allocator
@@ -182,7 +182,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::ImportExpression(inner) => allocator
@@ -190,7 +190,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::LogicalExpression(inner) => allocator
@@ -198,7 +198,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::NewExpression(inner) => allocator
@@ -206,7 +206,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::ObjectExpression(inner) => allocator
@@ -214,7 +214,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::ParenthesizedExpression(inner) => allocator
@@ -222,7 +222,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::SequenceExpression(inner) => allocator
@@ -230,7 +230,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::TaggedTemplateExpression(inner) => allocator
@@ -238,7 +238,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::ThisExpression(inner) => allocator
@@ -246,7 +246,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::UnaryExpression(inner) => allocator
@@ -254,7 +254,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::UpdateExpression(inner) => allocator
@@ -262,7 +262,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::YieldExpression(inner) => allocator
@@ -270,7 +270,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::PrivateInExpression(inner) => allocator
@@ -278,7 +278,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::JSXElement(inner) => allocator
@@ -286,7 +286,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::JSXFragment(inner) => allocator
@@ -294,7 +294,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::TSAsExpression(inner) => allocator
@@ -302,7 +302,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::TSSatisfiesExpression(inner) => allocator
@@ -310,7 +310,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::TSTypeAssertion(inner) => allocator
@@ -318,7 +318,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::TSNonNullExpression(inner) => allocator
@@ -326,7 +326,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::TSInstantiationExpression(inner) => allocator
@@ -334,7 +334,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Expression::V8IntrinsicExpression(inner) => allocator
@@ -342,7 +342,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             it @ match_member_expression!(Expression) => {
@@ -352,7 +352,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .fmt(f)
             }
@@ -467,7 +467,7 @@ impl<'a> Format<'a> for AstNode<'a, ArrayExpressionElement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             ArrayExpressionElement::Elision(inner) => allocator
@@ -475,7 +475,7 @@ impl<'a> Format<'a> for AstNode<'a, ArrayExpressionElement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             it @ match_expression!(ArrayExpressionElement) => {
@@ -485,7 +485,7 @@ impl<'a> Format<'a> for AstNode<'a, ArrayExpressionElement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .fmt(f)
             }
@@ -536,7 +536,7 @@ impl<'a> Format<'a> for AstNode<'a, ObjectPropertyKind<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             ObjectPropertyKind::SpreadProperty(inner) => allocator
@@ -544,7 +544,7 @@ impl<'a> Format<'a> for AstNode<'a, ObjectPropertyKind<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -573,7 +573,7 @@ impl<'a> Format<'a> for AstNode<'a, PropertyKey<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             PropertyKey::PrivateIdentifier(inner) => allocator
@@ -581,7 +581,7 @@ impl<'a> Format<'a> for AstNode<'a, PropertyKey<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             it @ match_expression!(PropertyKey) => {
@@ -591,7 +591,7 @@ impl<'a> Format<'a> for AstNode<'a, PropertyKey<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .fmt(f)
             }
@@ -665,7 +665,7 @@ impl<'a> Format<'a> for AstNode<'a, MemberExpression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             MemberExpression::StaticMemberExpression(inner) => allocator
@@ -673,7 +673,7 @@ impl<'a> Format<'a> for AstNode<'a, MemberExpression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             MemberExpression::PrivateFieldExpression(inner) => allocator
@@ -681,7 +681,7 @@ impl<'a> Format<'a> for AstNode<'a, MemberExpression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -836,7 +836,7 @@ impl<'a> Format<'a> for AstNode<'a, Argument<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             it @ match_expression!(Argument) => {
@@ -846,7 +846,7 @@ impl<'a> Format<'a> for AstNode<'a, Argument<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .fmt(f)
             }
@@ -1014,7 +1014,7 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTarget<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .fmt(f)
             }
@@ -1025,7 +1025,7 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTarget<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .fmt(f)
             }
@@ -1044,7 +1044,7 @@ impl<'a> Format<'a> for AstNode<'a, SimpleAssignmentTarget<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             SimpleAssignmentTarget::TSAsExpression(inner) => allocator
@@ -1052,7 +1052,7 @@ impl<'a> Format<'a> for AstNode<'a, SimpleAssignmentTarget<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             SimpleAssignmentTarget::TSSatisfiesExpression(inner) => allocator
@@ -1060,7 +1060,7 @@ impl<'a> Format<'a> for AstNode<'a, SimpleAssignmentTarget<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             SimpleAssignmentTarget::TSNonNullExpression(inner) => allocator
@@ -1068,7 +1068,7 @@ impl<'a> Format<'a> for AstNode<'a, SimpleAssignmentTarget<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             SimpleAssignmentTarget::TSTypeAssertion(inner) => allocator
@@ -1076,7 +1076,7 @@ impl<'a> Format<'a> for AstNode<'a, SimpleAssignmentTarget<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             it @ match_member_expression!(SimpleAssignmentTarget) => {
@@ -1086,7 +1086,7 @@ impl<'a> Format<'a> for AstNode<'a, SimpleAssignmentTarget<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .fmt(f)
             }
@@ -1105,7 +1105,7 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTargetPattern<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             AssignmentTargetPattern::ObjectAssignmentTarget(inner) => allocator
@@ -1113,7 +1113,7 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTargetPattern<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -1164,7 +1164,7 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTargetMaybeDefault<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             it @ match_assignment_target!(AssignmentTargetMaybeDefault) => {
@@ -1174,7 +1174,7 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTargetMaybeDefault<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .fmt(f)
             }
@@ -1204,7 +1204,7 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTargetProperty<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             AssignmentTargetProperty::AssignmentTargetPropertyProperty(inner) => allocator
@@ -1212,7 +1212,7 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTargetProperty<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -1336,7 +1336,7 @@ impl<'a> Format<'a> for AstNode<'a, ChainElement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             ChainElement::TSNonNullExpression(inner) => allocator
@@ -1344,7 +1344,7 @@ impl<'a> Format<'a> for AstNode<'a, ChainElement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             it @ match_member_expression!(ChainElement) => {
@@ -1354,7 +1354,7 @@ impl<'a> Format<'a> for AstNode<'a, ChainElement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .fmt(f)
             }
@@ -1394,7 +1394,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Statement::BreakStatement(inner) => allocator
@@ -1402,7 +1402,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Statement::ContinueStatement(inner) => allocator
@@ -1410,7 +1410,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Statement::DebuggerStatement(inner) => allocator
@@ -1418,7 +1418,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Statement::DoWhileStatement(inner) => allocator
@@ -1426,7 +1426,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Statement::EmptyStatement(inner) => allocator
@@ -1434,7 +1434,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Statement::ExpressionStatement(inner) => allocator
@@ -1442,7 +1442,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Statement::ForInStatement(inner) => allocator
@@ -1450,7 +1450,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Statement::ForOfStatement(inner) => allocator
@@ -1458,7 +1458,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Statement::ForStatement(inner) => allocator
@@ -1466,7 +1466,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Statement::IfStatement(inner) => allocator
@@ -1474,7 +1474,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Statement::LabeledStatement(inner) => allocator
@@ -1482,7 +1482,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Statement::ReturnStatement(inner) => allocator
@@ -1490,7 +1490,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Statement::SwitchStatement(inner) => allocator
@@ -1498,7 +1498,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Statement::ThrowStatement(inner) => allocator
@@ -1506,7 +1506,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Statement::TryStatement(inner) => allocator
@@ -1514,7 +1514,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Statement::WhileStatement(inner) => allocator
@@ -1522,7 +1522,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Statement::WithStatement(inner) => allocator
@@ -1530,7 +1530,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             it @ match_declaration!(Statement) => {
@@ -1540,7 +1540,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .fmt(f)
             }
@@ -1551,7 +1551,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .fmt(f)
             }
@@ -1603,7 +1603,7 @@ impl<'a> Format<'a> for AstNode<'a, Declaration<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Declaration::FunctionDeclaration(inner) => allocator
@@ -1611,7 +1611,7 @@ impl<'a> Format<'a> for AstNode<'a, Declaration<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Declaration::ClassDeclaration(inner) => allocator
@@ -1619,7 +1619,7 @@ impl<'a> Format<'a> for AstNode<'a, Declaration<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Declaration::TSTypeAliasDeclaration(inner) => allocator
@@ -1627,7 +1627,7 @@ impl<'a> Format<'a> for AstNode<'a, Declaration<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Declaration::TSInterfaceDeclaration(inner) => allocator
@@ -1635,7 +1635,7 @@ impl<'a> Format<'a> for AstNode<'a, Declaration<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Declaration::TSEnumDeclaration(inner) => allocator
@@ -1643,7 +1643,7 @@ impl<'a> Format<'a> for AstNode<'a, Declaration<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Declaration::TSModuleDeclaration(inner) => allocator
@@ -1651,7 +1651,7 @@ impl<'a> Format<'a> for AstNode<'a, Declaration<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             Declaration::TSImportEqualsDeclaration(inner) => allocator
@@ -1659,7 +1659,7 @@ impl<'a> Format<'a> for AstNode<'a, Declaration<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -1763,7 +1763,7 @@ impl<'a> Format<'a> for AstNode<'a, ForStatementInit<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             it @ match_expression!(ForStatementInit) => {
@@ -1773,7 +1773,7 @@ impl<'a> Format<'a> for AstNode<'a, ForStatementInit<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .fmt(f)
             }
@@ -1803,7 +1803,7 @@ impl<'a> Format<'a> for AstNode<'a, ForStatementLeft<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             it @ match_assignment_target!(ForStatementLeft) => {
@@ -1813,7 +1813,7 @@ impl<'a> Format<'a> for AstNode<'a, ForStatementLeft<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .fmt(f)
             }
@@ -1990,7 +1990,7 @@ impl<'a> Format<'a> for AstNode<'a, BindingPatternKind<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             BindingPatternKind::ObjectPattern(inner) => allocator
@@ -1998,7 +1998,7 @@ impl<'a> Format<'a> for AstNode<'a, BindingPatternKind<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             BindingPatternKind::ArrayPattern(inner) => allocator
@@ -2006,7 +2006,7 @@ impl<'a> Format<'a> for AstNode<'a, BindingPatternKind<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             BindingPatternKind::AssignmentPattern(inner) => allocator
@@ -2014,7 +2014,7 @@ impl<'a> Format<'a> for AstNode<'a, BindingPatternKind<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -2275,7 +2275,7 @@ impl<'a> Format<'a> for AstNode<'a, ClassElement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             ClassElement::MethodDefinition(inner) => allocator
@@ -2283,7 +2283,7 @@ impl<'a> Format<'a> for AstNode<'a, ClassElement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             ClassElement::PropertyDefinition(inner) => allocator
@@ -2291,7 +2291,7 @@ impl<'a> Format<'a> for AstNode<'a, ClassElement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             ClassElement::AccessorProperty(inner) => allocator
@@ -2299,7 +2299,7 @@ impl<'a> Format<'a> for AstNode<'a, ClassElement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             ClassElement::TSIndexSignature(inner) => allocator
@@ -2307,7 +2307,7 @@ impl<'a> Format<'a> for AstNode<'a, ClassElement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -2369,7 +2369,7 @@ impl<'a> Format<'a> for AstNode<'a, ModuleDeclaration<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             ModuleDeclaration::ExportAllDeclaration(inner) => allocator
@@ -2377,7 +2377,7 @@ impl<'a> Format<'a> for AstNode<'a, ModuleDeclaration<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             ModuleDeclaration::ExportDefaultDeclaration(inner) => allocator
@@ -2385,7 +2385,7 @@ impl<'a> Format<'a> for AstNode<'a, ModuleDeclaration<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             ModuleDeclaration::ExportNamedDeclaration(inner) => allocator
@@ -2393,7 +2393,7 @@ impl<'a> Format<'a> for AstNode<'a, ModuleDeclaration<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             ModuleDeclaration::TSExportAssignment(inner) => allocator
@@ -2401,7 +2401,7 @@ impl<'a> Format<'a> for AstNode<'a, ModuleDeclaration<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             ModuleDeclaration::TSNamespaceExportDeclaration(inner) => allocator
@@ -2409,7 +2409,7 @@ impl<'a> Format<'a> for AstNode<'a, ModuleDeclaration<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -2470,7 +2470,7 @@ impl<'a> Format<'a> for AstNode<'a, ImportDeclarationSpecifier<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             ImportDeclarationSpecifier::ImportDefaultSpecifier(inner) => allocator
@@ -2478,7 +2478,7 @@ impl<'a> Format<'a> for AstNode<'a, ImportDeclarationSpecifier<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             ImportDeclarationSpecifier::ImportNamespaceSpecifier(inner) => allocator
@@ -2486,7 +2486,7 @@ impl<'a> Format<'a> for AstNode<'a, ImportDeclarationSpecifier<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -2565,7 +2565,7 @@ impl<'a> Format<'a> for AstNode<'a, ImportAttributeKey<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             ImportAttributeKey::StringLiteral(inner) => allocator
@@ -2573,7 +2573,7 @@ impl<'a> Format<'a> for AstNode<'a, ImportAttributeKey<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -2641,7 +2641,7 @@ impl<'a> Format<'a> for AstNode<'a, ExportDefaultDeclarationKind<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             ExportDefaultDeclarationKind::ClassDeclaration(inner) => allocator
@@ -2649,7 +2649,7 @@ impl<'a> Format<'a> for AstNode<'a, ExportDefaultDeclarationKind<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             ExportDefaultDeclarationKind::TSInterfaceDeclaration(inner) => allocator
@@ -2657,7 +2657,7 @@ impl<'a> Format<'a> for AstNode<'a, ExportDefaultDeclarationKind<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             it @ match_expression!(ExportDefaultDeclarationKind) => {
@@ -2667,7 +2667,7 @@ impl<'a> Format<'a> for AstNode<'a, ExportDefaultDeclarationKind<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .fmt(f)
             }
@@ -2686,7 +2686,7 @@ impl<'a> Format<'a> for AstNode<'a, ModuleExportName<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             ModuleExportName::IdentifierReference(inner) => allocator
@@ -2694,7 +2694,7 @@ impl<'a> Format<'a> for AstNode<'a, ModuleExportName<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             ModuleExportName::StringLiteral(inner) => allocator
@@ -2702,7 +2702,7 @@ impl<'a> Format<'a> for AstNode<'a, ModuleExportName<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -2945,7 +2945,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXElementName<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             JSXElementName::IdentifierReference(inner) => allocator
@@ -2953,7 +2953,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXElementName<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             JSXElementName::NamespacedName(inner) => allocator
@@ -2961,7 +2961,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXElementName<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             JSXElementName::MemberExpression(inner) => allocator
@@ -2969,7 +2969,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXElementName<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             JSXElementName::ThisExpression(inner) => allocator
@@ -2977,7 +2977,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXElementName<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -3017,7 +3017,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXMemberExpressionObject<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             JSXMemberExpressionObject::MemberExpression(inner) => allocator
@@ -3025,7 +3025,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXMemberExpressionObject<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             JSXMemberExpressionObject::ThisExpression(inner) => allocator
@@ -3033,7 +3033,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXMemberExpressionObject<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -3062,7 +3062,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXExpression<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             it @ match_expression!(JSXExpression) => {
@@ -3072,7 +3072,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXExpression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .fmt(f)
             }
@@ -3102,7 +3102,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXAttributeItem<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             JSXAttributeItem::SpreadAttribute(inner) => allocator
@@ -3110,7 +3110,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXAttributeItem<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -3150,7 +3150,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXAttributeName<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             JSXAttributeName::NamespacedName(inner) => allocator
@@ -3158,7 +3158,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXAttributeName<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -3176,7 +3176,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXAttributeValue<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             JSXAttributeValue::ExpressionContainer(inner) => allocator
@@ -3184,7 +3184,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXAttributeValue<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             JSXAttributeValue::Element(inner) => allocator
@@ -3192,7 +3192,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXAttributeValue<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             JSXAttributeValue::Fragment(inner) => allocator
@@ -3200,7 +3200,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXAttributeValue<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -3229,7 +3229,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXChild<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             JSXChild::Element(inner) => allocator
@@ -3237,7 +3237,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXChild<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             JSXChild::Fragment(inner) => allocator
@@ -3245,7 +3245,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXChild<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             JSXChild::ExpressionContainer(inner) => allocator
@@ -3253,7 +3253,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXChild<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             JSXChild::Spread(inner) => allocator
@@ -3261,7 +3261,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXChild<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -3345,7 +3345,7 @@ impl<'a> Format<'a> for AstNode<'a, TSEnumMemberName<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSEnumMemberName::String(inner) => allocator
@@ -3353,7 +3353,7 @@ impl<'a> Format<'a> for AstNode<'a, TSEnumMemberName<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSEnumMemberName::ComputedString(inner) => allocator
@@ -3361,7 +3361,7 @@ impl<'a> Format<'a> for AstNode<'a, TSEnumMemberName<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSEnumMemberName::ComputedTemplateString(inner) => allocator
@@ -3369,7 +3369,7 @@ impl<'a> Format<'a> for AstNode<'a, TSEnumMemberName<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -3409,7 +3409,7 @@ impl<'a> Format<'a> for AstNode<'a, TSLiteral<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSLiteral::NumericLiteral(inner) => allocator
@@ -3417,7 +3417,7 @@ impl<'a> Format<'a> for AstNode<'a, TSLiteral<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSLiteral::BigIntLiteral(inner) => allocator
@@ -3425,7 +3425,7 @@ impl<'a> Format<'a> for AstNode<'a, TSLiteral<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSLiteral::StringLiteral(inner) => allocator
@@ -3433,7 +3433,7 @@ impl<'a> Format<'a> for AstNode<'a, TSLiteral<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSLiteral::TemplateLiteral(inner) => allocator
@@ -3441,7 +3441,7 @@ impl<'a> Format<'a> for AstNode<'a, TSLiteral<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSLiteral::UnaryExpression(inner) => allocator
@@ -3449,7 +3449,7 @@ impl<'a> Format<'a> for AstNode<'a, TSLiteral<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -3467,7 +3467,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSBigIntKeyword(inner) => allocator
@@ -3475,7 +3475,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSBooleanKeyword(inner) => allocator
@@ -3483,7 +3483,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSIntrinsicKeyword(inner) => allocator
@@ -3491,7 +3491,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSNeverKeyword(inner) => allocator
@@ -3499,7 +3499,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSNullKeyword(inner) => allocator
@@ -3507,7 +3507,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSNumberKeyword(inner) => allocator
@@ -3515,7 +3515,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSObjectKeyword(inner) => allocator
@@ -3523,7 +3523,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSStringKeyword(inner) => allocator
@@ -3531,7 +3531,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSSymbolKeyword(inner) => allocator
@@ -3539,7 +3539,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSUndefinedKeyword(inner) => allocator
@@ -3547,7 +3547,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSUnknownKeyword(inner) => allocator
@@ -3555,7 +3555,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSVoidKeyword(inner) => allocator
@@ -3563,7 +3563,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSArrayType(inner) => allocator
@@ -3571,7 +3571,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSConditionalType(inner) => allocator
@@ -3579,7 +3579,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSConstructorType(inner) => allocator
@@ -3587,7 +3587,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSFunctionType(inner) => allocator
@@ -3595,7 +3595,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSImportType(inner) => allocator
@@ -3603,7 +3603,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSIndexedAccessType(inner) => allocator
@@ -3611,7 +3611,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSInferType(inner) => allocator
@@ -3619,7 +3619,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSIntersectionType(inner) => allocator
@@ -3627,7 +3627,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSLiteralType(inner) => allocator
@@ -3635,7 +3635,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSMappedType(inner) => allocator
@@ -3643,7 +3643,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSNamedTupleMember(inner) => allocator
@@ -3651,7 +3651,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSTemplateLiteralType(inner) => allocator
@@ -3659,7 +3659,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSThisType(inner) => allocator
@@ -3667,7 +3667,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSTupleType(inner) => allocator
@@ -3675,7 +3675,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSTypeLiteral(inner) => allocator
@@ -3683,7 +3683,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSTypeOperatorType(inner) => allocator
@@ -3691,7 +3691,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSTypePredicate(inner) => allocator
@@ -3699,7 +3699,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSTypeQuery(inner) => allocator
@@ -3707,7 +3707,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSTypeReference(inner) => allocator
@@ -3715,7 +3715,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSUnionType(inner) => allocator
@@ -3723,7 +3723,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::TSParenthesizedType(inner) => allocator
@@ -3731,7 +3731,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::JSDocNullableType(inner) => allocator
@@ -3739,7 +3739,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::JSDocNonNullableType(inner) => allocator
@@ -3747,7 +3747,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSType::JSDocUnknownType(inner) => allocator
@@ -3755,7 +3755,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -3924,7 +3924,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTupleElement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSTupleElement::TSRestType(inner) => allocator
@@ -3932,7 +3932,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTupleElement<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             it @ match_ts_type!(TSTupleElement) => {
@@ -3942,7 +3942,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTupleElement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .fmt(f)
             }
@@ -4126,7 +4126,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeName<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSTypeName::QualifiedName(inner) => allocator
@@ -4134,7 +4134,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeName<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSTypeName::ThisExpression(inner) => allocator
@@ -4142,7 +4142,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeName<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -4261,7 +4261,7 @@ impl<'a> Format<'a> for AstNode<'a, TSSignature<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSSignature::TSPropertySignature(inner) => allocator
@@ -4269,7 +4269,7 @@ impl<'a> Format<'a> for AstNode<'a, TSSignature<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSSignature::TSCallSignatureDeclaration(inner) => allocator
@@ -4277,7 +4277,7 @@ impl<'a> Format<'a> for AstNode<'a, TSSignature<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSSignature::TSConstructSignatureDeclaration(inner) => allocator
@@ -4285,7 +4285,7 @@ impl<'a> Format<'a> for AstNode<'a, TSSignature<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSSignature::TSMethodSignature(inner) => allocator
@@ -4293,7 +4293,7 @@ impl<'a> Format<'a> for AstNode<'a, TSSignature<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -4388,7 +4388,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTypePredicateName<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSTypePredicateName::This(inner) => allocator
@@ -4396,7 +4396,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTypePredicateName<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -4425,7 +4425,7 @@ impl<'a> Format<'a> for AstNode<'a, TSModuleDeclarationName<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSModuleDeclarationName::StringLiteral(inner) => allocator
@@ -4433,7 +4433,7 @@ impl<'a> Format<'a> for AstNode<'a, TSModuleDeclarationName<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -4451,7 +4451,7 @@ impl<'a> Format<'a> for AstNode<'a, TSModuleDeclarationBody<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSModuleDeclarationBody::TSModuleBlock(inner) => allocator
@@ -4459,7 +4459,7 @@ impl<'a> Format<'a> for AstNode<'a, TSModuleDeclarationBody<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -4541,7 +4541,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeQueryExprName<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             it @ match_ts_type_name!(TSTypeQueryExprName) => {
@@ -4551,7 +4551,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeQueryExprName<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .fmt(f)
             }
@@ -4581,7 +4581,7 @@ impl<'a> Format<'a> for AstNode<'a, TSImportTypeQualifier<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             TSImportTypeQualifier::QualifiedName(inner) => allocator
@@ -4589,7 +4589,7 @@ impl<'a> Format<'a> for AstNode<'a, TSImportTypeQualifier<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
         }
@@ -4756,7 +4756,7 @@ impl<'a> Format<'a> for AstNode<'a, TSModuleReference<'a>> {
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 })
                 .fmt(f),
             it @ match_ts_type_name!(TSModuleReference) => {
@@ -4766,7 +4766,7 @@ impl<'a> Format<'a> for AstNode<'a, TSModuleReference<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_node: self.following_node,
+                        following_span: self.following_span,
                     })
                     .fmt(f)
             }

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -291,7 +291,7 @@ fn generate_enum_implementation(enum_def: &EnumDef, schema: &Schema) -> TokenStr
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }).fmt(f)
             },
         })
@@ -314,7 +314,7 @@ fn generate_enum_implementation(enum_def: &EnumDef, schema: &Schema) -> TokenStr
                     inner,
                     parent,
                     allocator,
-                    following_node: self.following_node,
+                    following_span: self.following_span,
                 }).fmt(f)
             },
         };


### PR DESCRIPTION
Remove `SiblingNode`; all of the last usages are removed in https://github.com/oxc-project/oxc/pull/14544.