### PR TITLE
perf(linter): support getting `as_member_expression_kind()` variants

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -446,7 +446,11 @@ impl RuleRunner for crate::rules::eslint::no_irregular_whitespace::NoIrregularWh
 }
 
 impl RuleRunner for crate::rules::eslint::no_iterator::NoIterator {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::ComputedMemberExpression,
+        AstType::PrivateFieldExpression,
+        AstType::StaticMemberExpression,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -572,7 +576,11 @@ impl RuleRunner for crate::rules::eslint::no_plusplus::NoPlusplus {
 }
 
 impl RuleRunner for crate::rules::eslint::no_proto::NoProto {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::ComputedMemberExpression,
+        AstType::PrivateFieldExpression,
+        AstType::StaticMemberExpression,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -1201,7 +1209,11 @@ impl RuleRunner for crate::rules::jest::no_confusing_set_timeout::NoConfusingSet
 }
 
 impl RuleRunner for crate::rules::jest::no_deprecated_functions::NoDeprecatedFunctions {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::ComputedMemberExpression,
+        AstType::PrivateFieldExpression,
+        AstType::StaticMemberExpression,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -2066,7 +2078,11 @@ impl RuleRunner for crate::rules::promise::prefer_catch::PreferCatch {
 }
 
 impl RuleRunner for crate::rules::promise::spec_only::SpecOnly {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::ComputedMemberExpression,
+        AstType::PrivateFieldExpression,
+        AstType::StaticMemberExpression,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -3011,7 +3027,11 @@ impl RuleRunner for crate::rules::unicorn::no_array_sort::NoArraySort {
 }
 
 impl RuleRunner for crate::rules::unicorn::no_await_expression_member::NoAwaitExpressionMember {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::ComputedMemberExpression,
+        AstType::PrivateFieldExpression,
+        AstType::StaticMemberExpression,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/tasks/linter_codegen/src/member_expression_kinds.rs
+++ b/tasks/linter_codegen/src/member_expression_kinds.rs
@@ -1,0 +1,58 @@
+use syn::{Expr, Pat, Stmt};
+
+use crate::{node_type_set::NodeTypeSet, utils::find_impl_function};
+
+/// Fetches the current list of variants that can be returned by `AstKind::as_member_expression_kind()`.
+/// We read the source file to avoid hardcoding the list here and ensure this will stay updated.
+pub fn get_member_expression_kinds() -> Option<NodeTypeSet> {
+    // Read crates/oxc_ast/src/ast_kind_impl.rs and extract all variants in `as_member_expression_kind` function
+    let ast_kind_impl_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()?
+        .parent()?
+        .join("crates")
+        .join("oxc_ast")
+        .join("src")
+        .join("ast_kind_impl.rs");
+    let content = std::fs::read_to_string(ast_kind_impl_path).ok()?;
+    let syntax = syn::parse_file(&content).ok()?;
+    let mut node_type_set = NodeTypeSet::new();
+    for item in syntax.items {
+        if let syn::Item::Impl(impl_block) = item
+            && let syn::Type::Path(type_path) = impl_block.self_ty.as_ref()
+            && type_path.path.segments.last()?.ident == "AstKind"
+        {
+            let impl_fn = find_impl_function(&impl_block, "as_member_expression_kind")
+                .expect("as_member_expression_kind function not found");
+
+            // Look for `match self { ... }` inside the function body
+            if impl_fn.block.stmts.len() != 1 {
+                return None;
+            }
+            let stmt = &impl_fn.block.stmts[0];
+            if let Stmt::Expr(Expr::Match(match_expr), _) = stmt {
+                for arm in &match_expr.arms {
+                    if let Pat::TupleStruct(ts) = &arm.pat
+                        && let Some(variant) = self_astkind_variant_from_path(&ts.path)
+                    {
+                        node_type_set.insert(variant);
+                    }
+                }
+                if !node_type_set.is_empty() {
+                    return Some(node_type_set);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn self_astkind_variant_from_path(path: &syn::Path) -> Option<String> {
+    // Expect `Self::Variant`
+    if path.segments.len() != 2 {
+        return None;
+    }
+    if path.segments[0].ident != "Self" {
+        return None;
+    }
+    Some(path.segments[1].ident.to_string())
+}

--- a/tasks/linter_codegen/src/node_type_set.rs
+++ b/tasks/linter_codegen/src/node_type_set.rs
@@ -2,6 +2,7 @@ use rustc_hash::FxHashSet;
 
 /// A set of AstKind variants, used for storing the unique node types detected in a rule,
 /// or a portion of the rule file.
+#[derive(Clone)]
 pub struct NodeTypeSet {
     node_types: FxHashSet<String>,
 }


### PR DESCRIPTION
Previously, we bailed out on `node.kind().as_member_expression_kind()` diverging `let` statements. Now, we can compute those member expression kinds as they should be relatively constant.


+1-3% on the linter benchmarks, plus we just dropped sub-millisecond on the Radix UI benchmark!

<img width="719" height="427" alt="Screenshot 2025-10-15 at 5 11 00 PM" src="https://github.com/user-attachments/assets/a15d4a28-ad79-447a-9025-69368474a40e" />
