### PR TITLE
fix(formatter): correct printing trailing comments for if statement with non-block consequent

### DIFF
--- a/crates/oxc_formatter/src/formatter/comments.rs
+++ b/crates/oxc_formatter/src/formatter/comments.rs
@@ -189,7 +189,7 @@ impl<'a> Comments<'a> {
         let comments = self.unprinted_comments();
         for (index, comment) in comments.iter().enumerate() {
             if self.source_text.all_bytes_match(pos, comment.span.start, |b| {
-                matches!(b, b'\t' | b' ') || b.is_ascii_punctuation()
+                matches!(b, b'\t' | b' ' | b'=' | b':')
             }) {
                 if comment.is_line() || self.is_end_of_line_comment(comment) {
                     return &comments[..=index];

--- a/crates/oxc_formatter/tests/fixtures/js/comments/if.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/if.js
@@ -1,0 +1,3 @@
+if (base.endsWith('.js') || base === `/worker-entries`); // for dev
+if (base.endsWith('.js') || base === `/worker-entries`) base = '' // for dev
+if (base.endsWith('.js') || base === `/worker-entries`) a; // for dev

--- a/crates/oxc_formatter/tests/fixtures/js/comments/if.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/if.js.snap
@@ -1,0 +1,14 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+if (base.endsWith('.js') || base === `/worker-entries`); // for dev
+if (base.endsWith('.js') || base === `/worker-entries`) base = '' // for dev
+if (base.endsWith('.js') || base === `/worker-entries`) a; // for dev
+
+==================== Output ====================
+if (base.endsWith(".js") || base === `/worker-entries`); // for dev
+if (base.endsWith(".js") || base === `/worker-entries`) base = ""; // for dev
+if (base.endsWith(".js") || base === `/worker-entries`) a; // for dev
+
+===================== End =====================


### PR DESCRIPTION
Regressed caused by https://github.com/oxc-project/oxc/pull/14816.