### PR TITLE
fix(codegen): print legal comments above directives

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -68,6 +68,7 @@ impl Gen for Hashbang<'_> {
 
 impl Gen for Directive<'_> {
     fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+        p.print_comments_at(self.span.start);
         p.add_source_mapping(self.span);
         p.print_indent();
         // A Use Strict Directive may not contain an EscapeSequence or LineContinuation.

--- a/crates/oxc_codegen/tests/integration/comments.rs
+++ b/crates/oxc_codegen/tests/integration/comments.rs
@@ -224,6 +224,8 @@ pub mod legal {
 * @preserve
 */
 ",
+            // Issue #14953: legal comments above directives
+            "/*!\n * legal comment\n */\n\n\"use strict\";\n\nexport const foo = 'foo';",
         ]
     }
 

--- a/crates/oxc_codegen/tests/integration/snapshots/legal_eof_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/legal_eof_comments.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/oxc_codegen/tests/integration/main.rs
+source: crates/oxc_codegen/tests/integration/tester.rs
 ---
 ########## 0
 /* @license */
@@ -126,4 +126,20 @@ function foo() {
 
 /**
 * @preserve
+*/
+
+########## 9
+/*!
+ * legal comment
+ */
+
+"use strict";
+
+export const foo = 'foo';
+----------
+'use strict';
+export const foo = 'foo';
+
+/*!
+* legal comment
 */

--- a/crates/oxc_codegen/tests/integration/snapshots/legal_eof_minify_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/legal_eof_minify_comments.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/oxc_codegen/tests/integration/main.rs
+source: crates/oxc_codegen/tests/integration/tester.rs
 ---
 ########## 0
 /* @license */
@@ -108,4 +108,18 @@ function foo(){(()=>{
 
 /**
 * @preserve
+*/
+
+########## 9
+/*!
+ * legal comment
+ */
+
+"use strict";
+
+export const foo = 'foo';
+----------
+'use strict';export const foo=`foo`;
+/*!
+* legal comment
 */

--- a/crates/oxc_codegen/tests/integration/snapshots/legal_inline_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/legal_inline_comments.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/oxc_codegen/tests/integration/main.rs
+source: crates/oxc_codegen/tests/integration/tester.rs
 ---
 ########## 0
 /* @license */
@@ -112,3 +112,18 @@ function foo() {
 /**
 * @preserve
 */
+
+########## 9
+/*!
+ * legal comment
+ */
+
+"use strict";
+
+export const foo = 'foo';
+----------
+/*!
+* legal comment
+*/
+'use strict';
+export const foo = 'foo';

--- a/crates/oxc_codegen/tests/integration/snapshots/legal_linked_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/legal_linked_comments.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/oxc_codegen/tests/integration/main.rs
+source: crates/oxc_codegen/tests/integration/tester.rs
 ---
 ########## 0
 /* @license */
@@ -106,5 +106,18 @@ function foo() {
 /**
 * @preserve
 */
+
+/*! For license information please see test.js */
+########## 9
+/*!
+ * legal comment
+ */
+
+"use strict";
+
+export const foo = 'foo';
+----------
+'use strict';
+export const foo = 'foo';
 
 /*! For license information please see test.js */


### PR DESCRIPTION
## Summary

Fixes #14953

Legal comments (e.g., `/*! ... */`) that appear before directives like `"use strict"` are now properly preserved in the generated code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)