### PR TITLE
test(linter): add test case with function params in no-const-assign

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
@@ -108,6 +108,7 @@ fn test() {
         ("await using x = foo();", None),
         ("using x = foo(); bar(x);", None),
         ("await using x = foo(); bar(x);", None),
+        ("type t = (a, ...b) => void", None),
     ];
 
     let fail = vec![


### PR DESCRIPTION
fixes [#14675](https://github.com/oxc-project/oxc/issues/14675)