### PR TITLE
fix(oxfmt): Handle `.d.ts` file correctly

### DIFF
--- a/apps/oxfmt/tests/fixtures/multiple_files/app.tsx
+++ b/apps/oxfmt/tests/fixtures/multiple_files/app.tsx
@@ -1,0 +1,10 @@
+interface   Props   {
+    title  :  string
+    count  :  number
+}
+const   App   :   React.FC  <  Props  >   =   (  {  title  ,  count  }  )   =>   {
+return   <div  >
+        <h1  >  {  title  }  </h1>
+    <span  >  Count  :  {  count  }  </span>
+</div>
+}

--- a/apps/oxfmt/tests/fixtures/multiple_files/arrow.js
+++ b/apps/oxfmt/tests/fixtures/multiple_files/arrow.js
@@ -1,3 +1,3 @@
-const  fn1  =  (  )  =>  {  }
-const   fn2   =   x   =>   x   *   2
-const    fn3    =    (  a  ,  b  )    =>    a    +    b
+const   Element   =   (  )   =>   <button   onClick  =  {  (  )  =>  alert  (  "clicked"  )  }  >
+    Click   me
+</button>

--- a/apps/oxfmt/tests/fixtures/multiple_files/component.jsx
+++ b/apps/oxfmt/tests/fixtures/multiple_files/component.jsx
@@ -1,0 +1,6 @@
+const   Component   =   (  )   =>   {
+    return   <div   className  =  "container"  >
+        <h1  >  Hello  </h1>
+<p  >  World  </p>
+    </div>
+}

--- a/apps/oxfmt/tests/fixtures/multiple_files/simple.ts
+++ b/apps/oxfmt/tests/fixtures/multiple_files/simple.ts
@@ -1,0 +1,5 @@
+interface   Person   {
+    name  :  string
+age:number
+}
+const   user   :   Person   =   {  name  :  "Alice"  ,  age  :  30  }

--- a/apps/oxfmt/tests/fixtures/multiple_files/types.d.ts
+++ b/apps/oxfmt/tests/fixtures/multiple_files/types.d.ts
@@ -1,0 +1,9 @@
+declare   module   "my-module"   {
+export   function   hello  (  name  :  string  )  :  void
+    export   interface   Config   {
+        enabled  :  boolean
+    }
+}
+export const visitorKeys: Record<
+string, string[]
+>;

--- a/apps/oxfmt/tests/mod.rs
+++ b/apps/oxfmt/tests/mod.rs
@@ -28,6 +28,7 @@ fn multiple_files() {
                 // Explicit cwd
                 &["--check", "."],
                 &["--check", "./"],
+                &["--check", "!*.{ts,tsx}"],
             ],
         );
 }

--- a/apps/oxfmt/tests/snapshots/multiple_files@oxfmt.snap
+++ b/apps/oxfmt/tests/snapshots/multiple_files@oxfmt.snap
@@ -20,11 +20,15 @@ arguments: --check
 working directory: tests/fixtures/multiple_files
 ----------
 Checking formatting...
+app.tsx (<variable>ms)
 arrow.js (<variable>ms)
+component.jsx (<variable>ms)
 simple.js (<variable>ms)
+simple.ts (<variable>ms)
+types.d.ts (<variable>ms)
 
-Format issues found in above 2 files. Run without `--check` to fix.
-Finished in <variable>ms on 2 files using 1 threads.
+Format issues found in above 6 files. Run without `--check` to fix.
+Finished in <variable>ms on 6 files using 1 threads.
 ----------
 CLI result: FormatMismatch
 ----------
@@ -34,11 +38,15 @@ arguments: --check .
 working directory: tests/fixtures/multiple_files
 ----------
 Checking formatting...
+app.tsx (<variable>ms)
 arrow.js (<variable>ms)
+component.jsx (<variable>ms)
 simple.js (<variable>ms)
+simple.ts (<variable>ms)
+types.d.ts (<variable>ms)
 
-Format issues found in above 2 files. Run without `--check` to fix.
-Finished in <variable>ms on 2 files using 1 threads.
+Format issues found in above 6 files. Run without `--check` to fix.
+Finished in <variable>ms on 6 files using 1 threads.
 ----------
 CLI result: FormatMismatch
 ----------
@@ -48,11 +56,30 @@ arguments: --check ./
 working directory: tests/fixtures/multiple_files
 ----------
 Checking formatting...
+app.tsx (<variable>ms)
 arrow.js (<variable>ms)
+component.jsx (<variable>ms)
+simple.js (<variable>ms)
+simple.ts (<variable>ms)
+types.d.ts (<variable>ms)
+
+Format issues found in above 6 files. Run without `--check` to fix.
+Finished in <variable>ms on 6 files using 1 threads.
+----------
+CLI result: FormatMismatch
+----------
+
+########## 
+arguments: --check !*.{ts,tsx}
+working directory: tests/fixtures/multiple_files
+----------
+Checking formatting...
+arrow.js (<variable>ms)
+component.jsx (<variable>ms)
 simple.js (<variable>ms)
 
-Format issues found in above 2 files. Run without `--check` to fix.
-Finished in <variable>ms on 2 files using 1 threads.
+Format issues found in above 3 files. Run without `--check` to fix.
+Finished in <variable>ms on 3 files using 1 threads.
 ----------
 CLI result: FormatMismatch
 ----------

--- a/crates/oxc_formatter/src/service/source_type.rs
+++ b/crates/oxc_formatter/src/service/source_type.rs
@@ -31,12 +31,13 @@ const ADDITIONAL_JS_EXTENSIONS: &[&str] = &[
 ];
 
 pub fn get_supported_source_type(path: &std::path::Path) -> Option<SourceType> {
-    let extension = path.extension()?.to_string_lossy();
-
     // Standard extensions, also supported by `oxc_span::VALID_EXTENSIONS`
-    if let Ok(source_type) = SourceType::from_extension(&extension) {
+    // NOTE: Use `path` directly for `.d.ts` detection
+    if let Ok(source_type) = SourceType::from_path(path) {
         return Some(source_type);
     }
+
+    let extension = path.extension()?.to_string_lossy();
     // Additional extensions from linguist-languages, which Prettier also supports
     if ADDITIONAL_JS_EXTENSIONS.contains(&extension.as_ref()) {
         return Some(SourceType::default());


### PR DESCRIPTION
> https://github.com/oxc-project/oxc/issues/14803#issuecomment-3424313272

`.d.ts` was parsed as `.ts` by `path.extension()`.