### PR TITLE
refactor(formatter): Remove redundunt public API

### DIFF
--- a/crates/oxc_formatter/examples/sort_imports.rs
+++ b/crates/oxc_formatter/examples/sort_imports.rs
@@ -60,15 +60,16 @@ fn main() -> Result<(), String> {
     };
 
     let formatter = Formatter::new(&allocator, options);
+    let formatted = formatter.format(&ret.program);
     if show_ir {
-        let doc = formatter.doc(&ret.program);
+        // Do not rely on `Display` of `Document` here, as it shows Prettier IR
         println!("[");
-        for el in doc.iter() {
+        for el in formatted.document().iter() {
             println!("  {el:?},");
         }
         println!("]");
     } else {
-        let code = formatter.build(&ret.program);
+        let code = formatted.print().map_err(|e| e.to_string())?.into_code();
         println!("{code}");
     }
 

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -55,12 +55,6 @@ impl<'a> Formatter<'a> {
         Self { allocator, source_text: "", options }
     }
 
-    /// Formats the given AST `Program` and returns the IR before printing.
-    pub fn doc(mut self, program: &'a Program<'a>) -> Document<'a> {
-        let formatted = self.format(program);
-        formatted.into_document()
-    }
-
     /// Formats the given AST `Program` and returns the formatted string.
     pub fn build(mut self, program: &Program<'a>) -> String {
         let formatted = self.format(program);


### PR DESCRIPTION
As far as I can remember, `doc()` function was only added for the sort-imports example.

Now that we made `format()` as `pub`, there is no reason to use it.