### PR TITLE
perf(linter): add codegen support for regex nodes

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -285,7 +285,11 @@ impl RuleRunner for crate::rules::eslint::no_continue::NoContinue {
 }
 
 impl RuleRunner for crate::rules::eslint::no_control_regex::NoControlRegex {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::CallExpression,
+        AstType::NewExpression,
+        AstType::RegExpLiteral,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -506,7 +510,11 @@ impl RuleRunner for crate::rules::eslint::no_magic_numbers::NoMagicNumbers {
 impl RuleRunner
     for crate::rules::eslint::no_misleading_character_class::NoMisleadingCharacterClass
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::CallExpression,
+        AstType::NewExpression,
+        AstType::RegExpLiteral,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -804,7 +812,11 @@ impl RuleRunner for crate::rules::eslint::no_unused_vars::NoUnusedVars {
 }
 
 impl RuleRunner for crate::rules::eslint::no_useless_backreference::NoUselessBackreference {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::CallExpression,
+        AstType::NewExpression,
+        AstType::RegExpLiteral,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/tasks/linter_codegen/src/regex_node_kinds.rs
+++ b/tasks/linter_codegen/src/regex_node_kinds.rs
@@ -1,0 +1,42 @@
+use syn::{Expr, Pat, Stmt};
+
+use crate::{node_type_set::NodeTypeSet, utils::astkind_variant_from_path};
+
+/// Fetches the current list of variants that are handled by `run_on_regex_node`.
+/// We read the source file to avoid hardcoding the list here and ensure this will stay updated.
+pub fn get_regex_node_kinds() -> Option<NodeTypeSet> {
+    // Read crates/oxc_linter/src/utils/regex.rs and extract all variants in `run_on_regex_node` function
+    let regex_utils_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()?
+        .parent()?
+        .join("crates")
+        .join("oxc_linter")
+        .join("src")
+        .join("utils")
+        .join("regex.rs");
+    let content = std::fs::read_to_string(regex_utils_path).ok()?;
+    let syntax = syn::parse_file(&content).ok()?;
+    let mut node_type_set = NodeTypeSet::new();
+    for item in syntax.items {
+        if let syn::Item::Fn(func) = item
+            && func.sig.ident == "run_on_regex_node"
+        {
+            // Look for `match node.kind() { ... }` inside the function body
+            for stmt in &func.block.stmts {
+                if let Stmt::Expr(Expr::Match(match_expr), _) = stmt {
+                    for arm in &match_expr.arms {
+                        if let Pat::TupleStruct(ts) = &arm.pat
+                            && let Some(variant) = astkind_variant_from_path(&ts.path)
+                        {
+                            node_type_set.insert(variant);
+                        }
+                    }
+                    if !node_type_set.is_empty() {
+                        return Some(node_type_set);
+                    }
+                }
+            }
+        }
+    }
+    None
+}


### PR DESCRIPTION
Adds linter codegen support for recognizing `run` functions which have only a call to `run_regex_node` in them. In that case, we return the `AstKind`s that we parsed out from the `run_regex_node` file and return that as the node types to check for.

