### PR TITLE
fix(oxlint,oxfmt): Skip traversing `.git` directories

### DIFF
--- a/apps/oxlint/src/walk.rs
+++ b/apps/oxlint/src/walk.rs
@@ -52,6 +52,11 @@ impl ignore::ParallelVisitor for WalkCollector {
     fn visit(&mut self, entry: Result<ignore::DirEntry, ignore::Error>) -> ignore::WalkState {
         match entry {
             Ok(entry) => {
+                // Skip traversing `.git` directories because `.git` is not a special case for `.hidden(false)`.
+                // <https://github.com/BurntSushi/ripgrep/issues/3099#issuecomment-3052460027>
+                if entry.file_type().is_some_and(|ty| ty.is_dir()) && entry.file_name() == ".git" {
+                    return ignore::WalkState::Skip;
+                }
                 if Walk::is_wanted_entry(&entry, &self.extensions) {
                     self.paths.push(entry.path().as_os_str().into());
                 }


### PR DESCRIPTION
fixes #13315

`.git` is not a special case for `.hidden(false)`.

See https://github.com/BurntSushi/ripgrep/issues/3099#issuecomment-3052460027

Only tested this manually, can't really create a reproduction ...