### PR TITLE
perf(linter/plugins): lazy deserialize comments array

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -64,10 +64,7 @@ function deserializeProgram(pos) {
           uint8 =
           sourceText =
             void 0;
-        Object.defineProperty(this, 'comments', {
-          value: comments,
-          enumerable: true,
-        });
+        Object.defineProperty(this, 'comments', { value: comments });
         return comments;
       },
       start: 0,

--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -49,9 +49,11 @@ function deserializeProgram(pos) {
       sourceType: deserializeModuleKind(pos + 125),
       hashbang: null,
       get comments() {
-        if (localAstId !== astId) {throw Error(
+        if (localAstId !== astId) {
+          throw Error(
             'The AST being accessed has already been cleaned up. Please ensure that the plugin works synchronously.',
-          );}
+          );
+        }
         // Restore buffers
         uint32 = refUint32;
         uint8 = refUint8;

--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -38,9 +38,9 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInpu
 
 function deserializeProgram(pos) {
   let end = deserializeU32(pos + 4),
-    ref_uint32 = uint32,
-    ref_uint8 = uint8,
-    ref_sourceText = sourceText,
+    refUint32 = uint32,
+    refUint8 = uint8,
+    refSourceText = sourceText,
     localAstId = ++astId,
     program = parent = {
       __proto__: NodeProto,
@@ -52,18 +52,16 @@ function deserializeProgram(pos) {
         if (localAstId !== astId) {throw Error(
             'The AST being accessed has already been cleaned up. Please ensure that the plugin works synchronously.',
           );}
-        // restore buffers
-        uint32 = ref_uint32;
-        uint8 = ref_uint8;
-        sourceText = ref_sourceText;
-        // deserialize the comments
-        let c = deserializeVecComment(pos + 24);
-        // drop the references
-        ref_uint32 = void 0;
-        ref_uint8 = void 0;
-        ref_sourceText = void 0;
-        Object.defineProperty(this, 'comments', { value: c });
-        return c;
+        // Restore buffers
+        uint32 = refUint32;
+        uint8 = refUint8;
+        sourceText = refSourceText;
+        // Deserialize the comments
+        let comments = deserializeVecComment(pos + 24);
+        // Drop the references
+        refUint32 = refUint8 = refSourceText = void 0;
+        Object.defineProperty(this, 'comments', { value: comments });
+        return comments;
       },
       start: 0,
       end,

--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -49,11 +49,7 @@ function deserializeProgram(pos) {
       sourceType: deserializeModuleKind(pos + 125),
       hashbang: null,
       get comments() {
-        if (localAstId !== astId) {
-          throw Error(
-            'The AST being accessed has already been cleaned up. Please ensure that the plugin works synchronously.',
-          );
-        }
+        if (localAstId !== astId) throw Error('Comments are only accessible while linting the file');
         // Restore buffers
         uint32 = refUint32;
         uint8 = refUint8;

--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -1,7 +1,7 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
-let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen, parent = null, getLoc;
+let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen, astId = 0, parent = null, getLoc;
 
 const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
@@ -38,13 +38,33 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInpu
 
 function deserializeProgram(pos) {
   let end = deserializeU32(pos + 4),
+    ref_uint32 = uint32,
+    ref_uint8 = uint8,
+    ref_sourceText = sourceText,
+    localAstId = ++astId,
     program = parent = {
       __proto__: NodeProto,
       type: 'Program',
       body: null,
       sourceType: deserializeModuleKind(pos + 125),
       hashbang: null,
-      comments: deserializeVecComment(pos + 24),
+      get comments() {
+        if (localAstId !== astId) {throw Error(
+            'The AST being accessed has already been cleaned up. Please ensure that the plugin works synchronously.',
+          );}
+        // restore buffers
+        uint32 = ref_uint32;
+        uint8 = ref_uint8;
+        sourceText = ref_sourceText;
+        // deserialize the comments
+        let c = deserializeVecComment(pos + 24);
+        // drop the references
+        ref_uint32 = void 0;
+        ref_uint8 = void 0;
+        ref_sourceText = void 0;
+        Object.defineProperty(this, 'comments', { value: c });
+        return c;
+      },
       start: 0,
       end,
       range: [0, end],

--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -57,8 +57,17 @@ function deserializeProgram(pos) {
         // Deserialize the comments
         let comments = deserializeVecComment(pos + 24);
         // Drop the references
-        refUint32 = refUint8 = refSourceText = void 0;
-        Object.defineProperty(this, 'comments', { value: comments });
+        refUint32 =
+          refUint8 =
+          refSourceText =
+          uint32 =
+          uint8 =
+          sourceText =
+            void 0;
+        Object.defineProperty(this, 'comments', {
+          value: comments,
+          enumerable: true,
+        });
         return comments;
       },
       start: 0,

--- a/crates/oxc_ast/src/serialize/mod.rs
+++ b/crates/oxc_ast/src/serialize/mod.rs
@@ -149,7 +149,7 @@ impl Program<'_> {
             // Deserialize the comments
             const comments = DESER[Vec<Comment>](POS_OFFSET.comments);
             // Drop the references
-            refUint32 = refUint8 = refSourceText = undefined;
+            refUint32 = refUint8 = refSourceText = uint32 = uint8 = sourceText = undefined;
             Object.defineProperty(this, 'comments', { value: comments, enumerable: true });
             return comments;
         },

--- a/crates/oxc_ast/src/serialize/mod.rs
+++ b/crates/oxc_ast/src/serialize/mod.rs
@@ -128,9 +128,9 @@ impl Program<'_> {
     /* IF LINTER */
     // Buffers will be cleaned up after the main program is deserialized.
     // We hold references here in case the comments need to be later accessed.
-    let ref_uint32 = uint32;
-    let ref_uint8 = uint8;
-    let ref_sourceText = sourceText;
+    let refUint32 = uint32;
+    let refUint8 = uint8;
+    let refSourceText = sourceText;
     const localAstId = ++astId;
     /* END_IF */
 
@@ -142,18 +142,16 @@ impl Program<'_> {
         /* IF LINTER */
         get comments() {
             if (localAstId !== astId) throw new Error(`The AST being accessed has already been cleaned up. Please ensure that the plugin works synchronously.`);
-            // restore buffers
-            uint32 = ref_uint32;
-            uint8 = ref_uint8;
-            sourceText = ref_sourceText;
-            // deserialize the comments
-            const c = DESER[Vec<Comment>](POS_OFFSET.comments);
-            // drop the references
-            ref_uint32 = undefined;
-            ref_uint8 = undefined;
-            ref_sourceText = undefined;
-            Object.defineProperty(this, 'comments', { value: c });
-            return c;
+            // Restore buffers
+            uint32 = refUint32;
+            uint8 = refUint8;
+            sourceText = refSourceText;
+            // Deserialize the comments
+            const comments = DESER[Vec<Comment>](POS_OFFSET.comments);
+            // Drop the references
+            refUint32 = refUint8 = refSourceText = undefined;
+            Object.defineProperty(this, 'comments', { value: comments });
+            return comments;
         },
         /* END_IF */
         start,

--- a/crates/oxc_ast/src/serialize/mod.rs
+++ b/crates/oxc_ast/src/serialize/mod.rs
@@ -141,7 +141,7 @@ impl Program<'_> {
         hashbang: null,
         /* IF LINTER */
         get comments() {
-            if (localAstId !== astId) throw new Error(`The AST being accessed has already been cleaned up. Please ensure that the plugin works synchronously.`);
+            if (localAstId !== astId) throw new Error('Comments are only accessible while linting the file');
             // Restore buffers
             uint32 = refUint32;
             uint8 = refUint8;

--- a/crates/oxc_ast/src/serialize/mod.rs
+++ b/crates/oxc_ast/src/serialize/mod.rs
@@ -125,7 +125,7 @@ impl Program<'_> {
         end = DESER[u32](POS_OFFSET.span.end);
 
 
-    /* IF LINTER */
+    /* IF COMMENTS */
     // Buffers will be cleaned up after the main program is deserialized.
     // We hold references here in case the comments need to be later accessed.
     let refUint32 = uint32;
@@ -139,7 +139,7 @@ impl Program<'_> {
         body: null,
         sourceType: DESER[ModuleKind](POS_OFFSET.source_type.module_kind),
         hashbang: null,
-        /* IF LINTER */
+        /* IF COMMENTS */
         get comments() {
             if (localAstId !== astId) throw new Error('Comments are only accessible while linting the file');
             // Restore buffers

--- a/crates/oxc_ast/src/serialize/mod.rs
+++ b/crates/oxc_ast/src/serialize/mod.rs
@@ -150,7 +150,7 @@ impl Program<'_> {
             const comments = DESER[Vec<Comment>](POS_OFFSET.comments);
             // Drop the references
             refUint32 = refUint8 = refSourceText = uint32 = uint8 = sourceText = undefined;
-            Object.defineProperty(this, 'comments', { value: comments, enumerable: true });
+            Object.defineProperty(this, 'comments', { value: comments });
             return comments;
         },
         /* END_IF */

--- a/crates/oxc_ast/src/serialize/mod.rs
+++ b/crates/oxc_ast/src/serialize/mod.rs
@@ -141,9 +141,7 @@ impl Program<'_> {
         hashbang: null,
         /* IF LINTER */
         get comments() {
-            if (localAstId !== astId) {
-                throw new Error(`The AST being accessed has already been cleaned up. Please ensure that the plugin works synchronously.`);
-            }
+            if (localAstId !== astId) throw new Error(`The AST being accessed has already been cleaned up. Please ensure that the plugin works synchronously.`);
             // restore buffers
             uint32 = ref_uint32;
             uint8 = ref_uint8;

--- a/crates/oxc_ast/src/serialize/mod.rs
+++ b/crates/oxc_ast/src/serialize/mod.rs
@@ -150,7 +150,7 @@ impl Program<'_> {
             const comments = DESER[Vec<Comment>](POS_OFFSET.comments);
             // Drop the references
             refUint32 = refUint8 = refSourceText = undefined;
-            Object.defineProperty(this, 'comments', { value: comments });
+            Object.defineProperty(this, 'comments', { value: comments, enumerable: true });
             return comments;
         },
         /* END_IF */

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -221,11 +221,11 @@ fn generate_deserializers(
         variant_paths: Vec<String>,
     }
 
-    impl VariantGenerator<6> for VariantGen {
-        const FLAG_NAMES: [&str; 6] =
-            ["IS_TS", "RANGE", "LOC", "PARENT", "PRESERVE_PARENS", "LINTER"];
+    impl VariantGenerator<7> for VariantGen {
+        const FLAG_NAMES: [&str;7] =
+            ["IS_TS", "RANGE", "LOC", "PARENT", "PRESERVE_PARENS", "COMMENTS", "LINTER"];
 
-        fn variants(&mut self) -> Vec<[bool; 6]> {
+        fn variants(&mut self) -> Vec<[bool; 7]> {
             let mut variants = Vec::with_capacity(9);
 
             // Parser deserializers
@@ -241,7 +241,7 @@ fn generate_deserializers(
 
                         variants.push([
                             is_ts, range, /* loc */ false, parent,
-                            /* preserve_parens */ true, /* linter */ false,
+                            /* preserve_parens */ true, /* comments */ false, /* linter */ false,
                         ]);
                     }
                 }
@@ -251,7 +251,7 @@ fn generate_deserializers(
             self.variant_paths.push(format!("{OXLINT_APP_PATH}/src-js/generated/deserialize.js"));
             variants.push([
                 /* is_ts */ true, /* range */ true, /* loc */ true,
-                /* parent */ true, /* preserve_parens */ false, /* linter */ true,
+                /* parent */ true, /* preserve_parens */ false, /* comments */ true, /* linter */ true,
             ]);
 
             variants
@@ -260,7 +260,7 @@ fn generate_deserializers(
         fn pre_process_variant<'a>(
             &self,
             program: &mut Program<'a>,
-            flags: [bool; 6],
+            flags: [bool; 7],
             allocator: &'a Allocator,
         ) {
             if flags[2] {

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -222,7 +222,7 @@ fn generate_deserializers(
     }
 
     impl VariantGenerator<7> for VariantGen {
-        const FLAG_NAMES: [&str;7] =
+        const FLAG_NAMES: [&str; 7] =
             ["IS_TS", "RANGE", "LOC", "PARENT", "PRESERVE_PARENS", "COMMENTS", "LINTER"];
 
         fn variants(&mut self) -> Vec<[bool; 7]> {
@@ -241,7 +241,8 @@ fn generate_deserializers(
 
                         variants.push([
                             is_ts, range, /* loc */ false, parent,
-                            /* preserve_parens */ true, /* comments */ false, /* linter */ false,
+                            /* preserve_parens */ true, /* comments */ false,
+                            /* linter */ false,
                         ]);
                     }
                 }
@@ -251,7 +252,8 @@ fn generate_deserializers(
             self.variant_paths.push(format!("{OXLINT_APP_PATH}/src-js/generated/deserialize.js"));
             variants.push([
                 /* is_ts */ true, /* range */ true, /* loc */ true,
-                /* parent */ true, /* preserve_parens */ false, /* comments */ true, /* linter */ true,
+                /* parent */ true, /* preserve_parens */ false, /* comments */ true,
+                /* linter */ true,
             ]);
 
             variants

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -136,6 +136,7 @@ fn generate_deserializers(
     let mut code = format!("
         let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen;
 
+        let astId = 0;
         let parent = null;
         let getLoc;
 
@@ -220,11 +221,11 @@ fn generate_deserializers(
         variant_paths: Vec<String>,
     }
 
-    impl VariantGenerator<7> for VariantGen {
-        const FLAG_NAMES: [&str; 7] =
-            ["IS_TS", "RANGE", "LOC", "PARENT", "PRESERVE_PARENS", "COMMENTS", "LINTER"];
+    impl VariantGenerator<6> for VariantGen {
+        const FLAG_NAMES: [&str; 6] =
+            ["IS_TS", "RANGE", "LOC", "PARENT", "PRESERVE_PARENS", "LINTER"];
 
-        fn variants(&mut self) -> Vec<[bool; 7]> {
+        fn variants(&mut self) -> Vec<[bool; 6]> {
             let mut variants = Vec::with_capacity(9);
 
             // Parser deserializers
@@ -240,8 +241,7 @@ fn generate_deserializers(
 
                         variants.push([
                             is_ts, range, /* loc */ false, parent,
-                            /* preserve_parens */ true, /* comments */ false,
-                            /* linter */ false,
+                            /* preserve_parens */ true, /* linter */ false,
                         ]);
                     }
                 }
@@ -251,8 +251,7 @@ fn generate_deserializers(
             self.variant_paths.push(format!("{OXLINT_APP_PATH}/src-js/generated/deserialize.js"));
             variants.push([
                 /* is_ts */ true, /* range */ true, /* loc */ true,
-                /* parent */ true, /* preserve_parens */ false, /* comments */ true,
-                /* linter */ true,
+                /* parent */ true, /* preserve_parens */ false, /* linter */ true,
             ]);
 
             variants
@@ -261,7 +260,7 @@ fn generate_deserializers(
         fn pre_process_variant<'a>(
             &self,
             program: &mut Program<'a>,
-            flags: [bool; 7],
+            flags: [bool; 6],
             allocator: &'a Allocator,
         ) {
             if flags[2] {


### PR DESCRIPTION
Part of #14564.

Deserialize `program.comments` lazily upon first access, instead of eagerly, on assumption that most JS plugins won't access comments.

`deserializeWith` cleans up the buffer once deserializing AST is complete, so we keep a local copy of the buffer in scope of the `comments` getter, and restore it when the getter is triggered.

Buffers are reused, so the `if (localAstId !== astId)` check is required to make sure the AST in the buffer is same AST i.e. that the getter isn't accessed *after* the file has completed linting.