### PR TITLE
fix(semantic): add condition basic blocks to CFG for logical expressions

### DIFF
--- a/crates/oxc_semantic/tests/integration/snapshots/assignment_operators.snap
+++ b/crates/oxc_semantic/tests/integration/snapshots/assignment_operators.snap
@@ -12,19 +12,19 @@ bb1: {
 }
 
 bb2: {
-
+	condition
 }
 
 bb3: {
-	statement
+
 }
 
 bb4: {
-
+	statement
 }
 
 bb5: {
-	statement
+	condition
 }
 
 bb6: {
@@ -33,6 +33,18 @@ bb6: {
 
 bb7: {
 	statement
+}
+
+bb8: {
+	condition
+}
+
+bb9: {
+
+}
+
+bb10: {
+	statement
 	statement
 }
 
@@ -40,30 +52,42 @@ digraph {
     0 [ label = "bb0" shape = box]
     1 [ label = "bb1
 ExpressionStatement" shape = box]
-    2 [ label = "bb2" shape = box]
-    3 [ label = "bb3
+    2 [ label = "bb2
+Condition(IdentifierReference(x))" shape = box]
+    3 [ label = "bb3" shape = box]
+    4 [ label = "bb4
 ExpressionStatement" shape = box]
-    4 [ label = "bb4" shape = box]
     5 [ label = "bb5
-ExpressionStatement" shape = box]
+Condition(IdentifierReference(x))" shape = box]
     6 [ label = "bb6" shape = box]
     7 [ label = "bb7
+ExpressionStatement" shape = box]
+    8 [ label = "bb8
+Condition(IdentifierReference(x))" shape = box]
+    9 [ label = "bb9" shape = box]
+    10 [ label = "bb10
 ExpressionStatement
 ExpressionStatement" shape = box]
     1 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     2 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     3 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
-    1 -> 2 [ label="Normal"]
-    1 -> 3 [ label="Normal"]
-    2 -> 3 [ label="Normal"]
     4 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
-    5 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    1 -> 2 [ label="Normal"]
+    2 -> 3 [ label="Normal"]
+    2 -> 4 [ label="Normal"]
     3 -> 4 [ label="Normal"]
-    3 -> 5 [ label="Normal"]
-    4 -> 5 [ label="Normal"]
+    5 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     6 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     7 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    4 -> 5 [ label="Normal"]
     5 -> 6 [ label="Normal"]
     5 -> 7 [ label="Normal"]
     6 -> 7 [ label="Normal"]
+    8 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    9 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    10 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    7 -> 8 [ label="Normal"]
+    8 -> 9 [ label="Normal"]
+    8 -> 10 [ label="Normal"]
+    9 -> 10 [ label="Normal"]
 }

--- a/crates/oxc_semantic/tests/integration/snapshots/function_as_expression.snap
+++ b/crates/oxc_semantic/tests/integration/snapshots/function_as_expression.snap
@@ -96,15 +96,15 @@ bb22: {
 }
 
 bb23: {
-
+	condition
 }
 
 bb24: {
-	return
+
 }
 
 bb25: {
-
+	return
 }
 
 bb26: {
@@ -112,15 +112,15 @@ bb26: {
 }
 
 bb27: {
-	statement
+
 }
 
 bb28: {
-
+	statement
 }
 
 bb29: {
-	return
+	condition
 }
 
 bb30: {
@@ -128,11 +128,11 @@ bb30: {
 }
 
 bb31: {
-
+	return
 }
 
 bb32: {
-	statement
+
 }
 
 bb33: {
@@ -140,22 +140,30 @@ bb33: {
 }
 
 bb34: {
-	return
-}
-
-bb35: {
 	statement
 }
 
-bb36: {
+bb35: {
 
 }
 
-bb37: {
+bb36: {
 	return
 }
 
+bb37: {
+	statement
+}
+
 bb38: {
+
+}
+
+bb39: {
+	return
+}
+
+bb40: {
 
 }
 
@@ -198,29 +206,33 @@ ExpressionStatement" shape = box]
 return" shape = box]
     22 [ label = "bb22
 ExpressionStatement" shape = box]
-    23 [ label = "bb23" shape = box]
-    24 [ label = "bb24
+    23 [ label = "bb23
+Condition(Function(f))" shape = box]
+    24 [ label = "bb24" shape = box]
+    25 [ label = "bb25
 return" shape = box]
-    25 [ label = "bb25" shape = box]
     26 [ label = "bb26" shape = box]
-    27 [ label = "bb27
+    27 [ label = "bb27" shape = box]
+    28 [ label = "bb28
 ExpressionStatement" shape = box]
-    28 [ label = "bb28" shape = box]
     29 [ label = "bb29
-return" shape = box]
+Condition(Function(<anonymous>))" shape = box]
     30 [ label = "bb30" shape = box]
-    31 [ label = "bb31" shape = box]
-    32 [ label = "bb32
-ExpressionStatement" shape = box]
+    31 [ label = "bb31
+return" shape = box]
+    32 [ label = "bb32" shape = box]
     33 [ label = "bb33" shape = box]
     34 [ label = "bb34
-return" shape = box]
-    35 [ label = "bb35
 ExpressionStatement" shape = box]
-    36 [ label = "bb36" shape = box]
-    37 [ label = "bb37
+    35 [ label = "bb35" shape = box]
+    36 [ label = "bb36
 return" shape = box]
+    37 [ label = "bb37
+ExpressionStatement" shape = box]
     38 [ label = "bb38" shape = box]
+    39 [ label = "bb39
+return" shape = box]
+    40 [ label = "bb40" shape = box]
     1 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     3 -> 2 [ label="Error(Implicit)", color=red, style=dashed]
     1 -> 3 [ label="NewFunction"]
@@ -250,30 +262,34 @@ return" shape = box]
     19 -> 21 [ label="NewFunction"]
     22 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     19 -> 22 [ label="Normal"]
-    24 -> 23 [ label="Error(Implicit)", color=red, style=dashed]
-    22 -> 24 [ label="NewFunction"]
-    25 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
-    22 -> 25 [ label="Normal"]
+    23 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    25 -> 24 [ label="Error(Implicit)", color=red, style=dashed]
+    23 -> 25 [ label="NewFunction"]
     26 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    23 -> 26 [ label="Normal"]
     27 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
-    25 -> 26 [ label="Normal"]
-    25 -> 27 [ label="Normal"]
+    28 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    22 -> 23 [ label="Normal"]
     26 -> 27 [ label="Normal"]
-    29 -> 28 [ label="Error(Implicit)", color=red, style=dashed]
-    27 -> 29 [ label="NewFunction"]
-    30 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
-    27 -> 30 [ label="Normal"]
-    31 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    26 -> 28 [ label="Normal"]
+    27 -> 28 [ label="Normal"]
+    29 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    31 -> 30 [ label="Error(Implicit)", color=red, style=dashed]
+    29 -> 31 [ label="NewFunction"]
     32 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
-    30 -> 31 [ label="Normal"]
-    30 -> 32 [ label="Normal"]
-    31 -> 32 [ label="Normal"]
-    34 -> 33 [ label="Error(Implicit)", color=red, style=dashed]
-    32 -> 34 [ label="NewFunction"]
-    35 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
-    32 -> 35 [ label="Normal"]
-    37 -> 36 [ label="Error(Implicit)", color=red, style=dashed]
-    35 -> 37 [ label="NewFunction"]
-    38 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
-    35 -> 38 [ label="Normal"]
+    29 -> 32 [ label="Normal"]
+    33 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    34 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    28 -> 29 [ label="Normal"]
+    32 -> 33 [ label="Normal"]
+    32 -> 34 [ label="Normal"]
+    33 -> 34 [ label="Normal"]
+    36 -> 35 [ label="Error(Implicit)", color=red, style=dashed]
+    34 -> 36 [ label="NewFunction"]
+    37 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    34 -> 37 [ label="Normal"]
+    39 -> 38 [ label="Error(Implicit)", color=red, style=dashed]
+    37 -> 39 [ label="NewFunction"]
+    40 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    37 -> 40 [ label="Normal"]
 }

--- a/crates/oxc_semantic/tests/integration/snapshots/if_else.snap
+++ b/crates/oxc_semantic/tests/integration/snapshots/if_else.snap
@@ -24,7 +24,7 @@ bb4: {
 }
 
 bb5: {
-
+	condition
 }
 
 bb6: {
@@ -32,32 +32,36 @@ bb6: {
 }
 
 bb7: {
-	statement
-	return <value>
+
 }
 
 bb8: {
-	unreachable
-}
-
-bb9: {
 	statement
 	return <value>
 }
 
-bb10: {
+bb9: {
 	unreachable
 }
 
-bb11: {
+bb10: {
+	statement
 	return <value>
 }
 
-bb12: {
+bb11: {
 	unreachable
 }
 
+bb12: {
+	return <value>
+}
+
 bb13: {
+	unreachable
+}
+
+bb14: {
 
 }
 
@@ -69,46 +73,50 @@ digraph {
 IfStatement" shape = box]
     4 [ label = "bb4
 Condition(LogicalExpression)" shape = box]
-    5 [ label = "bb5" shape = box]
+    5 [ label = "bb5
+Condition(true)" shape = box]
     6 [ label = "bb6" shape = box]
-    7 [ label = "bb7
-BlockStatement
-return <value>" shape = box]
+    7 [ label = "bb7" shape = box]
     8 [ label = "bb8
-unreachable" shape = box]
-    9 [ label = "bb9
 BlockStatement
 return <value>" shape = box]
+    9 [ label = "bb9
+unreachable" shape = box]
     10 [ label = "bb10
-unreachable" shape = box]
-    11 [ label = "bb11
+BlockStatement
 return <value>" shape = box]
-    12 [ label = "bb12
+    11 [ label = "bb11
 unreachable" shape = box]
-    13 [ label = "bb13" shape = box]
+    12 [ label = "bb12
+return <value>" shape = box]
+    13 [ label = "bb13
+unreachable" shape = box]
+    14 [ label = "bb14" shape = box]
     1 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     3 -> 2 [ label="Error(Implicit)", color=red, style=dashed]
     1 -> 3 [ label="NewFunction"]
     4 -> 2 [ label="Error(Implicit)", color=red, style=dashed]
     5 -> 2 [ label="Error(Implicit)", color=red, style=dashed]
     6 -> 2 [ label="Error(Implicit)", color=red, style=dashed]
-    4 -> 5 [ label="Normal"]
-    4 -> 6 [ label="Normal"]
-    5 -> 6 [ label="Normal"]
     7 -> 2 [ label="Error(Implicit)", color=red, style=dashed]
-    8 -> 2 [ label="Error(Implicit)", style=dashed, color=red]
-    7 -> 8 [ label="Unreachable", style="dotted"]
-    9 -> 2 [ label="Error(Implicit)", color=red, style=dashed]
-    10 -> 2 [ label="Error(Implicit)", style=dashed, color=red]
-    9 -> 10 [ label="Unreachable", style="dotted"]
+    4 -> 5 [ label="Normal"]
+    5 -> 6 [ label="Normal"]
+    5 -> 7 [ label="Normal"]
+    6 -> 7 [ label="Normal"]
+    8 -> 2 [ label="Error(Implicit)", color=red, style=dashed]
+    9 -> 2 [ label="Error(Implicit)", style=dashed, color=red]
+    8 -> 9 [ label="Unreachable", style="dotted"]
+    10 -> 2 [ label="Error(Implicit)", color=red, style=dashed]
     11 -> 2 [ label="Error(Implicit)", style=dashed, color=red]
-    3 -> 4 [ label="Normal"]
-    6 -> 7 [ label="Jump", color=green]
-    8 -> 11 [ label="Normal", style="dotted"]
-    6 -> 9 [ label="Jump", color=green]
-    10 -> 11 [ label="Normal", style="dotted"]
+    10 -> 11 [ label="Unreachable", style="dotted"]
     12 -> 2 [ label="Error(Implicit)", style=dashed, color=red]
-    11 -> 12 [ label="Unreachable", style="dotted"]
-    13 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
-    1 -> 13 [ label="Normal"]
+    3 -> 4 [ label="Normal"]
+    7 -> 8 [ label="Jump", color=green]
+    9 -> 12 [ label="Normal", style="dotted"]
+    7 -> 10 [ label="Jump", color=green]
+    11 -> 12 [ label="Normal", style="dotted"]
+    13 -> 2 [ label="Error(Implicit)", style=dashed, color=red]
+    12 -> 13 [ label="Unreachable", style="dotted"]
+    14 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    1 -> 14 [ label="Normal"]
 }

--- a/crates/oxc_semantic/tests/integration/snapshots/infix_operators.snap
+++ b/crates/oxc_semantic/tests/integration/snapshots/infix_operators.snap
@@ -13,10 +13,14 @@ bb1: {
 }
 
 bb2: {
-
+	condition
 }
 
 bb3: {
+
+}
+
+bb4: {
 
 }
 
@@ -25,12 +29,16 @@ digraph {
     1 [ label = "bb1
 ExpressionStatement
 ExpressionStatement" shape = box]
-    2 [ label = "bb2" shape = box]
+    2 [ label = "bb2
+Condition(IdentifierReference(a))" shape = box]
     3 [ label = "bb3" shape = box]
+    4 [ label = "bb4" shape = box]
     1 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     2 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     3 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    4 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     1 -> 2 [ label="Normal"]
-    1 -> 3 [ label="Normal"]
     2 -> 3 [ label="Normal"]
+    2 -> 4 [ label="Normal"]
+    3 -> 4 [ label="Normal"]
 }

--- a/crates/oxc_semantic/tests/integration/snapshots/logical_expressions_short_circuit.snap
+++ b/crates/oxc_semantic/tests/integration/snapshots/logical_expressions_short_circuit.snap
@@ -16,7 +16,7 @@ bb2: {
 }
 
 bb3: {
-
+	condition
 }
 
 bb4: {
@@ -24,51 +24,63 @@ bb4: {
 }
 
 bb5: {
-	statement
-	statement
+
 }
 
 bb6: {
 	statement
+	statement
 }
 
 bb7: {
-	condition
+	statement
 }
 
 bb8: {
-
-}
-
-bb9: {
-
-}
-
-bb10: {
-	statement
-}
-
-bb11: {
-	statement
-}
-
-bb12: {
 	condition
 }
 
-bb13: {
+bb9: {
+	condition
+}
+
+bb10: {
 
 }
 
-bb14: {
+bb11: {
 
 }
 
-bb15: {
+bb12: {
 	statement
 }
 
+bb13: {
+	statement
+}
+
+bb14: {
+	condition
+}
+
+bb15: {
+	condition
+}
+
 bb16: {
+
+}
+
+bb17: {
+
+}
+
+bb18: {
+	statement
+}
+
+bb19: {
 
 }
 
@@ -78,63 +90,75 @@ digraph {
 IfStatement" shape = box]
     2 [ label = "bb2
 Condition(LogicalExpression)" shape = box]
-    3 [ label = "bb3" shape = box]
+    3 [ label = "bb3
+Condition(true)" shape = box]
     4 [ label = "bb4" shape = box]
-    5 [ label = "bb5
+    5 [ label = "bb5" shape = box]
+    6 [ label = "bb6
 BlockStatement
 ExpressionStatement" shape = box]
-    6 [ label = "bb6
-IfStatement" shape = box]
     7 [ label = "bb7
-Condition(LogicalExpression)" shape = box]
-    8 [ label = "bb8" shape = box]
-    9 [ label = "bb9" shape = box]
-    10 [ label = "bb10
-ExpressionStatement" shape = box]
-    11 [ label = "bb11
 IfStatement" shape = box]
-    12 [ label = "bb12
+    8 [ label = "bb8
 Condition(LogicalExpression)" shape = box]
-    13 [ label = "bb13" shape = box]
-    14 [ label = "bb14" shape = box]
-    15 [ label = "bb15
+    9 [ label = "bb9
+Condition(true)" shape = box]
+    10 [ label = "bb10" shape = box]
+    11 [ label = "bb11" shape = box]
+    12 [ label = "bb12
 ExpressionStatement" shape = box]
+    13 [ label = "bb13
+IfStatement" shape = box]
+    14 [ label = "bb14
+Condition(LogicalExpression)" shape = box]
+    15 [ label = "bb15
+Condition(IdentifierReference(x))" shape = box]
     16 [ label = "bb16" shape = box]
+    17 [ label = "bb17" shape = box]
+    18 [ label = "bb18
+ExpressionStatement" shape = box]
+    19 [ label = "bb19" shape = box]
     1 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     2 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     3 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     4 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
-    2 -> 3 [ label="Normal"]
-    2 -> 4 [ label="Normal"]
-    3 -> 4 [ label="Normal"]
     5 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    2 -> 3 [ label="Normal"]
+    3 -> 4 [ label="Normal"]
+    3 -> 5 [ label="Normal"]
+    4 -> 5 [ label="Normal"]
     6 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
-    1 -> 2 [ label="Normal"]
-    4 -> 5 [ label="Jump", color=green]
-    5 -> 6 [ label="Normal"]
-    4 -> 6 [ label="Jump", color=green]
     7 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    1 -> 2 [ label="Normal"]
+    5 -> 6 [ label="Jump", color=green]
+    6 -> 7 [ label="Normal"]
+    5 -> 7 [ label="Jump", color=green]
     8 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     9 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
-    7 -> 8 [ label="Normal"]
-    7 -> 9 [ label="Normal"]
-    8 -> 9 [ label="Normal"]
     10 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     11 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
-    6 -> 7 [ label="Normal"]
-    9 -> 10 [ label="Jump", color=green]
+    8 -> 9 [ label="Normal"]
+    9 -> 10 [ label="Normal"]
+    9 -> 11 [ label="Normal"]
     10 -> 11 [ label="Normal"]
-    9 -> 11 [ label="Jump", color=green]
     12 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     13 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
-    14 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    7 -> 8 [ label="Normal"]
+    11 -> 12 [ label="Jump", color=green]
     12 -> 13 [ label="Normal"]
-    12 -> 14 [ label="Normal"]
-    13 -> 14 [ label="Normal"]
+    11 -> 13 [ label="Jump", color=green]
+    14 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     15 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     16 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
-    11 -> 12 [ label="Normal"]
-    14 -> 15 [ label="Jump", color=green]
+    17 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    14 -> 15 [ label="Normal"]
     15 -> 16 [ label="Normal"]
-    14 -> 16 [ label="Jump", color=green]
+    15 -> 17 [ label="Normal"]
+    16 -> 17 [ label="Normal"]
+    18 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    19 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    13 -> 14 [ label="Normal"]
+    17 -> 18 [ label="Jump", color=green]
+    18 -> 19 [ label="Normal"]
+    17 -> 19 [ label="Jump", color=green]
 }

--- a/crates/oxc_semantic/tests/integration/snapshots/while.snap
+++ b/crates/oxc_semantic/tests/integration/snapshots/while.snap
@@ -24,7 +24,7 @@ bb4: {
 }
 
 bb5: {
-
+	condition
 }
 
 bb6: {
@@ -32,23 +32,27 @@ bb6: {
 }
 
 bb7: {
+
+}
+
+bb8: {
 	statement
 	return <value>
 }
 
-bb8: {
-	unreachable
-}
-
 bb9: {
-	return <value>
+	unreachable
 }
 
 bb10: {
-	unreachable
+	return <value>
 }
 
 bb11: {
+	unreachable
+}
+
+bb12: {
 
 }
 
@@ -60,37 +64,41 @@ digraph {
 WhileStatement" shape = box]
     4 [ label = "bb4
 Condition(LogicalExpression)" shape = box]
-    5 [ label = "bb5" shape = box]
+    5 [ label = "bb5
+Condition(0)" shape = box]
     6 [ label = "bb6" shape = box]
-    7 [ label = "bb7
+    7 [ label = "bb7" shape = box]
+    8 [ label = "bb8
 BlockStatement
 return <value>" shape = box]
-    8 [ label = "bb8
-unreachable" shape = box]
     9 [ label = "bb9
-return <value>" shape = box]
-    10 [ label = "bb10
 unreachable" shape = box]
-    11 [ label = "bb11" shape = box]
+    10 [ label = "bb10
+return <value>" shape = box]
+    11 [ label = "bb11
+unreachable" shape = box]
+    12 [ label = "bb12" shape = box]
     1 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     3 -> 2 [ label="Error(Implicit)", color=red, style=dashed]
     1 -> 3 [ label="NewFunction"]
     4 -> 2 [ label="Error(Implicit)", color=red, style=dashed]
     5 -> 2 [ label="Error(Implicit)", color=red, style=dashed]
     6 -> 2 [ label="Error(Implicit)", color=red, style=dashed]
-    4 -> 5 [ label="Normal"]
-    4 -> 6 [ label="Normal"]
-    5 -> 6 [ label="Normal"]
     7 -> 2 [ label="Error(Implicit)", color=red, style=dashed]
-    8 -> 2 [ label="Error(Implicit)", style=dashed, color=red]
-    7 -> 8 [ label="Unreachable", style="dotted"]
-    9 -> 2 [ label="Error(Implicit)", color=red, style=dashed]
+    4 -> 5 [ label="Normal"]
+    5 -> 6 [ label="Normal"]
+    5 -> 7 [ label="Normal"]
+    6 -> 7 [ label="Normal"]
+    8 -> 2 [ label="Error(Implicit)", color=red, style=dashed]
+    9 -> 2 [ label="Error(Implicit)", style=dashed, color=red]
+    8 -> 9 [ label="Unreachable", style="dotted"]
+    10 -> 2 [ label="Error(Implicit)", color=red, style=dashed]
     3 -> 4 [ label="Normal"]
-    4 -> 7 [ label="Jump", color=green]
-    8 -> 4 [ label="Backedge", style="dotted", color=grey]
-    4 -> 9 [ label="Normal"]
-    10 -> 2 [ label="Error(Implicit)", style=dashed, color=red]
-    9 -> 10 [ label="Unreachable", style="dotted"]
-    11 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
-    1 -> 11 [ label="Normal"]
+    4 -> 8 [ label="Jump", color=green]
+    9 -> 4 [ label="Backedge", style="dotted", color=grey]
+    4 -> 10 [ label="Normal"]
+    11 -> 2 [ label="Error(Implicit)", style=dashed, color=red]
+    10 -> 11 [ label="Unreachable", style="dotted"]
+    12 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    1 -> 12 [ label="Normal"]
 }


### PR DESCRIPTION
Add explicit condition basic blocks in the control flow graph for logical
expressions and logical assignment operators. This improves CFG accuracy by
representing condition evaluation as distinct nodes.

Changes:
- Create condition basic blocks before evaluating left operands of logical expressions (&&, ||, ??)
- Record and attach AST nodes to condition blocks for better traceability
- Add edges from preceding blocks to condition blocks
- Apply same treatment to logical assignment operators (&&=, ||=, ??=)

This affects CFG generation for:
- LogicalExpression nodes
- AssignmentExpression nodes with logical operators