### PR TITLE
perf(linter): `max-classes-per-file`: skip when no classes

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
@@ -118,6 +118,10 @@ impl Rule for MaxClassesPerFile {
 
         ctx.diagnostic(max_classes_per_file_diagnostic(class_count, self.max, span));
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().classes().len() > 0
+    }
 }
 
 #[test]


### PR DESCRIPTION
Starting to get into writing some manual rule skips now. This one should be fairly robust, as this rule will always require >0 classes in the file to return any diagnostics. Allows the rule to be filtered out and for less space needed to be allocated in the rules `Vec`.