### PR TITLE
feat(editor): Workspace Mode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,17 +3,18 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Launch Client",
       "type": "extensionHost",
       "request": "launch",
-      "name": "Launch Client",
       "runtimeExecutable": "${execPath}",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}/editors/vscode"],
       "sourceMaps": true,
-      "outFiles": ["${workspaceFolder}/editors/vscode/dist/*.js"],
+      "outFiles": ["${workspaceFolder}/editors/vscode/out/**/*.js"],
       "env": {
         "SERVER_PATH_DEV": "${workspaceRoot}/editors/vscode/target/debug/oxc_language_server",
         "RUST_LOG": "debug"
-      }
+      },
+      "preLaunchTask": "build: extension+rust"
     },
     {
       "type": "lldb",
@@ -31,6 +32,61 @@
       }
       // "args": ["--ARGS-TO-OXLINT"],
       // "cwd": "PATH-TO-TEST-PROJECT"
+    },
+    {
+      "name": "Language Server (Socket)",
+      "type": "lldb",
+      "request": "launch",
+      "cargo": {
+        "args": ["build", "--package", "oxc_language_server"],
+        "filter": {
+          "name": "oxc_language_server",
+          "kind": "bin"
+        }
+      },
+      "env": {
+        "OXC_LS_LISTEN": "unix:/tmp/oxc_ls.sock",
+        "RUST_LOG": "debug"
+      },
+      "sourceLanguages": ["rust"],
+      "expressions": "native",
+      "stopOnEntry": false,
+      "presentation": {
+        "hidden": true,
+        "group": "",
+        "order": 1
+      }
+    },
+    {
+      "name": "Launch Client (External LS)",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}/editors/vscode"],
+      "sourceMaps": true,
+      "outFiles": ["${workspaceFolder}/editors/vscode/out/**/*.js"],
+      "env": {
+        "OXC_LS_CONNECT": "unix:/tmp/oxc_ls.sock",
+        "RUST_LOG": "debug"
+      },
+      "presentation": {
+        "hidden": true,
+        "group": "",
+        "order": 1,
+      }
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Debug VS Code Extension and Oxc Language Server",
+      "configurations": ["Language Server (Socket)", "Launch Client (External LS)"],
+      "stopAll": true,
+      "preLaunchTask": "build: extension+rust",
+      "presentation": {
+        "hidden": false,
+        "group": "",
+        "order": 1
+      }
     }
   ]
 }

--- a/.vscode/lldb_rust_init.py
+++ b/.vscode/lldb_rust_init.py
@@ -14,8 +14,10 @@ home = os.environ.get("HOME", "")
 if home:
     cargo_bin = os.path.join(home, ".cargo", "bin")
     path = os.environ.get("PATH", "")
-    if cargo_bin not in path.split(":"):
-        os.environ["PATH"] = cargo_bin + (":" + path if path else "")
+    parts = path.split(os.pathsep) if path else []
+    if cargo_bin not in parts:
+        # Prepend cargo_bin preserving existing PATH using the correct platform-specific separator.
+        os.environ["PATH"] = os.pathsep.join([cargo_bin] + parts)
         log("PATH prepended with", cargo_bin)
 else:
     log("HOME unset; skipping PATH prepend")
@@ -112,7 +114,7 @@ try:
         'type summary add -e -x -F lldb_rust_init.uri_summary "^(.*(::)+)(Url|Uri)$" --category Rust'
     )
     log("Registered custom Url/Uri summary")
-except Exception as e:  # noqa: BLE001
+except Exception as e:
     log("Failed to register custom Url/Uri summary:", e)
 
 log("Rust formatter initialization complete")

--- a/.vscode/lldb_rust_init.py
+++ b/.vscode/lldb_rust_init.py
@@ -1,0 +1,118 @@
+"""LLDB Rust pretty-printer bootstrap for CodeLLDB.
+
+Loads official Rust formatters (lldb_lookup + lldb_commands) without hardcoded toolchain paths.
+Adds summaries for core collection types and adjusts string length. Safe to re-run.
+"""
+from __future__ import annotations
+import os, sys, shutil, subprocess
+
+def log(*parts: object) -> None:
+    print("[lldb_rust_init]", *parts)
+
+# 1) Ensure ~/.cargo/bin on PATH so rustc is discoverable when launched via CodeLLDB.
+home = os.environ.get("HOME", "")
+if home:
+    cargo_bin = os.path.join(home, ".cargo", "bin")
+    path = os.environ.get("PATH", "")
+    if cargo_bin not in path.split(":"):
+        os.environ["PATH"] = cargo_bin + (":" + path if path else "")
+        log("PATH prepended with", cargo_bin)
+else:
+    log("HOME unset; skipping PATH prepend")
+
+# 2) Locate rustc & sysroot.
+rustc = shutil.which("rustc")
+if not rustc:
+    log("rustc NOT FOUND; aborting formatter init")
+    raise SystemExit
+log("rustc ->", rustc)
+try:
+    sysroot = subprocess.check_output([rustc, "--print", "sysroot"], text=True).strip()
+except Exception as e:  # noqa: BLE001
+    log("Failed to get sysroot:", e)
+    raise SystemExit
+log("sysroot ->", sysroot)
+
+etc_dir = os.path.join(sysroot, "lib", "rustlib", "etc")
+if not os.path.isdir(etc_dir):
+    log("Missing etc dir:", etc_dir)
+    raise SystemExit
+log("Loading Rust formatters from", etc_dir)
+
+# 3) Import lldb_lookup & source lldb_commands via LLDB command API.
+if etc_dir not in sys.path:
+    sys.path.append(etc_dir)
+try:
+    import lldb_lookup  # type: ignore
+    log("Imported lldb_lookup OK")
+except Exception as e:  # noqa: BLE001
+    log("Import lldb_lookup FAILED:", e)
+    raise SystemExit
+
+# Acquire lldb debugger object from injected global 'lldb' (provided by CodeLLDB environment).
+try:
+    import lldb  # type: ignore
+except Exception as e:  # noqa: BLE001
+    log("Unable to import lldb module (unexpected):", e)
+    raise SystemExit
+
+dbg = lldb.debugger
+
+# Source the static commands file for additional summaries (matches rust-lldb behavior).
+commands_path = os.path.join(etc_dir, "lldb_commands")
+if os.path.isfile(commands_path):
+    dbg.HandleCommand(f"command source -s 0 {commands_path}")
+    log("Sourced", commands_path)
+else:
+    log("Commands file not found:", commands_path)
+
+# Enable Rust category & increase max string summary length.
+dbg.HandleCommand("type category enable Rust")
+dbg.HandleCommand("settings set target.max-string-summary-length 2000")
+
+# Register Vec printers explicitly (defensive if commands file changes in future).
+dbg.HandleCommand(
+    'type synthetic add -l lldb_lookup.synthetic_lookup -x "^(alloc::([a-z_]+::)+)Vec<.+>$" --category Rust'
+)
+dbg.HandleCommand(
+    'type summary add -F lldb_lookup.summary_lookup -e -x -h "^(alloc::([a-z_]+::)+)Vec<.+>$" --category Rust'
+)
+
+# Provide a concise summary for URI types (lsp_types::Url / fluent_uri::Uri wrappers).
+# These commonly contain an inner String we want to display directly.
+# We attempt a regex that matches types ending with `::Uri` or `::Url` and which have a
+# single field referencing alloc::string::String.
+def uri_summary(val_obj):  # noqa: D401
+    """LLDB summary callback for various Uri/Url wrapper types.
+
+    Tries to locate an inner alloc::string::String and return its contents.
+    Falls back to existing lldb_lookup.summary_lookup if structure differs.
+    """
+    try:
+        # Heuristics: search immediate children then recurse one level.
+        for child in val_obj.children:
+            ty = child.type.name or ""
+            if "alloc::string::String" in ty:
+                # Use the default Rust String summary by delegating to lldb_lookup.
+                import lldb_lookup  # type: ignore
+                return lldb_lookup.summary_lookup(child)
+        # Recurse one level for wrappers like tuple struct or newtype.
+        for child in val_obj.children:
+            for gchild in child.children:
+                ty = gchild.type.name or ""
+                if "alloc::string::String" in ty:
+                    import lldb_lookup  # type: ignore
+                    return lldb_lookup.summary_lookup(gchild)
+    except Exception as e:  # noqa: BLE001
+        return f"<uri err: {e}>"
+    return "<uri>"
+
+try:
+    dbg.HandleCommand(
+        'type summary add -e -x -F lldb_rust_init.uri_summary "^(.*(::)+)(Url|Uri)$" --category Rust'
+    )
+    log("Registered custom Url/Uri summary")
+except Exception as e:  # noqa: BLE001
+    log("Failed to register custom Url/Uri summary:", e)
+
+log("Rust formatter initialization complete")

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,10 @@
     //
     // Reference: https://github.com/vadimcn/codelldb/issues/1166
     "lldb.launch.initCommands": [
-        // Import external module so its functions (uri_summary) are addressable by name.
-        "script import os, sys; mod_path = os.path.join(os.getcwd(), '.vscode'); print('[codelldb:init] adding', mod_path); sys.path.append(mod_path) if mod_path not in sys.path else None; import lldb_rust_init"
+        // Import Rust LLDB formatters and custom URI summaries
+        "script import sys; sys.path.append('.vscode'); import lldb_rust_init"
     ],
+    "lldb.showDisassembly": "auto",
+    "lldb.dereferencePointers": true,
+    "lldb.consoleMode": "commands",
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+    // Fix for CodeLLDB v1.11.0+ not showing Rust Vec contents in debugger
+    //
+    // Problem: CodeLLDB v1.11.0+ stopped bundling Rust pretty printers and expects
+    // them to load automatically from the Rust toolchain, but this often fails.
+    // Symptoms: Vec<T> shows only "buf" and "len" instead of expandable elements
+    //
+    // Solution: Manually load the Rust LLDB formatters using preRunCommands
+    // - Uses dynamic path resolution via `rustc --print sysroot` for cross-platform compatibility
+    // - Works on Linux, Windows, and macOS without hardcoded paths
+    //
+    // Reference: https://github.com/vadimcn/codelldb/issues/1166
+    "lldb.launch.initCommands": [
+        // Import external module so its functions (uri_summary) are addressable by name.
+        "script import os, sys; mod_path = os.path.join(os.getcwd(), '.vscode'); print('[codelldb:init] adding', mod_path); sys.path.append(mod_path) if mod_path not in sys.path else None; import lldb_rust_init"
+    ],
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -59,6 +59,23 @@
       ]
     },
     {
+      "label": "extension: compile",
+      "type": "npm",
+      "script": "compile",
+      "options": {
+        "cwd": "${workspaceFolder}/editors/vscode"
+      },
+      "group": "build",
+      "presentation": {
+        "panel": "dedicated",
+        "reveal": "silent",
+        "clear": true
+      },
+      "problemMatcher": [
+        "$tsc"
+      ]
+    },
+    {
       "type": "shell",
       "command": "cd ./editors/vscode && npm run watch",
       "windows": {
@@ -70,6 +87,17 @@
       "presentation": {
         "panel": "dedicated",
         "reveal": "never"
+      }
+    },
+    {
+      "label": "build: extension+rust",
+      "dependsOn": [
+        "extension: compile",
+        "rust: cargo test --no-run"
+      ],
+      "problemMatcher": [],
+      "group": {
+        "kind": "build"
       }
     }
   ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1443,6 +1443,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "napi"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3509,6 +3520,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
+name = "socket2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3685,8 +3706,13 @@ version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
+ "bytes",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4211,7 +4237,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4220,7 +4246,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -4238,14 +4273,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4264,10 +4316,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4276,10 +4340,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4288,10 +4364,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4300,10 +4388,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -252,6 +252,14 @@ oxc_ast_macros.opt-level = 1
 insta.opt-level = 3
 similar.opt-level = 3
 
+# Re-enable debuginfo for the language server specifically so Rust breakpoints bind when
+# debugging via the "Language Server (Socket)" launch configuration. The top-level
+# `[profile.dev] debug = false` disables DWARF info globally which caused LLDB to only
+# show assembly and ignore source breakpoints in this binary.
+[profile.dev.package.oxc_language_server]
+debug = true
+opt-level = 0
+
 [profile.release.package.oxc_playground_napi]
 opt-level = 'z'
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,27 @@ For more information, check out our website at [oxc.rs](https://oxc.rs).
 
 <sub>* Oxidation is the chemical process that creates rust</sub>
 
+## Workspace-wide Linting (Experimental)
+
+Oxlint now supports an optional workspace-wide linting mode in the VS Code extension.
+
+When enabled, all lintable files in the workspace are analyzed eagerly (not only the ones you open). This provides:
+
+- Immediate visibility of problems across the entire codebase in the Problems panel
+- Automatic incremental re-linting of changed files via LSP file watchers
+- Respect for `.gitignore` and oxlint ignore patterns
+- High performance through internal parallelization and batching
+
+Enable it via the VS Code setting: `oxc.lint.workspaceMode`.
+
+Notes:
+- This feature is currently experimental and disabled by default.
+- Designed to scale to large monorepos (thousands of files) while remaining fast.
+- Only re-lints changed files after the initial scan to minimize overhead.
+- Supports common JS/TS framework file extensions (js, mjs, cjs, jsx, ts, mts, cts, tsx, vue, svelte, astro).
+
+Planned improvements include progress reporting during the initial scan and additional configurability (custom include/exclude globs).
+
 ## 🏗️ Design Principles
 
 - **Performance**: Through rigorous performance engineering.

--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -38,7 +38,7 @@ papaya = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "io-std", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "io-std", "io-util", "macros", "net"] }
 tower-lsp-server = { workspace = true, features = ["proposed"] }
 
 [dev-dependencies]

--- a/crates/oxc_language_server/src/linter/options.rs
+++ b/crates/oxc_language_server/src/linter/options.rs
@@ -31,6 +31,7 @@ pub struct LintOptions {
     pub type_aware: bool,
     pub disable_nested_config: bool,
     pub fix_kind: LintFixKindFlag,
+    pub workspace_mode: bool,
 }
 
 #[derive(Debug, Default, Serialize, PartialEq, Eq, Deserialize, Clone)]
@@ -135,6 +136,9 @@ impl TryFrom<Value> for LintOptions {
                     Some(&"all") => LintFixKindFlag::All,
                     _ => LintFixKindFlag::default(),
                 }),
+            workspace_mode: object
+                .get("workspaceMode")
+                .is_some_and(|key| serde_json::from_value::<bool>(key.clone()).unwrap_or_default()),
         })
     }
 }

--- a/crates/oxc_language_server/src/linter/tsgo_linter.rs
+++ b/crates/oxc_language_server/src/linter/tsgo_linter.rs
@@ -1,14 +1,16 @@
 use std::{
-    path::Path,
+    path::{Path, PathBuf},
     sync::{Arc, OnceLock},
 };
 
+use log::debug;
 use oxc_data_structures::rope::Rope;
 use oxc_linter::{
     ConfigStore, LINTABLE_EXTENSIONS, TsGoLintState, loader::LINT_PARTIAL_LOADER_EXTENSIONS,
     read_to_string,
 };
 use rustc_hash::FxHashSet;
+use std::time::Instant;
 use tower_lsp_server::{UriExt, lsp_types::Uri};
 
 use crate::linter::error_with_position::{
@@ -36,8 +38,9 @@ impl TsgoLinter {
         let rope = Rope::from_str(&source_text);
 
         // TODO: Avoid cloning the source text
-        let messages =
-            self.state.lint_source(&Arc::from(path.as_os_str()), source_text.clone()).ok()?;
+        let t0 = Instant::now();
+        let messages_group = self.state.lint_source(&[Arc::from(path.as_os_str())]).ok()?;
+        let messages = messages_group.into_iter().next().map(|(_, v)| v)?;
 
         let mut diagnostics: Vec<DiagnosticReport> = messages
             .iter()
@@ -47,6 +50,12 @@ impl TsgoLinter {
         let mut inverted_diagnostics = generate_inverted_diagnostics(&diagnostics, uri);
         diagnostics.append(&mut inverted_diagnostics);
 
+        debug!(
+            "[profile] tsgo single internal uri={:?} diagnostics={} ms={}",
+            uri,
+            diagnostics.len(),
+            t0.elapsed().as_millis()
+        );
         Some(diagnostics)
     }
 
@@ -63,5 +72,87 @@ impl TsgoLinter {
         path.extension()
             .and_then(std::ffi::OsStr::to_str)
             .is_some_and(|ext| wanted_exts.contains(ext))
+    }
+
+    /// Batch lint multiple URIs using a single tsgolint invocation.
+    /// Returns vector of (Uri, DiagnosticReport) for each file with diagnostics.
+    pub fn lint_batch(&self, uris: &[Uri]) -> Vec<(Uri, Vec<DiagnosticReport>)> {
+        // Prepare eligible paths (filter out unsupported extensions early).
+        let mut path_map: Vec<(Uri, PathBuf)> = Vec::with_capacity(uris.len());
+        for uri in uris {
+            if let Some(p) = uri.to_file_path() {
+                let owned = p.into_owned();
+                if Self::should_lint_path(&owned) {
+                    path_map.push((uri.clone(), owned));
+                }
+            }
+        }
+
+        if path_map.is_empty() {
+            return Vec::new();
+        }
+
+        let arcs: Vec<Arc<std::ffi::OsStr>> =
+            path_map.iter().map(|(_, p)| Arc::from(p.as_os_str())).collect();
+        // Collect simple metrics before invoking lint_source.
+        let mut total_bytes: u64 = 0;
+        let mut ext_counts: std::collections::HashMap<String, usize> =
+            std::collections::HashMap::new();
+        for (_, p) in &path_map {
+            if let Ok(meta) = std::fs::metadata(p) {
+                total_bytes += meta.len();
+            }
+            if let Some(ext) = p.extension().and_then(std::ffi::OsStr::to_str) {
+                *ext_counts.entry(ext.to_string()).or_insert(0) += 1;
+            }
+        }
+        let t0 = Instant::now();
+        log::info!(
+            "[tsgo] internal batch start eligible_paths={} total_bytes={} ext_stats={:?}",
+            arcs.len(),
+            total_bytes,
+            ext_counts
+        );
+        let t_invoke = Instant::now();
+        let batch_result = self.state.lint_source(&arcs);
+        let invoke_ms = t_invoke.elapsed().as_millis();
+        let mut out = Vec::new();
+
+        match batch_result {
+            Ok(grouped) => {
+                for (path_buf, messages) in grouped.into_iter() {
+                    // Map back to Uri by matching file path string
+                    if let Some((uri, _)) =
+                        path_map.iter().find(|(_, original)| original == &path_buf)
+                    {
+                        if let Ok(source_text) = read_to_string(&path_buf) {
+                            let rope = Rope::from_str(&source_text);
+                            let mut diagnostics: Vec<DiagnosticReport> = messages
+                                .iter()
+                                .map(|m| message_to_lsp_diagnostic(m, uri, &source_text, &rope))
+                                .collect();
+                            let mut inverted = generate_inverted_diagnostics(&diagnostics, uri);
+                            diagnostics.append(&mut inverted);
+                            out.push((uri.clone(), diagnostics));
+                        }
+                    }
+                }
+            }
+            Err(_err) => {
+                // On failure, degrade gracefully: no batch diagnostics (caller may fall back to sequential path).
+            }
+        }
+
+        // Deterministic ordering
+        out.sort_unstable_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
+        debug!(
+            "[tsgo] internal batch done eligible_paths={} produced={} elapsed_ms_total={} invoke_ms={} total_bytes={}",
+            path_map.len(),
+            out.len(),
+            t0.elapsed().as_millis(),
+            invoke_ms,
+            total_bytes
+        );
+        out
     }
 }

--- a/crates/oxc_language_server/src/log_bridge.rs
+++ b/crates/oxc_language_server/src/log_bridge.rs
@@ -1,0 +1,75 @@
+use std::sync::{OnceLock, RwLock};
+use tower_lsp_server::{Client, lsp_types::MessageType};
+
+// Global LSP client used for window/logMessage forwarding. We allow replacement
+// on language server restarts. OnceLock guards initialization of the RwLock itself.
+static GLOBAL_CLIENT: OnceLock<RwLock<Option<Client>>> = OnceLock::new();
+
+fn client_cell() -> &'static RwLock<Option<Client>> {
+    GLOBAL_CLIENT.get_or_init(|| RwLock::new(None))
+}
+
+/// Set or replace the global client (called from Backend::new on each start/restart).
+pub fn set_global_client(client: Client) {
+    *client_cell().write().unwrap() = Some(client);
+}
+
+/// Get a clone of the current client for sending notifications.
+pub fn get_global_client() -> Option<Client> {
+    client_cell().read().unwrap().as_ref().cloned()
+}
+
+// Global logger wrapper forwarding ALL log crate emissions to LSP window/logMessage.
+pub struct LspForwardingLogger {
+    fallback: env_logger::Logger,
+}
+
+impl log::Log for LspForwardingLogger {
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        self.fallback.enabled(metadata)
+    }
+
+    fn log(&self, record: &log::Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+        // Try forwarding to LSP client if initialized.
+        if let Some(client) = get_global_client() {
+            let level = match record.level() {
+                log::Level::Error => MessageType::ERROR,
+                log::Level::Warn => MessageType::WARNING,
+                log::Level::Info => MessageType::INFO,
+                _ => MessageType::LOG,
+            };
+            // The tower_lsp_server Client API is async; calling log_message returns a lazy Future.
+            // Previously we ignored it, so the notification was never actually sent.
+            // Spawn the future on the current Tokio runtime if available. If no runtime is
+            // present (e.g. in certain test contexts), we silently skip forwarding to avoid
+            // panicking. The fallback logger below still emits the message to stdout/stderr.
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                let msg = record.args().to_string();
+                handle.spawn(async move {
+                    client.log_message(level, msg).await;
+                });
+            }
+        }
+        // Always emit via fallback (stdout/stderr formatting, filtering, etc.).
+        self.fallback.log(record);
+    }
+
+    fn flush(&self) {
+        self.fallback.flush();
+    }
+}
+
+/// Initialize the global logger with LSP forwarding. Call exactly once at program start.
+pub fn init_global_logger() {
+    // Build env_logger using environment configuration (RUST_LOG, etc.)
+    let mut builder = env_logger::Builder::from_env(env_logger::Env::default());
+    let fallback = builder.build();
+    // Install composite logger. Ignore error if someone already set a logger (tests).
+    if log::set_boxed_logger(Box::new(LspForwardingLogger { fallback })).is_ok() {
+        // Allow logger's internal filter to decide; pass everything through log crate.
+        log::set_max_level(log::LevelFilter::Trace);
+    }
+}

--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -1,4 +1,8 @@
 use rustc_hash::FxBuildHasher;
+#[cfg(unix)]
+use std::path::PathBuf;
+#[cfg(unix)]
+use tokio::net::UnixListener;
 use tower_lsp_server::{LspService, Server};
 
 mod backend;
@@ -8,6 +12,7 @@ mod commands;
 mod file_system;
 mod formatter;
 mod linter;
+mod log_bridge;
 mod options;
 #[cfg(test)]
 mod tester;
@@ -23,8 +28,71 @@ const FORMAT_CONFIG_FILES: &[&str; 2] = &[".oxfmtrc.json", ".oxfmtrc.jsonc"];
 
 #[tokio::main]
 async fn main() {
-    env_logger::init();
+    // Initialize composite logger that forwards log crate events to LSP (client set later).
+    crate::log_bridge::init_global_logger();
+    // Optional external listen mode for debugger / external host integration.
+    // Activate by setting env var: OXC_LS_LISTEN=unix:/tmp/oxc_ls.sock
+    #[cfg(unix)]
+    if let Ok(listen_spec) = std::env::var("OXC_LS_LISTEN") {
+        if let Some(path) = listen_spec.strip_prefix("unix:") {
+            // Remove stale socket file (ignore errors) to avoid bind failures.
+            let _ = std::fs::remove_file(path);
 
+            match UnixListener::bind(path) {
+                Ok(listener) => {
+                    // Guard to remove the socket file when the process exits (listener dropped).
+                    struct SocketCleanup(PathBuf);
+                    impl Drop for SocketCleanup {
+                        fn drop(&mut self) {
+                            // Best-effort cleanup; ignore errors.
+                            let _ = std::fs::remove_file(&self.0);
+                        }
+                    }
+                    let _cleanup = SocketCleanup(PathBuf::from(path));
+
+                    eprintln!("[oxc-language-server] Listening on unix socket: {path}");
+
+                    // Accept loop: allow sequential LSP sessions (e.g., VSCode client.restart())
+                    // without requiring an external supervisor to recreate the server.
+                    // Each iteration runs a full LSP lifecycle (initialize -> ... -> shutdown/exit).
+                    // The VSCode extension sends explicit shutdown/exit before a restart when
+                    // OXC_LS_CONNECT is set. After serve() returns we immediately accept the next
+                    // connection. This prevents connection refusal races previously observed when
+                    // the server exited entirely and the client retried before a new process was
+                    // spawned.
+                    loop {
+                        let (stream, _addr) = match listener.accept().await {
+                            Ok(v) => v,
+                            Err(err) => {
+                                eprintln!(
+                                    "[oxc-language-server] Accept error: {err}. Shutting down accept loop."
+                                );
+                                break; // exit to stdio fallback? we already bound unix, so just end.
+                            }
+                        };
+
+                        eprintln!("[oxc-language-server] Client connected. Starting LSP session.");
+                        let (service, socket) = LspService::build(Backend::new).finish();
+                        let (read_half, write_half) = tokio::io::split(stream);
+                        Server::new(read_half, write_half, socket).serve(service).await;
+                        eprintln!(
+                            "[oxc-language-server] LSP session ended. Waiting for next client..."
+                        );
+                        // Loop continues to accept next connection (e.g., after a client restart).
+                    }
+                    // After breaking from loop (e.g., accept error), exit main.
+                    return;
+                }
+                Err(err) => {
+                    eprintln!(
+                        "[oxc-language-server] Failed to bind unix socket {path}: {err}. Falling back to stdio."
+                    );
+                }
+            }
+        }
+    }
+
+    // Fallback stdio mode (default when no listen spec provided)
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 

--- a/crates/oxc_language_server/src/options.rs
+++ b/crates/oxc_language_server/src/options.rs
@@ -3,13 +3,25 @@ use tower_lsp_server::lsp_types::Uri;
 
 use crate::{formatter::options::FormatOptions, linter::options::LintOptions};
 
-#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Options {
     #[serde(flatten)]
     pub lint: LintOptions,
     #[serde(flatten)]
     pub format: FormatOptions,
+    #[serde(default)]
+    pub supported_extensions: Vec<String>,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            lint: LintOptions::default(),
+            format: FormatOptions::default(),
+            supported_extensions: Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -1,4 +1,6 @@
 use std::borrow::Cow;
+#[cfg(feature = "language_server")]
+use std::{ffi::OsStr, sync::Arc};
 
 use oxc_codegen::{Codegen, CodegenOptions};
 use oxc_diagnostics::OxcDiagnostic;
@@ -225,6 +227,8 @@ pub struct Message {
     fixed: bool,
     #[cfg(feature = "language_server")]
     pub section_offset: u32,
+    #[cfg(feature = "language_server")]
+    pub file_path: Arc<OsStr>,
 }
 
 impl Message {
@@ -244,6 +248,8 @@ impl Message {
             fixed: false,
             #[cfg(feature = "language_server")]
             section_offset: 0,
+            #[cfg(feature = "language_server")]
+            file_path: Arc::from(OsStr::new("")), // will be set later via with_file_path
         }
     }
 
@@ -251,6 +257,13 @@ impl Message {
     #[must_use]
     pub fn with_section_offset(mut self, section_offset: u32) -> Self {
         self.section_offset = section_offset;
+        self
+    }
+
+    #[cfg(feature = "language_server")]
+    #[must_use]
+    pub fn with_file_path(mut self, path: &Arc<OsStr>) -> Self {
+        self.file_path = Arc::clone(path);
         self
     }
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -74,6 +74,13 @@
           "default": "onType",
           "description": "Run the linter on save (onSave) or on type (onType)"
         },
+        "oxc.lint.workspaceMode": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "description": "Enable workspace-wide linting. When enabled, all files in the workspace will be analyzed, not just open files.",
+          "tags": ["experimental"]
+        },
         "oxc.enable": {
           "type": "boolean",
           "default": true,
@@ -157,7 +164,8 @@
           "type": "boolean",
           "scope": "resource",
           "default": false,
-          "description": "Enable experimental formatting support. This feature is experimental and might not work as expected."
+          "description": "Enable experimental formatting support. This feature is experimental and might not work as expected.",
+          "tags": ["experimental"]
         },
         "oxc.fmt.configPath": {
           "type": [


### PR DESCRIPTION
- Introduced `workspace_mode` option in `LintOptions` to enable workspace-wide linting.
- Updated `ServerLinter` to handle workspace mode, suppressing per-file tsgo linting.
- Implemented `lint_workspace` method in `WorkspaceWorker` for batch linting of all files.
- Added support for workspace mode in `TsgoLinter` for batch linting.
- Created `log_bridge` to forward log messages to the LSP client.
- Enhanced logging for linting operations, including performance metrics.
- Updated VSCode extension configuration to include `workspaceMode` setting.
- Modified `Options` struct to support `supported_extensions` for linting.
- Improved diagnostics caching and handling for isolated and tsgo linting.