### PR TITLE
perf(linter): remove simple `phf_map!` calls

### DIFF
--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -485,23 +485,21 @@ impl<'a> LintContext<'a> {
 /// ```
 #[inline]
 fn plugin_name_to_prefix(plugin_name: &'static str) -> &'static str {
-    PLUGIN_PREFIXES.get(plugin_name).copied().unwrap_or(plugin_name)
+    match plugin_name {
+        "import" => "eslint-plugin-import",
+        "jest" => "eslint-plugin-jest",
+        "jsdoc" => "eslint-plugin-jsdoc",
+        "jsx_a11y" => "eslint-plugin-jsx-a11y",
+        "nextjs" => "eslint-plugin-next",
+        "promise" => "eslint-plugin-promise",
+        "react_perf" => "eslint-plugin-react-perf",
+        "react" => "eslint-plugin-react",
+        "typescript" => "typescript-eslint",
+        "unicorn" => "eslint-plugin-unicorn",
+        "vitest" => "eslint-plugin-vitest",
+        "node" => "eslint-plugin-node",
+        "vue" => "eslint-plugin-vue",
+        "regexp" => "eslint-plugin-regexp",
+        _ => plugin_name,
+    }
 }
-
-/// Map of plugin names to their prefixed versions.
-const PLUGIN_PREFIXES: phf::Map<&'static str, &'static str> = phf::phf_map! {
-    "import" => "eslint-plugin-import",
-    "jest" => "eslint-plugin-jest",
-    "jsdoc" => "eslint-plugin-jsdoc",
-    "jsx_a11y" => "eslint-plugin-jsx-a11y",
-    "nextjs" => "eslint-plugin-next",
-    "promise" => "eslint-plugin-promise",
-    "react_perf" => "eslint-plugin-react-perf",
-    "react" => "eslint-plugin-react",
-    "typescript" => "typescript-eslint",
-    "unicorn" => "eslint-plugin-unicorn",
-    "vitest" => "eslint-plugin-vitest",
-    "node" => "eslint-plugin-node",
-    "vue" => "eslint-plugin-vue",
-    "regexp" => "eslint-plugin-regexp",
-};

--- a/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
+++ b/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
@@ -4,7 +4,6 @@ use oxc_ast::ast::Expression;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
-use phf::{Map, phf_map};
 
 use crate::{context::LintContext, rule::Rule};
 
@@ -87,14 +86,16 @@ declare_oxc_lint!(
     fix
 );
 
-const DEPRECATED_FUNCTIONS_MAP: Map<&'static str, (usize, &'static str)> = phf_map! {
-    "jest.resetModuleRegistry" => (15, "jest.resetModules"),
-    "jest.addMatchers" => (17, "expect.extend"),
-    "require.requireMock" => (21, "jest.requireMock"),
-    "require.requireActual" => (21, "jest.requireMock"),
-    "jest.runTimersToTime" => (22, "jest.advanceTimersByTime"),
-    "jest.genMockFromModule" => (26, "jest.createMockFromModule"),
-};
+fn deprecated_functions_map(deprecated_fn: &str) -> Option<(usize, &'static str)> {
+    match deprecated_fn {
+        "jest.resetModuleRegistry" => Some((15, "jest.resetModules")),
+        "jest.addMatchers" => Some((17, "expect.extend")),
+        "require.requireMock" | "require.requireActual" => Some((21, "jest.requireMock")),
+        "jest.runTimersToTime" => Some((22, "jest.advanceTimersByTime")),
+        "jest.genMockFromModule" => Some((26, "jest.createMockFromModule")),
+        _ => None,
+    }
+}
 
 impl Rule for NoDeprecatedFunctions {
     fn from_configuration(value: serde_json::Value) -> Self {
@@ -133,12 +134,12 @@ impl Rule for NoDeprecatedFunctions {
         // Todo: read from configuration
         let jest_version_num: usize = self.jest.version.parse().unwrap_or(29);
 
-        if let Some((base_version, replacement)) = DEPRECATED_FUNCTIONS_MAP.get(&node_name)
-            && jest_version_num >= *base_version
+        if let Some((base_version, replacement)) = deprecated_functions_map(&node_name)
+            && jest_version_num >= base_version
         {
             ctx.diagnostic_with_fix(
                 deprecated_function(&node_name, replacement, mem_expr.span()),
-                |fixer| fixer.replace(mem_expr.span(), *replacement),
+                |fixer| fixer.replace(mem_expr.span(), replacement),
             );
         }
     }

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_props.rs
@@ -60,7 +60,7 @@ impl Rule for AriaProps {
             let name = get_jsx_attribute_name(&attr.name);
             let name = name.cow_to_ascii_lowercase();
             if name.starts_with("aria-") && !is_valid_aria_property(&name) {
-                let suggestion = COMMON_TYPOS.get(&name).copied();
+                let suggestion = get_common_aria_prop_typo(&name);
                 let diagnostic = aria_props_diagnostic(attr.span, &name, suggestion);
 
                 if let Some(suggestion) = suggestion {
@@ -75,13 +75,16 @@ impl Rule for AriaProps {
     }
 }
 
-const COMMON_TYPOS: phf::Map<&'static str, &'static str> = phf::phf_map! {
-    "aria-labeledby" => "aria-labelledby",
-    "aria-role" => "role",
-    "aria-sorted" => "aria-sort",
-    "aria-lable" => "aria-label",
-    "aria-value" => "aria-valuenow",
-};
+fn get_common_aria_prop_typo(prop_name: &str) -> Option<&'static str> {
+    match prop_name {
+        "aria-labeledby" => Some("aria-labelledby"),
+        "aria-role" => Some("role"),
+        "aria-sorted" => Some("aria-sort"),
+        "aria-lable" => Some("aria-label"),
+        "aria-value" => Some("aria-valuenow"),
+        _ => None,
+    }
+}
 
 #[test]
 fn test() {

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
@@ -5,7 +5,6 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
-use phf::phf_map;
 
 use crate::{
     AstNode,
@@ -52,11 +51,14 @@ declare_oxc_lint!(
     fix
 );
 
-static DEFAULT_ROLE_EXCEPTIONS: phf::Map<&'static str, &'static str> = phf_map! {
-    "nav" => "navigation",
-    "button" => "button",
-    "body" => "document",
-};
+fn get_default_role_exception(tag: &str) -> Option<&'static str> {
+    match tag {
+        "nav" => Some("navigation"),
+        "button" => Some("button"),
+        "body" => Some("document"),
+        _ => None,
+    }
+}
 
 impl Rule for NoRedundantRoles {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -71,7 +73,7 @@ impl Rule for NoRedundantRoles {
         {
             let roles = role_values.value.split_whitespace().collect::<Vec<_>>();
             for role in &roles {
-                let exceptions = DEFAULT_ROLE_EXCEPTIONS.get(&component);
+                let exceptions = get_default_role_exception(&component);
                 if exceptions.is_some_and(|set| set.contains(role)) {
                     ctx.diagnostic_with_fix(
                         no_redundant_roles_diagnostic(attr.span, &component, role),


### PR DESCRIPTION
Large `phf_map!` calls can be worth the cost, but small ones are probably not worth it. Profiling showed that a number of these small maps add some constant overhead when linting, so I've replaced them with some simple match calls.