### PR TITLE
test(linter/plugins): expand tests for module resolution of plugins

### DIFF
--- a/apps/oxlint/test/fixtures/load_paths/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/load_paths/.oxlintrc.json
@@ -9,7 +9,10 @@
     "./plugins/plugin7",
     "plugin8",
     "plugin9",
-    "plugin10"
+    "plugin10",
+    "plugin11",
+    "plugin12",
+    "plugin13"
   ],
   "rules": {
     "plugin1/no-debugger": "error",
@@ -21,6 +24,9 @@
     "plugin7/no-debugger": "error",
     "plugin8/no-debugger": "error",
     "plugin9/no-debugger": "error",
-    "plugin10/no-debugger": "error"
+    "plugin10/no-debugger": "error",
+    "plugin11/no-debugger": "error",
+    "plugin12/no-debugger": "error",
+    "plugin13/no-debugger": "error"
   }
 }

--- a/apps/oxlint/test/fixtures/load_paths/node_modules/plugin11/index.js
+++ b/apps/oxlint/test/fixtures/load_paths/node_modules/plugin11/index.js
@@ -1,0 +1,19 @@
+export default {
+  meta: {
+    name: "plugin11",
+  },
+  rules: {
+    "no-debugger": {
+      create(context) {
+        return {
+          DebuggerStatement(debuggerStatement) {
+            context.report({
+              message: "Unexpected Debugger Statement",
+              node: debuggerStatement,
+            });
+          },
+        };
+      },
+    },
+  },
+};

--- a/apps/oxlint/test/fixtures/load_paths/node_modules/plugin11/package.json
+++ b/apps/oxlint/test/fixtures/load_paths/node_modules/plugin11/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "plugin11",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./index.js"
+    }
+  }
+}

--- a/apps/oxlint/test/fixtures/load_paths/node_modules/plugin12/index.js
+++ b/apps/oxlint/test/fixtures/load_paths/node_modules/plugin12/index.js
@@ -1,0 +1,21 @@
+'use strict';
+
+module.exports = {
+  meta: {
+    name: "plugin12",
+  },
+  rules: {
+    "no-debugger": {
+      create(context) {
+        return {
+          DebuggerStatement(debuggerStatement) {
+            context.report({
+              message: "Unexpected Debugger Statement",
+              node: debuggerStatement,
+            });
+          },
+        };
+      },
+    },
+  },
+};

--- a/apps/oxlint/test/fixtures/load_paths/node_modules/plugin12/package.json
+++ b/apps/oxlint/test/fixtures/load_paths/node_modules/plugin12/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "plugin12",
+  "type": "commonjs",
+  "exports": {
+    ".": {
+      "default": "./index.js"
+    }
+  }
+}

--- a/apps/oxlint/test/fixtures/load_paths/node_modules/plugin13/index.js
+++ b/apps/oxlint/test/fixtures/load_paths/node_modules/plugin13/index.js
@@ -1,0 +1,19 @@
+export default {
+  meta: {
+    name: "plugin13",
+  },
+  rules: {
+    "no-debugger": {
+      create(context) {
+        return {
+          DebuggerStatement(debuggerStatement) {
+            context.report({
+              message: "Unexpected Debugger Statement",
+              node: debuggerStatement,
+            });
+          },
+        };
+      },
+    },
+  },
+};

--- a/apps/oxlint/test/fixtures/load_paths/node_modules/plugin13/package.json
+++ b/apps/oxlint/test/fixtures/load_paths/node_modules/plugin13/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "plugin13",
+  "type": "module",
+  "exports": {
+    ".": {
+      "default": "./index.js"
+    }
+  }
+}

--- a/apps/oxlint/test/fixtures/load_paths/output.snap.md
+++ b/apps/oxlint/test/fixtures/load_paths/output.snap.md
@@ -22,6 +22,24 @@
    : ^^^^^^^^^
    `----
 
+  x plugin11(no-debugger): Unexpected Debugger Statement
+   ,-[files/index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+
+  x plugin12(no-debugger): Unexpected Debugger Statement
+   ,-[files/index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+
+  x plugin13(no-debugger): Unexpected Debugger Statement
+   ,-[files/index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+
   x plugin2(no-debugger): Unexpected Debugger Statement
    ,-[files/index.js:1:1]
  1 | debugger;
@@ -70,7 +88,7 @@
    : ^^^^^^^^^
    `----
 
-Found 1 warning and 10 errors.
+Found 1 warning and 13 errors.
 Finished in Xms on 1 file using X threads.
 ```
 


### PR DESCRIPTION
Follow-on after #14541. Add more tests for module resolution of plugins, including `default` condition.