### PR TITLE
perf(linter): refactor `no-unsafe-finally` to have a diverging match as first statement

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -736,7 +736,12 @@ impl RuleRunner for crate::rules::eslint::no_unreachable::NoUnreachable {
 }
 
 impl RuleRunner for crate::rules::eslint::no_unsafe_finally::NoUnsafeFinally {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::BreakStatement,
+        AstType::ContinueStatement,
+        AstType::ReturnStatement,
+        AstType::ThrowStatement,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
@@ -51,9 +51,7 @@ declare_oxc_lint!(
 
 impl Rule for NoUnsafeFinally {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let kind = node.kind();
-
-        let sentinel_node_type = match kind {
+        let sentinel_node_type = match node.kind() {
             AstKind::BreakStatement(stmt) if stmt.label.is_none() => SentinelNodeType::Break,
             AstKind::ContinueStatement(_) => SentinelNodeType::Continue,
             AstKind::ReturnStatement(_)
@@ -62,7 +60,7 @@ impl Rule for NoUnsafeFinally {
             _ => return,
         };
 
-        let label_name = match kind {
+        let label_name = match node.kind() {
             AstKind::BreakStatement(BreakStatement { label, .. })
             | AstKind::ContinueStatement(ContinueStatement { label, .. }) => {
                 label.as_ref().map(|label| &label.name)


### PR DESCRIPTION
Removes `let` statement blocking node type analysis. This does duplicate the `node.kind()` check, but this is negligible in effect.