### PR TITLE
perf(linter): `id-length`: check if ident is ASCII before segmenting

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/id_length.rs
+++ b/crates/oxc_linter/src/rules/eslint/id_length.rs
@@ -216,10 +216,15 @@ impl IdLength {
             return;
         }
 
-        let segmenter = GraphemeClusterSegmenter::new();
-        let graphemes_length = segmenter.segment_str(&ident_name).count() - 1;
-        let is_too_long = self.is_too_long(graphemes_length);
-        let is_too_short = self.is_too_short(graphemes_length);
+        // If identifier is all ASCII, then we can use .len() instead of counting graphemes
+        let (is_too_long, is_too_short) = if ident_name.is_ascii() {
+            let ident_length = ident_name.len();
+            (self.is_too_long(ident_length), self.is_too_short(ident_length))
+        } else {
+            let segmenter = GraphemeClusterSegmenter::new();
+            let graphemes_length = segmenter.segment_str(&ident_name).count() - 1;
+            (self.is_too_long(graphemes_length), self.is_too_short(graphemes_length))
+        };
 
         if !is_too_long && !is_too_short {
             return;


### PR DESCRIPTION
Profiling shows that segmenting into graphemes is much slower than just looking at the number of bytes. A simple check on `is_ascii` allows us to avoid splitting into graphemes and use the identifier length instead, which is much faster. We could optimize this further in the future by doing some faster ASCII check, but this is a good start.