### PR TITLE
perf(linter): `no-dupe-class-members`: only run when there are any classes

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
@@ -80,6 +80,10 @@ impl Rule for NoDupeClassMembers {
             }
         });
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().classes().len() > 0
+    }
 }
 
 #[test]


### PR DESCRIPTION
Similar to https://github.com/oxc-project/oxc/pull/14865. Allows removing this rule from the array of rules if there are no classes in the file.

Benchmarks don't really show any difference here, but it might just be because we haven't yet crossed an allocation threshold (i.e., once we remove enough rules, we'll see a diff)