### PR TITLE
fix(linter/plugins): fall back to package name if meta.name is missing

### DIFF
--- a/apps/oxlint/src-js/bindings.d.ts
+++ b/apps/oxlint/src-js/bindings.d.ts
@@ -6,7 +6,7 @@ export type JsLintFileCb =
 
 /** JS callback to load a JS plugin. */
 export type JsLoadPluginCb =
-  ((arg: string) => Promise<string>)
+  ((arg0: string, arg1?: string | undefined | null) => Promise<string>)
 
 /**
  * NAPI entry point.

--- a/apps/oxlint/src-js/cli.ts
+++ b/apps/oxlint/src-js/cli.ts
@@ -6,13 +6,13 @@ import { lint } from './bindings.js';
 let loadPlugin: typeof loadPluginWrapper | null = null;
 let lintFile: typeof lintFileWrapper | null = null;
 
-function loadPluginWrapper(path: string): Promise<string> {
+function loadPluginWrapper(path: string, packageName?: string): Promise<string> {
   if (loadPlugin === null) {
     const require = createRequire(import.meta.url);
     // `plugins.js` is in root of `dist`. See `tsdown.config.ts`.
     ({ loadPlugin, lintFile } = require('./plugins.js'));
   }
-  return loadPlugin(path);
+  return loadPlugin(path, packageName);
 }
 
 function lintFileWrapper(filePath: string, bufferId: number, buffer: Uint8Array | null, ruleIds: number[]): string {

--- a/apps/oxlint/src/run.rs
+++ b/apps/oxlint/src/run.rs
@@ -16,11 +16,11 @@ use crate::{lint::CliRunner, result::CliRunResult};
 #[napi]
 pub type JsLoadPluginCb = ThreadsafeFunction<
     // Arguments
-    String, // Absolute path of plugin file
+    FnArgs<(String, Option<String>)>, // Absolute path of plugin file, optional package name
     // Return value
     Promise<String>, // `PluginLoadResult`, serialized to JSON
     // Arguments (repeated)
-    String,
+    FnArgs<(String, Option<String>)>,
     // Error status
     Status,
     // CalleeHandled

--- a/apps/oxlint/test/fixtures/load_paths/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/load_paths/.oxlintrc.json
@@ -12,7 +12,8 @@
     "plugin10",
     "plugin11",
     "plugin12",
-    "plugin13"
+    "plugin13",
+    "plugin14"
   ],
   "rules": {
     "plugin1/no-debugger": "error",
@@ -27,6 +28,7 @@
     "plugin10/no-debugger": "error",
     "plugin11/no-debugger": "error",
     "plugin12/no-debugger": "error",
-    "plugin13/no-debugger": "error"
+    "plugin13/no-debugger": "error",
+    "plugin14/no-debugger": "error"
   }
 }

--- a/apps/oxlint/test/fixtures/load_paths/node_modules/plugin14/index.js
+++ b/apps/oxlint/test/fixtures/load_paths/node_modules/plugin14/index.js
@@ -1,0 +1,17 @@
+// Plugin without meta.name - should fall back to package.json name
+export default {
+  rules: {
+    "no-debugger": {
+      create(context) {
+        return {
+          DebuggerStatement(debuggerStatement) {
+            context.report({
+              message: "Unexpected Debugger Statement",
+              node: debuggerStatement,
+            });
+          },
+        };
+      },
+    },
+  },
+};

--- a/apps/oxlint/test/fixtures/load_paths/node_modules/plugin14/package.json
+++ b/apps/oxlint/test/fixtures/load_paths/node_modules/plugin14/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "plugin14",
+  "type": "module",
+  "main": "index.js"
+}

--- a/apps/oxlint/test/fixtures/load_paths/output.snap.md
+++ b/apps/oxlint/test/fixtures/load_paths/output.snap.md
@@ -40,6 +40,12 @@
    : ^^^^^^^^^
    `----
 
+  x plugin14(no-debugger): Unexpected Debugger Statement
+   ,-[files/index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+
   x plugin2(no-debugger): Unexpected Debugger Statement
    ,-[files/index.js:1:1]
  1 | debugger;
@@ -88,7 +94,7 @@
    : ^^^^^^^^^
    `----
 
-Found 1 warning and 13 errors.
+Found 1 warning and 14 errors.
 Finished in Xms on 1 file using X threads.
 ```
 

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -538,9 +538,12 @@ impl ConfigStoreBuilder {
             return Ok(());
         }
 
+        // Extract package name from package.json if available
+        let package_name = resolved.package_json().and_then(|pkg| pkg.name().map(String::from));
+
         let result = {
             let plugin_path = plugin_path.clone();
-            (external_linter.load_plugin)(plugin_path).map_err(|e| {
+            (external_linter.load_plugin)(plugin_path, package_name).map_err(|e| {
                 ConfigBuilderError::PluginLoadFailed {
                     plugin_specifier: plugin_specifier.to_string(),
                     error: e.to_string(),

--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -5,7 +5,10 @@ use serde::Deserialize;
 use oxc_allocator::Allocator;
 
 pub type ExternalLinterLoadPluginCb = Arc<
-    dyn Fn(String) -> Result<PluginLoadResult, Box<dyn std::error::Error + Send + Sync>>
+    dyn Fn(
+            String,
+            Option<String>,
+        ) -> Result<PluginLoadResult, Box<dyn std::error::Error + Send + Sync>>
         + Send
         + Sync,
 >;


### PR DESCRIPTION
Fixes #14937