### PR TITLE
docs(linter): Add configuration option docs for typescript/explicit-module-boundary-types rule.

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
@@ -167,6 +167,7 @@ declare_oxc_lint!(
     ExplicitModuleBoundaryTypes,
     typescript,
     restriction,
+    config = Config,
 );
 
 impl Rule for ExplicitModuleBoundaryTypes {


### PR DESCRIPTION
This was just missing the config definition in the macro.

Part of #14743.

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### allowArgumentsExplicitlyTypedAsAny

type: `boolean`

default: `false`

Whether to ignore arguments that are explicitly typed as `any`.


### allowDirectConstAssertionInArrowFunctions

type: `boolean`

default: `true`

Whether to ignore return type annotations on body-less arrow functions
that return an `as const` type assertion. You must still type the
parameters of the function.


### allowHigherOrderFunctions

type: `boolean`

default: `true`

Whether to ignore return type annotations on functions immediately
returning another function expression. You must still type the
parameters of the function.


### allowOverloadFunctions

type: `boolean`

default: `false`

Whether to ignore return type annotations on functions with overload
signatures.


### allowTypedFunctionExpressions

type: `boolean`

default: `true`

Whether to ignore type annotations on the variable of a function
expression.


### allowedNames

type: `string[]`

default: `[]`

An array of function/method names that will not have their arguments or
return values checked.
```