### PR TITLE
perf(linter): update `typescript/array-type` to only have top-level match

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2416,7 +2416,17 @@ impl RuleRunner
 }
 
 impl RuleRunner for crate::rules::typescript::array_type::ArrayType {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::TSArrayType,
+        AstType::TSAsExpression,
+        AstType::TSConditionalType,
+        AstType::TSIndexedAccessType,
+        AstType::TSMappedType,
+        AstType::TSTypeAliasDeclaration,
+        AstType::TSTypeAnnotation,
+        AstType::TSTypeParameterInstantiation,
+        AstType::TSTypeReference,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 


### PR DESCRIPTION
In order to remove the `let` statements blocking node type analysis, adds `default_config` and `readonly_config` functions to replace them. Also removes some cloning that was occurring on the array option itself.