### PR TITLE
perf(linter): inline `is_function_node` calls for some jsdoc rules

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -1478,12 +1478,14 @@ impl RuleRunner for crate::rules::jsdoc::empty_tags::EmptyTags {
 }
 
 impl RuleRunner for crate::rules::jsdoc::implements_on_classes::ImplementsOnClasses {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ArrowFunctionExpression, AstType::Function]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::jsdoc::no_defaults::NoDefaults {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ArrowFunctionExpression, AstType::Function]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -1500,7 +1502,8 @@ impl RuleRunner for crate::rules::jsdoc::require_param_description::RequireParam
 }
 
 impl RuleRunner for crate::rules::jsdoc::require_param_name::RequireParamName {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ArrowFunctionExpression, AstType::Function]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -1536,12 +1539,14 @@ impl RuleRunner for crate::rules::jsdoc::require_returns::RequireReturns {
 }
 
 impl RuleRunner for crate::rules::jsdoc::require_returns_description::RequireReturnsDescription {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ArrowFunctionExpression, AstType::Function]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::jsdoc::require_returns_type::RequireReturnsType {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ArrowFunctionExpression, AstType::Function]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/jsdoc/implements_on_classes.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/implements_on_classes.rs
@@ -5,7 +5,6 @@ use oxc_span::Span;
 
 use crate::{
     AstNode,
-    ast_util::is_function_node,
     context::LintContext,
     rule::Rule,
     utils::{get_function_nearest_jsdoc_node, should_ignore_as_internal, should_ignore_as_private},
@@ -76,8 +75,10 @@ fn is_function_inside_of_class<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintConte
 
 impl Rule for ImplementsOnClasses {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if !is_function_node(node) {
-            return;
+        match node.kind() {
+            AstKind::Function(f) if f.is_function_declaration() || f.is_expression() => {}
+            AstKind::ArrowFunctionExpression(_) => {}
+            _ => return,
         }
 
         // Filter plain declared (arrow) function.
@@ -136,7 +137,7 @@ fn test() {
 			       * @class
 			       */
 			      function quux () {
-			
+
 			      }
 			      ",
             None,
@@ -149,7 +150,7 @@ fn test() {
 			       * @constructor
 			       */
 			      function quux () {
-			
+
 			      }
 			      ",
             None,
@@ -162,7 +163,7 @@ fn test() {
 			       * @constructor
 			       */
 			      const quux = () => {
-			
+
 			      }
 			      ",
             None,
@@ -178,7 +179,7 @@ fn test() {
 			         * @implements {SomeClass}
 			         */
 			        constructor () {
-			
+
 			        }
 			      }
 			      ",
@@ -195,7 +196,7 @@ fn test() {
 			         * @implements {SomeClass}
 			         */
 			        constructor () {
-			
+
 			        }
 			      }
 			      ",
@@ -212,7 +213,7 @@ fn test() {
 			         * @implements {SomeClass}
 			         */
 			        foo() {
-			
+
 			        }
 			      }
 			      ",
@@ -225,7 +226,7 @@ fn test() {
 			       *
 			       */
 			      function quux () {
-			
+
 			      }
 			      ",
             None,
@@ -260,7 +261,7 @@ fn test() {
 			       * @implements {SomeClass}
 			       */
 			      function quux () {
-			
+
 			      }
 			      ",
             None,
@@ -272,7 +273,7 @@ fn test() {
 			       * @implements {SomeClass}
 			       */
 			      const quux = () => {
-			
+
 			      }
 			      ",
             None,
@@ -285,7 +286,7 @@ fn test() {
 			       * @implements {SomeClass}
 			       */
 			      const quux = function() {
-			
+
 			      }
 			      ",
             None,

--- a/crates/oxc_linter/src/rules/jsdoc/no_defaults.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/no_defaults.rs
@@ -1,3 +1,4 @@
+use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -5,7 +6,6 @@ use serde::Deserialize;
 
 use crate::{
     AstNode,
-    ast_util::is_function_node,
     context::LintContext,
     rule::Rule,
     utils::{get_function_nearest_jsdoc_node, should_ignore_as_internal, should_ignore_as_private},
@@ -66,8 +66,10 @@ impl Rule for NoDefaults {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if !is_function_node(node) {
-            return;
+        match node.kind() {
+            AstKind::Function(f) if f.is_function_declaration() || f.is_expression() => {}
+            AstKind::ArrowFunctionExpression(_) => {}
+            _ => return,
         }
 
         let Some(jsdocs) = get_function_nearest_jsdoc_node(node, ctx)

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_name.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_name.rs
@@ -1,10 +1,10 @@
+use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
 use crate::{
     AstNode,
-    ast_util::is_function_node,
     context::LintContext,
     rule::Rule,
     utils::{get_function_nearest_jsdoc_node, should_ignore_as_internal, should_ignore_as_private},
@@ -48,8 +48,10 @@ declare_oxc_lint!(
 
 impl Rule for RequireParamName {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if !is_function_node(node) {
-            return;
+        match node.kind() {
+            AstKind::Function(f) if f.is_function_declaration() || f.is_expression() => {}
+            AstKind::ArrowFunctionExpression(_) => {}
+            _ => return,
         }
 
         // If no JSDoc is found, skip
@@ -96,7 +98,7 @@ fn test() {
 			           * @param foo
 			           */
 			          function quux (foo) {
-			
+
 			          }
 			      ",
             None,
@@ -108,7 +110,7 @@ fn test() {
 			           * @param {string} foo
 			           */
 			          function quux (foo) {
-			
+
 			          }
 			      ",
             None,
@@ -170,7 +172,7 @@ fn test() {
 			           * @param
 			           */
 			          function quux (foo) {
-			
+
 			          }
 			      ",
             None,
@@ -182,7 +184,7 @@ fn test() {
 			           * @param {string}
 			           */
 			          function quux (foo) {
-			
+
 			          }
 			      ",
             None,

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns_description.rs
@@ -1,10 +1,10 @@
+use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
 use crate::{
     AstNode,
-    ast_util::is_function_node,
     context::LintContext,
     rule::Rule,
     utils::{get_function_nearest_jsdoc_node, should_ignore_as_internal, should_ignore_as_private},
@@ -49,8 +49,10 @@ declare_oxc_lint!(
 
 impl Rule for RequireReturnsDescription {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if !is_function_node(node) {
-            return;
+        match node.kind() {
+            AstKind::Function(f) if f.is_function_declaration() || f.is_expression() => {}
+            AstKind::ArrowFunctionExpression(_) => {}
+            _ => return,
         }
 
         // If no JSDoc is found, skip

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns_type.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns_type.rs
@@ -1,10 +1,10 @@
+use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
 use crate::{
     AstNode,
-    ast_util::is_function_node,
     context::LintContext,
     rule::Rule,
     utils::{get_function_nearest_jsdoc_node, should_ignore_as_internal, should_ignore_as_private},
@@ -48,8 +48,10 @@ declare_oxc_lint!(
 
 impl Rule for RequireReturnsType {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if !is_function_node(node) {
-            return;
+        match node.kind() {
+            AstKind::Function(f) if f.is_function_declaration() || f.is_expression() => {}
+            AstKind::ArrowFunctionExpression(_) => {}
+            _ => return,
         }
 
         // If no JSDoc is found, skip


### PR DESCRIPTION
This one might be controversial, but inlining this simple function allows for better node type analysis.