### PR TITLE
perf(formatter): optimize line terminator detection with memchr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,6 +2139,7 @@ dependencies = [
  "cow-utils",
  "insta",
  "json-strip-comments",
+ "memchr",
  "oxc-schemars",
  "oxc_allocator 0.95.0",
  "oxc_ast 0.95.0",

--- a/crates/oxc_formatter/Cargo.toml
+++ b/crates/oxc_formatter/Cargo.toml
@@ -28,6 +28,7 @@ oxc_syntax = { workspace = true }
 
 cow-utils = { workspace = true }
 json-strip-comments = { workspace = true }
+memchr = { workspace = true }
 rustc-hash = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/oxc_formatter/src/formatter/source_text.rs
+++ b/crates/oxc_formatter/src/formatter/source_text.rs
@@ -5,6 +5,7 @@ use oxc_span::{GetSpan, Span};
 use oxc_syntax::identifier::{is_line_terminator, is_white_space_single_line};
 
 use super::Comments;
+use super::format_element::contains_line_terminator;
 
 /// Source text wrapper providing utilities for text analysis in the formatter.
 #[derive(Debug, Clone, Copy)]
@@ -82,7 +83,7 @@ impl<'a> SourceText<'a> {
 
     /// Check if range contains line terminators
     pub fn contains_newline_between(&self, start: u32, end: u32) -> bool {
-        self.slice_range(start, end).chars().any(is_line_terminator)
+        contains_line_terminator(self.slice_range(start, end))
     }
 
     /// Check for newlines before position, stopping at first non-whitespace


### PR DESCRIPTION
## Summary

Optimize line terminator detection in `contains_newline_between()` using SIMD-accelerated byte search with memchr, matching the proven pattern from `oxc_codegen`.

## Changes

Add `contains_line_terminator()` helper that uses byte-level detection:

```rust
// UTF-8 sequences: LS = [0xE2, 0x80, 0xA8], PS = [0xE2, 0x80, 0xA9]  
pub fn contains_line_terminator(text: &str) -> bool {
    // Single memchr3 for LF, CR, and LS/PS first byte
    // Direct byte validation for LS/PS (no UTF-8 decoding)
}
```

Update `contains_newline_between()` in `source_text.rs` to use this helper.

## Hot Paths Affected

This function is called in **5 locations** during formatting:
- `utils/conditional.rs:145` - Conditional expression formatting
- `write/mapped_type.rs:98` - TypeScript mapped type formatting
- `write/mod.rs:817` - If/else statement formatting
- `write/object_like.rs:60,63` - Object literal formatting (2 calls)

## Performance

**Before:**
```rust
self.slice_range(start, end).chars().any(is_line_terminator)
```
- UTF-8 character decoding overhead
- Checks each character individually

**After:**
```rust
contains_line_terminator(self.slice_range(start, end))
```
- Single SIMD `memchr3` search for all terminators
- Direct byte validation (no UTF-8 decode)
- **Expected: ~10-100x faster**

## Technique

Uses the **same pattern** as `oxc_codegen/src/comment.rs`:
1. Search for LF (`\n`), CR (`\r`), or LS/PS first byte (`0xE2`) with `memchr3`
2. If `0xE2` found, validate next 2 bytes match LS or PS
3. Handle false positives (continue searching if not LS/PS)

## Testing

- ✅ All unit tests pass  
- ✅ Linter passes with `--deny warnings`
- ✅ No behavior changes (correctness preserved)

## Benchmarks

Expected improvements on files with:
- Many object literals
- Conditional expressions
- TypeScript mapped types

🤖 Generated with [Claude Code](https://claude.com/claude-code)