### PR TITLE
ci(oxfmt): Stop uploading assets for immutable release

### DIFF
--- a/.github/workflows/release_oxfmt.yml
+++ b/.github/workflows/release_oxfmt.yml
@@ -197,10 +197,8 @@ jobs:
           body: ${{ steps.run.outputs.CHANGELOG }}
           prerelease: true
           draft: false
-          files: oxfmt-*
           name: oxfmt v${{ needs.check.outputs.version }}
           tag_name: oxfmt_v${{ needs.check.outputs.version }}
-          fail_on_unmatched_files: true
           target_commitish: ${{ github.sha }}
 
       - name: wait 3 minutes for smoke test


### PR DESCRIPTION
Refs #14603 , hopefully fixes https://github.com/oxc-project/oxc/actions/runs/18490169265

Now, the only difference with `oxlint`'s workflow is the `prerelease: true`.