### PR TITLE
perf(formatter): pre-allocate printer buffers based on source length

### DIFF
--- a/crates/oxc_formatter/src/formatter/mod.rs
+++ b/crates/oxc_formatter/src/formatter/mod.rs
@@ -114,8 +114,9 @@ impl<'a> Formatted<'a> {
 impl Formatted<'_> {
     pub fn print(&self) -> PrintResult<Printed> {
         let print_options = self.context.options().as_print_options();
+        let source_len = self.context.source_text().len();
 
-        let printed = Printer::new(print_options).print(&self.document)?;
+        let printed = Printer::new_with_capacity(print_options, source_len).print(&self.document)?;
 
         // let printed = match self.context.source_map() {
         // Some(source_map) => source_map.map_printed(printed),

--- a/crates/oxc_formatter/src/formatter/mod.rs
+++ b/crates/oxc_formatter/src/formatter/mod.rs
@@ -116,7 +116,8 @@ impl Formatted<'_> {
         let print_options = self.context.options().as_print_options();
         let source_len = self.context.source_text().len();
 
-        let printed = Printer::new_with_capacity(print_options, source_len).print(&self.document)?;
+        let printed =
+            Printer::new_with_capacity(print_options, source_len).print(&self.document)?;
 
         // let printed = match self.context.source_map() {
         // Some(source_map) => source_map.map_printed(printed),


### PR DESCRIPTION
## Summary

Pre-allocates the formatter's printer buffers based on source text length to reduce reallocations during formatting.

## Changes

- Added `PrinterState::with_source_len()` to pre-allocate buffers:
  - Output buffer: `source_len + 10%` (formatted output typically 0.9-1.1x input size)
  - Stack vectors: `estimated_depth` based on ~1 frame per 100 chars (minimum 16)
- Added `Printer::new_with_capacity()` constructor that uses the new initialization
- Updated `Formatted::print()` to pass source text length to printer

## Rationale

The printer's internal buffers (`buffer`, `fits_stack`, `fits_indent_stack`, etc.) currently start empty and grow on demand. This causes multiple reallocations during formatting, especially for larger files.

Since we know the source text length upfront, we can pre-allocate reasonable capacities:
- **Output buffer**: Formatted output is typically 0.9-1.1x the input size. Pre-allocating with 10% headroom avoids most reallocations.
- **Stack vectors**: Nesting depth correlates with source length. Using ~1 frame per 100 chars provides good balance.

## Performance Impact

This eliminates most buffer reallocations during formatting without changing output correctness or increasing memory usage for small files (heuristics scale with input size).

## Test plan

- ✅ `cargo test -p oxc_formatter --lib` - all tests pass
- ✅ `cargo run -p oxc_prettier_conformance` - conformance unchanged (94.71% JS, 93.02% TS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)