### PR TITLE
fix(linter/plugins): prevent `comments` being accessed after file is linted

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -19,6 +19,13 @@ export function deserializeProgramOnly(buffer, sourceText, sourceByteLen, getLoc
   return deserializeWith(buffer, sourceText, sourceByteLen, getLoc, deserializeProgram);
 }
 
+export function reset() {
+  // Increment `astId` counter.
+  // This prevents `program.comments` being accessed after the AST is done with.
+  // (see `deserializeProgram`)
+  astId++;
+}
+
 function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInput, deserialize) {
   uint8 = buffer;
   uint32 = buffer.uint32;
@@ -42,7 +49,7 @@ function deserializeProgram(pos) {
   let refUint32 = uint32,
     refUint8 = uint8,
     refSourceText = sourceText,
-    localAstId = ++astId,
+    localAstId = astId,
     end = deserializeU32(pos + 4),
     program = parent = {
       __proto__: NodeProto,

--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -3,7 +3,7 @@ import { DATA_POINTER_POS_32, SOURCE_LEN_OFFSET } from '../generated/constants.j
 // We use the deserializer which removes `ParenthesizedExpression`s from AST,
 // and with `range`, `loc`, and `parent` properties on AST nodes, to match ESLint
 // @ts-expect-error we need to generate `.d.ts` file for this module
-import { deserializeProgramOnly } from '../../dist/generated/deserialize.js';
+import { deserializeProgramOnly, reset as resetAst } from '../../dist/generated/deserialize.js';
 
 import visitorKeys from '../generated/keys.js';
 import {
@@ -78,6 +78,7 @@ export function resetSourceAndAst(): void {
   buffer = null;
   sourceText = null;
   ast = null;
+  resetAst();
   resetLines();
 }
 

--- a/crates/oxc_ast/src/serialize/mod.rs
+++ b/crates/oxc_ast/src/serialize/mod.rs
@@ -127,7 +127,7 @@ impl Program<'_> {
     let refUint32 = uint32;
     let refUint8 = uint8;
     let refSourceText = sourceText;
-    const localAstId = ++astId;
+    const localAstId = astId;
     /* END_IF */
 
     const start = IS_TS ? 0 : DESER[u32](POS_OFFSET.span.start),

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -163,6 +163,13 @@ fn generate_deserializers(
         export function deserializeProgramOnly(buffer, sourceText, sourceByteLen, getLoc) {{
             return deserializeWith(buffer, sourceText, sourceByteLen, getLoc, deserializeProgram);
         }}
+
+        export function reset() {{
+            // Increment `astId` counter.
+            // This prevents `program.comments` being accessed after the AST is done with.
+            // (see `deserializeProgram`)
+            astId++;
+        }}
         /* END_IF */
 
         function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInput, deserialize) {{


### PR DESCRIPTION
Follow on after #14637. I now realize that there was a subtle race condition.

We use `astId` counter in the getter for `program.comments`, to check that the getter is not called after that AST is done with. Buffers are reused, so the buffer held in local reference is the same, but the *contents* of the buffer could have changed - it may now contain a *different* AST.

Previously, `astId` was incremented in `deserializeProgram`. So if `comments` getter is accessed after another AST is deserialized, it (rightly) throws.

But there's a small period of time in between walking the AST on JS side and the *next* call to `deserializeProgram`. During that period, the buffer may be being mutated on Rust side (in another thread), but `astId` hasn't been incremented yet, so the `localAstId === astId` check in `comments` getter will pass, and it won't throw an error as it should.

Fix this by incrementing `astId` as soon as traversal of *this* AST ends, instead of before deserializing the *next* AST begins.