### PR TITLE
docs(linter): Add configuration option docs for unicorn/no-instanceof-builtins rule.

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_instanceof_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_instanceof_builtins.rs
@@ -3,6 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_syntax::operator::BinaryOperator;
+use schemars::JsonSchema;
 use serde_json::Value;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
@@ -63,15 +64,26 @@ const STRICT_STRATEGY_CONSTRUCTORS: &[&str] = &[
     "FinalizationRegistry",
 ];
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct NoInstanceofBuiltinsConfig {
+    /// Additional constructor names to check beyond the default set.
+    /// Use this to extend the rule with additional constructors.
     include: Vec<String>,
+    /// Constructor names to exclude from checking.
     exclude: Vec<String>,
+    /// When `true`, checks `instanceof Error` and suggests using `Error.isError()` instead.
+    /// Requires [the `Error.isError()` function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/isError)
+    /// to be available.
     use_error_is_error: bool,
+    /// Controls which built-in constructors are checked.
+    /// - `"loose"` (default): Only checks Array, Function, Error (if `useErrorIsError` is true), and primitive wrappers
+    /// - `"strict"`: Additionally checks Error types, collections, typed arrays, and other built-in constructors
     strategy: Strategy,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 enum Strategy {
     Strict,
     #[default]
@@ -111,7 +123,8 @@ declare_oxc_lint!(
     NoInstanceofBuiltins,
     unicorn,
     suspicious,
-    pending
+    pending,
+    config = NoInstanceofBuiltinsConfig,
 );
 
 impl Rule for NoInstanceofBuiltins {


### PR DESCRIPTION
Part of #14743.

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### exclude

type: `string[]`

default: `[]`

Constructor names to exclude from checking.


### include

type: `string[]`

default: `[]`

Additional constructor names to check beyond the default set.
Use this to extend the rule with additional constructors.


### strategy

type: `"strict" | "loose"`


Controls which built-in constructors are checked.
- `"loose"` (default): Only checks Array, Function, Error (if `useErrorIsError` is true), and primitive wrappers
- `"strict"`: Additionally checks Error types, collections, typed arrays, and other built-in constructors


### useErrorIsError

type: `boolean`

default: `false`

When `true`, checks `instanceof Error` and suggests using `Error.isError()` instead.
Requires [the `Error.isError()` function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/isError)
to be available.
```