### PR TITLE
perf(linter): update `catch-error-name` to use top-level match

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2949,7 +2949,8 @@ impl RuleRunner for crate::rules::typescript::use_unknown_in_catch_callback_vari
 }
 
 impl RuleRunner for crate::rules::unicorn::catch_error_name::CatchErrorName {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::CatchParameter]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/catch_error_name.rs
+++ b/crates/oxc_linter/src/rules/unicorn/catch_error_name.rs
@@ -152,24 +152,26 @@ impl Rule for CatchErrorName {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if let AstKind::CatchParameter(catch_param) = node.kind() {
-            self.check_binding_identifier(ctx, &catch_param.pattern.kind);
-        }
-
-        if let AstKind::CallExpression(call_expr) = node.kind()
-            && let Some(member_expr) = call_expr.callee.as_member_expression()
-        {
-            if member_expr.static_property_name() == Some("catch")
-                && let Some(arg) = call_expr.arguments.first()
-            {
-                self.check_function_arguments(arg, ctx);
+        match node.kind() {
+            AstKind::CatchParameter(catch_param) => {
+                self.check_binding_identifier(ctx, &catch_param.pattern.kind);
             }
+            AstKind::CallExpression(call_expr) => {
+                if let Some(member_expr) = call_expr.callee.as_member_expression() {
+                    if member_expr.static_property_name() == Some("catch")
+                        && let Some(arg) = call_expr.arguments.first()
+                    {
+                        self.check_function_arguments(arg, ctx);
+                    }
 
-            if member_expr.static_property_name() == Some("then")
-                && let Some(arg) = call_expr.arguments.get(1)
-            {
-                self.check_function_arguments(arg, ctx);
+                    if member_expr.static_property_name() == Some("then")
+                        && let Some(arg) = call_expr.arguments.get(1)
+                    {
+                        self.check_function_arguments(arg, ctx);
+                    }
+                }
             }
+            _ => {}
         }
     }
 }


### PR DESCRIPTION
Top-level `match` is simpler and enables node type analysis in the linter codegen.