### PR TITLE
perf(linter): use precomputed extension

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -167,10 +167,9 @@ impl Linter {
         #[cfg(debug_assertions)]
         let mut current_diagnostic_index = 0;
 
-        let is_partial_loader_file = path
-            .extension()
-            .and_then(|ext| ext.to_str())
-            .is_some_and(|ext| LINT_PARTIAL_LOADER_EXTENSIONS.contains(&ext));
+        let is_partial_loader_file = ctx_host
+            .file_extension()
+            .is_some_and(|ext| LINT_PARTIAL_LOADER_EXTENSIONS.iter().any(|e| e == &ext));
 
         loop {
             let mut rules = rules


### PR DESCRIPTION
Very marginally faster to use the precomputed file extension now.