### PR TITLE
perf(linter): update `no-const-assign` to run on nodes instead of symbols

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -229,8 +229,11 @@ impl RuleRunner for crate::rules::eslint::no_console::NoConsole {
 }
 
 impl RuleRunner for crate::rules::eslint::no_const_assign::NoConstAssign {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnSymbol;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::BindingRestElement,
+        AstType::VariableDeclarator,
+    ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner

--- a/crates/oxc_linter/src/snapshots/eslint_no_const_assign.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_const_assign.snap
@@ -136,3 +136,67 @@ source: crates/oxc_linter/src/tester.rs
    ·       │              ╰── b is re-assigned here
    ·       ╰── b is declared here as const
    ╰────
+
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+   ╭─[no_const_assign.tsx:1:7]
+ 1 │ using x = foo(); x = 1;
+   ·       ┬          ┬
+   ·       │          ╰── x is re-assigned here
+   ·       ╰── x is declared here as const
+   ╰────
+
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+   ╭─[no_const_assign.tsx:1:13]
+ 1 │ await using x = foo(); x = 1;
+   ·             ┬          ┬
+   ·             │          ╰── x is re-assigned here
+   ·             ╰── x is declared here as const
+   ╰────
+
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+   ╭─[no_const_assign.tsx:1:7]
+ 1 │ using x = foo(); x ??= bar();
+   ·       ┬          ┬
+   ·       │          ╰── x is re-assigned here
+   ·       ╰── x is declared here as const
+   ╰────
+
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+   ╭─[no_const_assign.tsx:1:13]
+ 1 │ await using x = foo(); x ||= bar();
+   ·             ┬          ┬
+   ·             │          ╰── x is re-assigned here
+   ·             ╰── x is declared here as const
+   ╰────
+
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+   ╭─[no_const_assign.tsx:1:7]
+ 1 │ using x = foo(); [x, y] = bar();
+   ·       ┬           ┬
+   ·       │           ╰── x is re-assigned here
+   ·       ╰── x is declared here as const
+   ╰────
+
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+   ╭─[no_const_assign.tsx:1:13]
+ 1 │ await using x = foo(); [x = baz, y] = bar();
+   ·             ┬           ┬
+   ·             │           ╰── x is re-assigned here
+   ·             ╰── x is declared here as const
+   ╰────
+
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+   ╭─[no_const_assign.tsx:1:7]
+ 1 │ using x = foo(); ({a: x} = bar());
+   ·       ┬               ┬
+   ·       │               ╰── x is re-assigned here
+   ·       ╰── x is declared here as const
+   ╰────
+
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+   ╭─[no_const_assign.tsx:1:13]
+ 1 │ await using x = foo(); ({a: x = baz} = bar());
+   ·             ┬               ┬
+   ·             │               ╰── x is re-assigned here
+   ·             ╰── x is declared here as const
+   ╰────


### PR DESCRIPTION
Allows optimization of this lint rule based on node types referenced. Also adds some additional test cases and support for `using` and `await using`, for parity with the ESLint version of this rule.