### PR TITLE
feat(ast_tools): add `#[estree(no_parent)]` attribute

### DIFF
--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -94,6 +94,7 @@ fn parse_estree_attr(location: AttrLocation, part: AttrPart) -> Result<()> {
             AttrPart::Tag("flatten") => struct_def.estree.flatten = true,
             AttrPart::Tag("no_type") => struct_def.estree.no_type = true,
             AttrPart::Tag("no_ts_def") => struct_def.estree.no_ts_def = true,
+            AttrPart::Tag("no_parent") => struct_def.estree.no_parent = true,
             AttrPart::List("add_fields", list) => {
                 for list_element in list {
                     let (name, value) = list_element.try_into_string()?;

--- a/tasks/ast_tools/src/schema/extensions/estree.rs
+++ b/tasks/ast_tools/src/schema/extensions/estree.rs
@@ -31,6 +31,8 @@ pub struct ESTreeStruct {
     /// Additional custom TS type definition to add along with the generated one.
     /// Does not include `export`.
     pub add_ts_def: Option<String>,
+    /// If `true`
+    pub no_parent: bool,
 }
 
 /// Configuration for ESTree generator on an enum.


### PR DESCRIPTION
Add support for `#[estree(no_parent)]` attribute, which tells raw transfer codegen not to add `parent` field to a struct. We use this in #14624 to remove `parent` field from `Comment`.