### PR TITLE
refactor(linter/plugins): simplify `comments` getter

### DIFF
--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -3,7 +3,7 @@ import { DATA_POINTER_POS_32, SOURCE_LEN_OFFSET } from '../generated/constants.j
 // We use the deserializer which removes `ParenthesizedExpression`s from AST,
 // and with `range`, `loc`, and `parent` properties on AST nodes, to match ESLint
 // @ts-expect-error we need to generate `.d.ts` file for this module
-import { deserializeProgramOnly, reset as resetAst } from '../../dist/generated/deserialize.js';
+import { deserializeProgramOnly, resetBuffer } from '../../dist/generated/deserialize.js';
 
 import visitorKeys from '../generated/keys.js';
 import {
@@ -78,7 +78,7 @@ export function resetSourceAndAst(): void {
   buffer = null;
   sourceText = null;
   ast = null;
-  resetAst();
+  resetBuffer();
   resetLines();
 }
 

--- a/crates/oxc_ast/src/serialize/mod.rs
+++ b/crates/oxc_ast/src/serialize/mod.rs
@@ -121,14 +121,7 @@ impl Program<'_> {
 /// `Program` span start is 0 (not 5).
 #[ast_meta]
 #[estree(raw_deser = "
-    /* IF COMMENTS */
-    // Buffers will be cleaned up after the main program is deserialized.
-    // We hold references here in case the comments need to be later accessed.
-    let refUint32 = uint32;
-    let refUint8 = uint8;
-    let refSourceText = sourceText;
     const localAstId = astId;
-    /* END_IF */
 
     const start = IS_TS ? 0 : DESER[u32](POS_OFFSET.span.start),
         end = DESER[u32](POS_OFFSET.span.end);
@@ -140,15 +133,11 @@ impl Program<'_> {
         hashbang: null,
         /* IF COMMENTS */
         get comments() {
+            // Check AST in buffer is still the same AST (buffers are reused)
             if (localAstId !== astId) throw new Error('Comments are only accessible while linting the file');
-            // Restore buffers
-            uint32 = refUint32;
-            uint8 = refUint8;
-            sourceText = refSourceText;
-            // Deserialize the comments
+            // Deserialize the comments.
+            // Replace this getter with the comments array, so we don't deserialize twice.
             const comments = DESER[Vec<Comment>](POS_OFFSET.comments);
-            // Drop the references
-            refUint32 = refUint8 = refSourceText = uint32 = uint8 = sourceText = undefined;
             Object.defineProperty(this, 'comments', { value: comments });
             return comments;
         },

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -8,7 +8,9 @@ const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   { fromCodePoint } = String;
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
-  return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+  let data = deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+  resetBuffer();
+  return data;
 }
 
 function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInput, deserialize) {
@@ -18,13 +20,16 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInpu
   sourceText = sourceTextInput;
   sourceByteLen = sourceByteLenInput;
   sourceIsAscii = sourceText.length === sourceByteLen;
-  let data = deserialize(uint32[536870902]);
+  return deserialize(uint32[536870902]);
+}
+
+export function resetBuffer() {
+  // Clear buffer and source text string to allow them to be garbage collected
   uint8 =
     uint32 =
     float64 =
     sourceText =
       void 0;
-  return data;
 }
 
 function deserializeProgram(pos) {

--- a/napi/parser/generated/deserialize/js_parent.js
+++ b/napi/parser/generated/deserialize/js_parent.js
@@ -8,7 +8,9 @@ const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   { fromCodePoint } = String;
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
-  return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+  let data = deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+  resetBuffer();
+  return data;
 }
 
 function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInput, deserialize) {
@@ -18,13 +20,16 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInpu
   sourceText = sourceTextInput;
   sourceByteLen = sourceByteLenInput;
   sourceIsAscii = sourceText.length === sourceByteLen;
-  let data = deserialize(uint32[536870902]);
+  return deserialize(uint32[536870902]);
+}
+
+export function resetBuffer() {
+  // Clear buffer and source text string to allow them to be garbage collected
   uint8 =
     uint32 =
     float64 =
     sourceText =
       void 0;
-  return data;
 }
 
 function deserializeProgram(pos) {

--- a/napi/parser/generated/deserialize/js_range.js
+++ b/napi/parser/generated/deserialize/js_range.js
@@ -8,7 +8,9 @@ const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   { fromCodePoint } = String;
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
-  return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+  let data = deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+  resetBuffer();
+  return data;
 }
 
 function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInput, deserialize) {
@@ -18,13 +20,16 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInpu
   sourceText = sourceTextInput;
   sourceByteLen = sourceByteLenInput;
   sourceIsAscii = sourceText.length === sourceByteLen;
-  let data = deserialize(uint32[536870902]);
+  return deserialize(uint32[536870902]);
+}
+
+export function resetBuffer() {
+  // Clear buffer and source text string to allow them to be garbage collected
   uint8 =
     uint32 =
     float64 =
     sourceText =
       void 0;
-  return data;
 }
 
 function deserializeProgram(pos) {

--- a/napi/parser/generated/deserialize/js_range_parent.js
+++ b/napi/parser/generated/deserialize/js_range_parent.js
@@ -8,7 +8,9 @@ const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   { fromCodePoint } = String;
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
-  return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+  let data = deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+  resetBuffer();
+  return data;
 }
 
 function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInput, deserialize) {
@@ -18,13 +20,16 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInpu
   sourceText = sourceTextInput;
   sourceByteLen = sourceByteLenInput;
   sourceIsAscii = sourceText.length === sourceByteLen;
-  let data = deserialize(uint32[536870902]);
+  return deserialize(uint32[536870902]);
+}
+
+export function resetBuffer() {
+  // Clear buffer and source text string to allow them to be garbage collected
   uint8 =
     uint32 =
     float64 =
     sourceText =
       void 0;
-  return data;
 }
 
 function deserializeProgram(pos) {

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -8,7 +8,9 @@ const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   { fromCodePoint } = String;
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
-  return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+  let data = deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+  resetBuffer();
+  return data;
 }
 
 function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInput, deserialize) {
@@ -18,13 +20,16 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInpu
   sourceText = sourceTextInput;
   sourceByteLen = sourceByteLenInput;
   sourceIsAscii = sourceText.length === sourceByteLen;
-  let data = deserialize(uint32[536870902]);
+  return deserialize(uint32[536870902]);
+}
+
+export function resetBuffer() {
+  // Clear buffer and source text string to allow them to be garbage collected
   uint8 =
     uint32 =
     float64 =
     sourceText =
       void 0;
-  return data;
 }
 
 function deserializeProgram(pos) {

--- a/napi/parser/generated/deserialize/ts_parent.js
+++ b/napi/parser/generated/deserialize/ts_parent.js
@@ -8,7 +8,9 @@ const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   { fromCodePoint } = String;
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
-  return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+  let data = deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+  resetBuffer();
+  return data;
 }
 
 function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInput, deserialize) {
@@ -18,13 +20,16 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInpu
   sourceText = sourceTextInput;
   sourceByteLen = sourceByteLenInput;
   sourceIsAscii = sourceText.length === sourceByteLen;
-  let data = deserialize(uint32[536870902]);
+  return deserialize(uint32[536870902]);
+}
+
+export function resetBuffer() {
+  // Clear buffer and source text string to allow them to be garbage collected
   uint8 =
     uint32 =
     float64 =
     sourceText =
       void 0;
-  return data;
 }
 
 function deserializeProgram(pos) {

--- a/napi/parser/generated/deserialize/ts_range.js
+++ b/napi/parser/generated/deserialize/ts_range.js
@@ -8,7 +8,9 @@ const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   { fromCodePoint } = String;
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
-  return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+  let data = deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+  resetBuffer();
+  return data;
 }
 
 function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInput, deserialize) {
@@ -18,13 +20,16 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInpu
   sourceText = sourceTextInput;
   sourceByteLen = sourceByteLenInput;
   sourceIsAscii = sourceText.length === sourceByteLen;
-  let data = deserialize(uint32[536870902]);
+  return deserialize(uint32[536870902]);
+}
+
+export function resetBuffer() {
+  // Clear buffer and source text string to allow them to be garbage collected
   uint8 =
     uint32 =
     float64 =
     sourceText =
       void 0;
-  return data;
 }
 
 function deserializeProgram(pos) {

--- a/napi/parser/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/generated/deserialize/ts_range_parent.js
@@ -8,7 +8,9 @@ const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   { fromCodePoint } = String;
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
-  return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+  let data = deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+  resetBuffer();
+  return data;
 }
 
 function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInput, deserialize) {
@@ -18,13 +20,16 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInpu
   sourceText = sourceTextInput;
   sourceByteLen = sourceByteLenInput;
   sourceIsAscii = sourceText.length === sourceByteLen;
-  let data = deserialize(uint32[536870902]);
+  return deserialize(uint32[536870902]);
+}
+
+export function resetBuffer() {
+  // Clear buffer and source text string to allow them to be garbage collected
   uint8 =
     uint32 =
     float64 =
     sourceText =
       void 0;
-  return data;
 }
 
 function deserializeProgram(pos) {

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -155,20 +155,15 @@ fn generate_deserializers(
 
         /* IF !LINTER */
         export function deserialize(buffer, sourceText, sourceByteLen) {{
-            return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+            const data = deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+            resetBuffer();
+            return data;
         }}
         /* END_IF */
 
         /* IF LINTER */
         export function deserializeProgramOnly(buffer, sourceText, sourceByteLen, getLoc) {{
             return deserializeWith(buffer, sourceText, sourceByteLen, getLoc, deserializeProgram);
-        }}
-
-        export function reset() {{
-            // Increment `astId` counter.
-            // This prevents `program.comments` being accessed after the AST is done with.
-            // (see `deserializeProgram`)
-            astId++;
         }}
         /* END_IF */
 
@@ -183,11 +178,17 @@ fn generate_deserializers(
 
             if (LOC) getLoc = getLocInput;
 
-            const data = deserialize(uint32[{data_pointer_pos_32}]);
+            return deserialize(uint32[{data_pointer_pos_32}]);
+        }}
 
+        export function resetBuffer() {{
+            // Clear buffer and source text string to allow them to be garbage collected
             uint8 = uint32 = float64 = sourceText = undefined;
 
-            return data;
+            // Increment `astId` counter.
+            // This prevents `program.comments` being accessed after the AST is done with.
+            // (see `deserializeProgram`)
+            if (COMMENTS) astId++;
         }}
     ");
 


### PR DESCRIPTION
Follow-on after #14727.

Since we now have to call into deserializer module to update `astId` at end of linting a file, we may as well reset the buffers at that point too. This allows simplifying the `comments` getter.