### PR TITLE
perf(linter): refactor class-methods-use-this to be analyzed

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -27,7 +27,11 @@ impl RuleRunner for crate::rules::eslint::block_scoped_var::BlockScopedVar {
 }
 
 impl RuleRunner for crate::rules::eslint::class_methods_use_this::ClassMethodsUseThis {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::AccessorProperty,
+        AstType::MethodDefinition,
+        AstType::PropertyDefinition,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 


### PR DESCRIPTION
Remove `let` statement that blocks simple node type analysis. 