### PR TITLE
fix(linter/no-standalone-expect): false positive when expect is in a callback

### DIFF
--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect/mod.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect/mod.rs
@@ -241,3 +241,6 @@ fn is_var_declarator_or_test_block<'a>(
 
     false
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect/tests/jest.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect/tests/jest.rs
@@ -1,6 +1,6 @@
 #[test]
 fn test() {
-    use super::PreferLowercaseTitle;
+    use super::NoStandaloneExpect;
     use crate::rule::RuleMeta;
     use crate::tester::Tester;
 
@@ -71,6 +71,18 @@ fn test() {
                   done();
                 });
               });
+            });",
+            None,
+        ),
+        (
+            "describe('example', () => {
+                it('should do something', async () => {
+                    render(React.createElement(ExampleComponent));
+
+                    await waitFor(() => {
+                        expect(screen.getByText('Option 2')).toBeInTheDocument();
+                    });
+                });
             });",
             None,
         ),

--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect/tests/vitest.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect/tests/vitest.rs
@@ -1,6 +1,6 @@
 #[test]
 fn test() {
-    use super::PreferLowercaseTitle;
+    use super::NoStandaloneExpect;
     use crate::rule::RuleMeta;
     use crate::tester::Tester;
 

--- a/crates/oxc_linter/src/snapshots/jest_no_standalone_expect.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_standalone_expect.snap
@@ -1,0 +1,142 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:1:29]
+ 1 │ (() => {})('testing', () => expect(true).toBe(false))
+   ·                             ──────
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:1:1]
+ 1 │ expect.hasAssertions()
+   · ──────
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:1:1]
+ 1 │ expect().hasAssertions()
+   · ──────
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:4:40]
+ 3 │                     const t = Math.random() ? it.only : it;
+ 4 │                     t('testing', () => expect(true).toBe(false));
+   ·                                        ──────
+ 5 │                 });
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:4:40]
+ 3 │                     const t = Math.random() ? it.only : it;
+ 4 │                     t('testing', () => expect(true).toBe(false));
+   ·                                        ──────
+ 5 │                 });
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:7:21]
+ 6 │                 ]).test('returns the result of adding %d to %d', (a, b, expected) => {
+ 7 │                     expect(a + b).toBe(expected);
+   ·                     ──────
+ 8 │                 });
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:7:21]
+ 6 │                 ]).test('returns the result of adding %d to %d', (a, b, expected) => {
+ 7 │                     expect(a + b).toBe(expected);
+   ·                     ──────
+ 8 │                 });
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:7:21]
+ 6 │                 ]).test('returns the result of adding %d to %d', (a, b, expected) => {
+ 7 │                     expect(a + b).toBe(expected);
+   ·                     ──────
+ 8 │                 });
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:1:28]
+ 1 │ describe('a test', () => { expect(1).toBe(1); });
+   ·                            ──────
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:1:26]
+ 1 │ describe('a test', () => expect(1).toBe(1));
+   ·                          ──────
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:1:71]
+ 1 │ describe('a test', () => { const func = () => { expect(1).toBe(1); }; expect(1).toBe(1); });
+   ·                                                                       ──────
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:1:63]
+ 1 │ describe('a test', () => {  it(() => { expect(1).toBe(1); }); expect(1).toBe(1); });
+   ·                                                               ──────
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:1:1]
+ 1 │ expect(1).toBe(1);
+   · ──────
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:1:2]
+ 1 │ {expect(1).toBe(1)}
+   ·  ──────
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:1:70]
+ 1 │ it.each([1, true])('trues', value => { expect(value).toBe(true); }); expect(1).toBe(1);
+   ·                                                                      ──────
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:1:46]
+ 1 │ describe.each([1, true])('trues', value => { expect(value).toBe(true); });
+   ·                                              ──────
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:3:44]
+ 2 │                 import { expect as pleaseExpect } from '@jest/globals';
+ 3 │                 describe('a test', () => { pleaseExpect(1).toBe(1); });
+   ·                                            ────────────
+ 4 │             
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:3:34]
+ 2 │                 import { expect as pleaseExpect } from '@jest/globals';
+ 3 │                 beforeEach(() => pleaseExpect.hasAssertions());
+   ·                                  ────────────
+ 4 │             
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?

--- a/crates/oxc_linter/src/snapshots/jest_no_standalone_expect@vitest.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_standalone_expect@vitest.snap
@@ -1,0 +1,85 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:1:29]
+ 1 │ (() => {})('testing', () => expect(true).toBe(false))
+   ·                             ──────
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:1:1]
+ 1 │ expect.hasAssertions()
+   · ──────
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:4:29]
+ 3 │                   const t = Math.random() ? it.only : it;
+ 4 │                   t('testing', () => expect(true).toBe(false));
+   ·                                      ──────
+ 5 │                    });
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:3:29]
+ 2 │                   const t = Math.random() ? it.only : it;
+ 3 │                   t('testing', () => expect(true).toBe(false));
+   ·                                      ──────
+ 4 │                    });
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:1:28]
+ 1 │ describe("a test", () => { expect(1).toBe(1); });
+   ·                            ──────
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:1:26]
+ 1 │ describe("a test", () => expect(1).toBe(1));
+   ·                          ──────
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:1:71]
+ 1 │ describe("a test", () => { const func = () => { expect(1).toBe(1); }; expect(1).toBe(1); });
+   ·                                                                       ──────
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:1:63]
+ 1 │ describe("a test", () => {  it(() => { expect(1).toBe(1); }); expect(1).toBe(1); });
+   ·                                                               ──────
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:1:1]
+ 1 │ expect(1).toBe(1);
+   · ──────
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:1:2]
+ 1 │ {expect(1).toBe(1)}
+   ·  ──────
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:7:11]
+ 6 │                  ]).test('returns the result of adding %d to %d', (a, b, expected) => {
+ 7 │                    expect(a + b).toBe(expected);
+   ·                    ──────
+ 8 │                  });
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?


### PR DESCRIPTION
- Closes #14888