### PR TITLE
perf(ast_tools): parallelize minifying code

### DIFF
--- a/tasks/ast_tools/src/generators/estree_visit.rs
+++ b/tasks/ast_tools/src/generators/estree_visit.rs
@@ -349,7 +349,7 @@ fn generate(codegen: &Codegen) -> Codes {
 
         // Remove extraneous `export const ancestors = [];` statement from parser version
         fn pre_process_variant<'a>(
-            &mut self,
+            &self,
             program: &mut oxc_ast::ast::Program<'a>,
             flags: [bool; 1],
             _allocator: &'a oxc_allocator::Allocator,

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -253,7 +253,7 @@ fn generate_deserializers(
         }
 
         fn pre_process_variant<'a>(
-            &mut self,
+            &self,
             program: &mut Program<'a>,
             flags: [bool; 6],
             allocator: &'a Allocator,


### PR DESCRIPTION
Parallelize generating multiple variants of code (which included minification). This is one of the slowest parts of the codegen, so spreading the work across multiple threads speeds it up a bit.