### PR TITLE
docs(linter): Add configuration option docs for typescript/no-empty-object-type rule.

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
@@ -10,7 +10,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::NodeId;
 use oxc_span::Span;
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 

--- a/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
@@ -237,7 +237,7 @@ fn check_type_literal(
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize, JsonSchema)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "kebab-case")]
 enum AllowInterfaces {
     #[default]
     Never,


### PR DESCRIPTION
Part of #14743. Unfortunately, because I couldn't figure out how to make the lazy regex serializable/deserializable, I had to have serde skip the `allow_with_name` option. It may be worth fixing that before we merge this PR.

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### allowInterfaces

type: `"never" | "always" | "with-single-extends"`


Whether to allow empty interfaces.

Allowed values are:
- `'always'`: to always allow interfaces with no fields
- `'never'` _(default)_: to never allow interfaces with no fields
- `'with-single-extends'`: to allow empty interfaces that `extend` from a single base interface

Examples of **correct** code for this rule with `{ allowInterfaces: 'with-single-extends' }`:
\```ts
interface Base {
value: boolean;
}
interface Derived extends Base {}
\```

### allowObjectTypes

type: `"never" | "always"`


Whether to allow empty object type literals.

Allowed values are:
- `'always'`: to always allow object type literals with no fields
- `'never'` _(default)_: to never allow object type literals with no fields
```