### PR TITLE
fix(formatter): should wrap parentheses with JSX arguments of `NewExpression`

### DIFF
--- a/crates/oxc_formatter/src/utils/jsx.rs
+++ b/crates/oxc_formatter/src/utils/jsx.rs
@@ -78,7 +78,6 @@ pub fn get_wrap_state(parent: &AstNodes<'_>) -> WrapState {
         AstNodes::ArrayExpression(_)
         | AstNodes::JSXAttribute(_)
         | AstNodes::JSXExpressionContainer(_)
-        | AstNodes::Argument(_)
         | AstNodes::ConditionalExpression(_) => WrapState::NoWrap,
         AstNodes::StaticMemberExpression(member) => {
             if member.optional {
@@ -86,6 +85,9 @@ pub fn get_wrap_state(parent: &AstNodes<'_>) -> WrapState {
             } else {
                 WrapState::WrapOnBreak
             }
+        }
+        AstNodes::Argument(argument) if matches!(argument.parent, AstNodes::CallExpression(_)) => {
+            WrapState::NoWrap
         }
         AstNodes::ExpressionStatement(stmt) => {
             // `() => <div></div>`

--- a/crates/oxc_formatter/tests/fixtures/js/jsx/new-expression.jsx
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx/new-expression.jsx
@@ -1,0 +1,6 @@
+return new ImageResponse(
+  (
+    <div>
+    </div>
+  ),
+)

--- a/crates/oxc_formatter/tests/fixtures/js/jsx/new-expression.jsx.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx/new-expression.jsx.snap
@@ -1,0 +1,14 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+return new ImageResponse(
+  (
+    <div>
+    </div>
+  ),
+)
+==================== Output ====================
+return new ImageResponse(<div></div>);
+
+===================== End =====================


### PR DESCRIPTION
Another weird case in Prettier, it only needs to wrap for NewExpression, why is CallexExpression excluded?