### PR TITLE
fix(napi/minify): s/passes/max_iterations to avoid confusion

### DIFF
--- a/napi/minify/index.d.ts
+++ b/napi/minify/index.d.ts
@@ -61,7 +61,7 @@ export interface CompressOptions {
    */
   sequences?: boolean
   /** Limit the maximum number of iterations for debugging purpose. */
-  passes?: number
+  maxIterations?: number
 }
 
 export interface CompressOptionsKeepNames {

--- a/napi/minify/src/options.rs
+++ b/napi/minify/src/options.rs
@@ -53,7 +53,7 @@ pub struct CompressOptions {
     pub sequences: Option<bool>,
 
     /// Limit the maximum number of iterations for debugging purpose.
-    pub passes: Option<u8>,
+    pub max_iterations: Option<u8>,
 }
 
 impl TryFrom<&CompressOptions> for oxc_minifier::CompressOptions {
@@ -81,7 +81,7 @@ impl TryFrom<&CompressOptions> for oxc_minifier::CompressOptions {
             },
             keep_names: o.keep_names.as_ref().map(Into::into).unwrap_or_default(),
             treeshake: TreeShakeOptions::default(),
-            max_iterations: o.passes,
+            max_iterations: o.max_iterations,
         })
     }
 }


### PR DESCRIPTION
`max_iterations` does not behave like `passes`, and may change in the future.

It should only be used for debugging purposes, as said on the
comment.