### PR TITLE
perf(linter): add codegen support for let statements before match

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -1525,7 +1525,8 @@ impl RuleRunner for crate::rules::jsdoc::require_returns_type::RequireReturnsTyp
 }
 
 impl RuleRunner for crate::rules::jsdoc::require_yields::RequireYields {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Function, AstType::YieldExpression]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -2389,7 +2390,17 @@ impl RuleRunner
 }
 
 impl RuleRunner for crate::rules::typescript::array_type::ArrayType {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::TSArrayType,
+        AstType::TSAsExpression,
+        AstType::TSConditionalType,
+        AstType::TSIndexedAccessType,
+        AstType::TSMappedType,
+        AstType::TSTypeAliasDeclaration,
+        AstType::TSTypeAnnotation,
+        AstType::TSTypeParameterInstantiation,
+        AstType::TSTypeReference,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 


### PR DESCRIPTION
Allows simple `let` statements before the `match node.kind()` return. For example:


```rust
let config = something;
match node.kind() {
  // use config and return
}
```

<img width="714" height="370" alt="Screenshot 2025-10-16 at 2 37 29 PM" src="https://github.com/user-attachments/assets/89beb7ca-6751-4035-85cc-aec87348fd3a" />
