### PR TITLE
docs(linter): show type-aware command if rule is tsgolint-based

### DIFF
--- a/tasks/website/src/linter/rules/doc_page.rs
+++ b/tasks/website/src/linter/rules/doc_page.rs
@@ -196,10 +196,14 @@ fn how_to_use(rule: &RuleTableRow) -> String {
         format!("{}/{}", normalized_plugin_name, rule.name)
     };
     let is_default_plugin = is_default_plugin(plugin);
+    let is_tsgolint_rule = &rule.is_tsgolint_rule;
+
+    let type_aware_flag = if *is_tsgolint_rule { "--type-aware " } else { "" };
+
     let enable_bash_example = if is_default_plugin {
-        format!(r"oxlint --deny {rule_full_name}")
+        format!(r"oxlint {type_aware_flag}--deny {rule_full_name}")
     } else {
-        format!(r"oxlint --deny {rule_full_name} --{normalized_plugin_name}-plugin")
+        format!(r"oxlint {type_aware_flag}--deny {rule_full_name} --{normalized_plugin_name}-plugin")
     };
     let enable_config_example = if is_default_plugin {
         format!(

--- a/tasks/website/src/linter/rules/doc_page.rs
+++ b/tasks/website/src/linter/rules/doc_page.rs
@@ -196,9 +196,9 @@ fn how_to_use(rule: &RuleTableRow) -> String {
         format!("{}/{}", normalized_plugin_name, rule.name)
     };
     let is_default_plugin = is_default_plugin(plugin);
-    let is_tsgolint_rule = &rule.is_tsgolint_rule;
+    let is_tsgolint_rule = rule.is_tsgolint_rule;
 
-    let type_aware_flag = if *is_tsgolint_rule { "--type-aware " } else { "" };
+    let type_aware_flag = if is_tsgolint_rule { "--type-aware " } else { "" };
 
     let enable_bash_example = if is_default_plugin {
         format!(r"oxlint {type_aware_flag}--deny {rule_full_name}")

--- a/tasks/website/src/linter/rules/doc_page.rs
+++ b/tasks/website/src/linter/rules/doc_page.rs
@@ -203,7 +203,9 @@ fn how_to_use(rule: &RuleTableRow) -> String {
     let enable_bash_example = if is_default_plugin {
         format!(r"oxlint {type_aware_flag}--deny {rule_full_name}")
     } else {
-        format!(r"oxlint {type_aware_flag}--deny {rule_full_name} --{normalized_plugin_name}-plugin")
+        format!(
+            r"oxlint {type_aware_flag}--deny {rule_full_name} --{normalized_plugin_name}-plugin"
+        )
     };
     let enable_config_example = if is_default_plugin {
         format!(


### PR DESCRIPTION
Inspired by #14587, the command flag was missing for them too.

Expected: `oxlint --type-aware --deny typescript/await-thenable`
Actual: `oxlint --deny typescript/await-thenable`

<img width="840" height="259" alt="image" src="https://github.com/user-attachments/assets/b9c5dc4b-5dfc-4558-a6e9-5187a60df8f2" />

