### PR TITLE
feat(cli): add --lsp flag to oxlint to run language server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.44"
+version = "1.2.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37521ac7aabe3d13122dc382493e20c9416f299d2ccd5b3a5340a2570cdeb0f3"
+checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1242,22 +1242,22 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+checksum = "49cce2b81f2098e7e3efc35bc2e0a6b7abec9d34128283d7a26fa8f32a6dbb35"
 dependencies = [
  "jiff-static",
  "log",
  "portable-atomic",
  "portable-atomic-util",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1439,12 +1439,13 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.5.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d00c1a7ffcf62e0889630f122f8920383f5a9ce4b54377b05c2833fb6123857"
+checksum = "d47d5651129e97a2a08f1e513ac3f14bd9a154c72b0716914024d60e7166140e"
 dependencies = [
  "bitflags 2.10.0",
  "ctor",
+ "futures",
  "napi-build",
  "napi-sys",
  "nohash-hasher",
@@ -1462,9 +1463,9 @@ checksum = "68064c4cf827376751236ee6785e0e38a6461f83a7a7f227c89f6256f3e96cc2"
 
 [[package]]
 name = "napi-derive"
-version = "3.3.0"
+version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78665d6bdf10e9a4e6b38123efb0f66962e6197c1aea2f07cff3f159a374696d"
+checksum = "ffc92539b472a0df8137f76cd4d3736e7d738e320449724de3d582f0b950354e"
 dependencies = [
  "convert_case",
  "ctor",
@@ -1476,9 +1477,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d55d01423e7264de3acc13b258fa48ca7cf38a4d25db848908ec3c1304a85a"
+checksum = "3a850a802342ed3883121e016c63e2ed625df24c36ef2b0920ca114469311f95"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1489,9 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "napi-sys"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f200fd782433de18d46d496223be780837b2f3772e5816f4425e0520bff26c2"
+checksum = "50ef9c1086f16aea2417c3788dbefed7591c3bccd800b827f4dfb271adff1149"
 dependencies = [
  "libloading",
 ]
@@ -2830,6 +2831,7 @@ dependencies = [
  "oxc-miette",
  "oxc_allocator 0.96.0",
  "oxc_diagnostics 0.96.0",
+ "oxc_language_server",
  "oxc_linter",
  "oxc_span 0.96.0",
  "rayon",
@@ -3056,9 +3058,9 @@ checksum = "8bccbff07d5ed689c4087d20d7307a52ab6141edeedf487c3876a55b86cf63df"
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -3229,15 +3231,6 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -3881,16 +3874,15 @@ checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "ureq"
-version = "3.1.2"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ba1025f18a4a3fc3e9b48c868e9beb4f24f4b4b1a325bada26bd4119f46537"
+checksum = "c42979584bacf4cff2f090f93b6a5348b9d5aad9107f41688956b88442b93331"
 dependencies = [
  "base64",
  "cookie_store",
  "log",
  "percent-encoding",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ oxc_traverse = { version = "0.96.0", path = "crates/oxc_traverse" } # AST traver
 
 # publish = false
 oxc_formatter = { path = "crates/oxc_formatter" } # Code formatting
+oxc_language_server = { path = "crates/oxc_language_server" } # Language server
 oxc_linter = { path = "crates/oxc_linter" } # Linting engine
 oxc_macros = { path = "crates/oxc_macros" } # Proc macros
 oxc_tasks_common = { path = "tasks/common" } # Task utilities

--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -29,6 +29,7 @@ doctest = false
 [dependencies]
 oxc_allocator = { workspace = true, features = ["fixed_size"] }
 oxc_diagnostics = { workspace = true }
+oxc_language_server = { workspace = true }
 oxc_linter = { workspace = true }
 oxc_span = { workspace = true }
 
@@ -44,7 +45,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 simdutf8 = { workspace = true }
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "io-std", "macros"] }
 tracing-subscriber = { workspace = true, features = [] } # Omit the `regex` feature
 
 [target.'cfg(not(any(target_os = "linux", target_os = "freebsd", target_arch = "arm", target_family = "wasm")))'.dependencies]

--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -39,6 +39,10 @@ pub struct LintCommand {
     #[bpaf(long("rules"), switch, hide_usage)]
     pub list_rules: bool,
 
+    /// Start the language server
+    #[bpaf(long("lsp"), switch, hide_usage)]
+    pub lsp: bool,
+
     #[bpaf(external)]
     pub misc_options: MiscOptions,
 

--- a/apps/oxlint/src/lib.rs
+++ b/apps/oxlint/src/lib.rs
@@ -4,6 +4,7 @@
 mod command;
 mod init;
 mod lint;
+mod lsp;
 mod output_formatter;
 mod result;
 mod walk;
@@ -13,7 +14,7 @@ mod tester;
 
 /// Re-exported CLI-related items for use in `tasks/website`.
 pub mod cli {
-    pub use super::{command::*, init::*, lint::CliRunner, result::CliRunResult};
+    pub use super::{command::*, init::*, lint::CliRunner, lsp::run_lsp, result::CliRunResult};
 }
 
 // Only include code to run linter when the `napi` feature is enabled.

--- a/apps/oxlint/src/lsp.rs
+++ b/apps/oxlint/src/lsp.rs
@@ -1,0 +1,4 @@
+/// Run the language server
+pub async fn run_lsp() {
+    oxc_language_server::run_server().await;
+}

--- a/crates/oxc_language_server/src/lib.rs
+++ b/crates/oxc_language_server/src/lib.rs
@@ -1,4 +1,5 @@
 use rustc_hash::FxBuildHasher;
+use tower_lsp_server::{LspService, Server};
 
 mod backend;
 mod capabilities;
@@ -17,3 +18,15 @@ pub type ConcurrentHashMap<K, V> = papaya::HashMap<K, V, FxBuildHasher>;
 
 pub const LINT_CONFIG_FILE: &str = ".oxlintrc.json";
 pub const FORMAT_CONFIG_FILES: &[&str; 2] = &[".oxfmtrc.json", ".oxfmtrc.jsonc"];
+
+/// Run the language server
+pub async fn run_server() {
+    env_logger::init();
+
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+
+    let (service, socket) = LspService::build(Backend::new).finish();
+
+    Server::new(stdin, stdout, socket).serve(service).await;
+}

--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -1,14 +1,4 @@
-use oxc_language_server::Backend;
-use tower_lsp_server::{LspService, Server};
-
 #[tokio::main]
 async fn main() {
-    env_logger::init();
-
-    let stdin = tokio::io::stdin();
-    let stdout = tokio::io::stdout();
-
-    let (service, socket) = LspService::build(Backend::new).finish();
-
-    Server::new(stdin, stdout, socket).serve(service).await;
+    oxc_language_server::run_server().await;
 }

--- a/tasks/website/src/linter/snapshots/cli.snap
+++ b/tasks/website/src/linter/snapshots/cli.snap
@@ -147,6 +147,8 @@ Arguments:
 ## Available options:
 - **`    --rules`** &mdash; 
   list all the rules that are currently registered
+- **`    --lsp`** &mdash; 
+  Start the language server
 - **`    --disable-nested-config`** &mdash; 
   Disables the automatic loading of nested configuration files.
 - **`    --type-aware`** &mdash; 

--- a/tasks/website/src/linter/snapshots/cli_terminal.snap
+++ b/tasks/website/src/linter/snapshots/cli_terminal.snap
@@ -91,6 +91,7 @@ Available positional items:
 
 Available options:
         --rules               list all the rules that are currently registered
+        --lsp                 Start the language server
         --disable-nested-config  Disables the automatic loading of nested configuration files.
         --type-aware          Enables rules that require type information.
     -h, --help                Prints help information


### PR DESCRIPTION
Closes #12251

## Summary

Adds `--lsp` flag to the oxlint CLI that starts the language server. This allows users to run `oxlint --lsp` instead of needing a separate `oxc_language_server` binary.
