### PR TITLE
fix(rulegen): update template to include comma after 'pending'.

### DIFF
--- a/tasks/rulegen/template.txt
+++ b/tasks/rulegen/template.txt
@@ -56,7 +56,7 @@ declare_oxc_lint!(
     {{mod_name}},
     nursery, // TODO: change category to `correctness`, `suspicious`, `pedantic`, `perf`, `restriction`, or `style`
              // See <https://oxc.rs/docs/contribute/linter.html#rule-category> for details
-    pending  // TODO: describe fix capabilities. Remove if no fix can be done,
+    pending, // TODO: describe fix capabilities. Remove if no fix can be done,
              // keep at 'pending' if you think one could be added but don't know how.
              // Options are 'fix', 'fix_dangerous', 'suggestion', and 'conditional_fix_suggestion'
 {{#if rule_config}}


### PR DESCRIPTION
Otherwise you end up with syntax errors when there are config options to generate.