### PR TITLE
perf(linter): refactor `no-amd` to do scope check after node type check

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -1077,7 +1077,8 @@ impl RuleRunner for crate::rules::import::no_absolute_path::NoAbsolutePath {
 }
 
 impl RuleRunner for crate::rules::import::no_amd::NoAmd {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/import/no_amd.rs
+++ b/crates/oxc_linter/src/rules/import/no_amd.rs
@@ -51,12 +51,10 @@ declare_oxc_lint!(
 /// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-amd.md>
 impl Rule for NoAmd {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        // not in top level
-        if node.scope_id() != ctx.scoping().root_scope_id() {
-            return;
-        }
         if let AstKind::CallExpression(call_expr) = node.kind()
             && let Expression::Identifier(identifier) = &call_expr.callee
+            // must be in top level
+            && node.scope_id() == ctx.scoping().root_scope_id()
         {
             if identifier.name != "define" && identifier.name != "require" {
                 return;


### PR DESCRIPTION
Check node type first, then check scope later, as this enables node type optimization.