### PR TITLE
feat(linter): generic interface for Vue, Svelte, and Astro globals

### DIFF
--- a/crates/oxc_linter/src/frameworks.rs
+++ b/crates/oxc_linter/src/frameworks.rs
@@ -135,8 +135,6 @@ impl FrameworkOptions {
     ///
     /// # Examples
     /// ```
-    /// use oxc_linter::frameworks::FrameworkOptions;
-    ///
     /// // In a Vue <script setup> context
     /// let options = FrameworkOptions::VueSetup;
     /// assert!(options.has_global("defineProps") == true);

--- a/crates/oxc_linter/src/frameworks.rs
+++ b/crates/oxc_linter/src/frameworks.rs
@@ -99,10 +99,11 @@ pub fn has_jest_imports(module_record: &ModuleRecord) -> bool {
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 
 pub enum FrameworkOptions {
-    Default,      // default
-    VueSetup,     // context is inside `<script setup>`
-    SvelteModule, // `<script module>`
-    Svelte,       // `<script>`
+    Default,          // default
+    VueSetup,         // context is inside `<script setup>`
+    SvelteModule,     // `<script module>`
+    Svelte,           // `<script>`
+    AstroFrontmatter, // within `---`-delimited block
 }
 
 /// Vue 3 compiler macros available in `<script setup>`
@@ -153,6 +154,8 @@ impl FrameworkOptions {
             Self::VueSetup => VUE_SETUP_GLOBALS.contains(&var),
             Self::SvelteModule => SVELTE_MODULE_GLOBALS.contains(&var),
             Self::Svelte => SVELTE_GLOBALS.contains(&var),
+            // All of Astro's utilities are grouped under the `Astro` namespace.
+            Self::AstroFrontmatter => var == "Astro",
         }
     }
 }
@@ -198,6 +201,12 @@ mod tests {
         assert!(!globals.has_global("$props"));
         assert!(!globals.has_global("$bindable"));
         assert!(!globals.has_global("$host"));
+    }
+
+    #[test]
+    fn test_astro_frontmatter_globals() {
+        let options = FrameworkOptions::AstroFrontmatter;
+        assert!(options.has_global("Astro"));
     }
 
     #[test]

--- a/crates/oxc_linter/src/frameworks.rs
+++ b/crates/oxc_linter/src/frameworks.rs
@@ -107,7 +107,7 @@ pub enum FrameworkOptions {
 }
 
 /// Vue 3 compiler macros available in `<script setup>`
-/// Reference: https://github.com/vuejs/vue-eslint-parser/blob/5ff1a4fda76b07608cc17687a976c2309f5648e2/src/script-setup/scope-analyzer.ts#L86
+/// Reference: <https://github.com/vuejs/vue-eslint-parser/blob/5ff1a4fda76b07608cc17687a976c2309f5648e2/src/script-setup/scope-analyzer.ts#L86>
 static VUE_SETUP_GLOBALS: [&str; 7] = [
     "defineProps",
     "defineEmits",
@@ -119,7 +119,7 @@ static VUE_SETUP_GLOBALS: [&str; 7] = [
 ];
 
 /// Svelte runes available in `<script>` context
-/// Reference: https://github.com/sveltejs/svelte/blob/da00abe1162a8e56455e92b79020c4e33290e10e/packages/svelte/src/ambient.d.ts#L23
+/// Reference: <https://github.com/sveltejs/svelte/blob/da00abe1162a8e56455e92b79020c4e33290e10e/packages/svelte/src/ambient.d.ts#L23>
 static SVELTE_GLOBALS: [&str; 7] =
     ["$state", "$derived", "$effect", "$props", "$bindable", "$inspect", "$host"];
 

--- a/crates/oxc_linter/src/loader/partial_loader/astro.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/astro.rs
@@ -2,7 +2,7 @@ use memchr::memmem::Finder;
 
 use oxc_span::{SourceType, Span};
 
-use crate::loader::JavaScriptSource;
+use crate::{frameworks::FrameworkOptions, loader::JavaScriptSource};
 
 use super::{SCRIPT_END, SCRIPT_START};
 
@@ -47,7 +47,12 @@ impl<'a> AstroPartialLoader<'a> {
         // move start to the end of the ASTRO_SPLIT
         let start = start + ASTRO_SPLIT.len() as u32;
         let js_code = Span::new(start, end).source_text(self.source_text);
-        Some(JavaScriptSource::partial(js_code, SourceType::ts(), start))
+        Some(JavaScriptSource::partial_with_framework_options(
+            js_code,
+            SourceType::ts(),
+            FrameworkOptions::AstroFrontmatter,
+            start,
+        ))
     }
 
     /// In .astro files, you can add client-side JavaScript by adding one (or more) `<script>` tags.

--- a/crates/oxc_linter/src/loader/partial_loader/svelte.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/svelte.rs
@@ -2,7 +2,7 @@ use memchr::memmem::Finder;
 
 use oxc_span::SourceType;
 
-use crate::loader::JavaScriptSource;
+use crate::{frameworks::FrameworkOptions, loader::JavaScriptSource};
 
 use super::{SCRIPT_END, SCRIPT_START, find_script_closing_angle};
 
@@ -48,6 +48,7 @@ impl<'a> SveltePartialLoader<'a> {
         // get lang="ts" attribute
         let content = &self.source_text[*pointer..*pointer + offset];
         let is_ts = content.contains("ts");
+        let is_module = content.contains("module");
 
         *pointer += offset + 1;
         let js_start = *pointer;
@@ -62,7 +63,12 @@ impl<'a> SveltePartialLoader<'a> {
 
         // NOTE: loader checked that source_text.len() is less than u32::MAX
         #[expect(clippy::cast_possible_truncation)]
-        Some(JavaScriptSource::partial(source_text, source_type, js_start as u32))
+        Some(JavaScriptSource::partial_with_framework_options(
+            source_text,
+            source_type,
+            if is_module { FrameworkOptions::SvelteModule } else { FrameworkOptions::Svelte },
+            js_start as u32,
+        ))
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
@@ -85,7 +85,9 @@ impl Rule for NoRedeclare {
             let name = ctx.scoping().symbol_name(symbol_id);
             let decl_span = ctx.scoping().symbol_span(symbol_id);
             let is_builtin = self.built_in_globals
-                && (GLOBALS["builtin"].contains_key(name) || ctx.globals().is_enabled(name));
+                && (GLOBALS["builtin"].contains_key(name)
+                    || ctx.globals().is_enabled(name)
+                    || ctx.frameworks_options().has_global(name));
 
             if is_builtin {
                 ctx.diagnostic(no_redeclare_as_builtin_in_diagnostic(name, decl_span));

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -67,6 +67,11 @@ impl Rule for NoUndef {
                     continue;
                 }
 
+                // Check framework-specific globals (e.g., Vue's defineProps in <script setup>)
+                if ctx.frameworks_options().has_global(name) {
+                    continue;
+                }
+
                 // Skip reporting error for 'arguments' if it's in a function scope
                 if name == "arguments"
                     && ctx


### PR DESCRIPTION
- `eslint-plugin-vue` depends on `vue-eslint-parser` to manage parsing and scopes.
- We don't have a pluggable infra for parsing, so I created a generic interface for framework globals around the `FrameworkOptions` enum.
- Rules can now call `ctx.frameworks_options().has_global(name)` to check if the effective framework provides a global variable by that name.
- Provides a pipeline to address false positives and negatives in framework files without directly bringing in framework logic in vanilla rules.
- Hopefully this is a good enough solution until there's a plan for handling `parserOptions` for linter milestone 2, which may touch on frameworks.
- Closes #14987

#### Tasks
- [x] Framework: Vue
- [x] Framework: Svelte
- [x] Framework: Astro
- [x] Rule: `no-undef`
- [x] Rule: `no-redeclare`
- [x] Unit Tests
- [ ] E2E Tests
