### PR TITLE
fix(linter): improve `jest/no_export` heuristic

### DIFF
--- a/crates/oxc_linter/src/rules/jest/no_export.rs
+++ b/crates/oxc_linter/src/rules/jest/no_export.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::context::LintContext;
 use crate::rule::Rule;
 use crate::utils::{
-    JestFnKind, JestGeneralFnKind, collect_possible_jest_call_node, is_jest_file,
+    JestFnKind, JestGeneralFnKind, is_jest_file, iter_possible_jest_call_node,
     parse_general_jest_fn_call,
 };
 
@@ -55,10 +55,10 @@ impl Rule for NoExport {
             return;
         }
 
-        // `collect_possible_jest_call_node` yields uses of `JEST_METHOD_NAMES`.
+        // `iter_possible_jest_call_node` yields uses of `JEST_METHOD_NAMES`.
         // We focus on "fit", "it", "test", "xit", and "xtest" (JestGeneralFnKind::Test).
         // Presence of any of these is taken to mean the module has tests, and the rule should enforce no exports.
-        let has_tests = collect_possible_jest_call_node(ctx).into_iter().any(|possible_node| {
+        let has_tests = iter_possible_jest_call_node(ctx).any(|possible_node| {
             let AstKind::CallExpression(call_expr) = possible_node.node.kind() else {
                 return false;
             };


### PR DESCRIPTION
- Closes #14592 
- The diagnostic was reported for `typescript-make-units-from-test.ts` because `jest/no_export` checks if the file name ends with `test.ts`, not if it ends with `.test.ts`.
- A quick fix would be to change the file name criteria, but checking for a test brings the rule closer to `eslint-plugin-jest` behavior.
- Direct edits from maintainers welcome.

### Before
<img width="744" height="222" alt="image" src="https://github.com/user-attachments/assets/3fa1248b-8709-443d-a0da-35858bbf1873" />

### After
<img width="744" height="93" alt="image" src="https://github.com/user-attachments/assets/3ec9f2df-d86a-41ce-a7f8-eac3a8ed9138" />

_The `oxlint-disable-next` directive was removed for these screenshots._