### PR TITLE
docs(linter): Add autogenerated docs for no-magic-numbers rule.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_magic_numbers.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_magic_numbers.rs
@@ -7,6 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::AstNodes;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::UnaryOperator;
+use schemars::JsonSchema;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -34,23 +35,34 @@ impl std::ops::Deref for NoMagicNumbers {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, JsonSchema)]
 pub enum NoMagicNumbersNumber {
     Float(f64),
     BigInt(String),
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct NoMagicNumbersConfig {
+    /// An array of numbers to ignore if used as magic numbers. Can include floats or BigInt strings.
     ignore: Vec<NoMagicNumbersNumber>,
+    /// When true, numeric literals used as array indexes are ignored.
     ignore_array_indexes: bool,
+    /// When true, numeric literals used as default values in function parameters and destructuring are ignored.
     ignore_default_values: bool,
+    /// When true, numeric literals used as initial values in class fields are ignored.
     ignore_class_field_initial_values: bool,
+    /// When true, enforces that number constants must be declared using `const` instead of `let` or `var`.
     enforce_const: bool,
+    /// When true, numeric literals used in object properties are considered magic numbers.
     detect_objects: bool,
+    /// When true, numeric literals in TypeScript enums are ignored.
     ignore_enums: bool,
+    /// When true, numeric literals used as TypeScript numeric literal types are ignored.
     ignore_numeric_literal_types: bool,
+    /// When true, numeric literals in readonly class properties are ignored.
     ignore_readonly_class_properties: bool,
+    /// When true, numeric literals used to index TypeScript types are ignored.
     ignore_type_indexes: bool,
 }
 
@@ -225,7 +237,8 @@ declare_oxc_lint!(
     NoMagicNumbers,
     eslint,
     style,
-    pending // TODO: enforceConst, probably copy from https://github.com/oxc-project/oxc/pull/5144
+    pending, // TODO: enforceConst, probably copy from https://github.com/oxc-project/oxc/pull/5144
+    config = NoMagicNumbersConfig
 );
 
 #[derive(Debug)]

--- a/crates/oxc_linter/src/rules/eslint/no_magic_numbers.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_magic_numbers.rs
@@ -8,6 +8,7 @@ use oxc_semantic::AstNodes;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::UnaryOperator;
 use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -35,7 +36,7 @@ impl std::ops::Deref for NoMagicNumbers {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub enum NoMagicNumbersNumber {
     Float(f64),
     BigInt(String),


### PR DESCRIPTION
Part of #14743.

This is a draft because this change results in an "index[n]" header in the generated page due to the type/structure of the struct. I'm not actually 100% sure if this is a problem I should fix in this class, or a problem with the doc generator itself that needs to be fixed somehow.

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### detectObjects

type: `boolean`

default: `false`

When true, numeric literals used in object properties are considered magic numbers.


### enforceConst

type: `boolean`

default: `false`

When true, enforces that number constants must be declared using `const` instead of `let` or `var`.


### ignore

type: `array`

default: `[]`

An array of numbers to ignore if used as magic numbers. Can include floats or BigInt strings.


#### ignore[n]






### ignoreArrayIndexes

type: `boolean`

default: `false`

When true, numeric literals used as array indexes are ignored.


### ignoreClassFieldInitialValues

type: `boolean`

default: `false`

When true, numeric literals used as initial values in class fields are ignored.


### ignoreDefaultValues

type: `boolean`

default: `false`

When true, numeric literals used as default values in function parameters and destructuring are ignored.


### ignoreEnums

type: `boolean`

default: `false`

When true, numeric literals in TypeScript enums are ignored.


### ignoreNumericLiteralTypes

type: `boolean`

default: `false`

When true, numeric literals used as TypeScript numeric literal types are ignored.


### ignoreReadonlyClassProperties

type: `boolean`

default: `false`

When true, numeric literals in readonly class properties are ignored.


### ignoreTypeIndexes

type: `boolean`

default: `false`

When true, numeric literals used to index TypeScript types are ignored.
```