### PR TITLE
fix(import/no-namespace): remove dot special case

### DIFF
--- a/crates/oxc_linter/src/snapshots/import_no_namespace.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_namespace.snap
@@ -21,3 +21,12 @@ source: crates/oxc_linter/src/tester.rs
    ·             ───
    ╰────
   help: Use named or default imports
+
+  ⚠ eslint-plugin-import(no-namespace): Usage of namespaced aka wildcard "*" imports prohibited
+   ╭─[index.js:3:25]
+ 2 │             import * as zod from 'zod'
+ 3 │             import * as DrizzleKit from 'drizzle-kit/api'
+   ·                         ──────────
+ 4 │             
+   ╰────
+  help: Use named or default imports


### PR DESCRIPTION
- Closes #15007 
- The original implementation from #7229 had an unexplained behavior where presence of any ignore pattern would skip all diagnostics if the import specifier did not have a dot.
- `eslint-plugin-import` does not have this behavior: [no-namespace.js#L109](https://github.com/import-js/eslint-plugin-import/blob/01c9eb04331d2efa8d63f2d7f4bfec3bc44c94f3/src/rules/no-namespace.js#L109).