### PR TITLE
refactor(oxfmt): Update CLI --help details

### DIFF
--- a/apps/oxfmt/src/command.rs
+++ b/apps/oxfmt/src/command.rs
@@ -23,18 +23,15 @@ const PATHS_ERROR_MESSAGE: &str = "PATH must not contain \"..\"";
 pub struct FormatCommand {
     #[bpaf(external, fallback(OutputOptions::DefaultWrite))]
     pub output_options: OutputOptions,
-
     #[bpaf(external)]
     pub basic_options: BasicOptions,
-
     #[bpaf(external)]
     pub ignore_options: IgnoreOptions,
-
     #[bpaf(external)]
     pub misc_options: MiscOptions,
-
     /// Single file, single path or list of paths.
     /// If not provided, current working directory is used.
+    /// Glob is supported only for exclude patterns like `'!**/fixtures/*.js'.
     // `bpaf(fallback)` seems to have issues with `many` or `positional`,
     // so we implement the fallback behavior in code instead.
     #[bpaf(positional("PATH"), many, guard(validate_paths, PATHS_ERROR_MESSAGE))]
@@ -44,7 +41,7 @@ pub struct FormatCommand {
 /// Output Options
 #[derive(Debug, Clone, Bpaf)]
 pub enum OutputOptions {
-    /// Default - when no output option is specified, behaves like `--write`
+    /// Default - when no output option is specified, behaves like `--write` mode in Prettier
     #[bpaf(hide)]
     DefaultWrite,
     /// Check mode - check if files are formatted
@@ -66,7 +63,7 @@ pub struct BasicOptions {
 /// Ignore Options
 #[derive(Debug, Clone, Bpaf)]
 pub struct IgnoreOptions {
-    /// Format code in node_modules directory (disabled by default)
+    /// Format code in node_modules directory (skipped by default)
     #[bpaf(switch, hide_usage)]
     pub with_node_modules: bool,
 }


### PR DESCRIPTION
```
Usage: [--check | --list-different] [-c=PATH] [PATH]...

Output Options
        --check              Check mode - check if files are formatted
        --list-different     List mode - list files that would be changed

Basic Options
    -c, --config=PATH        Path to the configuration file

Ignore Options
        --with-node-modules  Format code in node_modules directory (skipped by default)

Miscellaneous
        --no-error-on-unmatched-pattern  Do not exit with error when pattern is unmatched
        --threads=INT        Number of threads to use. Set to 1 for using only 1 CPU core

Available positional items:
    PATH                     Single file, single path or list of paths. If not provided, current
                             working directory is used. Glob is supported only for exclude patterns
                             like `'!**/fixtures/*.js'.

Available options:
    -h, --help               Prints help information
    -V, --version            Prints version information
```
