### PR TITLE
fix(linter): `no-unused-vars`: allow updates in for loop test/update

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -1287,9 +1287,16 @@ fn test_ts_in_assignment() {
 
 #[test]
 fn test_loops() {
-    let pass: Vec<&str> = vec![];
+    let pass: Vec<&str> = vec![
+        "for (let len = 10; len-- > 0;) {}",
+        "for (let len = 10; len < 0; len++) {}",
+        "for (let len = 10; len;) {}",
+        "for (let len = 10;; len++) {}",
+        "for (let len = 10; len < 0; len += 1) {}",
+        "for (const _unused of []) {}",
+    ];
 
-    let fail: Vec<&str> = vec![];
+    let fail: Vec<&str> = vec!["for (let len = 10;;) {}"];
     let fix = vec![
         ("for (const unused of arr) {}", "for (const _unused of arr) {}"),
         ("for (const unused in arr) {}", "for (const _unused in arr) {}"),
@@ -1297,6 +1304,7 @@ fn test_loops() {
             "for (const foo of arr) { console.log(foo); const unused = 1; }",
             "for (const foo of arr) { console.log(foo);  }",
         ),
+        ("for (let len = 10;;) {}", "for (;;) {}"),
     ];
 
     Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail).expect_fix(fix).test();


### PR DESCRIPTION
- Fixes https://github.com/oxc-project/oxc/issues/14765

Allows update expressions when they are within a for-loop update/test.