### PR TITLE
fix(tasks/prettier_conformance): Skip tests which cannot parse

### DIFF
--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 656/749 (87.58%)
+js compatibility: 673/749 (89.85%)
 
 # Failed
 
@@ -17,27 +17,11 @@ js compatibility: 656/749 (87.58%)
 | js/comments/if.js | 💥💥 | 74.83% |
 | js/comments/return-statement.js | 💥💥 | 98.28% |
 | js/comments/tagged-template-literal.js | 💥💥 | 92.86% |
-| js/comments/html-like/comment.js | 💥 | 0.00% |
 | js/comments/tagged-template-literal/11662.js | 💥 | 80.00% |
 | js/conditional/comments.js | 💥✨ | 23.69% |
 | js/conditional/new-ternary-examples.js | 💥✨ | 20.14% |
 | js/conditional/new-ternary-spec.js | 💥✨ | 24.35% |
 | js/conditional/postfix-ternary-regressions.js | 💥✨ | 20.77% |
-| js/discard-binding/array-pattern.js | 💥 | 0.00% |
-| js/discard-binding/basic.js | 💥 | 0.00% |
-| js/discard-binding/discard-binding-arrow-params.js | 💥 | 0.00% |
-| js/discard-binding/discard-binding-assignment.js | 💥 | 0.00% |
-| js/discard-binding/discard-binding-async-arrow-params.js | 💥 | 0.00% |
-| js/discard-binding/discard-binding-bindings.js | 💥 | 0.00% |
-| js/discard-binding/discard-binding-for-await-using-binding.js | 💥 | 0.00% |
-| js/discard-binding/discard-binding-for-bindings.js | 💥 | 0.00% |
-| js/discard-binding/discard-binding-for-lhs.js | 💥 | 0.00% |
-| js/discard-binding/discard-binding-for-using-binding.js | 💥 | 0.00% |
-| js/discard-binding/function-parameter.js | 💥 | 0.00% |
-| js/discard-binding/object-pattern.js | 💥 | 0.00% |
-| js/discard-binding/unary-expression-void.js | 💥 | 0.00% |
-| js/discard-binding/using-variable-declarator.js | 💥 | 0.00% |
-| js/discard-binding/using.js | 💥 | 0.00% |
 | js/explicit-resource-management/for-await-using-of-comments.js | 💥 | 0.00% |
 | js/explicit-resource-management/valid-await-using-comments.js | 💥 | 66.67% |
 | js/for/9812-unstable.js | 💥 | 45.45% |
@@ -90,7 +74,6 @@ js compatibility: 656/749 (87.58%)
 | js/test-declarations/angularjs_inject.js | 💥💥 | 91.53% |
 | js/test-declarations/test_declarations.js | 💥💥 | 95.88% |
 | js/trailing-comma/dynamic-import.js | 💥💥💥 | 0.00% |
-| jsx/expression-with-types/expression.js | 💥💥💥💥 | 0.00% |
 | jsx/fbt/test.js | 💥 | 84.06% |
 | jsx/jsx/quotes.js | 💥💥💥💥 | 79.41% |
 | jsx/jsx/regex.js | 💥💥💥💥 | 75.00% |

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,10 +1,9 @@
-ts compatibility: 532/598 (88.96%)
+ts compatibility: 537/598 (89.80%)
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
-| jsx/expression-with-types/expression.js | 💥💥💥💥 | 0.00% |
 | jsx/fbt/test.js | 💥 | 84.06% |
 | jsx/jsx/quotes.js | 💥💥💥💥 | 79.41% |
 | jsx/jsx/regex.js | 💥💥💥💥 | 75.00% |
@@ -36,9 +35,7 @@ ts compatibility: 532/598 (88.96%)
 | typescript/conditional-types/nested-in-condition.ts | 💥✨ | 15.79% |
 | typescript/conditional-types/new-ternary-spec.ts | 💥✨ | 10.67% |
 | typescript/conditional-types/parentheses.ts | 💥✨ | 15.22% |
-| typescript/conformance/types/functions/functionOverloadErrorsSyntax.ts | 💥 | 0.00% |
 | typescript/decorators-ts/angular.ts | 💥 | 87.50% |
-| typescript/definite/without-annotation.ts | 💥 | 91.67% |
 | typescript/import-require/comments.ts | 💥 | 33.33% |
 | typescript/import-type/long-module-name/long-module-name2.ts | 💥 | 25.00% |
 | typescript/import-type/long-module-name/long-module-name4.ts | 💥 | 89.29% |
@@ -61,8 +58,6 @@ ts compatibility: 532/598 (88.96%)
 | typescript/prettier-ignore/mapped-types.ts | 💥 | 96.61% |
 | typescript/property-signature/consistent-with-flow/comments.ts | 💥 | 80.00% |
 | typescript/property-signature/consistent-with-flow/union.ts | 💥 | 85.71% |
-| typescript/type-arguments-bit-shift-left-like/3.ts | 💥 | 0.00% |
-| typescript/type-arguments-bit-shift-left-like/5.tsx | 💥 | 0.00% |
 | typescript/type-params/18041.ts | 💥 | 43.75% |
 | typescript/type-params/constraints-and-default-2.ts | 💥 | 97.60% |
 | typescript/type-params/constraints-and-default.ts | 💥 | 87.32% |

--- a/tasks/prettier_conformance/src/ignore_list.rs
+++ b/tasks/prettier_conformance/src/ignore_list.rs
@@ -76,9 +76,6 @@ pub const IGNORE_TESTS: &[&str] = &[
     // non-standard syntax
     "js/deferred-import-evaluation",
     "js/bind-expressions",
-    // Unsupported stage3 features
-    "tuple-and-record.js",
-    "js/async-do-expressions",
     // Babel plugins (mostly experimental syntaxes)
     "js/babel-plugins",
     "js/destructuring-private-fields",


### PR DESCRIPTION
If the parser reports a syntax error, simply skip the test.
`oxfmt` already reports error for this case.

By this change, tests containing unsupported syntax such as stage 2, 3 will be automatically ignored.

I'll add notes in the line comments to explain what they were like.