### PR TITLE
perf(linter): update linter codegen to support wildcard with empty tuple

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -152,7 +152,8 @@ impl RuleRunner for crate::rules::eslint::max_params::MaxParams {
 }
 
 impl RuleRunner for crate::rules::eslint::new_cap::NewCap {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::NewExpression]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -953,7 +954,12 @@ impl RuleRunner for crate::rules::eslint::unicode_bom::UnicodeBom {
 }
 
 impl RuleRunner for crate::rules::eslint::use_isnan::UseIsnan {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::BinaryExpression,
+        AstType::CallExpression,
+        AstType::SwitchCase,
+        AstType::SwitchStatement,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -1269,7 +1275,8 @@ impl RuleRunner for crate::rules::jest::no_test_prefixes::NoTestPrefixes {
 }
 
 impl RuleRunner for crate::rules::jest::no_test_return_statement::NoTestReturnStatement {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::Function]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -2071,7 +2078,8 @@ impl RuleRunner for crate::rules::react::exhaustive_deps::ExhaustiveDeps {
 }
 
 impl RuleRunner for crate::rules::react::forbid_elements::ForbidElements {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::JSXOpeningElement]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -2171,7 +2179,8 @@ impl RuleRunner for crate::rules::react::jsx_props_no_spread_multi::JsxPropsNoSp
 }
 
 impl RuleRunner for crate::rules::react::no_array_index_key::NoArrayIndexKey {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::JSXElement]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -2188,7 +2197,8 @@ impl RuleRunner for crate::rules::react::no_danger::NoDanger {
 }
 
 impl RuleRunner for crate::rules::react::no_danger_with_children::NoDangerWithChildren {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::JSXElement]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/tasks/linter_codegen/src/match_detector.rs
+++ b/tasks/linter_codegen/src/match_detector.rs
@@ -65,9 +65,15 @@ impl MatchDetector {
                 }
             }
             Pat::Wild(_) => {
-                // Body must be completely empty.
+                // Body must be completely empty, or return empty type only `()`
                 if let Expr::Block(block) = &*arm.body {
                     if block.block.stmts.is_empty() {
+                        CollectionResult::Complete
+                    } else {
+                        CollectionResult::Incomplete
+                    }
+                } else if let Expr::Tuple(tuple) = &*arm.body {
+                    if tuple.elems.is_empty() {
                         CollectionResult::Complete
                     } else {
                         CollectionResult::Incomplete


### PR DESCRIPTION
Returning `()` in the wildcard of a match block like `match node.kind() { ... }` is effectively the same as `_ => {}`, we just didn't support this syntax yet.

+1-2% on the linter benchmarks.

<img width="717" height="373" alt="Screenshot 2025-10-14 at 11 51 51 PM" src="https://github.com/user-attachments/assets/5c5b03f0-15b2-4a2f-b7e5-ab57c61634b5" />
