### PR TITLE
docs(linter): improve `no-plusplus` and `no-irregular-whitespace` rule docs

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
@@ -39,6 +39,7 @@ declare_oxc_lint!(
     /// function example() {
     ///   var foo = 'bar'; // regular spaces only
     /// }
+    /// ```
     NoIrregularWhitespace,
     eslint,
     correctness

--- a/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
@@ -75,6 +75,7 @@ declare_oxc_lint!(
     /// for (let i = 0; i < l; i += 1) {
     ///    doSomething(i);
     /// }
+    /// ```
     ///
     /// ### Options
     ///


### PR DESCRIPTION
Closing code blocks were missing in the examples sections of both these rules.

As you can see on the website pages here:

- https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-plusplus.html#examples
- https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-irregular-whitespace.html#examples