### PR TITLE
fix(formatter): don't print CallExpression as MemberChain style when its only has one argument and it is a TemplateLiteral on its own line

### DIFF
--- a/crates/oxc_formatter/src/write/call_arguments.rs
+++ b/crates/oxc_formatter/src/write/call_arguments.rs
@@ -959,19 +959,11 @@ fn is_multiline_template_only_args(arguments: &[Argument], source_text: SourceTe
         return false;
     }
 
-    match arguments.first().unwrap() {
-        Argument::TemplateLiteral(template) => {
-            is_multiline_template_starting_on_same_line(template.span.start, template, source_text)
-        }
-        Argument::TaggedTemplateExpression(template) => {
-            is_multiline_template_starting_on_same_line(
-                template.span.start,
-                &template.quasi,
-                source_text,
-            )
-        }
-        _ => false,
-    }
+    arguments
+        .first()
+        .unwrap()
+        .as_expression()
+        .is_some_and(|expr| is_multiline_template_starting_on_same_line(expr, source_text))
 }
 
 /// This function is used to check if the code is a hook-like code:

--- a/crates/oxc_formatter/tests/fixtures/js/calls/template-literal-argument.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/calls/template-literal-argument.js.snap
@@ -12,15 +12,13 @@ expect(genCode(createVNodeCall(null, `"div"`, mockProps)))
     `)
 
 ==================== Output ====================
-expect(
-  genCode(createVNodeCall(null, `"div"`, mockProps)),
-).toMatchInlineSnapshot(`
+expect(genCode(createVNodeCall(null, `"div"`, mockProps)))
+  .toMatchInlineSnapshot(`
   `);
 
 expect(genCode(createVNodeCall(null, `"div"`, mockProps)))
   .toMatchInlineSnapshot(`
-  `)
-  .toMatchInlineSnapshot(`
+  `).toMatchInlineSnapshot(`
     `);
 
 ===================== End =====================


### PR DESCRIPTION
Align Prettier's behavior

https://github.com/prettier/prettier/blob/7584432401a47a26943dd7a9ca9a8e032ead7285/src/language-js/print/call-expression.js#L24-L53