### PR TITLE
refactor(napi/parser): shorten raw transfer deserializer for `Comment`

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -5579,9 +5579,8 @@ function deserializeComment(pos) {
       end,
       range: [start, end],
       parent,
-    },
-    endCut = type === 'Line' ? 0 : 2;
-  node.value = sourceText.slice(start + 2, end - endCut);
+    };
+  node.value = sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2));
   parent = previousParent;
   return node;
 }

--- a/crates/oxc_ast/src/serialize/mod.rs
+++ b/crates/oxc_ast/src/serialize/mod.rs
@@ -235,10 +235,7 @@ fn get_ts_start_span(program: &Program<'_>) -> u32 {
 #[ast_meta]
 #[estree(
     ts_type = "string",
-    raw_deser = "
-        const endCut = THIS.type === 'Line' ? 0 : 2;
-        SOURCE_TEXT.slice(THIS.start + 2, THIS.end - endCut)
-    "
+    raw_deser = "SOURCE_TEXT.slice(THIS.start + 2, THIS.end - (THIS.type === 'Line' ? 0 : 2))"
 )]
 pub struct CommentValue<'b>(#[expect(dead_code)] pub &'b Comment);
 

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -4187,9 +4187,8 @@ function deserializeComment(pos) {
       value: null,
       start,
       end,
-    },
-    endCut = type === 'Line' ? 0 : 2;
-  node.value = sourceText.slice(start + 2, end - endCut);
+    };
+  node.value = sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2));
   return node;
 }
 

--- a/napi/parser/generated/deserialize/js_parent.js
+++ b/napi/parser/generated/deserialize/js_parent.js
@@ -4914,9 +4914,8 @@ function deserializeComment(pos) {
       start,
       end,
       parent,
-    },
-    endCut = type === 'Line' ? 0 : 2;
-  node.value = sourceText.slice(start + 2, end - endCut);
+    };
+  node.value = sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2));
   parent = previousParent;
   return node;
 }

--- a/napi/parser/generated/deserialize/js_range.js
+++ b/napi/parser/generated/deserialize/js_range.js
@@ -4605,9 +4605,8 @@ function deserializeComment(pos) {
       start,
       end,
       range: [start, end],
-    },
-    endCut = type === 'Line' ? 0 : 2;
-  node.value = sourceText.slice(start + 2, end - endCut);
+    };
+  node.value = sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2));
   return node;
 }
 

--- a/napi/parser/generated/deserialize/js_range_parent.js
+++ b/napi/parser/generated/deserialize/js_range_parent.js
@@ -5128,9 +5128,8 @@ function deserializeComment(pos) {
       end,
       range: [start, end],
       parent,
-    },
-    endCut = type === 'Line' ? 0 : 2;
-  node.value = sourceText.slice(start + 2, end - endCut);
+    };
+  node.value = sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2));
   parent = previousParent;
   return node;
 }

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -4449,9 +4449,8 @@ function deserializeComment(pos) {
       value: null,
       start,
       end,
-    },
-    endCut = type === 'Line' ? 0 : 2;
-  node.value = sourceText.slice(start + 2, end - endCut);
+    };
+  node.value = sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2));
   return node;
 }
 

--- a/napi/parser/generated/deserialize/ts_parent.js
+++ b/napi/parser/generated/deserialize/ts_parent.js
@@ -5180,9 +5180,8 @@ function deserializeComment(pos) {
       start,
       end,
       parent,
-    },
-    endCut = type === 'Line' ? 0 : 2;
-  node.value = sourceText.slice(start + 2, end - endCut);
+    };
+  node.value = sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2));
   parent = previousParent;
   return node;
 }

--- a/napi/parser/generated/deserialize/ts_range.js
+++ b/napi/parser/generated/deserialize/ts_range.js
@@ -4865,9 +4865,8 @@ function deserializeComment(pos) {
       start,
       end,
       range: [start, end],
-    },
-    endCut = type === 'Line' ? 0 : 2;
-  node.value = sourceText.slice(start + 2, end - endCut);
+    };
+  node.value = sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2));
   return node;
 }
 

--- a/napi/parser/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/generated/deserialize/ts_range_parent.js
@@ -5401,9 +5401,8 @@ function deserializeComment(pos) {
       end,
       range: [start, end],
       parent,
-    },
-    endCut = type === 'Line' ? 0 : 2;
-  node.value = sourceText.slice(start + 2, end - endCut);
+    };
+  node.value = sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2));
   parent = previousParent;
   return node;
 }


### PR DESCRIPTION
Pure refactor. Shorten the raw transfer code for `Comment`, removing an unnecessary temp var. This also prepares the way for #14624, working around a bug in the codegen where preamble can get inserted after code that uses vars defined in that preamble.