### PR TITLE
feat(minifier): add `drop_labels` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,6 +2352,7 @@ dependencies = [
  "oxc_parser 0.95.0",
  "oxc_sourcemap 6.0.0",
  "oxc_span 0.95.0",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/crates/oxc_minifier/src/options.rs
+++ b/crates/oxc_minifier/src/options.rs
@@ -1,4 +1,5 @@
 use oxc_compat::EngineTargets;
+use rustc_hash::FxHashSet;
 
 pub use oxc_ecmascript::side_effects::PropertyReadSideEffects;
 
@@ -44,6 +45,13 @@ pub struct CompressOptions {
     /// <https://rollupjs.org/configuration-options/#treeshake>
     pub treeshake: TreeShakeOptions,
 
+    /// Set of label names to drop from the code.
+    ///
+    /// Labeled statements matching these names will be removed during minification.
+    ///
+    /// Default: empty (no labels dropped)
+    pub drop_labels: FxHashSet<String>,
+
     /// Limit the maximum number of iterations for debugging purpose.
     pub max_iterations: Option<u8>,
 }
@@ -65,6 +73,7 @@ impl CompressOptions {
             sequences: true,
             unused: CompressOptionsUnused::Remove,
             treeshake: TreeShakeOptions::default(),
+            drop_labels: FxHashSet::default(),
             max_iterations: None,
         }
     }
@@ -79,6 +88,7 @@ impl CompressOptions {
             sequences: true,
             unused: CompressOptionsUnused::Keep,
             treeshake: TreeShakeOptions::default(),
+            drop_labels: FxHashSet::default(),
             max_iterations: None,
         }
     }
@@ -93,6 +103,7 @@ impl CompressOptions {
             sequences: false,
             unused: CompressOptionsUnused::Remove,
             treeshake: TreeShakeOptions::default(),
+            drop_labels: FxHashSet::default(),
             max_iterations: None,
         }
     }

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -197,6 +197,13 @@ impl<'a> PeepholeOptimizations {
     pub fn try_fold_labeled(stmt: &mut Statement<'a>, ctx: &mut Ctx<'a, '_>) {
         let Statement::LabeledStatement(s) = stmt else { return };
         let id = s.label.name.as_str();
+
+        if ctx.options().drop_labels.contains(id) {
+            *stmt = ctx.ast.statement_empty(s.span);
+            ctx.state.changed = true;
+            return;
+        }
+
         // Check the first statement in the block, or just the `break [id] ` statement.
         // Check if we need to remove the whole block.
         match &mut s.body {

--- a/napi/minify/Cargo.toml
+++ b/napi/minify/Cargo.toml
@@ -34,6 +34,7 @@ oxc_span = { workspace = true }
 
 napi = { workspace = true }
 napi-derive = { workspace = true }
+rustc-hash = { workspace = true }
 
 [target.'cfg(not(any(target_os = "linux", target_os = "freebsd", target_arch = "arm", target_family = "wasm")))'.dependencies]
 mimalloc-safe = { workspace = true, optional = true, features = ["skip_collect_on_exit"] }

--- a/napi/minify/src/options.rs
+++ b/napi/minify/src/options.rs
@@ -3,6 +3,7 @@ use napi_derive::napi;
 
 use oxc_compat::EngineTargets;
 use oxc_minifier::TreeShakeOptions;
+use rustc_hash::FxHashSet;
 
 #[napi(object)]
 pub struct CompressOptions {
@@ -81,6 +82,7 @@ impl TryFrom<&CompressOptions> for oxc_minifier::CompressOptions {
             },
             keep_names: o.keep_names.as_ref().map(Into::into).unwrap_or_default(),
             treeshake: TreeShakeOptions::default(),
+            drop_labels: FxHashSet::default(),
             max_iterations: o.max_iterations,
         })
     }


### PR DESCRIPTION
Implemented `drop_labels` feature, which is implemented in [esbuild](https://esbuild.github.io/api/#drop-labels) and [rolldown](https://rolldown.rs/apis/config-options#droplabels).
The plan is to use this in Rolldown.
