### PR TITLE
release(oxfmt): v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,7 +2064,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_formatter"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "cow-utils",
  "insta",
@@ -2796,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "oxfmt"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bpaf",
  "cow-utils",

--- a/apps/oxfmt/CHANGELOG.md
+++ b/apps/oxfmt/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.6.0] - 2025-10-20
+
+### 🚀 Features
+
+- 7f91a26 oxfmt: Handle ignoring files (#14798) (leaysgur)
+- 199a2c6 oxfmt: Support `--with-node-modules` option (#14713) (leaysgur)
+- 26c5f5a oxfmt: Ignore VCS directories by default (#14616) (leaysgur)
+- fec2ed9 oxfmt: Use Prettier style config key and value (#14612) (leaysgur)
+- 1b58521 oxfmt,language_server: Enable JSX for all JS source type (#14605) (leaysgur)
+
+### 🐛 Bug Fixes
+
+- ef02760 oxfmt: Handle relative path starts with dot (#14708) (leaysgur)
+- ee37f5d oxfmt: Handle default cwd correctly (#14704) (leaysgur)
+- 0961c3a oxlint,oxfmt: Skip traversing `.git` directories (#14590) (Boshen)
+
+### 🚜 Refactor
+
+- b7926f3 oxfmt: Update CLI --help details (#14796) (leaysgur)
+- 173168b oxfmt: Refactor walk.rs and format.rs relationship (#14795) (leaysgur)
+- aea9d79 oxfmt: Pass `PathBuf` from walk.rs to service.rs (#14716) (leaysgur)
+
+### 🧪 Testing
+
+- 7c42ea0 oxfmt: Remove args from snapshot file name (#14800) (leaysgur)
+
+
 ## [0.5.0] - 2025-10-14
 
 ### 🚀 Features

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxfmt"
-version = "0.5.0"
+version = "0.6.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_formatter/CHANGELOG.md
+++ b/crates/oxc_formatter/CHANGELOG.md
@@ -4,6 +4,60 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.6.0] - 2025-10-20
+
+### 🚀 Features
+
+- 6bf8bac formatter: Reimplement formatting for `ImportExpression` (#14712) (Dunqing)
+- 3f2e036 formatter: Introduce `AstNode<ExpressionStatement>::is_arrow_function_body` (#14709) (Dunqing)
+- df225e9 formatter: Add `AstNode::ancestor` and `AstNode::grand_parent` methods (#14700) (Dunqing)
+- fec2ed9 oxfmt: Use Prettier style config key and value (#14612) (leaysgur)
+- 1b58521 oxfmt,language_server: Enable JSX for all JS source type (#14605) (leaysgur)
+
+### 🐛 Bug Fixes
+
+- 21c4285 formatter: Correct printing remaining trailing comments for `TSMappedType` (#14761) (Dunqing)
+- 1d1573e formatter: Correct adding semicolons for TypeScript left-hand side nodes (#14760) (Dunqing)
+- 4cc3b10 formatter: Improve handling of new lines between comments in `MemberChain` (#14759) (Dunqing)
+- e6bce8e formatter: Break the left hand side of AssignmentLike node if it is an `ObjectPattern` with three properties (#14756) (Dunqing)
+- dc57a2b formatter: Incorrect handling of `VariableDeclarator` with an `ArrowFunctionExpression` initializer (#14731) (Dunqing)
+- 537185d formatter: Should always group the left side of `AssignmentPattern` (#14730) (Dunqing)
+- 4283fd8 formatter: Correct printing comments for `JSXAttributeValue` (#14719) (Dunqing)
+- 59c9e1b formatter: Avoid conditional being broken in arguments by trailing comments (#14718) (Dunqing)
+- 7d64b96 formatter: Should wrap parentheses with JSX arguments of `NewExpression` (#14717) (Dunqing)
+- 2068a63 formatter: Should indent TemplateExpression if it is a member expression that is part of `ChainExpression` (#14714) (Dunqing)
+- 5ea3bb6 formatter: Incorrect handling of `ObjectPattern` as an `AssignmentPattern` of a parameter (#14711) (Dunqing)
+- eb52529 formatter: Incorrect handling of `ObjectPattern` as a parameter (#14670) (Dunqing)
+- 8ac10da formatter: Correct checking assignment layout for the right side with ownline comment and it is a `PrivateFieldExpression` (#14664) (Dunqing)
+- 6cba9b1 formatter: Should not merge tail with head for MemberChain when its parent is ArrowFunctionExpression (#14663) (Dunqing)
+- f44d3c0 formatter: Should not indent BinaryLikeExpression when its parent is `NewExpression` (#14662) (Dunqing)
+- bf953b8 formatter: Should group nested test for TSConditionalType (#14661) (Dunqing)
+- 63dc57b formatter: Correct handling if a template literal should be printed as a signle line (#14660) (Dunqing)
+- 0150ad5 formatter: Should group type parameters and parameters for method-like and function-like nodes (#14659) (Dunqing)
+- 392bf74 formatter: Improve handling of dangling comments in if statements (#14658) (Dunqing)
+- fd52b10 formatter: Don't print CallExpression as MemberChain style when its only has one argument and it is a TemplateLiteral on its own line (#14657) (Dunqing)
+- 29c3c60 formatter: Don't group nested await expression when its is the leftmost expression (#14656) (Dunqing)
+- 72c7503 formatter: Correct checking function composition when the arguments have an call expression before function (#14655) (Dunqing)
+- 2b645e2 formatter: Don't wrap parenthesis for `type` when its grandparent isn't a `ExpressionStatement` (#14654) (Dunqing)
+- e0eb966 formatter: Skip the leading semicolon when calculating leading lines (#14653) (Dunqing)
+
+### 🚜 Refactor
+
+- 83e783a formatter: Organize utils structure (#14710) (Dunqing)
+- 58dd74a formatter: Remove all `without_parentheses` usages (#14707) (Dunqing)
+- 75dfcad formatter: Simplify `ExpressionLeftSide` (#14706) (Dunqing)
+- 273f0fe formatter: Remove unnecessary lifetimes for the implementations of `NeedsParentheses` (#14703) (Dunqing)
+- bae5f11 formatter: Improve `AstNode` and `AstNodes` (#14686) (Dunqing)
+
+### ⚡ Performance
+
+- c6395c7 formatter: Optimize string reservation in print_text (#14751) (Boshen)
+
+### 🧪 Testing
+
+- 42d8c62 formatter: Add tests for sort-imports (#14685) (leaysgur)
+
+
 ## [0.5.0] - 2025-10-14
 
 ### 🚀 Features

--- a/crates/oxc_formatter/Cargo.toml
+++ b/crates/oxc_formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_formatter"
-version = "0.5.0"
+version = "0.6.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/npm/oxfmt/CHANGELOG.md
+++ b/npm/oxfmt/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.6.0] - 2025-10-20
+
+### 🚀 Features
+
+- fec2ed9 oxfmt: Use Prettier style config key and value (#14612) (leaysgur)
+
+
 ## [0.5.0] - 2025-10-14
 
 ### 🚀 Features

--- a/npm/oxfmt/package.json
+++ b/npm/oxfmt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxfmt",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "description": "Formatter for the JavaScript Oxidation Compiler",
   "keywords": [],


### PR DESCRIPTION
## [0.6.0] - 2025-10-20

### 🚀 Features

- 7f91a26 oxfmt: Handle ignoring files (#14798) (leaysgur)
- 199a2c6 oxfmt: Support `--with-node-modules` option (#14713) (leaysgur)
- 6bf8bac formatter: Reimplement formatting for `ImportExpression` (#14712) (Dunqing)
- 3f2e036 formatter: Introduce `AstNode<ExpressionStatement>::is_arrow_function_body` (#14709) (Dunqing)
- df225e9 formatter: Add `AstNode::ancestor` and `AstNode::grand_parent` methods (#14700) (Dunqing)
- 26c5f5a oxfmt: Ignore VCS directories by default (#14616) (leaysgur)
- fec2ed9 oxfmt: Use Prettier style config key and value (#14612) (leaysgur)
- 1b58521 oxfmt,language_server: Enable JSX for all JS source type (#14605) (leaysgur)

### 🐛 Bug Fixes

- 21c4285 formatter: Correct printing remaining trailing comments for `TSMappedType` (#14761) (Dunqing)
- 1d1573e formatter: Correct adding semicolons for TypeScript left-hand side nodes (#14760) (Dunqing)
- 4cc3b10 formatter: Improve handling of new lines between comments in `MemberChain` (#14759) (Dunqing)
- e6bce8e formatter: Break the left hand side of AssignmentLike node if it is an `ObjectPattern` with three properties (#14756) (Dunqing)
- dc57a2b formatter: Incorrect handling of `VariableDeclarator` with an `ArrowFunctionExpression` initializer (#14731) (Dunqing)
- 537185d formatter: Should always group the left side of `AssignmentPattern` (#14730) (Dunqing)
- ef02760 oxfmt: Handle relative path starts with dot (#14708) (leaysgur)
- ee37f5d oxfmt: Handle default cwd correctly (#14704) (leaysgur)
- 4283fd8 formatter: Correct printing comments for `JSXAttributeValue` (#14719) (Dunqing)
- 59c9e1b formatter: Avoid conditional being broken in arguments by trailing comments (#14718) (Dunqing)
- 7d64b96 formatter: Should wrap parentheses with JSX arguments of `NewExpression` (#14717) (Dunqing)
- 2068a63 formatter: Should indent TemplateExpression if it is a member expression that is part of `ChainExpression` (#14714) (Dunqing)
- 5ea3bb6 formatter: Incorrect handling of `ObjectPattern` as an `AssignmentPattern` of a parameter (#14711) (Dunqing)
- eb52529 formatter: Incorrect handling of `ObjectPattern` as a parameter (#14670) (Dunqing)
- 8ac10da formatter: Correct checking assignment layout for the right side with ownline comment and it is a `PrivateFieldExpression` (#14664) (Dunqing)
- 6cba9b1 formatter: Should not merge tail with head for MemberChain when its parent is ArrowFunctionExpression (#14663) (Dunqing)
- f44d3c0 formatter: Should not indent BinaryLikeExpression when its parent is `NewExpression` (#14662) (Dunqing)
- bf953b8 formatter: Should group nested test for TSConditionalType (#14661) (Dunqing)
- 63dc57b formatter: Correct handling if a template literal should be printed as a signle line (#14660) (Dunqing)
- 0150ad5 formatter: Should group type parameters and parameters for method-like and function-like nodes (#14659) (Dunqing)
- 392bf74 formatter: Improve handling of dangling comments in if statements (#14658) (Dunqing)
- fd52b10 formatter: Don't print CallExpression as MemberChain style when its only has one argument and it is a TemplateLiteral on its own line (#14657) (Dunqing)
- 29c3c60 formatter: Don't group nested await expression when its is the leftmost expression (#14656) (Dunqing)
- 72c7503 formatter: Correct checking function composition when the arguments have an call expression before function (#14655) (Dunqing)
- 2b645e2 formatter: Don't wrap parenthesis for `type` when its grandparent isn't a `ExpressionStatement` (#14654) (Dunqing)
- e0eb966 formatter: Skip the leading semicolon when calculating leading lines (#14653) (Dunqing)
- 0961c3a oxlint,oxfmt: Skip traversing `.git` directories (#14590) (Boshen)

### 🚜 Refactor

- b7926f3 oxfmt: Update CLI --help details (#14796) (leaysgur)
- 173168b oxfmt: Refactor walk.rs and format.rs relationship (#14795) (leaysgur)
- aea9d79 oxfmt: Pass `PathBuf` from walk.rs to service.rs (#14716) (leaysgur)
- 83e783a formatter: Organize utils structure (#14710) (Dunqing)
- 58dd74a formatter: Remove all `without_parentheses` usages (#14707) (Dunqing)
- 75dfcad formatter: Simplify `ExpressionLeftSide` (#14706) (Dunqing)
- 273f0fe formatter: Remove unnecessary lifetimes for the implementations of `NeedsParentheses` (#14703) (Dunqing)
- bae5f11 formatter: Improve `AstNode` and `AstNodes` (#14686) (Dunqing)

### ⚡ Performance

- c6395c7 formatter: Optimize string reservation in print_text (#14751) (Boshen)

### 🧪 Testing

- 7c42ea0 oxfmt: Remove args from snapshot file name (#14800) (leaysgur)
- 42d8c62 formatter: Add tests for sort-imports (#14685) (leaysgur)