### PR TITLE
feat(rulegen): Add options section for doc block in template.

### DIFF
--- a/tasks/rulegen/template.txt
+++ b/tasks/rulegen/template.txt
@@ -52,6 +52,26 @@ declare_oxc_lint!(
     /// ```{{language}}
     /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
     /// ```
+{{#if rule_config}}
+    ///
+    /// ### Options
+    ///
+    /// #### optionName
+    ///
+    /// `{ type: FIXME, default: FIXME }`
+    ///
+    /// FIXME: Explanation of what this option does.
+    ///
+    /// Example:
+    /// ```json
+    /// {
+    ///   "{{mod_name}}/{{kebab_rule_name}}": [
+    ///     "error",
+    ///     { "optionName": "FIXME: example option value" }
+    ///   ]
+    /// }
+    /// ```
+{{/if}}
     {{pascal_rule_name}},
     {{mod_name}},
     nursery, // TODO: change category to `correctness`, `suspicious`, `pedantic`, `perf`, `restriction`, or `style`


### PR DESCRIPTION
If there's a rule config option, add an Options section to the docs in the generated rule code.

This should help ensure new rules get this section in the future.

Part of #14743. Follows up on work in #13320.

Here is the output I get when I run `just new-rule strict` to generate an equivalent of [the ESLint strict rule](https://eslint.org/docs/latest/rules/strict):

```
declare_oxc_lint!(
    /// ### What it does
    ///
    /// Briefly describe the rule's purpose.
    ///
    /// ### Why is this bad?
    ///
    /// Explain why violating this rule is problematic.
    ///
    /// ### Examples
    ///
    /// Examples of **incorrect** code for this rule:
    /// ```js
    /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
    /// ```
    ///
    /// Examples of **correct** code for this rule:
    /// ```js
    /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
    /// ```
    ///
    /// ### Options
    ///
    /// #### optionName
    ///
    /// `{ type: FIXME, default: FIXME }`
    ///
    /// FIXME: Explanation of what this option does.
    ///
    /// Example:
    /// ```json
    /// {
    ///   "eslint/strict": [
    ///     "error",
    ///     { "optionName": "FIXME: example option value" }
    ///   ]
    /// }
    /// ```
```

I'm not sure if it's possible to get the option _names_ in the template, but if anyone has ideas on that I'd be happy to hear them. For now it just populates one option which is always `optionName`. 