### PR TITLE
fix(linter/plugins): add `comments` field to TS type def for `Program`

### DIFF
--- a/apps/oxlint/src-js/generated/types.d.ts
+++ b/apps/oxlint/src-js/generated/types.d.ts
@@ -1,14 +1,15 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/typescript.rs`.
 
-import { Span } from '../plugins/types.ts';
-export { Span };
+import { Comment, Span } from '../plugins/types.ts';
+export { Comment, Span };
 
 export interface Program extends Span {
   type: 'Program';
   body: Array<Directive | Statement>;
   sourceType: ModuleKind;
   hashbang: Hashbang | null;
+  comments: Comment[];
   parent?: null;
 }
 

--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -161,8 +161,6 @@ export const SOURCE_CODE = Object.freeze({
   getAllComments(): Comment[] {
     if (ast === null) initAst();
     // TODO: Deserializing strings is expensive, make this access lazy
-    // @ts-expect-error types are generated from `Program` attributes
-    // which are also twinned with ESTree generation so can't touch it
     return ast.comments;
   },
 


### PR DESCRIPTION
#14589 added `comments` field to `Program` in Oxlint JS plugins AST. Add this field to the TS type def for `Program`.