### PR TITLE
refactor(formatter): simplify foramtting import and export

### DIFF
--- a/crates/oxc_formatter/src/generated/format.rs
+++ b/crates/oxc_formatter/src/generated/format.rs
@@ -2496,39 +2496,33 @@ impl<'a> Format<'a> for AstNode<'a, ImportDeclarationSpecifier<'a>> {
 impl<'a> Format<'a> for AstNode<'a, ImportSpecifier<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if is_suppressed {
-            self.format_leading_comments(f)?;
-            FormatSuppressedNode(self.span()).fmt(f)?;
-            self.format_trailing_comments(f)
-        } else {
-            self.write(f)
-        }
+        self.format_leading_comments(f)?;
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        self.format_trailing_comments(f)?;
+        result
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ImportDefaultSpecifier<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if is_suppressed {
-            self.format_leading_comments(f)?;
-            FormatSuppressedNode(self.span()).fmt(f)?;
-            self.format_trailing_comments(f)
-        } else {
-            self.write(f)
-        }
+        self.format_leading_comments(f)?;
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        self.format_trailing_comments(f)?;
+        result
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ImportNamespaceSpecifier<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if is_suppressed {
-            self.format_leading_comments(f)?;
-            FormatSuppressedNode(self.span()).fmt(f)?;
-            self.format_trailing_comments(f)
-        } else {
-            self.write(f)
-        }
+        self.format_leading_comments(f)?;
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        self.format_trailing_comments(f)?;
+        result
     }
 }
 
@@ -2620,13 +2614,11 @@ impl<'a> Format<'a> for AstNode<'a, ExportAllDeclaration<'a>> {
 impl<'a> Format<'a> for AstNode<'a, ExportSpecifier<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if is_suppressed {
-            self.format_leading_comments(f)?;
-            FormatSuppressedNode(self.span()).fmt(f)?;
-            self.format_trailing_comments(f)
-        } else {
-            self.write(f)
-        }
+        self.format_leading_comments(f)?;
+        let result =
+            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        self.format_trailing_comments(f)?;
+        result
     }
 }
 

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -31,10 +31,6 @@ const AST_NODE_WITHOUT_PRINTING_COMMENTS_LIST: &[&str] = &[
     "JSXFragment",
     //
     "TemplateElement",
-    "ImportSpecifier",
-    "ImportDefaultSpecifier",
-    "ImportNamespaceSpecifier",
-    "ExportSpecifier",
 ];
 
 const AST_NODE_NEEDS_PARENTHESES: &[&str] = &[


### PR DESCRIPTION
Benefits from the changes of https://github.com/oxc-project/oxc/pull/14110, we don't need to print all remaining comments before `}` in import and export