### PR TITLE
feat(linter)!: `tsgolint`: request fixes when necessary

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -343,6 +343,7 @@ impl CliRunner {
         let lint_runner = match LintRunner::builder(options, linter)
             .with_type_aware(self.options.type_aware)
             .with_silent(misc_options.silent)
+            .with_fix_kind(fix_options.fix_kind())
             .build()
         {
             Ok(runner) => runner,

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -179,7 +179,7 @@ impl ServerLinter {
             lint_on_run: options.run,
             diagnostics: ServerLinterDiagnostics::default(),
             tsgo_linter: if options.type_aware {
-                Arc::new(Some(TsgoLinter::new(&root_path, config_store)))
+                Arc::new(Some(TsgoLinter::new(&root_path, config_store, fix_kind)))
             } else {
                 Arc::new(None)
             },
@@ -511,12 +511,16 @@ mod test {
     }
 
     #[test]
-    #[ignore = "Will be restored in #15048"]
     #[cfg(not(target_endian = "big"))]
     fn test_lint_on_run_on_type_on_save() {
         Tester::new(
             "fixtures/linter/lint_on_run/on_save",
-            Some(LintOptions { type_aware: true, run: Run::OnType, ..Default::default() }),
+            Some(LintOptions {
+                type_aware: true,
+                run: Run::OnType,
+                fix_kind: LintFixKindFlag::All,
+                ..Default::default()
+            }),
         )
         .test_and_snapshot_single_file_with_run_type("on-save.ts", Run::OnSave);
     }
@@ -532,12 +536,16 @@ mod test {
     }
 
     #[test]
-    #[ignore = "Will be restored in #15048"]
     #[cfg(not(target_endian = "big"))]
     fn test_lint_on_run_on_save_on_save() {
         Tester::new(
             "fixtures/linter/lint_on_run/on_type",
-            Some(LintOptions { type_aware: true, run: Run::OnSave, ..Default::default() }),
+            Some(LintOptions {
+                type_aware: true,
+                run: Run::OnSave,
+                fix_kind: LintFixKindFlag::All,
+                ..Default::default()
+            }),
         )
         .test_and_snapshot_single_file_with_run_type("on-save.ts", Run::OnSave);
     }
@@ -662,12 +670,16 @@ mod test {
     }
 
     #[test]
-    #[ignore = "Will be restored in #15048"]
     #[cfg(not(target_endian = "big"))] // TODO: tsgolint doesn't support big endian?
     fn test_tsgo_lint() {
         let tester = Tester::new(
             "fixtures/linter/tsgolint",
-            Some(LintOptions { type_aware: true, run: Run::OnSave, ..Default::default() }),
+            Some(LintOptions {
+                type_aware: true,
+                run: Run::OnSave,
+                fix_kind: LintFixKindFlag::All,
+                ..Default::default()
+            }),
         );
         tester.test_and_snapshot_single_file("no-floating-promises/index.ts");
     }

--- a/crates/oxc_language_server/src/linter/tsgo_linter.rs
+++ b/crates/oxc_language_server/src/linter/tsgo_linter.rs
@@ -5,8 +5,8 @@ use std::{
 
 use oxc_data_structures::rope::Rope;
 use oxc_linter::{
-    ConfigStore, LINTABLE_EXTENSIONS, TsGoLintState, loader::LINT_PARTIAL_LOADER_EXTENSIONS,
-    read_to_string,
+    ConfigStore, FixKind, LINTABLE_EXTENSIONS, TsGoLintState,
+    loader::LINT_PARTIAL_LOADER_EXTENSIONS, read_to_string,
 };
 use rustc_hash::FxHashSet;
 use tower_lsp_server::{UriExt, lsp_types::Uri};
@@ -20,8 +20,8 @@ pub struct TsgoLinter {
 }
 
 impl TsgoLinter {
-    pub fn new(root_uri: &Path, config_store: ConfigStore) -> Self {
-        let state = TsGoLintState::new(root_uri, config_store);
+    pub fn new(root_uri: &Path, config_store: ConfigStore, fix_kind: FixKind) -> Self {
+        let state = TsGoLintState::new(root_uri, config_store, fix_kind);
         Self { state }
     }
 

--- a/editors/vscode/tests/e2e_server.spec.ts
+++ b/editors/vscode/tests/e2e_server.spec.ts
@@ -265,6 +265,8 @@ suite('E2E Diagnostics', () => {
     await loadFixture('type_aware');
     const firstDiagnostics = await getDiagnostics('index.ts');
 
+    await workspace.getConfiguration('oxc').update('fixKind', 'all');
+
     strictEqual(firstDiagnostics.length, 0);
 
     await workspace.getConfiguration('oxc').update('typeAware', true);


### PR DESCRIPTION
With https://github.com/oxc-project/tsgolint/pull/317, tsgolint fixes will become opt-in. So, we need to pass the `-fix` and `-fix-suggestions` when fixes are enabled in oxlint.

@camc314 This will need to be added in oxlint with, or before switching to the next version of tsgolint.