### PR TITLE
refactor(language_server): move sub option for `flags` to the root + deprecate flags

### DIFF
--- a/crates/oxc_language_server/README.md
+++ b/crates/oxc_language_server/README.md
@@ -19,16 +19,27 @@ This crate provides an [LSP](https://microsoft.github.io/language-server-protoco
 
 These options can be passed with [initialize](#initialize), [workspace/didChangeConfiguration](#workspace/didChangeConfiguration) and [workspace/configuration](#workspace/configuration).
 
-| Option Key                | Value(s)                       | Default    | Description                                                                                                                                            |
-| ------------------------- | ------------------------------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `run`                     | `"onSave" \| "onType"`         | `"onType"` | Should the server lint the files when the user is typing or saving                                                                                     |
-| `configPath`              | `<string>` \| `null`           | `null`     | Path to a oxlint configuration file, passing a string will disable nested configuration                                                                |
-| `tsConfigPath`            | `<string>` \| `null`           | `null`     | Path to a TypeScript configuration file. If your `tsconfig.json` is not at the root, alias paths will not be resolve correctly for the `import` plugin |
-| `unusedDisableDirectives` | `"allow" \| "warn"` \| "deny"` | `"allow"`  | Define how directive comments like `// oxlint-disable-line` should be reported, when no errors would have been reported on that line anyway            |
-| `typeAware`               | `true` \| `false`              | `false`    | Enables type-aware linting                                                                                                                             |
-| `flags`                   | `Map<string, string>`          | `<empty>`  | Special oxc language server flags, currently only one flag key is supported: `disable_nested_config`                                                   |
-| `fmt.experimental`        | `true` \| `false`              | `false`    | Enables experimental formatting with `oxc_formatter`                                                                                                   |
-| `fmt.configPath`          | `<string>` \| `null`           | `null`     | Path to a oxfmt configuration file, when `null` is passed, the server will use `.oxfmtrc.json` and the workspace root                                  |
+| Option Key                | Value(s)                          | Default    | Description                                                                                                                                            |
+| ------------------------- | --------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `run`                     | `"onSave" \| "onType"`            | `"onType"` | Should the server lint the files when the user is typing or saving                                                                                     |
+| `configPath`              | `<string>` \| `null`              | `null`     | Path to a oxlint configuration file, passing a string will disable nested configuration                                                                |
+| `tsConfigPath`            | `<string>` \| `null`              | `null`     | Path to a TypeScript configuration file. If your `tsconfig.json` is not at the root, alias paths will not be resolve correctly for the `import` plugin |
+| `unusedDisableDirectives` | `"allow" \| "warn"` \| "deny"`    | `"allow"`  | Define how directive comments like `// oxlint-disable-line` should be reported, when no errors would have been reported on that line anyway            |
+| `typeAware`               | `true` \| `false`                 | `false`    | Enables type-aware linting                                                                                                                             |
+| `disableNestedConfig`     | `false` \| `true`                 | `false`    | Disabled nested configuration and searches only for `configPath`.                                                                                      |
+| `fixKind`                 | [fixKind values](#fixkind-values) | `safe_fix` | The level of a possible fix for a diagnostic, will be applied for the complete workspace (diagnostic, code action, commands and more).                 |
+| `fmt.experimental`        | `true` \| `false`                 | `false`    | Enables experimental formatting with `oxc_formatter`                                                                                                   |
+| `fmt.configPath`          | `<string>` \| `null`              | `null`     | Path to a oxfmt configuration file, when `null` is passed, the server will use `.oxfmtrc.json` and the workspace root                                  |
+| `flags`                   | `Map<string, string>`             | `<empty>`  | (deprecated) Custom flags passed to the language server.                                                                                               |
+
+### `fixKind` values:
+
+- `"safe_fix"` (default)
+- `"safe_fix_or_suggestion"`
+- `"dangerous_fix"`
+- `"dangerous_fix_or_suggestion"`
+- `"none"`
+- `"all"`
 
 ## Supported LSP Specifications from Server
 
@@ -47,7 +58,8 @@ The client can pass the workspace options like following:
       "tsConfigPath": null,
       "unusedDisableDirectives": "allow",
       "typeAware": false,
-      "flags": {},
+      "disableNestedConfig": false,
+      "fixKind": "safe_fix",
       "fmt.experimental": false,
       "fmt.configPath": null
     }
@@ -55,10 +67,10 @@ The client can pass the workspace options like following:
 }
 ```
 
-#### Flags
+#### Flags (deprecated)
 
 - `key: disable_nested_config`: Disabled nested configuration and searches only for `configPath`
-- `key: fix_kind`: default: `"safe_fix"`, possible values `"safe_fix" | "safe_fix_or_suggestion" | "dangerous_fix" | "dangerous_fix_or_suggestion" | "none" | "all"`
+- `key: fix_kind`: see [FixKind values](#fixkind-values) for possible values
 
 ### [initialized](https://microsoft.github.io/language-server-protocol/specification#initialized)
 
@@ -85,7 +97,8 @@ The client can pass the workspace options like following:
       "tsConfigPath": null,
       "unusedDisableDirectives": "allow",
       "typeAware": false,
-      "flags": {},
+      "disableNestedConfig": false,
+      "fixKind": "safe_fix",
       "fmt.experimental": false,
       "fmt.configPath": null
     }
@@ -180,7 +193,8 @@ The client can return a response like:
   "tsConfigPath": null,
   "unusedDisableDirectives": "allow",
   "typeAware": false,
-  "flags": {},
+  "disableNestedConfig": false,
+  "fixKind": "safe_fix",
   "fmt.experimental": false,
   "fmt.configPath": null
 }]

--- a/crates/oxc_language_server/src/options.rs
+++ b/crates/oxc_language_server/src/options.rs
@@ -23,7 +23,7 @@ pub struct WorkspaceOption {
 mod test {
     use serde_json::json;
 
-    use crate::linter::options::Run;
+    use crate::linter::options::{LintFixKindFlag, Run};
 
     use super::WorkspaceOption;
 
@@ -46,7 +46,11 @@ mod test {
         let options = &workspace[0].options;
         assert_eq!(options.lint.run, Run::OnType); // fallback
         assert_eq!(options.lint.config_path, Some("./custom.json".into()));
-        assert!(options.lint.flags.is_empty());
+        assert_eq!(options.lint.ts_config_path, None);
+        assert!(!options.lint.type_aware);
+        assert!(!options.lint.disable_nested_config);
+        assert_eq!(options.lint.fix_kind, LintFixKindFlag::SafeFix);
         assert!(options.format.experimental);
+        assert_eq!(options.format.config_path, None);
     }
 }


### PR DESCRIPTION
Moved the option inside `flags` to the "root" config, you IDE's can implement a simpler UI.
The old `flags` are still supported and gets remapped to the new config.