### PR TITLE
fix(formatter): don't group nested await expression when its is the leftmost expression

### DIFF
--- a/crates/oxc_formatter/src/parentheses/expression.rs
+++ b/crates/oxc_formatter/src/parentheses/expression.rs
@@ -1,3 +1,5 @@
+use std::ptr;
+
 use oxc_allocator::Address;
 use oxc_ast::ast::*;
 use oxc_data_structures::stack;
@@ -313,9 +315,8 @@ impl<'a> NeedsParentheses<'a> for AstNode<'a, CallExpression<'a>> {
                 // when the leftmost expression is not a class expression or a function expression
                 callee_span != leftmost.span()
                     && matches!(
-                        leftmost,
-                        ExpressionLeftSide::Expression(e)
-                         if matches!(e.as_ref(), Expression::ClassExpression(_) | Expression::FunctionExpression(_))
+                        leftmost.as_ref(),
+                        Expression::ClassExpression(_) | Expression::FunctionExpression(_)
                     )
             }
             _ => false,

--- a/crates/oxc_formatter/src/write/mod.rs
+++ b/crates/oxc_formatter/src/write/mod.rs
@@ -420,7 +420,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, AwaitExpression<'a>> {
 
         if is_callee_or_object {
             let mut parent = self.parent.parent();
-            let mut ancestor_is_await = false;
             loop {
                 match parent {
                     AstNodes::AwaitExpression(_)
@@ -436,7 +435,9 @@ impl<'a> FormatWrite<'a> for AstNode<'a, AwaitExpression<'a>> {
             let indented = format_with(|f| write!(f, [soft_block_indent(&format_inner)]));
 
             return if let AstNodes::AwaitExpression(expr) = parent {
-                if !expr.needs_parentheses(f) {
+                if !expr.needs_parentheses(f)
+                    && ExpressionLeftSide::leftmost(expr.argument()).span() != self.span()
+                {
                     return write!(f, [group(&indented)]);
                 }
 

--- a/crates/oxc_formatter/tests/fixtures/js/awaits/nested.js
+++ b/crates/oxc_formatter/tests/fixtures/js/awaits/nested.js
@@ -1,0 +1,5 @@
+vite = await (
+  await import('vite')
+).createServer({
+  appType
+})

--- a/crates/oxc_formatter/tests/fixtures/js/awaits/nested.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/awaits/nested.js.snap
@@ -1,0 +1,17 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+vite = await (
+  await import('vite')
+).createServer({
+  appType
+})
+==================== Output ====================
+vite = await (
+  await import("vite")
+).createServer({
+  appType,
+});
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/calls/template-literal-argument.js
+++ b/crates/oxc_formatter/tests/fixtures/js/calls/template-literal-argument.js
@@ -1,0 +1,8 @@
+expect(genCode(createVNodeCall(null, `"div"`, mockProps)))
+  .toMatchInlineSnapshot(`
+  `)
+
+expect(genCode(createVNodeCall(null, `"div"`, mockProps)))
+  .toMatchInlineSnapshot(`
+  `).toMatchInlineSnapshot(`
+    `)

--- a/crates/oxc_formatter/tests/fixtures/js/calls/template-literal-argument.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/calls/template-literal-argument.js.snap
@@ -1,0 +1,26 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+expect(genCode(createVNodeCall(null, `"div"`, mockProps)))
+  .toMatchInlineSnapshot(`
+  `)
+
+expect(genCode(createVNodeCall(null, `"div"`, mockProps)))
+  .toMatchInlineSnapshot(`
+  `).toMatchInlineSnapshot(`
+    `)
+
+==================== Output ====================
+expect(
+  genCode(createVNodeCall(null, `"div"`, mockProps)),
+).toMatchInlineSnapshot(`
+  `);
+
+expect(genCode(createVNodeCall(null, `"div"`, mockProps)))
+  .toMatchInlineSnapshot(`
+  `)
+  .toMatchInlineSnapshot(`
+    `);
+
+===================== End =====================


### PR DESCRIPTION
Align Prettier's behavior in https://github.com/prettier/prettier/blob/7584432401a47a26943dd7a9ca9a8e032ead7285/src/language-js/print/estree.js#L204-L212