### PR TITLE
fix(linter): Error on unexpected tokens when declaring lint rule

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/max_depth.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_depth.rs
@@ -108,7 +108,7 @@ declare_oxc_lint!(
     /// ```
     MaxDepth,
     eslint,
-    pedantic
+    pedantic,
     config = MaxDepth,
 );
 

--- a/crates/oxc_linter/src/rules/oxc/bad_bitwise_operator.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_bitwise_operator.rs
@@ -68,7 +68,7 @@ declare_oxc_lint!(
     /// ```
     BadBitwiseOperator,
     oxc,
-    restriction // Restricted because there are false positives for enum bitflags in TypeScript,
+    restriction, // Restricted because there are false positives for enum bitflags in TypeScript,
                 // e.g. in the vscode repo
     pending
 );

--- a/crates/oxc_linter/src/rules/react/forward_ref_uses_ref.rs
+++ b/crates/oxc_linter/src/rules/react/forward_ref_uses_ref.rs
@@ -60,7 +60,6 @@ declare_oxc_lint!(
     react,
     correctness,
     suggestion
-    suggestion
 );
 
 fn check_forward_ref_inner<'a>(

--- a/crates/oxc_macros/src/declare_oxc_lint.rs
+++ b/crates/oxc_macros/src/declare_oxc_lint.rs
@@ -116,8 +116,13 @@ impl Parse for LintRuleMeta {
             }
         }
 
-        // Ignore the rest
-        input.parse::<proc_macro2::TokenStream>()?;
+        let remaining = input.parse::<proc_macro2::TokenStream>()?;
+        if !remaining.is_empty() {
+            return Err(Error::new_spanned(
+                remaining,
+                "unexpected tokens in rule declaration, missing a comma?",
+            ));
+        }
 
         Ok(Self {
             name: struct_name,


### PR DESCRIPTION
Related to [this](https://github.com/oxc-project/oxc/pull/14807#issuecomment-3422865650) issue where missing commas in `declare_oxc_lint!` would cause documentation to be generated wrongly without erroring.

In the image below, there is no warning about the missing comma after `dangerou_suggestion`, this causes `config` to not be generated in the documentation.

<img width="436" height="196" alt="image" src="https://github.com/user-attachments/assets/0d40bc12-15e2-48a7-813b-62b61aafc718" />

With the fix, users will be notified about the missing comma.

<img width="436" height="196" alt="image" src="https://github.com/user-attachments/assets/ca75fb69-ce08-4de0-9cc0-7332a11a5e55" />