### PR TITLE
refactor(linter): make `Message.span` public

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2171,7 +2171,6 @@ dependencies = [
  "oxc_formatter",
  "oxc_linter",
  "oxc_parser 0.95.0",
- "oxc_span 0.95.0",
  "papaya",
  "rustc-hash",
  "serde",

--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -28,7 +28,6 @@ oxc_diagnostics = { workspace = true }
 oxc_formatter = { workspace = true }
 oxc_linter = { workspace = true, features = ["language_server"] }
 oxc_parser = { workspace = true }
-oxc_span = { workspace = true }
 
 #
 env_logger = { workspace = true, features = ["humantime"] }

--- a/crates/oxc_language_server/src/linter/error_with_position.rs
+++ b/crates/oxc_language_server/src/linter/error_with_position.rs
@@ -8,7 +8,6 @@ use tower_lsp_server::lsp_types::{
 use oxc_data_structures::rope::{Rope, get_line_column};
 use oxc_diagnostics::{OxcCode, Severity};
 use oxc_linter::{Fix, Message, PossibleFixes};
-use oxc_span::GetSpan;
 
 #[derive(Debug, Clone, Default)]
 pub struct DiagnosticReport {
@@ -67,8 +66,8 @@ pub fn message_to_lsp_diagnostic(
             .collect()
     });
 
-    let start_position = offset_to_position(rope, message.span().start, source_text);
-    let end_position = offset_to_position(rope, message.span().end, source_text);
+    let start_position = offset_to_position(rope, message.span.start, source_text);
+    let end_position = offset_to_position(rope, message.span.end, source_text);
     let range = Range::new(start_position, end_position);
 
     let code = message.error.code.to_string();
@@ -114,13 +113,13 @@ pub fn message_to_lsp_diagnostic(
     };
 
     // Add ignore fixes
-    let error_offset = message.span().start;
+    let error_offset = message.span.start;
     let section_offset = message.section_offset;
 
     // If the error is exactly at the section offset and has 0 span length, it means that the file is the problem
     // and attaching a ignore comment would not ignore the error.
     // This is because the ignore comment would need to be placed before the error offset, which is not possible.
-    if error_offset == section_offset && message.span().end == section_offset {
+    if error_offset == section_offset && message.span.end == section_offset {
         return DiagnosticReport { diagnostic, fixed_content };
     }
 

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -8,7 +8,7 @@ use oxc_ast::ast::IdentifierReference;
 use oxc_cfg::ControlFlowGraph;
 use oxc_diagnostics::{OxcDiagnostic, Severity};
 use oxc_semantic::Semantic;
-use oxc_span::{GetSpan, Span};
+use oxc_span::Span;
 
 #[cfg(debug_assertions)]
 use crate::rule::RuleFixMeta;
@@ -223,7 +223,7 @@ impl<'a> LintContext<'a> {
     /// Add a diagnostic message to the list of diagnostics. Outputs a diagnostic with the current rule
     /// name, severity, and a link to the rule's documentation URL.
     fn add_diagnostic(&self, mut message: Message) {
-        if self.parent.disable_directives().contains(self.current_rule_name, message.span()) {
+        if self.parent.disable_directives().contains(self.current_rule_name, message.span) {
             return;
         }
         message.error = message

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -221,7 +221,7 @@ pub struct FixResult<'a> {
 pub struct Message {
     pub error: OxcDiagnostic,
     pub fixes: PossibleFixes,
-    span: Span,
+    pub span: Span,
     fixed: bool,
     #[cfg(feature = "language_server")]
     pub section_offset: u32,

--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -855,7 +855,7 @@ pub fn try_find_tsgolint_executable(cwd: &Path) -> Result<PathBuf, String> {
 #[cfg(feature = "language_server")]
 mod test {
     use oxc_diagnostics::{LabeledSpan, OxcCode, Severity};
-    use oxc_span::{GetSpan, Span};
+    use oxc_span::Span;
 
     use crate::{
         fixer::{Message, PossibleFixes},
@@ -881,7 +881,7 @@ mod test {
 
         assert_eq!(message.error.message, "Some description");
         assert_eq!(message.error.severity, Severity::Warning);
-        assert_eq!(message.span(), Span::new(0, 10));
+        assert_eq!(message.span, Span::new(0, 10));
         assert_eq!(
             message.error.code,
             OxcCode { scope: Some("typescript-eslint".into()), number: Some("some_rule".into()) }


### PR DESCRIPTION
just a bit of refactoring. The `GetSpan` trait is still available for:
https://github.com/oxc-project/oxc/blob/e7c2748614453e7db707e53896e63f728bbc26b7/crates/oxc_linter/src/fixer/mod.rs#L374-L375