### PR TITLE
fix(formatter): corrct printing leading own line comments before method body

### DIFF
--- a/crates/oxc_formatter/src/write/class.rs
+++ b/crates/oxc_formatter/src/write/class.rs
@@ -121,13 +121,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, MethodDefinition<'a>> {
         )?;
 
         if let Some(body) = &value.body() {
-            // Handle block comments between method signature and body
-            // Example: method() /* comment */ {}
-            let comments = f.context().comments().comments_before(body.span.start);
-            if !comments.is_empty() {
-                write!(f, [space(), FormatTrailingComments::Comments(comments)])?;
-            }
-            write!(f, [space(), body])?;
+            write!(f, body)?;
         }
         if self.r#type().is_abstract()
             || matches!(value.r#type, FunctionType::TSEmptyBodyFunctionExpression)
@@ -641,7 +635,7 @@ pub fn format_grouped_parameters_with_return_type<'a>(
     group(&format_once(|f| {
         let mut format_type_parameters = type_parameters.memoized();
         let mut format_parameters = params.memoized();
-        let mut format_return_type = return_type.memoized();
+        let mut format_return_type = return_type.map(FormatNodeWithoutTrailingComments).memoized();
 
         // Inspect early, in case the `return_type` is formatted before `parameters`
         // in `should_group_function_parameters`.

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/method.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/method.ts
@@ -1,0 +1,16 @@
+class A {
+  m1(element: Element, key: string, undefined: undefined) /* block comment */ {
+    // method body
+  }
+  m2(element: Element, key: string, undefined: undefined): void /* block comment */ {
+    // method body
+  }
+  m3(tagName: string, rect: number[]): void // line comment
+  {
+    // method body
+  }
+  m4(tagName: string, rect: number[]) // line comment
+  {
+    // method body
+  }
+}

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/method.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/method.ts.snap
@@ -1,0 +1,44 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+class A {
+  m1(element: Element, key: string, undefined: undefined) /* block comment */ {
+    // method body
+  }
+  m2(element: Element, key: string, undefined: undefined): void /* block comment */ {
+    // method body
+  }
+  m3(tagName: string, rect: number[]): void // line comment
+  {
+    // method body
+  }
+  m4(tagName: string, rect: number[]) // line comment
+  {
+    // method body
+  }
+}
+
+==================== Output ====================
+class A {
+  m1(element: Element, key: string, undefined: undefined) /* block comment */ {
+    // method body
+  }
+  m2(
+    element: Element,
+    key: string,
+    undefined: undefined,
+  ): void /* block comment */ {
+    // method body
+  }
+  m3(tagName: string, rect: number[]): void {
+    // line comment
+    // method body
+  }
+  m4(tagName: string, rect: number[]) {
+    // line comment
+    // method body
+  }
+}
+
+===================== End =====================

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,9 +1,10 @@
-js compatibility: 662/699 (94.71%)
+js compatibility: 661/699 (94.56%)
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
+| js/class-comment/misc.js | 💥 | 72.73% |
 | js/comments/15661.js | 💥💥 | 55.17% |
 | js/comments/empty-statements.js | 💥💥 | 90.91% |
 | js/comments/function-declaration.js | 💥💥 | 92.80% |


### PR DESCRIPTION
There is a failed case, probably due to the Prettier bug