### PR TITLE
perf(linter): refactor `no-labels` to use top-level match on node kind

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -465,7 +465,11 @@ impl RuleRunner for crate::rules::eslint::no_label_var::NoLabelVar {
 }
 
 impl RuleRunner for crate::rules::eslint::no_labels::NoLabels {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::BreakStatement,
+        AstType::ContinueStatement,
+        AstType::LabeledStatement,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_labels.rs
@@ -141,33 +141,34 @@ impl Rule for NoLabels {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if let AstKind::LabeledStatement(labeled_stmt) = node.kind()
-            && !self.is_allowed(&labeled_stmt.body)
-        {
-            let label_span = labeled_stmt.label.span;
-            ctx.diagnostic(no_labels_diagnostic("Labeled statement is not allowed", label_span));
-        }
-
-        if let AstKind::BreakStatement(break_stmt) = node.kind() {
-            let Some(label) = &break_stmt.label else { return };
-
-            if !self.is_allowed_in_break_or_continue(label, node.id(), ctx) {
+        match node.kind() {
+            AstKind::LabeledStatement(labeled_stmt) if !self.is_allowed(&labeled_stmt.body) => {
                 ctx.diagnostic(no_labels_diagnostic(
-                    "Label in break statement is not allowed",
-                    label.span,
+                    "Labeled statement is not allowed",
+                    labeled_stmt.label.span,
                 ));
             }
-        }
-
-        if let AstKind::ContinueStatement(cont_stmt) = node.kind() {
-            let Some(label) = &cont_stmt.label else { return };
-
-            if !self.is_allowed_in_break_or_continue(label, node.id(), ctx) {
-                ctx.diagnostic(no_labels_diagnostic(
-                    "Label in continue statement is not allowed",
-                    label.span,
-                ));
+            AstKind::BreakStatement(break_stmt) => {
+                if let Some(label) = &break_stmt.label
+                    && !self.is_allowed_in_break_or_continue(label, node.id(), ctx)
+                {
+                    ctx.diagnostic(no_labels_diagnostic(
+                        "Label in break statement is not allowed",
+                        label.span,
+                    ));
+                }
             }
+            AstKind::ContinueStatement(cont_stmt) => {
+                if let Some(label) = &cont_stmt.label
+                    && !self.is_allowed_in_break_or_continue(label, node.id(), ctx)
+                {
+                    ctx.diagnostic(no_labels_diagnostic(
+                        "Label in continue statement is not allowed",
+                        label.span,
+                    ));
+                }
+            }
+            _ => {}
         }
     }
 }


### PR DESCRIPTION
Using a single `match node.kind()` should be a bit faster and simpler, and also allows node type analysis.