### PR TITLE
docs(linter): Update no-invalid-regexp rule to expose documentation for config options

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_invalid_regexp.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_invalid_regexp.rs
@@ -6,6 +6,7 @@ use oxc_regular_expression::{ConstructorParser, Options};
 use oxc_span::Span;
 use rustc_hash::FxHashSet;
 use serde::Deserialize;
+use schemars::JsonSchema;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -54,12 +55,13 @@ declare_oxc_lint!(
     NoInvalidRegexp,
     eslint,
     correctness,
+    config = NoInvalidRegexpConfig,
 );
 
-#[derive(Debug, Clone, Deserialize, Default)]
+#[derive(Debug, Clone, Deserialize, Default, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 struct NoInvalidRegexpConfig {
-    #[serde(default, rename = "allowConstructorFlags")]
-    /// Case-sensitive array of flags.
+    /// Case-sensitive array of flags that will be allowed.
     allow_constructor_flags: Vec<char>,
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_invalid_regexp.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_invalid_regexp.rs
@@ -5,8 +5,8 @@ use oxc_macros::declare_oxc_lint;
 use oxc_regular_expression::{ConstructorParser, Options};
 use oxc_span::Span;
 use rustc_hash::FxHashSet;
-use serde::Deserialize;
 use schemars::JsonSchema;
+use serde::Deserialize;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 


### PR DESCRIPTION
Results in the following generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### allowConstructorFlags

type: `string[]`

default: `[]`

Case-sensitive array of flags that will be allowed.
```

Part of #14743.