### PR TITLE
perf(linter): update `no-extra-non-null-assertion` to use diverging match

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2571,7 +2571,12 @@ impl RuleRunner for crate::rules::typescript::no_explicit_any::NoExplicitAny {
 }
 
 impl RuleRunner for crate::rules::typescript::no_extra_non_null_assertion::NoExtraNonNullAssertion {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::CallExpression,
+        AstType::ComputedMemberExpression,
+        AstType::StaticMemberExpression,
+        AstType::TSNonNullExpression,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
@@ -101,7 +101,7 @@ impl Rule for NoExtraNonNullAssertion {
                     None
                 }
             }
-            _ => None,
+            _ => return,
         };
 
         if let Some(expr) = expr {


### PR DESCRIPTION
Adding the diverging match here enables the linter codegen to recognize this pattern and do node type analysis.