### PR TITLE
perf(formatter): reduce string allocations using Cow borrowing

### DIFF
--- a/crates/oxc_formatter/src/utils/string_utils.rs
+++ b/crates/oxc_formatter/src/utils/string_utils.rs
@@ -224,7 +224,7 @@ impl<'a> LiteralStringNormaliser<'a> {
         let can_remove_quotes =
             !self.is_preserve_quote_properties() && is_identifier_name(quoteless);
         if can_remove_quotes {
-            Cow::Owned(quoteless.to_string())
+            Cow::Borrowed(quoteless)
         } else {
             self.normalise_string_literal(string_information)
         }
@@ -281,7 +281,7 @@ impl<'a> LiteralStringNormaliser<'a> {
             && (self.can_remove_number_quotes_by_file_type(source_type)
                 || is_identifier_name(quoteless));
         if can_remove_quotes {
-            Cow::Owned(quoteless.to_string())
+            Cow::Borrowed(quoteless)
         } else {
             self.normalise_string_literal(string_information)
         }
@@ -320,7 +320,11 @@ impl<'a> LiteralStringNormaliser<'a> {
         if original.starts_with(preferred_quote) {
             Cow::Borrowed(original)
         } else {
-            Cow::Owned(std::format!("{preferred_quote}{content_to_use}{preferred_quote}",))
+            let mut s = String::with_capacity(content_to_use.len() + 2);
+            s.push(preferred_quote);
+            s.push_str(content_to_use);
+            s.push(preferred_quote);
+            Cow::Owned(s)
         }
     }
 }


### PR DESCRIPTION
## Summary

Optimizes string handling in `string_utils.rs` to eliminate unnecessary heap allocations by using `Cow::Borrowed` instead of `Cow::Owned`.

**Changes:**

1. **normalise_import_attribute** (line 227): Return `Cow::Borrowed(quoteless)` instead of `Cow::Owned(quoteless.to_string())` when quotes can be removed
   
2. **normalise_type_member** (line 284): Return `Cow::Borrowed(quoteless)` instead of `Cow::Owned(quoteless.to_string())` when quotes can be removed
   
3. **swap_quotes** (line 323): Replace `format!()` macro with manual string construction using `String::with_capacity()` for better control over allocation

**Performance Impact:**
- Eliminates heap allocations for identifier-like object properties and import attributes that don't require quotes
- Common optimization for formatted code with many properties  
- Manual string construction avoids format! macro overhead

The `quoteless` variable is already `&'a str` with the correct lifetime, so borrowing it is safe and eliminates the need to allocate a new String.

## Test plan

- [x] Unit tests pass (`cargo test -p oxc_formatter`)
- [x] Conformance tests pass (`cargo run -p oxc_prettier_conformance`)  
- [x] Lint checks pass (`just lint`)
- [x] Code formatted (`just fmt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)