### PR TITLE
ci(benchmark): skip benchmark when PR has `0-merge` label

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,6 +32,7 @@ jobs:
   determine-matrix:
     name: Determine Benchmark
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, '0-merge') }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,7 +32,7 @@ jobs:
   determine-matrix:
     name: Determine Benchmark
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, '0-merge') }}
+    if: ${{ github.event.pull_request && !contains(github.event.pull_request.labels.*.name, '0-merge') }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,7 +32,7 @@ jobs:
   determine-matrix:
     name: Determine Benchmark
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request && !contains(github.event.pull_request.labels.*.name, '0-merge') }}
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, '0-merge') }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:


### PR DESCRIPTION
## Summary

- Skip running benchmarks for PRs labeled with `0-merge`

Benchmarks are expensive and unnecessary for merge commits that have already been tested.

## Test plan

- Add the `0-merge` label to a PR and verify benchmarks don't run

🤖 Generated with [Claude Code](https://claude.com/claude-code)