### PR TITLE
fix(formatter): `BestFitting` doesn't exactly matches the `conditinalGroup` behavior in Prettier

### DIFF
--- a/crates/oxc_formatter/src/formatter/printer/mod.rs
+++ b/crates/oxc_formatter/src/formatter/printer/mod.rs
@@ -378,9 +378,7 @@ impl<'a> Printer<'a> {
         } else {
             self.state.measured_group_fits = true;
 
-            let normal_variants = &best_fitting.variants()[..best_fitting.variants().len() - 1];
-
-            for variant in normal_variants {
+            for variant in best_fitting.variants() {
                 // Test if this variant fits and if so, use it. Otherwise try the next
                 // variant.
 

--- a/crates/oxc_formatter/src/utils/member_chain/mod.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/mod.rs
@@ -231,8 +231,7 @@ impl<'a> Format<'a> for MemberChain<'a, '_> {
             }
             Ok(())
         });
-
-        let format_expanded = format_with(|f| write!(f, [self.head, indent(&group(&format_tail))]));
+        let format_expanded = format_with(|f| write!(f, [self.head, indent(&format_tail)]));
 
         let format_content = format_with(|f| {
             if has_comment || has_new_line_or_comment_between || self.groups_should_break(f) {

--- a/crates/oxc_formatter/tests/fixtures/ts/member-chains/expanded.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/member-chains/expanded.ts
@@ -1,0 +1,3 @@
+const defaultColorDecoratorsEnablement = accessor
+  .get(IConfigurationService)
+  .getValue<'auto' | 'always' | 'never'>('longlonglonglonglonglonglonglonglong');

--- a/crates/oxc_formatter/tests/fixtures/ts/member-chains/expanded.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/member-chains/expanded.ts.snap
@@ -1,0 +1,16 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+const defaultColorDecoratorsEnablement = accessor
+  .get(IConfigurationService)
+  .getValue<'auto' | 'always' | 'never'>('longlonglonglonglonglonglonglonglong');
+
+==================== Output ====================
+const defaultColorDecoratorsEnablement = accessor
+  .get(IConfigurationService)
+  .getValue<
+    "auto" | "always" | "never"
+  >("longlonglonglonglonglonglonglonglong");
+
+===================== End =====================


### PR DESCRIPTION
I found a case where Oxfmt's output differs from Prettier. Honestly, I think the `Oxfmt` output is prettier than `Prettier`.  
Anyway, I investigated this case to find the root cause.

### Failed example

Input:
```ts
const defaultColorDecoratorsEnablement = accessor
  .get(IConfigurationService)
  .getValue<"auto" | "always" | "never">(
    "longlonglonglonglonglonglonglonglong",
  );
```

Oxfmt and Biome's output:
```ts
const defaultColorDecoratorsEnablement = accessor
  .get(IConfigurationService)
  .getValue<"auto" | "always" | "never">(
    "longlonglonglonglonglonglonglonglong",
  );
```

Prettier output:
```ts
const defaultColorDecoratorsEnablement = accessor
  .get(IConfigurationService)
  .getValue<
    "auto" | "always" | "never"
  >("longlonglonglonglonglonglonglonglong");
```
### Investigating the cause

Initially, I think the problem is that we generate inconsistent `IR`, so the output is different, which is a reasonable suspicion because, so far, almost all issues are due to this reason. However, after carefully comparing both IR of Oxfmt and Prettier, they are essentially the same, so the problem is moved to the printing IR part.

After spending a few days on this case, I finally found the reason why they produce the same IR but print different outputs. The cause is inside the `BestFitting`, which is a graceful solution for Prettier's `conditionalGroup`.

Let's take a look at how Prettier handles `conditionalGroup`

#### Prettier implementation:
**conditionalGroup**
https://github.com/prettier/prettier/blob/7584432401a47a26943dd7a9ca9a8e032ead7285/src/document/builders.js#L99-L106
```js
/**
 * @param {Doc[]} states
 * @param {object} [opts] - TBD ???
 * @returns Doc
 */
function conditionalGroup(states, opts) {
  return group(states[0], { ...opts, expandedStates: states });
}
```

**handling of conditionalGroup**
https://github.com/prettier/prettier/blob/7584432401a47a26943dd7a9ca9a8e032ead7285/src/document/printer.js#L408-L445
```js
// Expanded states are a rare case where a document
// can manually provide multiple representations of
// itself. It provides an array of documents
// going from the least expanded (most flattened)
// representation first to the most expanded. If a
// group has these, we need to manually go through
// these states and find the first one that fits.
// eslint-disable-next-line no-lonely-if
if (doc.expandedStates) {
  const mostExpanded = doc.expandedStates.at(-1);

  if (doc.break) {
    cmds.push({ ind, mode: MODE_BREAK, doc: mostExpanded });

    break;
  } else {
    for (let i = 1; i < doc.expandedStates.length + 1; i++) {
      if (i >= doc.expandedStates.length) {
        cmds.push({ ind, mode: MODE_BREAK, doc: mostExpanded });

        break;
      } else {
        const state = doc.expandedStates[i];
        /** @type {Command} */
        const cmd = { ind, mode: MODE_FLAT, doc: state };

        if (fits(cmd, cmds, rem, hasLineSuffix, groupModeMap)) {
          cmds.push(cmd);

          break;
        }
      }
    }
  }
} else {
  cmds.push({ ind, mode: MODE_BREAK, doc: doc.contents });
}
```

#### Oxfmt implementation

https://github.com/oxc-project/oxc/blob/d9f7df8bc6bf7e48c90ba99638502c87afba0e04/crates/oxc_formatter/src/formatter/printer/mod.rs#L366-L418

The difference between the implementations is in handling different `expandedStates` (Called as `variants` in Oxfmt).

In prettier, it will try to get all `expandedStates` to check whether they fit or not in the `MODE_FLAT` mode. If not, they will fall back to the `mostExpanded` and print it in `MODE_BREAK` mode.

In Oxfmt, it will try to get all `variants` except the last one (most expanded) to check whether they fit or not in the `PrintMode::Flat` mode. If not, they will fall back to the `mostExpanded` and print it in `PrintMode::Expanded` mode.

So the root cause is Oxfmt, which doesn't check the `mostExpanded` one, whether it fits in the `PrintMode::Fit` mode. After aligning this, the issue was solved. 

### Thinking

After understanding the use of `conditionalGroup`, although this issue is due to Oxfmt not exactly aligning with Prettier's behavior, I suspect this is a bug in Prettier because `mostExpanded` is expected to be printed in break mode, but `Prettier` prints it in flat mode if it fits. It's not intuitive, and it's not as if the variable names describe it. Additionally, this case is a little complex, and the Prettier tests don't include such cases, so the Prettier team probably wasn't aware of this case.