### PR TITLE
perf(linter): update `react/prefer-es6-class` to use top-level match

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2263,7 +2263,8 @@ impl RuleRunner for crate::rules::react::only_export_components::OnlyExportCompo
 }
 
 impl RuleRunner for crate::rules::react::prefer_es6_class::PreferEs6Class {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::Class]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
@@ -61,20 +61,22 @@ impl Rule for PreferEs6Class {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if matches!(self.prefer_es6_class_option, PreferES6ClassOptionType::Always) {
-            if is_es5_component(node) {
-                let AstKind::CallExpression(call_expr) = node.kind() else {
-                    return;
-                };
+        match node.kind() {
+            AstKind::CallExpression(call_expr)
+                if matches!(self.prefer_es6_class_option, PreferES6ClassOptionType::Always)
+                    && is_es5_component(node) =>
+            {
                 ctx.diagnostic(expected_es6_class_diagnostic(call_expr.callee.span()));
             }
-        } else if is_es6_component(node) {
-            let AstKind::Class(class_expr) = node.kind() else {
-                return;
-            };
-            ctx.diagnostic(unexpected_es6_class_diagnostic(
-                class_expr.id.as_ref().map_or(class_expr.span, |id| id.span),
-            ));
+            AstKind::Class(class_expr)
+                if !matches!(self.prefer_es6_class_option, PreferES6ClassOptionType::Always)
+                    && is_es6_component(node) =>
+            {
+                ctx.diagnostic(unexpected_es6_class_diagnostic(
+                    class_expr.id.as_ref().map_or(class_expr.span, |id| id.span),
+                ));
+            }
+            _ => {}
         }
     }
 


### PR DESCRIPTION
Simple refactor to make the code style here a bit more consistent with other lint rules and also take advantage of the linter codegen analysis.

+1% perf on the radix UI benchmark.