### PR TITLE
refactor(language_server): improve file watching for different tools

### DIFF
--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -3,7 +3,6 @@ use std::{str::FromStr, sync::Arc};
 use futures::future::join_all;
 use log::{debug, info, warn};
 use rustc_hash::FxBuildHasher;
-use serde_json::json;
 use tokio::sync::{OnceCell, RwLock, SetError};
 use tower_lsp_server::{
     Client, LanguageServer,
@@ -11,10 +10,10 @@ use tower_lsp_server::{
     lsp_types::{
         CodeActionParams, CodeActionResponse, ConfigurationItem, Diagnostic,
         DidChangeConfigurationParams, DidChangeTextDocumentParams, DidChangeWatchedFilesParams,
-        DidChangeWatchedFilesRegistrationOptions, DidChangeWorkspaceFoldersParams,
-        DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams,
-        DocumentFormattingParams, ExecuteCommandParams, InitializeParams, InitializeResult,
-        InitializedParams, Registration, ServerInfo, TextEdit, Unregistration, Uri, WorkspaceEdit,
+        DidChangeWorkspaceFoldersParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
+        DidSaveTextDocumentParams, DocumentFormattingParams, ExecuteCommandParams,
+        InitializeParams, InitializeResult, InitializedParams, Registration, ServerInfo, TextEdit,
+        Unregistration, Uri, WorkspaceEdit,
     },
 };
 
@@ -204,13 +203,7 @@ impl LanguageServer for Backend {
         // init all file watchers
         if capabilities.dynamic_watchers {
             for worker in workers {
-                registrations.push(Registration {
-                    id: format!("watcher-{}", worker.get_root_uri().as_str()),
-                    method: "workspace/didChangeWatchedFiles".to_string(),
-                    register_options: Some(json!(DidChangeWatchedFilesRegistrationOptions {
-                        watchers: worker.init_watchers().await
-                    })),
-                });
+                registrations.extend(worker.init_watchers().await);
             }
         }
 
@@ -326,7 +319,7 @@ impl LanguageServer for Backend {
                 continue;
             };
 
-            let (diagnostics, watchers, formatter_activated) =
+            let (diagnostics, registrations, unregistrations, formatter_activated) =
                 worker.did_change_configuration(&option.options).await;
 
             if formatter_activated && self.capabilities.get().is_some_and(|c| c.dynamic_formatting)
@@ -338,23 +331,8 @@ impl LanguageServer for Backend {
                 new_diagnostics.extend(diagnostics);
             }
 
-            if let Some(watchers) = watchers
-                && self.capabilities.get().is_some_and(|capabilities| capabilities.dynamic_watchers)
-            {
-                // remove the old watcher
-                removing_registrations.push(Unregistration {
-                    id: format!("watcher-{}", worker.get_root_uri().as_str()),
-                    method: "workspace/didChangeWatchedFiles".to_string(),
-                });
-                // add the new watcher
-                adding_registrations.push(Registration {
-                    id: format!("watcher-{}", worker.get_root_uri().as_str()),
-                    method: "workspace/didChangeWatchedFiles".to_string(),
-                    register_options: Some(json!(DidChangeWatchedFilesRegistrationOptions {
-                        watchers
-                    })),
-                });
-            }
+            removing_registrations.extend(unregistrations);
+            adding_registrations.extend(registrations);
         }
 
         if !new_diagnostics.is_empty() {
@@ -464,13 +442,7 @@ impl LanguageServer for Backend {
 
                 worker.start_worker(options).await;
 
-                added_registrations.push(Registration {
-                    id: format!("watcher-{}", worker.get_root_uri().as_str()),
-                    method: "workspace/didChangeWatchedFiles".to_string(),
-                    register_options: Some(json!(DidChangeWatchedFilesRegistrationOptions {
-                        watchers: worker.init_watchers().await
-                    })),
-                });
+                added_registrations.extend(worker.init_watchers().await);
                 workers.push(worker);
             }
         // client does not support the request

--- a/crates/oxc_language_server/src/formatter/server_formatter.rs
+++ b/crates/oxc_language_server/src/formatter/server_formatter.rs
@@ -9,7 +9,7 @@ use oxc_formatter::{
 use oxc_parser::{ParseOptions, Parser};
 use tower_lsp_server::{
     UriExt,
-    lsp_types::{Position, Range, TextEdit, Uri},
+    lsp_types::{Pattern, Position, Range, TextEdit, Uri},
 };
 
 use crate::formatter::options::FormatOptions as LSPFormatOptions;
@@ -102,6 +102,23 @@ impl ServerFormatter {
                 FormatOptions::default()
             }
         }
+    }
+
+    #[expect(clippy::unused_self)]
+    pub fn get_watcher_patterns(&self, options: &LSPFormatOptions) -> Pattern {
+        options.config_path.as_ref().map_or(FORMAT_CONFIG_FILE, |v| v).to_owned()
+    }
+
+    pub fn get_changed_watch_patterns(
+        &self,
+        old_options: &LSPFormatOptions,
+        new_options: &LSPFormatOptions,
+    ) -> Option<Pattern> {
+        if old_options != new_options && new_options.experimental {
+            return Some(self.get_watcher_patterns(new_options));
+        }
+
+        None
     }
 }
 


### PR DESCRIPTION
Now the worker is responsible to provide the dynamic registration with `Registration` and `Unregistration`.
The worker will use the provided tools to detect the needed watcher changes. 
Before this PR, the server/Backend created the `Registration` struct for each worker, this was not great because we needed to register the watchers for the other tools too.
Now every tool has its own `Registration.id` which can be unregistered.

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#client_registerCapability
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#client_unregisterCapability