### PR TITLE
fix(linter/explicit-module-boundary-types): false negative with export default function

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
@@ -281,7 +281,7 @@ impl ExplicitModuleBoundaryTypes {
                 // walk::walk_variable_declarator(&mut checker, it)
             }
             AstKind::Function(it) => {
-                walk::walk_function(checker, it, ScopeFlags::Function);
+                checker.visit_function(it, ScopeFlags::Function);
             }
             AstKind::Class(it) => walk::walk_class(checker, it),
             _ => {}
@@ -1991,6 +1991,7 @@ mod test {
                 "function Test(): void { const _x = () => { }; } function Test2() { return () => { }; } export { Test2 };",
                 None,
             ),
+            ("function App() { return 42; } export default App", None),
         ];
 
         Tester::new(

--- a/crates/oxc_linter/src/snapshots/typescript_explicit_module_boundary_types.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_explicit_module_boundary_types.snap
@@ -373,11 +373,11 @@ source: crates/oxc_linter/src/tester.rs
  3 │               return arg;
    ╰────
 
-  ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
-   ╭─[explicit_module_boundary_types.tsx:2:26]
+  ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
+   ╭─[explicit_module_boundary_types.tsx:2:22]
  1 │ 
  2 │             function foo(arg) {
-   ·                          ───
+   ·                      ───
  3 │               return arg;
    ╰────
 
@@ -386,6 +386,30 @@ source: crates/oxc_linter/src/tester.rs
  1 │ 
  2 │             function foo(arg) {
    ·                          ───
+ 3 │               return arg;
+   ╰────
+
+  ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
+   ╭─[explicit_module_boundary_types.tsx:2:22]
+ 1 │ 
+ 2 │             function foo(arg) {
+   ·                      ───
+ 3 │               return arg;
+   ╰────
+
+  ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
+   ╭─[explicit_module_boundary_types.tsx:2:26]
+ 1 │ 
+ 2 │             function foo(arg) {
+   ·                          ───
+ 3 │               return arg;
+   ╰────
+
+  ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
+   ╭─[explicit_module_boundary_types.tsx:2:22]
+ 1 │ 
+ 2 │             function foo(arg) {
+   ·                      ───
  3 │               return arg;
    ╰────
 
@@ -682,7 +706,13 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
-   ╭─[explicit_module_boundary_types.tsx:1:75]
+   ╭─[explicit_module_boundary_types.tsx:1:58]
  1 │ function Test(): void { const _x = () => { }; } function Test2() { return () => { }; } export { Test2 };
-   ·                                                                           ──
+   ·                                                          ─────
+   ╰────
+
+  ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
+   ╭─[explicit_module_boundary_types.tsx:1:10]
+ 1 │ function App() { return 42; } export default App
+   ·          ───
    ╰────


### PR DESCRIPTION
fixes #14831