### PR TITLE
docs(linter): Add configuration docs to no-useless-escape lint rule.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
@@ -8,6 +8,7 @@ use oxc_regular_expression::{
 };
 use oxc_semantic::NodeId;
 use oxc_span::Span;
+use schemars::JsonSchema;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -26,8 +27,10 @@ impl std::ops::Deref for NoUselessEscape {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct NoUselessEscapeConfig {
+    /// An array of characters that are allowed to be escaped unnecessarily in regexes.
     allow_regex_characters: Vec<char>,
 }
 
@@ -81,27 +84,11 @@ declare_oxc_lint!(
     /// /[\]]/;
     /// /[a-z-]/;
     /// ```
-    ///
-    /// ### Options
-    ///
-    /// #### allowRegexCharacters
-    ///
-    /// `{ type: string[], default: [] }`
-    ///
-    /// An array of characters that are allowed to be escaped unnecessarily in regexes.
-    ///
-    /// Example:
-    /// ```json
-    /// {
-    ///   "no-useless-escape": ["error", {
-    ///     "allowRegexCharacters": ["!", "@", "#"]
-    ///   }]
-    /// }
-    /// ```
     NoUselessEscape,
     eslint,
     correctness,
-    fix
+    fix,
+    config = NoUselessEscapeConfig,
 );
 
 impl Rule for NoUselessEscape {

--- a/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
@@ -28,7 +28,7 @@ impl std::ops::Deref for NoUselessEscape {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", default)]
 pub struct NoUselessEscapeConfig {
     /// An array of characters that are allowed to be escaped unnecessarily in regexes.
     allow_regex_characters: Vec<char>,

--- a/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
@@ -38,9 +38,9 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// Escaping characters unnecessarily has no effect on the regex behavior,
-    /// and can make regexes harder to read and understand by adding
-    /// unnecessary complexity.
+    /// Escaping characters unnecessarily has no effect on the behavior of strings or regexes,
+    /// and can make code harder to read and understand by adding unnecessary complexity.
+    /// This applies to string literals, template literals, and regular expressions.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
@@ -34,10 +34,13 @@ pub struct NoUselessEscapeConfig {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow unnecessary escape characters
+    /// Disallow unnecessary escape characters.
     ///
     /// ### Why is this bad?
     ///
+    /// Escaping characters unnecessarily has no effect on the regex behavior,
+    /// and can make regexes harder to read and understand by adding
+    /// unnecessary complexity.
     ///
     /// ### Examples
     ///
@@ -77,6 +80,23 @@ declare_oxc_lint!(
     /// /[[]/;
     /// /[\]]/;
     /// /[a-z-]/;
+    /// ```
+    ///
+    /// ### Options
+    ///
+    /// #### allowRegexCharacters
+    ///
+    /// `{ type: string[], default: [] }`
+    ///
+    /// An array of characters that are allowed to be escaped unnecessarily in regexes.
+    ///
+    /// Example:
+    /// ```json
+    /// {
+    ///   "no-useless-escape": ["error", {
+    ///     "allowRegexCharacters": ["!", "@", "#"]
+    ///   }]
+    /// }
     /// ```
     NoUselessEscape,
     eslint,


### PR DESCRIPTION
Also add missing text for "Why is this bad?" section. I've updated this to use the autogen docs rather than an explicit Options section, since that seems to be the preferred implementation path for this kind of addition.

Part of #14743.

Results in:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### allowRegexCharacters

type: `string[]`

default: `[]`

An array of characters that are allowed to be escaped unnecessarily in regexes.
```