### PR TITLE
refactor(language_server): use Message span for Diagnostic's Range

### DIFF
--- a/crates/oxc_language_server/src/linter/error_with_position.rs
+++ b/crates/oxc_language_server/src/linter/error_with_position.rs
@@ -67,15 +67,9 @@ pub fn message_to_lsp_diagnostic(
             .collect()
     });
 
-    let range = message.error.labels.as_ref().map_or(Range::default(), |labels| {
-        let offset = labels.first().map(|span| span.offset() as u32).unwrap_or_default();
-        let length = labels.first().map(|span| span.len() as u32).unwrap_or_default();
-
-        let start_position = offset_to_position(rope, offset, source_text);
-        let end_position = offset_to_position(rope, offset + length, source_text);
-
-        Range::new(start_position, end_position)
-    });
+    let start_position = offset_to_position(rope, message.span().start, source_text);
+    let end_position = offset_to_position(rope, message.span().end, source_text);
+    let range = Range::new(start_position, end_position);
 
     let code = message.error.code.to_string();
     let code_description = message


### PR DESCRIPTION
~~Now the language server can use the primary span for the diagnostic. This was not possible before.
The idea came from @camc314 in a previous PR, when I refactored away the `MessageWithPosition` struct~~

Use the message span, it is already the primary span