### PR TITLE
fix(linter): prevent underflow in count_comment_lines for JSX files

### DIFF
--- a/crates/oxc_linter/src/utils/comment.rs
+++ b/crates/oxc_linter/src/utils/comment.rs
@@ -23,6 +23,37 @@ pub fn count_comment_lines(comment: &Comment, source_text: &str) -> usize {
         if line_has_just_comment(comment_end_line, "*/") {
             end_line += 1;
         }
-        end_line - start_line
+        end_line.saturating_sub(start_line)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use oxc_allocator::Allocator;
+    use oxc_parser::Parser;
+    use oxc_semantic::SemanticBuilder;
+    use oxc_span::SourceType;
+
+    #[test]
+    fn test_jsx_comment_should_panic() {
+        let source = r#"export function Component() {
+  return (
+    <div>
+      {/* hello */}
+      <span>content</span>
+    </div>
+  );
+}"#;
+
+        let allocator = Allocator::default();
+        let source_type = SourceType::tsx();
+        let ret = Parser::new(&allocator, source, source_type).parse();
+        let semantic = SemanticBuilder::new().build(&ret.program).semantic;
+
+        // This should panic with integer overflow
+        for comment in semantic.comments() {
+            let _lines = count_comment_lines(comment, source);
+        }
     }
 }


### PR DESCRIPTION
When processing JSX inline comments like `{/* comment */}` with the eslint/max-lines rule using skipComments: true, the count_comment_lines function would calculate start_line > end_line, causing integer underflow.

This resulted in:
- Debug mode: panic with "attempt to subtract with overflow"
- Release mode: wrapping to usize::MAX, incorrect line count

Fix by using saturating_sub which:
- Prevents panic in all build modes
- Returns 0 for inline comments (logically correct)
- Maintains correct behavior for multi-line comments

Added test case to prevent regression.