### PR TITLE
perf(formatter): change TokenText API to use Cow instead of String

### DIFF
--- a/crates/oxc_formatter/src/formatter/builders.rs
+++ b/crates/oxc_formatter/src/formatter/builders.rs
@@ -339,7 +339,7 @@ impl<'a> Format<'a> for SyntaxTokenCowSlice<'a> {
                 // let slice = self.token.token_text().slice(relative_range);
 
                 f.write_element(FormatElement::LocatedTokenText {
-                    slice: TokenText::new((*text).to_string(), self.span),
+                    slice: TokenText::new(*text, self.span),
                     source_position: self.span.start,
                 })
             }
@@ -358,19 +358,19 @@ impl std::fmt::Debug for SyntaxTokenCowSlice<'_> {
 }
 
 /// Copies a source text 1:1 into the output text.
-pub fn located_token_text(span: Span, source_text: &str) -> LocatedTokenText {
+pub fn located_token_text(span: Span, source_text: &str) -> LocatedTokenText<'_> {
     let slice = span.source_text(source_text);
     debug_assert_no_newlines(slice);
-    LocatedTokenText { text: TokenText::new(slice.to_string(), span), source_position: span.start }
+    LocatedTokenText { text: TokenText::new(slice, span), source_position: span.start }
 }
 
-pub struct LocatedTokenText {
-    text: TokenText,
+pub struct LocatedTokenText<'a> {
+    text: TokenText<'a>,
     source_position: TextSize,
 }
 
-impl Format<'_> for LocatedTokenText {
-    fn fmt(&self, f: &mut Formatter) -> FormatResult<()> {
+impl<'a> Format<'a> for LocatedTokenText<'a> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         f.write_element(FormatElement::LocatedTokenText {
             slice: self.text.clone(),
             source_position: self.source_position,
@@ -378,7 +378,7 @@ impl Format<'_> for LocatedTokenText {
     }
 }
 
-impl std::fmt::Debug for LocatedTokenText {
+impl std::fmt::Debug for LocatedTokenText<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::write!(f, "LocatedTokenText({})", self.text)
     }

--- a/crates/oxc_formatter/src/formatter/format_element/mod.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/mod.rs
@@ -43,7 +43,7 @@ pub enum FormatElement<'a> {
         /// The start position of the token in the unformatted source code
         source_position: TextSize,
         /// The token text
-        slice: TokenText,
+        slice: TokenText<'a>,
     },
 
     /// Prevents that line suffixes move past this boundary. Forces the printer to print any pending

--- a/crates/oxc_formatter/src/formatter/token_text.rs
+++ b/crates/oxc_formatter/src/formatter/token_text.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     fmt::{self, Debug, Display},
     ops::Deref,
 };
@@ -7,17 +8,16 @@ use super::TextRange;
 
 /// Reference to the text of a SyntaxToken without having to worry about the lifetime of `&str`.
 #[derive(Eq, Clone, PartialEq)]
-pub struct TokenText {
-    // TODO: Do not allocate.
-    string: String,
+pub struct TokenText<'a> {
+    string: Cow<'a, str>,
 
     /// Relative range of the "selected" token text.
     range: TextRange,
 }
 
-impl TokenText {
-    pub fn new(string: String, range: TextRange) -> Self {
-        Self { string, range }
+impl<'a> TokenText<'a> {
+    pub fn new(string: impl Into<Cow<'a, str>>, range: TextRange) -> Self {
+        Self { string: string.into(), range }
     }
 
     fn text(&self) -> &str {
@@ -25,7 +25,7 @@ impl TokenText {
     }
 }
 
-impl Deref for TokenText {
+impl Deref for TokenText<'_> {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {
@@ -33,13 +33,13 @@ impl Deref for TokenText {
     }
 }
 
-impl Display for TokenText {
+impl Display for TokenText<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt(self.text(), f)
     }
 }
 
-impl Debug for TokenText {
+impl Debug for TokenText<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Debug::fmt(self.text(), f)
     }

--- a/crates/oxc_formatter/src/utils/string_utils.rs
+++ b/crates/oxc_formatter/src/utils/string_utils.rs
@@ -78,9 +78,13 @@ pub struct CleanedStringLiteralText<'a> {
     width: usize,
 }
 
-impl CleanedStringLiteralText<'_> {
+impl<'a> CleanedStringLiteralText<'a> {
     pub fn width(&self) -> usize {
         self.width
+    }
+
+    pub fn into_format(self) -> SyntaxTokenCowSlice<'a> {
+        syntax_token_cow_slice(self.text, self.span)
     }
 }
 
@@ -92,7 +96,7 @@ impl<'a> Format<'a> for CleanedStringLiteralText<'a> {
 
 impl<'a> Format<'a> for FormatLiteralStringToken<'a> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        self.clean_text(f.context().source_type(), f.options()).fmt(f)
+        self.clean_text(f.context().source_type(), f.options()).into_format().fmt(f)
     }
 }
 


### PR DESCRIPTION
## Summary

Major API refactoring to eliminate string allocations in the formatting pipeline by changing `TokenText` from always allocating a `String` to using `Cow<'a, str>` for zero-copy text handling.

**This addresses the TODO comment in `token_text.rs`: `// TODO: Do not allocate.`**

## Changes

### 1. TokenText struct (`token_text.rs`)
- Changed `string: String` → `string: Cow<'a, str>`
- Updated `new()` to accept `impl Into<Cow<'a, str>>`
- Added lifetime parameter `'a` to struct and all impl blocks

### 2. LocatedTokenText (`builders.rs`)
- Added lifetime parameter `'a`
- **KEY OPTIMIZATION**: `located_token_text()` now passes borrowed slice instead of `slice.to_string()`
- Fixed Format impl to use proper lifetime bounds

### 3. SyntaxTokenCowSlice (`builders.rs`)
- Changed `TokenText::new((*text).to_string(), ...)` → `TokenText::new(*text, ...)`
- Eliminates string allocation for borrowed text

### 4. CleanedStringLiteralText (`string_utils.rs`)
- Added `into_format()` consuming method to avoid Cow clone
- Updated `FormatLiteralStringToken::fmt` to use `into_format()`

### 5. FormatElement (`format_element/mod.rs`)
- Updated `LocatedTokenText` variant to use `TokenText<'a>`

## Performance Impact

**BEFORE:**
- TokenText always allocated `String`, even for source text that could be borrowed
- Every token required a heap allocation + deallocation
- CleanedStringLiteralText cloned Cow when formatting

**AFTER:**
- TokenText borrows source text when possible via `Cow::Borrowed`
- Only allocates (`Cow::Owned`) when text needs transformation
- String literals avoid Cow clone by consuming via `into_format()`
- **Major reduction in heap allocations** during formatting (most tokens are borrowed from source)

## Test plan

- [x] Unit tests pass (`cargo test -p oxc_formatter`)
- [x] Conformance tests pass (`cargo run -p oxc_prettier_conformance`)
- [x] Lint checks pass (`just lint`)
- [x] Code formatted (`just fmt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)