### PR TITLE
feat(oxfmt): Use Prettier style config key and value

### DIFF
--- a/apps/oxfmt/tests/fixtures/config_file/.oxfmtrc.json
+++ b/apps/oxfmt/tests/fixtures/config_file/.oxfmtrc.json
@@ -1,3 +1,3 @@
 {
-  "semicolons": "always"
+  "semi": true
 }

--- a/apps/oxfmt/tests/fixtures/config_file/fmt.json
+++ b/apps/oxfmt/tests/fixtures/config_file/fmt.json
@@ -1,3 +1,3 @@
 {
-  "semicolons": "always"
+  "semi": true
 }

--- a/apps/oxfmt/tests/fixtures/config_file/fmt.jsonc
+++ b/apps/oxfmt/tests/fixtures/config_file/fmt.jsonc
@@ -1,4 +1,4 @@
 {
   // Supports JSONC!
-  "semicolons": "always"
+  "semi": true
 }

--- a/apps/oxfmt/tests/fixtures/config_file/nested/.oxfmtrc.jsonc
+++ b/apps/oxfmt/tests/fixtures/config_file/nested/.oxfmtrc.jsonc
@@ -1,3 +1,3 @@
 {
-  "semicolons": "always"
+  "semi": true
 }

--- a/crates/oxc_formatter/tests/snapshots/schema_json.snap
+++ b/crates/oxc_formatter/tests/snapshots/schema_json.snap
@@ -5,15 +5,10 @@ expression: json
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Oxfmtrc",
+  "description": "Configuration options for the formatter.\nMost options are the same as Prettier's options.\nSee also <https://prettier.io/docs/options>",
   "type": "object",
   "properties": {
-    "arrowParentheses": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "attributePosition": {
+    "arrowParens": {
       "type": [
         "string",
         "null"
@@ -31,7 +26,7 @@ expression: json
         "null"
       ]
     },
-    "expand": {
+    "endOfLine": {
       "type": [
         "string",
         "null"
@@ -53,33 +48,19 @@ expression: json
         }
       ]
     },
-    "indentStyle": {
+    "jsxSingleQuote": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "objectWrap": {
       "type": [
         "string",
         "null"
       ]
     },
-    "indentWidth": {
-      "type": [
-        "integer",
-        "null"
-      ],
-      "format": "uint8",
-      "minimum": 0.0
-    },
-    "jsxQuoteStyle": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "lineEnding": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "lineWidth": {
+    "printWidth": {
       "type": [
         "integer",
         "null"
@@ -87,27 +68,47 @@ expression: json
       "format": "uint16",
       "minimum": 0.0
     },
-    "quoteProperties": {
+    "quoteProps": {
       "type": [
         "string",
         "null"
       ]
     },
-    "quoteStyle": {
+    "semi": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "singleAttributePerLine": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "singleQuote": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "tabWidth": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint8",
+      "minimum": 0.0
+    },
+    "trailingComma": {
       "type": [
         "string",
         "null"
       ]
     },
-    "semicolons": {
+    "useTabs": {
       "type": [
-        "string",
-        "null"
-      ]
-    },
-    "trailingCommas": {
-      "type": [
-        "string",
+        "boolean",
         "null"
       ]
     }

--- a/crates/oxc_language_server/fixtures/formatter/custom_config_path/format.json
+++ b/crates/oxc_language_server/fixtures/formatter/custom_config_path/format.json
@@ -1,3 +1,3 @@
 {
-  "semicolons": "as-needed"
+  "semi": false
 }

--- a/crates/oxc_language_server/fixtures/formatter/root_config/.oxfmtrc.json
+++ b/crates/oxc_language_server/fixtures/formatter/root_config/.oxfmtrc.json
@@ -1,3 +1,3 @@
 {
-  "semicolons": "as-needed"
+  "semi": false
 }

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -1,15 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Oxfmtrc",
+  "description": "Configuration options for the formatter.\nMost options are the same as Prettier's options.\nSee also <https://prettier.io/docs/options>",
   "type": "object",
   "properties": {
-    "arrowParentheses": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "attributePosition": {
+    "arrowParens": {
       "type": [
         "string",
         "null"
@@ -27,7 +22,7 @@
         "null"
       ]
     },
-    "expand": {
+    "endOfLine": {
       "type": [
         "string",
         "null"
@@ -49,33 +44,19 @@
         }
       ]
     },
-    "indentStyle": {
+    "jsxSingleQuote": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "objectWrap": {
       "type": [
         "string",
         "null"
       ]
     },
-    "indentWidth": {
-      "type": [
-        "integer",
-        "null"
-      ],
-      "format": "uint8",
-      "minimum": 0.0
-    },
-    "jsxQuoteStyle": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "lineEnding": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "lineWidth": {
+    "printWidth": {
       "type": [
         "integer",
         "null"
@@ -83,27 +64,47 @@
       "format": "uint16",
       "minimum": 0.0
     },
-    "quoteProperties": {
+    "quoteProps": {
       "type": [
         "string",
         "null"
       ]
     },
-    "quoteStyle": {
+    "semi": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "singleAttributePerLine": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "singleQuote": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "tabWidth": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint8",
+      "minimum": 0.0
+    },
+    "trailingComma": {
       "type": [
         "string",
         "null"
       ]
     },
-    "semicolons": {
+    "useTabs": {
       "type": [
-        "string",
-        "null"
-      ]
-    },
-    "trailingCommas": {
-      "type": [
-        "string",
+        "boolean",
         "null"
       ]
     }


### PR DESCRIPTION
Fixes #14591 

`Oxfmtrc` format is now compatible with Prettier's configuration file.

e.g. `{ "semicolons": "as-needed" }` -> `{ "semi": false }`

Note about a few exceptions:

- `endOfLine: "auto"` is not supported
- `quoteProps: "consistent"` is not supported
- `objectWrap: "always"` is also supported in addition to "preserve" and "collapse"