### PR TITLE
refactor(napi/parser, linter/plugins): shorten generated raw transfer deserializer code

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -1,7 +1,7 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
-let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen;
+let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen, parent = null, getLoc;
 const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
   { fromCodePoint } = String,
@@ -13,7 +13,6 @@ const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
       enumerable: true,
     },
   });
-let parent = null, getLoc;
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);

--- a/napi/parser/generated/deserialize/js_parent.js
+++ b/napi/parser/generated/deserialize/js_parent.js
@@ -1,11 +1,10 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
-let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen;
+let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen, parent = null;
 const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
   { fromCodePoint } = String;
-let parent = null;
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);

--- a/napi/parser/generated/deserialize/js_range_parent.js
+++ b/napi/parser/generated/deserialize/js_range_parent.js
@@ -1,11 +1,10 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
-let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen;
+let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen, parent = null;
 const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
   { fromCodePoint } = String;
-let parent = null;
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);

--- a/napi/parser/generated/deserialize/ts_parent.js
+++ b/napi/parser/generated/deserialize/ts_parent.js
@@ -1,11 +1,10 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
-let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen;
+let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen, parent = null;
 const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
   { fromCodePoint } = String;
-let parent = null;
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);

--- a/napi/parser/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/generated/deserialize/ts_range_parent.js
@@ -1,11 +1,10 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
-let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen;
+let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen, parent = null;
 const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
   { fromCodePoint } = String;
-let parent = null;
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -136,6 +136,9 @@ fn generate_deserializers(
     let mut code = format!("
         let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen;
 
+        let parent = null;
+        let getLoc;
+
         const textDecoder = new TextDecoder('utf-8', {{ ignoreBOM: true }}),
             decodeStr = textDecoder.decode.bind(textDecoder),
             {{ fromCodePoint }} = String;
@@ -148,9 +151,6 @@ fn generate_deserializers(
                 enumerable: true,
             }}
         }});
-
-        let parent = null;
-        let getLoc;
 
         export function deserialize(buffer, sourceText, sourceByteLen) {{
             return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);


### PR DESCRIPTION
Tiny improvement to generated code for raw transfer serializers. Make it shorter by grouping `let` statements together.