### PR TITLE
fix(semantic): fix quote handling in jsdoc parser(#13776)

### DIFF
--- a/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
@@ -1109,6 +1109,19 @@ fn test() {
             None,
             None,
         ),
+        (
+            "
+			          /**
+                       * Has single quote ' in comment.
+			           * @returns Foo.
+			           */
+			          function quux () {
+			            return foo;
+			          }
+			      ",
+            None,
+            None,
+        ),
     ];
 
     let fail = vec![

--- a/crates/oxc_semantic/src/jsdoc/parser/jsdoc_tag.rs
+++ b/crates/oxc_semantic/src/jsdoc/parser/jsdoc_tag.rs
@@ -243,7 +243,7 @@ mod test {
                  * @import {T} from '@k6'
                  */",
                 "@import {T} from '@k6'\n                 ",
-            )
+            ),
         ] {
             let allocator = Allocator::default();
             let semantic = build_semantic(&allocator, source_text);

--- a/crates/oxc_semantic/src/jsdoc/parser/jsdoc_tag.rs
+++ b/crates/oxc_semantic/src/jsdoc/parser/jsdoc_tag.rs
@@ -229,6 +229,21 @@ mod test {
                 "@k3 c3\n                 ",
             ),
             ("/** single line @k4 c4 */", "@k4 c4 "),
+            (
+                "
+                /**
+                 * Has single quote ' in comment
+                 * @k5 c5
+                 */",
+                "@k5 c5\n                 ",
+            ),
+            (
+                "
+                /**
+                 * @import {T} from '@k6'
+                 */",
+                "@import {T} from '@k6'\n                 ",
+            )
         ] {
             let allocator = Allocator::default();
             let semantic = build_semantic(&allocator, source_text);

--- a/crates/oxc_semantic/src/jsdoc/parser/parse.rs
+++ b/crates/oxc_semantic/src/jsdoc/parser/parse.rs
@@ -81,7 +81,7 @@ pub fn parse_jsdoc(
             '\n' => {
                 in_double_quotes = false;
                 in_single_quotes = false;
-            },
+            }
             '{' => curly_brace_depth += 1,
             '}' => curly_brace_depth = curly_brace_depth.saturating_sub(1),
             '(' => brace_depth += 1,

--- a/crates/oxc_semantic/src/jsdoc/parser/parse.rs
+++ b/crates/oxc_semantic/src/jsdoc/parser/parse.rs
@@ -78,6 +78,10 @@ pub fn parse_jsdoc(
             }
             '"' => in_double_quotes = !in_double_quotes,
             '\'' => in_single_quotes = !in_single_quotes,
+            '\n' => {
+                in_double_quotes = false;
+                in_single_quotes = false;
+            },
             '{' => curly_brace_depth += 1,
             '}' => curly_brace_depth = curly_brace_depth.saturating_sub(1),
             '(' => brace_depth += 1,


### PR DESCRIPTION
Fixed #13776 