### PR TITLE
fix(ast): treat `TSEmptyBodyFunctionExpression` as expression in Function::is_expression

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -1421,6 +1421,7 @@ impl<'a> Function<'a> {
     /// `true` for function expressions
     pub fn is_expression(&self) -> bool {
         self.r#type == FunctionType::FunctionExpression
+            || self.r#type == FunctionType::TSEmptyBodyFunctionExpression
     }
 
     /// `true` for function declarations

--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -1418,7 +1418,7 @@ impl<'a> Function<'a> {
         self.r#type.is_typescript_syntax() || self.body.is_none() || self.declare
     }
 
-    /// `true` for function expressions
+    /// `true` for both function expressions and typescript empty body function expressions
     pub fn is_expression(&self) -> bool {
         self.r#type == FunctionType::FunctionExpression
             || self.r#type == FunctionType::TSEmptyBodyFunctionExpression


### PR DESCRIPTION
About #14944 

Prevents panic by regarding `TSEmptyBodyFunctionExpression` as expressions

ps: 
- This PR resolve the panic issue, but doesn't include the syntax validation changes, so please **don't close the issue if the PR closes**
- This fix doesn't include additional test cases as existing tests keep passing. If the tests are needed, I may need guidance on how to write them (or any document urls).

Thanks ❤️