### PR TITLE
fix(linter/no-empty-object-type): parse `"allowWithName"` as regular expressions

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
@@ -204,7 +204,7 @@ fn check_interface_declaration(
     if allow_interfaces == AllowInterfaces::Always {
         return;
     }
-    if let Some(pattern) = allow_with_name.as_ref()
+    if let Some(pattern) = allow_with_name
         && pattern.is_match(interface.id.name.as_str())
     {
         return;
@@ -232,7 +232,7 @@ fn check_type_literal(
     match ctx.nodes().parent_kind(node_id) {
         AstKind::TSIntersectionType(_) => return,
         AstKind::TSTypeAliasDeclaration(alias) => {
-            if let Some(pattern) = allow_with_name.as_ref()
+            if let Some(pattern) = allow_with_name
                 && pattern.is_match(alias.id.name.as_str())
             {
                 return;


### PR DESCRIPTION
- Closes #14936 
- Tests are adapted from https://github.com/typescript-eslint/typescript-eslint/blob/55ca033ee88cc95cfac4ad6dea2257fbeb1d4657/packages/eslint-plugin/tests/rules/no-empty-object-type.test.ts#L66
- Docs are taken from https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-empty-object-type.mdx