### PR TITLE
fix(formatter): should group type parameters and parameters for method-like and function-like nodes

### DIFF
--- a/crates/oxc_formatter/src/write/class.rs
+++ b/crates/oxc_formatter/src/write/class.rs
@@ -102,15 +102,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, MethodDefinition<'a>> {
             write!(f, "?")?;
         }
 
-        if value.type_parameters.is_none() {
-            // // Handle comments between method name and parameters
-            // // Example: method /* comment */ (param) {}
-            // let comments = f.context().comments().comments_before(value.params().span.start);
-            // if !comments.is_empty() {
-            //     write!(f, [space(), FormatTrailingComments::Comments(comments)])?;
-            // }
-        }
-
         format_grouped_parameters_with_return_type(
             value.type_parameters(),
             value.this_param.as_deref(),
@@ -639,30 +630,28 @@ pub fn format_grouped_parameters_with_return_type<'a>(
     return_type: Option<&AstNode<'a, TSTypeAnnotation<'a>>>,
     f: &mut Formatter<'_, 'a>,
 ) -> FormatResult<()> {
-    write!(f, [type_parameters])?;
-
     group(&format_once(|f| {
+        let mut format_type_parameters = type_parameters.memoized();
         let mut format_parameters = params.memoized();
         let mut format_return_type = return_type.memoized();
 
         // Inspect early, in case the `return_type` is formatted before `parameters`
         // in `should_group_function_parameters`.
+        format_type_parameters.inspect(f)?;
         format_parameters.inspect(f)?;
 
         let group_parameters = should_group_function_parameters(
             type_parameters.map(AsRef::as_ref),
-            params.items.len()
-                + usize::from(params.rest.is_some())
-                + usize::from(this_param.is_some()),
+            params.parameters_count() + usize::from(this_param.is_some()),
             return_type.map(AsRef::as_ref),
             &mut format_return_type,
             f,
         )?;
 
         if group_parameters {
-            write!(f, [group(&format_parameters)])
+            write!(f, [group(&format_args!(format_type_parameters, format_parameters))])
         } else {
-            write!(f, [format_parameters])
+            write!(f, [format_type_parameters, format_parameters])
         }?;
 
         write!(f, [format_return_type])

--- a/crates/oxc_formatter/src/write/function.rs
+++ b/crates/oxc_formatter/src/write/function.rs
@@ -108,9 +108,7 @@ impl<'a> FormatWrite<'a> for FormatFunction<'a, '_> {
 
                 let group_parameters = should_group_function_parameters(
                     self.type_parameters.as_deref(),
-                    params.items.len()
-                        + usize::from(params.rest.is_some())
-                        + usize::from(self.this_param.is_some()),
+                    params.parameters_count() + usize::from(self.this_param.is_some()),
                     self.return_type.as_deref(),
                     &mut format_return_type,
                     f,

--- a/crates/oxc_formatter/tests/fixtures/ts/method-signatures/grouped.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/method-signatures/grouped.ts
@@ -1,0 +1,24 @@
+
+type A = {
+  new(...args): T<{
+    A
+  }
+  >
+};
+
+
+type A1 = {
+  (...args): T<{
+    A
+  }
+  >
+};
+
+type A2 = {
+  bar(
+    ...args
+  ): T<{
+    A
+  }>
+}
+

--- a/crates/oxc_formatter/tests/fixtures/ts/method-signatures/grouped.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/method-signatures/grouped.ts.snap
@@ -1,0 +1,49 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+
+type A = {
+  new(...args): T<{
+    A
+  }
+  >
+};
+
+
+type A1 = {
+  (...args): T<{
+    A
+  }
+  >
+};
+
+type A2 = {
+  bar(
+    ...args
+  ): T<{
+    A
+  }>
+}
+
+
+==================== Output ====================
+type A = {
+  new (...args): T<{
+    A;
+  }>;
+};
+
+type A1 = {
+  (...args): T<{
+    A;
+  }>;
+};
+
+type A2 = {
+  bar(...args): T<{
+    A;
+  }>;
+};
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/objects/methods.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/objects/methods.ts
@@ -1,0 +1,6 @@
+const builder = {
+  build(environment: BuildEnvironment): Promise<
+    RollupOutput | RollupOutput[]
+  > {
+  },
+}

--- a/crates/oxc_formatter/tests/fixtures/ts/objects/methods.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/objects/methods.ts.snap
@@ -1,0 +1,19 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+const builder = {
+  build(environment: BuildEnvironment): Promise<
+    RollupOutput | RollupOutput[]
+  > {
+  },
+}
+
+==================== Output ====================
+const builder = {
+  build(
+    environment: BuildEnvironment,
+  ): Promise<RollupOutput | RollupOutput[]> {},
+};
+
+===================== End =====================


### PR DESCRIPTION
Align Prettier's behavior. The biome's implementation missed some nodes to do the same thing.