### PR TITLE
fix(language_server): make unused directives fixable again

### DIFF
--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_unused_disabled_directives@test.js.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_unused_disabled_directives@test.js.snap
@@ -127,7 +127,24 @@ related_information[0].location.range: Range { start: Position { line: 0, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
-fixed: None
+fixed: Single(
+    FixedContent {
+        message: Some(
+            "remove unused disable directive",
+        ),
+        code: "",
+        range: Range {
+            start: Position {
+                line: 0,
+                character: 2,
+            },
+            end: Position {
+                line: 0,
+                character: 56,
+            },
+        },
+    },
+)
 
 
 code: ""
@@ -140,7 +157,24 @@ related_information[0].location.range: Range { start: Position { line: 5, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
-fixed: None
+fixed: Single(
+    FixedContent {
+        message: Some(
+            "remove unused disable directive",
+        ),
+        code: "",
+        range: Range {
+            start: Position {
+                line: 5,
+                character: 39,
+            },
+            end: Position {
+                line: 5,
+                character: 52,
+            },
+        },
+    },
+)
 
 
 code: ""
@@ -153,4 +187,21 @@ related_information[0].location.range: Range { start: Position { line: 8, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
-fixed: None
+fixed: Single(
+    FixedContent {
+        message: Some(
+            "remove unused disable directive",
+        ),
+        code: "",
+        range: Range {
+            start: Position {
+                line: 8,
+                character: 2,
+            },
+            end: Position {
+                line: 8,
+                character: 52,
+            },
+        },
+    },
+)

--- a/editors/vscode/tests/code_actions.spec.ts
+++ b/editors/vscode/tests/code_actions.spec.ts
@@ -175,42 +175,37 @@ suite('code actions', () => {
     strictEqual(quickFixesWithFix.length, 3);
   });
 
-  // TODO(camc314): FIXME
-  // test('changing configuration "unusedDisableDirectives" will reveal more code actions', async () => {
-  //   await loadFixture('changing_unused_disable_directives');
-  //   const fileUri = Uri.joinPath(fixturesWorkspaceUri(), 'fixtures', 'unused_disable_directives.js');
-  //   await window.showTextDocument(fileUri);
-  //   const codeActionsNoFix: ProviderResult<Array<CodeAction>> = await commands.executeCommand(
-  //     'vscode.executeCodeActionProvider',
-  //     fileUri,
-  //     {
-  //       start: { line: 0, character: 0 },
-  //       end: { line: 0, character: 10 },
-  //     },
-  //   );
-
-  //   assert(Array.isArray(codeActionsNoFix));
-  //   const quickFixesNoFix = codeActionsNoFix.filter(
-  //     (action) => action.kind?.value === 'quickfix',
-  //   );
-  //   strictEqual(quickFixesNoFix.length, 0);
-
-  //   await workspace.getConfiguration('oxc').update('unusedDisableDirectives', "warn");
-  //   await workspace.saveAll();
-
-  //   const codeActionsWithFix: ProviderResult<Array<CodeAction>> = await commands.executeCommand(
-  //     'vscode.executeCodeActionProvider',
-  //     fileUri,
-  //     {
-  //       start: { line: 0, character: 2 },
-  //       end: { line: 0, character: 10 },
-  //     },
-  //   );
-
-  //   assert(Array.isArray(codeActionsWithFix));
-  //   const quickFixesWithFix = codeActionsWithFix.filter(
-  //     (action) => action.kind?.value === 'quickfix',
-  //   );
-  //   strictEqual(quickFixesWithFix.length, 1);
-  // });
+  test('changing configuration "unusedDisableDirectives" will reveal more code actions', async () => {
+    await loadFixture('changing_unused_disable_directives');
+    const fileUri = Uri.joinPath(fixturesWorkspaceUri(), 'fixtures', 'unused_disable_directives.js');
+    await window.showTextDocument(fileUri);
+    const codeActionsNoFix: ProviderResult<Array<CodeAction>> = await commands.executeCommand(
+      'vscode.executeCodeActionProvider',
+      fileUri,
+      {
+        start: { line: 0, character: 0 },
+        end: { line: 0, character: 10 },
+      },
+    );
+    assert(Array.isArray(codeActionsNoFix));
+    const quickFixesNoFix = codeActionsNoFix.filter(
+      (action) => action.kind?.value === 'quickfix',
+    );
+    strictEqual(quickFixesNoFix.length, 0);
+    await workspace.getConfiguration('oxc').update('unusedDisableDirectives', "warn");
+    await workspace.saveAll();
+    const codeActionsWithFix: ProviderResult<Array<CodeAction>> = await commands.executeCommand(
+      'vscode.executeCodeActionProvider',
+      fileUri,
+      {
+        start: { line: 0, character: 2 },
+        end: { line: 0, character: 10 },
+      },
+    );
+    assert(Array.isArray(codeActionsWithFix));
+    const quickFixesWithFix = codeActionsWithFix.filter(
+      (action) => action.kind?.value === 'quickfix',
+    );
+    strictEqual(quickFixesWithFix.length, 1);
+  });
 });


### PR DESCRIPTION
https://github.com/oxc-project/oxc/pull/14052 created diagnostics without a fix.
Fixed it for the language server, maybe the CLI should support this too with `--fix --report-unused-disable-directives`.
It was at least possible before the PR.