### PR TITLE
perf(linter): update `prefer-node-protocol` to use diverging match

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3541,7 +3541,13 @@ impl RuleRunner for crate::rules::unicorn::prefer_negative_index::PreferNegative
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_node_protocol::PreferNodeProtocol {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::CallExpression,
+        AstType::ExportNamedDeclaration,
+        AstType::ImportDeclaration,
+        AstType::ImportExpression,
+        AstType::TSImportEqualsDeclaration,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
@@ -64,7 +64,7 @@ impl Rule for PreferNodeProtocol {
             AstKind::ExportNamedDeclaration(export) => {
                 export.source.as_ref().map(|item| (item.value, item.span))
             }
-            _ => None,
+            _ => return,
         };
         let Some((string_lit_value, span)) = string_lit_value_with_span else {
             return;


### PR DESCRIPTION
Diverging match is recognized by the linter codegen, so adding the `return` here enables node type analysis.