### PR TITLE
docs(linter): Add configuration option docs for jest/require-hook rule.

### DIFF
--- a/crates/oxc_linter/src/rules/jest/require_hook.rs
+++ b/crates/oxc_linter/src/rules/jest/require_hook.rs
@@ -7,6 +7,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::AstNode;
 use oxc_span::{CompactStr, Span};
+use schemars::JsonSchema;
 
 use crate::{
     context::LintContext,
@@ -23,8 +24,10 @@ fn use_hook(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct RequireHookConfig {
+    /// An array of function names that are allowed to be called outside of hooks.
     allowed_function_calls: Vec<CompactStr>,
 }
 
@@ -157,7 +160,8 @@ declare_oxc_lint!(
     /// ```
     RequireHook,
     jest,
-    style
+    style,
+    config = RequireHookConfig
 );
 
 impl Rule for RequireHook {


### PR DESCRIPTION
Part of #14743.

Generated docs:

```md

## Configuration

This rule accepts a configuration object with the following properties:

### allowedFunctionCalls

type: `string[]`

default: `[]`

An array of function names that are allowed to be called outside of hooks.
```