### PR TITLE
perf(linter): switch `if !matches!(node.kind(), ...)` to match block

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -484,7 +484,8 @@ impl RuleRunner for crate::rules::eslint::no_loss_of_precision::NoLossOfPrecisio
 }
 
 impl RuleRunner for crate::rules::eslint::no_magic_numbers::NoMagicNumbers {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BigIntLiteral, AstType::NumericLiteral]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -2307,7 +2308,8 @@ impl RuleRunner for crate::rules::react::react_in_jsx_scope::ReactInJsxScope {
 }
 
 impl RuleRunner for crate::rules::react::require_render_return::RequireRenderReturn {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ArrowFunctionExpression, AstType::Function]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -2939,7 +2941,8 @@ impl RuleRunner for crate::rules::unicorn::empty_brace_spaces::EmptyBraceSpaces 
 }
 
 impl RuleRunner for crate::rules::unicorn::error_message::ErrorMessage {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::NewExpression]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -3270,7 +3273,8 @@ impl RuleRunner
 }
 
 impl RuleRunner for crate::rules::unicorn::no_useless_spread::NoUselessSpread {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ArrayExpression, AstType::ObjectExpression]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_magic_numbers.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_magic_numbers.rs
@@ -289,8 +289,9 @@ impl Rule for NoMagicNumbers {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if !matches!(node.kind(), AstKind::NumericLiteral(_) | AstKind::BigIntLiteral(_)) {
-            return;
+        match node.kind() {
+            AstKind::NumericLiteral(_) | AstKind::BigIntLiteral(_) => {}
+            _ => return,
         }
 
         let nodes = ctx.nodes();

--- a/crates/oxc_linter/src/rules/react/require_render_return.rs
+++ b/crates/oxc_linter/src/rules/react/require_render_return.rs
@@ -70,9 +70,11 @@ declare_oxc_lint!(
 
 impl Rule for RequireRenderReturn {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if !matches!(node.kind(), AstKind::ArrowFunctionExpression(_) | AstKind::Function(_)) {
-            return;
+        match node.kind() {
+            AstKind::ArrowFunctionExpression(_) | AstKind::Function(_) => {}
+            _ => return,
         }
+
         let parent = ctx.nodes().parent_node(node.id());
         if !is_render_fn(parent) {
             return;

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -725,9 +725,6 @@ fn is_property_of_object_with_type(node: &AstNode, ctx: &LintContext) -> bool {
     if !matches!(node.kind(), AstKind::ObjectProperty(_)) {
         return false;
     }
-    if !matches!(node.kind(), AstKind::ObjectProperty(_)) {
-        return false;
-    }
     let parent = ctx.nodes().parent_node(node.id());
     if !matches!(parent.kind(), AstKind::ObjectExpression(_)) {
         return false;

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
@@ -145,8 +145,9 @@ declare_oxc_lint!(
 
 impl Rule for NoUselessSpread {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if !matches!(node.kind(), AstKind::ArrayExpression(_) | AstKind::ObjectExpression(_)) {
-            return;
+        match node.kind() {
+            AstKind::ArrayExpression(_) | AstKind::ObjectExpression(_) => {}
+            _ => return,
         }
 
         if check_useless_spread_in_list(node, ctx) {


### PR DESCRIPTION
Adding support for `matches!` in the linter codegen would be somewhat tedious as we'd need to start parsing macros. Instead, there is a similar idiom that we already support: diverging `match` on `node.kind()`. So, I've updated the linter codegen to support `|` in match arms, plus updated rules to use this new pattern instead of `if !matches!(...)`.

<img width="1392" height="664" alt="CleanShot 2025-10-16 at 12 12 45@2x" src="https://github.com/user-attachments/assets/75762f93-152a-49e4-83ab-46240d7b2b62" />
