### PR TITLE
fix(linter): Implement proper deep merging for settings, env, and globals in config extension and overrides

### DIFF
--- a/apps/oxlint/src/snapshots/_-c fixtures__print_config__ban_rules__eslintrc.json -A all -D eqeqeq --print-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__print_config__ban_rules__eslintrc.json -A all -D eqeqeq --print-config@oxlint.snap
@@ -26,13 +26,8 @@ working directory:
       "components": {},
       "attributes": {}
     },
-    "next": {
-      "rootDir": []
-    },
-    "react": {
-      "formComponents": [],
-      "linkComponents": []
-    },
+    "next": {},
+    "react": {},
     "jsdoc": {
       "ignorePrivate": false,
       "ignoreInternal": false,

--- a/apps/oxlint/src/snapshots/fixtures_-A all --print-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures_-A all --print-config@oxlint.snap
@@ -19,13 +19,8 @@ working directory: fixtures
       "components": {},
       "attributes": {}
     },
-    "next": {
-      "rootDir": []
-    },
-    "react": {
-      "formComponents": [],
-      "linkComponents": []
-    },
+    "next": {},
+    "react": {},
     "jsdoc": {
       "ignorePrivate": false,
       "ignoreInternal": false,

--- a/crates/oxc_linter/fixtures/extends_config/merge/env_parent.json
+++ b/crates/oxc_linter/fixtures/extends_config/merge/env_parent.json
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "browser": true,
+    "es6": true
+  }
+}

--- a/crates/oxc_linter/fixtures/extends_config/merge/globals_parent.json
+++ b/crates/oxc_linter/fixtures/extends_config/merge/globals_parent.json
@@ -1,0 +1,6 @@
+{
+  "globals": {
+    "Foo": "readonly",
+    "Baz": "writable"
+  }
+}

--- a/crates/oxc_linter/fixtures/extends_config/merge/settings_parent.json
+++ b/crates/oxc_linter/fixtures/extends_config/merge/settings_parent.json
@@ -1,0 +1,10 @@
+{
+  "settings": {
+    "jsx-a11y": {
+      "polymorphicPropName": "as",
+      "components": {
+        "Link": "a"
+      }
+    }
+  }
+}

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -1125,6 +1125,7 @@ mod test {
                 env: None,
                 globals: None,
                 plugins: None,
+                settings: None,
                 // Override redefines the same rule with options B and severity error
                 rules: ResolvedOxlintOverrideRules {
                     builtin_rules: vec![],

--- a/crates/oxc_linter/src/config/env.rs
+++ b/crates/oxc_linter/src/config/env.rs
@@ -43,6 +43,15 @@ impl OxlintEnv {
         self.0.iter().filter_map(|(k, v)| (*v).then_some(k.as_str()))
     }
 
+    /// Merge this env into another, overriding any conflicting keys.
+    /// This implements shallow merge semantics compatible with ESLint.
+    pub fn merge(self, mut other: Self) -> Self {
+        for (env, supported) in self.0 {
+            other.0.insert(env, supported);
+        }
+        other
+    }
+
     pub(crate) fn override_envs(&self, envs_to_override: &mut OxlintEnv) {
         for (env, supported) in self.0.clone() {
             envs_to_override.0.insert(env, supported);

--- a/crates/oxc_linter/src/config/globals.rs
+++ b/crates/oxc_linter/src/config/globals.rs
@@ -50,6 +50,15 @@ impl OxlintGlobals {
         self.0.get(name).is_some_and(|value| *value != GlobalValue::Off)
     }
 
+    /// Merge this globals into another, overriding any conflicting keys.
+    /// This implements shallow merge semantics compatible with ESLint.
+    pub fn merge(self, mut other: Self) -> Self {
+        for (key, value) in self.0 {
+            other.0.insert(key, value);
+        }
+        other
+    }
+
     pub(crate) fn override_globals(&self, globals_to_override: &mut OxlintGlobals) {
         for (env, supported) in self.0.clone() {
             globals_to_override.0.insert(env, supported);

--- a/crates/oxc_linter/src/config/overrides.rs
+++ b/crates/oxc_linter/src/config/overrides.rs
@@ -91,6 +91,9 @@ pub struct OxlintOverride {
     /// Enabled or disabled specific global variables.
     pub globals: Option<OxlintGlobals>,
 
+    /// Plugin settings for this override.
+    pub settings: Option<super::OxlintSettings>,
+
     /// Optionally change what plugins are enabled for this override. When
     /// omitted, the base config's plugins are used.
     #[serde(default)]

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -291,9 +291,10 @@ impl Oxlintrc {
             .map(|rule| (**rule).clone())
             .collect::<Vec<_>>();
 
-        let settings = self.settings.clone();
-        let env = self.env.clone();
-        let globals = self.globals.clone();
+        // Merge settings, env, and globals with shallow merge semantics (self takes priority)
+        let settings = self.settings.clone().merge(other.settings.clone());
+        let env = self.env.clone().merge(other.env.clone());
+        let globals = self.globals.clone().merge(other.globals.clone());
 
         let mut overrides = other.overrides;
         overrides.extend(self.overrides.clone());

--- a/crates/oxc_linter/src/config/settings/react.rs
+++ b/crates/oxc_linter/src/config/settings/react.rs
@@ -29,8 +29,9 @@ pub struct ReactPluginSettings {
     /// }
     /// ```
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "formComponents")]
-    form_components: Vec<CustomComponent>,
+    form_components: Option<Vec<CustomComponent>>,
 
     /// Components used as alternatives to `<a>` for linking, such as `<Link>`.
     ///
@@ -53,19 +54,49 @@ pub struct ReactPluginSettings {
     /// }
     /// ```
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "linkComponents")]
-    link_components: Vec<CustomComponent>,
+    link_components: Option<Vec<CustomComponent>>,
     // TODO: More properties should be added
 }
 
 pub type ComponentAttrs<'c> = Cow<'c, Vec<CompactStr>>;
 impl ReactPluginSettings {
     pub fn get_form_component_attrs(&self, name: &str) -> Option<ComponentAttrs<'_>> {
-        get_component_attrs_by_name(&self.form_components, name)
+        self.form_components
+            .as_ref()
+            .and_then(|components| get_component_attrs_by_name(components, name))
     }
 
     pub fn get_link_component_attrs(&self, name: &str) -> Option<ComponentAttrs<'_>> {
-        get_component_attrs_by_name(&self.link_components, name)
+        self.link_components
+            .as_ref()
+            .and_then(|components| get_component_attrs_by_name(components, name))
+    }
+
+    /// Deep merge self into other (self takes priority).
+    /// Arrays are replaced, not merged (ESLint behavior).
+    pub(crate) fn merge(mut self, other: Self) -> Self {
+        // If self has components, use them; otherwise use other's
+        if self.form_components.is_none() {
+            self.form_components = other.form_components;
+        }
+        if self.link_components.is_none() {
+            self.link_components = other.link_components;
+        }
+        self
+    }
+
+    /// Deep merge self into base (self takes priority), mutating base in place.
+    /// Arrays are replaced, not merged (ESLint behavior).
+    pub(crate) fn merge_into(&self, base: &mut Self) {
+        // If self has components, replace base's
+        if self.form_components.is_some() {
+            base.form_components.clone_from(&self.form_components);
+        }
+        if self.link_components.is_some() {
+            base.link_components.clone_from(&self.link_components);
+        }
     }
 }
 

--- a/crates/oxc_linter/src/config/settings/vitest.rs
+++ b/crates/oxc_linter/src/config/settings/vitest.rs
@@ -13,3 +13,26 @@ pub struct VitestPluginSettings {
     #[serde(default)]
     pub typecheck: bool,
 }
+
+impl VitestPluginSettings {
+    pub(crate) fn is_empty(&self) -> bool {
+        !self.typecheck
+    }
+
+    /// Deep merge self into other (self takes priority).
+    pub(crate) fn merge(self, other: Self) -> Self {
+        // If self is empty (default), use other's values
+        if self.is_empty() {
+            return other;
+        }
+        self
+    }
+
+    /// Deep merge self into base (self takes priority), mutating base in place.
+    pub(crate) fn merge_into(&self, base: &mut Self) {
+        // If self is not empty, override base's values
+        if !self.is_empty() {
+            base.typecheck = self.typecheck;
+        }
+    }
+}

--- a/crates/oxc_linter/src/snapshots/schema_json.snap
+++ b/crates/oxc_linter/src/snapshots/schema_json.snap
@@ -118,13 +118,8 @@ expression: json
           "components": {},
           "attributes": {}
         },
-        "next": {
-          "rootDir": []
-        },
-        "react": {
-          "formComponents": [],
-          "linkComponents": []
-        },
+        "next": {},
+        "react": {},
         "jsdoc": {
           "ignorePrivate": false,
           "ignoreInternal": false,
@@ -406,10 +401,12 @@ expression: json
       "properties": {
         "rootDir": {
           "description": "The root directory of the Next.js project.\n\nThis is particularly useful when you have a monorepo and your Next.js\nproject is in a subfolder.\n\nExample:\n\n```json\n{\n\"settings\": {\n\"next\": {\n\"rootDir\": \"apps/dashboard/\"\n}\n}\n}\n```",
-          "default": [],
-          "allOf": [
+          "anyOf": [
             {
               "$ref": "#/definitions/OneOrMany_for_String"
+            },
+            {
+              "type": "null"
             }
           ],
           "markdownDescription": "The root directory of the Next.js project.\n\nThis is particularly useful when you have a monorepo and your Next.js\nproject is in a subfolder.\n\nExample:\n\n```json\n{\n\"settings\": {\n\"next\": {\n\"rootDir\": \"apps/dashboard/\"\n}\n}\n}\n```"
@@ -556,6 +553,17 @@ expression: json
               "$ref": "#/definitions/OxlintRules"
             }
           ]
+        },
+        "settings": {
+          "description": "Plugin settings for this override.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OxlintSettings"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false
@@ -604,9 +612,7 @@ expression: json
           ]
         },
         "next": {
-          "default": {
-            "rootDir": []
-          },
+          "default": {},
           "allOf": [
             {
               "$ref": "#/definitions/NextPluginSettings"
@@ -614,10 +620,7 @@ expression: json
           ]
         },
         "react": {
-          "default": {
-            "formComponents": [],
-            "linkComponents": []
-          },
+          "default": {},
           "allOf": [
             {
               "$ref": "#/definitions/ReactPluginSettings"
@@ -643,8 +646,10 @@ expression: json
       "properties": {
         "formComponents": {
           "description": "Components used as alternatives to `<form>` for forms, such as `<Formik>`.\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"formComponents\": [\n\"CustomForm\",\n// OtherForm is considered a form component and has an endpoint attribute\n{ \"name\": \"OtherForm\", \"formAttribute\": \"endpoint\" },\n// allows specifying multiple properties if necessary\n{ \"name\": \"Form\", \"formAttribute\": [\"registerEndpoint\", \"loginEndpoint\"] }\n]\n}\n}\n}\n```",
-          "default": [],
-          "type": "array",
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "$ref": "#/definitions/CustomComponent"
           },
@@ -652,8 +657,10 @@ expression: json
         },
         "linkComponents": {
           "description": "Components used as alternatives to `<a>` for linking, such as `<Link>`.\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"linkComponents\": [\n\"HyperLink\",\n// Use `linkAttribute` for components that use a different prop name\n// than `href`.\n{ \"name\": \"MyLink\", \"linkAttribute\": \"to\" },\n// allows specifying multiple properties if necessary\n{ \"name\": \"Link\", \"linkAttribute\": [\"to\", \"href\"] }\n]\n}\n}\n}\n```",
-          "default": [],
-          "type": "array",
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "$ref": "#/definitions/CustomComponent"
           },

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -114,13 +114,8 @@
           "components": {},
           "attributes": {}
         },
-        "next": {
-          "rootDir": []
-        },
-        "react": {
-          "formComponents": [],
-          "linkComponents": []
-        },
+        "next": {},
+        "react": {},
         "jsdoc": {
           "ignorePrivate": false,
           "ignoreInternal": false,
@@ -402,10 +397,12 @@
       "properties": {
         "rootDir": {
           "description": "The root directory of the Next.js project.\n\nThis is particularly useful when you have a monorepo and your Next.js\nproject is in a subfolder.\n\nExample:\n\n```json\n{\n\"settings\": {\n\"next\": {\n\"rootDir\": \"apps/dashboard/\"\n}\n}\n}\n```",
-          "default": [],
-          "allOf": [
+          "anyOf": [
             {
               "$ref": "#/definitions/OneOrMany_for_String"
+            },
+            {
+              "type": "null"
             }
           ],
           "markdownDescription": "The root directory of the Next.js project.\n\nThis is particularly useful when you have a monorepo and your Next.js\nproject is in a subfolder.\n\nExample:\n\n```json\n{\n\"settings\": {\n\"next\": {\n\"rootDir\": \"apps/dashboard/\"\n}\n}\n}\n```"
@@ -552,6 +549,17 @@
               "$ref": "#/definitions/OxlintRules"
             }
           ]
+        },
+        "settings": {
+          "description": "Plugin settings for this override.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OxlintSettings"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false
@@ -600,9 +608,7 @@
           ]
         },
         "next": {
-          "default": {
-            "rootDir": []
-          },
+          "default": {},
           "allOf": [
             {
               "$ref": "#/definitions/NextPluginSettings"
@@ -610,10 +616,7 @@
           ]
         },
         "react": {
-          "default": {
-            "formComponents": [],
-            "linkComponents": []
-          },
+          "default": {},
           "allOf": [
             {
               "$ref": "#/definitions/ReactPluginSettings"
@@ -639,8 +642,10 @@
       "properties": {
         "formComponents": {
           "description": "Components used as alternatives to `<form>` for forms, such as `<Formik>`.\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"formComponents\": [\n\"CustomForm\",\n// OtherForm is considered a form component and has an endpoint attribute\n{ \"name\": \"OtherForm\", \"formAttribute\": \"endpoint\" },\n// allows specifying multiple properties if necessary\n{ \"name\": \"Form\", \"formAttribute\": [\"registerEndpoint\", \"loginEndpoint\"] }\n]\n}\n}\n}\n```",
-          "default": [],
-          "type": "array",
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "$ref": "#/definitions/CustomComponent"
           },
@@ -648,8 +653,10 @@
         },
         "linkComponents": {
           "description": "Components used as alternatives to `<a>` for linking, such as `<Link>`.\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"linkComponents\": [\n\"HyperLink\",\n// Use `linkAttribute` for components that use a different prop name\n// than `href`.\n{ \"name\": \"MyLink\", \"linkAttribute\": \"to\" },\n// allows specifying multiple properties if necessary\n{ \"name\": \"Link\", \"linkAttribute\": [\"to\", \"href\"] }\n]\n}\n}\n}\n```",
-          "default": [],
-          "type": "array",
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "$ref": "#/definitions/CustomComponent"
           },


### PR DESCRIPTION
_Yes, this was written with AI. However, I have manually reviewed all of it and it seems correct and high quality to me. That said, I am new to this codebase._

## Problem

When extending configs or using overrides, `settings`, `env`, and `globals` were completely replaced instead of being merged. This meant you had to redeclare entire configuration objects even if you only wanted to change one value.

## Solution

Implemented **deep merge semantics** (ESLint compatible) for config extension and added settings support to overrides:

### Config Extension (`extends`)

- **env & globals**: Deep merge - nested properties are merged, child values override parent values
- **settings**: Deep merge at all levels:
  - **Objects** (like `components`, `attributes`): Merged recursively - both parent and child entries are preserved, child overrides on conflict
  - **Arrays** (like `formComponents`, `rootDir`): Replaced, not merged (ESLint v9 behavior)
  - **Primitives** (like `polymorphicPropName`, booleans): Child overrides parent

### File Overrides (`overrides`)

- **settings**: Now supported - can specify different settings for specific file patterns using same deep merge logic
- **env & globals**: Already worked, now uses consistent deep merge behavior

## Changes

- Added `merge()` methods to all plugin settings types (`JSXA11yPluginSettings`, `ReactPluginSettings`, `NextPluginSettings`, `JSDocPluginSettings`, `VitestPluginSettings`)
- Updated `OxlintSettings::merge()` to orchestrate deep merging across all plugin settings
- Updated `OxlintEnv::merge()` and `OxlintGlobals::merge()` for deep merge
- Updated `Oxlintrc::merge()` to use new merge methods
- Added `settings` field to `OxlintOverride` struct
- Applied settings in override resolution logic with deep merge
- Added `PartialEq` to settings structs for comparison optimization

## Testing

- 5 tests covering env, globals, and settings merging in both extension and overrides
- All 816 tests pass
- Test fixtures added in `fixtures/extends_config/merge/`

## Example (Deep Merge)

```jsonc
// parent.json
{
  "env": { "browser": true },
  "settings": {
    "jsx-a11y": {
      "polymorphicPropName": "as",
      "components": { "Link": "a" }
    }
  }
}

// child.json
{
  "extends": ["./parent.json"],
  "env": { "node": true },
  "settings": {
    "jsx-a11y": {
      "polymorphicPropName": "component",
      "components": { "Button": "button" }
    },
    "react": { "formComponents": ["CustomForm"] }
  }
}
```

### Result (Deep Merge):

* env: `{ "browser": true, "node": true }` — Both merged
* settings.jsx-a11y:
  * `polymorphicPropName: "component"` — Child overrides
  * `components: { "Link": "a", "Button": "button" }` — Both merged
* settings.react: `{ "formComponents": ["CustomForm"] }` — Added from child

This matches ESLint's deep merge behavior where nested objects are recursively merged but arrays are replaced.