### PR TITLE
perf(linter): cache file extension

### DIFF
--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -1,6 +1,6 @@
 #![expect(rustdoc::private_intra_doc_links)] // useful for intellisense
 
-use std::{ops::Deref, path::Path, rc::Rc};
+use std::{ffi::OsStr, ops::Deref, path::Path, rc::Rc};
 
 use javascript_globals::GLOBALS;
 
@@ -139,6 +139,12 @@ impl<'a> LintContext<'a> {
     #[inline]
     pub fn file_path(&self) -> &Path {
         &self.parent.file_path
+    }
+
+    /// Extension of the file currently being linted, without the leading dot.
+    #[inline]
+    pub fn file_extension(&self) -> Option<&OsStr> {
+        self.parent.file_extension()
     }
 
     /// Plugin settings

--- a/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
@@ -65,7 +65,7 @@ impl Rule for NoUnusedLabels {
     }
 
     fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
-        ctx.file_path().extension().is_some_and(|ext| ext != "svelte")
+        ctx.file_extension().is_some_and(|ext| ext != "svelte")
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -223,8 +223,7 @@ impl Rule for NoUnusedVars {
         //    we can't detect
         !ctx.source_type().is_typescript_definition()
             && !ctx
-                .file_path()
-                .extension()
+                .file_extension()
                 .is_some_and(|ext| ext == "vue" || ext == "svelte" || ext == "astro")
     }
 }

--- a/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
@@ -1,4 +1,4 @@
-use std::{ops::Deref, path::Path};
+use std::ops::Deref;
 
 use lazy_regex::Regex;
 use oxc_ast::{
@@ -170,9 +170,7 @@ impl Rule for NoLargeSnapshots {
     }
 
     fn run_once(&self, ctx: &LintContext) {
-        let is_snap = ctx.file_path().to_str().is_some_and(|p| {
-            Path::new(p).extension().is_some_and(|ext| ext.eq_ignore_ascii_case("snap"))
-        });
+        let is_snap = ctx.file_extension().is_some_and(|ext| ext.eq_ignore_ascii_case("snap"));
 
         if is_snap {
             for node in ctx.nodes().iter() {

--- a/crates/oxc_linter/src/rules/react/jsx_filename_extension.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_filename_extension.rs
@@ -157,7 +157,7 @@ impl Rule for JsxFilenameExtension {
     }
 
     fn run_once(&self, ctx: &LintContext) {
-        let file_extension = ctx.file_path().extension().and_then(OsStr::to_str).unwrap_or("");
+        let file_extension = ctx.file_extension().and_then(OsStr::to_str).unwrap_or("");
         let has_ext_allowed = self.extensions.contains(&CompactStr::new(file_extension));
 
         if !has_ext_allowed {

--- a/crates/oxc_linter/src/rules/react/only_export_components.rs
+++ b/crates/oxc_linter/src/rules/react/only_export_components.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use oxc_ast::{AstKind, ast::*};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -262,7 +260,7 @@ impl Rule for OnlyExportComponents {
         };
 
         let should_scan = {
-            let ext = Path::new(filename).extension().and_then(|e| e.to_str());
+            let ext = ctx.file_extension();
             matches!(ext, Some(e) if e.eq_ignore_ascii_case("tsx") || e.eq_ignore_ascii_case("jsx"))
                 || (self.check_js && matches!(ext, Some(e) if e.eq_ignore_ascii_case("js")))
         };

--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -173,7 +173,7 @@ impl Rule for RulesOfHooks {
         // disable this rule in vue/nuxt and svelte(kit) files
         // react hook can be build in only `.ts` files,
         // but `useX` functions are popular and can be false positive in other frameworks
-        !ctx.file_path().extension().is_some_and(|ext| ext == "vue" || ext == "svelte")
+        !ctx.file_extension().is_some_and(|ext| ext == "vue" || ext == "svelte")
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/unicorn/no_empty_file.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_empty_file.rs
@@ -62,9 +62,8 @@ impl Rule for NoEmptyFile {
     }
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.file_path().extension().is_some_and(|ext| {
-            !LINT_PARTIAL_LOADER_EXTENSIONS.contains(&ext.to_string_lossy().as_ref())
-        })
+        ctx.file_extension()
+            .is_some_and(|ext| !LINT_PARTIAL_LOADER_EXTENSIONS.iter().any(|e| *e == ext))
     }
 }
 

--- a/crates/oxc_linter/src/rules/vue/max_props.rs
+++ b/crates/oxc_linter/src/rules/vue/max_props.rs
@@ -105,7 +105,7 @@ impl Rule for MaxProps {
     }
 
     fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
-        ctx.file_path().extension().is_some_and(|ext| ext == "vue")
+        ctx.file_extension().is_some_and(|ext| ext == "vue")
     }
 }
 

--- a/crates/oxc_linter/src/rules/vue/no_multiple_slot_args.rs
+++ b/crates/oxc_linter/src/rules/vue/no_multiple_slot_args.rs
@@ -144,7 +144,7 @@ impl Rule for NoMultipleSlotArgs {
     }
 
     fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
-        ctx.file_path().extension().is_some_and(|ext| ext == "vue")
+        ctx.file_extension().is_some_and(|ext| ext == "vue")
             && ctx.frameworks_options() != FrameworkOptions::VueSetup
     }
 }

--- a/crates/oxc_linter/src/rules/vue/no_required_prop_with_default.rs
+++ b/crates/oxc_linter/src/rules/vue/no_required_prop_with_default.rs
@@ -73,7 +73,7 @@ declare_oxc_lint!(
 
 impl Rule for NoRequiredPropWithDefault {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let is_vue = ctx.file_path().extension().is_some_and(|ext| ext == "vue");
+        let is_vue = ctx.file_extension().is_some_and(|ext| ext == "vue");
         if is_vue {
             self.run_on_vue(node, ctx);
         } else {

--- a/crates/oxc_linter/src/rules/vue/require_default_export.rs
+++ b/crates/oxc_linter/src/rules/vue/require_default_export.rs
@@ -93,7 +93,7 @@ impl Rule for RequireDefaultExport {
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
         // only on vue files
-        if ctx.file_path().extension().is_none_or(|ext| ext != "vue") {
+        if ctx.file_extension().is_none_or(|ext| ext != "vue") {
             return false;
         }
 


### PR DESCRIPTION
Getting file extensions shows up as slow in multiple rules. Computing it once and then storing it should be much faster.

<img width="713" height="366" alt="Screenshot 2025-10-20 at 12 00 35 AM" src="https://github.com/user-attachments/assets/b074bbf1-8a1f-4910-98d0-40f66eb3b39c" />
