### PR TITLE
feat(editor): add `oxc.path.node` option

### DIFF
--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -52,6 +52,7 @@ Following configuration are supported via `settings.json` and effect the window 
 | `oxc.requireConfig` | `false`       | `true` \| `false`                | Start the language server only when a `.oxlintrc.json` file exists in one of the workspaces. |
 | `oxc.trace.server`  | `off`         | `off` \| `messages` \| `verbose` | Traces the communication between VS Code and the language server.                            |
 | `oxc.path.server`   | -             | `<string>`                       | Path to Oxc language server binary. Mostly for testing the language server.                  |
+| `oxc.path.node`     | -             | `<string>`                       | Path to a Node.js binary. Will be added to the language server `PATH` environment.           |
 
 ### Workspace Configuration
 

--- a/editors/vscode/client/VSCodeConfig.ts
+++ b/editors/vscode/client/VSCodeConfig.ts
@@ -5,6 +5,7 @@ export class VSCodeConfig implements VSCodeConfigInterface {
   private _enable!: boolean;
   private _trace!: TraceLevel;
   private _binPath: string | undefined;
+  private _nodePath: string | undefined;
   private _requireConfig!: boolean;
 
   constructor() {
@@ -19,6 +20,7 @@ export class VSCodeConfig implements VSCodeConfigInterface {
     this._enable = this.configuration.get<boolean>('enable') ?? true;
     this._trace = this.configuration.get<TraceLevel>('trace.server') || 'off';
     this._binPath = this.configuration.get<string>('path.server');
+    this._nodePath = this.configuration.get<string>('path.node');
     this._requireConfig = this.configuration.get<boolean>('requireConfig') ?? false;
   }
 
@@ -47,6 +49,15 @@ export class VSCodeConfig implements VSCodeConfigInterface {
   updateBinPath(value: string | undefined): PromiseLike<void> {
     this._binPath = value;
     return this.configuration.update('path.server', value);
+  }
+
+  get nodePath(): string | undefined {
+    return this._nodePath;
+  }
+
+  updateNodePath(value: string | undefined): PromiseLike<void> {
+    this._nodePath = value;
+    return this.configuration.update('path.node', value);
   }
 
   get requireConfig(): boolean {
@@ -84,6 +95,14 @@ interface VSCodeConfigInterface {
    * @default undefined
    */
   binPath: string | undefined;
+
+  /**
+   * Path to Node.js
+   * `oxc.path.node`
+   * @default undefined
+   */
+  nodePath: string | undefined;
+
   /**
    * Start the language server only when a `.oxlintrc.json` file exists in one of the workspaces.
    * `oxc.requireConfig`

--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -116,7 +116,9 @@ export async function activate(context: ExtensionContext) {
     await client.sendRequest(ExecuteCommandRequest.type, params);
   });
 
-  const outputChannel = window.createOutputChannel(outputChannelName, { log: true });
+  const outputChannel = window.createOutputChannel(outputChannelName, {
+    log: true,
+  });
 
   context.subscriptions.push(
     applyAllFixesFile,
@@ -143,13 +145,19 @@ export async function activate(context: ExtensionContext) {
   }
 
   const command = await findBinary();
+
+  const nodePath = configService.vsCodeConfig.nodePath;
+  const serverEnv: Record<string, string> = {
+    ...process.env,
+    RUST_LOG: process.env.RUST_LOG || 'info',
+  };
+  if (nodePath) {
+    serverEnv.PATH = `${nodePath}${process.platform === 'win32' ? ';' : ':'}${process.env.PATH ?? ''}`;
+  }
   const run: Executable = {
     command: command!,
     options: {
-      env: {
-        ...process.env,
-        RUST_LOG: process.env.RUST_LOG || 'info',
-      },
+      env: serverEnv,
     },
   };
   const serverOptions: ServerOptions = {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -102,11 +102,6 @@
           "default": "off",
           "description": "Traces the communication between VS Code and the language server."
         },
-        "oxc.path.server": {
-          "type": "string",
-          "scope": "window",
-          "description": "Path to Oxc language server binary. Mostly for testing the language server."
-        },
         "oxc.configPath": {
           "type": [
             "string",
@@ -196,6 +191,16 @@
           "scope": "resource",
           "default": null,
           "description": "Path to an oxfmt configuration file"
+        },
+        "oxc.path.server": {
+          "type": "string",
+          "scope": "window",
+          "description": "Path to Oxc language server binary. Mostly for testing the language server."
+        },
+        "oxc.path.node": {
+          "type": "string",
+          "scope": "window",
+          "description": "Path to a Node.js binary. Will be added to the language server `PATH` environment."
         }
       }
     },

--- a/editors/vscode/tests/VSCodeConfig.spec.ts
+++ b/editors/vscode/tests/VSCodeConfig.spec.ts
@@ -6,15 +6,12 @@ import { testSingleFolderMode } from './test-helpers.js';
 const conf = workspace.getConfiguration('oxc');
 
 suite('VSCodeConfig', () => {
+  const keys = ['enable', 'requireConfig', 'trace.server', 'path.server', 'path.node'];
   setup(async () => {
-    const keys = ['enable', 'requireConfig', 'trace.server', 'path.server'];
-
     await Promise.all(keys.map(key => conf.update(key, undefined)));
   });
 
   teardown(async () => {
-    const keys = ['enable', 'requireConfig', 'trace.server', 'path.server'];
-
     await Promise.all(keys.map(key => conf.update(key, undefined)));
   });
 
@@ -25,6 +22,7 @@ suite('VSCodeConfig', () => {
     strictEqual(config.requireConfig, false);
     strictEqual(config.trace, 'off');
     strictEqual(config.binPath, '');
+    strictEqual(config.nodePath, '');
   });
 
   testSingleFolderMode('updating values updates the workspace configuration', async () => {
@@ -35,6 +33,7 @@ suite('VSCodeConfig', () => {
       config.updateRequireConfig(true),
       config.updateTrace('messages'),
       config.updateBinPath('./binary'),
+      config.updateNodePath('./node'),
     ]);
 
     const wsConfig = workspace.getConfiguration('oxc');
@@ -43,5 +42,6 @@ suite('VSCodeConfig', () => {
     strictEqual(wsConfig.get('requireConfig'), true);
     strictEqual(wsConfig.get('trace.server'), 'messages');
     strictEqual(wsConfig.get('path.server'), './binary');
+    strictEqual(wsConfig.get('path.node'), './node');
   });
 });


### PR DESCRIPTION
see https://github.com/oxc-project/oxc/pull/14920#issuecomment-3443163653

> When Node.js isn't on the PATH by default but rather added dynamically by a 3rd-party tool (mostly to manage on-the-fly multiple Node versions), the type aware checking in the VS Code extension will fail to run.

