### PR TITLE
feat(formatter): add `AstNode::ancestor` and `AstNode::grand_parent` methods

### DIFF
--- a/crates/oxc_formatter/src/ast_nodes/impls/ast_nodes.rs
+++ b/crates/oxc_formatter/src/ast_nodes/impls/ast_nodes.rs
@@ -1,0 +1,26 @@
+//! Implementations of methods for [`AstNodes`].
+
+use crate::ast_nodes::AstNodes;
+
+impl<'a> AstNodes<'a> {
+    /// Returns an iterator over all ancestor nodes in the AST, starting from self.
+    ///
+    /// The iteration includes the current node and proceeds upward through the tree,
+    /// terminating after yielding the root `Program` node.
+    ///
+    /// # Example hierarchy
+    /// ```text
+    /// Program
+    ///   └─ BlockStatement
+    ///       └─ ExpressionStatement  <- self
+    /// ```
+    /// For `self` as ExpressionStatement, this yields: [ExpressionStatement, BlockStatement, Program]
+    pub fn ancestors(&self) -> impl Iterator<Item = &AstNodes<'a>> {
+        // Start with the current node and walk up the tree, including Program
+        std::iter::successors(Some(self), |node| {
+            // Continue iteration until we've yielded Program (root node)
+            // After Program, parent() would still return Program, so stop there
+            if matches!(node, AstNodes::Program(_)) { None } else { Some(node.parent()) }
+        })
+    }
+}

--- a/crates/oxc_formatter/src/ast_nodes/impls/mod.rs
+++ b/crates/oxc_formatter/src/ast_nodes/impls/mod.rs
@@ -1,0 +1,1 @@
+pub mod ast_nodes;

--- a/crates/oxc_formatter/src/ast_nodes/mod.rs
+++ b/crates/oxc_formatter/src/ast_nodes/mod.rs
@@ -1,4 +1,5 @@
 pub mod generated;
+pub mod impls;
 mod iterator;
 mod node;
 

--- a/crates/oxc_formatter/src/ast_nodes/node.rs
+++ b/crates/oxc_formatter/src/ast_nodes/node.rs
@@ -63,6 +63,48 @@ impl<T: GetSpan> GetSpan for &AstNode<'_, T> {
     }
 }
 
+impl<T> AstNode<'_, T> {
+    /// Returns an iterator over all ancestor nodes in the AST, starting from self.
+    ///
+    /// The iteration includes the current node and proceeds upward through the tree,
+    /// terminating after yielding the root `Program` node.
+    ///
+    /// This is a convenience method that delegates to `self.parent.ancestors()`.
+    ///
+    /// # Example
+    /// ```text
+    /// Program
+    ///   └─ BlockStatement
+    ///       └─ ExpressionStatement  <- self
+    /// ```
+    /// For `self` as ExpressionStatement, this yields: [ExpressionStatement, BlockStatement, Program]
+    ///
+    /// # Usage
+    /// ```ignore
+    /// // Find the first ancestor that matches a condition
+    /// let parent = self.ancestors()
+    ///     .find(|p| matches!(p, AstNodes::ForStatement(_)))
+    ///     .unwrap();
+    ///
+    /// // Get the nth ancestor
+    /// let great_grandparent = self.ancestors().nth(3);
+    ///
+    /// // Check if any ancestor is a specific type
+    /// let in_arrow_fn = self.ancestors()
+    ///     .any(|p| matches!(p, AstNodes::ArrowFunctionExpression(_)));
+    /// ```
+    pub fn ancestors(&self) -> impl Iterator<Item = &AstNodes<'_>> {
+        self.parent.ancestors()
+    }
+
+    /// Returns the grandparent node (parent's parent).
+    ///
+    /// This is a convenience method equivalent to `self.parent.parent()`.
+    pub fn grand_parent(&self) -> &AstNodes<'_> {
+        self.parent.parent()
+    }
+}
+
 impl<'a> AstNode<'a, Program<'a>> {
     pub fn new(inner: &'a Program<'a>, parent: &'a AstNodes<'a>, allocator: &'a Allocator) -> Self {
         AstNode { inner, parent, allocator, following_span: None }

--- a/crates/oxc_formatter/src/utils/call_expression.rs
+++ b/crates/oxc_formatter/src/utils/call_expression.rs
@@ -37,7 +37,7 @@ pub fn is_test_call_expression(call: &AstNode<CallExpression<'_>>) -> bool {
     match (args.next(), args.next(), args.next()) {
         (Some(argument), None, None) if arguments.len() == 1 => {
             if is_angular_test_wrapper(call) && {
-                if let AstNodes::CallExpression(call) = call.parent.parent() {
+                if let AstNodes::CallExpression(call) = call.grand_parent() {
                     is_test_call_expression(call)
                 } else {
                     false

--- a/crates/oxc_formatter/src/utils/member_chain/mod.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/mod.rs
@@ -96,7 +96,7 @@ impl<'a, 'b> MemberChain<'a, 'b> {
                 is_factory(&identifier.name) ||
                 // If an identifier has a name that is shorter than the tab with, then we join it with the "head"
                 (matches!(parent, AstNodes::ExpressionStatement(stmt) if {
-                     if let AstNodes::ArrowFunctionExpression(arrow) = stmt.parent.parent() {
+                     if let AstNodes::ArrowFunctionExpression(arrow) = stmt.grand_parent() {
                         !arrow.expression
                      } else {
                         true

--- a/crates/oxc_formatter/src/write/call_arguments.rs
+++ b/crates/oxc_formatter/src/write/call_arguments.rs
@@ -115,7 +115,7 @@ impl<'a> Format<'a> for AstNode<'a, ArenaVec<'a, Argument<'a>>> {
         });
 
         if has_empty_line
-            || (!matches!(self.parent.parent(), AstNodes::Decorator(_))
+            || (!matches!(self.grand_parent(), AstNodes::Decorator(_))
                 && is_function_composition_args(self))
         {
             return format_all_args_broken_out(self, true, f);

--- a/crates/oxc_formatter/src/write/class.rs
+++ b/crates/oxc_formatter/src/write/class.rs
@@ -425,7 +425,7 @@ impl<'a> Format<'a> for FormatClass<'a, '_> {
                         }
                     });
 
-                    if matches!(extends.parent.parent(), AstNodes::AssignmentExpression(_)) {
+                    if matches!(extends.grand_parent(), AstNodes::AssignmentExpression(_)) {
                         if has_trailing_comments {
                             write!(f, [text("("), &content, text(")")])
                         } else {

--- a/crates/oxc_formatter/src/write/jsx/element.rs
+++ b/crates/oxc_formatter/src/write/jsx/element.rs
@@ -181,10 +181,10 @@ impl<'a> Format<'a> for AnyJsxTagWithChildren<'a, '_> {
 ///  </div>;
 /// ```
 pub fn should_expand(mut parent: &AstNodes<'_>) -> bool {
-    if matches!(parent, AstNodes::ExpressionStatement(_)) {
+    if let AstNodes::ExpressionStatement(stmt) = parent {
         // If the parent is a JSXExpressionContainer, we need to check its parent
         // to determine if it should expand.
-        parent = parent.parent().parent();
+        parent = stmt.grand_parent();
     }
     let maybe_jsx_expression_child = match parent {
         AstNodes::ArrowFunctionExpression(arrow) if arrow.expression => match arrow.parent {
@@ -192,7 +192,7 @@ pub fn should_expand(mut parent: &AstNodes<'_>) -> bool {
             AstNodes::Argument(argument)
                 if matches!(argument.parent, AstNodes::CallExpression(_)) =>
             {
-                argument.parent.parent()
+                argument.grand_parent()
             }
             // Callee
             AstNodes::CallExpression(call) => call.parent,

--- a/crates/oxc_formatter/src/write/parameters.rs
+++ b/crates/oxc_formatter/src/write/parameters.rs
@@ -49,10 +49,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, FormalParameters<'a>> {
         let layout = if !self.has_parameter() && this_param.is_none() {
             ParameterLayout::NoParameters
         } else if can_hug || {
-            // `self.parent`: Function
-            // `self.parent.parent()`: Argument
-            // `self.parent.parent().parent()` CallExpression
-            if let AstNodes::CallExpression(call) = self.parent.parent().parent() {
+            // `self`: Function
+            // `self.ancestors().nth(1)`: Argument
+            // `self.ancestors().nth(2)`: CallExpression
+            if let Some(AstNodes::CallExpression(call)) = self.ancestors().nth(2) {
                 is_test_call_expression(call)
             } else {
                 false

--- a/crates/oxc_formatter/src/write/sequence_expression.rs
+++ b/crates/oxc_formatter/src/write/sequence_expression.rs
@@ -33,7 +33,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, SequenceExpression<'a>> {
 
             if matches!(self.parent, AstNodes::ForStatement(_))
                 || (matches!(self.parent, AstNodes::ExpressionStatement(statement) if
-                    !matches!(statement.parent.parent(), AstNodes::ArrowFunctionExpression(arrow) if arrow.expression)))
+                    !matches!(statement.grand_parent(), AstNodes::ArrowFunctionExpression(arrow) if arrow.expression)))
             {
                 write!(f, [indent(&rest)])
             } else {

--- a/crates/oxc_formatter/src/write/type_parameters.rs
+++ b/crates/oxc_formatter/src/write/type_parameters.rs
@@ -69,7 +69,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSTypeParameter<'a>>> {
         let trailing_separator = if self.len() == 1
         // This only concern sources that allow JSX or a restricted standard variant.
         && f.context().source_type().is_jsx()
-        && matches!(self.parent.parent(), AstNodes::ArrowFunctionExpression(_))
+        && matches!(self.grand_parent(), AstNodes::ArrowFunctionExpression(_))
         // Ignore Type parameter with an `extends` clause or a default type.
         && !self.first().is_some_and(|t| t.constraint().is_some() || t.default().is_some())
         {
@@ -113,7 +113,7 @@ impl<'a> Format<'a> for FormatTSTypeParameters<'a, '_> {
             write!(
                 f,
                 [group(&format_args!("<", format_once(|f| {
-                    if matches!( self.decl.parent.parent().parent(), AstNodes::CallExpression(call) if is_test_call_expression(call))
+                    if matches!(self.decl.ancestors().nth(2), Some(AstNodes::CallExpression(call)) if is_test_call_expression(call))
                     {
                         f.join_nodes_with_space().entries_with_trailing_separator(params, ",", TrailingSeparator::Omit).finish()
                     } else {
@@ -204,7 +204,7 @@ fn is_arrow_function_variable_type_argument<'a>(
 
     // `node.parent` is `TSTypeReference`
     matches!(
-        &node.parent.parent(),
+        &node.grand_parent(),
         AstNodes::TSTypeAnnotation(type_annotation)
             if matches!(
                 &type_annotation.parent,

--- a/crates/oxc_formatter/src/write/union_type.rs
+++ b/crates/oxc_formatter/src/write/union_type.rs
@@ -46,12 +46,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSUnionType<'a>> {
         let leading_comments = f.context().comments().comments_before(self.span().start);
         let has_leading_comments = !leading_comments.is_empty();
         let mut union_type_at_top = self;
-        while let AstNodes::TSUnionType(parent) = union_type_at_top.parent {
-            if parent.types().len() == 1 {
-                union_type_at_top = parent;
-            } else {
-                break;
-            }
+        while let AstNodes::TSUnionType(parent) = union_type_at_top.parent
+            && parent.types().len() == 1
+        {
+            union_type_at_top = parent;
         }
 
         let should_indent = {

--- a/crates/oxc_formatter/src/write/variable_declaration.rs
+++ b/crates/oxc_formatter/src/write/variable_declaration.rs
@@ -52,7 +52,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, VariableDeclarator<'a>>> {
         let length = self.len();
 
         let is_parent_for_loop = matches!(
-            self.parent.parent(),
+            self.grand_parent(),
             AstNodes::ForStatement(_) | AstNodes::ForInStatement(_) | AstNodes::ForOfStatement(_)
         );
 


### PR DESCRIPTION
Added a `AstNode::ancestor` to simplify the traverse upward pattern, and added a `AstNode::grand_parent` to simplify `self.parent.parent()` usages