### PR TITLE
docs(linter): Add configuration option docs for eslint/sort-keys rule.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/sort_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_keys.rs
@@ -7,25 +7,34 @@ use oxc_ast::{AstKind, ast::ObjectPropertyKind};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 #[derive(Debug, Default, Clone)]
 pub struct SortKeys(Box<SortKeysOptions>);
 
-#[derive(Debug, Default, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
 pub enum SortOrder {
     Desc,
     #[default]
     Asc,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct SortKeysOptions {
+    /// Sorting order for keys. Accepts "asc" for ascending or "desc" for descending.
     sort_order: SortOrder,
+    /// Whether the sort comparison is case-sensitive (A < a when true).
     case_sensitive: bool,
+    /// Use natural sort order so that, for example, "a2" comes before "a10".
     natural: bool,
+    /// Minimum number of properties required in an object before sorting is enforced.
     min_keys: usize,
+    /// When true, groups of properties separated by a blank line are sorted independently.
     allow_line_separated_groups: bool,
 }
 
@@ -84,7 +93,8 @@ declare_oxc_lint!(
     SortKeys,
     eslint,
     style,
-    conditional_fix
+    conditional_fix,
+    config = SortKeysOptions
 );
 
 impl Rule for SortKeys {


### PR DESCRIPTION
Part of #14743.

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### allowLineSeparatedGroups

type: `boolean`

default: `false`

When true, groups of properties separated by a blank line are sorted independently.


### caseSensitive

type: `boolean`

default: `true`

Whether the sort comparison is case-sensitive (A < a when true).


### minKeys

type: `integer`

default: `2`

Minimum number of properties required in an object before sorting is enforced.


### natural

type: `boolean`

default: `false`

Use natural sort order so that, for example, "a2" comes before "a10".


### sortOrder

type: `"desc" | "asc"`

default: `"asc"`

Sorting order for keys. Accepts "asc" for ascending or "desc" for descending.
```