### PR TITLE
fix(linter/plugins): remove `parent` property from comments

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -5567,22 +5567,15 @@ function deserializeCommentKind(pos) {
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12),
-    start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
-    node = parent = {
-      __proto__: NodeProto,
-      type,
-      value: null,
-      start,
-      end,
-      range: [start, end],
-      parent,
-    };
-  node.value = sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2));
-  parent = previousParent;
-  return node;
+  let type = deserializeCommentKind(pos + 12), start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  return {
+    __proto__: NodeProto,
+    type,
+    value: sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2)),
+    start,
+    end,
+    range: [start, end],
+  };
 }
 
 function deserializeNameSpan(pos) {

--- a/crates/oxc_ast/src/ast/comment.rs
+++ b/crates/oxc_ast/src/ast/comment.rs
@@ -123,7 +123,7 @@ impl<'alloc> CloneIn<'alloc> for CommentNewlines {
 #[ast]
 #[generate_derive(CloneIn, ContentEq, ESTree)]
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
-#[estree(add_fields(value = CommentValue), no_ts_def)]
+#[estree(add_fields(value = CommentValue), no_ts_def, no_parent)]
 pub struct Comment {
     /// The span of the comment text, with leading and trailing delimiters.
     pub span: Span,

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -4179,17 +4179,13 @@ function deserializeCommentKind(pos) {
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12),
-    start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type,
-      value: null,
-      start,
-      end,
-    };
-  node.value = sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2));
-  return node;
+  let type = deserializeCommentKind(pos + 12), start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  return {
+    type,
+    value: sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2)),
+    start,
+    end,
+  };
 }
 
 function deserializeNameSpan(pos) {

--- a/napi/parser/generated/deserialize/js_parent.js
+++ b/napi/parser/generated/deserialize/js_parent.js
@@ -4904,20 +4904,13 @@ function deserializeCommentKind(pos) {
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12),
-    start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
-    node = parent = {
-      type,
-      value: null,
-      start,
-      end,
-      parent,
-    };
-  node.value = sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2));
-  parent = previousParent;
-  return node;
+  let type = deserializeCommentKind(pos + 12), start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  return {
+    type,
+    value: sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2)),
+    start,
+    end,
+  };
 }
 
 function deserializeNameSpan(pos) {

--- a/napi/parser/generated/deserialize/js_range.js
+++ b/napi/parser/generated/deserialize/js_range.js
@@ -4596,18 +4596,14 @@ function deserializeCommentKind(pos) {
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12),
-    start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type,
-      value: null,
-      start,
-      end,
-      range: [start, end],
-    };
-  node.value = sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2));
-  return node;
+  let type = deserializeCommentKind(pos + 12), start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  return {
+    type,
+    value: sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2)),
+    start,
+    end,
+    range: [start, end],
+  };
 }
 
 function deserializeNameSpan(pos) {

--- a/napi/parser/generated/deserialize/js_range_parent.js
+++ b/napi/parser/generated/deserialize/js_range_parent.js
@@ -5117,21 +5117,14 @@ function deserializeCommentKind(pos) {
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12),
-    start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
-    node = parent = {
-      type,
-      value: null,
-      start,
-      end,
-      range: [start, end],
-      parent,
-    };
-  node.value = sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2));
-  parent = previousParent;
-  return node;
+  let type = deserializeCommentKind(pos + 12), start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  return {
+    type,
+    value: sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2)),
+    start,
+    end,
+    range: [start, end],
+  };
 }
 
 function deserializeNameSpan(pos) {

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -4441,17 +4441,13 @@ function deserializeCommentKind(pos) {
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12),
-    start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type,
-      value: null,
-      start,
-      end,
-    };
-  node.value = sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2));
-  return node;
+  let type = deserializeCommentKind(pos + 12), start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  return {
+    type,
+    value: sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2)),
+    start,
+    end,
+  };
 }
 
 function deserializeNameSpan(pos) {

--- a/napi/parser/generated/deserialize/ts_parent.js
+++ b/napi/parser/generated/deserialize/ts_parent.js
@@ -5170,20 +5170,13 @@ function deserializeCommentKind(pos) {
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12),
-    start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
-    node = parent = {
-      type,
-      value: null,
-      start,
-      end,
-      parent,
-    };
-  node.value = sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2));
-  parent = previousParent;
-  return node;
+  let type = deserializeCommentKind(pos + 12), start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  return {
+    type,
+    value: sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2)),
+    start,
+    end,
+  };
 }
 
 function deserializeNameSpan(pos) {

--- a/napi/parser/generated/deserialize/ts_range.js
+++ b/napi/parser/generated/deserialize/ts_range.js
@@ -4856,18 +4856,14 @@ function deserializeCommentKind(pos) {
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12),
-    start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type,
-      value: null,
-      start,
-      end,
-      range: [start, end],
-    };
-  node.value = sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2));
-  return node;
+  let type = deserializeCommentKind(pos + 12), start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  return {
+    type,
+    value: sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2)),
+    start,
+    end,
+    range: [start, end],
+  };
 }
 
 function deserializeNameSpan(pos) {

--- a/napi/parser/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/generated/deserialize/ts_range_parent.js
@@ -5390,21 +5390,14 @@ function deserializeCommentKind(pos) {
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12),
-    start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
-    node = parent = {
-      type,
-      value: null,
-      start,
-      end,
-      range: [start, end],
-      parent,
-    };
-  node.value = sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2));
-  parent = previousParent;
-  return node;
+  let type = deserializeCommentKind(pos + 12), start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  return {
+    type,
+    value: sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2)),
+    start,
+    end,
+    range: [start, end],
+  };
 }
 
 function deserializeNameSpan(pos) {


### PR DESCRIPTION
Part of #14564.

#14589 added first part of support for comments-related APIs in Oxlint JS plugins, but `Comment` objects had an extraneous `parent` field. This PR removes that field, using the `#[estree(no_parent)]` attribute (added in #14622).
