### PR TITLE
docs(linter): fix documentation formatting for max_params options

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -81,7 +81,7 @@ declare_oxc_lint!(
     ///
     /// ### Options
     ///
-    /// ### max
+    /// #### max
     ///
     /// `{ "max": number }`
     ///
@@ -90,7 +90,7 @@ declare_oxc_lint!(
     /// For example `{ "max": 4 }` would mean that having a function take four
     /// parameters is allowed which overrides the default of three.
     ///
-    /// ### countVoidThis
+    /// #### countVoidThis
     ///
     /// `{ "countVoidThis": boolean }`
     ///


### PR DESCRIPTION
Was using the wrong headers for the page structure: https://oxc.rs/docs/guide/usage/linter/rules/eslint/max-params.html#options