### PR TITLE
docs(linter): Improve the Options documentation for no-empty-function rule

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
@@ -117,10 +117,12 @@ declare_oxc_lint!(
     ///
     /// Example:
     /// ```json
-    /// "no-empty-function": [
-    ///   "error",
-    ///   { "allow": ["functions"] }
-    /// ]
+    /// {
+    ///   "no-empty-function": [
+    ///     "error",
+    ///     { "allow": ["functions"] }
+    ///   ]
+    /// }
     /// ```
     ///
     /// `allow` accepts the following values:

--- a/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
@@ -112,7 +112,7 @@ declare_oxc_lint!(
     ///
     /// `{ type: string[], default: [] }`
     ///
-    /// You may pass a list of `allow`ed function kinds, which will allow functions of
+    /// You may pass a list of allowed function kinds, which will allow functions of
     /// these kinds to be empty.
     ///
     /// Example:

--- a/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
@@ -106,16 +106,21 @@ declare_oxc_lint!(
     /// Empty functions can reduce readability because readers need to guess whether it's
     /// intentional or not. So writing a clear comment for empty functions is a good practice.
     ///
-    /// ### Configuration
-    /// You may pass an object containing a list of `allow`ed function kinds.
-    /// For example:
+    /// ### Options
+    ///
+    /// #### allow
+    ///
+    /// `{ type: string[], default: [] }`
+    ///
+    /// You may pass a list of `allow`ed function kinds, which will allow functions of
+    /// these kinds to be empty.
+    ///
+    /// Example:
     /// ```json
-    /// // oxlint.json
-    /// {
-    ///     "rules": {
-    ///         "no-empty-function": ["error", { "allow": ["functions"] }]
-    ///     }
-    /// }
+    /// "no-empty-function": [
+    ///   "error",
+    ///   { "allow": ["functions"] }
+    /// ]
     /// ```
     ///
     /// `allow` accepts the following values:
@@ -157,7 +162,7 @@ declare_oxc_lint!(
     /// }
     ///
     /// function foo() {
-    ///     return;
+    ///   return;
     /// }
     /// const add = (a, b) => a + b
     ///


### PR DESCRIPTION
Previously this wasn't following the same format as most other rules with options, now it is.

Related to #14743

I tried converting this to auto-gen docs, but I have no idea how to get that working without the compiler complaining, honestly.