### PR TITLE
perf(linter): move root scope check into match arms in `import/no-webpack-loader-syntax`

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -1175,7 +1175,8 @@ impl RuleRunner for crate::rules::import::no_unassigned_import::NoUnassignedImpo
 }
 
 impl RuleRunner for crate::rules::import::no_webpack_loader_syntax::NoWebpackLoaderSyntax {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::ImportDeclaration]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/import/no_webpack_loader_syntax.rs
+++ b/crates/oxc_linter/src/rules/import/no_webpack_loader_syntax.rs
@@ -54,11 +54,6 @@ declare_oxc_lint!(
 
 impl Rule for NoWebpackLoaderSyntax {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        // not in top level
-        if node.scope_id() != ctx.scoping().root_scope_id() {
-            return;
-        }
-
         match node.kind() {
             AstKind::CallExpression(call_expr) => {
                 if let Expression::Identifier(identifier) = &call_expr.callee {
@@ -74,6 +69,11 @@ impl Rule for NoWebpackLoaderSyntax {
                         return;
                     };
 
+                    // not in top level
+                    if node.scope_id() != ctx.scoping().root_scope_id() {
+                        return;
+                    }
+
                     if ident.value.contains('!') {
                         ctx.diagnostic(no_named_as_default_diagnostic(
                             ident.value.as_str(),
@@ -83,6 +83,11 @@ impl Rule for NoWebpackLoaderSyntax {
                 }
             }
             AstKind::ImportDeclaration(import_decl) => {
+                // not in top level
+                if node.scope_id() != ctx.scoping().root_scope_id() {
+                    return;
+                }
+
                 if import_decl.source.value.contains('!') {
                     ctx.diagnostic(no_named_as_default_diagnostic(
                         &import_decl.source.value,


### PR DESCRIPTION
Check scope later, and check node type first, as this enables node type optimization.