### PR TITLE
feat(linter): add eslint/constructor-super rule

### DIFF
--- a/apps/oxlint/src/snapshots/_--ignore-path fixtures__linter__.customignore --no-ignore fixtures__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-path fixtures__linter__.customignore --no-ignore fixtures__linter__nan.js@oxlint.snap
@@ -21,7 +21,7 @@ working directory:
   help: Use the isNaN function to compare with NaN.
 
 Found 2 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--ignore-pattern _____.js --ignore-pattern _____.vue fixtures__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-pattern _____.js --ignore-pattern _____.vue fixtures__linter@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --ignore-pattern **/*.js --ignore-pattern **/*.vue fixtures/linter
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 89 rules using 1 threads.
+Finished in <variable>ms on 0 files with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--import-plugin -A all -D no-cycle fixtures__flow__@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--import-plugin -A all -D no-cycle fixtures__flow__@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --import-plugin -A all -D no-cycle fixtures/flow/
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 2 files with 91 rules using 1 threads.
+Finished in <variable>ms on 2 files with 92 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--import-plugin fixtures__flow__index.mjs@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--import-plugin fixtures__flow__index.mjs@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --import-plugin fixtures/flow/index.mjs
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 91 rules using 1 threads.
+Finished in <variable>ms on 1 file with 92 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
@@ -23,7 +23,7 @@ working directory:
   help: Remove the appending `.skip`
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 102 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-D correctness fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-D correctness fixtures__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-W correctness -A no-debugger fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W correctness -A no-debugger fixtures__linter__debugger.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -W correctness -A no-debugger fixtures/linter/debugger.js
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 88 rules using 1 threads.
+Finished in <variable>ms on 1 file with 89 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__eslintrc_env__eslintrc_no_env.json fixtures__eslintrc_env__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__eslintrc_env__eslintrc_no_env.json fixtures__eslintrc_env__test.js@oxlint.snap
@@ -13,7 +13,7 @@ working directory:
    `----
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__no_undef__eslintrc.json fixtures__no_undef__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__no_undef__eslintrc.json fixtures__no_undef__test.js@oxlint.snap
@@ -13,7 +13,7 @@ working directory:
    `----
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension@oxlint.snap
@@ -12,7 +12,7 @@ working directory:
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension__main.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension__main.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/config_ignore_patterns/ignore_extension/eslintrc.json fix
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 89 rules using 1 threads.
+Finished in <variable>ms on 0 files with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_env__eslintrc_env_browser.json fixtures__eslintrc_env__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_env__eslintrc_env_browser.json fixtures__eslintrc_env__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/eslintrc_env/eslintrc_env_browser.json fixtures/eslintrc_
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_off__eslintrc.json fixtures__eslintrc_off__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_off__eslintrc.json fixtures__eslintrc_off__test.js@oxlint.snap
@@ -12,7 +12,7 @@ working directory:
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/eslintrc_vitest_replace/eslintrc.json fixtures/eslintrc_v
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__linter__eslintrc.json fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__linter__eslintrc.json fixtures__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_console_off__eslintrc.json fixtures__no_console_off__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_console_off__eslintrc.json fixtures__no_console_off__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/no_console_off/eslintrc.json fixtures/no_console_off/test
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_empty_allow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_allow_empty_catch__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_empty_allow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_allow_empty_catch__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/no_empty_allow_empty_catch/eslintrc.json -W no-empty fixt
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_empty_disallow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_disallow_empty_catch__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_empty_disallow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_disallow_empty_catch__test.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove this block or add a comment inside it
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.js -c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.ts -c fixtures__overrides__.oxlintrc.json fixtures__overrides__other.jsx@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.js -c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.ts -c fixtures__overrides__.oxlintrc.json fixtures__overrides__other.jsx@oxlint.snap
@@ -15,7 +15,7 @@ working directory:
   help: Replace var with let or const
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 91 rules using 1 threads.
+Finished in <variable>ms on 1 file with 92 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------
@@ -42,7 +42,7 @@ working directory:
   help: Delete this console statement.
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 91 rules using 1 threads.
+Finished in <variable>ms on 1 file with 92 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------
@@ -61,7 +61,7 @@ working directory:
   help: Replace var with let or const
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 91 rules using 1 threads.
+Finished in <variable>ms on 1 file with 92 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__overrides__directories-config.json fixtures__overrides@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__overrides__directories-config.json fixtures__overrides@oxlint.snap
@@ -35,7 +35,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 2 warnings and 2 errors.
-Finished in <variable>ms on 7 files with 88 rules using 1 threads.
+Finished in <variable>ms on 7 files with 89 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json --disable-typescript-plugin fixtures__typescript_eslint__test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json --disable-typescript-plugin fixtures__typescript_eslint__test.ts@oxlint.snap
@@ -31,7 +31,7 @@ working directory:
   help: Consider using this expression or removing it
 
 Found 2 warnings and 1 error.
-Finished in <variable>ms on 1 file with 52 rules using 1 threads.
+Finished in <variable>ms on 1 file with 53 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json fixtures__typescript_eslint__test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json fixtures__typescript_eslint__test.ts@oxlint.snap
@@ -39,7 +39,7 @@ working directory:
   help: Consider using this expression or removing it
 
 Found 3 warnings and 1 error.
-Finished in <variable>ms on 1 file with 64 rules using 1 threads.
+Finished in <variable>ms on 1 file with 65 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__astro__debugger.astro@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__astro__debugger.astro@oxlint.snap
@@ -43,7 +43,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 4 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter@oxlint.snap
@@ -36,7 +36,7 @@ working directory:
   help: Use the isNaN function to compare with NaN.
 
 Found 4 warnings and 0 errors.
-Finished in <variable>ms on 3 files with 89 rules using 1 threads.
+Finished in <variable>ms on 3 files with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js fixtures__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js fixtures__linter__nan.js@oxlint.snap
@@ -28,7 +28,7 @@ working directory:
   help: Use the isNaN function to compare with NaN.
 
 Found 3 warnings and 0 errors.
-Finished in <variable>ms on 2 files with 89 rules using 1 threads.
+Finished in <variable>ms on 2 files with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter__js_as_jsx.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__js_as_jsx.js@oxlint.snap
@@ -15,7 +15,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__svelte__debugger.svelte@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__svelte__debugger.svelte@oxlint.snap
@@ -34,7 +34,7 @@ working directory:
   help: Variable declared without assignment. Either assign a value or remove the declaration.
 
 Found 3 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__vue__debugger.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__vue__debugger.vue@oxlint.snap
@@ -25,7 +25,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 2 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__vue__empty.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__vue__empty.vue@oxlint.snap
@@ -6,7 +6,7 @@ arguments: fixtures/vue/empty.vue
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_foo.asdf@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_foo.asdf@oxlint.snap
@@ -6,7 +6,7 @@ arguments: foo.asdf
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 89 rules using 1 threads.
+Finished in <variable>ms on 0 files with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__ignore_directory_-c eslintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__ignore_directory_-c eslintrc.json@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/config_ignore_patterns/ignore_directory
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__with_oxlintrc_-c .__test__eslintrc.json --ignore-pattern _.ts .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__with_oxlintrc_-c .__test__eslintrc.json --ignore-pattern _.ts .@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c ./test/eslintrc.json --ignore-pattern *.ts .
 working directory: fixtures/config_ignore_patterns/with_oxlintrc
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 89 rules using 1 threads.
+Finished in <variable>ms on 0 files with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__disable_eslint_and_unicorn_alias_rules_-c .oxlintrc-eslint.json test.js -c .oxlintrc-unicorn.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__disable_eslint_and_unicorn_alias_rules_-c .oxlintrc-eslint.json test.js -c .oxlintrc-unicorn.json test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c .oxlintrc-eslint.json test.js
 working directory: fixtures/disable_eslint_and_unicorn_alias_rules
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 52 rules using 1 threads.
+Finished in <variable>ms on 1 file with 53 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------
@@ -16,7 +16,7 @@ arguments: -c .oxlintrc-unicorn.json test.js
 working directory: fixtures/disable_eslint_and_unicorn_alias_rules
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 65 rules using 1 threads.
+Finished in <variable>ms on 1 file with 66 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__dot_folder_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__dot_folder_@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/dot_folder
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--config extends_rules_config.json console.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--config extends_rules_config.json console.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/extends_config
   help: Delete this console statement.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--config relative_paths__extends_extends_config.json console.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--config relative_paths__extends_extends_config.json console.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/extends_config
   help: Delete this console statement.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--disable-nested-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--disable-nested-config@oxlint.snap
@@ -31,7 +31,7 @@ working directory: fixtures/extends_config
   help: Remove the debugger statement
 
 Found 3 warnings and 0 errors.
-Finished in <variable>ms on 4 files with 89 rules using 1 threads.
+Finished in <variable>ms on 4 files with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__import-cycle_--import-plugin -D import__no-cycle@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__import-cycle_--import-plugin -D import__no-cycle@oxlint.snap
@@ -27,7 +27,7 @@ working directory: fixtures/import-cycle
         -> ./b - fixtures/import-cycle/b.ts
 
 Found 0 warnings and 2 errors.
-Finished in <variable>ms on 2 files with 92 rules using 1 threads.
+Finished in <variable>ms on 2 files with 93 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__import_-c .oxlintrc.json test.js -c .oxlintrc-import-x.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__import_-c .oxlintrc.json test.js -c .oxlintrc-import-x.json test.js@oxlint.snap
@@ -15,7 +15,7 @@ working directory: fixtures/import
    `----
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 54 rules using 1 threads.
+Finished in <variable>ms on 1 file with 55 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------
@@ -34,7 +34,7 @@ working directory: fixtures/import
    `----
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 54 rules using 1 threads.
+Finished in <variable>ms on 1 file with 55 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__issue_10394_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__issue_10394_-c .oxlintrc.json@oxlint.snap
@@ -15,7 +15,7 @@ working directory: fixtures/issue_10394
   help: "Write a meaningful title for your test"
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__issue_11054_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__issue_11054_-c .oxlintrc.json@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c .oxlintrc.json
 working directory: fixtures/issue_11054
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__issue_11644_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__issue_11644_-c .oxlintrc.json@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c .oxlintrc.json
 working directory: fixtures/issue_11644
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 161 rules using 1 threads.
+Finished in <variable>ms on 1 file with 162 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__linter_debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__linter_debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/linter
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__overrides_env_globals_-c .oxlintrc.json .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__overrides_env_globals_-c .oxlintrc.json .@oxlint.snap
@@ -51,7 +51,7 @@ working directory: fixtures/overrides_env_globals
    `----
 
 Found 5 warnings and 0 errors.
-Finished in <variable>ms on 3 files with 89 rules using 1 threads.
+Finished in <variable>ms on 3 files with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__overrides_with_plugin_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__overrides_with_plugin_-c .oxlintrc.json@oxlint.snap
@@ -42,7 +42,7 @@ working directory: fixtures/overrides_with_plugin
   help: Consider removing this declaration.
 
 Found 2 warnings and 2 errors.
-Finished in <variable>ms on 2 files with 89 rules using 1 threads.
+Finished in <variable>ms on 2 files with 90 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__report_unused_directives_-c .oxlintrc.json --report-unused-disable-directives@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__report_unused_directives_-c .oxlintrc.json --report-unused-disable-directives@oxlint.snap
@@ -321,7 +321,7 @@ working directory: fixtures/report_unused_directives
     `----
 
 Found 38 warnings and 0 errors.
-Finished in <variable>ms on 5 files with 90 rules using 1 threads.
+Finished in <variable>ms on 5 files with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__tsgolint_disable_directives_--type-aware --report-unused-disable-directives unused.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__tsgolint_disable_directives_--type-aware --report-unused-disable-directives unused.ts@oxlint.snap
@@ -76,7 +76,7 @@ working directory: fixtures/tsgolint_disable_directives
     `----
 
 Found 8 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 103 rules using 1 threads.
+Finished in <variable>ms on 1 file with 104 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__tsgolint_disable_directives_--type-aware test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__tsgolint_disable_directives_--type-aware test.ts@oxlint.snap
@@ -96,7 +96,7 @@ working directory: fixtures/tsgolint_disable_directives
   help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
 
 Found 10 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 103 rules using 1 threads.
+Finished in <variable>ms on 1 file with 104 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__two_rules_with_same_rule_name_-c .oxlintrc.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__two_rules_with_same_rule_name_-c .oxlintrc.json test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c .oxlintrc.json test.js
 working directory: fixtures/two_rules_with_same_rule_name
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 65 rules using 1 threads.
+Finished in <variable>ms on 1 file with 66 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/crates/oxc_cfg/src/visit.rs
+++ b/crates/oxc_cfg/src/visit.rs
@@ -14,6 +14,7 @@ pub fn neighbors_filtered_by_edge_weight<State: Default + Clone, NodeWeight, Edg
     node: BlockNodeId,
     edge_filter: &F,
     visitor: &mut G,
+    allow_revisit: bool,
 ) -> Vec<State>
 where
     F: Fn(&EdgeWeight) -> Option<State>,
@@ -36,7 +37,7 @@ where
         let mut edges = 0;
 
         for edge in graph.edges_directed(graph_ix, Direction::Outgoing) {
-            if visited.contains(&edge.target()) {
+            if !allow_revisit && visited.contains(&edge.target()) {
                 continue;
             }
             if let Some(result_of_edge_filtering) = edge_filter(edge.weight()) {

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -30,6 +30,11 @@ impl RuleRunner for crate::rules::eslint::class_methods_use_this::ClassMethodsUs
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::eslint::constructor_super::ConstructorSuper {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Class]));
+}
+
 impl RuleRunner for crate::rules::eslint::curly::Curly {
     const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
         AstType::DoWhileStatement,

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -44,6 +44,7 @@ pub(crate) mod eslint {
     pub mod arrow_body_style;
     pub mod block_scoped_var;
     pub mod class_methods_use_this;
+    pub mod constructor_super;
     pub mod curly;
     pub mod default_case;
     pub mod default_case_last;
@@ -664,6 +665,7 @@ oxc_macros::declare_all_lint_rules! {
     eslint::arrow_body_style,
     eslint::block_scoped_var,
     eslint::class_methods_use_this,
+    eslint::constructor_super,
     eslint::curly,
     eslint::default_case,
     eslint::default_case_last,

--- a/crates/oxc_linter/src/rules/eslint/constructor_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/constructor_super.rs
@@ -1,0 +1,550 @@
+use oxc_ast::{
+    AstKind,
+    ast::{self, MethodDefinitionKind},
+};
+use oxc_cfg::{
+    BlockNodeId, EdgeType, ErrorEdgeKind, InstructionKind, ReturnInstructionKind,
+    graph::{
+        Direction,
+        visit::{EdgeRef, NodeRef},
+    },
+    visit::neighbors_filtered_by_edge_weight,
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::GetSpan;
+use oxc_span::Span;
+use rustc_hash::FxHashMap;
+
+use crate::{context::LintContext, rule::Rule};
+
+fn constructor_super_diagnostic_unexpected_super(span: Span) -> OxcDiagnostic {
+    // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
+    OxcDiagnostic::warn("Unexpected 'super()' because 'super' is not a constructor.")
+        .with_help("Remove the 'super()' call from the constructor")
+        .with_label(span)
+}
+
+fn constructor_super_diagnostic_missing_some_super(span: Span) -> OxcDiagnostic {
+    // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
+    OxcDiagnostic::warn("Missing a call of 'super()' in some code paths.")
+        .with_help("Add a 'super()' call to the some code paths")
+        .with_label(span)
+}
+
+fn constructor_super_diagnostic_missing_super(span: Span) -> OxcDiagnostic {
+    // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
+    OxcDiagnostic::warn("Missing a call of 'super()' in the constructor.")
+        .with_help("Add a 'super()' call to the constructor")
+        .with_label(span)
+}
+
+fn constructor_super_diagnostic_duplicate_super(span: Span) -> OxcDiagnostic {
+    // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
+    OxcDiagnostic::warn("Duplicate 'super()' call in the constructor.")
+        .with_help("Remove the duplicate 'super()' call from the constructor")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ConstructorSuper;
+
+// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// This rule checks whether or not there is a valid super() call.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Constructors of derived classes must call super(). Constructors of non derived classes must not call super(). If this is not observed, the JavaScript engine will raise a runtime error.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// class A extends B {
+    ///     constructor() { }  // Would throw a ReferenceError.
+    /// }
+
+    /// // Classes which inherits from a non constructor are always problems.
+    /// class C extends null {
+    ///     constructor() {
+    ///         super();  // Would throw a TypeError.
+    ///     }
+    /// }
+
+    /// class D extends null {
+    ///     constructor() { }  // Would throw a ReferenceError.
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// class A {
+    ///     constructor() { }
+    /// }
+
+    /// class B extends C {
+    ///     constructor() {
+    ///         super();
+    ///     }
+    /// }
+    /// ```
+    ConstructorSuper,
+    eslint,
+    correctness, // TODO: change category to `correctness`, `suspicious`, `pedantic`, `perf`, `restriction`, or `style`
+             // See <https://oxc.rs/docs/contribute/linter.html#rule-category> for details
+);
+
+#[derive(Default, Clone, Debug)]
+struct TraverseState {
+    super_called: bool,
+    spans_in_loop: Option<Vec<Span>>,
+    loop_ends_at: Option<BlockNodeId>,
+}
+impl Rule for ConstructorSuper {
+    fn run_once<'a>(&self, ctx: &LintContext<'a>) {
+        let mut basic_blocks_with_super_called = FxHashMap::<BlockNodeId, Span>::default();
+
+        let graph = ctx.cfg().graph();
+
+        // First pass: collect all basic blocks that contain a `super()` call
+        for node in ctx.nodes() {
+            if let AstKind::Super(_) = node.kind()
+                && let AstKind::CallExpression(_) = ctx.nodes().parent_kind(node.id())
+            {
+                let cfg_id = ctx.nodes().cfg_id(node.id());
+                match basic_blocks_with_super_called.entry(cfg_id) {
+                    std::collections::hash_map::Entry::Occupied(_) => {
+                        ctx.diagnostic(constructor_super_diagnostic_duplicate_super(node.span()));
+                    }
+                    std::collections::hash_map::Entry::Vacant(e) => {
+                        e.insert(node.span());
+                    }
+                }
+            }
+        }
+
+        // Second pass: for each constructor, check the rules regarding `super()` calls.
+        // Note: only constructors of classes that have a `super_class` are examined.
+        // We are skipping class with or without valid `super_class` here because
+        // 1. If a class has a valid superclass and no explicit constructor, it implicitly has a constructor that calls `super()`.
+        // 2. If a class has an invalid superclass (e.g. a non-constructor), omitting a constructor is valid because no `super()` call is required.
+        for node in ctx.nodes() {
+            if let AstKind::MethodDefinition(method) = node.kind()
+                && method.kind == MethodDefinitionKind::Constructor
+            {
+                let class_node: Option<&'a ast::Class<'a>> =
+                    ctx.nodes().ancestors(node.id()).find_map(|parent| parent.kind().as_class());
+
+                if let Some(class) = class_node
+                    && let Some(super_class) = &class.super_class
+                {
+                    let is_constructor_like = Self::is_constructor_like(super_class);
+                    let is_valid_superclass = super_class.is_null() || is_constructor_like;
+
+                    let mut has_super_path = false;
+                    let mut has_none_super_path = false;
+
+                    // finding the entry block of the constructor function
+                    let function_entry_block = graph
+                        .edges_directed(ctx.nodes().cfg_id(node.id()), Direction::Outgoing)
+                        .find(|edge| matches!(edge.weight(), EdgeType::NewFunction))
+                        .map(|edge| edge.target())
+                        .expect("Constructor should have a NewFunction edge");
+
+                    neighbors_filtered_by_edge_weight(
+                        graph,
+                        function_entry_block,
+                        &|edge| match edge {
+                            EdgeType::Jump
+                            | EdgeType::Normal
+                            | EdgeType::Finalize
+                            | EdgeType::Error(ErrorEdgeKind::Explicit) => None,
+                            _ => Some(TraverseState::default()),
+                        },
+                        &mut |basic_block_id, mut state| {
+                            let has_super =
+                                basic_blocks_with_super_called.contains_key(basic_block_id);
+
+                            // Mark the start of a loop by its end point.
+                            if let Some(backage) = graph
+                                .edges_directed(*basic_block_id, Direction::Incoming)
+                                .find(|e| matches!(e.weight(), EdgeType::Backedge))
+                            {
+                                state.loop_ends_at = Some(backage.source().id());
+                            }
+
+                            // If we are in a loop and see a `super()` call, record it.
+                            if has_super
+                                && state.loop_ends_at.is_some()
+                                && let Some(span) =
+                                    basic_blocks_with_super_called.get(basic_block_id).copied()
+                            {
+                                match &mut state.spans_in_loop {
+                                    Some(spans) => spans.push(span),
+                                    None => state.spans_in_loop = Some(vec![span]),
+                                }
+                            }
+
+                            // If we reach the end of a loop, report any duplicate `super()` calls in the loop.
+                            if graph
+                                .edges_directed(*basic_block_id, Direction::Outgoing)
+                                .any(|e| matches!(e.weight(), EdgeType::Backedge))
+                            {
+                                state.loop_ends_at = None;
+
+                                for span in state.spans_in_loop.clone().unwrap_or_default() {
+                                    ctx.diagnostic(constructor_super_diagnostic_duplicate_super(
+                                        span,
+                                    ));
+                                }
+                            }
+
+                            // If the current basic block ends with `throw` or `return <expr>`, then it does not lead to any other blocks.
+                            let terminates_abnormally =
+                                ctx.cfg().basic_block(*basic_block_id).instructions().iter().any(
+                                    |inst| {
+                                        matches!(
+                                            inst.kind,
+                                            InstructionKind::Throw
+                                                | InstructionKind::Return(
+                                                    ReturnInstructionKind::NotImplicitUndefined
+                                                )
+                                        )
+                                    },
+                                );
+
+                            if terminates_abnormally {
+                                return (state, false);
+                            }
+
+                            if has_super {
+                                let has_catch_edge = ctx
+                                    .cfg()
+                                    .graph()
+                                    .edges_directed(*basic_block_id, Direction::Outgoing)
+                                    .any(|e| {
+                                        matches!(
+                                            e.weight(),
+                                            EdgeType::Error(ErrorEdgeKind::Explicit)
+                                        )
+                                    });
+
+                                // If there is an outgoing edge to a catch block, the `super()` call may not be executed.
+                                if !has_catch_edge {
+                                    if state.super_called {
+                                        ctx.diagnostic(
+                                            constructor_super_diagnostic_duplicate_super(
+                                                basic_blocks_with_super_called
+                                                    .get(basic_block_id)
+                                                    .copied()
+                                                    .unwrap(),
+                                            ),
+                                        );
+                                    }
+
+                                    state.super_called = true;
+                                }
+
+                                // special handling for null superclass
+                                if !is_valid_superclass {
+                                    ctx.diagnostic(constructor_super_diagnostic_unexpected_super(
+                                        basic_blocks_with_super_called
+                                            .get(basic_block_id)
+                                            .copied()
+                                            .unwrap(),
+                                    ));
+                                }
+                            }
+
+                            let is_end_of_path = graph
+                                .edges_directed(*basic_block_id, Direction::Outgoing)
+                                .all(|e| {
+                                    !matches!(
+                                        e.weight(),
+                                        EdgeType::Normal
+                                            | EdgeType::Jump
+                                            | EdgeType::Backedge
+                                            | EdgeType::Finalize
+                                            | EdgeType::Error(ErrorEdgeKind::Explicit)
+                                    )
+                                });
+
+                            if is_end_of_path {
+                                if state.super_called {
+                                    has_super_path = true;
+                                } else {
+                                    has_none_super_path = true;
+                                }
+                            }
+
+                            (state, true)
+                        },
+                        true,
+                    );
+
+                    if is_valid_superclass && has_super_path && !is_constructor_like {
+                        ctx.diagnostic(constructor_super_diagnostic_unexpected_super(method.span));
+                    }
+
+                    if is_valid_superclass && !has_super_path && has_none_super_path {
+                        ctx.diagnostic(constructor_super_diagnostic_missing_super(method.span));
+                    }
+
+                    if is_valid_superclass && has_super_path && has_none_super_path {
+                        ctx.diagnostic(constructor_super_diagnostic_missing_some_super(
+                            method.span,
+                        ));
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl ConstructorSuper {
+    fn is_constructor_like(expr: &ast::Expression) -> bool {
+        match expr {
+            ast::Expression::Identifier(_)
+            | ast::Expression::FunctionExpression(_)
+            | ast::Expression::NewExpression(_)
+            | ast::Expression::ThisExpression(_)
+            | ast::Expression::YieldExpression(_)
+            | ast::Expression::TaggedTemplateExpression(_)
+            | ast::Expression::MetaProperty(_)
+            | ast::Expression::ChainExpression(_)
+            | ast::Expression::StaticMemberExpression(_)
+            | ast::Expression::ComputedMemberExpression(_)
+            | ast::Expression::PrivateFieldExpression(_)
+            | ast::Expression::ClassExpression(_) => true,
+            ast::Expression::ParenthesizedExpression(paren) => {
+                Self::is_constructor_like(&paren.expression)
+            }
+            ast::Expression::AssignmentExpression(assign) => match assign.operator {
+                ast::AssignmentOperator::Assign | ast::AssignmentOperator::LogicalAnd => {
+                    Self::is_constructor_like(&assign.right)
+                }
+                ast::AssignmentOperator::LogicalOr | ast::AssignmentOperator::LogicalNullish => {
+                    !matches!(
+                        assign.left,
+                        ast::AssignmentTarget::ArrayAssignmentTarget(_)
+                            | ast::AssignmentTarget::ObjectAssignmentTarget(_)
+                    ) || Self::is_constructor_like(&assign.right)
+                }
+                _ => false,
+            },
+            ast::Expression::LogicalExpression(logical) => match logical.operator {
+                ast::LogicalOperator::And => Self::is_constructor_like(&logical.right),
+                _ => {
+                    Self::is_constructor_like(&logical.left)
+                        || Self::is_constructor_like(&logical.right)
+                }
+            },
+            ast::Expression::ConditionalExpression(cond) => {
+                Self::is_constructor_like(&cond.alternate)
+                    || Self::is_constructor_like(&cond.consequent)
+            }
+            ast::Expression::SequenceExpression(seq) => {
+                Self::is_constructor_like(seq.expressions.last().unwrap())
+            }
+            _ => false,
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass: Vec<&'static str> = vec![
+        "class A { }",
+        "class A { constructor() { } }",
+        "class A extends null { }",
+        "class A extends B { }",
+        "class A extends B { constructor() { super(); } }",
+        "class A extends B { constructor() { if (true) { super(); } else { super(); } } }",
+        "class A extends (class B {}) { constructor() { super(); } }",
+        "class A extends (B = C) { constructor() { super(); } }",
+        "class A extends (B &&= C) { constructor() { super(); } }",
+        "class A extends (B ||= C) { constructor() { super(); } }",
+        "class A extends (B ??= C) { constructor() { super(); } }",
+        "class A extends (B ||= 5) { constructor() { super(); } }",
+        "class A extends (B ??= 5) { constructor() { super(); } }",
+        "class A extends (B || C) { constructor() { super(); } }",
+        "class A extends (5 && B) { constructor() { super(); } }",
+        "class A extends (false && B) { constructor() { super(); } }",
+        "class A extends (B || 5) { constructor() { super(); } }",
+        "class A extends (B ?? 5) { constructor() { super(); } }",
+        "class A extends (a ? B : C) { constructor() { super(); } }",
+        "class A extends (B, C) { constructor() { super(); } }",
+        "class A { constructor() { class B extends C { constructor() { super(); } } } }",
+        "class A extends B { constructor() { super(); class C extends D { constructor() { super(); } } } }",
+        "class A extends B { constructor() { super(); class C { constructor() { } } } }",
+        "class A extends B { constructor() { a ? super() : super(); } }",
+        "class A extends B { constructor() { if (a) super(); else super(); } }",
+        "class A extends B { constructor() { switch (a) { case 0: super(); break; default: super(); } } }",
+        "class A extends B { constructor() { try {} finally { super(); } } }",
+        "class A extends B { constructor() { if (a) throw Error(); super(); } }",
+        "class A extends B { constructor() { if (true) return a; super(); } }",
+        "class A extends null { constructor() { return a; } }",
+        "class A { constructor() { return a; } }",
+        "class A extends B { constructor(a) { super(); for (const b of a) { this.a(); } } }",
+        "class A extends B { constructor(a) { super(); for (b in a) ( foo(b) ); } }",
+        "class Foo extends Object { constructor(method) { super(); this.method = method || function() {}; } }",
+        "class A extends Object {
+        	    constructor() {
+        	        super();
+        	        for (let i = 0; i < 0; i++);
+        	    }
+        	}
+        	",
+        "class A extends Object {
+        	    constructor() {
+        	        super();
+        	        for (; i < 0; i++);
+        	    }
+        	}
+        	",
+        "class A extends Object {
+        	    constructor() {
+        	        super();
+        	        for (let i = 0;; i++) {
+        	            if (foo) break;
+        	        }
+        	    }
+        	}
+        	",
+        "class A extends Object {
+        	    constructor() {
+        	        super();
+        	        for (let i = 0; i < 0;);
+        	    }
+        	}
+        	",
+        "class A extends Object {
+        	    constructor() {
+        	        super();
+        	        for (let i = 0;;) {
+        	            if (foo) break;
+        	        }
+        	    }
+        	}
+        	",
+        "
+        	            class A extends B {
+        	                constructor(props) {
+        	                    super(props);
+
+        	                    try {
+        	                        let arr = [];
+        	                        for (let a of arr) {
+        	                        }
+        	                    } catch (err) {
+        	                    }
+        	                }
+        	            }
+        	        ",
+        "class A extends obj?.prop { constructor() { super(); } }",
+        "
+        	            class A extends Base {
+        	                constructor(list) {
+        	                    for (const a of list) {
+        	                        if (a.foo) {
+        	                            super(a);
+        	                            return;
+        	                        }
+        	                    }
+        	                    super();
+        	                }
+        	            }
+        	        ",
+    ];
+
+    let fail = vec![
+        "class A extends null { constructor() { super(); } }",
+        "class A extends null { constructor() { } }",
+        "class A extends 100 { constructor() { super(); } }",
+        "class A extends 'test' { constructor() { super(); } }",
+        "class A extends (B = 5) { constructor() { super(); } }",
+        "class A extends (B && 5) { constructor() { super(); } }",
+        "class A extends (B &&= 5) { constructor() { super(); } }",
+        "class A extends (B += C) { constructor() { super(); } }",
+        "class A extends (B -= C) { constructor() { super(); } }",
+        "class A extends (B **= C) { constructor() { super(); } }",
+        "class A extends (B |= C) { constructor() { super(); } }",
+        "class A extends (B &= C) { constructor() { super(); } }",
+        "class A extends B { constructor() { } }",
+        "class A extends B { constructor() { for (var a of b) super.foo(); } }",
+        "class A extends B { constructor() { for (var i = 1; i < 10; i++) super.foo(); } }",
+        "class A extends B { constructor() { var c = class extends D { constructor() { super(); } } } }",
+        "class A extends B { constructor() { var c = () => super(); } }",
+        "class A extends B { constructor() { class C extends D { constructor() { super(); } } } }",
+        "class A extends B { constructor() { var C = class extends D { constructor() { super(); } } } }",
+        "class A extends B { constructor() { super(); class C extends D { constructor() { } } } }",
+        "class A extends B { constructor() { super(); var C = class extends D { constructor() { } } } }",
+        "class A extends B { constructor() { if (a) super(); } }",
+        "class A extends B { constructor() { if (a); else super(); } }",
+        "class A extends B { constructor() { a && super(); } }",
+        "class A extends B { constructor() { switch (a) { case 0: super(); } } }",
+        "class A extends B { constructor() { switch (a) { case 0: break; default: super(); } } }",
+        "class A extends B { constructor() { try { super(); } catch (err) {} } }",
+        "class A extends B { constructor() { try { a; } catch (err) { super(); } } }",
+        "class A extends B { constructor() { if (a) return; super(); } }",
+        "class A extends B { constructor() { super(); super(); } }",
+        "class A extends B { constructor() { super() || super(); } }",
+        "class A extends B { constructor() { if (a) super(); super(); } }",
+        "class A extends B { constructor() { switch (a) { case 0: super(); default: super(); } } }",
+        "class A extends B { constructor(a) { while (a) super(); } }",
+        "class A extends B { constructor() { return; super(); } }",
+        "class Foo extends Bar {
+        	                constructor() {
+        	                    for (a in b) for (c in d);
+        	                }
+        	            }",
+        "class C extends D {
+
+        	                constructor() {
+        	                    do {
+        	                        something();
+        	                    } while (foo);
+        	                }
+
+        	            }",
+        "class C extends D {
+
+        	                constructor() {
+        	                    for (let i = 1;;i++) {
+        	                        if (bar) {
+        	                            break;
+        	                        }
+        	                    }
+        	                }
+
+        	            }",
+        "class C extends D {
+
+        	                constructor() {
+        	                    do {
+        	                        super();
+        	                    } while (foo);
+        	                }
+
+        	            }",
+        "class C extends D {
+
+        	                constructor() {
+        	                    while (foo) {
+        	                        if (bar) {
+        	                            super();
+        	                            break;
+        	                        }
+        	                    }
+        	                }
+
+        	            }",
+    ];
+
+    Tester::new(ConstructorSuper::NAME, ConstructorSuper::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/eslint/constructor_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/constructor_super.rs
@@ -28,7 +28,7 @@ fn constructor_super_diagnostic_unexpected_super(span: Span) -> OxcDiagnostic {
 fn constructor_super_diagnostic_missing_some_super(span: Span) -> OxcDiagnostic {
     // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
     OxcDiagnostic::warn("Missing a call of 'super()' in some code paths.")
-        .with_help("Add a 'super()' call to the some code paths")
+        .with_help("Add a 'super()' call to some code paths")
         .with_label(span)
 }
 
@@ -93,7 +93,7 @@ declare_oxc_lint!(
     /// ```
     ConstructorSuper,
     eslint,
-    correctness, // TODO: change category to `correctness`, `suspicious`, `pedantic`, `perf`, `restriction`, or `style`
+    correctness,
              // See <https://oxc.rs/docs/contribute/linter.html#rule-category> for details
 );
 
@@ -195,7 +195,7 @@ impl Rule for ConstructorSuper {
                             {
                                 state.loop_ends_at = None;
 
-                                for span in state.spans_in_loop.clone().unwrap_or_default() {
+                                for span in state.spans_in_loop.take().unwrap_or_default() {
                                     ctx.diagnostic(constructor_super_diagnostic_duplicate_super(
                                         span,
                                     ));
@@ -347,7 +347,7 @@ impl ConstructorSuper {
                     || Self::is_constructor_like(&cond.consequent)
             }
             ast::Expression::SequenceExpression(seq) => {
-                Self::is_constructor_like(seq.expressions.last().unwrap())
+                seq.expressions.last().is_some_and(|expr| Self::is_constructor_like(expr))
             }
             _ => false,
         }

--- a/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
@@ -298,6 +298,7 @@ impl Rule for NoFallthrough {
                     (fallthrough, fallthrough.is_none())
                 }
             },
+            false,
         )
         .into_iter()
         .flatten()

--- a/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
@@ -207,6 +207,7 @@ impl NoThisBeforeSuper {
                     (DefinitelyCallsThisBeforeSuper::Maybe(*basic_block_id), false)
                 }
             },
+            false,
         )
     }
 

--- a/crates/oxc_linter/src/rules/react/require_render_return.rs
+++ b/crates/oxc_linter/src/rules/react/require_render_return.rs
@@ -156,6 +156,7 @@ fn contains_return_statement(node: &AstNode, ctx: &LintContext) -> bool {
 
             (FoundReturn::No, KEEP_WALKING_ON_THIS_PATH)
         },
+        false,
     );
 
     state.contains(&FoundReturn::Yes)

--- a/crates/oxc_linter/src/snapshots/eslint_constructor_super.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_constructor_super.snap
@@ -153,35 +153,35 @@ source: crates/oxc_linter/src/tester.rs
  1 │ class A extends B { constructor() { if (a) super(); } }
    ·                     ─────────────────────────────────
    ╰────
-  help: Add a 'super()' call to the some code paths
+  help: Add a 'super()' call to some code paths
 
   ⚠ eslint(constructor-super): Missing a call of 'super()' in some code paths.
    ╭─[constructor_super.tsx:1:21]
  1 │ class A extends B { constructor() { if (a); else super(); } }
    ·                     ───────────────────────────────────────
    ╰────
-  help: Add a 'super()' call to the some code paths
+  help: Add a 'super()' call to some code paths
 
   ⚠ eslint(constructor-super): Missing a call of 'super()' in some code paths.
    ╭─[constructor_super.tsx:1:21]
  1 │ class A extends B { constructor() { a && super(); } }
    ·                     ───────────────────────────────
    ╰────
-  help: Add a 'super()' call to the some code paths
+  help: Add a 'super()' call to some code paths
 
   ⚠ eslint(constructor-super): Missing a call of 'super()' in some code paths.
    ╭─[constructor_super.tsx:1:21]
  1 │ class A extends B { constructor() { switch (a) { case 0: super(); } } }
    ·                     ─────────────────────────────────────────────────
    ╰────
-  help: Add a 'super()' call to the some code paths
+  help: Add a 'super()' call to some code paths
 
   ⚠ eslint(constructor-super): Missing a call of 'super()' in some code paths.
    ╭─[constructor_super.tsx:1:21]
  1 │ class A extends B { constructor() { switch (a) { case 0: break; default: super(); } } }
    ·                     ─────────────────────────────────────────────────────────────────
    ╰────
-  help: Add a 'super()' call to the some code paths
+  help: Add a 'super()' call to some code paths
 
   ⚠ eslint(constructor-super): Missing a call of 'super()' in the constructor.
    ╭─[constructor_super.tsx:1:21]
@@ -195,14 +195,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ class A extends B { constructor() { try { a; } catch (err) { super(); } } }
    ·                     ─────────────────────────────────────────────────────
    ╰────
-  help: Add a 'super()' call to the some code paths
+  help: Add a 'super()' call to some code paths
 
   ⚠ eslint(constructor-super): Missing a call of 'super()' in some code paths.
    ╭─[constructor_super.tsx:1:21]
  1 │ class A extends B { constructor() { if (a) return; super(); } }
    ·                     ─────────────────────────────────────────
    ╰────
-  help: Add a 'super()' call to the some code paths
+  help: Add a 'super()' call to some code paths
 
   ⚠ eslint(constructor-super): Duplicate 'super()' call in the constructor.
    ╭─[constructor_super.tsx:1:46]
@@ -311,4 +311,4 @@ source: crates/oxc_linter/src/tester.rs
  10 │ ╰─▶                             }
  11 │     
     ╰────
-  help: Add a 'super()' call to the some code paths
+  help: Add a 'super()' call to some code paths

--- a/crates/oxc_linter/src/snapshots/eslint_constructor_super.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_constructor_super.snap
@@ -1,0 +1,314 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint(constructor-super): Unexpected 'super()' because 'super' is not a constructor.
+   ╭─[constructor_super.tsx:1:24]
+ 1 │ class A extends null { constructor() { super(); } }
+   ·                        ──────────────────────────
+   ╰────
+  help: Remove the 'super()' call from the constructor
+
+  ⚠ eslint(constructor-super): Missing a call of 'super()' in the constructor.
+   ╭─[constructor_super.tsx:1:24]
+ 1 │ class A extends null { constructor() { } }
+   ·                        ─────────────────
+   ╰────
+  help: Add a 'super()' call to the constructor
+
+  ⚠ eslint(constructor-super): Unexpected 'super()' because 'super' is not a constructor.
+   ╭─[constructor_super.tsx:1:39]
+ 1 │ class A extends 100 { constructor() { super(); } }
+   ·                                       ─────
+   ╰────
+  help: Remove the 'super()' call from the constructor
+
+  ⚠ eslint(constructor-super): Unexpected 'super()' because 'super' is not a constructor.
+   ╭─[constructor_super.tsx:1:42]
+ 1 │ class A extends 'test' { constructor() { super(); } }
+   ·                                          ─────
+   ╰────
+  help: Remove the 'super()' call from the constructor
+
+  ⚠ eslint(constructor-super): Unexpected 'super()' because 'super' is not a constructor.
+   ╭─[constructor_super.tsx:1:43]
+ 1 │ class A extends (B = 5) { constructor() { super(); } }
+   ·                                           ─────
+   ╰────
+  help: Remove the 'super()' call from the constructor
+
+  ⚠ eslint(constructor-super): Unexpected 'super()' because 'super' is not a constructor.
+   ╭─[constructor_super.tsx:1:44]
+ 1 │ class A extends (B && 5) { constructor() { super(); } }
+   ·                                            ─────
+   ╰────
+  help: Remove the 'super()' call from the constructor
+
+  ⚠ eslint(constructor-super): Unexpected 'super()' because 'super' is not a constructor.
+   ╭─[constructor_super.tsx:1:45]
+ 1 │ class A extends (B &&= 5) { constructor() { super(); } }
+   ·                                             ─────
+   ╰────
+  help: Remove the 'super()' call from the constructor
+
+  ⚠ eslint(constructor-super): Unexpected 'super()' because 'super' is not a constructor.
+   ╭─[constructor_super.tsx:1:44]
+ 1 │ class A extends (B += C) { constructor() { super(); } }
+   ·                                            ─────
+   ╰────
+  help: Remove the 'super()' call from the constructor
+
+  ⚠ eslint(constructor-super): Unexpected 'super()' because 'super' is not a constructor.
+   ╭─[constructor_super.tsx:1:44]
+ 1 │ class A extends (B -= C) { constructor() { super(); } }
+   ·                                            ─────
+   ╰────
+  help: Remove the 'super()' call from the constructor
+
+  ⚠ eslint(constructor-super): Unexpected 'super()' because 'super' is not a constructor.
+   ╭─[constructor_super.tsx:1:45]
+ 1 │ class A extends (B **= C) { constructor() { super(); } }
+   ·                                             ─────
+   ╰────
+  help: Remove the 'super()' call from the constructor
+
+  ⚠ eslint(constructor-super): Unexpected 'super()' because 'super' is not a constructor.
+   ╭─[constructor_super.tsx:1:44]
+ 1 │ class A extends (B |= C) { constructor() { super(); } }
+   ·                                            ─────
+   ╰────
+  help: Remove the 'super()' call from the constructor
+
+  ⚠ eslint(constructor-super): Unexpected 'super()' because 'super' is not a constructor.
+   ╭─[constructor_super.tsx:1:44]
+ 1 │ class A extends (B &= C) { constructor() { super(); } }
+   ·                                            ─────
+   ╰────
+  help: Remove the 'super()' call from the constructor
+
+  ⚠ eslint(constructor-super): Missing a call of 'super()' in the constructor.
+   ╭─[constructor_super.tsx:1:21]
+ 1 │ class A extends B { constructor() { } }
+   ·                     ─────────────────
+   ╰────
+  help: Add a 'super()' call to the constructor
+
+  ⚠ eslint(constructor-super): Missing a call of 'super()' in the constructor.
+   ╭─[constructor_super.tsx:1:21]
+ 1 │ class A extends B { constructor() { for (var a of b) super.foo(); } }
+   ·                     ───────────────────────────────────────────────
+   ╰────
+  help: Add a 'super()' call to the constructor
+
+  ⚠ eslint(constructor-super): Missing a call of 'super()' in the constructor.
+   ╭─[constructor_super.tsx:1:21]
+ 1 │ class A extends B { constructor() { for (var i = 1; i < 10; i++) super.foo(); } }
+   ·                     ───────────────────────────────────────────────────────────
+   ╰────
+  help: Add a 'super()' call to the constructor
+
+  ⚠ eslint(constructor-super): Missing a call of 'super()' in the constructor.
+   ╭─[constructor_super.tsx:1:21]
+ 1 │ class A extends B { constructor() { var c = class extends D { constructor() { super(); } } } }
+   ·                     ────────────────────────────────────────────────────────────────────────
+   ╰────
+  help: Add a 'super()' call to the constructor
+
+  ⚠ eslint(constructor-super): Missing a call of 'super()' in the constructor.
+   ╭─[constructor_super.tsx:1:21]
+ 1 │ class A extends B { constructor() { var c = () => super(); } }
+   ·                     ────────────────────────────────────────
+   ╰────
+  help: Add a 'super()' call to the constructor
+
+  ⚠ eslint(constructor-super): Missing a call of 'super()' in the constructor.
+   ╭─[constructor_super.tsx:1:21]
+ 1 │ class A extends B { constructor() { class C extends D { constructor() { super(); } } } }
+   ·                     ──────────────────────────────────────────────────────────────────
+   ╰────
+  help: Add a 'super()' call to the constructor
+
+  ⚠ eslint(constructor-super): Missing a call of 'super()' in the constructor.
+   ╭─[constructor_super.tsx:1:21]
+ 1 │ class A extends B { constructor() { var C = class extends D { constructor() { super(); } } } }
+   ·                     ────────────────────────────────────────────────────────────────────────
+   ╰────
+  help: Add a 'super()' call to the constructor
+
+  ⚠ eslint(constructor-super): Missing a call of 'super()' in the constructor.
+   ╭─[constructor_super.tsx:1:66]
+ 1 │ class A extends B { constructor() { super(); class C extends D { constructor() { } } } }
+   ·                                                                  ─────────────────
+   ╰────
+  help: Add a 'super()' call to the constructor
+
+  ⚠ eslint(constructor-super): Missing a call of 'super()' in the constructor.
+   ╭─[constructor_super.tsx:1:72]
+ 1 │ class A extends B { constructor() { super(); var C = class extends D { constructor() { } } } }
+   ·                                                                        ─────────────────
+   ╰────
+  help: Add a 'super()' call to the constructor
+
+  ⚠ eslint(constructor-super): Missing a call of 'super()' in some code paths.
+   ╭─[constructor_super.tsx:1:21]
+ 1 │ class A extends B { constructor() { if (a) super(); } }
+   ·                     ─────────────────────────────────
+   ╰────
+  help: Add a 'super()' call to the some code paths
+
+  ⚠ eslint(constructor-super): Missing a call of 'super()' in some code paths.
+   ╭─[constructor_super.tsx:1:21]
+ 1 │ class A extends B { constructor() { if (a); else super(); } }
+   ·                     ───────────────────────────────────────
+   ╰────
+  help: Add a 'super()' call to the some code paths
+
+  ⚠ eslint(constructor-super): Missing a call of 'super()' in some code paths.
+   ╭─[constructor_super.tsx:1:21]
+ 1 │ class A extends B { constructor() { a && super(); } }
+   ·                     ───────────────────────────────
+   ╰────
+  help: Add a 'super()' call to the some code paths
+
+  ⚠ eslint(constructor-super): Missing a call of 'super()' in some code paths.
+   ╭─[constructor_super.tsx:1:21]
+ 1 │ class A extends B { constructor() { switch (a) { case 0: super(); } } }
+   ·                     ─────────────────────────────────────────────────
+   ╰────
+  help: Add a 'super()' call to the some code paths
+
+  ⚠ eslint(constructor-super): Missing a call of 'super()' in some code paths.
+   ╭─[constructor_super.tsx:1:21]
+ 1 │ class A extends B { constructor() { switch (a) { case 0: break; default: super(); } } }
+   ·                     ─────────────────────────────────────────────────────────────────
+   ╰────
+  help: Add a 'super()' call to the some code paths
+
+  ⚠ eslint(constructor-super): Missing a call of 'super()' in the constructor.
+   ╭─[constructor_super.tsx:1:21]
+ 1 │ class A extends B { constructor() { try { super(); } catch (err) {} } }
+   ·                     ─────────────────────────────────────────────────
+   ╰────
+  help: Add a 'super()' call to the constructor
+
+  ⚠ eslint(constructor-super): Missing a call of 'super()' in some code paths.
+   ╭─[constructor_super.tsx:1:21]
+ 1 │ class A extends B { constructor() { try { a; } catch (err) { super(); } } }
+   ·                     ─────────────────────────────────────────────────────
+   ╰────
+  help: Add a 'super()' call to the some code paths
+
+  ⚠ eslint(constructor-super): Missing a call of 'super()' in some code paths.
+   ╭─[constructor_super.tsx:1:21]
+ 1 │ class A extends B { constructor() { if (a) return; super(); } }
+   ·                     ─────────────────────────────────────────
+   ╰────
+  help: Add a 'super()' call to the some code paths
+
+  ⚠ eslint(constructor-super): Duplicate 'super()' call in the constructor.
+   ╭─[constructor_super.tsx:1:46]
+ 1 │ class A extends B { constructor() { super(); super(); } }
+   ·                                              ─────
+   ╰────
+  help: Remove the duplicate 'super()' call from the constructor
+
+  ⚠ eslint(constructor-super): Duplicate 'super()' call in the constructor.
+   ╭─[constructor_super.tsx:1:48]
+ 1 │ class A extends B { constructor() { super() || super(); } }
+   ·                                                ─────
+   ╰────
+  help: Remove the duplicate 'super()' call from the constructor
+
+  ⚠ eslint(constructor-super): Duplicate 'super()' call in the constructor.
+   ╭─[constructor_super.tsx:1:53]
+ 1 │ class A extends B { constructor() { if (a) super(); super(); } }
+   ·                                                     ─────
+   ╰────
+  help: Remove the duplicate 'super()' call from the constructor
+
+  ⚠ eslint(constructor-super): Duplicate 'super()' call in the constructor.
+   ╭─[constructor_super.tsx:1:76]
+ 1 │ class A extends B { constructor() { switch (a) { case 0: super(); default: super(); } } }
+   ·                                                                            ─────
+   ╰────
+  help: Remove the duplicate 'super()' call from the constructor
+
+  ⚠ eslint(constructor-super): Duplicate 'super()' call in the constructor.
+   ╭─[constructor_super.tsx:1:48]
+ 1 │ class A extends B { constructor(a) { while (a) super(); } }
+   ·                                                ─────
+   ╰────
+  help: Remove the duplicate 'super()' call from the constructor
+
+  ⚠ eslint(constructor-super): Missing a call of 'super()' in the constructor.
+   ╭─[constructor_super.tsx:1:21]
+ 1 │ class A extends B { constructor(a) { while (a) super(); } }
+   ·                     ─────────────────────────────────────
+   ╰────
+  help: Add a 'super()' call to the constructor
+
+  ⚠ eslint(constructor-super): Missing a call of 'super()' in the constructor.
+   ╭─[constructor_super.tsx:1:21]
+ 1 │ class A extends B { constructor() { return; super(); } }
+   ·                     ──────────────────────────────────
+   ╰────
+  help: Add a 'super()' call to the constructor
+
+  ⚠ eslint(constructor-super): Missing a call of 'super()' in the constructor.
+   ╭─[constructor_super.tsx:2:26]
+ 1 │     class Foo extends Bar {
+ 2 │ ╭─▶                             constructor() {
+ 3 │ │                                   for (a in b) for (c in d);
+ 4 │ ╰─▶                             }
+ 5 │                             }
+   ╰────
+  help: Add a 'super()' call to the constructor
+
+  ⚠ eslint(constructor-super): Missing a call of 'super()' in the constructor.
+   ╭─[constructor_super.tsx:3:26]
+ 2 │     
+ 3 │ ╭─▶                             constructor() {
+ 4 │ │                                   do {
+ 5 │ │                                       something();
+ 6 │ │                                   } while (foo);
+ 7 │ ╰─▶                             }
+ 8 │     
+   ╰────
+  help: Add a 'super()' call to the constructor
+
+  ⚠ eslint(constructor-super): Missing a call of 'super()' in the constructor.
+    ╭─[constructor_super.tsx:3:26]
+  2 │     
+  3 │ ╭─▶                             constructor() {
+  4 │ │                                   for (let i = 1;;i++) {
+  5 │ │                                       if (bar) {
+  6 │ │                                           break;
+  7 │ │                                       }
+  8 │ │                                   }
+  9 │ ╰─▶                             }
+ 10 │     
+    ╰────
+  help: Add a 'super()' call to the constructor
+
+  ⚠ eslint(constructor-super): Duplicate 'super()' call in the constructor.
+   ╭─[constructor_super.tsx:5:34]
+ 4 │                                 do {
+ 5 │                                     super();
+   ·                                     ─────
+ 6 │                                 } while (foo);
+   ╰────
+  help: Remove the duplicate 'super()' call from the constructor
+
+  ⚠ eslint(constructor-super): Missing a call of 'super()' in some code paths.
+    ╭─[constructor_super.tsx:3:26]
+  2 │     
+  3 │ ╭─▶                             constructor() {
+  4 │ │                                   while (foo) {
+  5 │ │                                       if (bar) {
+  6 │ │                                           super();
+  7 │ │                                           break;
+  8 │ │                                       }
+  9 │ │                                   }
+ 10 │ ╰─▶                             }
+ 11 │     
+    ╰────
+  help: Add a 'super()' call to the some code paths


### PR DESCRIPTION
Hi @camc314 , I’m new to Rust — please help me review this PR and let me know if I’m making any beginner mistakes. Thanks!

Also, I need some guidance on how to get rid of those snapshot file commits if necessary. I added them just to make the “just ready” command pass.

I also added one more argument to neighbors_filtered_by_edge_weight that allows revisiting nodes in order to detect duplicate supers in every code path. I wasn’t sure if that’s allowed.