### PR TITLE
test(oxlint): add test for nested configs importing the same plugin 2x

### DIFF
--- a/apps/oxlint/test/e2e.test.ts
+++ b/apps/oxlint/test/e2e.test.ts
@@ -85,6 +85,11 @@ describe('oxlint CLI', () => {
       overrideFiles: '.',
     });
   });
+  it('should do something', async () => {
+    await testFixture('custom_plugin_nested_config_duplicate', {
+      overrideFiles: '.',
+    });
+  });
 
   it('should load a custom plugin when configured in overrides', async () => {
     await testFixture('custom_plugin_via_overrides');

--- a/apps/oxlint/test/fixtures/custom_plugin_nested_config_duplicate/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_nested_config_duplicate/.oxlintrc.json
@@ -1,0 +1,7 @@
+{
+  "jsPlugins": ["./plugin.ts"],
+  "rules": {
+    "basic-custom-plugin/no-debugger": "error"
+  },
+  "categories": { "correctness": "off" }
+}

--- a/apps/oxlint/test/fixtures/custom_plugin_nested_config_duplicate/nested/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/custom_plugin_nested_config_duplicate/nested/.oxlintrc.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["../plugin.ts"],
+  "extends": ["../.oxlintrc.json"]
+}

--- a/apps/oxlint/test/fixtures/custom_plugin_nested_config_duplicate/nested/index.ts
+++ b/apps/oxlint/test/fixtures/custom_plugin_nested_config_duplicate/nested/index.ts
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/fixtures/custom_plugin_nested_config_duplicate/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_nested_config_duplicate/output.snap.md
@@ -1,0 +1,20 @@
+# Exit code
+1
+
+# stdout
+```
+  x basic-custom-plugin(no-debugger): Unexpected Debugger Statement
+   ,-[nested/index.ts:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+
+Found 0 warnings and 1 error.
+Finished in Xms on 2 files using X threads.
+```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/custom_plugin_nested_config_duplicate/plugin.ts
+++ b/apps/oxlint/test/fixtures/custom_plugin_nested_config_duplicate/plugin.ts
@@ -1,0 +1,23 @@
+import type { Plugin } from '../../../dist/index.js';
+
+const plugin: Plugin = {
+  meta: {
+    name: 'basic-custom-plugin',
+  },
+  rules: {
+    'no-debugger': {
+      create(context) {
+        return {
+          DebuggerStatement(debuggerStatement) {
+            context.report({
+              message: 'Unexpected Debugger Statement',
+              node: debuggerStatement,
+            });
+          },
+        };
+      },
+    },
+  },
+};
+
+export default plugin;


### PR DESCRIPTION
@overlookmotel looks like we already handle this case here:

https://github.com/oxc-project/oxc/blob/55becc5ffc4392bb5ae1d9c19bed0d9073e0d13f/crates/oxc_linter/src/config/config_builder.rs#L535-L537