### PR TITLE
feat(linter): add plugin for angular and implement rule prefer standalone

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -313,6 +313,10 @@ pub struct EnablePlugins {
     /// Enable the vue plugin and detect vue usage problems
     #[bpaf(flag(OverrideToggle::Enable, OverrideToggle::NotSet), hide_usage)]
     pub vue_plugin: OverrideToggle,
+
+    /// Enable the Angular plugin and detect Angular usage problems
+    #[bpaf(flag(OverrideToggle::Enable, OverrideToggle::NotSet), hide_usage)]
+    pub angular_plugin: OverrideToggle,
 }
 
 /// Enables or disables a boolean option, or leaves it unset.
@@ -389,6 +393,7 @@ impl EnablePlugins {
         self.node_plugin.inspect(|yes| plugins.set(LintPlugins::NODE, yes));
         self.regex_plugin.inspect(|yes| plugins.set(LintPlugins::REGEX, yes));
         self.vue_plugin.inspect(|yes| plugins.set(LintPlugins::VUE, yes));
+        self.angular_plugin.inspect(|yes| plugins.set(LintPlugins::ANGULAR, yes));
 
         // Without this, jest plugins adapted to vitest will not be enabled.
         if self.vitest_plugin.is_enabled() && self.jest_plugin.is_not_set() {

--- a/crates/oxc_linter/src/config/plugins.rs
+++ b/crates/oxc_linter/src/config/plugins.rs
@@ -38,6 +38,8 @@ bitflags! {
         const REGEX = 1 << 13;
         /// `eslint-plugin-vue`
         const VUE = 1 << 14;
+        /// `eslint-plugin-angular`
+        const ANGULAR = 1 << 15;
     }
 }
 
@@ -99,6 +101,7 @@ impl TryFrom<&str> for LintPlugins {
             "node" => Ok(LintPlugins::NODE),
             "regex" => Ok(LintPlugins::REGEX),
             "vue" => Ok(LintPlugins::VUE),
+            "angular" => Ok(LintPlugins::ANGULAR),
             // "eslint" is not really a plugin, so it's 'empty'. This has the added benefit of
             // making it the default value.
             "eslint" => Ok(LintPlugins::ESLINT),
@@ -125,6 +128,7 @@ impl From<LintPlugins> for &'static str {
             LintPlugins::NODE => "node",
             LintPlugins::REGEX => "regex",
             LintPlugins::VUE => "vue",
+            LintPlugins::ANGULAR => "angular",
             _ => "",
         }
     }

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -505,6 +505,7 @@ fn plugin_name_to_prefix(plugin_name: &'static str) -> &'static str {
         "vitest" => "eslint-plugin-vitest",
         "node" => "eslint-plugin-node",
         "vue" => "eslint-plugin-vue",
+        "angular" => "eslint-plugin-angular",
         "regexp" => "eslint-plugin-regexp",
         _ => plugin_name,
     }

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3837,3 +3837,8 @@ impl RuleRunner for crate::rules::vue::valid_define_props::ValidDefineProps {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
+
+impl RuleRunner for crate::rules::angular::prefer_standalone::PreferStandalone {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -664,6 +664,7 @@ pub(crate) mod vue {
 }
 
 pub(crate) mod angular {
+    pub mod prefer_standalone;
 }
 
 oxc_macros::declare_all_lint_rules! {
@@ -1278,4 +1279,5 @@ oxc_macros::declare_all_lint_rules! {
     vue::require_typed_ref,
     vue::valid_define_emits,
     vue::valid_define_props,
+    angular::prefer_standalone,
 }

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -663,6 +663,9 @@ pub(crate) mod vue {
     pub mod valid_define_props;
 }
 
+pub(crate) mod angular {
+}
+
 oxc_macros::declare_all_lint_rules! {
     eslint::array_callback_return,
     eslint::arrow_body_style,

--- a/crates/oxc_linter/src/rules/angular/prefer_standalone.rs
+++ b/crates/oxc_linter/src/rules/angular/prefer_standalone.rs
@@ -1,0 +1,291 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::{
+    CallExpression, Class, Expression, ObjectExpression, ObjectProperty, ObjectPropertyKind,
+    PropertyKey,
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn prefer_standalone_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Prefer standalone components.").with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferStandalone;
+
+// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Components, Directives and Pipes should not opt out of standalone.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Since Angular 19, components, directives and pipes have been standalone by default.
+    /// It is the recommended way to create them.
+    ///  Therefore, you should not opt out of standalone.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// @Component({ standalone: false })
+    /// class TestComponent {}
+    ///
+    /// @Directive({ standalone: false })
+    /// class TestDirective {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// @Component()
+    /// class TestComponent {}
+    ///
+    /// @Component({ standalone: true })
+    /// class TestComponent {}
+    ///
+    /// @Directive()
+    /// class TestDirective {}
+    ///
+    /// @Directive({ standalone: true })
+    /// class TestDirective {}
+    /// ```
+    PreferStandalone,
+    angular,
+    style,
+    suggestion
+);
+
+impl Rule for PreferStandalone {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Class(class) = node.kind() else {
+            return;
+        };
+        let Some(call_expression) = get_relevant_decorator_call_expression(class) else { return };
+        let Some(first_arg) = call_expression.arguments.first() else {
+            return;
+        };
+        let Expression::ObjectExpression(obj_expression) = &first_arg.to_expression() else {
+            return;
+        };
+        let Some(prop) = get_standalone_property(obj_expression) else { return };
+        let Expression::BooleanLiteral(bool_value) = &prop.value else {
+            return;
+        };
+
+        if !bool_value.value {
+            ctx.diagnostic_with_suggestion(prefer_standalone_diagnostic(prop.span()), |fixer| {
+                fixer.replace(prop.span(), "")
+            });
+        }
+    }
+}
+
+fn get_relevant_decorator_call_expression<'a>(
+    class: &'a Class<'a>,
+) -> Option<&'a CallExpression<'a>> {
+    for decorator in &class.decorators {
+        let Expression::CallExpression(call_expr) = &decorator.expression else {
+            continue;
+        };
+        let Some(callee_identifier) = call_expr.callee.get_identifier_reference() else { continue };
+        if ["Component", "Directive", "Pipe"].contains(&callee_identifier.name.as_str()) {
+            return Some(call_expr);
+        }
+    }
+    None
+}
+
+fn get_standalone_property<'a>(
+    decorator_object_expression: &'a ObjectExpression<'a>,
+) -> Option<&'a ObjectProperty<'a>> {
+    for property in &decorator_object_expression.properties {
+        let ObjectPropertyKind::ObjectProperty(prop) = &property else {
+            continue;
+        };
+        let PropertyKey::StaticIdentifier(ident) = &prop.key else {
+            continue;
+        };
+        if ident.name == "standalone" {
+            return Some(prop);
+        }
+    }
+    None
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "@Component({})
+        class Test {}",
+        "@Component({
+            standalone: true,
+        })
+        class Test {}",
+        "@Component({
+            selector: 'test-selector'
+        })
+        class Test {}",
+        "@Component({
+            standalone: true,
+            selector: 'test-selector'
+        })
+        class Test {}",
+        "@Component({
+            selector: 'test-selector',
+            template: '<div></div>',
+            styleUrls: ['./test.css']
+        })
+        class Test {}",
+        "@Component({
+            selector: 'test-selector',
+            standalone: true,
+            template: '<div></div>',
+            styleUrls: ['./test.css']
+        })
+        class Test {}",
+        "@Directive({})
+        class Test {}",
+        "@Directive({
+            standalone: true,
+        })
+        class Test {}",
+        "@Directive({
+            selector: 'test-selector'
+        })
+        class Test {}",
+        "@Directive({
+            standalone: true,
+            selector: 'test-selector'
+        })
+        class Test {}",
+        "@Directive({
+            selector: 'test-selector',
+            providers: []
+        })
+        class Test {}",
+        "@Directive({
+            selector: 'test-selector',
+            standalone: true,
+            providers: []
+        })
+        class Test {}",
+        "@Directive()
+        abstract class Test {}",
+        "@Pipe({})
+        class Test {}",
+        "@Pipe({
+            standalone: true,
+        })
+        class Test {}",
+        "@Pipe({
+            name: 'test-pipe'
+        })
+        class Test {}",
+        "@Pipe({
+            standalone: true,
+            name: 'test-pipe'
+        })
+        class Test {}",
+        "@Pipe({
+            name: 'my-pipe',
+            pure: true
+        })
+        class Test {}",
+        "@Pipe({
+            name: 'my-pipe',
+            standalone: true,
+            pure: true
+        })
+        class Test {}",
+    ];
+
+    let fail = vec![
+        "@Component({ standalone: false })
+        class Test {}",
+        "@Component({
+            standalone: false,
+            template: '<div></div>'
+        })
+        class Test {}",
+        "@Directive({ standalone: false })
+        class Test {}",
+        "@Directive({
+            standalone: false,
+            selector: 'x-selector'
+        })
+        class Test {}",
+        "@Pipe({ standalone: false })
+        class Test {}",
+        "@Pipe({
+            standalone: false,
+            name: 'pipe-name'
+        })
+        class Test {}",
+    ];
+
+    let fix = vec![
+        (
+            "@Component({ standalone: false })
+            class Test {}",
+            "@Component({  })
+            class Test {}",
+        ),
+        (
+            "@Component({
+                standalone: false,
+                template: '<div></div>'
+            })
+            class Test {}",
+            "@Component({
+                ,
+                template: '<div></div>'
+            })
+            class Test {}",
+        ),
+        (
+            "@Directive({ standalone: false })
+            class Test {}",
+            "@Directive({  })
+            class Test {}",
+        ),
+        (
+            "@Directive({
+                standalone: false,
+                selector: 'x-selector'
+            })
+            class Test {}",
+            "@Directive({
+                ,
+                selector: 'x-selector'
+            })
+            class Test {}",
+        ),
+        (
+            "@Pipe({ standalone: false })
+            class Test {}",
+            "@Pipe({  })
+            class Test {}",
+        ),
+        (
+            "@Pipe({
+                standalone: false,
+                name: 'pipe-name'
+            })
+            class Test {}",
+            "@Pipe({
+                ,
+                name: 'pipe-name'
+            })
+            class Test {}",
+        ),
+    ];
+    Tester::new(PreferStandalone::NAME, PreferStandalone::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/angular_prefer_standalone.snap
+++ b/crates/oxc_linter/src/snapshots/angular_prefer_standalone.snap
@@ -1,0 +1,53 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint-plugin-angular(prefer-standalone): Prefer standalone components.
+   ╭─[prefer_standalone.tsx:1:14]
+ 1 │ @Component({ standalone: false })
+   ·              ─────────────────
+ 2 │         class Test {}
+   ╰────
+  help: Replace `standalone: false` with ``.
+
+  ⚠ eslint-plugin-angular(prefer-standalone): Prefer standalone components.
+   ╭─[prefer_standalone.tsx:2:13]
+ 1 │ @Component({
+ 2 │             standalone: false,
+   ·             ─────────────────
+ 3 │             template: '<div></div>'
+   ╰────
+  help: Replace `standalone: false` with ``.
+
+  ⚠ eslint-plugin-angular(prefer-standalone): Prefer standalone components.
+   ╭─[prefer_standalone.tsx:1:14]
+ 1 │ @Directive({ standalone: false })
+   ·              ─────────────────
+ 2 │         class Test {}
+   ╰────
+  help: Replace `standalone: false` with ``.
+
+  ⚠ eslint-plugin-angular(prefer-standalone): Prefer standalone components.
+   ╭─[prefer_standalone.tsx:2:13]
+ 1 │ @Directive({
+ 2 │             standalone: false,
+   ·             ─────────────────
+ 3 │             selector: 'x-selector'
+   ╰────
+  help: Replace `standalone: false` with ``.
+
+  ⚠ eslint-plugin-angular(prefer-standalone): Prefer standalone components.
+   ╭─[prefer_standalone.tsx:1:9]
+ 1 │ @Pipe({ standalone: false })
+   ·         ─────────────────
+ 2 │         class Test {}
+   ╰────
+  help: Replace `standalone: false` with ``.
+
+  ⚠ eslint-plugin-angular(prefer-standalone): Prefer standalone components.
+   ╭─[prefer_standalone.tsx:2:13]
+ 1 │ @Pipe({
+ 2 │             standalone: false,
+   ·             ─────────────────
+ 3 │             name: 'pipe-name'
+   ╰────
+  help: Replace `standalone: false` with ``.

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_standalone.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_standalone.snap
@@ -1,0 +1,9 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint(prefer-standalone): Prefer standalone components.
+   ╭─[prefer_standalone.tsx:1:26]
+ 1 │ @Component({ standalone: false })
+   ·                          ─────
+ 2 │         class Test {}
+   ╰────

--- a/tasks/lint_rules/package.json
+++ b/tasks/lint_rules/package.json
@@ -4,6 +4,7 @@
   "main": "./src/main.mjs",
   "version": "0.0.0",
   "dependencies": {
+    "@angular-eslint/eslint-plugin": "latest",
     "@next/eslint-plugin-next": "latest",
     "@typescript-eslint/eslint-plugin": "latest",
     "eslint": "^9.13.0",

--- a/tasks/lint_rules/src/eslint-rules.mjs
+++ b/tasks/lint_rules/src/eslint-rules.mjs
@@ -41,6 +41,8 @@ import pluginVitest from 'eslint-plugin-vitest';
 import pluginRegexp from 'eslint-plugin-regexp';
 // https://github.com/vuejs/eslint-plugin-vue
 import pluginVue from 'eslint-plugin-vue';
+// https://github.com/angular-eslint/angular-eslint
+import pluginAngular from '@angular-eslint/eslint-plugin';
 
 // destructuring default exports
 const {
@@ -89,6 +91,10 @@ const {
   configs: pluginVueConfigs,
   rules: pluginVueRules,
 } = pluginVue;
+const {
+  configs: pluginAngularConfigs,
+  rules: pluginAngularRules,
+} = pluginAngular;
 
 /** @param {import("eslint").Linter} linter */
 const loadPluginTypeScriptRules = (linter) => {
@@ -317,6 +323,20 @@ const loadPluginVueRules = (linter) => {
   }
 };
 
+/** @param {import("eslint").Linter} linter */
+const loadPluginAngularRules = (linter) => {
+  const pluginAngularRecommendedRules = new Map(
+      Object.entries(pluginAngularConfigs.recommended.rules || {}),
+  );
+  for (const [name, rule] of Object.entries(pluginAngularRules)) {
+    const prefixedName = `angular/${name}`;
+
+    rule.meta.docs.recommended = pluginAngularRecommendedRules.has(prefixedName);
+
+    linter.defineRule(prefixedName, rule);
+  }
+};
+
 /**
  * @typedef {{
  *   npm: string[];
@@ -346,6 +366,7 @@ export const ALL_TARGET_PLUGINS = new Map([
   ['vitest', { npm: ['eslint-plugin-vitest'], issueNo: 4656 }],
   ['regexp', { npm: ['eslint-plugin-regexp'], issueNo: 11439 }],
   ['vue', { npm: ['eslint-plugin-vue'], issueNo: 11440 }],
+  ['angular', { npm: ['@angular-eslint/eslint-plugin'], issueNo: 14958 }],
 ]);
 
 // All rules(including deprecated, recommended) are loaded initially.
@@ -370,4 +391,5 @@ export const loadTargetPluginRules = (linter) => {
   loadPluginVitestRules(linter);
   loadPluginRegexpRules(linter);
   loadPluginVueRules(linter);
+  loadPluginAngularRules(linter);
 };

--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -95,6 +95,11 @@ const VUE_TEST_PATH: &str =
 const VUE_RULES_PATH: &str =
     "https://raw.githubusercontent.com/vuejs/eslint-plugin-vue/master/lib/rules/";
 
+const ANGULAR_TEST_PATH: &str =
+    "https://raw.githubusercontent.com/angular-eslint/angular-eslint/tree/main/packages/eslint-plugin/tests/rules";
+const ANGULAR_RULES_PATH: &str =
+    "https://raw.githubusercontent.com/angular-eslint/angular-eslint/tree/main/packages/eslint-plugin/src/rules";
+
 struct TestCase {
     source_text: String,
     code: Option<String>,
@@ -1337,6 +1342,7 @@ pub enum RuleKind {
     Vitest,
     Regexp,
     Vue,
+    Angular,
 }
 
 impl TryFrom<&str> for RuleKind {
@@ -1416,6 +1422,7 @@ fn main() {
         RuleKind::Vitest => format!("{VITEST_TEST_PATH}/{kebab_rule_name}.test.ts"),
         RuleKind::Regexp => format!("{REGEXP_TEST_PATH}/{kebab_rule_name}.ts"),
         RuleKind::Vue => format!("{VUE_TEST_PATH}/{kebab_rule_name}.js"),
+        RuleKind::Angular => format!("{ANGULAR_TEST_PATH}/{kebab_rule_name}.js"),
         RuleKind::Oxc => String::new(),
     };
     let rule_src_path = match rule_kind {
@@ -1434,6 +1441,7 @@ fn main() {
         RuleKind::Vitest => format!("{VITEST_RULES_PATH}/{kebab_rule_name}.ts"),
         RuleKind::Regexp => format!("{REGEXP_RULES_PATH}/{kebab_rule_name}.ts"),
         RuleKind::Vue => format!("{VUE_RULES_PATH}/{kebab_rule_name}.js"),
+        RuleKind::Angular => format!("{ANGULAR_RULES_PATH}/{kebab_rule_name}.js"),
         RuleKind::Oxc => String::new(),
     };
     let language = match rule_kind {
@@ -1638,6 +1646,7 @@ fn get_mod_name(rule_kind: RuleKind) -> String {
         RuleKind::Node => "node".into(),
         RuleKind::Regexp => "regexp".into(),
         RuleKind::Vue => "vue".into(),
+        RuleKind::Angular => "angular".into(),
     }
 }
 

--- a/tasks/rulegen/src/template.rs
+++ b/tasks/rulegen/src/template.rs
@@ -46,6 +46,7 @@ impl<'a> Template<'a> {
             RuleKind::Vitest => Path::new("crates/oxc_linter/src/rules/vitest"),
             RuleKind::Regexp => Path::new("crates/oxc_linter/src/rules/regexp"),
             RuleKind::Vue => Path::new("crates/oxc_linter/src/rules/vue"),
+            RuleKind::Angular => Path::new("crates/oxc_linter/src/rules/angular"),
         };
 
         std::fs::create_dir_all(path)?;


### PR DESCRIPTION
This PR adds support for Angular ESLint rules according to [angular-eslint/angular-eslint](https://github.com/angular-eslint/angular-eslint).

It also implements first recommended rule `prefer-standalone`.