### PR TITLE
fix(formatter): should not break when the parent of root of `StaticMemberExpression` is used as the `Argument` of `NewExpression`

### DIFF
--- a/crates/oxc_formatter/src/write/member_expression.rs
+++ b/crates/oxc_formatter/src/write/member_expression.rs
@@ -147,7 +147,9 @@ fn layout<'a>(
     }
 
     match first_non_static_member_ancestor {
-        AstNodes::NewExpression(_) => StaticMemberLayout::NoBreak,
+        AstNodes::Argument(argument) if matches!(argument.parent, AstNodes::NewExpression(_)) => {
+            StaticMemberLayout::NoBreak
+        }
         AstNodes::AssignmentExpression(assignment) => {
             if matches!(assignment.left, AssignmentTarget::AssignmentTargetIdentifier(_)) {
                 StaticMemberLayout::BreakAfterObject

--- a/crates/oxc_formatter/tests/fixtures/ts/static-members/argument.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/static-members/argument.ts
@@ -1,0 +1,11 @@
+TelemetryTrustedValue(
+  instance.capabilities.get(
+    TerminalCapability?.PromptTypeDetection
+  )?.promptType
+)
+
+new TelemetryTrustedValue(
+  instance.capabilities.get(
+    TerminalCapability?.PromptTypeDetection
+  )?.promptType
+)

--- a/crates/oxc_formatter/tests/fixtures/ts/static-members/argument.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/static-members/argument.ts.snap
@@ -1,0 +1,28 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+TelemetryTrustedValue(
+  instance.capabilities.get(
+    TerminalCapability?.PromptTypeDetection
+  )?.promptType
+)
+
+new TelemetryTrustedValue(
+  instance.capabilities.get(
+    TerminalCapability?.PromptTypeDetection
+  )?.promptType
+)
+==================== Output ====================
+TelemetryTrustedValue(
+  instance.capabilities.get(TerminalCapability?.PromptTypeDetection)
+    ?.promptType,
+);
+
+new TelemetryTrustedValue(
+  instance.capabilities.get(
+    TerminalCapability?.PromptTypeDetection,
+  )?.promptType,
+);
+
+===================== End =====================


### PR DESCRIPTION
Align Prettier's behavior