### PR TITLE
perf(linter): refactor `jest/no-conditional-in-test` to use diverging match

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -1226,7 +1226,12 @@ impl RuleRunner for crate::rules::jest::no_conditional_expect::NoConditionalExpe
 }
 
 impl RuleRunner for crate::rules::jest::no_conditional_in_test::NoConditionalInTest {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::ConditionalExpression,
+        AstType::IfStatement,
+        AstType::LogicalExpression,
+        AstType::SwitchStatement,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_conditional_in_test.rs
+++ b/crates/oxc_linter/src/rules/jest/no_conditional_in_test.rs
@@ -99,36 +99,36 @@ declare_oxc_lint!(
 
 impl Rule for NoConditionalInTest {
     fn run<'a>(&self, node: &oxc_semantic::AstNode<'a>, ctx: &LintContext<'a>) {
-        if matches!(
-            node.kind(),
+        match node.kind() {
             AstKind::IfStatement(_)
-                | AstKind::SwitchStatement(_)
-                | AstKind::ConditionalExpression(_)
-                | AstKind::LogicalExpression(_)
-        ) {
-            let is_if_statement_in_test = ctx.nodes().ancestors(node.id()).any(|node| {
-                let AstKind::CallExpression(call_expr) = node.kind() else { return false };
-                let vitest_node = PossibleJestNode { node, original: None };
+            | AstKind::SwitchStatement(_)
+            | AstKind::ConditionalExpression(_)
+            | AstKind::LogicalExpression(_) => {}
+            _ => return,
+        }
 
-                is_type_of_jest_fn_call(
-                    call_expr,
-                    &vitest_node,
-                    ctx,
-                    &[JestFnKind::General(crate::utils::JestGeneralFnKind::Test)],
-                )
-            });
+        let is_if_statement_in_test = ctx.nodes().ancestors(node.id()).any(|node| {
+            let AstKind::CallExpression(call_expr) = node.kind() else { return false };
+            let vitest_node = PossibleJestNode { node, original: None };
 
-            if is_if_statement_in_test {
-                let span = match node.kind() {
-                    AstKind::IfStatement(stmt) => stmt.span,
-                    AstKind::SwitchStatement(stmt) => stmt.span,
-                    AstKind::ConditionalExpression(expr) => expr.span,
-                    AstKind::LogicalExpression(expr) => expr.span,
-                    _ => unreachable!(),
-                };
+            is_type_of_jest_fn_call(
+                call_expr,
+                &vitest_node,
+                ctx,
+                &[JestFnKind::General(crate::utils::JestGeneralFnKind::Test)],
+            )
+        });
 
-                ctx.diagnostic(no_conditional_in_test(span));
-            }
+        if is_if_statement_in_test {
+            let span = match node.kind() {
+                AstKind::IfStatement(stmt) => stmt.span,
+                AstKind::SwitchStatement(stmt) => stmt.span,
+                AstKind::ConditionalExpression(expr) => expr.span,
+                AstKind::LogicalExpression(expr) => expr.span,
+                _ => unreachable!(),
+            };
+
+            ctx.diagnostic(no_conditional_in_test(span));
         }
     }
 }


### PR DESCRIPTION
Use diverging `match node.kind()` instead of `if !matches!(node.kind(), ...)`