### PR TITLE
fix(cfg): append switch case condition to correct block

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -1482,11 +1482,13 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
 
         if let Some(expr) = &case.test {
             #[cfg(feature = "cfg")]
+            let condition_block_ix = control_flow!(self, |cfg| cfg.current_node_ix);
+            #[cfg(feature = "cfg")]
             self.record_ast_nodes();
             self.visit_expression(expr);
             #[cfg(feature = "cfg")]
             let test_node_id = self.retrieve_recorded_ast_node();
-            control_flow!(self, |cfg| cfg.append_condition_to(cfg.current_node_ix, test_node_id));
+            control_flow!(self, |cfg| cfg.append_condition_to(condition_block_ix, test_node_id));
         }
 
         /* cfg */


### PR DESCRIPTION
When a switch case test contains a logical expression (|| or &&), visiting the expression creates multiple CFG blocks for short-circuit evaluation and changes current_node_ix. The condition instruction must be appended to the block BEFORE visiting the expression, not after.

This matches the pattern used in visit_if_statement and ensures the condition instruction is placed in the case entry block, making it discoverable by code that identifies case test blocks.

Before:
```rust
self.visit_expression(expr);  // moves current_node_ix
cfg.append_condition_to(cfg.current_node_ix, ...);  // wrong block
```
After:
```rust
let condition_block_ix = cfg.current_node_ix;  // save before
self.visit_expression(expr);
cfg.append_condition_to(condition_block_ix, ...);  // correct block
```