### PR TITLE
fix(linter): `unicorn/filename-case` report only on the first js block for `astro`, `vue` and `svelte` files

### DIFF
--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -194,6 +194,11 @@ impl<'a> ContextHost<'a> {
         &mut self.sub_hosts[self.current_sub_host_index.get()]
     }
 
+    // Whether the current sub host is the first one.
+    pub fn is_first_sub_host(&self) -> bool {
+        self.current_sub_host_index.get() == 0
+    }
+
     /// Shared reference to the [`Semantic`] analysis of current script block.
     #[inline]
     pub fn semantic(&self) -> &Semantic<'a> {

--- a/crates/oxc_linter/src/snapshots/unicorn_filename_case.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_filename_case.snap
@@ -160,3 +160,10 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[filename_case.tsx:1:1]
    ╰────
   help: Rename the file to 'foo-bar.tsx'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab case
+   ╭─[filename_case.tsx:1:9]
+ 1 │ <script></script><script setup></script>
+   ·         ▲
+   ╰────
+  help: Rename the file to 'foo-bar.vue'


### PR DESCRIPTION
before:
reported for each `<script>` block, the diagnostic
after:
only for the first `<script>` block.