### PR TITLE
refactor(language_server): Extract library interface from main.rs

### DIFF
--- a/crates/oxc_language_server/src/lib.rs
+++ b/crates/oxc_language_server/src/lib.rs
@@ -1,0 +1,23 @@
+use rustc_hash::FxBuildHasher;
+
+mod backend;
+mod capabilities;
+mod code_actions;
+mod commands;
+mod file_system;
+mod formatter;
+mod linter;
+mod options;
+#[cfg(test)]
+mod tester;
+mod utils;
+mod worker;
+
+pub use crate::backend::Backend;
+pub use crate::linter::server_linter::ServerLinter;
+pub use crate::worker::WorkspaceWorker;
+
+pub type ConcurrentHashMap<K, V> = papaya::HashMap<K, V, FxBuildHasher>;
+
+pub const LINT_CONFIG_FILE: &str = ".oxlintrc.json";
+pub const FORMAT_CONFIG_FILES: &[&str; 2] = &[".oxfmtrc.json", ".oxfmtrc.jsonc"];

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -86,6 +86,8 @@ impl ServerLinterDiagnostics {
 }
 
 impl ServerLinter {
+    /// # Panics
+    /// Panics if the root URI cannot be converted to a file path.
     pub fn new(root_uri: &Uri, options: &LSPLintOptions) -> Self {
         let root_path = root_uri.to_file_path().unwrap();
         let mut nested_ignore_patterns = Vec::new();

--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -1,25 +1,5 @@
-use rustc_hash::FxBuildHasher;
+use oxc_language_server::Backend;
 use tower_lsp_server::{LspService, Server};
-
-mod backend;
-mod capabilities;
-mod code_actions;
-mod commands;
-mod file_system;
-mod formatter;
-mod linter;
-mod options;
-#[cfg(test)]
-mod tester;
-mod utils;
-mod worker;
-
-use crate::backend::Backend;
-
-type ConcurrentHashMap<K, V> = papaya::HashMap<K, V, FxBuildHasher>;
-
-const LINT_CONFIG_FILE: &str = ".oxlintrc.json";
-const FORMAT_CONFIG_FILES: &[&str; 2] = &[".oxfmtrc.json", ".oxfmtrc.jsonc"];
 
 #[tokio::main]
 async fn main() {

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -56,6 +56,9 @@ impl WorkspaceWorker {
     /// e.g. root URI: file:///path/to/root
     ///      responsible for: file:///path/to/root/file.js
     ///      not responsible for: file:///path/to/other/file.js
+    ///
+    /// # Panics
+    /// Panics if the root URI cannot be converted to a file path.
     pub fn is_responsible_for_uri(&self, uri: &Uri) -> bool {
         if let Some(path) = uri.to_file_path() {
             return path.starts_with(self.root_uri.to_file_path().unwrap());
@@ -336,6 +339,9 @@ impl WorkspaceWorker {
     }
 
     /// Handle server configuration changes from the client
+    ///
+    /// # Panics
+    /// Panics if the root URI cannot be converted to a file path.
     pub async fn did_change_configuration(
         &self,
         changed_options: &Options,


### PR DESCRIPTION
## Summary
- Created `lib.rs` to expose the language server as a library
- Moved module declarations, type aliases, and constants from `main.rs` to `lib.rs`
- Simplified `main.rs` to only contain the binary entry point

## Test plan
- [ ] Build succeeds: `cargo build -p oxc_language_server`
- [ ] Tests pass: `cargo test -p oxc_language_server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)