### PR TITLE
refactor(oxfmt): Pass `PathBuf` from walk.rs to service.rs

### DIFF
--- a/apps/oxfmt/src/service.rs
+++ b/apps/oxfmt/src/service.rs
@@ -44,7 +44,7 @@ impl FormatService {
     fn process_entry(&self, entry: &WalkEntry, tx_error: &DiagnosticSender) {
         let start_time = Instant::now();
 
-        let path = Path::new(&entry.path);
+        let path = &entry.path;
         let source_type = enable_jsx_source_type(entry.source_type);
 
         // TODO: Use `read_to_arena_str()` like `oxlint`?
@@ -69,7 +69,7 @@ impl FormatService {
                 &source_text,
                 ret.errors,
             );
-            tx_error.send((path.to_path_buf(), diagnostics)).unwrap();
+            tx_error.send((path.clone(), diagnostics)).unwrap();
             return;
         }
 
@@ -106,7 +106,7 @@ impl FormatService {
             ))),
             _ => None,
         } {
-            tx_error.send((path.to_path_buf(), vec![diagnostic.into()])).unwrap();
+            tx_error.send((path.clone(), vec![diagnostic.into()])).unwrap();
         }
     }
 }

--- a/apps/oxfmt/src/walk.rs
+++ b/apps/oxfmt/src/walk.rs
@@ -1,4 +1,4 @@
-use std::{ffi::OsStr, path::PathBuf, sync::Arc, sync::mpsc};
+use std::{ffi::OsStr, path::PathBuf, sync::mpsc};
 
 use ignore::overrides::Override;
 
@@ -58,7 +58,7 @@ impl Walk {
 }
 
 pub struct WalkEntry {
-    pub path: Arc<OsStr>,
+    pub path: PathBuf,
     pub source_type: SourceType,
 }
 
@@ -112,8 +112,7 @@ impl ignore::ParallelVisitor for WalkVisitor {
                 }
 
                 if let Some(source_type) = get_supported_source_type(entry.path()) {
-                    let walk_entry =
-                        WalkEntry { path: entry.path().as_os_str().into(), source_type };
+                    let walk_entry = WalkEntry { path: entry.path().to_path_buf(), source_type };
                     // Send each entry immediately through the channel
                     // If send fails, the receiver has been dropped, so stop walking
                     if self.sender.send(walk_entry).is_err() {


### PR DESCRIPTION
Pure refactor to avoid useless conversion.

- Before: `Path` > `OsStr` > `Arc<OsStr>` > `&Path`
- After: `Path` > `PathBuf` > `&Path`
