### PR TITLE
chore(ci): revert temporarily disable big-endian (#14729)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
         shell: bash
 
   test-big-endian:
-    if: false # ${{ github.ref_name == 'main' }}
+    if: ${{ github.ref_name == 'main' }}
     name: Test big-endian # s390x-unknown-linux-gnu is a big-endian
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This reverts commit 2b0f5a4a42bde6af6f2640238a001465554f8cb0.