### PR TITLE
release(oxlint): v1.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_language_server"
-version = "1.23.0"
+version = "1.24.0"
 dependencies = [
  "env_logger",
  "futures",
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_linter"
-version = "1.23.0"
+version = "1.24.0"
 dependencies = [
  "bitflags 2.10.0",
  "constcat",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "oxlint"
-version = "1.23.0"
+version = "1.24.0"
 dependencies = [
  "bpaf",
  "cow-utils",

--- a/apps/oxlint/CHANGELOG.md
+++ b/apps/oxlint/CHANGELOG.md
@@ -4,6 +4,58 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.24.0] - 2025-10-22
+
+### 🚀 Features
+
+- 54ec8e3 linter: Add `cwd` property to JS plugin `Context` (#14814) (magic-akari)
+- 9700a56 linter/plugins: Comment-related APIs (#14715) (Arsh)
+- bec7a7d semantic: Add scope to `TSConstructorType` (#14676) (camc314)
+- b1a9a03 linter/plugins: Implement `SourceCode#getAllComments` (#14589) (Arsh)
+
+### 🐛 Bug Fixes
+
+- 28e76ec oxlint: Resolving JS plugin failing when `extends` is used (#14556) (camc314)
+- 78ee7b8 linter/plugins: Handle utf16 characters within comment spans (#14768) (Arsh)
+- 47d8db1 linter/plugins: Prevent `comments` being accessed after file is linted (#14727) (overlookmotel)
+- 5238891 linter/plugins: Add `comments` field to TS type def for `Program` (#14626) (overlookmotel)
+- 84b2605 linter/plugins: Remove `parent` property from comments (#14624) (overlookmotel)
+- 0961c3a oxlint,oxfmt: Skip traversing `.git` directories (#14590) (Boshen)
+
+### 🚜 Refactor
+
+- 4520695 linter/plugins: Reorganise `SourceCode` methods (#14773) (overlookmotel)
+- 6942d75 linter/plugins: Shorten import of comment-related `SourceCode` methods (#14772) (overlookmotel)
+- b9a3f46 linter/plugins: Move scope-related `SourceCode` methods into separate file (#14771) (overlookmotel)
+- cd068aa linter/plugins: Move token-related `SourceCode` methods into separate file (#14770) (overlookmotel)
+- ec816ba linter/plugins: Move comments-related code into separate file (#14753) (overlookmotel)
+- e9c3b18 linter/plugins: Update outdated comment (#14750) (overlookmotel)
+- 14de671 linter/plugins: Simplify `comments` getter (#14728) (overlookmotel)
+- b402024 linter/plugins: Rename function (#14726) (overlookmotel)
+- 85a2743 linter/plugins, napi/parser: Remove extraneous code from raw transfer deserializers (#14683) (overlookmotel)
+- 2b14abc napi/parser: Shorten raw transfer deserializer for `Comment` (#14623) (overlookmotel)
+
+### 📚 Documentation
+
+- 207b62b linter/plugins: Correct JSDoc comments for `SourceCode` tokens methods (#14776) (overlookmotel)
+- cd266b4 linter/plugins: Improve docs for comments APIs (#14754) (overlookmotel)
+
+### ⚡ Performance
+
+- 10182e8 linter/plugins: Use binary search (#14778) (Arsh)
+- e6f351d linter/plugins: Speed up `SourceCode#getAncestors` (#14747) (overlookmotel)
+- 58ba6d6 linter/plugins: Lazy deserialize comments array (#14637) (Arsh)
+
+### 🎨 Styling
+
+- 3029dfb linter/plugins: Reorder code (#14725) (overlookmotel)
+
+### 🧪 Testing
+
+- 5933097 oxlint: Add test for nested configs importing the same plugin 2x (#14646) (camc314)
+- 6570f36 linter/custom-plugins: Snapshot test start, end, range, and loc for comments (#14779) (Arsh)
+
+
 ## [1.23.0] - 2025-10-13
 
 ### 🐛 Bug Fixes

--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxlint"
-version = "1.23.0"
+version = "1.24.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "type": "module",
   "main": "dist/index.js",
   "bin": "dist/cli.js",

--- a/apps/oxlint/src-js/bindings.js
+++ b/apps/oxlint/src-js/bindings.js
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/android-arm64')
         const bindingPackageVersion = require('@oxlint/android-arm64/package.json').version
-        if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/android-arm-eabi')
         const bindingPackageVersion = require('@oxlint/android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -118,8 +118,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/win32-x64-gnu')
         const bindingPackageVersion = require('@oxlint/win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -134,8 +134,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/win32-x64')
         const bindingPackageVersion = require('@oxlint/win32-x64/package.json').version
-        if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -151,8 +151,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/win32-ia32')
         const bindingPackageVersion = require('@oxlint/win32-ia32/package.json').version
-        if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -167,8 +167,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/win32-arm64')
         const bindingPackageVersion = require('@oxlint/win32-arm64/package.json').version
-        if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -186,8 +186,8 @@ function requireNative() {
     try {
       const binding = require('@oxlint/darwin-universal')
       const bindingPackageVersion = require('@oxlint/darwin-universal/package.json').version
-      if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -202,8 +202,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/darwin-x64')
         const bindingPackageVersion = require('@oxlint/darwin-x64/package.json').version
-        if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -218,8 +218,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/darwin-arm64')
         const bindingPackageVersion = require('@oxlint/darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -238,8 +238,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/freebsd-x64')
         const bindingPackageVersion = require('@oxlint/freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -254,8 +254,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/freebsd-arm64')
         const bindingPackageVersion = require('@oxlint/freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -275,8 +275,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-x64-musl')
           const bindingPackageVersion = require('@oxlint/linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-x64-gnu')
           const bindingPackageVersion = require('@oxlint/linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -309,8 +309,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-arm64-musl')
           const bindingPackageVersion = require('@oxlint/linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-arm64-gnu')
           const bindingPackageVersion = require('@oxlint/linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -343,8 +343,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-arm-musleabihf')
           const bindingPackageVersion = require('@oxlint/linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-arm-gnueabihf')
           const bindingPackageVersion = require('@oxlint/linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -377,8 +377,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-loong64-musl')
           const bindingPackageVersion = require('@oxlint/linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-loong64-gnu')
           const bindingPackageVersion = require('@oxlint/linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -411,8 +411,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-riscv64-musl')
           const bindingPackageVersion = require('@oxlint/linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -427,8 +427,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-riscv64-gnu')
           const bindingPackageVersion = require('@oxlint/linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -444,8 +444,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/linux-ppc64-gnu')
         const bindingPackageVersion = require('@oxlint/linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -460,8 +460,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/linux-s390x-gnu')
         const bindingPackageVersion = require('@oxlint/linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -480,8 +480,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/openharmony-arm64')
         const bindingPackageVersion = require('@oxlint/openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -496,8 +496,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/openharmony-x64')
         const bindingPackageVersion = require('@oxlint/openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -512,8 +512,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/openharmony-arm')
         const bindingPackageVersion = require('@oxlint/openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '1.23.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.23.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/crates/oxc_language_server/CHANGELOG.md
+++ b/crates/oxc_language_server/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.24.0] - 2025-10-22
+
+### 🚀 Features
+
+- e3d65c3 language_server: Search both .json and .jsonc config file (#14868) (Sysix)
+- 2609c74 language_server: Watch for `fmt.configPath` file content change (#14509) (Sysix)
+- fec2ed9 oxfmt: Use Prettier style config key and value (#14612) (leaysgur)
+- 1b58521 oxfmt,language_server: Enable JSX for all JS source type (#14605) (leaysgur)
+
+### 🐛 Bug Fixes
+
+- 644dfd4 language_server: Make unused directives fixable again (#14872) (Sysix)
+- e560cc1 language_server: Fix panic when "disable rule for this line" position is after error span (#14597) (Sysix)
+
+### 🚜 Refactor
+
+- 699c91c language_server: Improve file watching for different tools (#14645) (Sysix)
+- 3bfb8e1 linter: Make `Message.span` public (#14601) (Sysix)
+- 9a589ca language_server: Use Message span for Diagnostic's Range (#14600) (Sysix)
+- b301795 linter: Remove unused allocator param in `Runtime` for LSP & tests (#14489) (Sysix)
+
+### ⚡ Performance
+
+- df48416 language_server: Return `Diagnostic` when relinting all files (#14737) (Sysix)
+- 22ee19f language_server: Avoid creating HashMap in `Backend::did_change_configuration` (#14736) (Sysix)
+- ed922ec language_server: Avoid creating HashMap in `Backend::did_change_watched_files` (#14735) (Sysix)
+
+
 ## [1.23.0] - 2025-10-13
 
 ### 🚀 Features

--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_language_server"
-version = "1.23.0"
+version = "1.24.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_linter/CHANGELOG.md
+++ b/crates/oxc_linter/CHANGELOG.md
@@ -4,6 +4,102 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.24.0] - 2025-10-22
+
+### 🚀 Features
+
+- dd1fdd4 linter: Add react/forbid-dom-props rule (#14365) (Mikhail Baev)
+- 8b02074 linter: Merge vitest/prefer-to-be rule into existing jest/prefer-to-be rule implementation (#14738) (Tyler Earls)
+- ba6517b linter: Add `no-warning-comments` rule (#14734) (Iván Ovejero)
+- 5858641 linter: Implement constructor-super rule (#14506) (Tyler Earls)
+- ae2003c semantic: Add `symbol_id` to ts function type binding idents (#14673) (camc314)
+- 9cd7a67 linter/no-unused-vars: Support `ignoreUsingDeclarations` option (#14632) (camc314)
+
+### 🐛 Bug Fixes
+
+- 831974f linter: Postmessage is not called on window (#14192) (Kenzo Wada)
+- 801e1d1 linter: Error on unexpected tokens when declaring lint rule (#14881) (howen)
+- dc03c3a linter/no-invalid-fetch-options: Ignore non static method (#14806) (camc314)
+- 28e76ec oxlint: Resolving JS plugin failing when `extends` is used (#14556) (camc314)
+- aa562f7 linter/no-unused-private-class-members: Fix false positive in default param (#14801) (camc314)
+- ad12974 linter: `no-unused-vars`: allow updates in for loop test/update (#14766) (camchenry)
+- 78ee7b8 linter/plugins: Handle utf16 characters within comment spans (#14768) (Arsh)
+- c69201c linter: Copy over js plugins when applying overrides (#14542) (Arsh)
+- 6bb9902 linter: Improve `jest/no_export` heuristic (#14620) (Arsh)
+- c8ea37d linter: `unicorn/filename-case` report only on the first js block for `astro`, `vue` and `svelte` files (#14599) (Sysix)
+- baab7eb semantic: Fix quote handling in jsdoc parser(#13776) (#14561) (Li Wei)
+
+### 🚜 Refactor
+
+- 1e93ceb linter/no-unwanted-polyfillio: Move `NEXT_POLYFILLED_FEATURES` to shared utils (#14793) (shulaoda)
+- 3bfb8e1 linter: Make `Message.span` public (#14601) (Sysix)
+- 544c092 linter/no-process-env: Restructure match to improve generated node types (#14643) (camc314)
+- 90f5f89 linter: Remove `run_on_symbol` (#14610) (camchenry)
+- b301795 linter: Remove unused allocator param in `Runtime` for LSP & tests (#14489) (Sysix)
+
+### 📚 Documentation
+
+- 3f1c3c7 linter: Add documentation on `ignoreRestSiblings` option for `no-unused-vars` rule (#14807) (howen)
+- 9cd4160 linter: Fix documentation formatting for max_params options (#14744) (Connor Shea)
+- cbdf261 linter: Document no-shadow-restricted-names rule config options. (#14843) (Connor Shea)
+- a6f720b linter: Expose use-isnan rule config options. (#14844) (Connor Shea)
+- 7dc609b linter: Add docs for no-param-reassign config options. (#14849) (Connor Shea)
+- 983c31c linter: Improve the Options documentation for no-empty-function rule (#14789) (Connor Shea)
+- 77e4b30 linter: Add autogen doc support for max_nested_describe in jest plugin. (#14797) (Connor Shea)
+- b6402dd linter: Move documentation comments for the valid-typeof rule to the struct (#14841) (Connor Shea)
+- a02567f linter: Update no-invalid-regexp rule to expose documentation for config options (#14838) (Connor Shea)
+- ebca4a6 linter: Update no-plusplus rule to expose documentation for config options (#14837) (Connor Shea)
+- 1665ab4 linter: Add doc comments for func_style options. (#14847) (Connor Shea)
+- b1fb269 linter: Add configuration docs info for import/namespace rule (#14799) (Connor Shea)
+- c80da95 linter: Add configuration docs to no-useless-escape lint rule. (#14791) (Connor Shea)
+- 7b64f27 linter: Improve `no-plusplus` and `no-irregular-whitespace` rule docs (#14790) (Connor Shea)
+
+### ⚡ Performance
+
+- 11b055e linter: `no-unused-private-class-members`: only run when there are any classes (#14869) (camchenry)
+- 5493278 linter: `no-dupe-class-members`: only run when there are any classes (#14867) (camchenry)
+- ef53462 linter: `no-this-before-super`: only run when file contains super or this (#14866) (camchenry)
+- 19d168a linter: `max-classes-per-file`: skip when no classes (#14865) (camchenry)
+- b8f8ce5 linter: `id-length`: reduce allocations and add more ASCII checks (#14821) (camchenry)
+- bb4347c linter: Use precomputed extension (#14819) (camchenry)
+- 92b4302 linter: `id-length`: check if ident is ASCII before segmenting (#14767) (camchenry)
+- 7be9489 linter: Cache file extension (#14794) (camchenry)
+- 86ecae1 linter: Remove simple `phf_map!` calls (#14701) (camchenry)
+- 2fe9dfa linter: Update `prefer-node-protocol` to use diverging match (#14699) (camchenry)
+- 07db921 linter: Update `catch-error-name` to use top-level match (#14698) (camchenry)
+- 2582a50 linter: Update `no-extra-non-null-assertion` to use diverging match (#14697) (camchenry)
+- 231bac0 linter: Update `typescript/array-type` to only have top-level match (#14696) (camchenry)
+- 6b9b972 linter: Refactor `jsdoc/require-yields` to deref instead of `self.0` (#14695) (camchenry)
+- 9ac561c linter: Inline `is_function_node` calls for some jsdoc rules (#14694) (camchenry)
+- 5e014cb linter: Refactor `jest/require-hook` to use top-level match (#14693) (camchenry)
+- c8d775c linter: Refactor `jest/no-conditional-in-test` to use diverging match (#14692) (camchenry)
+- b666c26 linter: Move root scope check into match arms in `import/no-webpack-loader-syntax` (#14691) (camchenry)
+- be33a15 linter: Refactor `no-amd` to do scope check after node type check (#14690) (camchenry)
+- 71cfeaa linter: Refactor `no-unsafe-finally` to have a diverging match as first statement (#14689) (camchenry)
+- 801bb10 linter: Refactor `no-labels` to use top-level match on node kind (#14688) (camchenry)
+- 1217411 linter: Refactor class-methods-use-this to be analyzed (#14687) (camchenry)
+- f830bea linter: Add codegen support for `is_member_expression_kind` in match (#14677) (camchenry)
+- 400a99a linter: Switch `if !matches!(node.kind(), ...)` to match block (#14650) (camchenry)
+- f2c33f5 linter: Rearrange rules for node type analysis (#14648) (camchenry)
+- 73f2cbb linter: Support getting `as_member_expression_kind()` variants (#14642) (camchenry)
+- 58e17ae linter: Only check for call expr once in `unicorn/no-array-method-this` (#14641) (camchenry)
+- 12a9934 linter: Detect diverging match blocks for node type skipping (#14631) (camchenry)
+- 82196e7 linter: Update `react/prefer-es6-class` to use top-level match (#14630) (camchenry)
+- 48e3348 linter: Update linter codegen to support wildcard with empty tuple (#14611) (camchenry)
+- 0485859 linter: Update `no-const-assign` to run on nodes instead of symbols (#14609) (camchenry)
+- 976bde0 linter: Run `next/no-duplicate-head` on nodes instead of symbols (#14607) (camchenry)
+- c821c50 linter: Switch `no-param-reassign` to run on nodes (#14604) (camchenry)
+- 676ee99 linter: Run `no-class-assign` on class nodes instead of symbols (#14578) (camchenry)
+- 463be73 linter: Support `as_*` for node type codegen (#14582) (camchenry)
+- 8df1e24 linter: Use top-level match for `const-comparisons` (#14581) (camchenry)
+
+### 🧪 Testing
+
+- a64180e linter/no-fallthrough: Add another test case with logical expr (#14832) (camc314)
+- 1fcf56c linter/no-fallthrough: Add test for switch with logical operators + break (#14811) (camc314)
+- cd9ef3e linter: Add test case with function params in no-const-assign (#14674) (camc314)
+
+
 ## [1.23.0] - 2025-10-13
 
 ### 🚀 Features

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_linter"
-version = "1.23.0"
+version = "1.24.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.24.0] - 2025-10-22
+
+### 🚀 Features
+
+- 8b322d4 editor: Support `oxc.fmt.configPath` configuration (#14639) (Sysix)
+
+### 🐛 Bug Fixes
+
+- 644dfd4 language_server: Make unused directives fixable again (#14872) (Sysix)
+
+### 🧪 Testing
+
+- faada4d editor: Reduce sleep time (#14749) (Sysix)
+
+
 
 
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "oxc-vscode",
   "description": "oxc vscode extension",
   "license": "MIT",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "icon": "icon.png",
   "publisher": "oxc",
   "displayName": "Oxc",

--- a/npm/oxlint/CHANGELOG.md
+++ b/npm/oxlint/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.24.0] - 2025-10-22
+
+### 🐛 Bug Fixes
+
+- 28e76ec oxlint: Resolving JS plugin failing when `extends` is used (#14556) (camc314)
+
+
 
 
 ## [1.21.0] - 2025-10-08

--- a/npm/oxlint/package.json
+++ b/npm/oxlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "type": "module",
   "description": "Linter for the JavaScript Oxidation Compiler",
   "keywords": [],


### PR DESCRIPTION
## [1.24.0] - 2025-10-22

### 🚀 Features

- dd1fdd4 linter: Add react/forbid-dom-props rule (#14365) (Mikhail Baev)
- e3d65c3 language_server: Search both .json and .jsonc config file (#14868) (Sysix)
- 54ec8e3 linter: Add `cwd` property to JS plugin `Context` (#14814) (magic-akari)
- 8b02074 linter: Merge vitest/prefer-to-be rule into existing jest/prefer-to-be rule implementation (#14738) (Tyler Earls)
- 9700a56 linter/plugins: Comment-related APIs (#14715) (Arsh)
- ba6517b linter: Add `no-warning-comments` rule (#14734) (Iván Ovejero)
- 5858641 linter: Implement constructor-super rule (#14506) (Tyler Earls)
- 8b322d4 editor: Support `oxc.fmt.configPath` configuration (#14639) (Sysix)
- 2609c74 language_server: Watch for `fmt.configPath` file content change (#14509) (Sysix)
- ae2003c semantic: Add `symbol_id` to ts function type binding idents (#14673) (camc314)
- bec7a7d semantic: Add scope to `TSConstructorType` (#14676) (camc314)
- fec2ed9 oxfmt: Use Prettier style config key and value (#14612) (leaysgur)
- 9cd7a67 linter/no-unused-vars: Support `ignoreUsingDeclarations` option (#14632) (camc314)
- 1b58521 oxfmt,language_server: Enable JSX for all JS source type (#14605) (leaysgur)
- b1a9a03 linter/plugins: Implement `SourceCode#getAllComments` (#14589) (Arsh)

### 🐛 Bug Fixes

- 831974f linter: Postmessage is not called on window (#14192) (Kenzo Wada)
- 644dfd4 language_server: Make unused directives fixable again (#14872) (Sysix)
- 801e1d1 linter: Error on unexpected tokens when declaring lint rule (#14881) (howen)
- dc03c3a linter/no-invalid-fetch-options: Ignore non static method (#14806) (camc314)
- 28e76ec oxlint: Resolving JS plugin failing when `extends` is used (#14556) (camc314)
- aa562f7 linter/no-unused-private-class-members: Fix false positive in default param (#14801) (camc314)
- ad12974 linter: `no-unused-vars`: allow updates in for loop test/update (#14766) (camchenry)
- 78ee7b8 linter/plugins: Handle utf16 characters within comment spans (#14768) (Arsh)
- 47d8db1 linter/plugins: Prevent `comments` being accessed after file is linted (#14727) (overlookmotel)
- c69201c linter: Copy over js plugins when applying overrides (#14542) (Arsh)
- 6bb9902 linter: Improve `jest/no_export` heuristic (#14620) (Arsh)
- c8ea37d linter: `unicorn/filename-case` report only on the first js block for `astro`, `vue` and `svelte` files (#14599) (Sysix)
- e560cc1 language_server: Fix panic when "disable rule for this line" position is after error span (#14597) (Sysix)
- 5238891 linter/plugins: Add `comments` field to TS type def for `Program` (#14626) (overlookmotel)
- 84b2605 linter/plugins: Remove `parent` property from comments (#14624) (overlookmotel)
- baab7eb semantic: Fix quote handling in jsdoc parser(#13776) (#14561) (Li Wei)
- 0961c3a oxlint,oxfmt: Skip traversing `.git` directories (#14590) (Boshen)

### 🚜 Refactor

- 1e93ceb linter/no-unwanted-polyfillio: Move `NEXT_POLYFILLED_FEATURES` to shared utils (#14793) (shulaoda)
- 4520695 linter/plugins: Reorganise `SourceCode` methods (#14773) (overlookmotel)
- 6942d75 linter/plugins: Shorten import of comment-related `SourceCode` methods (#14772) (overlookmotel)
- b9a3f46 linter/plugins: Move scope-related `SourceCode` methods into separate file (#14771) (overlookmotel)
- cd068aa linter/plugins: Move token-related `SourceCode` methods into separate file (#14770) (overlookmotel)
- ec816ba linter/plugins: Move comments-related code into separate file (#14753) (overlookmotel)
- e9c3b18 linter/plugins: Update outdated comment (#14750) (overlookmotel)
- 699c91c language_server: Improve file watching for different tools (#14645) (Sysix)
- 14de671 linter/plugins: Simplify `comments` getter (#14728) (overlookmotel)
- b402024 linter/plugins: Rename function (#14726) (overlookmotel)
- 85a2743 linter/plugins, napi/parser: Remove extraneous code from raw transfer deserializers (#14683) (overlookmotel)
- 3bfb8e1 linter: Make `Message.span` public (#14601) (Sysix)
- 544c092 linter/no-process-env: Restructure match to improve generated node types (#14643) (camc314)
- 9a589ca language_server: Use Message span for Diagnostic's Range (#14600) (Sysix)
- 2b14abc napi/parser: Shorten raw transfer deserializer for `Comment` (#14623) (overlookmotel)
- 90f5f89 linter: Remove `run_on_symbol` (#14610) (camchenry)
- b301795 linter: Remove unused allocator param in `Runtime` for LSP & tests (#14489) (Sysix)

### 📚 Documentation

- 3f1c3c7 linter: Add documentation on `ignoreRestSiblings` option for `no-unused-vars` rule (#14807) (howen)
- 9cd4160 linter: Fix documentation formatting for max_params options (#14744) (Connor Shea)
- cbdf261 linter: Document no-shadow-restricted-names rule config options. (#14843) (Connor Shea)
- a6f720b linter: Expose use-isnan rule config options. (#14844) (Connor Shea)
- 7dc609b linter: Add docs for no-param-reassign config options. (#14849) (Connor Shea)
- 983c31c linter: Improve the Options documentation for no-empty-function rule (#14789) (Connor Shea)
- 77e4b30 linter: Add autogen doc support for max_nested_describe in jest plugin. (#14797) (Connor Shea)
- b6402dd linter: Move documentation comments for the valid-typeof rule to the struct (#14841) (Connor Shea)
- a02567f linter: Update no-invalid-regexp rule to expose documentation for config options (#14838) (Connor Shea)
- ebca4a6 linter: Update no-plusplus rule to expose documentation for config options (#14837) (Connor Shea)
- 1665ab4 linter: Add doc comments for func_style options. (#14847) (Connor Shea)
- b1fb269 linter: Add configuration docs info for import/namespace rule (#14799) (Connor Shea)
- c80da95 linter: Add configuration docs to no-useless-escape lint rule. (#14791) (Connor Shea)
- 7b64f27 linter: Improve `no-plusplus` and `no-irregular-whitespace` rule docs (#14790) (Connor Shea)
- 207b62b linter/plugins: Correct JSDoc comments for `SourceCode` tokens methods (#14776) (overlookmotel)
- cd266b4 linter/plugins: Improve docs for comments APIs (#14754) (overlookmotel)

### ⚡ Performance

- 11b055e linter: `no-unused-private-class-members`: only run when there are any classes (#14869) (camchenry)
- 5493278 linter: `no-dupe-class-members`: only run when there are any classes (#14867) (camchenry)
- ef53462 linter: `no-this-before-super`: only run when file contains super or this (#14866) (camchenry)
- 19d168a linter: `max-classes-per-file`: skip when no classes (#14865) (camchenry)
- b8f8ce5 linter: `id-length`: reduce allocations and add more ASCII checks (#14821) (camchenry)
- bb4347c linter: Use precomputed extension (#14819) (camchenry)
- 92b4302 linter: `id-length`: check if ident is ASCII before segmenting (#14767) (camchenry)
- 7be9489 linter: Cache file extension (#14794) (camchenry)
- 10182e8 linter/plugins: Use binary search (#14778) (Arsh)
- 86ecae1 linter: Remove simple `phf_map!` calls (#14701) (camchenry)
- e6f351d linter/plugins: Speed up `SourceCode#getAncestors` (#14747) (overlookmotel)
- df48416 language_server: Return `Diagnostic` when relinting all files (#14737) (Sysix)
- 22ee19f language_server: Avoid creating HashMap in `Backend::did_change_configuration` (#14736) (Sysix)
- ed922ec language_server: Avoid creating HashMap in `Backend::did_change_watched_files` (#14735) (Sysix)
- 58ba6d6 linter/plugins: Lazy deserialize comments array (#14637) (Arsh)
- 2fe9dfa linter: Update `prefer-node-protocol` to use diverging match (#14699) (camchenry)
- 07db921 linter: Update `catch-error-name` to use top-level match (#14698) (camchenry)
- 2582a50 linter: Update `no-extra-non-null-assertion` to use diverging match (#14697) (camchenry)
- 231bac0 linter: Update `typescript/array-type` to only have top-level match (#14696) (camchenry)
- 6b9b972 linter: Refactor `jsdoc/require-yields` to deref instead of `self.0` (#14695) (camchenry)
- 9ac561c linter: Inline `is_function_node` calls for some jsdoc rules (#14694) (camchenry)
- 5e014cb linter: Refactor `jest/require-hook` to use top-level match (#14693) (camchenry)
- c8d775c linter: Refactor `jest/no-conditional-in-test` to use diverging match (#14692) (camchenry)
- b666c26 linter: Move root scope check into match arms in `import/no-webpack-loader-syntax` (#14691) (camchenry)
- be33a15 linter: Refactor `no-amd` to do scope check after node type check (#14690) (camchenry)
- 71cfeaa linter: Refactor `no-unsafe-finally` to have a diverging match as first statement (#14689) (camchenry)
- 801bb10 linter: Refactor `no-labels` to use top-level match on node kind (#14688) (camchenry)
- 1217411 linter: Refactor class-methods-use-this to be analyzed (#14687) (camchenry)
- f830bea linter: Add codegen support for `is_member_expression_kind` in match (#14677) (camchenry)
- 400a99a linter: Switch `if !matches!(node.kind(), ...)` to match block (#14650) (camchenry)
- f2c33f5 linter: Rearrange rules for node type analysis (#14648) (camchenry)
- 73f2cbb linter: Support getting `as_member_expression_kind()` variants (#14642) (camchenry)
- 58e17ae linter: Only check for call expr once in `unicorn/no-array-method-this` (#14641) (camchenry)
- 12a9934 linter: Detect diverging match blocks for node type skipping (#14631) (camchenry)
- 82196e7 linter: Update `react/prefer-es6-class` to use top-level match (#14630) (camchenry)
- 48e3348 linter: Update linter codegen to support wildcard with empty tuple (#14611) (camchenry)
- 0485859 linter: Update `no-const-assign` to run on nodes instead of symbols (#14609) (camchenry)
- 976bde0 linter: Run `next/no-duplicate-head` on nodes instead of symbols (#14607) (camchenry)
- c821c50 linter: Switch `no-param-reassign` to run on nodes (#14604) (camchenry)
- 676ee99 linter: Run `no-class-assign` on class nodes instead of symbols (#14578) (camchenry)
- 463be73 linter: Support `as_*` for node type codegen (#14582) (camchenry)
- 8df1e24 linter: Use top-level match for `const-comparisons` (#14581) (camchenry)

### 🎨 Styling

- 3029dfb linter/plugins: Reorder code (#14725) (overlookmotel)

### 🧪 Testing

- a64180e linter/no-fallthrough: Add another test case with logical expr (#14832) (camc314)
- 1fcf56c linter/no-fallthrough: Add test for switch with logical operators + break (#14811) (camc314)
- 5933097 oxlint: Add test for nested configs importing the same plugin 2x (#14646) (camc314)
- faada4d editor: Reduce sleep time (#14749) (Sysix)
- 6570f36 linter/custom-plugins: Snapshot test start, end, range, and loc for comments (#14779) (Arsh)
- cd9ef3e linter: Add test case with function params in no-const-assign (#14674) (camc314)