### PR TITLE
feat(formatter): reimplement formatting for `ImportExpression`

### DIFF
--- a/crates/oxc_formatter/src/write/import_expression.rs
+++ b/crates/oxc_formatter/src/write/import_expression.rs
@@ -1,3 +1,4 @@
+use oxc_allocator::Vec;
 use oxc_ast::ast::*;
 
 use crate::{
@@ -17,63 +18,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ImportExpression<'a>> {
             write!(f, [".", phase.as_str()])?;
         }
 
-        // The formatting implementation of `source` and `options` picks from `call_arguments`.
-        if self.options.is_none()
-            && (!matches!(
-                self.source,
-                Expression::StringLiteral(_)
-                    | Expression::TemplateLiteral(_)
-                    // Theoretically dynamic import shouldn't have this.
-                    | Expression::TaggedTemplateExpression(_)
-            ) || f.comments().has_comment_before(self.span.end))
-        {
-            return write!(
-                f,
-                [
-                    "(",
-                    group(&soft_block_indent(&format_once(|f| {
-                        write!(f, [self.source()])?;
-                        if let Some(options) = self.options() {
-                            write!(
-                                f,
-                                [
-                                    ",",
-                                    soft_line_break_or_space(),
-                                    group(&options).should_expand(true)
-                                ]
-                            )?;
-                        }
-                        Ok(())
-                    }))),
-                    ")"
-                ]
-            );
-        }
-
-        let source = self.source().memoized();
-        let options = self.options().memoized();
-
-        best_fitting![
-            group(&format_once(|f| {
-                write!(f, ["(", source])?;
-                if self.options().is_some() {
-                    write!(f, [",", space(), group(&options).should_expand(true)])?;
-                }
-                write!(f, ")")
-            })),
-            group(&format_args!(
-                "(",
-                &soft_block_indent(&format_once(|f| {
-                    write!(f, [source])?;
-                    if self.options.is_some() {
-                        write!(f, [",", soft_line_break_or_space(), options])?;
-                    }
-                    Ok(())
-                })),
-                ")"
-            ))
-            .should_expand(true),
-        ]
-        .fmt(f)
+        // Use the same logic as CallExpression arguments formatting
+        write!(f, self.to_arguments())
     }
 }

--- a/crates/oxc_formatter/tests/fixtures/js/comments/import-expression.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/import-expression.js
@@ -1,0 +1,13 @@
+import(
+  // comment1
+  `../alias/${base}.js`
+  // comment2
+);
+
+import(
+  // comment1
+  `../alias/${base}.js`,
+  // comment2
+  { with: { type: "json" }}
+  // comment2
+);

--- a/crates/oxc_formatter/tests/fixtures/js/comments/import-expression.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/import-expression.js.snap
@@ -1,0 +1,34 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+import(
+  // comment1
+  `../alias/${base}.js`
+  // comment2
+);
+
+import(
+  // comment1
+  `../alias/${base}.js`,
+  // comment2
+  { with: { type: "json" }}
+  // comment2
+);
+
+==================== Output ====================
+import(
+  // comment1
+  `../alias/${base}.js`
+  // comment2
+);
+
+import(
+  // comment1
+  `../alias/${base}.js`,
+  // comment2
+  { with: { type: "json" } }
+  // comment2
+);
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/import-expressions/grouped.js
+++ b/crates/oxc_formatter/tests/fixtures/js/import-expressions/grouped.js
@@ -1,0 +1,6 @@
+const fixturePackageJson = (
+  await import(
+    pathToFileURL(path.join(fixtureDir, 'package.json')).href,
+    { with: { type: 'json' } }
+  )
+).default;

--- a/crates/oxc_formatter/tests/fixtures/js/import-expressions/grouped.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/import-expressions/grouped.js.snap
@@ -1,0 +1,19 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+const fixturePackageJson = (
+  await import(
+    pathToFileURL(path.join(fixtureDir, 'package.json')).href,
+    { with: { type: 'json' } }
+  )
+).default;
+
+==================== Output ====================
+const fixturePackageJson = (
+  await import(pathToFileURL(path.join(fixtureDir, "package.json")).href, {
+    with: { type: "json" },
+  })
+).default;
+
+===================== End =====================


### PR DESCRIPTION
The formatting logic of `arguments` in `ImportExpression` and `CallExpression` is the same, but our AST differs between these two nodes. Previously, I tried to pick up some logic from `CallExpression` to `ImportExpression` to cover most cases. However, it turns out that it isn't covered very well. In this PR, I tried to convert `ImportExpression`'s `source` and `options` to `AstNode<Vec<Argument>` with a tricky unsafe transmute so that it matches the Prettier behavior. 