### PR TITLE
fix(linter): use aliases when parsing cli rules

### DIFF
--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -240,7 +240,10 @@ fn parse_rule_key(name: &str) -> (String, String) {
             name.to_string(),
         );
     };
+    unalias_plugin_name(plugin_name, rule_name)
+}
 
+pub(super) fn unalias_plugin_name(plugin_name: &str, rule_name: &str) -> (String, String) {
     let (oxlint_plugin_name, rule_name) = match plugin_name {
         "@typescript-eslint" => ("typescript", rule_name),
         // import-x has the same rules but better performance


### PR DESCRIPTION
- Fixes #14906 
#### What went wrong
- `parse_rule_key` has the logic for aliasing, and it is called by `OxlintRules`, but only during deserialization.
- `CliRunner`, via `ConfigStoreBuilder`, instantiates `OxlintRules` directly. No post processing, aliasing doesn't take place.
#### Fix
- Aliasing logic in `parse_rule_key` is split off as `unalias_plugin_name`.
- `unalias_plugin_name` is now called by `ConfigStoreBuilder`.
- `LintFilterKind::parse` seemed like a better place at first, but lifetimes required cloning.