### PR TITLE
fix(oxlintrc): resolve relative plugin specifiers before merging extended configs

### DIFF
--- a/apps/oxlint/test/e2e.test.ts
+++ b/apps/oxlint/test/e2e.test.ts
@@ -15,6 +15,8 @@ interface TestOptions {
   snapshotName?: string;
   // Function to get extra data to include in the snapshot
   getExtraSnapshotData?: (dirPath: string) => Promise<{ [key: string]: string }>;
+
+  overrideFiles?: string;
 }
 
 /**
@@ -29,7 +31,7 @@ async function testFixture(fixtureName: string, options?: TestOptions): Promise<
     // Use current NodeJS executable, rather than `node`, to avoid problems with a Node version manager
     // installed on system resulting in using wrong NodeJS version
     command: process.execPath,
-    args: [CLI_PATH, ...args, 'files'],
+    args: [CLI_PATH, ...args, options?.overrideFiles ?? 'files'],
     fixtureName,
     snapshotName: options?.snapshotName ?? 'output',
     getExtraSnapshotData: options?.getExtraSnapshotData,
@@ -71,6 +73,12 @@ describe('oxlint CLI', () => {
 
   it('should load a custom plugin with multiple files', async () => {
     await testFixture('basic_custom_plugin_many_files');
+  });
+
+  it('should load a custom plugin correctly when extending in a nested config', async () => {
+    await testFixture('custom_plugin_nested_config', {
+      overrideFiles: '.',
+    });
   });
 
   it('should load a custom plugin when configured in overrides', async () => {

--- a/apps/oxlint/test/fixtures/custom_plugin_nested_config/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_nested_config/.oxlintrc.json
@@ -1,0 +1,7 @@
+{
+  "jsPlugins": ["./plugin.ts"],
+  "rules": {
+    "basic-custom-plugin/no-debugger": "error"
+  },
+  "categories": { "correctness": "off" }
+}

--- a/apps/oxlint/test/fixtures/custom_plugin_nested_config/nested/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_nested_config/nested/.oxlintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../.oxlintrc.json"]
+}

--- a/apps/oxlint/test/fixtures/custom_plugin_nested_config/nested/index.ts
+++ b/apps/oxlint/test/fixtures/custom_plugin_nested_config/nested/index.ts
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/fixtures/custom_plugin_nested_config/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_nested_config/output.snap.md
@@ -1,0 +1,20 @@
+# Exit code
+1
+
+# stdout
+```
+  x basic-custom-plugin(no-debugger): Unexpected Debugger Statement
+   ,-[nested/index.ts:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+
+Found 0 warnings and 1 error.
+Finished in Xms on 2 files using X threads.
+```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/custom_plugin_nested_config/plugin.ts
+++ b/apps/oxlint/test/fixtures/custom_plugin_nested_config/plugin.ts
@@ -1,0 +1,23 @@
+import type { Plugin } from '../../../dist/index.js';
+
+const plugin: Plugin = {
+  meta: {
+    name: 'basic-custom-plugin',
+  },
+  rules: {
+    'no-debugger': {
+      create(context) {
+        return {
+          DebuggerStatement(debuggerStatement) {
+            context.report({
+              message: 'Unexpected Debugger Statement',
+              node: debuggerStatement,
+            });
+          },
+        };
+      },
+    },
+  },
+};
+
+export default plugin;

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -153,29 +153,28 @@ impl Oxlintrc {
         config.path = path.to_path_buf();
 
         // resolve relative paths
-        if let Some(external_plugins) = &mut config.external_plugins {
-            if let Some(config_dir) = config.path.parent() {
-                *external_plugins = std::mem::take(external_plugins)
-                    .into_iter()
-                    .map(|specifier| {
-                        let is_relative =
-                            specifier.starts_with("./") || specifier.starts_with("../");
-                        if is_relative {
-                            config_dir
-                                .join(&specifier)
-                                .into_os_string()
-                                .into_string()
-                                // there is a corner case where this can fail
-                                // for non-utf8 paths, this relative plugin specifier
-                                // may be resolved relative to the wrong config file
-                                // when two are merged.
-                                .unwrap_or(specifier.clone())
-                        } else {
-                            specifier
-                        }
-                    })
-                    .collect();
-            }
+        if let Some(external_plugins) = &mut config.external_plugins
+            && let Some(config_dir) = config.path.parent()
+        {
+            *external_plugins = std::mem::take(external_plugins)
+                .into_iter()
+                .map(|specifier| {
+                    let is_relative = specifier.starts_with("./") || specifier.starts_with("../");
+                    if is_relative {
+                        config_dir
+                            .join(&specifier)
+                            .into_os_string()
+                            .into_string()
+                            // there is a corner case where this can fail
+                            // for non-utf8 paths, this relative plugin specifier
+                            // may be resolved relative to the wrong config file
+                            // when two are merged.
+                            .unwrap_or(specifier)
+                    } else {
+                        specifier
+                    }
+                })
+                .collect();
         }
         Ok(config)
     }


### PR DESCRIPTION
- Fixes #14478
## What's going wrong
- Relative specifiers need to joined with their config's directory path.
- When extended configs are merged. we drop the "other" config's path.
- In this "extends" case, the plugins from the "other" config are resolved relative to the "self" config's path. That shouldn't happen.

## Fix
- All relative specifiers are resolved _before_ the merge.
- Since full platform-specific (correct) paths to the plugin are logged when loading fails, this won't work well with the snapshot tests.

<img width="898" height="249" alt="image" src="https://github.com/user-attachments/assets/7e4d0fa1-c0c1-4dc5-8135-dbf663900902" />

I am vacillating on this solution. Maybe external_plugin should be an enum.