### PR TITLE
perf(linter): run `no-class-assign` on class nodes instead of symbols

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -200,8 +200,9 @@ impl RuleRunner for crate::rules::eslint::no_case_declarations::NoCaseDeclaratio
 }
 
 impl RuleRunner for crate::rules::eslint::no_class_assign::NoClassAssign {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnSymbol;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Class]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::eslint::no_compare_neg_zero::NoCompareNegZero {


### PR DESCRIPTION
Enables skipping by node type. Marginally faster for files that don't contain a class.