### PR TITLE
perf(linter): `no-unused-private-class-members`: only run when there are any classes

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
@@ -111,6 +111,10 @@ impl Rule for NoUnusedPrivateClassMembers {
             }
         });
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().classes().len() > 0
+    }
 }
 
 fn is_read(current_node_id: NodeId, semantic: &Semantic) -> bool {


### PR DESCRIPTION
Same story as https://github.com/oxc-project/oxc/pull/14865.

Initial codspeed benchmark showed an anomalously large drop, though I'm not sure why. I'd expect a measurable but very small improvement.