### PR TITLE
perf(formatter): replace String buffer with byte-oriented CodeBuffer

### DIFF
--- a/crates/oxc_formatter/Cargo.toml
+++ b/crates/oxc_formatter/Cargo.toml
@@ -22,7 +22,7 @@ doctest = false
 [dependencies]
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
-oxc_data_structures = { workspace = true, features = ["stack"] }
+oxc_data_structures = { workspace = true, features = ["stack", "code_buffer"] }
 oxc_parser = { workspace = true }
 oxc_semantic = { workspace = true, optional = true }
 oxc_span = { workspace = true }

--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -181,11 +181,11 @@ pub enum LineEnding {
 
 impl LineEnding {
     #[inline]
-    pub const fn as_str(self) -> &'static str {
+    pub const fn as_bytes(self) -> &'static [u8] {
         match self {
-            LineEnding::Lf => "\n",
-            LineEnding::Crlf => "\r\n",
-            LineEnding::Cr => "\r",
+            LineEnding::Lf => b"\n",
+            LineEnding::Crlf => b"\r\n",
+            LineEnding::Cr => b"\r",
         }
     }
 


### PR DESCRIPTION

- Use CodeBuffer (Vec<u8>) instead of String for internal buffer
- SIMD-optimized indentation via CodeBuffer.print_indent()
- Unified byte-level iteration eliminates .chars() iterator overhead
- ASCII fast-path (95%+ of JavaScript) handled inline without UTF-8 decoding
- Multi-byte UTF-8 decoded on-demand only when needed
- Maintains Unicode width calculation correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)
