### PR TITLE
feat(minifier): implement hoisting of static methods

### DIFF
--- a/crates/oxc_minifier/src/peephole/hoist_static_methods.rs
+++ b/crates/oxc_minifier/src/peephole/hoist_static_methods.rs
@@ -1,0 +1,174 @@
+use oxc_ast::{NONE, ast::*};
+use oxc_semantic::{ReferenceFlags, ReferenceId, SymbolFlags};
+use oxc_span::SPAN;
+use oxc_traverse::BoundIdentifier;
+use rustc_hash::FxHashMap;
+
+use crate::ctx::Ctx;
+
+use super::PeepholeOptimizations;
+
+#[derive(Debug, Default)]
+pub struct HoistStaticMethodsState<'a> {
+    methods: FxHashMap<Atom<'a>, MethodInfo<'a>>,
+}
+
+#[derive(Debug)]
+struct MethodInfo<'a> {
+    ref_ids: Vec<ReferenceId>,
+    binding: Option<BoundIdentifier<'a>>,
+    inserted: bool,
+}
+
+impl<'a> PeepholeOptimizations {
+    pub fn hoist_static_methods(expr: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) {
+        let Expression::CallExpression(call_expr) = expr else { return };
+        let Expression::StaticMemberExpression(e) = &call_expr.callee else { return };
+
+        if !e.object.is_specific_id("Object") {
+            return;
+        }
+
+        if !matches!(
+            e.property.name.as_str(),
+            "keys" | "entries" | "freeze" | "defineProperty" | "seal" | "getOwnPropertyDescriptor"
+        ) {
+            return;
+        }
+
+        let method_name_key = e.property.name;
+        let needs_new_binding =
+            !ctx.state.hoist_known_methods_state.methods.contains_key(&method_name_key)
+                || ctx.state.hoist_known_methods_state.methods[&method_name_key].binding.is_none();
+
+        let binding_name = if needs_new_binding {
+            let uid = ctx.generate_uid_in_root_scope("c", SymbolFlags::Variable);
+            let name = uid.name;
+            let method_info =
+                ctx.state.hoist_known_methods_state.methods.entry(method_name_key).or_insert_with(
+                    || MethodInfo { ref_ids: Vec::new(), binding: None, inserted: false },
+                );
+            method_info.binding = Some(uid);
+            name
+        } else {
+            ctx.state.hoist_known_methods_state.methods[&method_name_key]
+                .binding
+                .as_ref()
+                .unwrap()
+                .name
+        };
+
+        let reference_id =
+            ctx.create_unbound_reference(binding_name.as_str(), ReferenceFlags::Read);
+        call_expr.callee = ctx.ast.expression_identifier_with_reference_id(
+            SPAN,
+            binding_name.as_str(),
+            reference_id,
+        );
+
+        ctx.state
+            .hoist_known_methods_state
+            .methods
+            .get_mut(&method_name_key)
+            .unwrap()
+            .ref_ids
+            .push(reference_id);
+        ctx.state.changed = true;
+    }
+
+    pub fn insert_static_methods_bindings(program: &mut Program<'a>, ctx: &mut Ctx<'a, '_>) {
+        if ctx.state.hoist_known_methods_state.methods.is_empty() {
+            return;
+        }
+
+        let has_methods = ctx
+            .state
+            .hoist_known_methods_state
+            .methods
+            .values()
+            .any(|info| !info.ref_ids.is_empty() && !info.inserted);
+
+        if !has_methods {
+            return;
+        }
+
+        let reference_id = ctx.create_unbound_reference("Object", ReferenceFlags::Read);
+        let mut properties = ctx.ast.vec();
+
+        let mut tmp = FxHashMap::default();
+        std::mem::swap(&mut ctx.state.hoist_known_methods_state.methods, &mut tmp);
+
+        {
+            for (key, method_info) in &mut tmp {
+                let key_str = key.as_str();
+                if method_info.ref_ids.is_empty() || method_info.inserted {
+                    continue;
+                }
+
+                let binding = method_info.binding.as_ref().unwrap();
+                properties.push(ctx.ast.binding_property(
+                    SPAN,
+                    ctx.ast.property_key_static_identifier(SPAN, key_str),
+                    ctx.ast.binding_pattern(
+                        ctx.ast.binding_pattern_kind_binding_identifier_with_symbol_id(
+                            SPAN,
+                            binding.name,
+                            binding.symbol_id,
+                        ),
+                        NONE,
+                        false,
+                    ),
+                    true,
+                    false,
+                ));
+
+                if !method_info.ref_ids.is_empty() {
+                    method_info.inserted = true;
+                }
+            }
+        }
+
+        if properties.is_empty() {
+            return;
+        }
+
+        let declarations = ctx.ast.vec1(ctx.ast.variable_declarator(
+            SPAN,
+            VariableDeclarationKind::Const,
+            ctx.ast.binding_pattern(
+                ctx.ast.binding_pattern_kind_object_pattern(SPAN, properties, NONE),
+                NONE,
+                false,
+            ),
+            Some(ctx.ast.expression_identifier_with_reference_id(SPAN, "Object", reference_id)),
+            false,
+        ));
+
+        let var_decl = ctx.ast.alloc_variable_declaration(
+            SPAN,
+            VariableDeclarationKind::Const,
+            declarations,
+            false,
+        );
+
+        program.body.insert(0, Statement::VariableDeclaration(var_decl));
+
+        ctx.state.changed = true;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use oxc_span::SourceType;
+
+    use crate::{
+        CompressOptions,
+        tester::{
+            test_options, test_options_source_type, test_same_options,
+            test_same_options_source_type,
+        },
+    };
+
+    #[test]
+    fn testing() {}
+}

--- a/crates/oxc_minifier/src/state.rs
+++ b/crates/oxc_minifier/src/state.rs
@@ -5,7 +5,7 @@ use oxc_data_structures::stack::NonEmptyStack;
 use oxc_span::{Atom, SourceType};
 use oxc_syntax::symbol::SymbolId;
 
-use crate::{CompressOptions, symbol_value::SymbolValues};
+use crate::{CompressOptions, peephole::HoistStaticMethodsState, symbol_value::SymbolValues};
 
 pub struct MinifierState<'a> {
     pub source_type: SourceType,
@@ -20,6 +20,8 @@ pub struct MinifierState<'a> {
     /// Private member usage for classes
     pub class_symbols_stack: ClassSymbolsStack<'a>,
 
+    pub hoist_known_methods_state: HoistStaticMethodsState<'a>,
+
     pub changed: bool,
 }
 
@@ -31,6 +33,7 @@ impl MinifierState<'_> {
             pure_functions: FxHashMap::default(),
             symbol_values: SymbolValues::default(),
             class_symbols_stack: ClassSymbolsStack::new(),
+            hoist_known_methods_state: HoistStaticMethodsState::default(),
             changed: false,
         }
     }

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -1,27 +1,27 @@
            | Oxc        | ESBuild    | Oxc        | ESBuild    |
 Original   | minified   | minified   | gzip       | gzip       | Iterations | File      
 -------------------------------------------------------------------------------------
-72.14 kB   | 23.18 kB   | 23.70 kB   | 8.38 kB    | 8.54 kB    |          2 | react.development.js 
+72.14 kB   | 22.91 kB   | 23.70 kB   | 8.39 kB    | 8.54 kB    |          2 | react.development.js 
 
 173.90 kB  | 59.40 kB   | 59.82 kB   | 19.16 kB   | 19.33 kB   |          2 | moment.js  
 
-287.63 kB  | 89.26 kB   | 90.07 kB   | 30.91 kB   | 31.95 kB   |          2 | jquery.js  
+287.63 kB  | 89.25 kB   | 90.07 kB   | 30.95 kB   | 31.95 kB   |          2 | jquery.js  
 
-342.15 kB  | 116.98 kB  | 118.14 kB  | 43.17 kB   | 44.37 kB   |          2 | vue.js     
+342.15 kB  | 116.67 kB  | 118.14 kB  | 43.10 kB   | 44.37 kB   |          2 | vue.js     
 
 544.10 kB  | 71.04 kB   | 72.48 kB   | 25.78 kB   | 26.20 kB   |          2 | lodash.js  
 
-555.77 kB  | 267.39 kB  | 270.13 kB  | 88.01 kB   | 90.80 kB   |          2 | d3.js      
+555.77 kB  | 267.40 kB  | 270.13 kB  | 88.03 kB   | 90.80 kB   |          2 | d3.js      
 
-1.01 MB    | 439.40 kB  | 458.89 kB  | 122.06 kB  | 126.71 kB  |          2 | bundle.min.js 
+1.01 MB    | 439.38 kB  | 458.89 kB  | 122.12 kB  | 126.71 kB  |          2 | bundle.min.js 
 
-1.25 MB    | 642.65 kB  | 646.76 kB  | 159.39 kB  | 163.73 kB  |          2 | three.js   
+1.25 MB    | 641.97 kB  | 646.76 kB  | 159.51 kB  | 163.73 kB  |          2 | three.js   
 
-2.14 MB    | 711.15 kB  | 724.14 kB  | 160.43 kB  | 181.07 kB  |          2 | victory.js 
+2.14 MB    | 703.85 kB  | 724.14 kB  | 161.01 kB  | 181.07 kB  |          2 | victory.js 
 
-3.20 MB    | 1.00 MB    | 1.01 MB    | 322.59 kB  | 331.56 kB  |          3 | echarts.js 
+3.20 MB    | 1.00 MB    | 1.01 MB    | 322.61 kB  | 331.56 kB  |          3 | echarts.js 
 
-6.69 MB    | 2.22 MB    | 2.31 MB    | 458.41 kB  | 488.28 kB  |          4 | antd.js    
+6.69 MB    | 2.22 MB    | 2.31 MB    | 460.33 kB  | 488.28 kB  |          4 | antd.js    
 
-10.95 MB   | 3.33 MB    | 3.49 MB    | 853.34 kB  | 915.50 kB  |          4 | typescript.js 
+10.95 MB   | 3.33 MB    | 3.49 MB    | 853.24 kB  | 915.50 kB  |          4 | typescript.js 
 


### PR DESCRIPTION
@Boshen @sapphi-red is this an optimization worth making to the minifier?

My original aim here, was to be able to drop code such as:

https://github.com/oxc-project/oxc/blob/cd068aab769e540566ad73de4c33c2788e51a6ab/apps/oxlint/src-js/index.ts#L37

from oxlint, as I think it makes it harder to read, but appears to have an impact on performance.

However, this change of course makes the minifier slower, while increasing the grip size (not sure why) in some scenarios.



```
$ cat test.ts 
import { Bench } from "tinybench";

const bench = new Bench({ name: "simple benchmark", time: 100 });

const { keys: ObjectKeys } = Object;

bench
  .add("`Object.keys` (hoisted)", () => {
    const a = {};
    ObjectKeys(a);
  })
  .add("`Object.keys` (inline)", async () => {
    const a = {};
    Object.keys(a);
  });

await bench.run();

console.log(bench.name);
console.table(bench.table());

$ node test.ts
simple benchmark
┌─────────┬───────────────────────────┬──────────────────┬──────────────────┬────────────────────────┬────────────────────────┬─────────┐
│ (index) │ Task name                 │ Latency avg (ns) │ Latency med (ns) │ Throughput avg (ops/s) │ Throughput med (ops/s) │ Samples │
├─────────┼───────────────────────────┼──────────────────┼──────────────────┼────────────────────────┼────────────────────────┼─────────┤
│ 0       │ '`Object.keys` (hoisted)' │ '30.69 ± 0.34%'  │ '41.00 ± 1.00'   │ '26437517 ± 0.02%'     │ '24390244 ± 580720'    │ 3258807 │
│ 1       │ '`Object.keys` (inline)'  │ '88.60 ± 15.84%' │ '83.00 ± 0.00'   │ '13461800 ± 0.06%'     │ '12048193 ± 0'         │ 1128687 │
└─────────┴───────────────────────────┴──────────────────┴──────────────────┴────────────────────────┴────────────────────────┴─────────┘
```