### PR TITLE
feat(formatter): wrap parenthesis for `AssignmentExpression` that are inside `ComputedMemberExpression`

### DIFF
--- a/crates/oxc_formatter/src/parentheses/expression.rs
+++ b/crates/oxc_formatter/src/parentheses/expression.rs
@@ -551,9 +551,9 @@ impl NeedsParentheses<'_> for AstNode<'_, AssignmentExpression<'_>> {
             // - `a = (b = c)` = nested assignments don't need extra parens
             AstNodes::AssignmentExpression(_) => false,
             // Computed member expressions: need parens when assignment is the object
-            // - `obj[a = b]` = no parens needed for property
+            // - `obj[(a = b)]` parens needed for explicitness
             // - `(a = b)[obj]` = parens needed for object
-            AstNodes::ComputedMemberExpression(member) => member.object.span() == self.span(),
+            AstNodes::ComputedMemberExpression(member) => true,
             // For statements, no parens needed in initializer or update sections:
             // - `for (a = 1; ...; a = 2) {}` = both assignments don't need parens
             AstNodes::ForStatement(stmt) => {

--- a/crates/oxc_formatter/tests/fixtures/js/assignments/parenthesis.js
+++ b/crates/oxc_formatter/tests/fixtures/js/assignments/parenthesis.js
@@ -1,0 +1,1 @@
+object[key = "a" + "b"];

--- a/crates/oxc_formatter/tests/fixtures/js/assignments/parenthesis.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/assignments/parenthesis.js.snap
@@ -1,0 +1,10 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+object[key = "a" + "b"];
+
+==================== Output ====================
+object[(key = "a" + "b")];
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/comments/computed-member.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/computed-member.js.snap
@@ -18,7 +18,7 @@ prop[
 ] = shouldCast;
 
 let handler =
-  props[handlerName = toHandlerKey(event)] || // also try camelCase event handler (#2249)
-  props[handlerName = toHandlerKey(camelize(event))];
+  props[(handlerName = toHandlerKey(event))] || // also try camelCase event handler (#2249)
+  props[(handlerName = toHandlerKey(camelize(event)))];
 
 ===================== End =====================


### PR DESCRIPTION
related: https://github.com/oxc-project/oxc/discussions/14669#discussioncomment-14723451