### PR TITLE
perf(linter): move up rule retainment into initial collection to reduce allocation size

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -173,32 +173,32 @@ impl Linter {
             .is_some_and(|ext| LINT_PARTIAL_LOADER_EXTENSIONS.iter().any(|e| e == &ext));
 
         loop {
-            let mut rules = rules
+            let semantic = ctx_host.semantic();
+            let rules = rules
                 .iter()
-                .filter(|(rule, _)| rule.should_run(&ctx_host) && !rule.is_tsgolint_rule())
+                .filter(|(rule, _)| {
+                    if rule.is_tsgolint_rule() {
+                        return false;
+                    }
+
+                    // If only the `run` function is implemented, we can skip running the file entirely if the current
+                    // file does not contain any of the relevant AST node types.
+                    if rule.run_info() == RuleRunFunctionsImplemented::Run
+                        && let Some(ast_types) = rule.types_info()
+                        && !semantic.nodes().contains_any(ast_types)
+                    {
+                        return false;
+                    }
+
+                    rule.should_run(&ctx_host)
+                })
                 .map(|(rule, severity)| (rule, Rc::clone(&ctx_host).spawn(rule, *severity)))
                 .collect::<Vec<_>>();
-
-            let semantic = ctx_host.semantic();
 
             let should_run_on_jest_node =
                 ctx_host.plugins().has_test() && ctx_host.frameworks().is_test();
 
-            let mut execute_rules = |with_runtime_optimization: bool| {
-                // If only the `run` function is implemented, we can skip running the file entirely if the current
-                // file does not contain any of the relevant AST node types.
-                if with_runtime_optimization {
-                    rules.retain(|(rule, _)| {
-                        let run_info = rule.run_info();
-                        if run_info == RuleRunFunctionsImplemented::Run
-                            && let Some(ast_types) = rule.types_info()
-                        {
-                            semantic.nodes().contains_any(ast_types)
-                        } else {
-                            true
-                        }
-                    });
-                }
+            let execute_rules = |with_runtime_optimization: bool| {
                 // IMPORTANT: We have two branches here for performance reasons:
                 //
                 // 1) Branch where we iterate over each node, then each rule


### PR DESCRIPTION
In the current implementation, we collect all rules, and then remove rules that only run on specific node types and that have no relevant node types in the current file. This leads to a larger allocation size because we only remove the rules after we've already collected all of the rules.

This PR switches the order so that we filter out the rules before we actually collect them into a `Vec`. The downside of this is I can't see an easy way currently to make this work with the debug assertions we have for ensuring the runtime optimizations don't affect the output. The benefit of this is that the constant overhead for small files is much less, as shown by the benchmarks.