### PR TITLE
feat(formatter): Experiment sort-imports by sort-AST w/ IR approach

### DIFF
--- a/crates/oxc_formatter/src/formatter/comments.rs
+++ b/crates/oxc_formatter/src/formatter/comments.rs
@@ -167,12 +167,6 @@ impl<'a> Comments<'a> {
         self.comments
     }
 
-    /// Returns the current printed count cursor position.
-    #[inline]
-    pub fn printed_count(&self) -> usize {
-        self.printed_count
-    }
-
     /// Returns an iterator over comments that end before or at the given position.
     pub fn comments_before_iter(&self, pos: u32) -> impl Iterator<Item = &Comment> {
         self.unprinted_comments().iter().take_while(move |c| c.span.end <= pos)


### PR DESCRIPTION
Alternative approach to #14647.

The most painful part of the previous approach was:

- looking up comments and empty lines
- printing comments with tweaking the rule of `formatter/comments.rs`

And that was probably the reason why we didn't see the performance improvements we expected.

This PR, following Dunqing's advice, I adopted the `intern()` method, which converts the AST to IR on the spot.
To be precise, it uses a temporary `VecBuffer` and write to it, rather than using the `intern()` API. (This is a pattern also used in existing formatter logic.)

Using IR allows us to treat `import ..` and associated comments as a single unit, thereby reducing the need to refer back to the `SourceText`.
This dramatically reduces the amount of code in simple cases!

However, depending on the `partition_by_comment` options, it may be necessary to locate and extract comments from the neatly organized IR...
As a result, the code did not become as concise as possible.

The `partition_by_newline` option is worse because it requires you to detect empty lines.

Because, the `Line::Empty` is generated at the join of each statement's IR at the end.
This ultimately means that we need to refer to the `SourceText`.