### PR TITLE
fix(formatter): should indent TemplateExpression if it is a member expression that is part of `ChainExpression`

### DIFF
--- a/crates/oxc_formatter/src/write/template.rs
+++ b/crates/oxc_formatter/src/write/template.rs
@@ -295,18 +295,22 @@ impl<'a> Format<'a> for FormatTemplateExpression<'a, '_> {
                 let indent = match self.expression {
                     TemplateExpression::Expression(e) => {
                         has_comment_in_expression
-                            || matches!(
-                                e.as_ref(),
+                            || match e.as_ref() {
                                 Expression::StaticMemberExpression(_)
-                                    | Expression::ComputedMemberExpression(_)
-                                    | Expression::ConditionalExpression(_)
-                                    | Expression::SequenceExpression(_)
-                                    | Expression::TSAsExpression(_)
-                                    | Expression::TSSatisfiesExpression(_)
-                                    | Expression::BinaryExpression(_)
-                                    | Expression::LogicalExpression(_)
-                                    | Expression::Identifier(_)
-                            )
+                                | Expression::ComputedMemberExpression(_)
+                                | Expression::PrivateFieldExpression(_)
+                                | Expression::ConditionalExpression(_)
+                                | Expression::SequenceExpression(_)
+                                | Expression::TSAsExpression(_)
+                                | Expression::TSSatisfiesExpression(_)
+                                | Expression::BinaryExpression(_)
+                                | Expression::LogicalExpression(_)
+                                | Expression::Identifier(_) => true,
+                                Expression::ChainExpression(chain) => {
+                                    chain.expression.is_member_expression()
+                                }
+                                _ => false,
+                            }
                     }
                     TemplateExpression::TSType(t) => {
                         self.options.after_new_line || is_complex_type(t.as_ref())

--- a/crates/oxc_formatter/tests/fixtures/js/template-literals/chain.js
+++ b/crates/oxc_formatter/tests/fixtures/js/template-literals/chain.js
@@ -1,0 +1,5 @@
+const A = {
+  "--theme-primary": `hsl(${theme?.activeColor[
+    mode === "dark" ? "dark" : "light"
+  ]})`,
+};

--- a/crates/oxc_formatter/tests/fixtures/js/template-literals/chain.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/template-literals/chain.js.snap
@@ -1,0 +1,17 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+const A = {
+  "--theme-primary": `hsl(${theme?.activeColor[
+    mode === "dark" ? "dark" : "light"
+  ]})`,
+};
+==================== Output ====================
+const A = {
+  "--theme-primary": `hsl(${
+    theme?.activeColor[mode === "dark" ? "dark" : "light"]
+  })`,
+};
+
+===================== End =====================


### PR DESCRIPTION
This is an error-prone case for `ChainExpression`, because Biome doesn't have this node, so we have to look into the ChainExpression further