### PR TITLE
perf(linter): support `as_*` for node type codegen

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -304,7 +304,8 @@ impl RuleRunner for crate::rules::eslint::no_dupe_keys::NoDupeKeys {
 }
 
 impl RuleRunner for crate::rules::eslint::no_duplicate_case::NoDuplicateCase {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::SwitchStatement]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -1967,12 +1968,14 @@ impl RuleRunner for crate::rules::promise::catch_or_return::CatchOrReturn {
 }
 
 impl RuleRunner for crate::rules::promise::no_callback_in_promise::NoCallbackInPromise {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::promise::no_multiple_resolved::NoMultipleResolved {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::NewExpression]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 


### PR DESCRIPTION
Enables the linter codegen to recognize code like `let foo = node.kind().as_ast_kind() else { return };` and generate the relevant AST kinds.

<img width="724" height="429" alt="Screenshot 2025-10-13 at 11 30 46 PM" src="https://github.com/user-attachments/assets/8b71b44a-c22a-48c4-80c7-6d96f4960ca0" />
