### PR TITLE
fix(formatter): should not indent BinaryLikeExpression when its parent is `NewExpression`

### DIFF
--- a/crates/oxc_formatter/src/write/binary_like_expression.rs
+++ b/crates/oxc_formatter/src/write/binary_like_expression.rs
@@ -165,15 +165,18 @@ impl<'a, 'b> BinaryLikeExpression<'a, 'b> {
                     false
                 }
             }
-            AstNodes::ConditionalExpression(conditional) => !matches!(
-                parent.parent(),
-                AstNodes::ReturnStatement(_)
-                    | AstNodes::ThrowStatement(_)
-                    | AstNodes::CallExpression(_)
-                    | AstNodes::ImportExpression(_)
-                    | AstNodes::Argument(_)
-                    | AstNodes::MetaProperty(_)
-            ),
+            AstNodes::ConditionalExpression(conditional) => {
+                !matches!(
+                    parent.parent(),
+                    AstNodes::ReturnStatement(_)
+                        | AstNodes::ThrowStatement(_)
+                        | AstNodes::CallExpression(_)
+                        | AstNodes::ImportExpression(_)
+                        | AstNodes::MetaProperty(_)
+                    ) &&
+                    // TODO(prettier): Why not include `NewExpression` ???
+                    !matches!(parent.parent(), AstNodes::Argument(argument) if matches!(argument.parent, AstNodes::CallExpression(_)))
+            }
             _ => false,
         }
     }

--- a/crates/oxc_formatter/tests/fixtures/js/logicals/indent.js
+++ b/crates/oxc_formatter/tests/fixtures/js/logicals/indent.js
@@ -1,0 +1,8 @@
+{
+  RESOLUTION_CACHE = new ExpiringCache(
+    options.singleRun
+      ? 'Infinity'
+      : (options.cacheLifetime?.glob ??
+        DEFAULT_TSCONFIG_CACHE_DURATION_SECONDS),
+  );
+}

--- a/crates/oxc_formatter/tests/fixtures/js/logicals/indent.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/logicals/indent.js.snap
@@ -1,0 +1,24 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+{
+  RESOLUTION_CACHE = new ExpiringCache(
+    options.singleRun
+      ? 'Infinity'
+      : (options.cacheLifetime?.glob ??
+        DEFAULT_TSCONFIG_CACHE_DURATION_SECONDS),
+  );
+}
+
+==================== Output ====================
+{
+  RESOLUTION_CACHE = new ExpiringCache(
+    options.singleRun
+      ? "Infinity"
+      : (options.cacheLifetime?.glob ??
+        DEFAULT_TSCONFIG_CACHE_DURATION_SECONDS),
+  );
+}
+
+===================== End =====================


### PR DESCRIPTION
Align Prettier's behavior in https://github.com/prettier/prettier/blob/7584432401a47a26943dd7a9ca9a8e032ead7285/src/language-js/print/binaryish.js#L107