### PR TITLE
docs(linter): Add configuration option docs for eslint/no-extra-boolean-cast rule.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
@@ -72,7 +72,8 @@ declare_oxc_lint!(
     NoExtraBooleanCast,
     eslint,
     correctness,
-    conditional_fix_or_conditional_suggestion
+    conditional_fix_or_conditional_suggestion,
+    config = NoExtraBooleanCast,
 );
 
 impl Rule for NoExtraBooleanCast {


### PR DESCRIPTION
This was just missing the config definition in the macro.

Part of #14743.

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### enforceForInnerExpressions

type: `boolean`

default: `false`

when set to `true`, in addition to checking default contexts, checks
whether extra boolean casts are present in expressions whose result is
used in a boolean context. See examples below. Default is `false`,
meaning that this rule by default does not warn about extra booleans
cast inside inner expressions.
```