### PR TITLE
refactor(formatter): Export unified way to get_parse_options

### DIFF
--- a/apps/oxfmt/src/service.rs
+++ b/apps/oxfmt/src/service.rs
@@ -5,8 +5,8 @@ use rayon::prelude::*;
 
 use oxc_allocator::Allocator;
 use oxc_diagnostics::{DiagnosticSender, DiagnosticService, OxcDiagnostic};
-use oxc_formatter::{FormatOptions, Formatter, enable_jsx_source_type};
-use oxc_parser::{ParseOptions, Parser};
+use oxc_formatter::{FormatOptions, Formatter, enable_jsx_source_type, get_parse_options};
+use oxc_parser::Parser;
 
 use crate::{command::OutputOptions, walk::WalkEntry};
 
@@ -53,14 +53,7 @@ impl FormatService {
         let allocator = Allocator::new();
 
         let ret = Parser::new(&allocator, &source_text, source_type)
-            .with_options(ParseOptions {
-                parse_regular_expression: false,
-                // Enable all syntax features
-                allow_v8_intrinsics: true,
-                allow_return_outside_function: true,
-                // `oxc_formatter` expects this to be false
-                preserve_parens: false,
-            })
+            .with_options(get_parse_options())
             .parse();
         if !ret.errors.is_empty() {
             let diagnostics = DiagnosticService::wrap_diagnostics(

--- a/crates/oxc_formatter/Cargo.toml
+++ b/crates/oxc_formatter/Cargo.toml
@@ -23,6 +23,7 @@ doctest = false
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_data_structures = { workspace = true, features = ["stack"] }
+oxc_parser = { workspace = true }
 oxc_span = { workspace = true }
 oxc_syntax = { workspace = true }
 
@@ -36,7 +37,6 @@ unicode-width = "0.2"
 
 [dev-dependencies]
 insta = { workspace = true }
-oxc_parser = { workspace = true }
 pico-args = { workspace = true }
 project-root = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/oxc_formatter/examples/formatter.rs
+++ b/crates/oxc_formatter/examples/formatter.rs
@@ -14,8 +14,8 @@
 use std::{fs, path::Path};
 
 use oxc_allocator::Allocator;
-use oxc_formatter::{BracketSameLine, FormatOptions, Formatter, Semicolons};
-use oxc_parser::{ParseOptions, Parser};
+use oxc_formatter::{BracketSameLine, FormatOptions, Formatter, Semicolons, get_parse_options};
+use oxc_parser::Parser;
 use oxc_span::SourceType;
 use pico_args::Arguments;
 
@@ -34,14 +34,7 @@ fn main() -> Result<(), String> {
 
     // Parse the source code
     let ret = Parser::new(&allocator, &source_text, source_type)
-        .with_options(ParseOptions {
-            parse_regular_expression: false,
-            // Enable all syntax features
-            allow_v8_intrinsics: true,
-            allow_return_outside_function: true,
-            // `oxc_formatter` expects this to be false
-            preserve_parens: false,
-        })
+        .with_options(get_parse_options())
         .parse();
 
     // Report any parsing errors

--- a/crates/oxc_formatter/examples/sort_imports.rs
+++ b/crates/oxc_formatter/examples/sort_imports.rs
@@ -3,8 +3,8 @@
 use std::{fs, path::Path};
 
 use oxc_allocator::Allocator;
-use oxc_formatter::{FormatOptions, Formatter, SortImports, SortOrder};
-use oxc_parser::{ParseOptions, Parser};
+use oxc_formatter::{FormatOptions, Formatter, SortImports, SortOrder, get_parse_options};
+use oxc_parser::Parser;
 use oxc_span::SourceType;
 use pico_args::Arguments;
 
@@ -36,14 +36,7 @@ fn main() -> Result<(), String> {
 
     // Parse the source code
     let ret = Parser::new(&allocator, &source_text, source_type)
-        .with_options(ParseOptions {
-            parse_regular_expression: false,
-            // Enable all syntax features
-            allow_v8_intrinsics: true,
-            allow_return_outside_function: true,
-            // `oxc_formatter` expects this to be false
-            preserve_parens: false,
-        })
+        .with_options(get_parse_options())
         .parse();
 
     // Report any parsing errors

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -32,10 +32,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use write::FormatWrite;
 
 pub use crate::options::*;
-pub use crate::service::{
-    oxfmtrc::Oxfmtrc,
-    source_type::{enable_jsx_source_type, get_supported_source_type},
-};
+pub use crate::service::{oxfmtrc::Oxfmtrc, parse_utils::*};
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     formatter::{FormatContext, Formatted, format_element::document::Document},

--- a/crates/oxc_formatter/src/service/mod.rs
+++ b/crates/oxc_formatter/src/service/mod.rs
@@ -1,2 +1,2 @@
 pub mod oxfmtrc;
-pub mod source_type;
+pub mod parse_utils;

--- a/crates/oxc_formatter/src/service/parse_utils.rs
+++ b/crates/oxc_formatter/src/service/parse_utils.rs
@@ -1,6 +1,19 @@
 use std::ffi::OsStr;
 
+use oxc_parser::ParseOptions;
 use oxc_span::SourceType;
+
+pub fn get_parse_options() -> ParseOptions {
+    ParseOptions {
+        // Do not need to parse regexp
+        parse_regular_expression: false,
+        // Enable all syntax features
+        allow_return_outside_function: true,
+        allow_v8_intrinsics: true,
+        // `oxc_formatter` expects this to be `false`, otherwise panics
+        preserve_parens: false,
+    }
+}
 
 // Additional extensions from linguist-languages, which Prettier also supports
 // - https://github.com/ikatyang-collab/linguist-languages/blob/d1dc347c7ced0f5b42dd66c7d1c4274f64a3eb6b/data/JavaScript.js

--- a/crates/oxc_formatter/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter/tests/fixtures/mod.rs
@@ -3,9 +3,9 @@ use std::{env::current_dir, fs, path::Path, str::FromStr};
 use oxc_allocator::Allocator;
 use oxc_formatter::{
     ArrowParentheses, BracketSameLine, BracketSpacing, FormatOptions, Formatter, IndentStyle,
-    IndentWidth, LineWidth, QuoteStyle, Semicolons, TrailingCommas,
+    IndentWidth, LineWidth, QuoteStyle, Semicolons, TrailingCommas, get_parse_options,
 };
-use oxc_parser::{ParseOptions, Parser};
+use oxc_parser::Parser;
 use oxc_span::SourceType;
 
 type OptionSet = serde_json::Map<String, serde_json::Value>;
@@ -141,14 +141,8 @@ fn format_options_display(json: &OptionSet) -> String {
 /// Format a source file with given options
 fn format_source(source_text: &str, source_type: SourceType, options: FormatOptions) -> String {
     let allocator = Allocator::default();
-    let ret = Parser::new(&allocator, source_text, source_type)
-        .with_options(ParseOptions {
-            parse_regular_expression: false,
-            allow_v8_intrinsics: true,
-            allow_return_outside_function: true,
-            preserve_parens: false,
-        })
-        .parse();
+    let ret =
+        Parser::new(&allocator, source_text, source_type).with_options(get_parse_options()).parse();
 
     let formatter = Formatter::new(&allocator, options);
     formatter.build(&ret.program)

--- a/crates/oxc_formatter/tests/ir_transform/mod.rs
+++ b/crates/oxc_formatter/tests/ir_transform/mod.rs
@@ -39,23 +39,14 @@ pub fn assert_format(code: &str, options: &FormatOptions, expected: &str) {
 
 fn format_code(code: &str, options: &FormatOptions) -> String {
     use oxc_allocator::Allocator;
-    use oxc_formatter::Formatter;
-    use oxc_parser::{ParseOptions, Parser};
+    use oxc_formatter::{Formatter, get_parse_options};
+    use oxc_parser::Parser;
     use oxc_span::SourceType;
 
     let allocator = Allocator::new();
     let source_type = SourceType::from_path("dummy.tsx").unwrap();
 
-    let ret = Parser::new(&allocator, code, source_type)
-        .with_options(ParseOptions {
-            parse_regular_expression: false,
-            // Enable all syntax features
-            allow_v8_intrinsics: true,
-            allow_return_outside_function: true,
-            // `oxc_formatter` expects this to be false
-            preserve_parens: false,
-        })
-        .parse();
+    let ret = Parser::new(&allocator, code, source_type).with_options(get_parse_options()).parse();
 
     if let Some(error) = ret.errors.first() {
         panic!("💥 Parser error: {}", error.message);

--- a/crates/oxc_language_server/src/formatter/server_formatter.rs
+++ b/crates/oxc_language_server/src/formatter/server_formatter.rs
@@ -4,9 +4,10 @@ use log::warn;
 use oxc_allocator::Allocator;
 use oxc_data_structures::rope::{Rope, get_line_column};
 use oxc_formatter::{
-    FormatOptions, Formatter, Oxfmtrc, enable_jsx_source_type, get_supported_source_type,
+    FormatOptions, Formatter, Oxfmtrc, enable_jsx_source_type, get_parse_options,
+    get_supported_source_type,
 };
-use oxc_parser::{ParseOptions, Parser};
+use oxc_parser::Parser;
 use tower_lsp_server::{
     UriExt,
     lsp_types::{Pattern, Position, Range, TextEdit, Uri},
@@ -42,14 +43,7 @@ impl ServerFormatter {
 
         let allocator = Allocator::new();
         let ret = Parser::new(&allocator, &source_text, source_type)
-            .with_options(ParseOptions {
-                parse_regular_expression: false,
-                // Enable all syntax features
-                allow_v8_intrinsics: true,
-                allow_return_outside_function: true,
-                // `oxc_formatter` expects this to be false
-                preserve_parens: false,
-            })
+            .with_options(get_parse_options())
             .parse();
 
         if !ret.errors.is_empty() {

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -32,7 +32,7 @@ use oxc::{
 use oxc_formatter::{
     ArrowParentheses, AttributePosition, BracketSameLine, BracketSpacing, Expand, FormatOptions,
     Formatter, IndentStyle, IndentWidth, LineEnding, LineWidth, OperatorPosition, QuoteProperties,
-    QuoteStyle, Semicolons, SortImports, SortOrder, TrailingCommas,
+    QuoteStyle, Semicolons, SortImports, SortOrder, TrailingCommas, get_parse_options,
 };
 use oxc_linter::{
     ConfigStore, ConfigStoreBuilder, ContextSubHost, ExternalPluginStore, LintOptions, Linter,
@@ -537,12 +537,7 @@ impl Oxc {
         let allocator = Allocator::default();
         if run_options.formatter {
             let ret = Parser::new(&allocator, source_text, source_type)
-                .with_options(ParseOptions {
-                    preserve_parens: false,
-                    allow_return_outside_function: true,
-                    allow_v8_intrinsics: true,
-                    parse_regular_expression: false,
-                })
+                .with_options(get_parse_options())
                 .parse();
 
             let format_options = Self::convert_formatter_options(formatter_options);

--- a/tasks/benchmark/benches/formatter.rs
+++ b/tasks/benchmark/benches/formatter.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::Allocator;
 use oxc_benchmark::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use oxc_formatter::{FormatOptions, Formatter};
-use oxc_parser::{ParseOptions, Parser};
+use oxc_formatter::{FormatOptions, Formatter, get_parse_options};
+use oxc_parser::Parser;
 use oxc_tasks_common::TestFiles;
 
 fn bench_formatter(criterion: &mut Criterion) {
@@ -15,16 +15,8 @@ fn bench_formatter(criterion: &mut Criterion) {
         group.bench_function(id, |b| {
             b.iter_with_setup_wrapper(|runner| {
                 allocator.reset();
-                let parse_options = ParseOptions {
-                    parse_regular_expression: false,
-                    // Enable all syntax features
-                    allow_v8_intrinsics: true,
-                    allow_return_outside_function: true,
-                    // `oxc_formatter` expects this to be false
-                    preserve_parens: false,
-                };
                 let program = Parser::new(&allocator, source_text, source_type)
-                    .with_options(parse_options)
+                    .with_options(get_parse_options())
                     .parse()
                     .program;
                 let format_options = FormatOptions::default();

--- a/tasks/coverage/src/tools/formatter.rs
+++ b/tasks/coverage/src/tools/formatter.rs
@@ -2,10 +2,10 @@ use std::path::{Path, PathBuf};
 
 use oxc::{
     allocator::Allocator,
-    parser::{ParseOptions, Parser, ParserReturn},
+    parser::{Parser, ParserReturn},
     span::SourceType,
 };
-use oxc_formatter::{FormatOptions, Formatter};
+use oxc_formatter::{FormatOptions, Formatter, get_parse_options};
 
 use crate::{
     babel::BabelCase,
@@ -20,21 +20,14 @@ fn get_result(source_text: &str, source_type: SourceType) -> TestResult {
     let options = FormatOptions::default();
 
     let allocator = Allocator::default();
-    let parse_options = ParseOptions {
-        parse_regular_expression: false,
-        // Enable all syntax features
-        allow_v8_intrinsics: true,
-        allow_return_outside_function: true,
-        // `oxc_formatter` expects this to be false
-        preserve_parens: false,
-    };
     let ParserReturn { program, .. } =
-        Parser::new(&allocator, source_text, source_type).with_options(parse_options).parse();
+        Parser::new(&allocator, source_text, source_type).with_options(get_parse_options()).parse();
     let source_text1 = Formatter::new(&allocator, options.clone()).build(&program);
 
     let allocator = Allocator::default();
-    let ParserReturn { program, errors, .. } =
-        Parser::new(&allocator, &source_text1, source_type).with_options(parse_options).parse();
+    let ParserReturn { program, errors, .. } = Parser::new(&allocator, &source_text1, source_type)
+        .with_options(get_parse_options())
+        .parse();
 
     if !errors.is_empty() {
         return TestResult::ParseError(

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -15,8 +15,8 @@ use similar::TextDiff;
 use walkdir::WalkDir;
 
 use oxc_allocator::Allocator;
-use oxc_formatter::{FormatOptions, Formatter};
-use oxc_parser::{ParseOptions, Parser};
+use oxc_formatter::{FormatOptions, Formatter, get_parse_options};
+use oxc_parser::Parser;
 use oxc_span::SourceType;
 
 use crate::{ignore_list::IGNORE_TESTS, options::TestRunnerOptions, spec::parse_spec};
@@ -421,14 +421,7 @@ impl TestRunner {
         let allocator = Allocator::default();
         let source_type = source_type.with_jsx(source_type.is_javascript());
         let ret = Parser::new(&allocator, source_text, source_type)
-            .with_options(ParseOptions {
-                parse_regular_expression: false,
-                // Enable all syntax features
-                allow_v8_intrinsics: true,
-                allow_return_outside_function: true,
-                // `oxc_formatter` expects this to be false
-                preserve_parens: false,
-            })
+            .with_options(get_parse_options())
             .parse();
         Formatter::new(&allocator, formatter_options).build(&ret.program)
     }


### PR DESCRIPTION
Export `oxc_formatter::get_parse_options` to get this options everywhere.

```rs
ParseOpitons {
    parse_regular_expression: false,
    // Enable all syntax features
    allow_v8_intrinsics: true,
    allow_return_outside_function: true,
    // `oxc_formatter` expects this to be false
    preserve_parens: false,
}
```