### PR TITLE
docs(linter): Expose use-isnan rule config options.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/use_isnan.rs
+++ b/crates/oxc_linter/src/rules/eslint/use_isnan.rs
@@ -6,6 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::BinaryOperator;
+use schemars::JsonSchema;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -35,7 +36,8 @@ fn index_of_na_n(method_name: &str, span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct UseIsnan {
     /// Whether to disallow NaN in switch cases and discriminants
     enforce_for_switch_case: bool,
@@ -80,7 +82,8 @@ declare_oxc_lint!(
     UseIsnan,
     eslint,
     correctness,
-    conditional_fix
+    conditional_fix,
+    config = UseIsnan,
 );
 
 impl Rule for UseIsnan {


### PR DESCRIPTION
So it'll now get picked up by the auto-generated documentation. Part of #14743.

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### enforceForIndexOf

type: `boolean`

default: `false`

Whether to disallow NaN as arguments of `indexOf` and `lastIndexOf`


### enforceForSwitchCase

type: `boolean`

default: `true`

Whether to disallow NaN in switch cases and discriminants
```