### PR TITLE
feat(transformer_plugins): add changed field to InjectGlobalVariablesReturn

### DIFF
--- a/crates/oxc_transformer_plugins/tests/integrations/inject_global_variables.rs
+++ b/crates/oxc_transformer_plugins/tests/integrations/inject_global_variables.rs
@@ -18,7 +18,8 @@ fn test(source_text: &str, expected: &str, config: InjectGlobalVariablesConfig) 
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let mut program = ret.program;
     let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
-    let _ = InjectGlobalVariables::new(&allocator, config).build(scoping, &mut program);
+    let ret = InjectGlobalVariables::new(&allocator, config).build(scoping, &mut program);
+    assert_eq!(ret.changed, source_text != expected);
     let result = Codegen::new()
         .with_options(CodegenOptions { single_quote: true, ..CodegenOptions::default() })
         .build(&program)


### PR DESCRIPTION
## Summary

Add a `changed: bool` field to `InjectGlobalVariablesReturn` to track whether the AST was modified during the global variable injection transformation.

- Adds `changed` field to `InjectGlobalVariablesReturn` struct
- Tracks changes via consolidated `mark_as_changed()` helper method
- Updates `replace_dot_defines` when dot define replacements occur
- Updates `inject_imports` when import statements are injected
- Updates `build` method to return `changed` in all paths

This allows callers to efficiently determine if injections or replacements were made without needing to compare the AST before and after transformation.

## Test plan

- [x] All existing tests pass
- [x] No new tests needed - change tracking is straightforward

🤖 Generated with [Claude Code](https://claude.com/claude-code)