### PR TITLE
docs(linter): Add doc comments for func_style options.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/func_style.rs
+++ b/crates/oxc_linter/src/rules/eslint/func_style.rs
@@ -57,9 +57,13 @@ impl From<&str> for NamedExports {
 #[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default)]
 pub struct FuncStyle {
+    /// The style to enforce. Either "expression" (default) or "declaration".
     style: Style,
+    /// When true, arrow functions are allowed regardless of the style setting.
     allow_arrow_functions: bool,
+    /// When true, functions with type annotations are allowed regardless of the style setting.
     allow_type_annotation: bool,
+    /// Override the style specifically for named exports. Can be "expression", "declaration", or "ignore" (default).
     named_exports: Option<NamedExports>,
 }
 


### PR DESCRIPTION
This one is a bit weird in that there's an overrides > namedExports option that's nested? But the struct doesn't appear to quite match that expectation. Also, the struct doesn't quite match the fact that there's no key for `style`, it's just a string value at the top level.

Part of #14743.

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### allowArrowFunctions

type: `boolean`

default: `false`

When true, arrow functions are allowed regardless of the style setting.


### allowTypeAnnotation

type: `boolean`

default: `false`

When true, functions with type annotations are allowed regardless of the style setting.


### style

type: `"expression" | "declaration"`

default: `"expression"`

The style to enforce. Either "expression" (default) or "declaration".
```