### PR TITLE
perf(linter): refactor `jest/require-hook` to use top-level match

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -1427,7 +1427,8 @@ impl RuleRunner for crate::rules::jest::prefer_todo::PreferTodo {
 }
 
 impl RuleRunner for crate::rules::jest::require_hook::RequireHook {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::Program]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/jest/require_hook.rs
+++ b/crates/oxc_linter/src/rules/jest/require_hook.rs
@@ -173,34 +173,35 @@ impl Rule for RequireHook {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let kind = node.kind();
-
-        if let AstKind::Program(program) = kind {
-            self.check_block_body(node, &program.body, ctx);
-        } else if let AstKind::CallExpression(call_expr) = kind {
-            if !is_type_of_jest_fn_call(
-                call_expr,
-                &PossibleJestNode { node, original: None },
-                ctx,
-                &[JestFnKind::General(JestGeneralFnKind::Describe)],
-            ) || call_expr.arguments.len() < 2
-            {
-                return;
+        match node.kind() {
+            AstKind::Program(program) => {
+                self.check_block_body(node, &program.body, ctx);
             }
-
-            match &call_expr.arguments[1] {
-                Argument::FunctionExpression(func_expr) => {
-                    if let Some(func_body) = &func_expr.body {
-                        self.check_block_body(node, &func_body.statements, ctx);
-                    }
+            AstKind::CallExpression(call_expr) => {
+                if !is_type_of_jest_fn_call(
+                    call_expr,
+                    &PossibleJestNode { node, original: None },
+                    ctx,
+                    &[JestFnKind::General(JestGeneralFnKind::Describe)],
+                ) || call_expr.arguments.len() < 2
+                {
+                    return;
                 }
-                Argument::ArrowFunctionExpression(arrow_func_expr) => {
-                    if !arrow_func_expr.expression {
-                        self.check_block_body(node, &arrow_func_expr.body.statements, ctx);
+                match &call_expr.arguments[1] {
+                    Argument::FunctionExpression(func_expr) => {
+                        if let Some(func_body) = &func_expr.body {
+                            self.check_block_body(node, &func_body.statements, ctx);
+                        }
                     }
+                    Argument::ArrowFunctionExpression(arrow_func_expr) => {
+                        if !arrow_func_expr.expression {
+                            self.check_block_body(node, &arrow_func_expr.body.statements, ctx);
+                        }
+                    }
+                    _ => (),
                 }
-                _ => (),
             }
+            _ => {}
         }
     }
 }


### PR DESCRIPTION
Single `match` is simpler and enables node type analysis.