### PR TITLE
refactor(ci): Extract "Check version" jobs into reusable action

### DIFF
--- a/.github/actions/check-version/action.yml
+++ b/.github/actions/check-version/action.yml
@@ -1,0 +1,51 @@
+name: Check version
+
+description: Check if package version has changed
+
+inputs:
+  file-name:
+    required: true
+    type: string
+    description: Path to the package.json file to check
+
+  file-url:
+    required: false
+    type: string
+    description: URL to compare version against (e.g., https://unpkg.com/oxlint@latest/package.json)
+
+  diff-search:
+    required: false
+    type: boolean
+    default: false
+    description: Use git diff to check for version changes instead of comparing with external URL
+
+outputs:
+  version:
+    description: The version from the package.json
+    value: ${{ steps.version.outputs.version }}
+  version_changed:
+    description: Whether the version has changed
+    value: ${{ steps.version.outputs.changed }}
+
+runs:
+  using: composite
+  steps:
+    - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
+
+    - name: Check version changes
+      uses: EndBug/version-check@5102328418c0130d66ca712d755c303e93368ce2 # v2.1.7
+      id: version
+      with:
+        static-checking: ${{ inputs.diff-search == false && 'localIsNew' || '' }}
+        diff-search: ${{ inputs.diff-search }}
+        file-url: ${{ inputs.file-url }}
+        file-name: ${{ inputs.file-name }}
+
+    - name: Print version
+      if: steps.version.outputs.changed == 'true'
+      shell: bash
+      env:
+        VERSION_NUMBER: ${{ steps.version.outputs.version }}
+        VERSION_TYPE: ${{ steps.version.outputs.version_type }}
+      run: |
+        echo "Version change found! New version: ${VERSION_NUMBER} (${VERSION_TYPE})"

--- a/.github/workflows/release_oxfmt.yml
+++ b/.github/workflows/release_oxfmt.yml
@@ -19,25 +19,14 @@ jobs:
     name: Check version
     runs-on: ubuntu-latest
     outputs:
-      version_changed: ${{ steps.version.outputs.changed }}
-      version: ${{ steps.version.outputs.version }}
+      version_changed: ${{ steps.check.outputs.version_changed }}
+      version: ${{ steps.check.outputs.version }}
     steps:
-      - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
-
-      - name: Check version changes
-        uses: EndBug/version-check@5102328418c0130d66ca712d755c303e93368ce2 # v2.1.7
-        id: version
+      - uses: ./.github/actions/check-version
+        id: check
         with:
-          static-checking: localIsNew
-          file-url: https://unpkg.com/oxfmt@latest/package.json
           file-name: npm/oxfmt/package.json
-
-      - name: Print version
-        if: steps.version.outputs.changed == 'true'
-        env:
-          NEW_VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          echo "Version change found! New version: ${NEW_VERSION}"
+          file-url: https://unpkg.com/oxfmt@latest/package.json
 
   build:
     needs: check

--- a/.github/workflows/release_oxlint.yml
+++ b/.github/workflows/release_oxlint.yml
@@ -19,25 +19,14 @@ jobs:
     name: Check version
     runs-on: ubuntu-latest
     outputs:
-      version_changed: ${{ steps.version.outputs.changed }}
-      version: ${{ steps.version.outputs.version }}
+      version_changed: ${{ steps.check.outputs.version_changed }}
+      version: ${{ steps.check.outputs.version }}
     steps:
-      - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
-
-      - name: Check version changes
-        uses: EndBug/version-check@5102328418c0130d66ca712d755c303e93368ce2 # v2.1.7
-        id: version
+      - uses: ./.github/actions/check-version
+        id: check
         with:
-          static-checking: localIsNew
-          file-url: https://unpkg.com/oxlint@latest/package.json
           file-name: npm/oxlint/package.json
-
-      - name: Print version
-        if: steps.version.outputs.changed == 'true'
-        env:
-          NEW_VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          echo "Version change found! New version: ${NEW_VERSION}"
+          file-url: https://unpkg.com/oxlint@latest/package.json
 
   build:
     needs: check

--- a/.github/workflows/release_runtime.yml
+++ b/.github/workflows/release_runtime.yml
@@ -20,26 +20,14 @@ jobs:
     name: Check version
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.version.outputs.version }}
-      version_changed: ${{ steps.version.outputs.changed }}
+      version: ${{ steps.check.outputs.version }}
+      version_changed: ${{ steps.check.outputs.version_changed }}
     steps:
-      - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
-
-      - name: Check version changes
-        uses: EndBug/version-check@5102328418c0130d66ca712d755c303e93368ce2 # v2.1.7
-        id: version
+      - uses: ./.github/actions/check-version
+        id: check
         with:
-          static-checking: localIsNew
-          file-url: https://unpkg.com/@oxc-project/runtime/package.json
           file-name: npm/runtime/package.json
-
-      - name: Set version name
-        if: steps.version.outputs.changed == 'true'
-        env:
-          VERSION_NUMBER: ${{ steps.version.outputs.version }}
-          VERSION_TYPE: ${{ steps.version.outputs.version_type }}
-        run: |
-          echo "Version change found! New version: ${VERSION_NUMBER} (${VERSION_TYPE})"
+          file-url: https://unpkg.com/@oxc-project/runtime/package.json
 
   build:
     needs: check

--- a/.github/workflows/release_types.yml
+++ b/.github/workflows/release_types.yml
@@ -20,26 +20,14 @@ jobs:
     name: Check version
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.version.outputs.version }}
-      version_changed: ${{ steps.version.outputs.changed }}
+      version: ${{ steps.check.outputs.version }}
+      version_changed: ${{ steps.check.outputs.version_changed }}
     steps:
-      - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
-
-      - name: Check version changes
-        uses: EndBug/version-check@5102328418c0130d66ca712d755c303e93368ce2 # v2.1.7
-        id: version
+      - uses: ./.github/actions/check-version
+        id: check
         with:
-          static-checking: localIsNew
-          file-url: https://unpkg.com/@oxc-project/types/package.json
           file-name: npm/oxc-types/package.json
-
-      - name: Set version name
-        if: steps.version.outputs.changed == 'true'
-        env:
-          VERSION_NUMBER: ${{ steps.version.outputs.version }}
-          VERSION_TYPE: ${{ steps.version.outputs.version_type }}
-        run: |
-          echo "Version change found! New version: ${VERSION_NUMBER} (${VERSION_TYPE})"
+          file-url: https://unpkg.com/@oxc-project/types/package.json
 
   build:
     needs: check

--- a/.github/workflows/release_vscode.yml
+++ b/.github/workflows/release_vscode.yml
@@ -22,26 +22,14 @@ jobs:
     name: Check version
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ env.version }}
-      version_changed: ${{ steps.version.outputs.changed }}
+      version: ${{ steps.check.outputs.version }}
+      version_changed: ${{ steps.check.outputs.version_changed }}
     steps:
-      - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
-
-      - name: Check vscode version changes
-        uses: EndBug/version-check@5102328418c0130d66ca712d755c303e93368ce2 # v2.1.7
-        id: version
+      - uses: ./.github/actions/check-version
+        id: check
         with:
-          diff-search: true
           file-name: editors/vscode/package.json
-
-      - name: Set version name
-        if: steps.version.outputs.changed == 'true'
-        env:
-          VERSION_NUMBER: ${{ steps.version.outputs.version }}
-          VERSION_TYPE: ${{ steps.version.outputs.version_type }}
-        run: |
-          echo "Version change found! New version: ${VERSION_NUMBER} (${VERSION_TYPE})"
-          echo "version=${VERSION_NUMBER}" >> $GITHUB_ENV
+          diff-search: true
 
   build:
     needs: check

--- a/.github/workflows/reusable_release_napi.yml
+++ b/.github/workflows/reusable_release_napi.yml
@@ -15,24 +15,15 @@ jobs:
     name: Check version
     runs-on: ubuntu-latest
     outputs:
-      version_changed: ${{ steps.version.outputs.changed }}
+      version_changed: ${{ steps.check.outputs.version_changed }}
     env:
       name: ${{ inputs.name }}
     steps:
-      - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
-
-      - uses: EndBug/version-check@5102328418c0130d66ca712d755c303e93368ce2 # v2.1.7
-        id: version
+      - uses: ./.github/actions/check-version
+        id: check
         with:
-          static-checking: localIsNew
-          file-url: https://unpkg.com/oxc-${{ inputs.name }}@latest/package.json
           file-name: napi/${{ inputs.name }}/package.json
-
-      - name: Show version
-        if: steps.version.outputs.changed == 'true'
-        env:
-          version: ${{ steps.version.outputs.version }}
-        run: echo "version=${version}"
+          file-url: https://unpkg.com/oxc-${{ inputs.name }}@latest/package.json
 
   build:
     needs: check


### PR DESCRIPTION
## Summary
- Consolidates duplicate version checking logic from 6 workflows into a single reusable action
- Creates `.github/actions/check-version/action.yml` to encapsulate the common pattern
- Updates all affected workflows to use the new action

🤖 Generated with [Claude Code](https://claude.com/claude-code)