### PR TITLE
perf(linter): use top-level match for `const-comparisons`

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -1854,7 +1854,8 @@ impl RuleRunner for crate::rules::oxc::branches_sharing_code::BranchesSharingCod
 }
 
 impl RuleRunner for crate::rules::oxc::const_comparisons::ConstComparisons {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression, AstType::LogicalExpression]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 


### PR DESCRIPTION
Using a match means we only need to call one function instead of two. Also enables the linter codegen to analyze this rule.