### PR TITLE
fix(ast-tools): use oxfmt to format generated code

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -1,7 +1,15 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
-let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen, astId = 0, parent = null, getLoc;
+let uint8,
+  uint32,
+  float64,
+  sourceText,
+  sourceIsAscii,
+  sourceByteLen,
+  astId = 0,
+  parent = null,
+  getLoc;
 
 const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
@@ -32,18 +40,14 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInpu
 
 export function resetBuffer() {
   // Clear buffer and source text string to allow them to be garbage collected
-  uint8 =
-    uint32 =
-    float64 =
-    sourceText =
-      void 0;
+  uint8 = uint32 = float64 = sourceText = void 0;
   astId++;
 }
 
 function deserializeProgram(pos) {
   let localAstId = astId,
     end = deserializeU32(pos + 4),
-    program = parent = {
+    program = (parent = {
       __proto__: NodeProto,
       type: 'Program',
       body: null,
@@ -62,9 +66,9 @@ function deserializeProgram(pos) {
       end,
       range: [0, end],
       parent: null,
-    };
+    });
   program.hashbang = deserializeOptionHashbang(pos + 48);
-  let body = program.body = deserializeVecDirective(pos + 72);
+  let body = (program.body = deserializeVecDirective(pos + 72));
   body.push(...deserializeVecStatement(pos + 96));
   {
     let start;
@@ -182,7 +186,7 @@ function deserializeIdentifierName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'Identifier',
       decorators: null,
@@ -193,7 +197,7 @@ function deserializeIdentifierName(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = [];
   node.optional = false;
   node.typeAnnotation = null;
@@ -205,7 +209,7 @@ function deserializeIdentifierReference(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'Identifier',
       decorators: null,
@@ -216,7 +220,7 @@ function deserializeIdentifierReference(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = [];
   node.optional = false;
   node.typeAnnotation = null;
@@ -228,7 +232,7 @@ function deserializeBindingIdentifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'Identifier',
       decorators: null,
@@ -239,7 +243,7 @@ function deserializeBindingIdentifier(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = [];
   node.optional = false;
   node.typeAnnotation = null;
@@ -251,7 +255,7 @@ function deserializeLabelIdentifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'Identifier',
       decorators: null,
@@ -262,7 +266,7 @@ function deserializeLabelIdentifier(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = [];
   node.optional = false;
   node.typeAnnotation = null;
@@ -271,7 +275,8 @@ function deserializeLabelIdentifier(pos) {
 }
 
 function deserializeThisExpression(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'ThisExpression',
@@ -286,7 +291,7 @@ function deserializeArrayExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ArrayExpression',
       elements: null,
@@ -294,7 +299,7 @@ function deserializeArrayExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.elements = deserializeVecArrayExpressionElement(pos + 8);
   parent = previousParent;
   return node;
@@ -405,7 +410,7 @@ function deserializeObjectExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ObjectExpression',
       properties: null,
@@ -413,7 +418,7 @@ function deserializeObjectExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.properties = deserializeVecObjectPropertyKind(pos + 8);
   parent = previousParent;
   return node;
@@ -434,7 +439,7 @@ function deserializeObjectProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'Property',
       kind: deserializePropertyKind(pos + 40),
@@ -448,7 +453,7 @@ function deserializeObjectProperty(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.key = deserializePropertyKey(pos + 8);
   node.value = deserializeExpression(pos + 24);
   node.optional = false;
@@ -570,7 +575,7 @@ function deserializeTemplateLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TemplateLiteral',
       quasis: null,
@@ -579,7 +584,7 @@ function deserializeTemplateLiteral(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.quasis = deserializeVecTemplateElement(pos + 8);
   node.expressions = deserializeVecExpression(pos + 32);
   parent = previousParent;
@@ -590,7 +595,7 @@ function deserializeTaggedTemplateExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TaggedTemplateExpression',
       tag: null,
@@ -600,7 +605,7 @@ function deserializeTaggedTemplateExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.tag = deserializeExpression(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   node.quasi = deserializeTemplateLiteral(pos + 32);
@@ -613,7 +618,8 @@ function deserializeTemplateElement(pos) {
     start = deserializeU32(pos) - 1,
     end = deserializeU32(pos + 4) + 2 - tail,
     value = deserializeTemplateElementValue(pos + 8);
-  value.cooked !== null && deserializeBool(pos + 41) &&
+  value.cooked !== null &&
+    deserializeBool(pos + 41) &&
     (value.cooked = value.cooked.replace(/\uFFFD(.{4})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16))));
   return {
     __proto__: NodeProto,
@@ -638,7 +644,7 @@ function deserializeComputedMemberExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'MemberExpression',
       object: null,
@@ -649,7 +655,7 @@ function deserializeComputedMemberExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.object = deserializeExpression(pos + 8);
   node.property = deserializeExpression(pos + 24);
   node.computed = true;
@@ -661,7 +667,7 @@ function deserializeStaticMemberExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'MemberExpression',
       object: null,
@@ -672,7 +678,7 @@ function deserializeStaticMemberExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.object = deserializeExpression(pos + 8);
   node.property = deserializeIdentifierName(pos + 24);
   node.computed = false;
@@ -684,7 +690,7 @@ function deserializePrivateFieldExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'MemberExpression',
       object: null,
@@ -695,7 +701,7 @@ function deserializePrivateFieldExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.object = deserializeExpression(pos + 8);
   node.property = deserializePrivateIdentifier(pos + 24);
   node.computed = false;
@@ -707,7 +713,7 @@ function deserializeCallExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'CallExpression',
       callee: null,
@@ -718,7 +724,7 @@ function deserializeCallExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.callee = deserializeExpression(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   node.arguments = deserializeVecArgument(pos + 32);
@@ -730,7 +736,7 @@ function deserializeNewExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'NewExpression',
       callee: null,
@@ -740,7 +746,7 @@ function deserializeNewExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.callee = deserializeExpression(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   node.arguments = deserializeVecArgument(pos + 32);
@@ -752,7 +758,7 @@ function deserializeMetaProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'MetaProperty',
       meta: null,
@@ -761,7 +767,7 @@ function deserializeMetaProperty(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.meta = deserializeIdentifierName(pos + 8);
   node.property = deserializeIdentifierName(pos + 32);
   parent = previousParent;
@@ -772,7 +778,7 @@ function deserializeSpreadElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'SpreadElement',
       argument: null,
@@ -780,7 +786,7 @@ function deserializeSpreadElement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -885,7 +891,7 @@ function deserializeUpdateExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'UpdateExpression',
       operator: deserializeUpdateOperator(pos + 24),
@@ -895,7 +901,7 @@ function deserializeUpdateExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeSimpleAssignmentTarget(pos + 8);
   parent = previousParent;
   return node;
@@ -905,7 +911,7 @@ function deserializeUnaryExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'UnaryExpression',
       operator: deserializeUnaryOperator(pos + 24),
@@ -915,7 +921,7 @@ function deserializeUnaryExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   node.prefix = true;
   parent = previousParent;
@@ -926,7 +932,7 @@ function deserializeBinaryExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'BinaryExpression',
       left: null,
@@ -936,7 +942,7 @@ function deserializeBinaryExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializeExpression(pos + 8);
   node.right = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -947,7 +953,7 @@ function deserializePrivateInExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'BinaryExpression',
       left: null,
@@ -957,7 +963,7 @@ function deserializePrivateInExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializePrivateIdentifier(pos + 8);
   node.operator = 'in';
   node.right = deserializeExpression(pos + 32);
@@ -969,7 +975,7 @@ function deserializeLogicalExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'LogicalExpression',
       left: null,
@@ -979,7 +985,7 @@ function deserializeLogicalExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializeExpression(pos + 8);
   node.right = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -990,7 +996,7 @@ function deserializeConditionalExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ConditionalExpression',
       test: null,
@@ -1000,7 +1006,7 @@ function deserializeConditionalExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.test = deserializeExpression(pos + 8);
   node.consequent = deserializeExpression(pos + 24);
   node.alternate = deserializeExpression(pos + 40);
@@ -1012,7 +1018,7 @@ function deserializeAssignmentExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'AssignmentExpression',
       operator: deserializeAssignmentOperator(pos + 40),
@@ -1022,7 +1028,7 @@ function deserializeAssignmentExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializeAssignmentTarget(pos + 8);
   node.right = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -1083,7 +1089,7 @@ function deserializeArrayAssignmentTarget(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ArrayPattern',
       decorators: null,
@@ -1094,7 +1100,7 @@ function deserializeArrayAssignmentTarget(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     elements = deserializeVecOptionAssignmentTargetMaybeDefault(pos + 8),
     rest = deserializeOptionBoxAssignmentTargetRest(pos + 32);
   rest !== null && elements.push(rest);
@@ -1110,7 +1116,7 @@ function deserializeObjectAssignmentTarget(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ObjectPattern',
       decorators: null,
@@ -1121,7 +1127,7 @@ function deserializeObjectAssignmentTarget(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     properties = deserializeVecAssignmentTargetProperty(pos + 8),
     rest = deserializeOptionBoxAssignmentTargetRest(pos + 32);
   rest !== null && properties.push(rest);
@@ -1137,7 +1143,7 @@ function deserializeAssignmentTargetRest(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'RestElement',
       decorators: null,
@@ -1149,7 +1155,7 @@ function deserializeAssignmentTargetRest(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = [];
   node.argument = deserializeAssignmentTarget(pos + 8);
   node.optional = false;
@@ -1192,7 +1198,7 @@ function deserializeAssignmentTargetWithDefault(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'AssignmentPattern',
       decorators: null,
@@ -1204,7 +1210,7 @@ function deserializeAssignmentTargetWithDefault(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = [];
   node.left = deserializeAssignmentTarget(pos + 8);
   node.right = deserializeExpression(pos + 24);
@@ -1229,7 +1235,7 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'Property',
       kind: null,
@@ -1243,12 +1249,13 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     key = deserializeIdentifierReference(pos + 8),
     init = deserializeOptionExpression(pos + 40),
     value = { ...key };
   if (init !== null) {
-    let left = value, previousParent = parent;
+    let left = value,
+      previousParent = parent;
     value = parent = {
       __proto__: NodeProto,
       type: 'AssignmentPattern',
@@ -1281,7 +1288,7 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'Property',
       kind: null,
@@ -1295,7 +1302,7 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.kind = 'init';
   node.key = deserializePropertyKey(pos + 8);
   node.value = deserializeAssignmentTargetMaybeDefault(pos + 24);
@@ -1310,7 +1317,7 @@ function deserializeSequenceExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'SequenceExpression',
       expressions: null,
@@ -1318,14 +1325,15 @@ function deserializeSequenceExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expressions = deserializeVecExpression(pos + 8);
   parent = previousParent;
   return node;
 }
 
 function deserializeSuper(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'Super',
@@ -1340,7 +1348,7 @@ function deserializeAwaitExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'AwaitExpression',
       argument: null,
@@ -1348,7 +1356,7 @@ function deserializeAwaitExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -1358,7 +1366,7 @@ function deserializeChainExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ChainExpression',
       expression: null,
@@ -1366,7 +1374,7 @@ function deserializeChainExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeChainElement(pos + 8);
   parent = previousParent;
   return node;
@@ -1470,7 +1478,7 @@ function deserializeDirective(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ExpressionStatement',
       expression: null,
@@ -1479,14 +1487,15 @@ function deserializeDirective(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeStringLiteral(pos + 8);
   parent = previousParent;
   return node;
 }
 
 function deserializeHashbang(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'Hashbang',
@@ -1502,7 +1511,7 @@ function deserializeBlockStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'BlockStatement',
       body: null,
@@ -1510,7 +1519,7 @@ function deserializeBlockStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.body = deserializeVecStatement(pos + 8);
   parent = previousParent;
   return node;
@@ -1543,7 +1552,7 @@ function deserializeVariableDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'VariableDeclaration',
       kind: deserializeVariableDeclarationKind(pos + 32),
@@ -1553,7 +1562,7 @@ function deserializeVariableDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.declarations = deserializeVecVariableDeclarator(pos + 8);
   parent = previousParent;
   return node;
@@ -1580,7 +1589,7 @@ function deserializeVariableDeclarator(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'VariableDeclarator',
       id: null,
@@ -1590,7 +1599,7 @@ function deserializeVariableDeclarator(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.id = deserializeBindingPattern(pos + 8);
   node.init = deserializeOptionExpression(pos + 40);
   parent = previousParent;
@@ -1598,7 +1607,8 @@ function deserializeVariableDeclarator(pos) {
 }
 
 function deserializeEmptyStatement(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'EmptyStatement',
@@ -1613,7 +1623,7 @@ function deserializeExpressionStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ExpressionStatement',
       expression: null,
@@ -1622,7 +1632,7 @@ function deserializeExpressionStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   node.directive = null;
   parent = previousParent;
@@ -1633,7 +1643,7 @@ function deserializeIfStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'IfStatement',
       test: null,
@@ -1643,7 +1653,7 @@ function deserializeIfStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.test = deserializeExpression(pos + 8);
   node.consequent = deserializeStatement(pos + 24);
   node.alternate = deserializeOptionStatement(pos + 40);
@@ -1655,7 +1665,7 @@ function deserializeDoWhileStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'DoWhileStatement',
       body: null,
@@ -1664,7 +1674,7 @@ function deserializeDoWhileStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.body = deserializeStatement(pos + 8);
   node.test = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -1675,7 +1685,7 @@ function deserializeWhileStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'WhileStatement',
       test: null,
@@ -1684,7 +1694,7 @@ function deserializeWhileStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.test = deserializeExpression(pos + 8);
   node.body = deserializeStatement(pos + 24);
   parent = previousParent;
@@ -1695,7 +1705,7 @@ function deserializeForStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ForStatement',
       init: null,
@@ -1706,7 +1716,7 @@ function deserializeForStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.init = deserializeOptionForStatementInit(pos + 8);
   node.test = deserializeOptionExpression(pos + 24);
   node.update = deserializeOptionExpression(pos + 40);
@@ -1814,7 +1824,7 @@ function deserializeForInStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ForInStatement',
       left: null,
@@ -1824,7 +1834,7 @@ function deserializeForInStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializeForStatementLeft(pos + 8);
   node.right = deserializeExpression(pos + 24);
   node.body = deserializeStatement(pos + 40);
@@ -1865,7 +1875,7 @@ function deserializeForOfStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ForOfStatement',
       await: deserializeBool(pos + 60),
@@ -1876,7 +1886,7 @@ function deserializeForOfStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializeForStatementLeft(pos + 8);
   node.right = deserializeExpression(pos + 24);
   node.body = deserializeStatement(pos + 40);
@@ -1888,7 +1898,7 @@ function deserializeContinueStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ContinueStatement',
       label: null,
@@ -1896,7 +1906,7 @@ function deserializeContinueStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.label = deserializeOptionLabelIdentifier(pos + 8);
   parent = previousParent;
   return node;
@@ -1906,7 +1916,7 @@ function deserializeBreakStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'BreakStatement',
       label: null,
@@ -1914,7 +1924,7 @@ function deserializeBreakStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.label = deserializeOptionLabelIdentifier(pos + 8);
   parent = previousParent;
   return node;
@@ -1924,7 +1934,7 @@ function deserializeReturnStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ReturnStatement',
       argument: null,
@@ -1932,7 +1942,7 @@ function deserializeReturnStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeOptionExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -1942,7 +1952,7 @@ function deserializeWithStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'WithStatement',
       object: null,
@@ -1951,7 +1961,7 @@ function deserializeWithStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.object = deserializeExpression(pos + 8);
   node.body = deserializeStatement(pos + 24);
   parent = previousParent;
@@ -1962,7 +1972,7 @@ function deserializeSwitchStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'SwitchStatement',
       discriminant: null,
@@ -1971,7 +1981,7 @@ function deserializeSwitchStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.discriminant = deserializeExpression(pos + 8);
   node.cases = deserializeVecSwitchCase(pos + 24);
   parent = previousParent;
@@ -1982,7 +1992,7 @@ function deserializeSwitchCase(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'SwitchCase',
       test: null,
@@ -1991,7 +2001,7 @@ function deserializeSwitchCase(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.test = deserializeOptionExpression(pos + 8);
   node.consequent = deserializeVecStatement(pos + 24);
   parent = previousParent;
@@ -2002,7 +2012,7 @@ function deserializeLabeledStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'LabeledStatement',
       label: null,
@@ -2011,7 +2021,7 @@ function deserializeLabeledStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.label = deserializeLabelIdentifier(pos + 8);
   node.body = deserializeStatement(pos + 32);
   parent = previousParent;
@@ -2022,7 +2032,7 @@ function deserializeThrowStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ThrowStatement',
       argument: null,
@@ -2030,7 +2040,7 @@ function deserializeThrowStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -2040,7 +2050,7 @@ function deserializeTryStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TryStatement',
       block: null,
@@ -2050,7 +2060,7 @@ function deserializeTryStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.block = deserializeBoxBlockStatement(pos + 8);
   node.handler = deserializeOptionBoxCatchClause(pos + 16);
   node.finalizer = deserializeOptionBoxBlockStatement(pos + 24);
@@ -2062,7 +2072,7 @@ function deserializeCatchClause(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'CatchClause',
       param: null,
@@ -2071,7 +2081,7 @@ function deserializeCatchClause(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.param = deserializeOptionCatchParameter(pos + 8);
   node.body = deserializeBoxBlockStatement(pos + 48);
   parent = previousParent;
@@ -2083,7 +2093,8 @@ function deserializeCatchParameter(pos) {
 }
 
 function deserializeDebuggerStatement(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'DebuggerStatement',
@@ -2125,7 +2136,7 @@ function deserializeAssignmentPattern(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'AssignmentPattern',
       decorators: null,
@@ -2137,7 +2148,7 @@ function deserializeAssignmentPattern(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = [];
   node.left = deserializeBindingPattern(pos + 8);
   node.right = deserializeExpression(pos + 40);
@@ -2151,7 +2162,7 @@ function deserializeObjectPattern(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ObjectPattern',
       decorators: null,
@@ -2162,7 +2173,7 @@ function deserializeObjectPattern(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     properties = deserializeVecBindingProperty(pos + 8),
     rest = deserializeOptionBoxBindingRestElement(pos + 32);
   rest !== null && properties.push(rest);
@@ -2178,7 +2189,7 @@ function deserializeBindingProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'Property',
       kind: null,
@@ -2192,7 +2203,7 @@ function deserializeBindingProperty(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.kind = 'init';
   node.key = deserializePropertyKey(pos + 8);
   node.value = deserializeBindingPattern(pos + 24);
@@ -2206,7 +2217,7 @@ function deserializeArrayPattern(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ArrayPattern',
       decorators: null,
@@ -2217,7 +2228,7 @@ function deserializeArrayPattern(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     elements = deserializeVecOptionBindingPattern(pos + 8),
     rest = deserializeOptionBoxBindingRestElement(pos + 32);
   rest !== null && elements.push(rest);
@@ -2233,7 +2244,7 @@ function deserializeBindingRestElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'RestElement',
       decorators: null,
@@ -2245,7 +2256,7 @@ function deserializeBindingRestElement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = [];
   node.argument = deserializeBindingPattern(pos + 8);
   node.optional = false;
@@ -2259,7 +2270,7 @@ function deserializeFunction(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: deserializeFunctionType(pos + 84),
       id: null,
@@ -2275,7 +2286,7 @@ function deserializeFunction(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     params = deserializeBoxFormalParameters(pos + 56);
   {
     let thisParam = deserializeOptionBoxTSThisParameter(pos + 48);
@@ -2308,12 +2319,12 @@ function deserializeFunctionType(pos) {
 
 function deserializeFormalParameters(pos) {
   let params = deserializeVecFormalParameter(pos + 8);
-  if (uint32[pos + 32 >> 2] !== 0 && uint32[pos + 36 >> 2] !== 0) {
-    pos = uint32[pos + 32 >> 2];
+  if (uint32[(pos + 32) >> 2] !== 0 && uint32[(pos + 36) >> 2] !== 0) {
+    pos = uint32[(pos + 32) >> 2];
     let start,
       end,
       previousParent = parent,
-      rest = parent = {
+      rest = (parent = {
         __proto__: NodeProto,
         type: 'RestElement',
         decorators: [],
@@ -2321,11 +2332,11 @@ function deserializeFormalParameters(pos) {
         optional: deserializeBool(pos + 32),
         typeAnnotation: null,
         value: null,
-        start: start = deserializeU32(pos),
-        end: end = deserializeU32(pos + 4),
+        start: (start = deserializeU32(pos)),
+        end: (end = deserializeU32(pos + 4)),
         range: [start, end],
         parent,
-      };
+      });
     rest.argument = deserializeBindingPatternKind(pos + 8);
     rest.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
     params.push(rest);
@@ -2357,8 +2368,8 @@ function deserializeFormalParameter(pos) {
         parameter: null,
         readonly,
         static: false,
-        start: start = deserializeU32(pos),
-        end: end = deserializeU32(pos + 4),
+        start: (start = deserializeU32(pos)),
+        end: (end = deserializeU32(pos + 4)),
         range: [start, end],
         parent,
       };
@@ -2374,7 +2385,7 @@ function deserializeFunctionBody(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'BlockStatement',
       body: null,
@@ -2382,7 +2393,7 @@ function deserializeFunctionBody(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     body = deserializeVecDirective(pos + 8);
   body.push(...deserializeVecStatement(pos + 32));
   node.body = body;
@@ -2395,7 +2406,7 @@ function deserializeArrowFunctionExpression(pos) {
     start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ArrowFunctionExpression',
       expression,
@@ -2410,7 +2421,7 @@ function deserializeArrowFunctionExpression(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     body = deserializeBoxFunctionBody(pos + 32);
   if (expression === true) {
     body = body.body[0].expression;
@@ -2430,7 +2441,7 @@ function deserializeYieldExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'YieldExpression',
       delegate: deserializeBool(pos + 24),
@@ -2439,7 +2450,7 @@ function deserializeYieldExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeOptionExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -2449,7 +2460,7 @@ function deserializeClass(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: deserializeClassType(pos + 132),
       decorators: null,
@@ -2465,7 +2476,7 @@ function deserializeClass(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = deserializeVecDecorator(pos + 8);
   node.id = deserializeOptionBindingIdentifier(pos + 32);
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 64);
@@ -2492,7 +2503,7 @@ function deserializeClassBody(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ClassBody',
       body: null,
@@ -2500,7 +2511,7 @@ function deserializeClassBody(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.body = deserializeVecClassElement(pos + 8);
   parent = previousParent;
   return node;
@@ -2527,7 +2538,7 @@ function deserializeMethodDefinition(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: deserializeMethodDefinitionType(pos + 56),
       decorators: null,
@@ -2543,7 +2554,7 @@ function deserializeMethodDefinition(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = deserializeVecDecorator(pos + 8);
   node.key = deserializePropertyKey(pos + 32);
   node.value = deserializeBoxFunction(pos + 48);
@@ -2566,7 +2577,7 @@ function deserializePropertyDefinition(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: deserializePropertyDefinitionType(pos + 72),
       decorators: null,
@@ -2585,7 +2596,7 @@ function deserializePropertyDefinition(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = deserializeVecDecorator(pos + 8);
   node.key = deserializePropertyKey(pos + 32);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 48);
@@ -2621,7 +2632,8 @@ function deserializeMethodDefinitionKind(pos) {
 }
 
 function deserializePrivateIdentifier(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'PrivateIdentifier',
@@ -2637,7 +2649,7 @@ function deserializeStaticBlock(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'StaticBlock',
       body: null,
@@ -2645,7 +2657,7 @@ function deserializeStaticBlock(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.body = deserializeVecStatement(pos + 8);
   parent = previousParent;
   return node;
@@ -2666,7 +2678,7 @@ function deserializeAccessorProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: deserializeAccessorPropertyType(pos + 72),
       decorators: null,
@@ -2685,7 +2697,7 @@ function deserializeAccessorProperty(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = deserializeVecDecorator(pos + 8);
   node.key = deserializePropertyKey(pos + 32);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 48);
@@ -2701,7 +2713,7 @@ function deserializeImportExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ImportExpression',
       source: null,
@@ -2711,7 +2723,7 @@ function deserializeImportExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.source = deserializeExpression(pos + 8);
   node.options = deserializeOptionExpression(pos + 24);
   parent = previousParent;
@@ -2722,7 +2734,7 @@ function deserializeImportDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ImportDeclaration',
       specifiers: null,
@@ -2734,7 +2746,7 @@ function deserializeImportDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     specifiers = deserializeOptionVecImportDeclarationSpecifier(pos + 8);
   specifiers === null && (specifiers = []);
   let withClause = deserializeOptionBoxWithClause(pos + 80);
@@ -2773,7 +2785,7 @@ function deserializeImportSpecifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ImportSpecifier',
       imported: null,
@@ -2783,7 +2795,7 @@ function deserializeImportSpecifier(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.imported = deserializeModuleExportName(pos + 8);
   node.local = deserializeBindingIdentifier(pos + 64);
   parent = previousParent;
@@ -2794,7 +2806,7 @@ function deserializeImportDefaultSpecifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ImportDefaultSpecifier',
       local: null,
@@ -2802,7 +2814,7 @@ function deserializeImportDefaultSpecifier(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.local = deserializeBindingIdentifier(pos + 8);
   parent = previousParent;
   return node;
@@ -2812,7 +2824,7 @@ function deserializeImportNamespaceSpecifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ImportNamespaceSpecifier',
       local: null,
@@ -2820,7 +2832,7 @@ function deserializeImportNamespaceSpecifier(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.local = deserializeBindingIdentifier(pos + 8);
   parent = previousParent;
   return node;
@@ -2834,7 +2846,7 @@ function deserializeImportAttribute(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ImportAttribute',
       key: null,
@@ -2843,7 +2855,7 @@ function deserializeImportAttribute(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.key = deserializeImportAttributeKey(pos + 8);
   node.value = deserializeStringLiteral(pos + 64);
   parent = previousParent;
@@ -2865,7 +2877,7 @@ function deserializeExportNamedDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ExportNamedDeclaration',
       declaration: null,
@@ -2877,7 +2889,7 @@ function deserializeExportNamedDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     withClause = deserializeOptionBoxWithClause(pos + 96);
   node.declaration = deserializeOptionDeclaration(pos + 8);
   node.specifiers = deserializeVecExportSpecifier(pos + 24);
@@ -2891,7 +2903,7 @@ function deserializeExportDefaultDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ExportDefaultDeclaration',
       declaration: null,
@@ -2900,7 +2912,7 @@ function deserializeExportDefaultDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.declaration = deserializeExportDefaultDeclarationKind(pos + 8);
   node.exportKind = 'value';
   parent = previousParent;
@@ -2911,7 +2923,7 @@ function deserializeExportAllDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ExportAllDeclaration',
       exported: null,
@@ -2922,7 +2934,7 @@ function deserializeExportAllDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     withClause = deserializeOptionBoxWithClause(pos + 112);
   node.exported = deserializeOptionModuleExportName(pos + 8);
   node.source = deserializeStringLiteral(pos + 64);
@@ -2935,7 +2947,7 @@ function deserializeExportSpecifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'ExportSpecifier',
       local: null,
@@ -2945,7 +2957,7 @@ function deserializeExportSpecifier(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.local = deserializeModuleExportName(pos + 8);
   node.exported = deserializeModuleExportName(pos + 64);
   parent = previousParent;
@@ -3068,7 +3080,7 @@ function deserializeV8IntrinsicExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'V8IntrinsicExpression',
       name: null,
@@ -3077,7 +3089,7 @@ function deserializeV8IntrinsicExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.name = deserializeIdentifierName(pos + 8);
   node.arguments = deserializeVecArgument(pos + 32);
   parent = previousParent;
@@ -3089,7 +3101,7 @@ function deserializeBooleanLiteral(pos) {
     start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'Literal',
       value,
@@ -3098,7 +3110,7 @@ function deserializeBooleanLiteral(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.raw = start === 0 && end === 0 ? null : value + '';
   parent = previousParent;
   return node;
@@ -3108,7 +3120,7 @@ function deserializeNullLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'Literal',
       value: null,
@@ -3117,7 +3129,7 @@ function deserializeNullLiteral(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.value = null;
   node.raw = start === 0 && end === 0 ? null : 'null';
   parent = previousParent;
@@ -3125,7 +3137,8 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'Literal',
@@ -3142,7 +3155,7 @@ function deserializeStringLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'Literal',
       value: null,
@@ -3151,7 +3164,7 @@ function deserializeStringLiteral(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     value = deserializeStr(pos + 8);
   deserializeBool(pos + 40) &&
     (value = value.replace(/\uFFFD(.{4})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16))));
@@ -3164,7 +3177,7 @@ function deserializeBigIntLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'Literal',
       value: null,
@@ -3174,7 +3187,7 @@ function deserializeBigIntLiteral(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     bigint = deserializeStr(pos + 8);
   node.value = BigInt(bigint);
   node.bigint = bigint;
@@ -3186,7 +3199,7 @@ function deserializeRegExpLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'Literal',
       value: null,
@@ -3196,7 +3209,7 @@ function deserializeRegExpLiteral(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     regex = deserializeRegExp(pos + 8),
     value = null;
   try {
@@ -3216,7 +3229,8 @@ function deserializeRegExp(pos) {
 }
 
 function deserializeRegExpFlags(pos) {
-  let flagBits = deserializeU8(pos), flags = '';
+  let flagBits = deserializeU8(pos),
+    flags = '';
   // Alphabetical order
   flagBits & 64 && (flags += 'd');
   flagBits & 1 && (flags += 'g');
@@ -3233,7 +3247,7 @@ function deserializeJSXElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'JSXElement',
       openingElement: null,
@@ -3243,7 +3257,7 @@ function deserializeJSXElement(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     closingElement = deserializeOptionBoxJSXClosingElement(pos + 40),
     openingElement = deserializeBoxJSXOpeningElement(pos + 8);
   closingElement === null && (openingElement.selfClosing = true);
@@ -3258,7 +3272,7 @@ function deserializeJSXOpeningElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'JSXOpeningElement',
       name: null,
@@ -3269,7 +3283,7 @@ function deserializeJSXOpeningElement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.name = deserializeJSXElementName(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   node.attributes = deserializeVecJSXAttributeItem(pos + 32);
@@ -3282,7 +3296,7 @@ function deserializeJSXClosingElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'JSXClosingElement',
       name: null,
@@ -3290,7 +3304,7 @@ function deserializeJSXClosingElement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.name = deserializeJSXElementName(pos + 8);
   parent = previousParent;
   return node;
@@ -3300,7 +3314,7 @@ function deserializeJSXFragment(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'JSXFragment',
       openingFragment: null,
@@ -3310,7 +3324,7 @@ function deserializeJSXFragment(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.openingFragment = deserializeJSXOpeningFragment(pos + 8);
   node.children = deserializeVecJSXChild(pos + 16);
   node.closingFragment = deserializeJSXClosingFragment(pos + 40);
@@ -3322,20 +3336,21 @@ function deserializeJSXOpeningFragment(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'JSXOpeningFragment',
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   parent = previousParent;
   return node;
 }
 
 function deserializeJSXClosingFragment(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'JSXClosingFragment',
@@ -3385,7 +3400,7 @@ function deserializeJSXNamespacedName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'JSXNamespacedName',
       namespace: null,
@@ -3394,7 +3409,7 @@ function deserializeJSXNamespacedName(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.namespace = deserializeJSXIdentifier(pos + 8);
   node.name = deserializeJSXIdentifier(pos + 32);
   parent = previousParent;
@@ -3405,7 +3420,7 @@ function deserializeJSXMemberExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'JSXMemberExpression',
       object: null,
@@ -3414,7 +3429,7 @@ function deserializeJSXMemberExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.object = deserializeJSXMemberExpressionObject(pos + 8);
   node.property = deserializeJSXIdentifier(pos + 24);
   parent = previousParent;
@@ -3456,7 +3471,7 @@ function deserializeJSXExpressionContainer(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'JSXExpressionContainer',
       expression: null,
@@ -3464,7 +3479,7 @@ function deserializeJSXExpressionContainer(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeJSXExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -3566,7 +3581,8 @@ function deserializeJSXExpression(pos) {
 }
 
 function deserializeJSXEmptyExpression(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'JSXEmptyExpression',
@@ -3592,7 +3608,7 @@ function deserializeJSXAttribute(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'JSXAttribute',
       name: null,
@@ -3601,7 +3617,7 @@ function deserializeJSXAttribute(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.name = deserializeJSXAttributeName(pos + 8);
   node.value = deserializeOptionJSXAttributeValue(pos + 24);
   parent = previousParent;
@@ -3612,7 +3628,7 @@ function deserializeJSXSpreadAttribute(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'JSXSpreadAttribute',
       argument: null,
@@ -3620,7 +3636,7 @@ function deserializeJSXSpreadAttribute(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -3653,7 +3669,8 @@ function deserializeJSXAttributeValue(pos) {
 }
 
 function deserializeJSXIdentifier(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'JSXIdentifier',
@@ -3686,7 +3703,7 @@ function deserializeJSXSpreadChild(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'JSXSpreadChild',
       expression: null,
@@ -3694,14 +3711,15 @@ function deserializeJSXSpreadChild(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
 }
 
 function deserializeJSXText(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'JSXText',
@@ -3718,7 +3736,7 @@ function deserializeTSThisParameter(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'Identifier',
       decorators: null,
@@ -3729,7 +3747,7 @@ function deserializeTSThisParameter(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = [];
   node.name = 'this';
   node.optional = false;
@@ -3742,7 +3760,7 @@ function deserializeTSEnumDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSEnumDeclaration',
       id: null,
@@ -3753,7 +3771,7 @@ function deserializeTSEnumDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.id = deserializeBindingIdentifier(pos + 8);
   node.body = deserializeTSEnumBody(pos + 40);
   parent = previousParent;
@@ -3764,7 +3782,7 @@ function deserializeTSEnumBody(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSEnumBody',
       members: null,
@@ -3772,7 +3790,7 @@ function deserializeTSEnumBody(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.members = deserializeVecTSEnumMember(pos + 8);
   parent = previousParent;
   return node;
@@ -3782,7 +3800,7 @@ function deserializeTSEnumMember(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSEnumMember',
       id: null,
@@ -3792,7 +3810,7 @@ function deserializeTSEnumMember(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.id = deserializeTSEnumMemberName(pos + 8);
   node.initializer = deserializeOptionExpression(pos + 24);
   node.computed = deserializeU8(pos + 8) > 1;
@@ -3819,7 +3837,7 @@ function deserializeTSTypeAnnotation(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSTypeAnnotation',
       typeAnnotation: null,
@@ -3827,7 +3845,7 @@ function deserializeTSTypeAnnotation(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3837,7 +3855,7 @@ function deserializeTSLiteralType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSLiteralType',
       literal: null,
@@ -3845,7 +3863,7 @@ function deserializeTSLiteralType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.literal = deserializeTSLiteral(pos + 8);
   parent = previousParent;
   return node;
@@ -3955,7 +3973,7 @@ function deserializeTSConditionalType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSConditionalType',
       checkType: null,
@@ -3966,7 +3984,7 @@ function deserializeTSConditionalType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.checkType = deserializeTSType(pos + 8);
   node.extendsType = deserializeTSType(pos + 24);
   node.trueType = deserializeTSType(pos + 40);
@@ -3979,7 +3997,7 @@ function deserializeTSUnionType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSUnionType',
       types: null,
@@ -3987,7 +4005,7 @@ function deserializeTSUnionType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.types = deserializeVecTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3997,7 +4015,7 @@ function deserializeTSIntersectionType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSIntersectionType',
       types: null,
@@ -4005,7 +4023,7 @@ function deserializeTSIntersectionType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.types = deserializeVecTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -4021,7 +4039,7 @@ function deserializeTSTypeOperator(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSTypeOperator',
       operator: deserializeTSTypeOperatorOperator(pos + 24),
@@ -4030,7 +4048,7 @@ function deserializeTSTypeOperator(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -4053,7 +4071,7 @@ function deserializeTSArrayType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSArrayType',
       elementType: null,
@@ -4061,7 +4079,7 @@ function deserializeTSArrayType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.elementType = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -4071,7 +4089,7 @@ function deserializeTSIndexedAccessType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSIndexedAccessType',
       objectType: null,
@@ -4080,7 +4098,7 @@ function deserializeTSIndexedAccessType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.objectType = deserializeTSType(pos + 8);
   node.indexType = deserializeTSType(pos + 24);
   parent = previousParent;
@@ -4091,7 +4109,7 @@ function deserializeTSTupleType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSTupleType',
       elementTypes: null,
@@ -4099,7 +4117,7 @@ function deserializeTSTupleType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.elementTypes = deserializeVecTSTupleElement(pos + 8);
   parent = previousParent;
   return node;
@@ -4109,7 +4127,7 @@ function deserializeTSNamedTupleMember(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSNamedTupleMember',
       label: null,
@@ -4119,7 +4137,7 @@ function deserializeTSNamedTupleMember(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.label = deserializeIdentifierName(pos + 8);
   node.elementType = deserializeTSTupleElement(pos + 32);
   parent = previousParent;
@@ -4130,7 +4148,7 @@ function deserializeTSOptionalType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSOptionalType',
       typeAnnotation: null,
@@ -4138,7 +4156,7 @@ function deserializeTSOptionalType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -4148,7 +4166,7 @@ function deserializeTSRestType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSRestType',
       typeAnnotation: null,
@@ -4156,7 +4174,7 @@ function deserializeTSRestType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -4248,7 +4266,8 @@ function deserializeTSTupleElement(pos) {
 }
 
 function deserializeTSAnyKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'TSAnyKeyword',
@@ -4260,7 +4279,8 @@ function deserializeTSAnyKeyword(pos) {
 }
 
 function deserializeTSStringKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'TSStringKeyword',
@@ -4272,7 +4292,8 @@ function deserializeTSStringKeyword(pos) {
 }
 
 function deserializeTSBooleanKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'TSBooleanKeyword',
@@ -4284,7 +4305,8 @@ function deserializeTSBooleanKeyword(pos) {
 }
 
 function deserializeTSNumberKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'TSNumberKeyword',
@@ -4296,7 +4318,8 @@ function deserializeTSNumberKeyword(pos) {
 }
 
 function deserializeTSNeverKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'TSNeverKeyword',
@@ -4308,7 +4331,8 @@ function deserializeTSNeverKeyword(pos) {
 }
 
 function deserializeTSIntrinsicKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'TSIntrinsicKeyword',
@@ -4320,7 +4344,8 @@ function deserializeTSIntrinsicKeyword(pos) {
 }
 
 function deserializeTSUnknownKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'TSUnknownKeyword',
@@ -4332,7 +4357,8 @@ function deserializeTSUnknownKeyword(pos) {
 }
 
 function deserializeTSNullKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'TSNullKeyword',
@@ -4344,7 +4370,8 @@ function deserializeTSNullKeyword(pos) {
 }
 
 function deserializeTSUndefinedKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'TSUndefinedKeyword',
@@ -4356,7 +4383,8 @@ function deserializeTSUndefinedKeyword(pos) {
 }
 
 function deserializeTSVoidKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'TSVoidKeyword',
@@ -4368,7 +4396,8 @@ function deserializeTSVoidKeyword(pos) {
 }
 
 function deserializeTSSymbolKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'TSSymbolKeyword',
@@ -4380,7 +4409,8 @@ function deserializeTSSymbolKeyword(pos) {
 }
 
 function deserializeTSThisType(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'TSThisType',
@@ -4392,7 +4422,8 @@ function deserializeTSThisType(pos) {
 }
 
 function deserializeTSObjectKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'TSObjectKeyword',
@@ -4404,7 +4435,8 @@ function deserializeTSObjectKeyword(pos) {
 }
 
 function deserializeTSBigIntKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'TSBigIntKeyword',
@@ -4419,7 +4451,7 @@ function deserializeTSTypeReference(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSTypeReference',
       typeName: null,
@@ -4428,7 +4460,7 @@ function deserializeTSTypeReference(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeName = deserializeTSTypeName(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   parent = previousParent;
@@ -4452,7 +4484,7 @@ function deserializeTSQualifiedName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSQualifiedName',
       left: null,
@@ -4461,7 +4493,7 @@ function deserializeTSQualifiedName(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializeTSTypeName(pos + 8);
   node.right = deserializeIdentifierName(pos + 24);
   parent = previousParent;
@@ -4472,7 +4504,7 @@ function deserializeTSTypeParameterInstantiation(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSTypeParameterInstantiation',
       params: null,
@@ -4480,7 +4512,7 @@ function deserializeTSTypeParameterInstantiation(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.params = deserializeVecTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -4490,7 +4522,7 @@ function deserializeTSTypeParameter(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSTypeParameter',
       name: null,
@@ -4503,7 +4535,7 @@ function deserializeTSTypeParameter(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.name = deserializeBindingIdentifier(pos + 8);
   node.constraint = deserializeOptionTSType(pos + 40);
   node.default = deserializeOptionTSType(pos + 56);
@@ -4515,7 +4547,7 @@ function deserializeTSTypeParameterDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSTypeParameterDeclaration',
       params: null,
@@ -4523,7 +4555,7 @@ function deserializeTSTypeParameterDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.params = deserializeVecTSTypeParameter(pos + 8);
   parent = previousParent;
   return node;
@@ -4533,7 +4565,7 @@ function deserializeTSTypeAliasDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSTypeAliasDeclaration',
       id: null,
@@ -4544,7 +4576,7 @@ function deserializeTSTypeAliasDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.id = deserializeBindingIdentifier(pos + 8);
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 40);
   node.typeAnnotation = deserializeTSType(pos + 48);
@@ -4569,7 +4601,7 @@ function deserializeTSClassImplements(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSClassImplements',
       expression: null,
@@ -4578,25 +4610,25 @@ function deserializeTSClassImplements(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     expression = deserializeTSTypeName(pos + 8);
   if (expression.type === 'TSQualifiedName') {
     let object = expression.left,
       { right } = expression,
       start,
       end,
-      previous = expression = {
+      previous = (expression = {
         __proto__: NodeProto,
         type: 'MemberExpression',
         object,
         property: right,
         optional: false,
         computed: false,
-        start: start = expression.start,
-        end: end = expression.end,
+        start: (start = expression.start),
+        end: (end = expression.end),
         range: [start, end],
         parent,
-      };
+      });
     right.parent = previous;
     for (;;) {
       if (object.type !== 'TSQualifiedName') {
@@ -4611,8 +4643,8 @@ function deserializeTSClassImplements(pos) {
         property: right,
         optional: false,
         computed: false,
-        start: start = object.start,
-        end: end = object.end,
+        start: (start = object.start),
+        end: (end = object.end),
         range: [start, end],
         parent: previous,
       };
@@ -4630,7 +4662,7 @@ function deserializeTSInterfaceDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSInterfaceDeclaration',
       id: null,
@@ -4642,7 +4674,7 @@ function deserializeTSInterfaceDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.id = deserializeBindingIdentifier(pos + 8);
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 40);
   node.extends = deserializeVecTSInterfaceHeritage(pos + 48);
@@ -4655,7 +4687,7 @@ function deserializeTSInterfaceBody(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSInterfaceBody',
       body: null,
@@ -4663,7 +4695,7 @@ function deserializeTSInterfaceBody(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.body = deserializeVecTSSignature(pos + 8);
   parent = previousParent;
   return node;
@@ -4673,7 +4705,7 @@ function deserializeTSPropertySignature(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSPropertySignature',
       computed: deserializeBool(pos + 32),
@@ -4687,7 +4719,7 @@ function deserializeTSPropertySignature(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.key = deserializePropertyKey(pos + 8);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   node.accessibility = null;
@@ -4717,7 +4749,7 @@ function deserializeTSIndexSignature(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSIndexSignature',
       parameters: null,
@@ -4729,7 +4761,7 @@ function deserializeTSIndexSignature(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.parameters = deserializeVecTSIndexSignatureName(pos + 8);
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
   node.accessibility = null;
@@ -4741,7 +4773,7 @@ function deserializeTSCallSignatureDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSCallSignatureDeclaration',
       typeParameters: null,
@@ -4751,7 +4783,7 @@ function deserializeTSCallSignatureDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     params = deserializeBoxFormalParameters(pos + 24),
     thisParam = deserializeOptionBoxTSThisParameter(pos + 16);
   thisParam !== null && params.unshift(thisParam);
@@ -4779,7 +4811,7 @@ function deserializeTSMethodSignature(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSMethodSignature',
       key: null,
@@ -4796,7 +4828,7 @@ function deserializeTSMethodSignature(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     params = deserializeBoxFormalParameters(pos + 40),
     thisParam = deserializeOptionBoxTSThisParameter(pos + 32);
   thisParam !== null && params.unshift(thisParam);
@@ -4815,7 +4847,7 @@ function deserializeTSConstructSignatureDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSConstructSignatureDeclaration',
       typeParameters: null,
@@ -4825,7 +4857,7 @@ function deserializeTSConstructSignatureDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 8);
   node.params = deserializeBoxFormalParameters(pos + 16);
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 24);
@@ -4837,7 +4869,7 @@ function deserializeTSIndexSignatureName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'Identifier',
       decorators: null,
@@ -4848,7 +4880,7 @@ function deserializeTSIndexSignatureName(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = [];
   node.optional = false;
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 24);
@@ -4860,7 +4892,7 @@ function deserializeTSInterfaceHeritage(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSInterfaceHeritage',
       expression: null,
@@ -4869,7 +4901,7 @@ function deserializeTSInterfaceHeritage(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   parent = previousParent;
@@ -4880,7 +4912,7 @@ function deserializeTSTypePredicate(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSTypePredicate',
       parameterName: null,
@@ -4890,7 +4922,7 @@ function deserializeTSTypePredicate(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.parameterName = deserializeTSTypePredicateName(pos + 8);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   parent = previousParent;
@@ -4962,8 +4994,8 @@ function deserializeTSModuleDeclaration(pos) {
               type: 'TSQualifiedName',
               left: id,
               right: innerId,
-              start: start = id.start,
-              end: end = innerId.end,
+              start: (start = id.start),
+              end: (end = innerId.end),
               range: [start, end],
               parent: node,
             };
@@ -4978,17 +5010,21 @@ function deserializeTSModuleDeclaration(pos) {
           if (innerId.left.type === 'Identifier') break;
           innerId = innerId.left;
         }
-        let end, right = innerId.left;
-        id.parent = right.parent = innerId.left = {
-          __proto__: NodeProto,
-          type: 'TSQualifiedName',
-          left: id,
-          right,
-          start,
-          end: end = right.end,
-          range: [start, end],
-          parent: innerId,
-        };
+        let end,
+          right = innerId.left;
+        id.parent =
+          right.parent =
+          innerId.left =
+            {
+              __proto__: NodeProto,
+              type: 'TSQualifiedName',
+              left: id,
+              right,
+              start,
+              end: (end = right.end),
+              range: [start, end],
+              parent: innerId,
+            };
       }
       if (Object.hasOwn(body, 'body')) {
         body = body.body;
@@ -5040,7 +5076,7 @@ function deserializeTSModuleBlock(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSModuleBlock',
       body: null,
@@ -5048,7 +5084,7 @@ function deserializeTSModuleBlock(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     body = deserializeVecDirective(pos + 8);
   body.push(...deserializeVecStatement(pos + 32));
   node.body = body;
@@ -5060,7 +5096,7 @@ function deserializeTSTypeLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSTypeLiteral',
       members: null,
@@ -5068,7 +5104,7 @@ function deserializeTSTypeLiteral(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.members = deserializeVecTSSignature(pos + 8);
   parent = previousParent;
   return node;
@@ -5078,7 +5114,7 @@ function deserializeTSInferType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSInferType',
       typeParameter: null,
@@ -5086,7 +5122,7 @@ function deserializeTSInferType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeParameter = deserializeBoxTSTypeParameter(pos + 8);
   parent = previousParent;
   return node;
@@ -5096,7 +5132,7 @@ function deserializeTSTypeQuery(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSTypeQuery',
       exprName: null,
@@ -5105,7 +5141,7 @@ function deserializeTSTypeQuery(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.exprName = deserializeTSTypeQueryExprName(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   parent = previousParent;
@@ -5131,7 +5167,7 @@ function deserializeTSImportType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSImportType',
       argument: null,
@@ -5142,7 +5178,7 @@ function deserializeTSImportType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeTSType(pos + 8);
   node.options = deserializeOptionBoxObjectExpression(pos + 24);
   node.qualifier = deserializeOptionTSImportTypeQualifier(pos + 32);
@@ -5166,7 +5202,7 @@ function deserializeTSImportTypeQualifiedName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSQualifiedName',
       left: null,
@@ -5175,7 +5211,7 @@ function deserializeTSImportTypeQualifiedName(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializeTSImportTypeQualifier(pos + 8);
   node.right = deserializeIdentifierName(pos + 24);
   parent = previousParent;
@@ -5186,7 +5222,7 @@ function deserializeTSFunctionType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSFunctionType',
       typeParameters: null,
@@ -5196,7 +5232,7 @@ function deserializeTSFunctionType(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     params = deserializeBoxFormalParameters(pos + 24),
     thisParam = deserializeOptionBoxTSThisParameter(pos + 16);
   thisParam !== null && params.unshift(thisParam);
@@ -5211,7 +5247,7 @@ function deserializeTSConstructorType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSConstructorType',
       abstract: deserializeBool(pos + 36),
@@ -5222,7 +5258,7 @@ function deserializeTSConstructorType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 8);
   node.params = deserializeBoxFormalParameters(pos + 16);
   node.returnType = deserializeBoxTSTypeAnnotation(pos + 24);
@@ -5234,7 +5270,7 @@ function deserializeTSMappedType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSMappedType',
       key: null,
@@ -5247,7 +5283,7 @@ function deserializeTSMappedType(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     typeParameter = deserializeBoxTSTypeParameter(pos + 8),
     key = typeParameter.name;
   key.parent = parent;
@@ -5281,7 +5317,7 @@ function deserializeTSTemplateLiteralType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSTemplateLiteralType',
       quasis: null,
@@ -5290,7 +5326,7 @@ function deserializeTSTemplateLiteralType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.quasis = deserializeVecTemplateElement(pos + 8);
   node.types = deserializeVecTSType(pos + 32);
   parent = previousParent;
@@ -5301,7 +5337,7 @@ function deserializeTSAsExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSAsExpression',
       expression: null,
@@ -5310,7 +5346,7 @@ function deserializeTSAsExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   node.typeAnnotation = deserializeTSType(pos + 24);
   parent = previousParent;
@@ -5321,7 +5357,7 @@ function deserializeTSSatisfiesExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSSatisfiesExpression',
       expression: null,
@@ -5330,7 +5366,7 @@ function deserializeTSSatisfiesExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   node.typeAnnotation = deserializeTSType(pos + 24);
   parent = previousParent;
@@ -5341,7 +5377,7 @@ function deserializeTSTypeAssertion(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSTypeAssertion',
       typeAnnotation: null,
@@ -5350,7 +5386,7 @@ function deserializeTSTypeAssertion(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   node.expression = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -5361,7 +5397,7 @@ function deserializeTSImportEqualsDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSImportEqualsDeclaration',
       id: null,
@@ -5371,7 +5407,7 @@ function deserializeTSImportEqualsDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.id = deserializeBindingIdentifier(pos + 8);
   node.moduleReference = deserializeTSModuleReference(pos + 40);
   parent = previousParent;
@@ -5397,7 +5433,7 @@ function deserializeTSExternalModuleReference(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSExternalModuleReference',
       expression: null,
@@ -5405,7 +5441,7 @@ function deserializeTSExternalModuleReference(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeStringLiteral(pos + 8);
   parent = previousParent;
   return node;
@@ -5415,7 +5451,7 @@ function deserializeTSNonNullExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSNonNullExpression',
       expression: null,
@@ -5423,7 +5459,7 @@ function deserializeTSNonNullExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -5433,7 +5469,7 @@ function deserializeDecorator(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'Decorator',
       expression: null,
@@ -5441,7 +5477,7 @@ function deserializeDecorator(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -5451,7 +5487,7 @@ function deserializeTSExportAssignment(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSExportAssignment',
       expression: null,
@@ -5459,7 +5495,7 @@ function deserializeTSExportAssignment(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -5469,7 +5505,7 @@ function deserializeTSNamespaceExportDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSNamespaceExportDeclaration',
       id: null,
@@ -5477,7 +5513,7 @@ function deserializeTSNamespaceExportDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.id = deserializeIdentifierName(pos + 8);
   parent = previousParent;
   return node;
@@ -5487,7 +5523,7 @@ function deserializeTSInstantiationExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSInstantiationExpression',
       expression: null,
@@ -5496,7 +5532,7 @@ function deserializeTSInstantiationExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   node.typeArguments = deserializeBoxTSTypeParameterInstantiation(pos + 24);
   parent = previousParent;
@@ -5518,7 +5554,7 @@ function deserializeJSDocNullableType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSJSDocNullableType',
       typeAnnotation: null,
@@ -5527,7 +5563,7 @@ function deserializeJSDocNullableType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -5537,7 +5573,7 @@ function deserializeJSDocNonNullableType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       __proto__: NodeProto,
       type: 'TSJSDocNonNullableType',
       typeAnnotation: null,
@@ -5546,14 +5582,15 @@ function deserializeJSDocNonNullableType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
 }
 
 function deserializeJSDocUnknownType(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: 'TSJSDocUnknownType',
@@ -5576,7 +5613,9 @@ function deserializeCommentKind(pos) {
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12), start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let type = deserializeCommentKind(pos + 12),
+    start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type,
@@ -5742,7 +5781,8 @@ function deserializeU8(pos) {
 }
 
 function deserializeStr(pos) {
-  let pos32 = pos >> 2, len = uint32[pos32 + 2];
+  let pos32 = pos >> 2,
+    len = uint32[pos32 + 2];
   if (len === 0) return '';
   pos = uint32[pos32];
   if (sourceIsAscii && pos < sourceByteLen) return sourceText.substr(pos, len);
@@ -5751,7 +5791,8 @@ function deserializeStr(pos) {
   let end = pos + len;
   if (len > 50) return decodeStr(uint8.subarray(pos, end));
   // Shorter strings decode by hand to avoid native call
-  let out = '', c;
+  let out = '',
+    c;
   do {
     c = uint8[pos++];
     if (c < 128) out += fromCodePoint(c);
@@ -5764,10 +5805,11 @@ function deserializeStr(pos) {
 }
 
 function deserializeVecComment(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeComment(pos));
     pos += 16;
   }
@@ -5775,15 +5817,16 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeHashbang(pos);
 }
 
 function deserializeVecDirective(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 72;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDirective(pos));
     pos += 72;
   }
@@ -5791,10 +5834,11 @@ function deserializeVecDirective(pos) {
 }
 
 function deserializeVecStatement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStatement(pos));
     pos += 16;
   }
@@ -5962,10 +6006,11 @@ function deserializeBoxV8IntrinsicExpression(pos) {
 }
 
 function deserializeVecArrayExpressionElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeArrayExpressionElement(pos));
     pos += 16;
   }
@@ -5977,10 +6022,11 @@ function deserializeBoxSpreadElement(pos) {
 }
 
 function deserializeVecObjectPropertyKind(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeObjectPropertyKind(pos));
     pos += 16;
   }
@@ -6004,10 +6050,11 @@ function deserializeBoxPrivateIdentifier(pos) {
 }
 
 function deserializeVecTemplateElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 48;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTemplateElement(pos));
     pos += 48;
   }
@@ -6015,10 +6062,11 @@ function deserializeVecTemplateElement(pos) {
 }
 
 function deserializeVecExpression(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExpression(pos));
     pos += 16;
   }
@@ -6030,12 +6078,12 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeStr(pos);
 }
 
@@ -6052,10 +6100,11 @@ function deserializeBoxPrivateFieldExpression(pos) {
 }
 
 function deserializeVecArgument(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeArgument(pos));
     pos += 16;
   }
@@ -6076,10 +6125,11 @@ function deserializeOptionAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeOptionAssignmentTargetMaybeDefault(pos));
     pos += 16;
   }
@@ -6091,15 +6141,16 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxAssignmentTargetRest(pos);
 }
 
 function deserializeVecAssignmentTargetProperty(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeAssignmentTargetProperty(pos));
     pos += 16;
   }
@@ -6220,10 +6271,11 @@ function deserializeBoxTSImportEqualsDeclaration(pos) {
 }
 
 function deserializeVecVariableDeclarator(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 64;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeVariableDeclarator(pos));
     pos += 64;
   }
@@ -6241,15 +6293,16 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeLabelIdentifier(pos);
 }
 
 function deserializeVecSwitchCase(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 48;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeSwitchCase(pos));
     pos += 48;
   }
@@ -6261,12 +6314,12 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxBlockStatement(pos);
 }
 
@@ -6280,7 +6333,7 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeAnnotation(pos);
 }
 
@@ -6301,10 +6354,11 @@ function deserializeBoxAssignmentPattern(pos) {
 }
 
 function deserializeVecBindingProperty(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 64;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeBindingProperty(pos));
     pos += 64;
   }
@@ -6316,7 +6370,7 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxBindingRestElement(pos);
 }
 
@@ -6326,10 +6380,11 @@ function deserializeOptionBindingPattern(pos) {
 }
 
 function deserializeVecOptionBindingPattern(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeOptionBindingPattern(pos));
     pos += 32;
   }
@@ -6337,7 +6392,7 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeBindingIdentifier(pos);
 }
 
@@ -6346,7 +6401,7 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
@@ -6355,7 +6410,7 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSThisParameter(pos);
 }
 
@@ -6368,15 +6423,16 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxFunctionBody(pos);
 }
 
 function deserializeVecFormalParameter(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 72;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeFormalParameter(pos));
     pos += 72;
   }
@@ -6384,10 +6440,11 @@ function deserializeVecFormalParameter(pos) {
 }
 
 function deserializeVecDecorator(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 24;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDecorator(pos));
     pos += 24;
   }
@@ -6400,10 +6457,11 @@ function deserializeOptionTSAccessibility(pos) {
 }
 
 function deserializeVecTSClassImplements(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSClassImplements(pos));
     pos += 32;
   }
@@ -6415,10 +6473,11 @@ function deserializeBoxClassBody(pos) {
 }
 
 function deserializeVecClassElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeClassElement(pos));
     pos += 16;
   }
@@ -6475,10 +6534,11 @@ function deserializeOptionImportPhase(pos) {
 }
 
 function deserializeVecImportDeclarationSpecifier(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportDeclarationSpecifier(pos));
     pos += 16;
   }
@@ -6486,7 +6546,7 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeVecImportDeclarationSpecifier(pos);
 }
 
@@ -6495,7 +6555,7 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxWithClause(pos);
 }
 
@@ -6512,10 +6572,11 @@ function deserializeBoxImportNamespaceSpecifier(pos) {
 }
 
 function deserializeVecImportAttribute(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 112;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportAttribute(pos));
     pos += 112;
   }
@@ -6528,10 +6589,11 @@ function deserializeOptionDeclaration(pos) {
 }
 
 function deserializeVecExportSpecifier(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 128;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExportSpecifier(pos));
     pos += 128;
   }
@@ -6557,10 +6619,11 @@ function deserializeBoxJSXOpeningElement(pos) {
 }
 
 function deserializeVecJSXChild(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeJSXChild(pos));
     pos += 16;
   }
@@ -6572,15 +6635,16 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxJSXClosingElement(pos);
 }
 
 function deserializeVecJSXAttributeItem(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeJSXAttributeItem(pos));
     pos += 16;
   }
@@ -6625,10 +6689,11 @@ function deserializeBoxJSXSpreadChild(pos) {
 }
 
 function deserializeVecTSEnumMember(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 40;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSEnumMember(pos));
     pos += 40;
   }
@@ -6784,10 +6849,11 @@ function deserializeBoxJSDocUnknownType(pos) {
 }
 
 function deserializeVecTSType(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSType(pos));
     pos += 16;
   }
@@ -6795,10 +6861,11 @@ function deserializeVecTSType(pos) {
 }
 
 function deserializeVecTSTupleElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSTupleElement(pos));
     pos += 16;
   }
@@ -6823,10 +6890,11 @@ function deserializeOptionTSType(pos) {
 }
 
 function deserializeVecTSTypeParameter(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 80;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSTypeParameter(pos));
     pos += 80;
   }
@@ -6834,10 +6902,11 @@ function deserializeVecTSTypeParameter(pos) {
 }
 
 function deserializeVecTSInterfaceHeritage(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSInterfaceHeritage(pos));
     pos += 32;
   }
@@ -6849,10 +6918,11 @@ function deserializeBoxTSInterfaceBody(pos) {
 }
 
 function deserializeVecTSSignature(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSSignature(pos));
     pos += 16;
   }
@@ -6876,10 +6946,11 @@ function deserializeBoxTSMethodSignature(pos) {
 }
 
 function deserializeVecTSIndexSignatureName(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
     pos += 32;
   }
@@ -6900,7 +6971,7 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxObjectExpression(pos);
 }
 

--- a/apps/oxlint/src-js/generated/types.d.ts
+++ b/apps/oxlint/src-js/generated/types.d.ts
@@ -1,8 +1,8 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/typescript.rs`.
 
-import { Comment, Span } from '../plugins/types.ts';
-export { Comment, Span };
+import { Span, Comment } from '../plugins/types.ts';
+export { Span, Comment };
 
 export interface Program extends Span {
   type: 'Program';
@@ -587,12 +587,10 @@ export interface DebuggerStatement extends Span {
   parent?: Node;
 }
 
-export type BindingPattern =
-  & ({
-    optional?: boolean;
-    typeAnnotation?: TSTypeAnnotation | null;
-  })
-  & (BindingIdentifier | ObjectPattern | ArrayPattern | AssignmentPattern);
+export type BindingPattern = {
+  optional?: boolean;
+  typeAnnotation?: TSTypeAnnotation | null;
+} & (BindingIdentifier | ObjectPattern | ArrayPattern | AssignmentPattern);
 
 export type BindingPatternKind = BindingIdentifier | ObjectPattern | ArrayPattern | AssignmentPattern;
 
@@ -677,11 +675,9 @@ export interface FormalParameterRest extends Span {
   value?: null;
 }
 
-export type FormalParameter =
-  & ({
-    decorators?: Array<Decorator>;
-  })
-  & BindingPattern;
+export type FormalParameter = {
+  decorators?: Array<Decorator>;
+} & BindingPattern;
 
 export interface TSParameterProperty extends Span {
   type: 'TSParameterProperty';

--- a/apps/oxlint/src-js/generated/walk.js
+++ b/apps/oxlint/src-js/generated/walk.js
@@ -12,7 +12,8 @@ function walkNode(node, visitors) {
   if (isArray(node)) {
     let len = node.length;
     for (let i = 0; i < len; i++) walkNode(node[i], visitors);
-  } else {switch (node.type) {
+  } else
+    switch (node.type) {
       case 'DebuggerStatement':
         walkDebuggerStatement(node, visitors);
         break;
@@ -508,7 +509,7 @@ function walkNode(node, visitors) {
       case 'TSUnionType':
         walkTSUnionType(node, visitors);
         break;
-    }}
+    }
 }
 
 function walkDebuggerStatement(node, visitors) {
@@ -647,7 +648,8 @@ function walkTSVoidKeyword(node, visitors) {
 }
 
 function walkAccessorProperty(node, visitors) {
-  let enterExit = visitors[27], exit = null;
+  let enterExit = visitors[27],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -663,7 +665,8 @@ function walkAccessorProperty(node, visitors) {
 }
 
 function walkArrayExpression(node, visitors) {
-  let enterExit = visitors[28], exit = null;
+  let enterExit = visitors[28],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -676,7 +679,8 @@ function walkArrayExpression(node, visitors) {
 }
 
 function walkArrayPattern(node, visitors) {
-  let enterExit = visitors[29], exit = null;
+  let enterExit = visitors[29],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -691,7 +695,8 @@ function walkArrayPattern(node, visitors) {
 }
 
 function walkArrowFunctionExpression(node, visitors) {
-  let enterExit = visitors[30], exit = null;
+  let enterExit = visitors[30],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -707,7 +712,8 @@ function walkArrowFunctionExpression(node, visitors) {
 }
 
 function walkAssignmentExpression(node, visitors) {
-  let enterExit = visitors[31], exit = null;
+  let enterExit = visitors[31],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -721,7 +727,8 @@ function walkAssignmentExpression(node, visitors) {
 }
 
 function walkAssignmentPattern(node, visitors) {
-  let enterExit = visitors[32], exit = null;
+  let enterExit = visitors[32],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -737,7 +744,8 @@ function walkAssignmentPattern(node, visitors) {
 }
 
 function walkAwaitExpression(node, visitors) {
-  let enterExit = visitors[33], exit = null;
+  let enterExit = visitors[33],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -750,7 +758,8 @@ function walkAwaitExpression(node, visitors) {
 }
 
 function walkBinaryExpression(node, visitors) {
-  let enterExit = visitors[34], exit = null;
+  let enterExit = visitors[34],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -764,7 +773,8 @@ function walkBinaryExpression(node, visitors) {
 }
 
 function walkBlockStatement(node, visitors) {
-  let enterExit = visitors[35], exit = null;
+  let enterExit = visitors[35],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -777,7 +787,8 @@ function walkBlockStatement(node, visitors) {
 }
 
 function walkBreakStatement(node, visitors) {
-  let enterExit = visitors[36], exit = null;
+  let enterExit = visitors[36],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -790,7 +801,8 @@ function walkBreakStatement(node, visitors) {
 }
 
 function walkCallExpression(node, visitors) {
-  let enterExit = visitors[37], exit = null;
+  let enterExit = visitors[37],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -805,7 +817,8 @@ function walkCallExpression(node, visitors) {
 }
 
 function walkCatchClause(node, visitors) {
-  let enterExit = visitors[38], exit = null;
+  let enterExit = visitors[38],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -819,7 +832,8 @@ function walkCatchClause(node, visitors) {
 }
 
 function walkChainExpression(node, visitors) {
-  let enterExit = visitors[39], exit = null;
+  let enterExit = visitors[39],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -832,7 +846,8 @@ function walkChainExpression(node, visitors) {
 }
 
 function walkClassBody(node, visitors) {
-  let enterExit = visitors[40], exit = null;
+  let enterExit = visitors[40],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -845,7 +860,8 @@ function walkClassBody(node, visitors) {
 }
 
 function walkClassDeclaration(node, visitors) {
-  let enterExit = visitors[41], exit = null;
+  let enterExit = visitors[41],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -864,7 +880,8 @@ function walkClassDeclaration(node, visitors) {
 }
 
 function walkClassExpression(node, visitors) {
-  let enterExit = visitors[42], exit = null;
+  let enterExit = visitors[42],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -883,7 +900,8 @@ function walkClassExpression(node, visitors) {
 }
 
 function walkConditionalExpression(node, visitors) {
-  let enterExit = visitors[43], exit = null;
+  let enterExit = visitors[43],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -898,7 +916,8 @@ function walkConditionalExpression(node, visitors) {
 }
 
 function walkContinueStatement(node, visitors) {
-  let enterExit = visitors[44], exit = null;
+  let enterExit = visitors[44],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -911,7 +930,8 @@ function walkContinueStatement(node, visitors) {
 }
 
 function walkDecorator(node, visitors) {
-  let enterExit = visitors[45], exit = null;
+  let enterExit = visitors[45],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -924,7 +944,8 @@ function walkDecorator(node, visitors) {
 }
 
 function walkDoWhileStatement(node, visitors) {
-  let enterExit = visitors[46], exit = null;
+  let enterExit = visitors[46],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -938,7 +959,8 @@ function walkDoWhileStatement(node, visitors) {
 }
 
 function walkExportAllDeclaration(node, visitors) {
-  let enterExit = visitors[47], exit = null;
+  let enterExit = visitors[47],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -953,7 +975,8 @@ function walkExportAllDeclaration(node, visitors) {
 }
 
 function walkExportDefaultDeclaration(node, visitors) {
-  let enterExit = visitors[48], exit = null;
+  let enterExit = visitors[48],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -966,7 +989,8 @@ function walkExportDefaultDeclaration(node, visitors) {
 }
 
 function walkExportNamedDeclaration(node, visitors) {
-  let enterExit = visitors[49], exit = null;
+  let enterExit = visitors[49],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -982,7 +1006,8 @@ function walkExportNamedDeclaration(node, visitors) {
 }
 
 function walkExportSpecifier(node, visitors) {
-  let enterExit = visitors[50], exit = null;
+  let enterExit = visitors[50],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -996,7 +1021,8 @@ function walkExportSpecifier(node, visitors) {
 }
 
 function walkExpressionStatement(node, visitors) {
-  let enterExit = visitors[51], exit = null;
+  let enterExit = visitors[51],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1009,7 +1035,8 @@ function walkExpressionStatement(node, visitors) {
 }
 
 function walkForInStatement(node, visitors) {
-  let enterExit = visitors[52], exit = null;
+  let enterExit = visitors[52],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1024,7 +1051,8 @@ function walkForInStatement(node, visitors) {
 }
 
 function walkForOfStatement(node, visitors) {
-  let enterExit = visitors[53], exit = null;
+  let enterExit = visitors[53],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1039,7 +1067,8 @@ function walkForOfStatement(node, visitors) {
 }
 
 function walkForStatement(node, visitors) {
-  let enterExit = visitors[54], exit = null;
+  let enterExit = visitors[54],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1055,7 +1084,8 @@ function walkForStatement(node, visitors) {
 }
 
 function walkFunctionDeclaration(node, visitors) {
-  let enterExit = visitors[55], exit = null;
+  let enterExit = visitors[55],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1072,7 +1102,8 @@ function walkFunctionDeclaration(node, visitors) {
 }
 
 function walkFunctionExpression(node, visitors) {
-  let enterExit = visitors[56], exit = null;
+  let enterExit = visitors[56],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1089,7 +1120,8 @@ function walkFunctionExpression(node, visitors) {
 }
 
 function walkIdentifier(node, visitors) {
-  let enterExit = visitors[57], exit = null;
+  let enterExit = visitors[57],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1103,7 +1135,8 @@ function walkIdentifier(node, visitors) {
 }
 
 function walkIfStatement(node, visitors) {
-  let enterExit = visitors[58], exit = null;
+  let enterExit = visitors[58],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1118,7 +1151,8 @@ function walkIfStatement(node, visitors) {
 }
 
 function walkImportAttribute(node, visitors) {
-  let enterExit = visitors[59], exit = null;
+  let enterExit = visitors[59],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1132,7 +1166,8 @@ function walkImportAttribute(node, visitors) {
 }
 
 function walkImportDeclaration(node, visitors) {
-  let enterExit = visitors[60], exit = null;
+  let enterExit = visitors[60],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1147,7 +1182,8 @@ function walkImportDeclaration(node, visitors) {
 }
 
 function walkImportDefaultSpecifier(node, visitors) {
-  let enterExit = visitors[61], exit = null;
+  let enterExit = visitors[61],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1160,7 +1196,8 @@ function walkImportDefaultSpecifier(node, visitors) {
 }
 
 function walkImportExpression(node, visitors) {
-  let enterExit = visitors[62], exit = null;
+  let enterExit = visitors[62],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1174,7 +1211,8 @@ function walkImportExpression(node, visitors) {
 }
 
 function walkImportNamespaceSpecifier(node, visitors) {
-  let enterExit = visitors[63], exit = null;
+  let enterExit = visitors[63],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1187,7 +1225,8 @@ function walkImportNamespaceSpecifier(node, visitors) {
 }
 
 function walkImportSpecifier(node, visitors) {
-  let enterExit = visitors[64], exit = null;
+  let enterExit = visitors[64],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1201,7 +1240,8 @@ function walkImportSpecifier(node, visitors) {
 }
 
 function walkLabeledStatement(node, visitors) {
-  let enterExit = visitors[65], exit = null;
+  let enterExit = visitors[65],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1215,7 +1255,8 @@ function walkLabeledStatement(node, visitors) {
 }
 
 function walkLogicalExpression(node, visitors) {
-  let enterExit = visitors[66], exit = null;
+  let enterExit = visitors[66],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1229,7 +1270,8 @@ function walkLogicalExpression(node, visitors) {
 }
 
 function walkMemberExpression(node, visitors) {
-  let enterExit = visitors[67], exit = null;
+  let enterExit = visitors[67],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1243,7 +1285,8 @@ function walkMemberExpression(node, visitors) {
 }
 
 function walkMetaProperty(node, visitors) {
-  let enterExit = visitors[68], exit = null;
+  let enterExit = visitors[68],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1257,7 +1300,8 @@ function walkMetaProperty(node, visitors) {
 }
 
 function walkMethodDefinition(node, visitors) {
-  let enterExit = visitors[69], exit = null;
+  let enterExit = visitors[69],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1272,7 +1316,8 @@ function walkMethodDefinition(node, visitors) {
 }
 
 function walkNewExpression(node, visitors) {
-  let enterExit = visitors[70], exit = null;
+  let enterExit = visitors[70],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1287,7 +1332,8 @@ function walkNewExpression(node, visitors) {
 }
 
 function walkObjectExpression(node, visitors) {
-  let enterExit = visitors[71], exit = null;
+  let enterExit = visitors[71],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1300,7 +1346,8 @@ function walkObjectExpression(node, visitors) {
 }
 
 function walkObjectPattern(node, visitors) {
-  let enterExit = visitors[72], exit = null;
+  let enterExit = visitors[72],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1315,7 +1362,8 @@ function walkObjectPattern(node, visitors) {
 }
 
 function walkParenthesizedExpression(node, visitors) {
-  let enterExit = visitors[73], exit = null;
+  let enterExit = visitors[73],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1328,7 +1376,8 @@ function walkParenthesizedExpression(node, visitors) {
 }
 
 function walkProgram(node, visitors) {
-  let enterExit = visitors[74], exit = null;
+  let enterExit = visitors[74],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1341,7 +1390,8 @@ function walkProgram(node, visitors) {
 }
 
 function walkProperty(node, visitors) {
-  let enterExit = visitors[75], exit = null;
+  let enterExit = visitors[75],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1355,7 +1405,8 @@ function walkProperty(node, visitors) {
 }
 
 function walkPropertyDefinition(node, visitors) {
-  let enterExit = visitors[76], exit = null;
+  let enterExit = visitors[76],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1371,7 +1422,8 @@ function walkPropertyDefinition(node, visitors) {
 }
 
 function walkRestElement(node, visitors) {
-  let enterExit = visitors[77], exit = null;
+  let enterExit = visitors[77],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1386,7 +1438,8 @@ function walkRestElement(node, visitors) {
 }
 
 function walkReturnStatement(node, visitors) {
-  let enterExit = visitors[78], exit = null;
+  let enterExit = visitors[78],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1399,7 +1452,8 @@ function walkReturnStatement(node, visitors) {
 }
 
 function walkSequenceExpression(node, visitors) {
-  let enterExit = visitors[79], exit = null;
+  let enterExit = visitors[79],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1412,7 +1466,8 @@ function walkSequenceExpression(node, visitors) {
 }
 
 function walkSpreadElement(node, visitors) {
-  let enterExit = visitors[80], exit = null;
+  let enterExit = visitors[80],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1425,7 +1480,8 @@ function walkSpreadElement(node, visitors) {
 }
 
 function walkStaticBlock(node, visitors) {
-  let enterExit = visitors[81], exit = null;
+  let enterExit = visitors[81],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1438,7 +1494,8 @@ function walkStaticBlock(node, visitors) {
 }
 
 function walkSwitchCase(node, visitors) {
-  let enterExit = visitors[82], exit = null;
+  let enterExit = visitors[82],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1452,7 +1509,8 @@ function walkSwitchCase(node, visitors) {
 }
 
 function walkSwitchStatement(node, visitors) {
-  let enterExit = visitors[83], exit = null;
+  let enterExit = visitors[83],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1466,7 +1524,8 @@ function walkSwitchStatement(node, visitors) {
 }
 
 function walkTaggedTemplateExpression(node, visitors) {
-  let enterExit = visitors[84], exit = null;
+  let enterExit = visitors[84],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1481,7 +1540,8 @@ function walkTaggedTemplateExpression(node, visitors) {
 }
 
 function walkTemplateLiteral(node, visitors) {
-  let enterExit = visitors[85], exit = null;
+  let enterExit = visitors[85],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1495,7 +1555,8 @@ function walkTemplateLiteral(node, visitors) {
 }
 
 function walkThrowStatement(node, visitors) {
-  let enterExit = visitors[86], exit = null;
+  let enterExit = visitors[86],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1508,7 +1569,8 @@ function walkThrowStatement(node, visitors) {
 }
 
 function walkTryStatement(node, visitors) {
-  let enterExit = visitors[87], exit = null;
+  let enterExit = visitors[87],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1523,7 +1585,8 @@ function walkTryStatement(node, visitors) {
 }
 
 function walkUnaryExpression(node, visitors) {
-  let enterExit = visitors[88], exit = null;
+  let enterExit = visitors[88],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1536,7 +1599,8 @@ function walkUnaryExpression(node, visitors) {
 }
 
 function walkUpdateExpression(node, visitors) {
-  let enterExit = visitors[89], exit = null;
+  let enterExit = visitors[89],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1549,7 +1613,8 @@ function walkUpdateExpression(node, visitors) {
 }
 
 function walkV8IntrinsicExpression(node, visitors) {
-  let enterExit = visitors[90], exit = null;
+  let enterExit = visitors[90],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1563,7 +1628,8 @@ function walkV8IntrinsicExpression(node, visitors) {
 }
 
 function walkVariableDeclaration(node, visitors) {
-  let enterExit = visitors[91], exit = null;
+  let enterExit = visitors[91],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1576,7 +1642,8 @@ function walkVariableDeclaration(node, visitors) {
 }
 
 function walkVariableDeclarator(node, visitors) {
-  let enterExit = visitors[92], exit = null;
+  let enterExit = visitors[92],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1590,7 +1657,8 @@ function walkVariableDeclarator(node, visitors) {
 }
 
 function walkWhileStatement(node, visitors) {
-  let enterExit = visitors[93], exit = null;
+  let enterExit = visitors[93],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1604,7 +1672,8 @@ function walkWhileStatement(node, visitors) {
 }
 
 function walkWithStatement(node, visitors) {
-  let enterExit = visitors[94], exit = null;
+  let enterExit = visitors[94],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1618,7 +1687,8 @@ function walkWithStatement(node, visitors) {
 }
 
 function walkYieldExpression(node, visitors) {
-  let enterExit = visitors[95], exit = null;
+  let enterExit = visitors[95],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1631,7 +1701,8 @@ function walkYieldExpression(node, visitors) {
 }
 
 function walkJSXAttribute(node, visitors) {
-  let enterExit = visitors[96], exit = null;
+  let enterExit = visitors[96],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1645,7 +1716,8 @@ function walkJSXAttribute(node, visitors) {
 }
 
 function walkJSXClosingElement(node, visitors) {
-  let enterExit = visitors[97], exit = null;
+  let enterExit = visitors[97],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1658,7 +1730,8 @@ function walkJSXClosingElement(node, visitors) {
 }
 
 function walkJSXElement(node, visitors) {
-  let enterExit = visitors[98], exit = null;
+  let enterExit = visitors[98],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1673,7 +1746,8 @@ function walkJSXElement(node, visitors) {
 }
 
 function walkJSXExpressionContainer(node, visitors) {
-  let enterExit = visitors[99], exit = null;
+  let enterExit = visitors[99],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1686,7 +1760,8 @@ function walkJSXExpressionContainer(node, visitors) {
 }
 
 function walkJSXFragment(node, visitors) {
-  let enterExit = visitors[100], exit = null;
+  let enterExit = visitors[100],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1701,7 +1776,8 @@ function walkJSXFragment(node, visitors) {
 }
 
 function walkJSXMemberExpression(node, visitors) {
-  let enterExit = visitors[101], exit = null;
+  let enterExit = visitors[101],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1715,7 +1791,8 @@ function walkJSXMemberExpression(node, visitors) {
 }
 
 function walkJSXNamespacedName(node, visitors) {
-  let enterExit = visitors[102], exit = null;
+  let enterExit = visitors[102],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1729,7 +1806,8 @@ function walkJSXNamespacedName(node, visitors) {
 }
 
 function walkJSXOpeningElement(node, visitors) {
-  let enterExit = visitors[103], exit = null;
+  let enterExit = visitors[103],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1744,7 +1822,8 @@ function walkJSXOpeningElement(node, visitors) {
 }
 
 function walkJSXSpreadAttribute(node, visitors) {
-  let enterExit = visitors[104], exit = null;
+  let enterExit = visitors[104],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1757,7 +1836,8 @@ function walkJSXSpreadAttribute(node, visitors) {
 }
 
 function walkJSXSpreadChild(node, visitors) {
-  let enterExit = visitors[105], exit = null;
+  let enterExit = visitors[105],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1770,7 +1850,8 @@ function walkJSXSpreadChild(node, visitors) {
 }
 
 function walkTSAbstractAccessorProperty(node, visitors) {
-  let enterExit = visitors[106], exit = null;
+  let enterExit = visitors[106],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1785,7 +1866,8 @@ function walkTSAbstractAccessorProperty(node, visitors) {
 }
 
 function walkTSAbstractMethodDefinition(node, visitors) {
-  let enterExit = visitors[107], exit = null;
+  let enterExit = visitors[107],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1799,7 +1881,8 @@ function walkTSAbstractMethodDefinition(node, visitors) {
 }
 
 function walkTSAbstractPropertyDefinition(node, visitors) {
-  let enterExit = visitors[108], exit = null;
+  let enterExit = visitors[108],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1814,7 +1897,8 @@ function walkTSAbstractPropertyDefinition(node, visitors) {
 }
 
 function walkTSArrayType(node, visitors) {
-  let enterExit = visitors[109], exit = null;
+  let enterExit = visitors[109],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1827,7 +1911,8 @@ function walkTSArrayType(node, visitors) {
 }
 
 function walkTSAsExpression(node, visitors) {
-  let enterExit = visitors[110], exit = null;
+  let enterExit = visitors[110],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1841,7 +1926,8 @@ function walkTSAsExpression(node, visitors) {
 }
 
 function walkTSCallSignatureDeclaration(node, visitors) {
-  let enterExit = visitors[111], exit = null;
+  let enterExit = visitors[111],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1856,7 +1942,8 @@ function walkTSCallSignatureDeclaration(node, visitors) {
 }
 
 function walkTSClassImplements(node, visitors) {
-  let enterExit = visitors[112], exit = null;
+  let enterExit = visitors[112],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1870,7 +1957,8 @@ function walkTSClassImplements(node, visitors) {
 }
 
 function walkTSConditionalType(node, visitors) {
-  let enterExit = visitors[113], exit = null;
+  let enterExit = visitors[113],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1886,7 +1974,8 @@ function walkTSConditionalType(node, visitors) {
 }
 
 function walkTSConstructSignatureDeclaration(node, visitors) {
-  let enterExit = visitors[114], exit = null;
+  let enterExit = visitors[114],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1901,7 +1990,8 @@ function walkTSConstructSignatureDeclaration(node, visitors) {
 }
 
 function walkTSConstructorType(node, visitors) {
-  let enterExit = visitors[115], exit = null;
+  let enterExit = visitors[115],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1916,7 +2006,8 @@ function walkTSConstructorType(node, visitors) {
 }
 
 function walkTSDeclareFunction(node, visitors) {
-  let enterExit = visitors[116], exit = null;
+  let enterExit = visitors[116],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1933,7 +2024,8 @@ function walkTSDeclareFunction(node, visitors) {
 }
 
 function walkTSEmptyBodyFunctionExpression(node, visitors) {
-  let enterExit = visitors[117], exit = null;
+  let enterExit = visitors[117],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1949,7 +2041,8 @@ function walkTSEmptyBodyFunctionExpression(node, visitors) {
 }
 
 function walkTSEnumBody(node, visitors) {
-  let enterExit = visitors[118], exit = null;
+  let enterExit = visitors[118],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1962,7 +2055,8 @@ function walkTSEnumBody(node, visitors) {
 }
 
 function walkTSEnumDeclaration(node, visitors) {
-  let enterExit = visitors[119], exit = null;
+  let enterExit = visitors[119],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1976,7 +2070,8 @@ function walkTSEnumDeclaration(node, visitors) {
 }
 
 function walkTSEnumMember(node, visitors) {
-  let enterExit = visitors[120], exit = null;
+  let enterExit = visitors[120],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1990,7 +2085,8 @@ function walkTSEnumMember(node, visitors) {
 }
 
 function walkTSExportAssignment(node, visitors) {
-  let enterExit = visitors[121], exit = null;
+  let enterExit = visitors[121],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2003,7 +2099,8 @@ function walkTSExportAssignment(node, visitors) {
 }
 
 function walkTSExternalModuleReference(node, visitors) {
-  let enterExit = visitors[122], exit = null;
+  let enterExit = visitors[122],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2016,7 +2113,8 @@ function walkTSExternalModuleReference(node, visitors) {
 }
 
 function walkTSFunctionType(node, visitors) {
-  let enterExit = visitors[123], exit = null;
+  let enterExit = visitors[123],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2031,7 +2129,8 @@ function walkTSFunctionType(node, visitors) {
 }
 
 function walkTSImportEqualsDeclaration(node, visitors) {
-  let enterExit = visitors[124], exit = null;
+  let enterExit = visitors[124],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2045,7 +2144,8 @@ function walkTSImportEqualsDeclaration(node, visitors) {
 }
 
 function walkTSImportType(node, visitors) {
-  let enterExit = visitors[125], exit = null;
+  let enterExit = visitors[125],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2061,7 +2161,8 @@ function walkTSImportType(node, visitors) {
 }
 
 function walkTSIndexSignature(node, visitors) {
-  let enterExit = visitors[126], exit = null;
+  let enterExit = visitors[126],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2075,7 +2176,8 @@ function walkTSIndexSignature(node, visitors) {
 }
 
 function walkTSIndexedAccessType(node, visitors) {
-  let enterExit = visitors[127], exit = null;
+  let enterExit = visitors[127],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2089,7 +2191,8 @@ function walkTSIndexedAccessType(node, visitors) {
 }
 
 function walkTSInferType(node, visitors) {
-  let enterExit = visitors[128], exit = null;
+  let enterExit = visitors[128],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2102,7 +2205,8 @@ function walkTSInferType(node, visitors) {
 }
 
 function walkTSInstantiationExpression(node, visitors) {
-  let enterExit = visitors[129], exit = null;
+  let enterExit = visitors[129],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2116,7 +2220,8 @@ function walkTSInstantiationExpression(node, visitors) {
 }
 
 function walkTSInterfaceBody(node, visitors) {
-  let enterExit = visitors[130], exit = null;
+  let enterExit = visitors[130],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2129,7 +2234,8 @@ function walkTSInterfaceBody(node, visitors) {
 }
 
 function walkTSInterfaceDeclaration(node, visitors) {
-  let enterExit = visitors[131], exit = null;
+  let enterExit = visitors[131],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2145,7 +2251,8 @@ function walkTSInterfaceDeclaration(node, visitors) {
 }
 
 function walkTSInterfaceHeritage(node, visitors) {
-  let enterExit = visitors[132], exit = null;
+  let enterExit = visitors[132],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2159,7 +2266,8 @@ function walkTSInterfaceHeritage(node, visitors) {
 }
 
 function walkTSIntersectionType(node, visitors) {
-  let enterExit = visitors[133], exit = null;
+  let enterExit = visitors[133],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2172,7 +2280,8 @@ function walkTSIntersectionType(node, visitors) {
 }
 
 function walkTSJSDocNonNullableType(node, visitors) {
-  let enterExit = visitors[134], exit = null;
+  let enterExit = visitors[134],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2185,7 +2294,8 @@ function walkTSJSDocNonNullableType(node, visitors) {
 }
 
 function walkTSJSDocNullableType(node, visitors) {
-  let enterExit = visitors[135], exit = null;
+  let enterExit = visitors[135],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2198,7 +2308,8 @@ function walkTSJSDocNullableType(node, visitors) {
 }
 
 function walkTSLiteralType(node, visitors) {
-  let enterExit = visitors[136], exit = null;
+  let enterExit = visitors[136],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2211,7 +2322,8 @@ function walkTSLiteralType(node, visitors) {
 }
 
 function walkTSMappedType(node, visitors) {
-  let enterExit = visitors[137], exit = null;
+  let enterExit = visitors[137],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2227,7 +2339,8 @@ function walkTSMappedType(node, visitors) {
 }
 
 function walkTSMethodSignature(node, visitors) {
-  let enterExit = visitors[138], exit = null;
+  let enterExit = visitors[138],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2243,7 +2356,8 @@ function walkTSMethodSignature(node, visitors) {
 }
 
 function walkTSModuleBlock(node, visitors) {
-  let enterExit = visitors[139], exit = null;
+  let enterExit = visitors[139],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2256,7 +2370,8 @@ function walkTSModuleBlock(node, visitors) {
 }
 
 function walkTSModuleDeclaration(node, visitors) {
-  let enterExit = visitors[140], exit = null;
+  let enterExit = visitors[140],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2270,7 +2385,8 @@ function walkTSModuleDeclaration(node, visitors) {
 }
 
 function walkTSNamedTupleMember(node, visitors) {
-  let enterExit = visitors[141], exit = null;
+  let enterExit = visitors[141],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2284,7 +2400,8 @@ function walkTSNamedTupleMember(node, visitors) {
 }
 
 function walkTSNamespaceExportDeclaration(node, visitors) {
-  let enterExit = visitors[142], exit = null;
+  let enterExit = visitors[142],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2297,7 +2414,8 @@ function walkTSNamespaceExportDeclaration(node, visitors) {
 }
 
 function walkTSNonNullExpression(node, visitors) {
-  let enterExit = visitors[143], exit = null;
+  let enterExit = visitors[143],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2310,7 +2428,8 @@ function walkTSNonNullExpression(node, visitors) {
 }
 
 function walkTSOptionalType(node, visitors) {
-  let enterExit = visitors[144], exit = null;
+  let enterExit = visitors[144],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2323,7 +2442,8 @@ function walkTSOptionalType(node, visitors) {
 }
 
 function walkTSParameterProperty(node, visitors) {
-  let enterExit = visitors[145], exit = null;
+  let enterExit = visitors[145],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2337,7 +2457,8 @@ function walkTSParameterProperty(node, visitors) {
 }
 
 function walkTSParenthesizedType(node, visitors) {
-  let enterExit = visitors[146], exit = null;
+  let enterExit = visitors[146],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2350,7 +2471,8 @@ function walkTSParenthesizedType(node, visitors) {
 }
 
 function walkTSPropertySignature(node, visitors) {
-  let enterExit = visitors[147], exit = null;
+  let enterExit = visitors[147],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2364,7 +2486,8 @@ function walkTSPropertySignature(node, visitors) {
 }
 
 function walkTSQualifiedName(node, visitors) {
-  let enterExit = visitors[148], exit = null;
+  let enterExit = visitors[148],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2378,7 +2501,8 @@ function walkTSQualifiedName(node, visitors) {
 }
 
 function walkTSRestType(node, visitors) {
-  let enterExit = visitors[149], exit = null;
+  let enterExit = visitors[149],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2391,7 +2515,8 @@ function walkTSRestType(node, visitors) {
 }
 
 function walkTSSatisfiesExpression(node, visitors) {
-  let enterExit = visitors[150], exit = null;
+  let enterExit = visitors[150],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2405,7 +2530,8 @@ function walkTSSatisfiesExpression(node, visitors) {
 }
 
 function walkTSTemplateLiteralType(node, visitors) {
-  let enterExit = visitors[151], exit = null;
+  let enterExit = visitors[151],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2419,7 +2545,8 @@ function walkTSTemplateLiteralType(node, visitors) {
 }
 
 function walkTSTupleType(node, visitors) {
-  let enterExit = visitors[152], exit = null;
+  let enterExit = visitors[152],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2432,7 +2559,8 @@ function walkTSTupleType(node, visitors) {
 }
 
 function walkTSTypeAliasDeclaration(node, visitors) {
-  let enterExit = visitors[153], exit = null;
+  let enterExit = visitors[153],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2447,7 +2575,8 @@ function walkTSTypeAliasDeclaration(node, visitors) {
 }
 
 function walkTSTypeAnnotation(node, visitors) {
-  let enterExit = visitors[154], exit = null;
+  let enterExit = visitors[154],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2460,7 +2589,8 @@ function walkTSTypeAnnotation(node, visitors) {
 }
 
 function walkTSTypeAssertion(node, visitors) {
-  let enterExit = visitors[155], exit = null;
+  let enterExit = visitors[155],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2474,7 +2604,8 @@ function walkTSTypeAssertion(node, visitors) {
 }
 
 function walkTSTypeLiteral(node, visitors) {
-  let enterExit = visitors[156], exit = null;
+  let enterExit = visitors[156],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2487,7 +2618,8 @@ function walkTSTypeLiteral(node, visitors) {
 }
 
 function walkTSTypeOperator(node, visitors) {
-  let enterExit = visitors[157], exit = null;
+  let enterExit = visitors[157],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2500,7 +2632,8 @@ function walkTSTypeOperator(node, visitors) {
 }
 
 function walkTSTypeParameter(node, visitors) {
-  let enterExit = visitors[158], exit = null;
+  let enterExit = visitors[158],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2515,7 +2648,8 @@ function walkTSTypeParameter(node, visitors) {
 }
 
 function walkTSTypeParameterDeclaration(node, visitors) {
-  let enterExit = visitors[159], exit = null;
+  let enterExit = visitors[159],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2528,7 +2662,8 @@ function walkTSTypeParameterDeclaration(node, visitors) {
 }
 
 function walkTSTypeParameterInstantiation(node, visitors) {
-  let enterExit = visitors[160], exit = null;
+  let enterExit = visitors[160],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2541,7 +2676,8 @@ function walkTSTypeParameterInstantiation(node, visitors) {
 }
 
 function walkTSTypePredicate(node, visitors) {
-  let enterExit = visitors[161], exit = null;
+  let enterExit = visitors[161],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2555,7 +2691,8 @@ function walkTSTypePredicate(node, visitors) {
 }
 
 function walkTSTypeQuery(node, visitors) {
-  let enterExit = visitors[162], exit = null;
+  let enterExit = visitors[162],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2569,7 +2706,8 @@ function walkTSTypeQuery(node, visitors) {
 }
 
 function walkTSTypeReference(node, visitors) {
-  let enterExit = visitors[163], exit = null;
+  let enterExit = visitors[163],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2583,7 +2721,8 @@ function walkTSTypeReference(node, visitors) {
 }
 
 function walkTSUnionType(node, visitors) {
-  let enterExit = visitors[164], exit = null;
+  let enterExit = visitors[164],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -25,11 +25,7 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInpu
 
 export function resetBuffer() {
   // Clear buffer and source text string to allow them to be garbage collected
-  uint8 =
-    uint32 =
-    float64 =
-    sourceText =
-      void 0;
+  uint8 = uint32 = float64 = sourceText = void 0;
 }
 
 function deserializeProgram(pos) {
@@ -142,7 +138,8 @@ function deserializeExpression(pos) {
 }
 
 function deserializeIdentifierName(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Identifier',
     name: deserializeStr(pos + 8),
@@ -152,7 +149,8 @@ function deserializeIdentifierName(pos) {
 }
 
 function deserializeIdentifierReference(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Identifier',
     name: deserializeStr(pos + 8),
@@ -162,7 +160,8 @@ function deserializeIdentifierReference(pos) {
 }
 
 function deserializeBindingIdentifier(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Identifier',
     name: deserializeStr(pos + 8),
@@ -172,7 +171,8 @@ function deserializeBindingIdentifier(pos) {
 }
 
 function deserializeLabelIdentifier(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Identifier',
     name: deserializeStr(pos + 8),
@@ -483,7 +483,8 @@ function deserializeTemplateElement(pos) {
     start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     value = deserializeTemplateElementValue(pos + 8);
-  value.cooked !== null && deserializeBool(pos + 41) &&
+  value.cooked !== null &&
+    deserializeBool(pos + 41) &&
     (value.cooked = value.cooked.replace(/\uFFFD(.{4})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16))));
   return {
     type: 'TemplateElement',
@@ -971,13 +972,14 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     key = deserializeIdentifierReference(pos + 8),
     init = deserializeOptionExpression(pos + 40),
     value = { ...key };
-  init !== null && (value = {
-    type: 'AssignmentPattern',
-    left: value,
-    right: init,
-    start,
-    end,
-  });
+  init !== null &&
+    (value = {
+      type: 'AssignmentPattern',
+      left: value,
+      right: init,
+      start,
+      end,
+    });
   node.kind = 'init';
   node.key = key;
   node.value = value;
@@ -1165,7 +1167,8 @@ function deserializeDirective(pos) {
 }
 
 function deserializeHashbang(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Hashbang',
     value: deserializeStr(pos + 8),
@@ -1753,8 +1756,8 @@ function deserializeFunctionType(pos) {
 
 function deserializeFormalParameters(pos) {
   let params = deserializeVecFormalParameter(pos + 8);
-  if (uint32[pos + 32 >> 2] !== 0 && uint32[pos + 36 >> 2] !== 0) {
-    pos = uint32[pos + 32 >> 2];
+  if (uint32[(pos + 32) >> 2] !== 0 && uint32[(pos + 36) >> 2] !== 0) {
+    pos = uint32[(pos + 32) >> 2];
     let rest = {
       type: 'RestElement',
       argument: null,
@@ -1959,7 +1962,8 @@ function deserializeMethodDefinitionKind(pos) {
 }
 
 function deserializePrivateIdentifier(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'PrivateIdentifier',
     name: deserializeStr(pos + 8),
@@ -2347,7 +2351,8 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Literal',
     value: deserializeF64(pos + 8),
@@ -2420,7 +2425,8 @@ function deserializeRegExp(pos) {
 }
 
 function deserializeRegExpFlags(pos) {
-  let flagBits = deserializeU8(pos), flags = '';
+  let flagBits = deserializeU8(pos),
+    flags = '';
   // Alphabetical order
   flagBits & 64 && (flags += 'd');
   flagBits & 1 && (flags += 'g');
@@ -2769,7 +2775,8 @@ function deserializeJSXAttributeValue(pos) {
 }
 
 function deserializeJSXIdentifier(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXIdentifier',
     name: deserializeStr(pos + 8),
@@ -2807,7 +2814,8 @@ function deserializeJSXSpreadChild(pos) {
 }
 
 function deserializeJSXText(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXText',
     value: deserializeStr(pos + 8),
@@ -3719,7 +3727,7 @@ function deserializeTSModuleDeclaration(pos) {
     if (body.type === 'TSModuleBlock') node.id = id;
     else {
       let innerId = body.id;
-      if (innerId.type === 'Identifier') {
+      if (innerId.type === 'Identifier')
         node.id = {
           type: 'TSQualifiedName',
           left: id,
@@ -3727,7 +3735,7 @@ function deserializeTSModuleDeclaration(pos) {
           start: id.start,
           end: innerId.end,
         };
-      } else {
+      else {
         // Replace `left` of innermost `TSQualifiedName` with a nested `TSQualifiedName` with `id` of
         // this module on left, and previous `left` of innermost `TSQualifiedName` on right
         node.id = innerId;
@@ -4180,7 +4188,9 @@ function deserializeCommentKind(pos) {
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12), start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let type = deserializeCommentKind(pos + 12),
+    start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type,
     value: sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2)),
@@ -4190,7 +4200,8 @@ function deserializeComment(pos) {
 }
 
 function deserializeNameSpan(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     value: deserializeStr(pos + 8),
     start,
@@ -4237,7 +4248,8 @@ function deserializeImportImportName(pos) {
 }
 
 function deserializeExportEntry(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
@@ -4346,7 +4358,8 @@ function deserializeExportLocalName(pos) {
 }
 
 function deserializeDynamicImport(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeSpan(pos + 8),
     start,
@@ -4540,7 +4553,8 @@ function deserializeErrorSeverity(pos) {
 }
 
 function deserializeErrorLabel(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     message: deserializeOptionStr(pos + 8),
     start,
@@ -4559,7 +4573,8 @@ function deserializeEcmaScriptModule(pos) {
 }
 
 function deserializeStaticImport(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeNameSpan(pos + 8),
     entries: deserializeVecImportEntry(pos + 32),
@@ -4569,7 +4584,8 @@ function deserializeStaticImport(pos) {
 }
 
 function deserializeStaticExport(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     entries: deserializeVecExportEntry(pos + 8),
     start,
@@ -4586,7 +4602,8 @@ function deserializeU8(pos) {
 }
 
 function deserializeStr(pos) {
-  let pos32 = pos >> 2, len = uint32[pos32 + 2];
+  let pos32 = pos >> 2,
+    len = uint32[pos32 + 2];
   if (len === 0) return '';
   pos = uint32[pos32];
   if (sourceIsAscii && pos < sourceByteLen) return sourceText.substr(pos, len);
@@ -4595,7 +4612,8 @@ function deserializeStr(pos) {
   let end = pos + len;
   if (len > 50) return decodeStr(uint8.subarray(pos, end));
   // Shorter strings decode by hand to avoid native call
-  let out = '', c;
+  let out = '',
+    c;
   do {
     c = uint8[pos++];
     if (c < 128) out += fromCodePoint(c);
@@ -4608,10 +4626,11 @@ function deserializeStr(pos) {
 }
 
 function deserializeVecComment(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeComment(pos));
     pos += 16;
   }
@@ -4619,15 +4638,16 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeHashbang(pos);
 }
 
 function deserializeVecDirective(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 72;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDirective(pos));
     pos += 72;
   }
@@ -4635,10 +4655,11 @@ function deserializeVecDirective(pos) {
 }
 
 function deserializeVecStatement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStatement(pos));
     pos += 16;
   }
@@ -4806,10 +4827,11 @@ function deserializeBoxV8IntrinsicExpression(pos) {
 }
 
 function deserializeVecArrayExpressionElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeArrayExpressionElement(pos));
     pos += 16;
   }
@@ -4821,10 +4843,11 @@ function deserializeBoxSpreadElement(pos) {
 }
 
 function deserializeVecObjectPropertyKind(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeObjectPropertyKind(pos));
     pos += 16;
   }
@@ -4848,10 +4871,11 @@ function deserializeBoxPrivateIdentifier(pos) {
 }
 
 function deserializeVecTemplateElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 48;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTemplateElement(pos));
     pos += 48;
   }
@@ -4859,10 +4883,11 @@ function deserializeVecTemplateElement(pos) {
 }
 
 function deserializeVecExpression(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExpression(pos));
     pos += 16;
   }
@@ -4874,12 +4899,12 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeStr(pos);
 }
 
@@ -4896,10 +4921,11 @@ function deserializeBoxPrivateFieldExpression(pos) {
 }
 
 function deserializeVecArgument(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeArgument(pos));
     pos += 16;
   }
@@ -4920,10 +4946,11 @@ function deserializeOptionAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeOptionAssignmentTargetMaybeDefault(pos));
     pos += 16;
   }
@@ -4935,15 +4962,16 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxAssignmentTargetRest(pos);
 }
 
 function deserializeVecAssignmentTargetProperty(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeAssignmentTargetProperty(pos));
     pos += 16;
   }
@@ -5064,10 +5092,11 @@ function deserializeBoxTSImportEqualsDeclaration(pos) {
 }
 
 function deserializeVecVariableDeclarator(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 64;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeVariableDeclarator(pos));
     pos += 64;
   }
@@ -5085,15 +5114,16 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeLabelIdentifier(pos);
 }
 
 function deserializeVecSwitchCase(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 48;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeSwitchCase(pos));
     pos += 48;
   }
@@ -5105,12 +5135,12 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxBlockStatement(pos);
 }
 
@@ -5124,7 +5154,7 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeAnnotation(pos);
 }
 
@@ -5145,10 +5175,11 @@ function deserializeBoxAssignmentPattern(pos) {
 }
 
 function deserializeVecBindingProperty(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 64;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeBindingProperty(pos));
     pos += 64;
   }
@@ -5160,7 +5191,7 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxBindingRestElement(pos);
 }
 
@@ -5170,10 +5201,11 @@ function deserializeOptionBindingPattern(pos) {
 }
 
 function deserializeVecOptionBindingPattern(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeOptionBindingPattern(pos));
     pos += 32;
   }
@@ -5181,7 +5213,7 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeBindingIdentifier(pos);
 }
 
@@ -5190,7 +5222,7 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
@@ -5199,7 +5231,7 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSThisParameter(pos);
 }
 
@@ -5212,15 +5244,16 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxFunctionBody(pos);
 }
 
 function deserializeVecFormalParameter(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 72;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeFormalParameter(pos));
     pos += 72;
   }
@@ -5228,10 +5261,11 @@ function deserializeVecFormalParameter(pos) {
 }
 
 function deserializeVecDecorator(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 24;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDecorator(pos));
     pos += 24;
   }
@@ -5243,10 +5277,11 @@ function deserializeBoxClassBody(pos) {
 }
 
 function deserializeVecClassElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeClassElement(pos));
     pos += 16;
   }
@@ -5303,10 +5338,11 @@ function deserializeOptionImportPhase(pos) {
 }
 
 function deserializeVecImportDeclarationSpecifier(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportDeclarationSpecifier(pos));
     pos += 16;
   }
@@ -5314,7 +5350,7 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeVecImportDeclarationSpecifier(pos);
 }
 
@@ -5323,7 +5359,7 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxWithClause(pos);
 }
 
@@ -5340,10 +5376,11 @@ function deserializeBoxImportNamespaceSpecifier(pos) {
 }
 
 function deserializeVecImportAttribute(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 112;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportAttribute(pos));
     pos += 112;
   }
@@ -5356,10 +5393,11 @@ function deserializeOptionDeclaration(pos) {
 }
 
 function deserializeVecExportSpecifier(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 128;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExportSpecifier(pos));
     pos += 128;
   }
@@ -5385,10 +5423,11 @@ function deserializeBoxJSXOpeningElement(pos) {
 }
 
 function deserializeVecJSXChild(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeJSXChild(pos));
     pos += 16;
   }
@@ -5400,15 +5439,16 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxJSXClosingElement(pos);
 }
 
 function deserializeVecJSXAttributeItem(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeJSXAttributeItem(pos));
     pos += 16;
   }
@@ -5453,10 +5493,11 @@ function deserializeBoxJSXSpreadChild(pos) {
 }
 
 function deserializeVecTSEnumMember(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 40;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSEnumMember(pos));
     pos += 40;
   }
@@ -5612,10 +5653,11 @@ function deserializeBoxJSDocUnknownType(pos) {
 }
 
 function deserializeVecTSType(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSType(pos));
     pos += 16;
   }
@@ -5623,10 +5665,11 @@ function deserializeVecTSType(pos) {
 }
 
 function deserializeVecTSTupleElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSTupleElement(pos));
     pos += 16;
   }
@@ -5651,10 +5694,11 @@ function deserializeOptionTSType(pos) {
 }
 
 function deserializeVecTSTypeParameter(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 80;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSTypeParameter(pos));
     pos += 80;
   }
@@ -5662,10 +5706,11 @@ function deserializeVecTSTypeParameter(pos) {
 }
 
 function deserializeVecTSInterfaceHeritage(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSInterfaceHeritage(pos));
     pos += 32;
   }
@@ -5677,10 +5722,11 @@ function deserializeBoxTSInterfaceBody(pos) {
 }
 
 function deserializeVecTSSignature(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSSignature(pos));
     pos += 16;
   }
@@ -5704,10 +5750,11 @@ function deserializeBoxTSMethodSignature(pos) {
 }
 
 function deserializeVecTSIndexSignatureName(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
     pos += 32;
   }
@@ -5728,7 +5775,7 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxObjectExpression(pos);
 }
 
@@ -5751,15 +5798,16 @@ function deserializeBoxTSExternalModuleReference(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeNameSpan(pos);
 }
 
 function deserializeVecError(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 80;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeError(pos));
     pos += 80;
   }
@@ -5767,10 +5815,11 @@ function deserializeVecError(pos) {
 }
 
 function deserializeVecErrorLabel(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 24;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeErrorLabel(pos));
     pos += 24;
   }
@@ -5778,10 +5827,11 @@ function deserializeVecErrorLabel(pos) {
 }
 
 function deserializeVecStaticImport(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 56;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStaticImport(pos));
     pos += 56;
   }
@@ -5789,10 +5839,11 @@ function deserializeVecStaticImport(pos) {
 }
 
 function deserializeVecStaticExport(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStaticExport(pos));
     pos += 32;
   }
@@ -5800,10 +5851,11 @@ function deserializeVecStaticExport(pos) {
 }
 
 function deserializeVecDynamicImport(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDynamicImport(pos));
     pos += 16;
   }
@@ -5811,10 +5863,11 @@ function deserializeVecDynamicImport(pos) {
 }
 
 function deserializeVecSpan(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 8;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeSpan(pos));
     pos += 8;
   }
@@ -5822,10 +5875,11 @@ function deserializeVecSpan(pos) {
 }
 
 function deserializeVecImportEntry(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 96;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportEntry(pos));
     pos += 96;
   }
@@ -5833,10 +5887,11 @@ function deserializeVecImportEntry(pos) {
 }
 
 function deserializeVecExportEntry(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 144;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExportEntry(pos));
     pos += 144;
   }

--- a/napi/parser/generated/deserialize/js_parent.js
+++ b/napi/parser/generated/deserialize/js_parent.js
@@ -1,7 +1,13 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
-let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen, parent = null;
+let uint8,
+  uint32,
+  float64,
+  sourceText,
+  sourceIsAscii,
+  sourceByteLen,
+  parent = null;
 
 const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
@@ -25,17 +31,13 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInpu
 
 export function resetBuffer() {
   // Clear buffer and source text string to allow them to be garbage collected
-  uint8 =
-    uint32 =
-    float64 =
-    sourceText =
-      void 0;
+  uint8 = uint32 = float64 = sourceText = void 0;
 }
 
 function deserializeProgram(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
-    program = parent = {
+    program = (parent = {
       type: 'Program',
       body: null,
       sourceType: deserializeModuleKind(pos + 125),
@@ -43,7 +45,7 @@ function deserializeProgram(pos) {
       start,
       end,
       parent: null,
-    };
+    });
   program.hashbang = deserializeOptionHashbang(pos + 48);
   (program.body = deserializeVecDirective(pos + 72)).push(...deserializeVecStatement(pos + 96));
   parent = null;
@@ -147,13 +149,13 @@ function deserializeIdentifierName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Identifier',
       name: deserializeStr(pos + 8),
       start,
       end,
       parent,
-    };
+    });
   parent = previousParent;
   return node;
 }
@@ -162,13 +164,13 @@ function deserializeIdentifierReference(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Identifier',
       name: deserializeStr(pos + 8),
       start,
       end,
       parent,
-    };
+    });
   parent = previousParent;
   return node;
 }
@@ -177,13 +179,13 @@ function deserializeBindingIdentifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Identifier',
       name: deserializeStr(pos + 8),
       start,
       end,
       parent,
-    };
+    });
   parent = previousParent;
   return node;
 }
@@ -192,13 +194,13 @@ function deserializeLabelIdentifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Identifier',
       name: deserializeStr(pos + 8),
       start,
       end,
       parent,
-    };
+    });
   parent = previousParent;
   return node;
 }
@@ -216,13 +218,13 @@ function deserializeArrayExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ArrayExpression',
       elements: null,
       start,
       end,
       parent,
-    };
+    });
   node.elements = deserializeVecArrayExpressionElement(pos + 8);
   parent = previousParent;
   return node;
@@ -333,13 +335,13 @@ function deserializeObjectExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ObjectExpression',
       properties: null,
       start,
       end,
       parent,
-    };
+    });
   node.properties = deserializeVecObjectPropertyKind(pos + 8);
   parent = previousParent;
   return node;
@@ -360,7 +362,7 @@ function deserializeObjectProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Property',
       kind: deserializePropertyKind(pos + 40),
       key: null,
@@ -371,7 +373,7 @@ function deserializeObjectProperty(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.key = deserializePropertyKey(pos + 8);
   node.value = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -492,14 +494,14 @@ function deserializeTemplateLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TemplateLiteral',
       quasis: null,
       expressions: null,
       start,
       end,
       parent,
-    };
+    });
   node.quasis = deserializeVecTemplateElement(pos + 8);
   node.expressions = deserializeVecExpression(pos + 32);
   parent = previousParent;
@@ -510,14 +512,14 @@ function deserializeTaggedTemplateExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TaggedTemplateExpression',
       tag: null,
       quasi: null,
       start,
       end,
       parent,
-    };
+    });
   node.tag = deserializeExpression(pos + 8);
   node.quasi = deserializeTemplateLiteral(pos + 32);
   parent = previousParent;
@@ -529,7 +531,8 @@ function deserializeTemplateElement(pos) {
     start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     value = deserializeTemplateElementValue(pos + 8);
-  value.cooked !== null && deserializeBool(pos + 41) &&
+  value.cooked !== null &&
+    deserializeBool(pos + 41) &&
     (value.cooked = value.cooked.replace(/\uFFFD(.{4})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16))));
   return {
     type: 'TemplateElement',
@@ -552,7 +555,7 @@ function deserializeComputedMemberExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'MemberExpression',
       object: null,
       property: null,
@@ -561,7 +564,7 @@ function deserializeComputedMemberExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.object = deserializeExpression(pos + 8);
   node.property = deserializeExpression(pos + 24);
   node.computed = true;
@@ -573,7 +576,7 @@ function deserializeStaticMemberExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'MemberExpression',
       object: null,
       property: null,
@@ -582,7 +585,7 @@ function deserializeStaticMemberExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.object = deserializeExpression(pos + 8);
   node.property = deserializeIdentifierName(pos + 24);
   node.computed = false;
@@ -594,7 +597,7 @@ function deserializePrivateFieldExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'MemberExpression',
       object: null,
       property: null,
@@ -603,7 +606,7 @@ function deserializePrivateFieldExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.object = deserializeExpression(pos + 8);
   node.property = deserializePrivateIdentifier(pos + 24);
   node.computed = false;
@@ -615,7 +618,7 @@ function deserializeCallExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'CallExpression',
       callee: null,
       arguments: null,
@@ -623,7 +626,7 @@ function deserializeCallExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.callee = deserializeExpression(pos + 8);
   node.arguments = deserializeVecArgument(pos + 32);
   parent = previousParent;
@@ -634,14 +637,14 @@ function deserializeNewExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'NewExpression',
       callee: null,
       arguments: null,
       start,
       end,
       parent,
-    };
+    });
   node.callee = deserializeExpression(pos + 8);
   node.arguments = deserializeVecArgument(pos + 32);
   parent = previousParent;
@@ -652,14 +655,14 @@ function deserializeMetaProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'MetaProperty',
       meta: null,
       property: null,
       start,
       end,
       parent,
-    };
+    });
   node.meta = deserializeIdentifierName(pos + 8);
   node.property = deserializeIdentifierName(pos + 32);
   parent = previousParent;
@@ -670,13 +673,13 @@ function deserializeSpreadElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'SpreadElement',
       argument: null,
       start,
       end,
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -781,7 +784,7 @@ function deserializeUpdateExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'UpdateExpression',
       operator: deserializeUpdateOperator(pos + 24),
       prefix: deserializeBool(pos + 25),
@@ -789,7 +792,7 @@ function deserializeUpdateExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.argument = deserializeSimpleAssignmentTarget(pos + 8);
   parent = previousParent;
   return node;
@@ -799,7 +802,7 @@ function deserializeUnaryExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'UnaryExpression',
       operator: deserializeUnaryOperator(pos + 24),
       argument: null,
@@ -807,7 +810,7 @@ function deserializeUnaryExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   node.prefix = true;
   parent = previousParent;
@@ -818,7 +821,7 @@ function deserializeBinaryExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'BinaryExpression',
       left: null,
       operator: deserializeBinaryOperator(pos + 40),
@@ -826,7 +829,7 @@ function deserializeBinaryExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.left = deserializeExpression(pos + 8);
   node.right = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -837,7 +840,7 @@ function deserializePrivateInExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'BinaryExpression',
       left: null,
       operator: null,
@@ -845,7 +848,7 @@ function deserializePrivateInExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.left = deserializePrivateIdentifier(pos + 8);
   node.operator = 'in';
   node.right = deserializeExpression(pos + 32);
@@ -857,7 +860,7 @@ function deserializeLogicalExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'LogicalExpression',
       left: null,
       operator: deserializeLogicalOperator(pos + 40),
@@ -865,7 +868,7 @@ function deserializeLogicalExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.left = deserializeExpression(pos + 8);
   node.right = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -876,7 +879,7 @@ function deserializeConditionalExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ConditionalExpression',
       test: null,
       consequent: null,
@@ -884,7 +887,7 @@ function deserializeConditionalExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.test = deserializeExpression(pos + 8);
   node.consequent = deserializeExpression(pos + 24);
   node.alternate = deserializeExpression(pos + 40);
@@ -896,7 +899,7 @@ function deserializeAssignmentExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'AssignmentExpression',
       operator: deserializeAssignmentOperator(pos + 40),
       left: null,
@@ -904,7 +907,7 @@ function deserializeAssignmentExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.left = deserializeAssignmentTarget(pos + 8);
   node.right = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -965,13 +968,13 @@ function deserializeArrayAssignmentTarget(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ArrayPattern',
       elements: null,
       start,
       end,
       parent,
-    },
+    }),
     elements = deserializeVecOptionAssignmentTargetMaybeDefault(pos + 8),
     rest = deserializeOptionBoxAssignmentTargetRest(pos + 32);
   rest !== null && elements.push(rest);
@@ -984,13 +987,13 @@ function deserializeObjectAssignmentTarget(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ObjectPattern',
       properties: null,
       start,
       end,
       parent,
-    },
+    }),
     properties = deserializeVecAssignmentTargetProperty(pos + 8),
     rest = deserializeOptionBoxAssignmentTargetRest(pos + 32);
   rest !== null && properties.push(rest);
@@ -1003,13 +1006,13 @@ function deserializeAssignmentTargetRest(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'RestElement',
       argument: null,
       start,
       end,
       parent,
-    };
+    });
   node.argument = deserializeAssignmentTarget(pos + 8);
   parent = previousParent;
   return node;
@@ -1048,14 +1051,14 @@ function deserializeAssignmentTargetWithDefault(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'AssignmentPattern',
       left: null,
       right: null,
       start,
       end,
       parent,
-    };
+    });
   node.left = deserializeAssignmentTarget(pos + 8);
   node.right = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -1077,7 +1080,7 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Property',
       kind: null,
       key: null,
@@ -1088,12 +1091,13 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
       start,
       end,
       parent,
-    },
+    }),
     key = deserializeIdentifierReference(pos + 8),
     init = deserializeOptionExpression(pos + 40),
     value = { ...key };
   if (init !== null) {
-    let left = value, previousParent = parent;
+    let left = value,
+      previousParent = parent;
     value = parent = {
       type: 'AssignmentPattern',
       left,
@@ -1120,7 +1124,7 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Property',
       kind: null,
       key: null,
@@ -1131,7 +1135,7 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.kind = 'init';
   node.key = deserializePropertyKey(pos + 8);
   node.value = deserializeAssignmentTargetMaybeDefault(pos + 24);
@@ -1145,13 +1149,13 @@ function deserializeSequenceExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'SequenceExpression',
       expressions: null,
       start,
       end,
       parent,
-    };
+    });
   node.expressions = deserializeVecExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -1170,13 +1174,13 @@ function deserializeAwaitExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'AwaitExpression',
       argument: null,
       start,
       end,
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -1186,13 +1190,13 @@ function deserializeChainExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ChainExpression',
       expression: null,
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeChainElement(pos + 8);
   parent = previousParent;
   return node;
@@ -1307,21 +1311,22 @@ function deserializeDirective(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ExpressionStatement',
       expression: null,
       directive: deserializeStr(pos + 56),
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeStringLiteral(pos + 8);
   parent = previousParent;
   return node;
 }
 
 function deserializeHashbang(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Hashbang',
     value: deserializeStr(pos + 8),
@@ -1335,13 +1340,13 @@ function deserializeBlockStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'BlockStatement',
       body: null,
       start,
       end,
       parent,
-    };
+    });
   node.body = deserializeVecStatement(pos + 8);
   parent = previousParent;
   return node;
@@ -1374,14 +1379,14 @@ function deserializeVariableDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'VariableDeclaration',
       kind: deserializeVariableDeclarationKind(pos + 32),
       declarations: null,
       start,
       end,
       parent,
-    };
+    });
   node.declarations = deserializeVecVariableDeclarator(pos + 8);
   parent = previousParent;
   return node;
@@ -1408,14 +1413,14 @@ function deserializeVariableDeclarator(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'VariableDeclarator',
       id: null,
       init: null,
       start,
       end,
       parent,
-    };
+    });
   node.id = deserializeBindingPattern(pos + 8);
   node.init = deserializeOptionExpression(pos + 40);
   parent = previousParent;
@@ -1435,13 +1440,13 @@ function deserializeExpressionStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ExpressionStatement',
       expression: null,
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -1451,7 +1456,7 @@ function deserializeIfStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'IfStatement',
       test: null,
       consequent: null,
@@ -1459,7 +1464,7 @@ function deserializeIfStatement(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.test = deserializeExpression(pos + 8);
   node.consequent = deserializeStatement(pos + 24);
   node.alternate = deserializeOptionStatement(pos + 40);
@@ -1471,14 +1476,14 @@ function deserializeDoWhileStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'DoWhileStatement',
       body: null,
       test: null,
       start,
       end,
       parent,
-    };
+    });
   node.body = deserializeStatement(pos + 8);
   node.test = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -1489,14 +1494,14 @@ function deserializeWhileStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'WhileStatement',
       test: null,
       body: null,
       start,
       end,
       parent,
-    };
+    });
   node.test = deserializeExpression(pos + 8);
   node.body = deserializeStatement(pos + 24);
   parent = previousParent;
@@ -1507,7 +1512,7 @@ function deserializeForStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ForStatement',
       init: null,
       test: null,
@@ -1516,7 +1521,7 @@ function deserializeForStatement(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.init = deserializeOptionForStatementInit(pos + 8);
   node.test = deserializeOptionExpression(pos + 24);
   node.update = deserializeOptionExpression(pos + 40);
@@ -1624,7 +1629,7 @@ function deserializeForInStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ForInStatement',
       left: null,
       right: null,
@@ -1632,7 +1637,7 @@ function deserializeForInStatement(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.left = deserializeForStatementLeft(pos + 8);
   node.right = deserializeExpression(pos + 24);
   node.body = deserializeStatement(pos + 40);
@@ -1673,7 +1678,7 @@ function deserializeForOfStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ForOfStatement',
       await: deserializeBool(pos + 60),
       left: null,
@@ -1682,7 +1687,7 @@ function deserializeForOfStatement(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.left = deserializeForStatementLeft(pos + 8);
   node.right = deserializeExpression(pos + 24);
   node.body = deserializeStatement(pos + 40);
@@ -1694,13 +1699,13 @@ function deserializeContinueStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ContinueStatement',
       label: null,
       start,
       end,
       parent,
-    };
+    });
   node.label = deserializeOptionLabelIdentifier(pos + 8);
   parent = previousParent;
   return node;
@@ -1710,13 +1715,13 @@ function deserializeBreakStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'BreakStatement',
       label: null,
       start,
       end,
       parent,
-    };
+    });
   node.label = deserializeOptionLabelIdentifier(pos + 8);
   parent = previousParent;
   return node;
@@ -1726,13 +1731,13 @@ function deserializeReturnStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ReturnStatement',
       argument: null,
       start,
       end,
       parent,
-    };
+    });
   node.argument = deserializeOptionExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -1742,14 +1747,14 @@ function deserializeWithStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'WithStatement',
       object: null,
       body: null,
       start,
       end,
       parent,
-    };
+    });
   node.object = deserializeExpression(pos + 8);
   node.body = deserializeStatement(pos + 24);
   parent = previousParent;
@@ -1760,14 +1765,14 @@ function deserializeSwitchStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'SwitchStatement',
       discriminant: null,
       cases: null,
       start,
       end,
       parent,
-    };
+    });
   node.discriminant = deserializeExpression(pos + 8);
   node.cases = deserializeVecSwitchCase(pos + 24);
   parent = previousParent;
@@ -1778,14 +1783,14 @@ function deserializeSwitchCase(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'SwitchCase',
       test: null,
       consequent: null,
       start,
       end,
       parent,
-    };
+    });
   node.test = deserializeOptionExpression(pos + 8);
   node.consequent = deserializeVecStatement(pos + 24);
   parent = previousParent;
@@ -1796,14 +1801,14 @@ function deserializeLabeledStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'LabeledStatement',
       label: null,
       body: null,
       start,
       end,
       parent,
-    };
+    });
   node.label = deserializeLabelIdentifier(pos + 8);
   node.body = deserializeStatement(pos + 32);
   parent = previousParent;
@@ -1814,13 +1819,13 @@ function deserializeThrowStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ThrowStatement',
       argument: null,
       start,
       end,
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -1830,7 +1835,7 @@ function deserializeTryStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TryStatement',
       block: null,
       handler: null,
@@ -1838,7 +1843,7 @@ function deserializeTryStatement(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.block = deserializeBoxBlockStatement(pos + 8);
   node.handler = deserializeOptionBoxCatchClause(pos + 16);
   node.finalizer = deserializeOptionBoxBlockStatement(pos + 24);
@@ -1850,14 +1855,14 @@ function deserializeCatchClause(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'CatchClause',
       param: null,
       body: null,
       start,
       end,
       parent,
-    };
+    });
   node.param = deserializeOptionCatchParameter(pos + 8);
   node.body = deserializeBoxBlockStatement(pos + 48);
   parent = previousParent;
@@ -1900,14 +1905,14 @@ function deserializeAssignmentPattern(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'AssignmentPattern',
       left: null,
       right: null,
       start,
       end,
       parent,
-    };
+    });
   node.left = deserializeBindingPattern(pos + 8);
   node.right = deserializeExpression(pos + 40);
   parent = previousParent;
@@ -1918,13 +1923,13 @@ function deserializeObjectPattern(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ObjectPattern',
       properties: null,
       start,
       end,
       parent,
-    },
+    }),
     properties = deserializeVecBindingProperty(pos + 8),
     rest = deserializeOptionBoxBindingRestElement(pos + 32);
   rest !== null && properties.push(rest);
@@ -1937,7 +1942,7 @@ function deserializeBindingProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Property',
       kind: null,
       key: null,
@@ -1948,7 +1953,7 @@ function deserializeBindingProperty(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.kind = 'init';
   node.key = deserializePropertyKey(pos + 8);
   node.value = deserializeBindingPattern(pos + 24);
@@ -1961,13 +1966,13 @@ function deserializeArrayPattern(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ArrayPattern',
       elements: null,
       start,
       end,
       parent,
-    },
+    }),
     elements = deserializeVecOptionBindingPattern(pos + 8),
     rest = deserializeOptionBoxBindingRestElement(pos + 32);
   rest !== null && elements.push(rest);
@@ -1980,13 +1985,13 @@ function deserializeBindingRestElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'RestElement',
       argument: null,
       start,
       end,
       parent,
-    };
+    });
   node.argument = deserializeBindingPattern(pos + 8);
   parent = previousParent;
   return node;
@@ -1996,7 +2001,7 @@ function deserializeFunction(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: deserializeFunctionType(pos + 84),
       id: null,
       generator: deserializeBool(pos + 85),
@@ -2007,7 +2012,7 @@ function deserializeFunction(pos) {
       start,
       end,
       parent,
-    },
+    }),
     params = deserializeBoxFormalParameters(pos + 56);
   node.id = deserializeOptionBindingIdentifier(pos + 8);
   node.params = params;
@@ -2034,16 +2039,16 @@ function deserializeFunctionType(pos) {
 
 function deserializeFormalParameters(pos) {
   let params = deserializeVecFormalParameter(pos + 8);
-  if (uint32[pos + 32 >> 2] !== 0 && uint32[pos + 36 >> 2] !== 0) {
-    pos = uint32[pos + 32 >> 2];
+  if (uint32[(pos + 32) >> 2] !== 0 && uint32[(pos + 36) >> 2] !== 0) {
+    pos = uint32[(pos + 32) >> 2];
     let previousParent = parent,
-      rest = parent = {
+      rest = (parent = {
         type: 'RestElement',
         argument: null,
         start: deserializeU32(pos),
         end: deserializeU32(pos + 4),
         parent,
-      };
+      });
     rest.argument = deserializeBindingPatternKind(pos + 8);
     params.push(rest);
     parent = previousParent;
@@ -2061,13 +2066,13 @@ function deserializeFunctionBody(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'BlockStatement',
       body: null,
       start,
       end,
       parent,
-    },
+    }),
     body = deserializeVecDirective(pos + 8);
   body.push(...deserializeVecStatement(pos + 32));
   node.body = body;
@@ -2080,7 +2085,7 @@ function deserializeArrowFunctionExpression(pos) {
     start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ArrowFunctionExpression',
       expression,
       async: deserializeBool(pos + 45),
@@ -2091,7 +2096,7 @@ function deserializeArrowFunctionExpression(pos) {
       start,
       end,
       parent,
-    },
+    }),
     body = deserializeBoxFunctionBody(pos + 32);
   if (expression === true) {
     body = body.body[0].expression;
@@ -2109,14 +2114,14 @@ function deserializeYieldExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'YieldExpression',
       delegate: deserializeBool(pos + 24),
       argument: null,
       start,
       end,
       parent,
-    };
+    });
   node.argument = deserializeOptionExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -2126,7 +2131,7 @@ function deserializeClass(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: deserializeClassType(pos + 132),
       decorators: null,
       id: null,
@@ -2135,7 +2140,7 @@ function deserializeClass(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.decorators = deserializeVecDecorator(pos + 8);
   node.id = deserializeOptionBindingIdentifier(pos + 32);
   node.superClass = deserializeOptionExpression(pos + 72);
@@ -2159,13 +2164,13 @@ function deserializeClassBody(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ClassBody',
       body: null,
       start,
       end,
       parent,
-    };
+    });
   node.body = deserializeVecClassElement(pos + 8);
   parent = previousParent;
   return node;
@@ -2192,7 +2197,7 @@ function deserializeMethodDefinition(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: deserializeMethodDefinitionType(pos + 56),
       decorators: null,
       key: null,
@@ -2203,7 +2208,7 @@ function deserializeMethodDefinition(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.decorators = deserializeVecDecorator(pos + 8);
   node.key = deserializePropertyKey(pos + 32);
   node.value = deserializeBoxFunction(pos + 48);
@@ -2226,7 +2231,7 @@ function deserializePropertyDefinition(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: deserializePropertyDefinitionType(pos + 72),
       decorators: null,
       key: null,
@@ -2236,7 +2241,7 @@ function deserializePropertyDefinition(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.decorators = deserializeVecDecorator(pos + 8);
   node.key = deserializePropertyKey(pos + 32);
   node.value = deserializeOptionExpression(pos + 56);
@@ -2271,7 +2276,8 @@ function deserializeMethodDefinitionKind(pos) {
 }
 
 function deserializePrivateIdentifier(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'PrivateIdentifier',
     name: deserializeStr(pos + 8),
@@ -2285,13 +2291,13 @@ function deserializeStaticBlock(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'StaticBlock',
       body: null,
       start,
       end,
       parent,
-    };
+    });
   node.body = deserializeVecStatement(pos + 8);
   parent = previousParent;
   return node;
@@ -2312,7 +2318,7 @@ function deserializeAccessorProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: deserializeAccessorPropertyType(pos + 72),
       decorators: null,
       key: null,
@@ -2322,7 +2328,7 @@ function deserializeAccessorProperty(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.decorators = deserializeVecDecorator(pos + 8);
   node.key = deserializePropertyKey(pos + 32);
   node.value = deserializeOptionExpression(pos + 56);
@@ -2334,7 +2340,7 @@ function deserializeImportExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ImportExpression',
       source: null,
       options: null,
@@ -2342,7 +2348,7 @@ function deserializeImportExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.source = deserializeExpression(pos + 8);
   node.options = deserializeOptionExpression(pos + 24);
   parent = previousParent;
@@ -2353,7 +2359,7 @@ function deserializeImportDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ImportDeclaration',
       specifiers: null,
       source: null,
@@ -2362,7 +2368,7 @@ function deserializeImportDeclaration(pos) {
       start,
       end,
       parent,
-    },
+    }),
     specifiers = deserializeOptionVecImportDeclarationSpecifier(pos + 8);
   specifiers === null && (specifiers = []);
   let withClause = deserializeOptionBoxWithClause(pos + 80);
@@ -2401,14 +2407,14 @@ function deserializeImportSpecifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ImportSpecifier',
       imported: null,
       local: null,
       start,
       end,
       parent,
-    };
+    });
   node.imported = deserializeModuleExportName(pos + 8);
   node.local = deserializeBindingIdentifier(pos + 64);
   parent = previousParent;
@@ -2419,13 +2425,13 @@ function deserializeImportDefaultSpecifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ImportDefaultSpecifier',
       local: null,
       start,
       end,
       parent,
-    };
+    });
   node.local = deserializeBindingIdentifier(pos + 8);
   parent = previousParent;
   return node;
@@ -2435,13 +2441,13 @@ function deserializeImportNamespaceSpecifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ImportNamespaceSpecifier',
       local: null,
       start,
       end,
       parent,
-    };
+    });
   node.local = deserializeBindingIdentifier(pos + 8);
   parent = previousParent;
   return node;
@@ -2455,14 +2461,14 @@ function deserializeImportAttribute(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ImportAttribute',
       key: null,
       value: null,
       start,
       end,
       parent,
-    };
+    });
   node.key = deserializeImportAttributeKey(pos + 8);
   node.value = deserializeStringLiteral(pos + 64);
   parent = previousParent;
@@ -2484,7 +2490,7 @@ function deserializeExportNamedDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ExportNamedDeclaration',
       declaration: null,
       specifiers: null,
@@ -2493,7 +2499,7 @@ function deserializeExportNamedDeclaration(pos) {
       start,
       end,
       parent,
-    },
+    }),
     withClause = deserializeOptionBoxWithClause(pos + 96);
   node.declaration = deserializeOptionDeclaration(pos + 8);
   node.specifiers = deserializeVecExportSpecifier(pos + 24);
@@ -2507,13 +2513,13 @@ function deserializeExportDefaultDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ExportDefaultDeclaration',
       declaration: null,
       start,
       end,
       parent,
-    };
+    });
   node.declaration = deserializeExportDefaultDeclarationKind(pos + 8);
   parent = previousParent;
   return node;
@@ -2523,7 +2529,7 @@ function deserializeExportAllDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ExportAllDeclaration',
       exported: null,
       source: null,
@@ -2531,7 +2537,7 @@ function deserializeExportAllDeclaration(pos) {
       start,
       end,
       parent,
-    },
+    }),
     withClause = deserializeOptionBoxWithClause(pos + 112);
   node.exported = deserializeOptionModuleExportName(pos + 8);
   node.source = deserializeStringLiteral(pos + 64);
@@ -2544,14 +2550,14 @@ function deserializeExportSpecifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ExportSpecifier',
       local: null,
       exported: null,
       start,
       end,
       parent,
-    };
+    });
   node.local = deserializeModuleExportName(pos + 8);
   node.exported = deserializeModuleExportName(pos + 64);
   parent = previousParent;
@@ -2674,14 +2680,14 @@ function deserializeV8IntrinsicExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'V8IntrinsicExpression',
       name: null,
       arguments: null,
       start,
       end,
       parent,
-    };
+    });
   node.name = deserializeIdentifierName(pos + 8);
   node.arguments = deserializeVecArgument(pos + 32);
   parent = previousParent;
@@ -2693,14 +2699,14 @@ function deserializeBooleanLiteral(pos) {
     start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Literal',
       value,
       raw: null,
       start,
       end,
       parent,
-    };
+    });
   node.raw = start === 0 && end === 0 ? null : value + '';
   parent = previousParent;
   return node;
@@ -2710,14 +2716,14 @@ function deserializeNullLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Literal',
       value: null,
       raw: null,
       start,
       end,
       parent,
-    };
+    });
   node.value = null;
   node.raw = start === 0 && end === 0 ? null : 'null';
   parent = previousParent;
@@ -2725,7 +2731,8 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Literal',
     value: deserializeF64(pos + 8),
@@ -2740,14 +2747,14 @@ function deserializeStringLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Literal',
       value: null,
       raw: deserializeOptionStr(pos + 24),
       start,
       end,
       parent,
-    },
+    }),
     value = deserializeStr(pos + 8);
   deserializeBool(pos + 40) &&
     (value = value.replace(/\uFFFD(.{4})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16))));
@@ -2760,7 +2767,7 @@ function deserializeBigIntLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Literal',
       value: null,
       raw: deserializeOptionStr(pos + 24),
@@ -2768,7 +2775,7 @@ function deserializeBigIntLiteral(pos) {
       start,
       end,
       parent,
-    },
+    }),
     bigint = deserializeStr(pos + 8);
   node.value = BigInt(bigint);
   node.bigint = bigint;
@@ -2780,7 +2787,7 @@ function deserializeRegExpLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Literal',
       value: null,
       raw: deserializeOptionStr(pos + 40),
@@ -2788,7 +2795,7 @@ function deserializeRegExpLiteral(pos) {
       start,
       end,
       parent,
-    },
+    }),
     regex = deserializeRegExp(pos + 8),
     value = null;
   try {
@@ -2808,7 +2815,8 @@ function deserializeRegExp(pos) {
 }
 
 function deserializeRegExpFlags(pos) {
-  let flagBits = deserializeU8(pos), flags = '';
+  let flagBits = deserializeU8(pos),
+    flags = '';
   // Alphabetical order
   flagBits & 64 && (flags += 'd');
   flagBits & 1 && (flags += 'g');
@@ -2825,7 +2833,7 @@ function deserializeJSXElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXElement',
       openingElement: null,
       children: null,
@@ -2833,7 +2841,7 @@ function deserializeJSXElement(pos) {
       start,
       end,
       parent,
-    },
+    }),
     closingElement = deserializeOptionBoxJSXClosingElement(pos + 40),
     openingElement = deserializeBoxJSXOpeningElement(pos + 8);
   closingElement === null && (openingElement.selfClosing = true);
@@ -2848,7 +2856,7 @@ function deserializeJSXOpeningElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXOpeningElement',
       name: null,
       attributes: null,
@@ -2856,7 +2864,7 @@ function deserializeJSXOpeningElement(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.name = deserializeJSXElementName(pos + 8);
   node.attributes = deserializeVecJSXAttributeItem(pos + 32);
   node.selfClosing = false;
@@ -2868,13 +2876,13 @@ function deserializeJSXClosingElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXClosingElement',
       name: null,
       start,
       end,
       parent,
-    };
+    });
   node.name = deserializeJSXElementName(pos + 8);
   parent = previousParent;
   return node;
@@ -2884,7 +2892,7 @@ function deserializeJSXFragment(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXFragment',
       openingFragment: null,
       children: null,
@@ -2892,7 +2900,7 @@ function deserializeJSXFragment(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.openingFragment = deserializeJSXOpeningFragment(pos + 8);
   node.children = deserializeVecJSXChild(pos + 16);
   node.closingFragment = deserializeJSXClosingFragment(pos + 40);
@@ -2904,14 +2912,14 @@ function deserializeJSXOpeningFragment(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXOpeningFragment',
       attributes: null,
       selfClosing: null,
       start,
       end,
       parent,
-    };
+    });
   node.attributes = [];
   node.selfClosing = false;
   parent = previousParent;
@@ -2962,14 +2970,14 @@ function deserializeJSXNamespacedName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXNamespacedName',
       namespace: null,
       name: null,
       start,
       end,
       parent,
-    };
+    });
   node.namespace = deserializeJSXIdentifier(pos + 8);
   node.name = deserializeJSXIdentifier(pos + 32);
   parent = previousParent;
@@ -2980,14 +2988,14 @@ function deserializeJSXMemberExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXMemberExpression',
       object: null,
       property: null,
       start,
       end,
       parent,
-    };
+    });
   node.object = deserializeJSXMemberExpressionObject(pos + 8);
   node.property = deserializeJSXIdentifier(pos + 24);
   parent = previousParent;
@@ -3025,13 +3033,13 @@ function deserializeJSXExpressionContainer(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXExpressionContainer',
       expression: null,
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeJSXExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -3156,14 +3164,14 @@ function deserializeJSXAttribute(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXAttribute',
       name: null,
       value: null,
       start,
       end,
       parent,
-    };
+    });
   node.name = deserializeJSXAttributeName(pos + 8);
   node.value = deserializeOptionJSXAttributeValue(pos + 24);
   parent = previousParent;
@@ -3174,13 +3182,13 @@ function deserializeJSXSpreadAttribute(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXSpreadAttribute',
       argument: null,
       start,
       end,
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -3213,7 +3221,8 @@ function deserializeJSXAttributeValue(pos) {
 }
 
 function deserializeJSXIdentifier(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXIdentifier',
     name: deserializeStr(pos + 8),
@@ -3244,20 +3253,21 @@ function deserializeJSXSpreadChild(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXSpreadChild',
       expression: null,
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
 }
 
 function deserializeJSXText(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXText',
     value: deserializeStr(pos + 8),
@@ -3272,7 +3282,7 @@ function deserializeTSThisParameter(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Identifier',
       decorators: null,
       name: null,
@@ -3281,7 +3291,7 @@ function deserializeTSThisParameter(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.decorators = [];
   node.name = 'this';
   node.optional = false;
@@ -3294,7 +3304,7 @@ function deserializeTSEnumDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSEnumDeclaration',
       id: null,
       body: null,
@@ -3303,7 +3313,7 @@ function deserializeTSEnumDeclaration(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.id = deserializeBindingIdentifier(pos + 8);
   node.body = deserializeTSEnumBody(pos + 40);
   parent = previousParent;
@@ -3314,13 +3324,13 @@ function deserializeTSEnumBody(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSEnumBody',
       members: null,
       start,
       end,
       parent,
-    };
+    });
   node.members = deserializeVecTSEnumMember(pos + 8);
   parent = previousParent;
   return node;
@@ -3330,7 +3340,7 @@ function deserializeTSEnumMember(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSEnumMember',
       id: null,
       initializer: null,
@@ -3338,7 +3348,7 @@ function deserializeTSEnumMember(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.id = deserializeTSEnumMemberName(pos + 8);
   node.initializer = deserializeOptionExpression(pos + 24);
   node.computed = deserializeU8(pos + 8) > 1;
@@ -3365,13 +3375,13 @@ function deserializeTSTypeAnnotation(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeAnnotation',
       typeAnnotation: null,
       start,
       end,
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3381,13 +3391,13 @@ function deserializeTSLiteralType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSLiteralType',
       literal: null,
       start,
       end,
       parent,
-    };
+    });
   node.literal = deserializeTSLiteral(pos + 8);
   parent = previousParent;
   return node;
@@ -3497,7 +3507,7 @@ function deserializeTSConditionalType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSConditionalType',
       checkType: null,
       extendsType: null,
@@ -3506,7 +3516,7 @@ function deserializeTSConditionalType(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.checkType = deserializeTSType(pos + 8);
   node.extendsType = deserializeTSType(pos + 24);
   node.trueType = deserializeTSType(pos + 40);
@@ -3519,13 +3529,13 @@ function deserializeTSUnionType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSUnionType',
       types: null,
       start,
       end,
       parent,
-    };
+    });
   node.types = deserializeVecTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3535,13 +3545,13 @@ function deserializeTSIntersectionType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSIntersectionType',
       types: null,
       start,
       end,
       parent,
-    };
+    });
   node.types = deserializeVecTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3568,14 +3578,14 @@ function deserializeTSTypeOperator(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeOperator',
       operator: deserializeTSTypeOperatorOperator(pos + 24),
       typeAnnotation: null,
       start,
       end,
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3598,13 +3608,13 @@ function deserializeTSArrayType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSArrayType',
       elementType: null,
       start,
       end,
       parent,
-    };
+    });
   node.elementType = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3614,14 +3624,14 @@ function deserializeTSIndexedAccessType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSIndexedAccessType',
       objectType: null,
       indexType: null,
       start,
       end,
       parent,
-    };
+    });
   node.objectType = deserializeTSType(pos + 8);
   node.indexType = deserializeTSType(pos + 24);
   parent = previousParent;
@@ -3632,13 +3642,13 @@ function deserializeTSTupleType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTupleType',
       elementTypes: null,
       start,
       end,
       parent,
-    };
+    });
   node.elementTypes = deserializeVecTSTupleElement(pos + 8);
   parent = previousParent;
   return node;
@@ -3648,7 +3658,7 @@ function deserializeTSNamedTupleMember(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSNamedTupleMember',
       label: null,
       elementType: null,
@@ -3656,7 +3666,7 @@ function deserializeTSNamedTupleMember(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.label = deserializeIdentifierName(pos + 8);
   node.elementType = deserializeTSTupleElement(pos + 32);
   parent = previousParent;
@@ -3667,13 +3677,13 @@ function deserializeTSOptionalType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSOptionalType',
       typeAnnotation: null,
       start,
       end,
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3683,13 +3693,13 @@ function deserializeTSRestType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSRestType',
       typeAnnotation: null,
       start,
       end,
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3910,14 +3920,14 @@ function deserializeTSTypeReference(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeReference',
       typeName: null,
       typeArguments: null,
       start,
       end,
       parent,
-    };
+    });
   node.typeName = deserializeTSTypeName(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   parent = previousParent;
@@ -3941,14 +3951,14 @@ function deserializeTSQualifiedName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSQualifiedName',
       left: null,
       right: null,
       start,
       end,
       parent,
-    };
+    });
   node.left = deserializeTSTypeName(pos + 8);
   node.right = deserializeIdentifierName(pos + 24);
   parent = previousParent;
@@ -3959,13 +3969,13 @@ function deserializeTSTypeParameterInstantiation(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeParameterInstantiation',
       params: null,
       start,
       end,
       parent,
-    };
+    });
   node.params = deserializeVecTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3975,7 +3985,7 @@ function deserializeTSTypeParameter(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeParameter',
       name: null,
       constraint: null,
@@ -3986,7 +3996,7 @@ function deserializeTSTypeParameter(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.name = deserializeBindingIdentifier(pos + 8);
   node.constraint = deserializeOptionTSType(pos + 40);
   node.default = deserializeOptionTSType(pos + 56);
@@ -3998,13 +4008,13 @@ function deserializeTSTypeParameterDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeParameterDeclaration',
       params: null,
       start,
       end,
       parent,
-    };
+    });
   node.params = deserializeVecTSTypeParameter(pos + 8);
   parent = previousParent;
   return node;
@@ -4014,7 +4024,7 @@ function deserializeTSTypeAliasDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeAliasDeclaration',
       id: null,
       typeParameters: null,
@@ -4023,7 +4033,7 @@ function deserializeTSTypeAliasDeclaration(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.id = deserializeBindingIdentifier(pos + 8);
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 40);
   node.typeAnnotation = deserializeTSType(pos + 48);
@@ -4035,7 +4045,7 @@ function deserializeTSInterfaceDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSInterfaceDeclaration',
       id: null,
       typeParameters: null,
@@ -4045,7 +4055,7 @@ function deserializeTSInterfaceDeclaration(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.id = deserializeBindingIdentifier(pos + 8);
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 40);
   node.extends = deserializeVecTSInterfaceHeritage(pos + 48);
@@ -4058,13 +4068,13 @@ function deserializeTSInterfaceBody(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSInterfaceBody',
       body: null,
       start,
       end,
       parent,
-    };
+    });
   node.body = deserializeVecTSSignature(pos + 8);
   parent = previousParent;
   return node;
@@ -4074,7 +4084,7 @@ function deserializeTSPropertySignature(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSPropertySignature',
       computed: deserializeBool(pos + 32),
       optional: deserializeBool(pos + 33),
@@ -4086,7 +4096,7 @@ function deserializeTSPropertySignature(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.key = deserializePropertyKey(pos + 8);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   node.accessibility = null;
@@ -4116,7 +4126,7 @@ function deserializeTSIndexSignature(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSIndexSignature',
       parameters: null,
       typeAnnotation: null,
@@ -4126,7 +4136,7 @@ function deserializeTSIndexSignature(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.parameters = deserializeVecTSIndexSignatureName(pos + 8);
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
   node.accessibility = null;
@@ -4138,7 +4148,7 @@ function deserializeTSCallSignatureDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSCallSignatureDeclaration',
       typeParameters: null,
       params: null,
@@ -4146,7 +4156,7 @@ function deserializeTSCallSignatureDeclaration(pos) {
       start,
       end,
       parent,
-    },
+    }),
     params = deserializeBoxFormalParameters(pos + 24),
     thisParam = deserializeOptionBoxTSThisParameter(pos + 16);
   thisParam !== null && params.unshift(thisParam);
@@ -4174,7 +4184,7 @@ function deserializeTSMethodSignature(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSMethodSignature',
       key: null,
       computed: deserializeBool(pos + 60),
@@ -4189,7 +4199,7 @@ function deserializeTSMethodSignature(pos) {
       start,
       end,
       parent,
-    },
+    }),
     params = deserializeBoxFormalParameters(pos + 40),
     thisParam = deserializeOptionBoxTSThisParameter(pos + 32);
   thisParam !== null && params.unshift(thisParam);
@@ -4208,7 +4218,7 @@ function deserializeTSConstructSignatureDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSConstructSignatureDeclaration',
       typeParameters: null,
       params: null,
@@ -4216,7 +4226,7 @@ function deserializeTSConstructSignatureDeclaration(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 8);
   node.params = deserializeBoxFormalParameters(pos + 16);
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 24);
@@ -4228,7 +4238,7 @@ function deserializeTSIndexSignatureName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Identifier',
       decorators: null,
       name: deserializeStr(pos + 8),
@@ -4237,7 +4247,7 @@ function deserializeTSIndexSignatureName(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.decorators = [];
   node.optional = false;
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 24);
@@ -4249,14 +4259,14 @@ function deserializeTSInterfaceHeritage(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSInterfaceHeritage',
       expression: null,
       typeArguments: null,
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   parent = previousParent;
@@ -4267,7 +4277,7 @@ function deserializeTSTypePredicate(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypePredicate',
       parameterName: null,
       asserts: deserializeBool(pos + 32),
@@ -4275,7 +4285,7 @@ function deserializeTSTypePredicate(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.parameterName = deserializeTSTypePredicateName(pos + 8);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   parent = previousParent;
@@ -4332,7 +4342,7 @@ function deserializeTSModuleDeclaration(pos) {
       body.parent = node;
     } else {
       let innerId = body.id;
-      if (innerId.type === 'Identifier') {
+      if (innerId.type === 'Identifier')
         id.parent =
           innerId.parent =
           node.id =
@@ -4345,7 +4355,7 @@ function deserializeTSModuleDeclaration(pos) {
               end: innerId.end,
               parent: node,
             };
-      } else {
+      else {
         // Replace `left` of innermost `TSQualifiedName` with a nested `TSQualifiedName` with `id` of
         // this module on left, and previous `left` of innermost `TSQualifiedName` on right
         node.id = innerId;
@@ -4357,14 +4367,17 @@ function deserializeTSModuleDeclaration(pos) {
           innerId = innerId.left;
         }
         let right = innerId.left;
-        id.parent = right.parent = innerId.left = {
-          type: 'TSQualifiedName',
-          left: id,
-          right,
-          start,
-          end: right.end,
-          parent: innerId,
-        };
+        id.parent =
+          right.parent =
+          innerId.left =
+            {
+              type: 'TSQualifiedName',
+              left: id,
+              right,
+              start,
+              end: right.end,
+              parent: innerId,
+            };
       }
       if (Object.hasOwn(body, 'body')) {
         body = body.body;
@@ -4416,13 +4429,13 @@ function deserializeTSModuleBlock(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSModuleBlock',
       body: null,
       start,
       end,
       parent,
-    },
+    }),
     body = deserializeVecDirective(pos + 8);
   body.push(...deserializeVecStatement(pos + 32));
   node.body = body;
@@ -4434,13 +4447,13 @@ function deserializeTSTypeLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeLiteral',
       members: null,
       start,
       end,
       parent,
-    };
+    });
   node.members = deserializeVecTSSignature(pos + 8);
   parent = previousParent;
   return node;
@@ -4450,13 +4463,13 @@ function deserializeTSInferType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSInferType',
       typeParameter: null,
       start,
       end,
       parent,
-    };
+    });
   node.typeParameter = deserializeBoxTSTypeParameter(pos + 8);
   parent = previousParent;
   return node;
@@ -4466,14 +4479,14 @@ function deserializeTSTypeQuery(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeQuery',
       exprName: null,
       typeArguments: null,
       start,
       end,
       parent,
-    };
+    });
   node.exprName = deserializeTSTypeQueryExprName(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   parent = previousParent;
@@ -4499,7 +4512,7 @@ function deserializeTSImportType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSImportType',
       argument: null,
       options: null,
@@ -4508,7 +4521,7 @@ function deserializeTSImportType(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.argument = deserializeTSType(pos + 8);
   node.options = deserializeOptionBoxObjectExpression(pos + 24);
   node.qualifier = deserializeOptionTSImportTypeQualifier(pos + 32);
@@ -4532,14 +4545,14 @@ function deserializeTSImportTypeQualifiedName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSQualifiedName',
       left: null,
       right: null,
       start,
       end,
       parent,
-    };
+    });
   node.left = deserializeTSImportTypeQualifier(pos + 8);
   node.right = deserializeIdentifierName(pos + 24);
   parent = previousParent;
@@ -4550,7 +4563,7 @@ function deserializeTSFunctionType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSFunctionType',
       typeParameters: null,
       params: null,
@@ -4558,7 +4571,7 @@ function deserializeTSFunctionType(pos) {
       start,
       end,
       parent,
-    },
+    }),
     params = deserializeBoxFormalParameters(pos + 24),
     thisParam = deserializeOptionBoxTSThisParameter(pos + 16);
   thisParam !== null && params.unshift(thisParam);
@@ -4573,7 +4586,7 @@ function deserializeTSConstructorType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSConstructorType',
       abstract: deserializeBool(pos + 36),
       typeParameters: null,
@@ -4582,7 +4595,7 @@ function deserializeTSConstructorType(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 8);
   node.params = deserializeBoxFormalParameters(pos + 16);
   node.returnType = deserializeBoxTSTypeAnnotation(pos + 24);
@@ -4594,7 +4607,7 @@ function deserializeTSMappedType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSMappedType',
       key: null,
       constraint: null,
@@ -4605,7 +4618,7 @@ function deserializeTSMappedType(pos) {
       start,
       end,
       parent,
-    },
+    }),
     typeParameter = deserializeBoxTSTypeParameter(pos + 8),
     key = typeParameter.name;
   key.parent = parent;
@@ -4639,14 +4652,14 @@ function deserializeTSTemplateLiteralType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTemplateLiteralType',
       quasis: null,
       types: null,
       start,
       end,
       parent,
-    };
+    });
   node.quasis = deserializeVecTemplateElement(pos + 8);
   node.types = deserializeVecTSType(pos + 32);
   parent = previousParent;
@@ -4657,14 +4670,14 @@ function deserializeTSAsExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSAsExpression',
       expression: null,
       typeAnnotation: null,
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   node.typeAnnotation = deserializeTSType(pos + 24);
   parent = previousParent;
@@ -4675,14 +4688,14 @@ function deserializeTSSatisfiesExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSSatisfiesExpression',
       expression: null,
       typeAnnotation: null,
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   node.typeAnnotation = deserializeTSType(pos + 24);
   parent = previousParent;
@@ -4693,14 +4706,14 @@ function deserializeTSTypeAssertion(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeAssertion',
       typeAnnotation: null,
       expression: null,
       start,
       end,
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   node.expression = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -4711,7 +4724,7 @@ function deserializeTSImportEqualsDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSImportEqualsDeclaration',
       id: null,
       moduleReference: null,
@@ -4719,7 +4732,7 @@ function deserializeTSImportEqualsDeclaration(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.id = deserializeBindingIdentifier(pos + 8);
   node.moduleReference = deserializeTSModuleReference(pos + 40);
   parent = previousParent;
@@ -4745,13 +4758,13 @@ function deserializeTSExternalModuleReference(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSExternalModuleReference',
       expression: null,
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeStringLiteral(pos + 8);
   parent = previousParent;
   return node;
@@ -4761,13 +4774,13 @@ function deserializeTSNonNullExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSNonNullExpression',
       expression: null,
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -4777,13 +4790,13 @@ function deserializeDecorator(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Decorator',
       expression: null,
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -4793,13 +4806,13 @@ function deserializeTSExportAssignment(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSExportAssignment',
       expression: null,
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -4809,13 +4822,13 @@ function deserializeTSNamespaceExportDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSNamespaceExportDeclaration',
       id: null,
       start,
       end,
       parent,
-    };
+    });
   node.id = deserializeIdentifierName(pos + 8);
   parent = previousParent;
   return node;
@@ -4825,14 +4838,14 @@ function deserializeTSInstantiationExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSInstantiationExpression',
       expression: null,
       typeArguments: null,
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   node.typeArguments = deserializeBoxTSTypeParameterInstantiation(pos + 24);
   parent = previousParent;
@@ -4854,14 +4867,14 @@ function deserializeJSDocNullableType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSJSDocNullableType',
       typeAnnotation: null,
       postfix: deserializeBool(pos + 24),
       start,
       end,
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -4871,14 +4884,14 @@ function deserializeJSDocNonNullableType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSJSDocNonNullableType',
       typeAnnotation: null,
       postfix: deserializeBool(pos + 24),
       start,
       end,
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -4905,7 +4918,9 @@ function deserializeCommentKind(pos) {
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12), start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let type = deserializeCommentKind(pos + 12),
+    start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type,
     value: sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2)),
@@ -4915,7 +4930,8 @@ function deserializeComment(pos) {
 }
 
 function deserializeNameSpan(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     value: deserializeStr(pos + 8),
     start,
@@ -4962,7 +4978,8 @@ function deserializeImportImportName(pos) {
 }
 
 function deserializeExportEntry(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
@@ -5071,7 +5088,8 @@ function deserializeExportLocalName(pos) {
 }
 
 function deserializeDynamicImport(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeSpan(pos + 8),
     start,
@@ -5265,7 +5283,8 @@ function deserializeErrorSeverity(pos) {
 }
 
 function deserializeErrorLabel(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     message: deserializeOptionStr(pos + 8),
     start,
@@ -5284,7 +5303,8 @@ function deserializeEcmaScriptModule(pos) {
 }
 
 function deserializeStaticImport(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeNameSpan(pos + 8),
     entries: deserializeVecImportEntry(pos + 32),
@@ -5294,7 +5314,8 @@ function deserializeStaticImport(pos) {
 }
 
 function deserializeStaticExport(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     entries: deserializeVecExportEntry(pos + 8),
     start,
@@ -5311,7 +5332,8 @@ function deserializeU8(pos) {
 }
 
 function deserializeStr(pos) {
-  let pos32 = pos >> 2, len = uint32[pos32 + 2];
+  let pos32 = pos >> 2,
+    len = uint32[pos32 + 2];
   if (len === 0) return '';
   pos = uint32[pos32];
   if (sourceIsAscii && pos < sourceByteLen) return sourceText.substr(pos, len);
@@ -5320,7 +5342,8 @@ function deserializeStr(pos) {
   let end = pos + len;
   if (len > 50) return decodeStr(uint8.subarray(pos, end));
   // Shorter strings decode by hand to avoid native call
-  let out = '', c;
+  let out = '',
+    c;
   do {
     c = uint8[pos++];
     if (c < 128) out += fromCodePoint(c);
@@ -5333,10 +5356,11 @@ function deserializeStr(pos) {
 }
 
 function deserializeVecComment(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeComment(pos));
     pos += 16;
   }
@@ -5344,15 +5368,16 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeHashbang(pos);
 }
 
 function deserializeVecDirective(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 72;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDirective(pos));
     pos += 72;
   }
@@ -5360,10 +5385,11 @@ function deserializeVecDirective(pos) {
 }
 
 function deserializeVecStatement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStatement(pos));
     pos += 16;
   }
@@ -5531,10 +5557,11 @@ function deserializeBoxV8IntrinsicExpression(pos) {
 }
 
 function deserializeVecArrayExpressionElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeArrayExpressionElement(pos));
     pos += 16;
   }
@@ -5546,10 +5573,11 @@ function deserializeBoxSpreadElement(pos) {
 }
 
 function deserializeVecObjectPropertyKind(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeObjectPropertyKind(pos));
     pos += 16;
   }
@@ -5573,10 +5601,11 @@ function deserializeBoxPrivateIdentifier(pos) {
 }
 
 function deserializeVecTemplateElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 48;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTemplateElement(pos));
     pos += 48;
   }
@@ -5584,10 +5613,11 @@ function deserializeVecTemplateElement(pos) {
 }
 
 function deserializeVecExpression(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExpression(pos));
     pos += 16;
   }
@@ -5599,12 +5629,12 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeStr(pos);
 }
 
@@ -5621,10 +5651,11 @@ function deserializeBoxPrivateFieldExpression(pos) {
 }
 
 function deserializeVecArgument(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeArgument(pos));
     pos += 16;
   }
@@ -5645,10 +5676,11 @@ function deserializeOptionAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeOptionAssignmentTargetMaybeDefault(pos));
     pos += 16;
   }
@@ -5660,15 +5692,16 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxAssignmentTargetRest(pos);
 }
 
 function deserializeVecAssignmentTargetProperty(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeAssignmentTargetProperty(pos));
     pos += 16;
   }
@@ -5789,10 +5822,11 @@ function deserializeBoxTSImportEqualsDeclaration(pos) {
 }
 
 function deserializeVecVariableDeclarator(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 64;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeVariableDeclarator(pos));
     pos += 64;
   }
@@ -5810,15 +5844,16 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeLabelIdentifier(pos);
 }
 
 function deserializeVecSwitchCase(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 48;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeSwitchCase(pos));
     pos += 48;
   }
@@ -5830,12 +5865,12 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxBlockStatement(pos);
 }
 
@@ -5849,7 +5884,7 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeAnnotation(pos);
 }
 
@@ -5870,10 +5905,11 @@ function deserializeBoxAssignmentPattern(pos) {
 }
 
 function deserializeVecBindingProperty(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 64;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeBindingProperty(pos));
     pos += 64;
   }
@@ -5885,7 +5921,7 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxBindingRestElement(pos);
 }
 
@@ -5895,10 +5931,11 @@ function deserializeOptionBindingPattern(pos) {
 }
 
 function deserializeVecOptionBindingPattern(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeOptionBindingPattern(pos));
     pos += 32;
   }
@@ -5906,7 +5943,7 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeBindingIdentifier(pos);
 }
 
@@ -5915,7 +5952,7 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
@@ -5924,7 +5961,7 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSThisParameter(pos);
 }
 
@@ -5937,15 +5974,16 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxFunctionBody(pos);
 }
 
 function deserializeVecFormalParameter(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 72;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeFormalParameter(pos));
     pos += 72;
   }
@@ -5953,10 +5991,11 @@ function deserializeVecFormalParameter(pos) {
 }
 
 function deserializeVecDecorator(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 24;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDecorator(pos));
     pos += 24;
   }
@@ -5968,10 +6007,11 @@ function deserializeBoxClassBody(pos) {
 }
 
 function deserializeVecClassElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeClassElement(pos));
     pos += 16;
   }
@@ -6028,10 +6068,11 @@ function deserializeOptionImportPhase(pos) {
 }
 
 function deserializeVecImportDeclarationSpecifier(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportDeclarationSpecifier(pos));
     pos += 16;
   }
@@ -6039,7 +6080,7 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeVecImportDeclarationSpecifier(pos);
 }
 
@@ -6048,7 +6089,7 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxWithClause(pos);
 }
 
@@ -6065,10 +6106,11 @@ function deserializeBoxImportNamespaceSpecifier(pos) {
 }
 
 function deserializeVecImportAttribute(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 112;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportAttribute(pos));
     pos += 112;
   }
@@ -6081,10 +6123,11 @@ function deserializeOptionDeclaration(pos) {
 }
 
 function deserializeVecExportSpecifier(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 128;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExportSpecifier(pos));
     pos += 128;
   }
@@ -6110,10 +6153,11 @@ function deserializeBoxJSXOpeningElement(pos) {
 }
 
 function deserializeVecJSXChild(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeJSXChild(pos));
     pos += 16;
   }
@@ -6125,15 +6169,16 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxJSXClosingElement(pos);
 }
 
 function deserializeVecJSXAttributeItem(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeJSXAttributeItem(pos));
     pos += 16;
   }
@@ -6178,10 +6223,11 @@ function deserializeBoxJSXSpreadChild(pos) {
 }
 
 function deserializeVecTSEnumMember(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 40;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSEnumMember(pos));
     pos += 40;
   }
@@ -6337,10 +6383,11 @@ function deserializeBoxJSDocUnknownType(pos) {
 }
 
 function deserializeVecTSType(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSType(pos));
     pos += 16;
   }
@@ -6348,10 +6395,11 @@ function deserializeVecTSType(pos) {
 }
 
 function deserializeVecTSTupleElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSTupleElement(pos));
     pos += 16;
   }
@@ -6376,10 +6424,11 @@ function deserializeOptionTSType(pos) {
 }
 
 function deserializeVecTSTypeParameter(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 80;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSTypeParameter(pos));
     pos += 80;
   }
@@ -6387,10 +6436,11 @@ function deserializeVecTSTypeParameter(pos) {
 }
 
 function deserializeVecTSInterfaceHeritage(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSInterfaceHeritage(pos));
     pos += 32;
   }
@@ -6402,10 +6452,11 @@ function deserializeBoxTSInterfaceBody(pos) {
 }
 
 function deserializeVecTSSignature(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSSignature(pos));
     pos += 16;
   }
@@ -6429,10 +6480,11 @@ function deserializeBoxTSMethodSignature(pos) {
 }
 
 function deserializeVecTSIndexSignatureName(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
     pos += 32;
   }
@@ -6453,7 +6505,7 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxObjectExpression(pos);
 }
 
@@ -6476,15 +6528,16 @@ function deserializeBoxTSExternalModuleReference(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeNameSpan(pos);
 }
 
 function deserializeVecError(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 80;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeError(pos));
     pos += 80;
   }
@@ -6492,10 +6545,11 @@ function deserializeVecError(pos) {
 }
 
 function deserializeVecErrorLabel(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 24;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeErrorLabel(pos));
     pos += 24;
   }
@@ -6503,10 +6557,11 @@ function deserializeVecErrorLabel(pos) {
 }
 
 function deserializeVecStaticImport(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 56;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStaticImport(pos));
     pos += 56;
   }
@@ -6514,10 +6569,11 @@ function deserializeVecStaticImport(pos) {
 }
 
 function deserializeVecStaticExport(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStaticExport(pos));
     pos += 32;
   }
@@ -6525,10 +6581,11 @@ function deserializeVecStaticExport(pos) {
 }
 
 function deserializeVecDynamicImport(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDynamicImport(pos));
     pos += 16;
   }
@@ -6536,10 +6593,11 @@ function deserializeVecDynamicImport(pos) {
 }
 
 function deserializeVecSpan(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 8;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeSpan(pos));
     pos += 8;
   }
@@ -6547,10 +6605,11 @@ function deserializeVecSpan(pos) {
 }
 
 function deserializeVecImportEntry(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 96;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportEntry(pos));
     pos += 96;
   }
@@ -6558,10 +6617,11 @@ function deserializeVecImportEntry(pos) {
 }
 
 function deserializeVecExportEntry(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 144;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExportEntry(pos));
     pos += 144;
   }

--- a/napi/parser/generated/deserialize/js_range.js
+++ b/napi/parser/generated/deserialize/js_range.js
@@ -25,11 +25,7 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInpu
 
 export function resetBuffer() {
   // Clear buffer and source text string to allow them to be garbage collected
-  uint8 =
-    uint32 =
-    float64 =
-    sourceText =
-      void 0;
+  uint8 = uint32 = float64 = sourceText = void 0;
 }
 
 function deserializeProgram(pos) {
@@ -143,7 +139,8 @@ function deserializeExpression(pos) {
 }
 
 function deserializeIdentifierName(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Identifier',
     name: deserializeStr(pos + 8),
@@ -154,7 +151,8 @@ function deserializeIdentifierName(pos) {
 }
 
 function deserializeIdentifierReference(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Identifier',
     name: deserializeStr(pos + 8),
@@ -165,7 +163,8 @@ function deserializeIdentifierReference(pos) {
 }
 
 function deserializeBindingIdentifier(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Identifier',
     name: deserializeStr(pos + 8),
@@ -176,7 +175,8 @@ function deserializeBindingIdentifier(pos) {
 }
 
 function deserializeLabelIdentifier(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Identifier',
     name: deserializeStr(pos + 8),
@@ -187,7 +187,8 @@ function deserializeLabelIdentifier(pos) {
 }
 
 function deserializeThisExpression(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'ThisExpression',
     start,
@@ -503,7 +504,8 @@ function deserializeTemplateElement(pos) {
     start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     value = deserializeTemplateElementValue(pos + 8);
-  value.cooked !== null && deserializeBool(pos + 41) &&
+  value.cooked !== null &&
+    deserializeBool(pos + 41) &&
     (value.cooked = value.cooked.replace(/\uFFFD(.{4})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16))));
   return {
     type: 'TemplateElement',
@@ -1029,14 +1031,15 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     key = deserializeIdentifierReference(pos + 8),
     init = deserializeOptionExpression(pos + 40),
     value = { ...key };
-  init !== null && (value = {
-    type: 'AssignmentPattern',
-    left: value,
-    right: init,
-    start,
-    end,
-    range: [start, end],
-  });
+  init !== null &&
+    (value = {
+      type: 'AssignmentPattern',
+      left: value,
+      right: init,
+      start,
+      end,
+      range: [start, end],
+    });
   node.kind = 'init';
   node.key = key;
   node.value = value;
@@ -1084,7 +1087,8 @@ function deserializeSequenceExpression(pos) {
 }
 
 function deserializeSuper(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Super',
     start,
@@ -1145,8 +1149,8 @@ function deserializeParenthesizedExpression(pos) {
     node = {
       type: 'ParenthesizedExpression',
       expression: null,
-      start: start = deserializeU32(pos),
-      end: end = deserializeU32(pos + 4),
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
     node.expression = deserializeExpression(pos + 8);
@@ -1241,7 +1245,8 @@ function deserializeDirective(pos) {
 }
 
 function deserializeHashbang(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Hashbang',
     value: deserializeStr(pos + 8),
@@ -1337,7 +1342,8 @@ function deserializeVariableDeclarator(pos) {
 }
 
 function deserializeEmptyStatement(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'EmptyStatement',
     start,
@@ -1750,7 +1756,8 @@ function deserializeCatchParameter(pos) {
 }
 
 function deserializeDebuggerStatement(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'DebuggerStatement',
     start,
@@ -1904,15 +1911,15 @@ function deserializeFunctionType(pos) {
 
 function deserializeFormalParameters(pos) {
   let params = deserializeVecFormalParameter(pos + 8);
-  if (uint32[pos + 32 >> 2] !== 0 && uint32[pos + 36 >> 2] !== 0) {
-    pos = uint32[pos + 32 >> 2];
+  if (uint32[(pos + 32) >> 2] !== 0 && uint32[(pos + 36) >> 2] !== 0) {
+    pos = uint32[(pos + 32) >> 2];
     let start,
       end,
       rest = {
         type: 'RestElement',
         argument: null,
-        start: start = deserializeU32(pos),
-        end: end = deserializeU32(pos + 4),
+        start: (start = deserializeU32(pos)),
+        end: (end = deserializeU32(pos + 4)),
         range: [start, end],
       };
     rest.argument = deserializeBindingPatternKind(pos + 8);
@@ -2124,7 +2131,8 @@ function deserializeMethodDefinitionKind(pos) {
 }
 
 function deserializePrivateIdentifier(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'PrivateIdentifier',
     name: deserializeStr(pos + 8),
@@ -2548,7 +2556,8 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Literal',
     value: deserializeF64(pos + 8),
@@ -2625,7 +2634,8 @@ function deserializeRegExp(pos) {
 }
 
 function deserializeRegExpFlags(pos) {
-  let flagBits = deserializeU8(pos), flags = '';
+  let flagBits = deserializeU8(pos),
+    flags = '';
   // Alphabetical order
   flagBits & 64 && (flags += 'd');
   flagBits & 1 && (flags += 'g');
@@ -2726,7 +2736,8 @@ function deserializeJSXOpeningFragment(pos) {
 }
 
 function deserializeJSXClosingFragment(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXClosingFragment',
     start,
@@ -2935,7 +2946,8 @@ function deserializeJSXExpression(pos) {
 }
 
 function deserializeJSXEmptyExpression(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXEmptyExpression',
     start,
@@ -3012,7 +3024,8 @@ function deserializeJSXAttributeValue(pos) {
 }
 
 function deserializeJSXIdentifier(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXIdentifier',
     name: deserializeStr(pos + 8),
@@ -3054,7 +3067,8 @@ function deserializeJSXSpreadChild(pos) {
 }
 
 function deserializeJSXText(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXText',
     value: deserializeStr(pos + 8),
@@ -3333,8 +3347,8 @@ function deserializeTSParenthesizedType(pos) {
     node = {
       type: 'TSParenthesizedType',
       typeAnnotation: null,
-      start: start = deserializeU32(pos),
-      end: end = deserializeU32(pos + 4),
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
     node.typeAnnotation = deserializeTSType(pos + 8);
@@ -3545,7 +3559,8 @@ function deserializeTSTupleElement(pos) {
 }
 
 function deserializeTSAnyKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSAnyKeyword',
     start,
@@ -3555,7 +3570,8 @@ function deserializeTSAnyKeyword(pos) {
 }
 
 function deserializeTSStringKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSStringKeyword',
     start,
@@ -3565,7 +3581,8 @@ function deserializeTSStringKeyword(pos) {
 }
 
 function deserializeTSBooleanKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSBooleanKeyword',
     start,
@@ -3575,7 +3592,8 @@ function deserializeTSBooleanKeyword(pos) {
 }
 
 function deserializeTSNumberKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSNumberKeyword',
     start,
@@ -3585,7 +3603,8 @@ function deserializeTSNumberKeyword(pos) {
 }
 
 function deserializeTSNeverKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSNeverKeyword',
     start,
@@ -3595,7 +3614,8 @@ function deserializeTSNeverKeyword(pos) {
 }
 
 function deserializeTSIntrinsicKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSIntrinsicKeyword',
     start,
@@ -3605,7 +3625,8 @@ function deserializeTSIntrinsicKeyword(pos) {
 }
 
 function deserializeTSUnknownKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSUnknownKeyword',
     start,
@@ -3615,7 +3636,8 @@ function deserializeTSUnknownKeyword(pos) {
 }
 
 function deserializeTSNullKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSNullKeyword',
     start,
@@ -3625,7 +3647,8 @@ function deserializeTSNullKeyword(pos) {
 }
 
 function deserializeTSUndefinedKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSUndefinedKeyword',
     start,
@@ -3635,7 +3658,8 @@ function deserializeTSUndefinedKeyword(pos) {
 }
 
 function deserializeTSVoidKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSVoidKeyword',
     start,
@@ -3645,7 +3669,8 @@ function deserializeTSVoidKeyword(pos) {
 }
 
 function deserializeTSSymbolKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSSymbolKeyword',
     start,
@@ -3655,7 +3680,8 @@ function deserializeTSSymbolKeyword(pos) {
 }
 
 function deserializeTSThisType(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSThisType',
     start,
@@ -3665,7 +3691,8 @@ function deserializeTSThisType(pos) {
 }
 
 function deserializeTSObjectKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSObjectKeyword',
     start,
@@ -3675,7 +3702,8 @@ function deserializeTSObjectKeyword(pos) {
 }
 
 function deserializeTSBigIntKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSBigIntKeyword',
     start,
@@ -4081,8 +4109,8 @@ function deserializeTSModuleDeclaration(pos) {
           type: 'TSQualifiedName',
           left: id,
           right: innerId,
-          start: start = id.start,
-          end: end = innerId.end,
+          start: (start = id.start),
+          end: (end = innerId.end),
           range: [start, end],
         };
       } else {
@@ -4095,13 +4123,14 @@ function deserializeTSModuleDeclaration(pos) {
           if (innerId.left.type === 'Identifier') break;
           innerId = innerId.left;
         }
-        let end, right = innerId.left;
+        let end,
+          right = innerId.left;
         innerId.left = {
           type: 'TSQualifiedName',
           left: id,
           right,
           start,
-          end: end = right.end,
+          end: (end = right.end),
           range: [start, end],
         };
       }
@@ -4576,7 +4605,8 @@ function deserializeJSDocNonNullableType(pos) {
 }
 
 function deserializeJSDocUnknownType(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSJSDocUnknownType',
     start,
@@ -4597,7 +4627,9 @@ function deserializeCommentKind(pos) {
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12), start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let type = deserializeCommentKind(pos + 12),
+    start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type,
     value: sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2)),
@@ -4608,7 +4640,8 @@ function deserializeComment(pos) {
 }
 
 function deserializeNameSpan(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     value: deserializeStr(pos + 8),
     start,
@@ -4659,7 +4692,8 @@ function deserializeImportImportName(pos) {
 }
 
 function deserializeExportEntry(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
@@ -4779,7 +4813,8 @@ function deserializeExportLocalName(pos) {
 }
 
 function deserializeDynamicImport(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeSpan(pos + 8),
     start,
@@ -4974,7 +5009,8 @@ function deserializeErrorSeverity(pos) {
 }
 
 function deserializeErrorLabel(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     message: deserializeOptionStr(pos + 8),
     start,
@@ -4994,7 +5030,8 @@ function deserializeEcmaScriptModule(pos) {
 }
 
 function deserializeStaticImport(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeNameSpan(pos + 8),
     entries: deserializeVecImportEntry(pos + 32),
@@ -5005,7 +5042,8 @@ function deserializeStaticImport(pos) {
 }
 
 function deserializeStaticExport(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     entries: deserializeVecExportEntry(pos + 8),
     start,
@@ -5023,7 +5061,8 @@ function deserializeU8(pos) {
 }
 
 function deserializeStr(pos) {
-  let pos32 = pos >> 2, len = uint32[pos32 + 2];
+  let pos32 = pos >> 2,
+    len = uint32[pos32 + 2];
   if (len === 0) return '';
   pos = uint32[pos32];
   if (sourceIsAscii && pos < sourceByteLen) return sourceText.substr(pos, len);
@@ -5032,7 +5071,8 @@ function deserializeStr(pos) {
   let end = pos + len;
   if (len > 50) return decodeStr(uint8.subarray(pos, end));
   // Shorter strings decode by hand to avoid native call
-  let out = '', c;
+  let out = '',
+    c;
   do {
     c = uint8[pos++];
     if (c < 128) out += fromCodePoint(c);
@@ -5045,10 +5085,11 @@ function deserializeStr(pos) {
 }
 
 function deserializeVecComment(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeComment(pos));
     pos += 16;
   }
@@ -5056,15 +5097,16 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeHashbang(pos);
 }
 
 function deserializeVecDirective(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 72;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDirective(pos));
     pos += 72;
   }
@@ -5072,10 +5114,11 @@ function deserializeVecDirective(pos) {
 }
 
 function deserializeVecStatement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStatement(pos));
     pos += 16;
   }
@@ -5243,10 +5286,11 @@ function deserializeBoxV8IntrinsicExpression(pos) {
 }
 
 function deserializeVecArrayExpressionElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeArrayExpressionElement(pos));
     pos += 16;
   }
@@ -5258,10 +5302,11 @@ function deserializeBoxSpreadElement(pos) {
 }
 
 function deserializeVecObjectPropertyKind(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeObjectPropertyKind(pos));
     pos += 16;
   }
@@ -5285,10 +5330,11 @@ function deserializeBoxPrivateIdentifier(pos) {
 }
 
 function deserializeVecTemplateElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 48;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTemplateElement(pos));
     pos += 48;
   }
@@ -5296,10 +5342,11 @@ function deserializeVecTemplateElement(pos) {
 }
 
 function deserializeVecExpression(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExpression(pos));
     pos += 16;
   }
@@ -5311,12 +5358,12 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeStr(pos);
 }
 
@@ -5333,10 +5380,11 @@ function deserializeBoxPrivateFieldExpression(pos) {
 }
 
 function deserializeVecArgument(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeArgument(pos));
     pos += 16;
   }
@@ -5357,10 +5405,11 @@ function deserializeOptionAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeOptionAssignmentTargetMaybeDefault(pos));
     pos += 16;
   }
@@ -5372,15 +5421,16 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxAssignmentTargetRest(pos);
 }
 
 function deserializeVecAssignmentTargetProperty(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeAssignmentTargetProperty(pos));
     pos += 16;
   }
@@ -5501,10 +5551,11 @@ function deserializeBoxTSImportEqualsDeclaration(pos) {
 }
 
 function deserializeVecVariableDeclarator(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 64;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeVariableDeclarator(pos));
     pos += 64;
   }
@@ -5522,15 +5573,16 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeLabelIdentifier(pos);
 }
 
 function deserializeVecSwitchCase(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 48;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeSwitchCase(pos));
     pos += 48;
   }
@@ -5542,12 +5594,12 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxBlockStatement(pos);
 }
 
@@ -5561,7 +5613,7 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeAnnotation(pos);
 }
 
@@ -5582,10 +5634,11 @@ function deserializeBoxAssignmentPattern(pos) {
 }
 
 function deserializeVecBindingProperty(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 64;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeBindingProperty(pos));
     pos += 64;
   }
@@ -5597,7 +5650,7 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxBindingRestElement(pos);
 }
 
@@ -5607,10 +5660,11 @@ function deserializeOptionBindingPattern(pos) {
 }
 
 function deserializeVecOptionBindingPattern(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeOptionBindingPattern(pos));
     pos += 32;
   }
@@ -5618,7 +5672,7 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeBindingIdentifier(pos);
 }
 
@@ -5627,7 +5681,7 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
@@ -5636,7 +5690,7 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSThisParameter(pos);
 }
 
@@ -5649,15 +5703,16 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxFunctionBody(pos);
 }
 
 function deserializeVecFormalParameter(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 72;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeFormalParameter(pos));
     pos += 72;
   }
@@ -5665,10 +5720,11 @@ function deserializeVecFormalParameter(pos) {
 }
 
 function deserializeVecDecorator(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 24;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDecorator(pos));
     pos += 24;
   }
@@ -5680,10 +5736,11 @@ function deserializeBoxClassBody(pos) {
 }
 
 function deserializeVecClassElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeClassElement(pos));
     pos += 16;
   }
@@ -5740,10 +5797,11 @@ function deserializeOptionImportPhase(pos) {
 }
 
 function deserializeVecImportDeclarationSpecifier(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportDeclarationSpecifier(pos));
     pos += 16;
   }
@@ -5751,7 +5809,7 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeVecImportDeclarationSpecifier(pos);
 }
 
@@ -5760,7 +5818,7 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxWithClause(pos);
 }
 
@@ -5777,10 +5835,11 @@ function deserializeBoxImportNamespaceSpecifier(pos) {
 }
 
 function deserializeVecImportAttribute(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 112;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportAttribute(pos));
     pos += 112;
   }
@@ -5793,10 +5852,11 @@ function deserializeOptionDeclaration(pos) {
 }
 
 function deserializeVecExportSpecifier(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 128;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExportSpecifier(pos));
     pos += 128;
   }
@@ -5822,10 +5882,11 @@ function deserializeBoxJSXOpeningElement(pos) {
 }
 
 function deserializeVecJSXChild(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeJSXChild(pos));
     pos += 16;
   }
@@ -5837,15 +5898,16 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxJSXClosingElement(pos);
 }
 
 function deserializeVecJSXAttributeItem(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeJSXAttributeItem(pos));
     pos += 16;
   }
@@ -5890,10 +5952,11 @@ function deserializeBoxJSXSpreadChild(pos) {
 }
 
 function deserializeVecTSEnumMember(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 40;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSEnumMember(pos));
     pos += 40;
   }
@@ -6049,10 +6112,11 @@ function deserializeBoxJSDocUnknownType(pos) {
 }
 
 function deserializeVecTSType(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSType(pos));
     pos += 16;
   }
@@ -6060,10 +6124,11 @@ function deserializeVecTSType(pos) {
 }
 
 function deserializeVecTSTupleElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSTupleElement(pos));
     pos += 16;
   }
@@ -6088,10 +6153,11 @@ function deserializeOptionTSType(pos) {
 }
 
 function deserializeVecTSTypeParameter(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 80;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSTypeParameter(pos));
     pos += 80;
   }
@@ -6099,10 +6165,11 @@ function deserializeVecTSTypeParameter(pos) {
 }
 
 function deserializeVecTSInterfaceHeritage(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSInterfaceHeritage(pos));
     pos += 32;
   }
@@ -6114,10 +6181,11 @@ function deserializeBoxTSInterfaceBody(pos) {
 }
 
 function deserializeVecTSSignature(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSSignature(pos));
     pos += 16;
   }
@@ -6141,10 +6209,11 @@ function deserializeBoxTSMethodSignature(pos) {
 }
 
 function deserializeVecTSIndexSignatureName(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
     pos += 32;
   }
@@ -6165,7 +6234,7 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxObjectExpression(pos);
 }
 
@@ -6188,15 +6257,16 @@ function deserializeBoxTSExternalModuleReference(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeNameSpan(pos);
 }
 
 function deserializeVecError(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 80;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeError(pos));
     pos += 80;
   }
@@ -6204,10 +6274,11 @@ function deserializeVecError(pos) {
 }
 
 function deserializeVecErrorLabel(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 24;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeErrorLabel(pos));
     pos += 24;
   }
@@ -6215,10 +6286,11 @@ function deserializeVecErrorLabel(pos) {
 }
 
 function deserializeVecStaticImport(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 56;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStaticImport(pos));
     pos += 56;
   }
@@ -6226,10 +6298,11 @@ function deserializeVecStaticImport(pos) {
 }
 
 function deserializeVecStaticExport(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStaticExport(pos));
     pos += 32;
   }
@@ -6237,10 +6310,11 @@ function deserializeVecStaticExport(pos) {
 }
 
 function deserializeVecDynamicImport(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDynamicImport(pos));
     pos += 16;
   }
@@ -6248,10 +6322,11 @@ function deserializeVecDynamicImport(pos) {
 }
 
 function deserializeVecSpan(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 8;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeSpan(pos));
     pos += 8;
   }
@@ -6259,10 +6334,11 @@ function deserializeVecSpan(pos) {
 }
 
 function deserializeVecImportEntry(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 96;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportEntry(pos));
     pos += 96;
   }
@@ -6270,10 +6346,11 @@ function deserializeVecImportEntry(pos) {
 }
 
 function deserializeVecExportEntry(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 144;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExportEntry(pos));
     pos += 144;
   }

--- a/napi/parser/generated/deserialize/js_range_parent.js
+++ b/napi/parser/generated/deserialize/js_range_parent.js
@@ -1,7 +1,13 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
-let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen, parent = null;
+let uint8,
+  uint32,
+  float64,
+  sourceText,
+  sourceIsAscii,
+  sourceByteLen,
+  parent = null;
 
 const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
@@ -25,17 +31,13 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInpu
 
 export function resetBuffer() {
   // Clear buffer and source text string to allow them to be garbage collected
-  uint8 =
-    uint32 =
-    float64 =
-    sourceText =
-      void 0;
+  uint8 = uint32 = float64 = sourceText = void 0;
 }
 
 function deserializeProgram(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
-    program = parent = {
+    program = (parent = {
       type: 'Program',
       body: null,
       sourceType: deserializeModuleKind(pos + 125),
@@ -44,7 +46,7 @@ function deserializeProgram(pos) {
       end,
       range: [start, end],
       parent: null,
-    };
+    });
   program.hashbang = deserializeOptionHashbang(pos + 48);
   (program.body = deserializeVecDirective(pos + 72)).push(...deserializeVecStatement(pos + 96));
   parent = null;
@@ -148,14 +150,14 @@ function deserializeIdentifierName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Identifier',
       name: deserializeStr(pos + 8),
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   parent = previousParent;
   return node;
 }
@@ -164,14 +166,14 @@ function deserializeIdentifierReference(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Identifier',
       name: deserializeStr(pos + 8),
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   parent = previousParent;
   return node;
 }
@@ -180,14 +182,14 @@ function deserializeBindingIdentifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Identifier',
       name: deserializeStr(pos + 8),
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   parent = previousParent;
   return node;
 }
@@ -196,20 +198,21 @@ function deserializeLabelIdentifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Identifier',
       name: deserializeStr(pos + 8),
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   parent = previousParent;
   return node;
 }
 
 function deserializeThisExpression(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'ThisExpression',
     start,
@@ -223,14 +226,14 @@ function deserializeArrayExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ArrayExpression',
       elements: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.elements = deserializeVecArrayExpressionElement(pos + 8);
   parent = previousParent;
   return node;
@@ -341,14 +344,14 @@ function deserializeObjectExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ObjectExpression',
       properties: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.properties = deserializeVecObjectPropertyKind(pos + 8);
   parent = previousParent;
   return node;
@@ -369,7 +372,7 @@ function deserializeObjectProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Property',
       kind: deserializePropertyKind(pos + 40),
       key: null,
@@ -381,7 +384,7 @@ function deserializeObjectProperty(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.key = deserializePropertyKey(pos + 8);
   node.value = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -502,7 +505,7 @@ function deserializeTemplateLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TemplateLiteral',
       quasis: null,
       expressions: null,
@@ -510,7 +513,7 @@ function deserializeTemplateLiteral(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.quasis = deserializeVecTemplateElement(pos + 8);
   node.expressions = deserializeVecExpression(pos + 32);
   parent = previousParent;
@@ -521,7 +524,7 @@ function deserializeTaggedTemplateExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TaggedTemplateExpression',
       tag: null,
       quasi: null,
@@ -529,7 +532,7 @@ function deserializeTaggedTemplateExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.tag = deserializeExpression(pos + 8);
   node.quasi = deserializeTemplateLiteral(pos + 32);
   parent = previousParent;
@@ -541,7 +544,8 @@ function deserializeTemplateElement(pos) {
     start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     value = deserializeTemplateElementValue(pos + 8);
-  value.cooked !== null && deserializeBool(pos + 41) &&
+  value.cooked !== null &&
+    deserializeBool(pos + 41) &&
     (value.cooked = value.cooked.replace(/\uFFFD(.{4})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16))));
   return {
     type: 'TemplateElement',
@@ -565,7 +569,7 @@ function deserializeComputedMemberExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'MemberExpression',
       object: null,
       property: null,
@@ -575,7 +579,7 @@ function deserializeComputedMemberExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.object = deserializeExpression(pos + 8);
   node.property = deserializeExpression(pos + 24);
   node.computed = true;
@@ -587,7 +591,7 @@ function deserializeStaticMemberExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'MemberExpression',
       object: null,
       property: null,
@@ -597,7 +601,7 @@ function deserializeStaticMemberExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.object = deserializeExpression(pos + 8);
   node.property = deserializeIdentifierName(pos + 24);
   node.computed = false;
@@ -609,7 +613,7 @@ function deserializePrivateFieldExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'MemberExpression',
       object: null,
       property: null,
@@ -619,7 +623,7 @@ function deserializePrivateFieldExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.object = deserializeExpression(pos + 8);
   node.property = deserializePrivateIdentifier(pos + 24);
   node.computed = false;
@@ -631,7 +635,7 @@ function deserializeCallExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'CallExpression',
       callee: null,
       arguments: null,
@@ -640,7 +644,7 @@ function deserializeCallExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.callee = deserializeExpression(pos + 8);
   node.arguments = deserializeVecArgument(pos + 32);
   parent = previousParent;
@@ -651,7 +655,7 @@ function deserializeNewExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'NewExpression',
       callee: null,
       arguments: null,
@@ -659,7 +663,7 @@ function deserializeNewExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.callee = deserializeExpression(pos + 8);
   node.arguments = deserializeVecArgument(pos + 32);
   parent = previousParent;
@@ -670,7 +674,7 @@ function deserializeMetaProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'MetaProperty',
       meta: null,
       property: null,
@@ -678,7 +682,7 @@ function deserializeMetaProperty(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.meta = deserializeIdentifierName(pos + 8);
   node.property = deserializeIdentifierName(pos + 32);
   parent = previousParent;
@@ -689,14 +693,14 @@ function deserializeSpreadElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'SpreadElement',
       argument: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -801,7 +805,7 @@ function deserializeUpdateExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'UpdateExpression',
       operator: deserializeUpdateOperator(pos + 24),
       prefix: deserializeBool(pos + 25),
@@ -810,7 +814,7 @@ function deserializeUpdateExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeSimpleAssignmentTarget(pos + 8);
   parent = previousParent;
   return node;
@@ -820,7 +824,7 @@ function deserializeUnaryExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'UnaryExpression',
       operator: deserializeUnaryOperator(pos + 24),
       argument: null,
@@ -829,7 +833,7 @@ function deserializeUnaryExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   node.prefix = true;
   parent = previousParent;
@@ -840,7 +844,7 @@ function deserializeBinaryExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'BinaryExpression',
       left: null,
       operator: deserializeBinaryOperator(pos + 40),
@@ -849,7 +853,7 @@ function deserializeBinaryExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializeExpression(pos + 8);
   node.right = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -860,7 +864,7 @@ function deserializePrivateInExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'BinaryExpression',
       left: null,
       operator: null,
@@ -869,7 +873,7 @@ function deserializePrivateInExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializePrivateIdentifier(pos + 8);
   node.operator = 'in';
   node.right = deserializeExpression(pos + 32);
@@ -881,7 +885,7 @@ function deserializeLogicalExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'LogicalExpression',
       left: null,
       operator: deserializeLogicalOperator(pos + 40),
@@ -890,7 +894,7 @@ function deserializeLogicalExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializeExpression(pos + 8);
   node.right = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -901,7 +905,7 @@ function deserializeConditionalExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ConditionalExpression',
       test: null,
       consequent: null,
@@ -910,7 +914,7 @@ function deserializeConditionalExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.test = deserializeExpression(pos + 8);
   node.consequent = deserializeExpression(pos + 24);
   node.alternate = deserializeExpression(pos + 40);
@@ -922,7 +926,7 @@ function deserializeAssignmentExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'AssignmentExpression',
       operator: deserializeAssignmentOperator(pos + 40),
       left: null,
@@ -931,7 +935,7 @@ function deserializeAssignmentExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializeAssignmentTarget(pos + 8);
   node.right = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -992,14 +996,14 @@ function deserializeArrayAssignmentTarget(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ArrayPattern',
       elements: null,
       start,
       end,
       range: [start, end],
       parent,
-    },
+    }),
     elements = deserializeVecOptionAssignmentTargetMaybeDefault(pos + 8),
     rest = deserializeOptionBoxAssignmentTargetRest(pos + 32);
   rest !== null && elements.push(rest);
@@ -1012,14 +1016,14 @@ function deserializeObjectAssignmentTarget(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ObjectPattern',
       properties: null,
       start,
       end,
       range: [start, end],
       parent,
-    },
+    }),
     properties = deserializeVecAssignmentTargetProperty(pos + 8),
     rest = deserializeOptionBoxAssignmentTargetRest(pos + 32);
   rest !== null && properties.push(rest);
@@ -1032,14 +1036,14 @@ function deserializeAssignmentTargetRest(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'RestElement',
       argument: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeAssignmentTarget(pos + 8);
   parent = previousParent;
   return node;
@@ -1078,7 +1082,7 @@ function deserializeAssignmentTargetWithDefault(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'AssignmentPattern',
       left: null,
       right: null,
@@ -1086,7 +1090,7 @@ function deserializeAssignmentTargetWithDefault(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializeAssignmentTarget(pos + 8);
   node.right = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -1108,7 +1112,7 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Property',
       kind: null,
       key: null,
@@ -1120,12 +1124,13 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     key = deserializeIdentifierReference(pos + 8),
     init = deserializeOptionExpression(pos + 40),
     value = { ...key };
   if (init !== null) {
-    let left = value, previousParent = parent;
+    let left = value,
+      previousParent = parent;
     value = parent = {
       type: 'AssignmentPattern',
       left,
@@ -1153,7 +1158,7 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Property',
       kind: null,
       key: null,
@@ -1165,7 +1170,7 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.kind = 'init';
   node.key = deserializePropertyKey(pos + 8);
   node.value = deserializeAssignmentTargetMaybeDefault(pos + 24);
@@ -1179,21 +1184,22 @@ function deserializeSequenceExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'SequenceExpression',
       expressions: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expressions = deserializeVecExpression(pos + 8);
   parent = previousParent;
   return node;
 }
 
 function deserializeSuper(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Super',
     start,
@@ -1207,14 +1213,14 @@ function deserializeAwaitExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'AwaitExpression',
       argument: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -1224,14 +1230,14 @@ function deserializeChainExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ChainExpression',
       expression: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeChainElement(pos + 8);
   parent = previousParent;
   return node;
@@ -1257,12 +1263,14 @@ function deserializeChainElement(pos) {
 function deserializeParenthesizedExpression(pos) {
   let node;
   {
-    let start, end, previousParent = parent;
+    let start,
+      end,
+      previousParent = parent;
     node = parent = {
       type: 'ParenthesizedExpression',
       expression: null,
-      start: start = deserializeU32(pos),
-      end: end = deserializeU32(pos + 4),
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     };
@@ -1347,7 +1355,7 @@ function deserializeDirective(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ExpressionStatement',
       expression: null,
       directive: deserializeStr(pos + 56),
@@ -1355,14 +1363,15 @@ function deserializeDirective(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeStringLiteral(pos + 8);
   parent = previousParent;
   return node;
 }
 
 function deserializeHashbang(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Hashbang',
     value: deserializeStr(pos + 8),
@@ -1377,14 +1386,14 @@ function deserializeBlockStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'BlockStatement',
       body: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.body = deserializeVecStatement(pos + 8);
   parent = previousParent;
   return node;
@@ -1417,7 +1426,7 @@ function deserializeVariableDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'VariableDeclaration',
       kind: deserializeVariableDeclarationKind(pos + 32),
       declarations: null,
@@ -1425,7 +1434,7 @@ function deserializeVariableDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.declarations = deserializeVecVariableDeclarator(pos + 8);
   parent = previousParent;
   return node;
@@ -1452,7 +1461,7 @@ function deserializeVariableDeclarator(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'VariableDeclarator',
       id: null,
       init: null,
@@ -1460,7 +1469,7 @@ function deserializeVariableDeclarator(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.id = deserializeBindingPattern(pos + 8);
   node.init = deserializeOptionExpression(pos + 40);
   parent = previousParent;
@@ -1468,7 +1477,8 @@ function deserializeVariableDeclarator(pos) {
 }
 
 function deserializeEmptyStatement(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'EmptyStatement',
     start,
@@ -1482,14 +1492,14 @@ function deserializeExpressionStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ExpressionStatement',
       expression: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -1499,7 +1509,7 @@ function deserializeIfStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'IfStatement',
       test: null,
       consequent: null,
@@ -1508,7 +1518,7 @@ function deserializeIfStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.test = deserializeExpression(pos + 8);
   node.consequent = deserializeStatement(pos + 24);
   node.alternate = deserializeOptionStatement(pos + 40);
@@ -1520,7 +1530,7 @@ function deserializeDoWhileStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'DoWhileStatement',
       body: null,
       test: null,
@@ -1528,7 +1538,7 @@ function deserializeDoWhileStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.body = deserializeStatement(pos + 8);
   node.test = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -1539,7 +1549,7 @@ function deserializeWhileStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'WhileStatement',
       test: null,
       body: null,
@@ -1547,7 +1557,7 @@ function deserializeWhileStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.test = deserializeExpression(pos + 8);
   node.body = deserializeStatement(pos + 24);
   parent = previousParent;
@@ -1558,7 +1568,7 @@ function deserializeForStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ForStatement',
       init: null,
       test: null,
@@ -1568,7 +1578,7 @@ function deserializeForStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.init = deserializeOptionForStatementInit(pos + 8);
   node.test = deserializeOptionExpression(pos + 24);
   node.update = deserializeOptionExpression(pos + 40);
@@ -1676,7 +1686,7 @@ function deserializeForInStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ForInStatement',
       left: null,
       right: null,
@@ -1685,7 +1695,7 @@ function deserializeForInStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializeForStatementLeft(pos + 8);
   node.right = deserializeExpression(pos + 24);
   node.body = deserializeStatement(pos + 40);
@@ -1726,7 +1736,7 @@ function deserializeForOfStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ForOfStatement',
       await: deserializeBool(pos + 60),
       left: null,
@@ -1736,7 +1746,7 @@ function deserializeForOfStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializeForStatementLeft(pos + 8);
   node.right = deserializeExpression(pos + 24);
   node.body = deserializeStatement(pos + 40);
@@ -1748,14 +1758,14 @@ function deserializeContinueStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ContinueStatement',
       label: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.label = deserializeOptionLabelIdentifier(pos + 8);
   parent = previousParent;
   return node;
@@ -1765,14 +1775,14 @@ function deserializeBreakStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'BreakStatement',
       label: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.label = deserializeOptionLabelIdentifier(pos + 8);
   parent = previousParent;
   return node;
@@ -1782,14 +1792,14 @@ function deserializeReturnStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ReturnStatement',
       argument: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeOptionExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -1799,7 +1809,7 @@ function deserializeWithStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'WithStatement',
       object: null,
       body: null,
@@ -1807,7 +1817,7 @@ function deserializeWithStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.object = deserializeExpression(pos + 8);
   node.body = deserializeStatement(pos + 24);
   parent = previousParent;
@@ -1818,7 +1828,7 @@ function deserializeSwitchStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'SwitchStatement',
       discriminant: null,
       cases: null,
@@ -1826,7 +1836,7 @@ function deserializeSwitchStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.discriminant = deserializeExpression(pos + 8);
   node.cases = deserializeVecSwitchCase(pos + 24);
   parent = previousParent;
@@ -1837,7 +1847,7 @@ function deserializeSwitchCase(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'SwitchCase',
       test: null,
       consequent: null,
@@ -1845,7 +1855,7 @@ function deserializeSwitchCase(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.test = deserializeOptionExpression(pos + 8);
   node.consequent = deserializeVecStatement(pos + 24);
   parent = previousParent;
@@ -1856,7 +1866,7 @@ function deserializeLabeledStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'LabeledStatement',
       label: null,
       body: null,
@@ -1864,7 +1874,7 @@ function deserializeLabeledStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.label = deserializeLabelIdentifier(pos + 8);
   node.body = deserializeStatement(pos + 32);
   parent = previousParent;
@@ -1875,14 +1885,14 @@ function deserializeThrowStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ThrowStatement',
       argument: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -1892,7 +1902,7 @@ function deserializeTryStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TryStatement',
       block: null,
       handler: null,
@@ -1901,7 +1911,7 @@ function deserializeTryStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.block = deserializeBoxBlockStatement(pos + 8);
   node.handler = deserializeOptionBoxCatchClause(pos + 16);
   node.finalizer = deserializeOptionBoxBlockStatement(pos + 24);
@@ -1913,7 +1923,7 @@ function deserializeCatchClause(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'CatchClause',
       param: null,
       body: null,
@@ -1921,7 +1931,7 @@ function deserializeCatchClause(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.param = deserializeOptionCatchParameter(pos + 8);
   node.body = deserializeBoxBlockStatement(pos + 48);
   parent = previousParent;
@@ -1933,7 +1943,8 @@ function deserializeCatchParameter(pos) {
 }
 
 function deserializeDebuggerStatement(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'DebuggerStatement',
     start,
@@ -1966,7 +1977,7 @@ function deserializeAssignmentPattern(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'AssignmentPattern',
       left: null,
       right: null,
@@ -1974,7 +1985,7 @@ function deserializeAssignmentPattern(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializeBindingPattern(pos + 8);
   node.right = deserializeExpression(pos + 40);
   parent = previousParent;
@@ -1985,14 +1996,14 @@ function deserializeObjectPattern(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ObjectPattern',
       properties: null,
       start,
       end,
       range: [start, end],
       parent,
-    },
+    }),
     properties = deserializeVecBindingProperty(pos + 8),
     rest = deserializeOptionBoxBindingRestElement(pos + 32);
   rest !== null && properties.push(rest);
@@ -2005,7 +2016,7 @@ function deserializeBindingProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Property',
       kind: null,
       key: null,
@@ -2017,7 +2028,7 @@ function deserializeBindingProperty(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.kind = 'init';
   node.key = deserializePropertyKey(pos + 8);
   node.value = deserializeBindingPattern(pos + 24);
@@ -2030,14 +2041,14 @@ function deserializeArrayPattern(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ArrayPattern',
       elements: null,
       start,
       end,
       range: [start, end],
       parent,
-    },
+    }),
     elements = deserializeVecOptionBindingPattern(pos + 8),
     rest = deserializeOptionBoxBindingRestElement(pos + 32);
   rest !== null && elements.push(rest);
@@ -2050,14 +2061,14 @@ function deserializeBindingRestElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'RestElement',
       argument: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeBindingPattern(pos + 8);
   parent = previousParent;
   return node;
@@ -2067,7 +2078,7 @@ function deserializeFunction(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: deserializeFunctionType(pos + 84),
       id: null,
       generator: deserializeBool(pos + 85),
@@ -2079,7 +2090,7 @@ function deserializeFunction(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     params = deserializeBoxFormalParameters(pos + 56);
   node.id = deserializeOptionBindingIdentifier(pos + 8);
   node.params = params;
@@ -2106,19 +2117,19 @@ function deserializeFunctionType(pos) {
 
 function deserializeFormalParameters(pos) {
   let params = deserializeVecFormalParameter(pos + 8);
-  if (uint32[pos + 32 >> 2] !== 0 && uint32[pos + 36 >> 2] !== 0) {
-    pos = uint32[pos + 32 >> 2];
+  if (uint32[(pos + 32) >> 2] !== 0 && uint32[(pos + 36) >> 2] !== 0) {
+    pos = uint32[(pos + 32) >> 2];
     let start,
       end,
       previousParent = parent,
-      rest = parent = {
+      rest = (parent = {
         type: 'RestElement',
         argument: null,
-        start: start = deserializeU32(pos),
-        end: end = deserializeU32(pos + 4),
+        start: (start = deserializeU32(pos)),
+        end: (end = deserializeU32(pos + 4)),
         range: [start, end],
         parent,
-      };
+      });
     rest.argument = deserializeBindingPatternKind(pos + 8);
     params.push(rest);
     parent = previousParent;
@@ -2136,14 +2147,14 @@ function deserializeFunctionBody(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'BlockStatement',
       body: null,
       start,
       end,
       range: [start, end],
       parent,
-    },
+    }),
     body = deserializeVecDirective(pos + 8);
   body.push(...deserializeVecStatement(pos + 32));
   node.body = body;
@@ -2156,7 +2167,7 @@ function deserializeArrowFunctionExpression(pos) {
     start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ArrowFunctionExpression',
       expression,
       async: deserializeBool(pos + 45),
@@ -2168,7 +2179,7 @@ function deserializeArrowFunctionExpression(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     body = deserializeBoxFunctionBody(pos + 32);
   if (expression === true) {
     body = body.body[0].expression;
@@ -2186,7 +2197,7 @@ function deserializeYieldExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'YieldExpression',
       delegate: deserializeBool(pos + 24),
       argument: null,
@@ -2194,7 +2205,7 @@ function deserializeYieldExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeOptionExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -2204,7 +2215,7 @@ function deserializeClass(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: deserializeClassType(pos + 132),
       decorators: null,
       id: null,
@@ -2214,7 +2225,7 @@ function deserializeClass(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = deserializeVecDecorator(pos + 8);
   node.id = deserializeOptionBindingIdentifier(pos + 32);
   node.superClass = deserializeOptionExpression(pos + 72);
@@ -2238,14 +2249,14 @@ function deserializeClassBody(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ClassBody',
       body: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.body = deserializeVecClassElement(pos + 8);
   parent = previousParent;
   return node;
@@ -2272,7 +2283,7 @@ function deserializeMethodDefinition(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: deserializeMethodDefinitionType(pos + 56),
       decorators: null,
       key: null,
@@ -2284,7 +2295,7 @@ function deserializeMethodDefinition(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = deserializeVecDecorator(pos + 8);
   node.key = deserializePropertyKey(pos + 32);
   node.value = deserializeBoxFunction(pos + 48);
@@ -2307,7 +2318,7 @@ function deserializePropertyDefinition(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: deserializePropertyDefinitionType(pos + 72),
       decorators: null,
       key: null,
@@ -2318,7 +2329,7 @@ function deserializePropertyDefinition(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = deserializeVecDecorator(pos + 8);
   node.key = deserializePropertyKey(pos + 32);
   node.value = deserializeOptionExpression(pos + 56);
@@ -2353,7 +2364,8 @@ function deserializeMethodDefinitionKind(pos) {
 }
 
 function deserializePrivateIdentifier(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'PrivateIdentifier',
     name: deserializeStr(pos + 8),
@@ -2368,14 +2380,14 @@ function deserializeStaticBlock(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'StaticBlock',
       body: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.body = deserializeVecStatement(pos + 8);
   parent = previousParent;
   return node;
@@ -2396,7 +2408,7 @@ function deserializeAccessorProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: deserializeAccessorPropertyType(pos + 72),
       decorators: null,
       key: null,
@@ -2407,7 +2419,7 @@ function deserializeAccessorProperty(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = deserializeVecDecorator(pos + 8);
   node.key = deserializePropertyKey(pos + 32);
   node.value = deserializeOptionExpression(pos + 56);
@@ -2419,7 +2431,7 @@ function deserializeImportExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ImportExpression',
       source: null,
       options: null,
@@ -2428,7 +2440,7 @@ function deserializeImportExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.source = deserializeExpression(pos + 8);
   node.options = deserializeOptionExpression(pos + 24);
   parent = previousParent;
@@ -2439,7 +2451,7 @@ function deserializeImportDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ImportDeclaration',
       specifiers: null,
       source: null,
@@ -2449,7 +2461,7 @@ function deserializeImportDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     specifiers = deserializeOptionVecImportDeclarationSpecifier(pos + 8);
   specifiers === null && (specifiers = []);
   let withClause = deserializeOptionBoxWithClause(pos + 80);
@@ -2488,7 +2500,7 @@ function deserializeImportSpecifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ImportSpecifier',
       imported: null,
       local: null,
@@ -2496,7 +2508,7 @@ function deserializeImportSpecifier(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.imported = deserializeModuleExportName(pos + 8);
   node.local = deserializeBindingIdentifier(pos + 64);
   parent = previousParent;
@@ -2507,14 +2519,14 @@ function deserializeImportDefaultSpecifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ImportDefaultSpecifier',
       local: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.local = deserializeBindingIdentifier(pos + 8);
   parent = previousParent;
   return node;
@@ -2524,14 +2536,14 @@ function deserializeImportNamespaceSpecifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ImportNamespaceSpecifier',
       local: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.local = deserializeBindingIdentifier(pos + 8);
   parent = previousParent;
   return node;
@@ -2545,7 +2557,7 @@ function deserializeImportAttribute(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ImportAttribute',
       key: null,
       value: null,
@@ -2553,7 +2565,7 @@ function deserializeImportAttribute(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.key = deserializeImportAttributeKey(pos + 8);
   node.value = deserializeStringLiteral(pos + 64);
   parent = previousParent;
@@ -2575,7 +2587,7 @@ function deserializeExportNamedDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ExportNamedDeclaration',
       declaration: null,
       specifiers: null,
@@ -2585,7 +2597,7 @@ function deserializeExportNamedDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     withClause = deserializeOptionBoxWithClause(pos + 96);
   node.declaration = deserializeOptionDeclaration(pos + 8);
   node.specifiers = deserializeVecExportSpecifier(pos + 24);
@@ -2599,14 +2611,14 @@ function deserializeExportDefaultDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ExportDefaultDeclaration',
       declaration: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.declaration = deserializeExportDefaultDeclarationKind(pos + 8);
   parent = previousParent;
   return node;
@@ -2616,7 +2628,7 @@ function deserializeExportAllDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ExportAllDeclaration',
       exported: null,
       source: null,
@@ -2625,7 +2637,7 @@ function deserializeExportAllDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     withClause = deserializeOptionBoxWithClause(pos + 112);
   node.exported = deserializeOptionModuleExportName(pos + 8);
   node.source = deserializeStringLiteral(pos + 64);
@@ -2638,7 +2650,7 @@ function deserializeExportSpecifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ExportSpecifier',
       local: null,
       exported: null,
@@ -2646,7 +2658,7 @@ function deserializeExportSpecifier(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.local = deserializeModuleExportName(pos + 8);
   node.exported = deserializeModuleExportName(pos + 64);
   parent = previousParent;
@@ -2769,7 +2781,7 @@ function deserializeV8IntrinsicExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'V8IntrinsicExpression',
       name: null,
       arguments: null,
@@ -2777,7 +2789,7 @@ function deserializeV8IntrinsicExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.name = deserializeIdentifierName(pos + 8);
   node.arguments = deserializeVecArgument(pos + 32);
   parent = previousParent;
@@ -2789,7 +2801,7 @@ function deserializeBooleanLiteral(pos) {
     start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Literal',
       value,
       raw: null,
@@ -2797,7 +2809,7 @@ function deserializeBooleanLiteral(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.raw = start === 0 && end === 0 ? null : value + '';
   parent = previousParent;
   return node;
@@ -2807,7 +2819,7 @@ function deserializeNullLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Literal',
       value: null,
       raw: null,
@@ -2815,7 +2827,7 @@ function deserializeNullLiteral(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.value = null;
   node.raw = start === 0 && end === 0 ? null : 'null';
   parent = previousParent;
@@ -2823,7 +2835,8 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Literal',
     value: deserializeF64(pos + 8),
@@ -2839,7 +2852,7 @@ function deserializeStringLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Literal',
       value: null,
       raw: deserializeOptionStr(pos + 24),
@@ -2847,7 +2860,7 @@ function deserializeStringLiteral(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     value = deserializeStr(pos + 8);
   deserializeBool(pos + 40) &&
     (value = value.replace(/\uFFFD(.{4})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16))));
@@ -2860,7 +2873,7 @@ function deserializeBigIntLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Literal',
       value: null,
       raw: deserializeOptionStr(pos + 24),
@@ -2869,7 +2882,7 @@ function deserializeBigIntLiteral(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     bigint = deserializeStr(pos + 8);
   node.value = BigInt(bigint);
   node.bigint = bigint;
@@ -2881,7 +2894,7 @@ function deserializeRegExpLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Literal',
       value: null,
       raw: deserializeOptionStr(pos + 40),
@@ -2890,7 +2903,7 @@ function deserializeRegExpLiteral(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     regex = deserializeRegExp(pos + 8),
     value = null;
   try {
@@ -2910,7 +2923,8 @@ function deserializeRegExp(pos) {
 }
 
 function deserializeRegExpFlags(pos) {
-  let flagBits = deserializeU8(pos), flags = '';
+  let flagBits = deserializeU8(pos),
+    flags = '';
   // Alphabetical order
   flagBits & 64 && (flags += 'd');
   flagBits & 1 && (flags += 'g');
@@ -2927,7 +2941,7 @@ function deserializeJSXElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXElement',
       openingElement: null,
       children: null,
@@ -2936,7 +2950,7 @@ function deserializeJSXElement(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     closingElement = deserializeOptionBoxJSXClosingElement(pos + 40),
     openingElement = deserializeBoxJSXOpeningElement(pos + 8);
   closingElement === null && (openingElement.selfClosing = true);
@@ -2951,7 +2965,7 @@ function deserializeJSXOpeningElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXOpeningElement',
       name: null,
       attributes: null,
@@ -2960,7 +2974,7 @@ function deserializeJSXOpeningElement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.name = deserializeJSXElementName(pos + 8);
   node.attributes = deserializeVecJSXAttributeItem(pos + 32);
   node.selfClosing = false;
@@ -2972,14 +2986,14 @@ function deserializeJSXClosingElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXClosingElement',
       name: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.name = deserializeJSXElementName(pos + 8);
   parent = previousParent;
   return node;
@@ -2989,7 +3003,7 @@ function deserializeJSXFragment(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXFragment',
       openingFragment: null,
       children: null,
@@ -2998,7 +3012,7 @@ function deserializeJSXFragment(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.openingFragment = deserializeJSXOpeningFragment(pos + 8);
   node.children = deserializeVecJSXChild(pos + 16);
   node.closingFragment = deserializeJSXClosingFragment(pos + 40);
@@ -3010,7 +3024,7 @@ function deserializeJSXOpeningFragment(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXOpeningFragment',
       attributes: null,
       selfClosing: null,
@@ -3018,7 +3032,7 @@ function deserializeJSXOpeningFragment(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.attributes = [];
   node.selfClosing = false;
   parent = previousParent;
@@ -3026,7 +3040,8 @@ function deserializeJSXOpeningFragment(pos) {
 }
 
 function deserializeJSXClosingFragment(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXClosingFragment',
     start,
@@ -3073,7 +3088,7 @@ function deserializeJSXNamespacedName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXNamespacedName',
       namespace: null,
       name: null,
@@ -3081,7 +3096,7 @@ function deserializeJSXNamespacedName(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.namespace = deserializeJSXIdentifier(pos + 8);
   node.name = deserializeJSXIdentifier(pos + 32);
   parent = previousParent;
@@ -3092,7 +3107,7 @@ function deserializeJSXMemberExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXMemberExpression',
       object: null,
       property: null,
@@ -3100,7 +3115,7 @@ function deserializeJSXMemberExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.object = deserializeJSXMemberExpressionObject(pos + 8);
   node.property = deserializeJSXIdentifier(pos + 24);
   parent = previousParent;
@@ -3140,14 +3155,14 @@ function deserializeJSXExpressionContainer(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXExpressionContainer',
       expression: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeJSXExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -3249,7 +3264,8 @@ function deserializeJSXExpression(pos) {
 }
 
 function deserializeJSXEmptyExpression(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXEmptyExpression',
     start,
@@ -3274,7 +3290,7 @@ function deserializeJSXAttribute(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXAttribute',
       name: null,
       value: null,
@@ -3282,7 +3298,7 @@ function deserializeJSXAttribute(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.name = deserializeJSXAttributeName(pos + 8);
   node.value = deserializeOptionJSXAttributeValue(pos + 24);
   parent = previousParent;
@@ -3293,14 +3309,14 @@ function deserializeJSXSpreadAttribute(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXSpreadAttribute',
       argument: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -3333,7 +3349,8 @@ function deserializeJSXAttributeValue(pos) {
 }
 
 function deserializeJSXIdentifier(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXIdentifier',
     name: deserializeStr(pos + 8),
@@ -3365,21 +3382,22 @@ function deserializeJSXSpreadChild(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXSpreadChild',
       expression: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
 }
 
 function deserializeJSXText(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXText',
     value: deserializeStr(pos + 8),
@@ -3395,7 +3413,7 @@ function deserializeTSThisParameter(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Identifier',
       decorators: null,
       name: null,
@@ -3405,7 +3423,7 @@ function deserializeTSThisParameter(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = [];
   node.name = 'this';
   node.optional = false;
@@ -3418,7 +3436,7 @@ function deserializeTSEnumDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSEnumDeclaration',
       id: null,
       body: null,
@@ -3428,7 +3446,7 @@ function deserializeTSEnumDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.id = deserializeBindingIdentifier(pos + 8);
   node.body = deserializeTSEnumBody(pos + 40);
   parent = previousParent;
@@ -3439,14 +3457,14 @@ function deserializeTSEnumBody(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSEnumBody',
       members: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.members = deserializeVecTSEnumMember(pos + 8);
   parent = previousParent;
   return node;
@@ -3456,7 +3474,7 @@ function deserializeTSEnumMember(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSEnumMember',
       id: null,
       initializer: null,
@@ -3465,7 +3483,7 @@ function deserializeTSEnumMember(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.id = deserializeTSEnumMemberName(pos + 8);
   node.initializer = deserializeOptionExpression(pos + 24);
   node.computed = deserializeU8(pos + 8) > 1;
@@ -3492,14 +3510,14 @@ function deserializeTSTypeAnnotation(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeAnnotation',
       typeAnnotation: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3509,14 +3527,14 @@ function deserializeTSLiteralType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSLiteralType',
       literal: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.literal = deserializeTSLiteral(pos + 8);
   parent = previousParent;
   return node;
@@ -3626,7 +3644,7 @@ function deserializeTSConditionalType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSConditionalType',
       checkType: null,
       extendsType: null,
@@ -3636,7 +3654,7 @@ function deserializeTSConditionalType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.checkType = deserializeTSType(pos + 8);
   node.extendsType = deserializeTSType(pos + 24);
   node.trueType = deserializeTSType(pos + 40);
@@ -3649,14 +3667,14 @@ function deserializeTSUnionType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSUnionType',
       types: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.types = deserializeVecTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3666,14 +3684,14 @@ function deserializeTSIntersectionType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSIntersectionType',
       types: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.types = deserializeVecTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3682,12 +3700,14 @@ function deserializeTSIntersectionType(pos) {
 function deserializeTSParenthesizedType(pos) {
   let node;
   {
-    let start, end, previousParent = parent;
+    let start,
+      end,
+      previousParent = parent;
     node = parent = {
       type: 'TSParenthesizedType',
       typeAnnotation: null,
-      start: start = deserializeU32(pos),
-      end: end = deserializeU32(pos + 4),
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     };
@@ -3701,7 +3721,7 @@ function deserializeTSTypeOperator(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeOperator',
       operator: deserializeTSTypeOperatorOperator(pos + 24),
       typeAnnotation: null,
@@ -3709,7 +3729,7 @@ function deserializeTSTypeOperator(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3732,14 +3752,14 @@ function deserializeTSArrayType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSArrayType',
       elementType: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.elementType = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3749,7 +3769,7 @@ function deserializeTSIndexedAccessType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSIndexedAccessType',
       objectType: null,
       indexType: null,
@@ -3757,7 +3777,7 @@ function deserializeTSIndexedAccessType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.objectType = deserializeTSType(pos + 8);
   node.indexType = deserializeTSType(pos + 24);
   parent = previousParent;
@@ -3768,14 +3788,14 @@ function deserializeTSTupleType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTupleType',
       elementTypes: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.elementTypes = deserializeVecTSTupleElement(pos + 8);
   parent = previousParent;
   return node;
@@ -3785,7 +3805,7 @@ function deserializeTSNamedTupleMember(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSNamedTupleMember',
       label: null,
       elementType: null,
@@ -3794,7 +3814,7 @@ function deserializeTSNamedTupleMember(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.label = deserializeIdentifierName(pos + 8);
   node.elementType = deserializeTSTupleElement(pos + 32);
   parent = previousParent;
@@ -3805,14 +3825,14 @@ function deserializeTSOptionalType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSOptionalType',
       typeAnnotation: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3822,14 +3842,14 @@ function deserializeTSRestType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSRestType',
       typeAnnotation: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3921,7 +3941,8 @@ function deserializeTSTupleElement(pos) {
 }
 
 function deserializeTSAnyKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSAnyKeyword',
     start,
@@ -3932,7 +3953,8 @@ function deserializeTSAnyKeyword(pos) {
 }
 
 function deserializeTSStringKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSStringKeyword',
     start,
@@ -3943,7 +3965,8 @@ function deserializeTSStringKeyword(pos) {
 }
 
 function deserializeTSBooleanKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSBooleanKeyword',
     start,
@@ -3954,7 +3977,8 @@ function deserializeTSBooleanKeyword(pos) {
 }
 
 function deserializeTSNumberKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSNumberKeyword',
     start,
@@ -3965,7 +3989,8 @@ function deserializeTSNumberKeyword(pos) {
 }
 
 function deserializeTSNeverKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSNeverKeyword',
     start,
@@ -3976,7 +4001,8 @@ function deserializeTSNeverKeyword(pos) {
 }
 
 function deserializeTSIntrinsicKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSIntrinsicKeyword',
     start,
@@ -3987,7 +4013,8 @@ function deserializeTSIntrinsicKeyword(pos) {
 }
 
 function deserializeTSUnknownKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSUnknownKeyword',
     start,
@@ -3998,7 +4025,8 @@ function deserializeTSUnknownKeyword(pos) {
 }
 
 function deserializeTSNullKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSNullKeyword',
     start,
@@ -4009,7 +4037,8 @@ function deserializeTSNullKeyword(pos) {
 }
 
 function deserializeTSUndefinedKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSUndefinedKeyword',
     start,
@@ -4020,7 +4049,8 @@ function deserializeTSUndefinedKeyword(pos) {
 }
 
 function deserializeTSVoidKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSVoidKeyword',
     start,
@@ -4031,7 +4061,8 @@ function deserializeTSVoidKeyword(pos) {
 }
 
 function deserializeTSSymbolKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSSymbolKeyword',
     start,
@@ -4042,7 +4073,8 @@ function deserializeTSSymbolKeyword(pos) {
 }
 
 function deserializeTSThisType(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSThisType',
     start,
@@ -4053,7 +4085,8 @@ function deserializeTSThisType(pos) {
 }
 
 function deserializeTSObjectKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSObjectKeyword',
     start,
@@ -4064,7 +4097,8 @@ function deserializeTSObjectKeyword(pos) {
 }
 
 function deserializeTSBigIntKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSBigIntKeyword',
     start,
@@ -4078,7 +4112,7 @@ function deserializeTSTypeReference(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeReference',
       typeName: null,
       typeArguments: null,
@@ -4086,7 +4120,7 @@ function deserializeTSTypeReference(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeName = deserializeTSTypeName(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   parent = previousParent;
@@ -4110,7 +4144,7 @@ function deserializeTSQualifiedName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSQualifiedName',
       left: null,
       right: null,
@@ -4118,7 +4152,7 @@ function deserializeTSQualifiedName(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializeTSTypeName(pos + 8);
   node.right = deserializeIdentifierName(pos + 24);
   parent = previousParent;
@@ -4129,14 +4163,14 @@ function deserializeTSTypeParameterInstantiation(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeParameterInstantiation',
       params: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.params = deserializeVecTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -4146,7 +4180,7 @@ function deserializeTSTypeParameter(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeParameter',
       name: null,
       constraint: null,
@@ -4158,7 +4192,7 @@ function deserializeTSTypeParameter(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.name = deserializeBindingIdentifier(pos + 8);
   node.constraint = deserializeOptionTSType(pos + 40);
   node.default = deserializeOptionTSType(pos + 56);
@@ -4170,14 +4204,14 @@ function deserializeTSTypeParameterDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeParameterDeclaration',
       params: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.params = deserializeVecTSTypeParameter(pos + 8);
   parent = previousParent;
   return node;
@@ -4187,7 +4221,7 @@ function deserializeTSTypeAliasDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeAliasDeclaration',
       id: null,
       typeParameters: null,
@@ -4197,7 +4231,7 @@ function deserializeTSTypeAliasDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.id = deserializeBindingIdentifier(pos + 8);
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 40);
   node.typeAnnotation = deserializeTSType(pos + 48);
@@ -4209,7 +4243,7 @@ function deserializeTSInterfaceDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSInterfaceDeclaration',
       id: null,
       typeParameters: null,
@@ -4220,7 +4254,7 @@ function deserializeTSInterfaceDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.id = deserializeBindingIdentifier(pos + 8);
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 40);
   node.extends = deserializeVecTSInterfaceHeritage(pos + 48);
@@ -4233,14 +4267,14 @@ function deserializeTSInterfaceBody(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSInterfaceBody',
       body: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.body = deserializeVecTSSignature(pos + 8);
   parent = previousParent;
   return node;
@@ -4250,7 +4284,7 @@ function deserializeTSPropertySignature(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSPropertySignature',
       computed: deserializeBool(pos + 32),
       optional: deserializeBool(pos + 33),
@@ -4263,7 +4297,7 @@ function deserializeTSPropertySignature(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.key = deserializePropertyKey(pos + 8);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   node.accessibility = null;
@@ -4293,7 +4327,7 @@ function deserializeTSIndexSignature(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSIndexSignature',
       parameters: null,
       typeAnnotation: null,
@@ -4304,7 +4338,7 @@ function deserializeTSIndexSignature(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.parameters = deserializeVecTSIndexSignatureName(pos + 8);
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
   node.accessibility = null;
@@ -4316,7 +4350,7 @@ function deserializeTSCallSignatureDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSCallSignatureDeclaration',
       typeParameters: null,
       params: null,
@@ -4325,7 +4359,7 @@ function deserializeTSCallSignatureDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     params = deserializeBoxFormalParameters(pos + 24),
     thisParam = deserializeOptionBoxTSThisParameter(pos + 16);
   thisParam !== null && params.unshift(thisParam);
@@ -4353,7 +4387,7 @@ function deserializeTSMethodSignature(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSMethodSignature',
       key: null,
       computed: deserializeBool(pos + 60),
@@ -4369,7 +4403,7 @@ function deserializeTSMethodSignature(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     params = deserializeBoxFormalParameters(pos + 40),
     thisParam = deserializeOptionBoxTSThisParameter(pos + 32);
   thisParam !== null && params.unshift(thisParam);
@@ -4388,7 +4422,7 @@ function deserializeTSConstructSignatureDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSConstructSignatureDeclaration',
       typeParameters: null,
       params: null,
@@ -4397,7 +4431,7 @@ function deserializeTSConstructSignatureDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 8);
   node.params = deserializeBoxFormalParameters(pos + 16);
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 24);
@@ -4409,7 +4443,7 @@ function deserializeTSIndexSignatureName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Identifier',
       decorators: null,
       name: deserializeStr(pos + 8),
@@ -4419,7 +4453,7 @@ function deserializeTSIndexSignatureName(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = [];
   node.optional = false;
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 24);
@@ -4431,7 +4465,7 @@ function deserializeTSInterfaceHeritage(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSInterfaceHeritage',
       expression: null,
       typeArguments: null,
@@ -4439,7 +4473,7 @@ function deserializeTSInterfaceHeritage(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   parent = previousParent;
@@ -4450,7 +4484,7 @@ function deserializeTSTypePredicate(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypePredicate',
       parameterName: null,
       asserts: deserializeBool(pos + 32),
@@ -4459,7 +4493,7 @@ function deserializeTSTypePredicate(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.parameterName = deserializeTSTypePredicateName(pos + 8);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   parent = previousParent;
@@ -4528,8 +4562,8 @@ function deserializeTSModuleDeclaration(pos) {
               type: 'TSQualifiedName',
               left: id,
               right: innerId,
-              start: start = id.start,
-              end: end = innerId.end,
+              start: (start = id.start),
+              end: (end = innerId.end),
               range: [start, end],
               parent: node,
             };
@@ -4544,16 +4578,20 @@ function deserializeTSModuleDeclaration(pos) {
           if (innerId.left.type === 'Identifier') break;
           innerId = innerId.left;
         }
-        let end, right = innerId.left;
-        id.parent = right.parent = innerId.left = {
-          type: 'TSQualifiedName',
-          left: id,
-          right,
-          start,
-          end: end = right.end,
-          range: [start, end],
-          parent: innerId,
-        };
+        let end,
+          right = innerId.left;
+        id.parent =
+          right.parent =
+          innerId.left =
+            {
+              type: 'TSQualifiedName',
+              left: id,
+              right,
+              start,
+              end: (end = right.end),
+              range: [start, end],
+              parent: innerId,
+            };
       }
       if (Object.hasOwn(body, 'body')) {
         body = body.body;
@@ -4605,14 +4643,14 @@ function deserializeTSModuleBlock(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSModuleBlock',
       body: null,
       start,
       end,
       range: [start, end],
       parent,
-    },
+    }),
     body = deserializeVecDirective(pos + 8);
   body.push(...deserializeVecStatement(pos + 32));
   node.body = body;
@@ -4624,14 +4662,14 @@ function deserializeTSTypeLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeLiteral',
       members: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.members = deserializeVecTSSignature(pos + 8);
   parent = previousParent;
   return node;
@@ -4641,14 +4679,14 @@ function deserializeTSInferType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSInferType',
       typeParameter: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeParameter = deserializeBoxTSTypeParameter(pos + 8);
   parent = previousParent;
   return node;
@@ -4658,7 +4696,7 @@ function deserializeTSTypeQuery(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeQuery',
       exprName: null,
       typeArguments: null,
@@ -4666,7 +4704,7 @@ function deserializeTSTypeQuery(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.exprName = deserializeTSTypeQueryExprName(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   parent = previousParent;
@@ -4692,7 +4730,7 @@ function deserializeTSImportType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSImportType',
       argument: null,
       options: null,
@@ -4702,7 +4740,7 @@ function deserializeTSImportType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeTSType(pos + 8);
   node.options = deserializeOptionBoxObjectExpression(pos + 24);
   node.qualifier = deserializeOptionTSImportTypeQualifier(pos + 32);
@@ -4726,7 +4764,7 @@ function deserializeTSImportTypeQualifiedName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSQualifiedName',
       left: null,
       right: null,
@@ -4734,7 +4772,7 @@ function deserializeTSImportTypeQualifiedName(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializeTSImportTypeQualifier(pos + 8);
   node.right = deserializeIdentifierName(pos + 24);
   parent = previousParent;
@@ -4745,7 +4783,7 @@ function deserializeTSFunctionType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSFunctionType',
       typeParameters: null,
       params: null,
@@ -4754,7 +4792,7 @@ function deserializeTSFunctionType(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     params = deserializeBoxFormalParameters(pos + 24),
     thisParam = deserializeOptionBoxTSThisParameter(pos + 16);
   thisParam !== null && params.unshift(thisParam);
@@ -4769,7 +4807,7 @@ function deserializeTSConstructorType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSConstructorType',
       abstract: deserializeBool(pos + 36),
       typeParameters: null,
@@ -4779,7 +4817,7 @@ function deserializeTSConstructorType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 8);
   node.params = deserializeBoxFormalParameters(pos + 16);
   node.returnType = deserializeBoxTSTypeAnnotation(pos + 24);
@@ -4791,7 +4829,7 @@ function deserializeTSMappedType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSMappedType',
       key: null,
       constraint: null,
@@ -4803,7 +4841,7 @@ function deserializeTSMappedType(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     typeParameter = deserializeBoxTSTypeParameter(pos + 8),
     key = typeParameter.name;
   key.parent = parent;
@@ -4837,7 +4875,7 @@ function deserializeTSTemplateLiteralType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTemplateLiteralType',
       quasis: null,
       types: null,
@@ -4845,7 +4883,7 @@ function deserializeTSTemplateLiteralType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.quasis = deserializeVecTemplateElement(pos + 8);
   node.types = deserializeVecTSType(pos + 32);
   parent = previousParent;
@@ -4856,7 +4894,7 @@ function deserializeTSAsExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSAsExpression',
       expression: null,
       typeAnnotation: null,
@@ -4864,7 +4902,7 @@ function deserializeTSAsExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   node.typeAnnotation = deserializeTSType(pos + 24);
   parent = previousParent;
@@ -4875,7 +4913,7 @@ function deserializeTSSatisfiesExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSSatisfiesExpression',
       expression: null,
       typeAnnotation: null,
@@ -4883,7 +4921,7 @@ function deserializeTSSatisfiesExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   node.typeAnnotation = deserializeTSType(pos + 24);
   parent = previousParent;
@@ -4894,7 +4932,7 @@ function deserializeTSTypeAssertion(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeAssertion',
       typeAnnotation: null,
       expression: null,
@@ -4902,7 +4940,7 @@ function deserializeTSTypeAssertion(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   node.expression = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -4913,7 +4951,7 @@ function deserializeTSImportEqualsDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSImportEqualsDeclaration',
       id: null,
       moduleReference: null,
@@ -4922,7 +4960,7 @@ function deserializeTSImportEqualsDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.id = deserializeBindingIdentifier(pos + 8);
   node.moduleReference = deserializeTSModuleReference(pos + 40);
   parent = previousParent;
@@ -4948,14 +4986,14 @@ function deserializeTSExternalModuleReference(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSExternalModuleReference',
       expression: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeStringLiteral(pos + 8);
   parent = previousParent;
   return node;
@@ -4965,14 +5003,14 @@ function deserializeTSNonNullExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSNonNullExpression',
       expression: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -4982,14 +5020,14 @@ function deserializeDecorator(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Decorator',
       expression: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -4999,14 +5037,14 @@ function deserializeTSExportAssignment(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSExportAssignment',
       expression: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -5016,14 +5054,14 @@ function deserializeTSNamespaceExportDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSNamespaceExportDeclaration',
       id: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.id = deserializeIdentifierName(pos + 8);
   parent = previousParent;
   return node;
@@ -5033,7 +5071,7 @@ function deserializeTSInstantiationExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSInstantiationExpression',
       expression: null,
       typeArguments: null,
@@ -5041,7 +5079,7 @@ function deserializeTSInstantiationExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   node.typeArguments = deserializeBoxTSTypeParameterInstantiation(pos + 24);
   parent = previousParent;
@@ -5063,7 +5101,7 @@ function deserializeJSDocNullableType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSJSDocNullableType',
       typeAnnotation: null,
       postfix: deserializeBool(pos + 24),
@@ -5071,7 +5109,7 @@ function deserializeJSDocNullableType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -5081,7 +5119,7 @@ function deserializeJSDocNonNullableType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSJSDocNonNullableType',
       typeAnnotation: null,
       postfix: deserializeBool(pos + 24),
@@ -5089,14 +5127,15 @@ function deserializeJSDocNonNullableType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
 }
 
 function deserializeJSDocUnknownType(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSJSDocUnknownType',
     start,
@@ -5118,7 +5157,9 @@ function deserializeCommentKind(pos) {
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12), start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let type = deserializeCommentKind(pos + 12),
+    start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type,
     value: sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2)),
@@ -5129,7 +5170,8 @@ function deserializeComment(pos) {
 }
 
 function deserializeNameSpan(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     value: deserializeStr(pos + 8),
     start,
@@ -5180,7 +5222,8 @@ function deserializeImportImportName(pos) {
 }
 
 function deserializeExportEntry(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
@@ -5300,7 +5343,8 @@ function deserializeExportLocalName(pos) {
 }
 
 function deserializeDynamicImport(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeSpan(pos + 8),
     start,
@@ -5495,7 +5539,8 @@ function deserializeErrorSeverity(pos) {
 }
 
 function deserializeErrorLabel(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     message: deserializeOptionStr(pos + 8),
     start,
@@ -5515,7 +5560,8 @@ function deserializeEcmaScriptModule(pos) {
 }
 
 function deserializeStaticImport(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeNameSpan(pos + 8),
     entries: deserializeVecImportEntry(pos + 32),
@@ -5526,7 +5572,8 @@ function deserializeStaticImport(pos) {
 }
 
 function deserializeStaticExport(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     entries: deserializeVecExportEntry(pos + 8),
     start,
@@ -5544,7 +5591,8 @@ function deserializeU8(pos) {
 }
 
 function deserializeStr(pos) {
-  let pos32 = pos >> 2, len = uint32[pos32 + 2];
+  let pos32 = pos >> 2,
+    len = uint32[pos32 + 2];
   if (len === 0) return '';
   pos = uint32[pos32];
   if (sourceIsAscii && pos < sourceByteLen) return sourceText.substr(pos, len);
@@ -5553,7 +5601,8 @@ function deserializeStr(pos) {
   let end = pos + len;
   if (len > 50) return decodeStr(uint8.subarray(pos, end));
   // Shorter strings decode by hand to avoid native call
-  let out = '', c;
+  let out = '',
+    c;
   do {
     c = uint8[pos++];
     if (c < 128) out += fromCodePoint(c);
@@ -5566,10 +5615,11 @@ function deserializeStr(pos) {
 }
 
 function deserializeVecComment(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeComment(pos));
     pos += 16;
   }
@@ -5577,15 +5627,16 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeHashbang(pos);
 }
 
 function deserializeVecDirective(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 72;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDirective(pos));
     pos += 72;
   }
@@ -5593,10 +5644,11 @@ function deserializeVecDirective(pos) {
 }
 
 function deserializeVecStatement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStatement(pos));
     pos += 16;
   }
@@ -5764,10 +5816,11 @@ function deserializeBoxV8IntrinsicExpression(pos) {
 }
 
 function deserializeVecArrayExpressionElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeArrayExpressionElement(pos));
     pos += 16;
   }
@@ -5779,10 +5832,11 @@ function deserializeBoxSpreadElement(pos) {
 }
 
 function deserializeVecObjectPropertyKind(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeObjectPropertyKind(pos));
     pos += 16;
   }
@@ -5806,10 +5860,11 @@ function deserializeBoxPrivateIdentifier(pos) {
 }
 
 function deserializeVecTemplateElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 48;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTemplateElement(pos));
     pos += 48;
   }
@@ -5817,10 +5872,11 @@ function deserializeVecTemplateElement(pos) {
 }
 
 function deserializeVecExpression(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExpression(pos));
     pos += 16;
   }
@@ -5832,12 +5888,12 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeStr(pos);
 }
 
@@ -5854,10 +5910,11 @@ function deserializeBoxPrivateFieldExpression(pos) {
 }
 
 function deserializeVecArgument(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeArgument(pos));
     pos += 16;
   }
@@ -5878,10 +5935,11 @@ function deserializeOptionAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeOptionAssignmentTargetMaybeDefault(pos));
     pos += 16;
   }
@@ -5893,15 +5951,16 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxAssignmentTargetRest(pos);
 }
 
 function deserializeVecAssignmentTargetProperty(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeAssignmentTargetProperty(pos));
     pos += 16;
   }
@@ -6022,10 +6081,11 @@ function deserializeBoxTSImportEqualsDeclaration(pos) {
 }
 
 function deserializeVecVariableDeclarator(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 64;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeVariableDeclarator(pos));
     pos += 64;
   }
@@ -6043,15 +6103,16 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeLabelIdentifier(pos);
 }
 
 function deserializeVecSwitchCase(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 48;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeSwitchCase(pos));
     pos += 48;
   }
@@ -6063,12 +6124,12 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxBlockStatement(pos);
 }
 
@@ -6082,7 +6143,7 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeAnnotation(pos);
 }
 
@@ -6103,10 +6164,11 @@ function deserializeBoxAssignmentPattern(pos) {
 }
 
 function deserializeVecBindingProperty(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 64;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeBindingProperty(pos));
     pos += 64;
   }
@@ -6118,7 +6180,7 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxBindingRestElement(pos);
 }
 
@@ -6128,10 +6190,11 @@ function deserializeOptionBindingPattern(pos) {
 }
 
 function deserializeVecOptionBindingPattern(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeOptionBindingPattern(pos));
     pos += 32;
   }
@@ -6139,7 +6202,7 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeBindingIdentifier(pos);
 }
 
@@ -6148,7 +6211,7 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
@@ -6157,7 +6220,7 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSThisParameter(pos);
 }
 
@@ -6170,15 +6233,16 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxFunctionBody(pos);
 }
 
 function deserializeVecFormalParameter(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 72;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeFormalParameter(pos));
     pos += 72;
   }
@@ -6186,10 +6250,11 @@ function deserializeVecFormalParameter(pos) {
 }
 
 function deserializeVecDecorator(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 24;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDecorator(pos));
     pos += 24;
   }
@@ -6201,10 +6266,11 @@ function deserializeBoxClassBody(pos) {
 }
 
 function deserializeVecClassElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeClassElement(pos));
     pos += 16;
   }
@@ -6261,10 +6327,11 @@ function deserializeOptionImportPhase(pos) {
 }
 
 function deserializeVecImportDeclarationSpecifier(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportDeclarationSpecifier(pos));
     pos += 16;
   }
@@ -6272,7 +6339,7 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeVecImportDeclarationSpecifier(pos);
 }
 
@@ -6281,7 +6348,7 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxWithClause(pos);
 }
 
@@ -6298,10 +6365,11 @@ function deserializeBoxImportNamespaceSpecifier(pos) {
 }
 
 function deserializeVecImportAttribute(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 112;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportAttribute(pos));
     pos += 112;
   }
@@ -6314,10 +6382,11 @@ function deserializeOptionDeclaration(pos) {
 }
 
 function deserializeVecExportSpecifier(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 128;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExportSpecifier(pos));
     pos += 128;
   }
@@ -6343,10 +6412,11 @@ function deserializeBoxJSXOpeningElement(pos) {
 }
 
 function deserializeVecJSXChild(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeJSXChild(pos));
     pos += 16;
   }
@@ -6358,15 +6428,16 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxJSXClosingElement(pos);
 }
 
 function deserializeVecJSXAttributeItem(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeJSXAttributeItem(pos));
     pos += 16;
   }
@@ -6411,10 +6482,11 @@ function deserializeBoxJSXSpreadChild(pos) {
 }
 
 function deserializeVecTSEnumMember(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 40;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSEnumMember(pos));
     pos += 40;
   }
@@ -6570,10 +6642,11 @@ function deserializeBoxJSDocUnknownType(pos) {
 }
 
 function deserializeVecTSType(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSType(pos));
     pos += 16;
   }
@@ -6581,10 +6654,11 @@ function deserializeVecTSType(pos) {
 }
 
 function deserializeVecTSTupleElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSTupleElement(pos));
     pos += 16;
   }
@@ -6609,10 +6683,11 @@ function deserializeOptionTSType(pos) {
 }
 
 function deserializeVecTSTypeParameter(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 80;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSTypeParameter(pos));
     pos += 80;
   }
@@ -6620,10 +6695,11 @@ function deserializeVecTSTypeParameter(pos) {
 }
 
 function deserializeVecTSInterfaceHeritage(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSInterfaceHeritage(pos));
     pos += 32;
   }
@@ -6635,10 +6711,11 @@ function deserializeBoxTSInterfaceBody(pos) {
 }
 
 function deserializeVecTSSignature(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSSignature(pos));
     pos += 16;
   }
@@ -6662,10 +6739,11 @@ function deserializeBoxTSMethodSignature(pos) {
 }
 
 function deserializeVecTSIndexSignatureName(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
     pos += 32;
   }
@@ -6686,7 +6764,7 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxObjectExpression(pos);
 }
 
@@ -6709,15 +6787,16 @@ function deserializeBoxTSExternalModuleReference(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeNameSpan(pos);
 }
 
 function deserializeVecError(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 80;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeError(pos));
     pos += 80;
   }
@@ -6725,10 +6804,11 @@ function deserializeVecError(pos) {
 }
 
 function deserializeVecErrorLabel(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 24;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeErrorLabel(pos));
     pos += 24;
   }
@@ -6736,10 +6816,11 @@ function deserializeVecErrorLabel(pos) {
 }
 
 function deserializeVecStaticImport(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 56;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStaticImport(pos));
     pos += 56;
   }
@@ -6747,10 +6828,11 @@ function deserializeVecStaticImport(pos) {
 }
 
 function deserializeVecStaticExport(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStaticExport(pos));
     pos += 32;
   }
@@ -6758,10 +6840,11 @@ function deserializeVecStaticExport(pos) {
 }
 
 function deserializeVecDynamicImport(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDynamicImport(pos));
     pos += 16;
   }
@@ -6769,10 +6852,11 @@ function deserializeVecDynamicImport(pos) {
 }
 
 function deserializeVecSpan(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 8;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeSpan(pos));
     pos += 8;
   }
@@ -6780,10 +6864,11 @@ function deserializeVecSpan(pos) {
 }
 
 function deserializeVecImportEntry(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 96;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportEntry(pos));
     pos += 96;
   }
@@ -6791,10 +6876,11 @@ function deserializeVecImportEntry(pos) {
 }
 
 function deserializeVecExportEntry(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 144;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExportEntry(pos));
     pos += 144;
   }

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -25,11 +25,7 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInpu
 
 export function resetBuffer() {
   // Clear buffer and source text string to allow them to be garbage collected
-  uint8 =
-    uint32 =
-    float64 =
-    sourceText =
-      void 0;
+  uint8 = uint32 = float64 = sourceText = void 0;
 }
 
 function deserializeProgram(pos) {
@@ -43,7 +39,7 @@ function deserializeProgram(pos) {
       end,
     };
   program.hashbang = deserializeOptionHashbang(pos + 48);
-  let body = program.body = deserializeVecDirective(pos + 72);
+  let body = (program.body = deserializeVecDirective(pos + 72));
   body.push(...deserializeVecStatement(pos + 96));
   {
     let start;
@@ -534,7 +530,8 @@ function deserializeTemplateElement(pos) {
     start = deserializeU32(pos) - 1,
     end = deserializeU32(pos + 4) + 2 - tail,
     value = deserializeTemplateElementValue(pos + 8);
-  value.cooked !== null && deserializeBool(pos + 41) &&
+  value.cooked !== null &&
+    deserializeBool(pos + 41) &&
     (value.cooked = value.cooked.replace(/\uFFFD(.{4})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16))));
   return {
     type: 'TemplateElement',
@@ -1053,16 +1050,17 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     key = deserializeIdentifierReference(pos + 8),
     init = deserializeOptionExpression(pos + 40),
     value = { ...key };
-  init !== null && (value = {
-    type: 'AssignmentPattern',
-    decorators: [],
-    left: value,
-    right: init,
-    optional: false,
-    typeAnnotation: null,
-    start,
-    end,
-  });
+  init !== null &&
+    (value = {
+      type: 'AssignmentPattern',
+      decorators: [],
+      left: value,
+      right: init,
+      optional: false,
+      typeAnnotation: null,
+      start,
+      end,
+    });
   node.kind = 'init';
   node.key = key;
   node.value = value;
@@ -1253,7 +1251,8 @@ function deserializeDirective(pos) {
 }
 
 function deserializeHashbang(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Hashbang',
     value: deserializeStr(pos + 8),
@@ -1887,8 +1886,8 @@ function deserializeFunctionType(pos) {
 
 function deserializeFormalParameters(pos) {
   let params = deserializeVecFormalParameter(pos + 8);
-  if (uint32[pos + 32 >> 2] !== 0 && uint32[pos + 36 >> 2] !== 0) {
-    pos = uint32[pos + 32 >> 2];
+  if (uint32[(pos + 32) >> 2] !== 0 && uint32[(pos + 36) >> 2] !== 0) {
+    pos = uint32[(pos + 32) >> 2];
     let rest = {
       type: 'RestElement',
       decorators: [],
@@ -2145,7 +2144,8 @@ function deserializeMethodDefinitionKind(pos) {
 }
 
 function deserializePrivateIdentifier(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'PrivateIdentifier',
     name: deserializeStr(pos + 8),
@@ -2559,7 +2559,8 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Literal',
     value: deserializeF64(pos + 8),
@@ -2632,7 +2633,8 @@ function deserializeRegExp(pos) {
 }
 
 function deserializeRegExpFlags(pos) {
-  let flagBits = deserializeU8(pos), flags = '';
+  let flagBits = deserializeU8(pos),
+    flags = '';
   // Alphabetical order
   flagBits & 64 && (flags += 'd');
   flagBits & 1 && (flags += 'g');
@@ -2978,7 +2980,8 @@ function deserializeJSXAttributeValue(pos) {
 }
 
 function deserializeJSXIdentifier(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXIdentifier',
     name: deserializeStr(pos + 8),
@@ -3016,7 +3019,8 @@ function deserializeJSXSpreadChild(pos) {
 }
 
 function deserializeJSXText(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXText',
     value: deserializeStr(pos + 8),
@@ -3695,7 +3699,7 @@ function deserializeTSClassImplements(pos) {
   if (expression.type === 'TSQualifiedName') {
     let object = expression.left,
       { right } = expression,
-      previous = expression = {
+      previous = (expression = {
         type: 'MemberExpression',
         object,
         property: right,
@@ -3703,8 +3707,8 @@ function deserializeTSClassImplements(pos) {
         computed: false,
         start: expression.start,
         end: expression.end,
-      };
-    for (; object.type === 'TSQualifiedName';) {
+      });
+    for (; object.type === 'TSQualifiedName'; ) {
       let { left, right } = object;
       previous = previous.object = {
         type: 'MemberExpression',
@@ -3981,7 +3985,7 @@ function deserializeTSModuleDeclaration(pos) {
     if (body.type === 'TSModuleBlock') node.id = id;
     else {
       let innerId = body.id;
-      if (innerId.type === 'Identifier') {
+      if (innerId.type === 'Identifier')
         node.id = {
           type: 'TSQualifiedName',
           left: id,
@@ -3989,7 +3993,7 @@ function deserializeTSModuleDeclaration(pos) {
           start: id.start,
           end: innerId.end,
         };
-      } else {
+      else {
         // Replace `left` of innermost `TSQualifiedName` with a nested `TSQualifiedName` with `id` of
         // this module on left, and previous `left` of innermost `TSQualifiedName` on right
         node.id = innerId;
@@ -4442,7 +4446,9 @@ function deserializeCommentKind(pos) {
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12), start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let type = deserializeCommentKind(pos + 12),
+    start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type,
     value: sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2)),
@@ -4452,7 +4458,8 @@ function deserializeComment(pos) {
 }
 
 function deserializeNameSpan(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     value: deserializeStr(pos + 8),
     start,
@@ -4499,7 +4506,8 @@ function deserializeImportImportName(pos) {
 }
 
 function deserializeExportEntry(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
@@ -4608,7 +4616,8 @@ function deserializeExportLocalName(pos) {
 }
 
 function deserializeDynamicImport(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeSpan(pos + 8),
     start,
@@ -4802,7 +4811,8 @@ function deserializeErrorSeverity(pos) {
 }
 
 function deserializeErrorLabel(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     message: deserializeOptionStr(pos + 8),
     start,
@@ -4821,7 +4831,8 @@ function deserializeEcmaScriptModule(pos) {
 }
 
 function deserializeStaticImport(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeNameSpan(pos + 8),
     entries: deserializeVecImportEntry(pos + 32),
@@ -4831,7 +4842,8 @@ function deserializeStaticImport(pos) {
 }
 
 function deserializeStaticExport(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     entries: deserializeVecExportEntry(pos + 8),
     start,
@@ -4848,7 +4860,8 @@ function deserializeU8(pos) {
 }
 
 function deserializeStr(pos) {
-  let pos32 = pos >> 2, len = uint32[pos32 + 2];
+  let pos32 = pos >> 2,
+    len = uint32[pos32 + 2];
   if (len === 0) return '';
   pos = uint32[pos32];
   if (sourceIsAscii && pos < sourceByteLen) return sourceText.substr(pos, len);
@@ -4857,7 +4870,8 @@ function deserializeStr(pos) {
   let end = pos + len;
   if (len > 50) return decodeStr(uint8.subarray(pos, end));
   // Shorter strings decode by hand to avoid native call
-  let out = '', c;
+  let out = '',
+    c;
   do {
     c = uint8[pos++];
     if (c < 128) out += fromCodePoint(c);
@@ -4870,10 +4884,11 @@ function deserializeStr(pos) {
 }
 
 function deserializeVecComment(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeComment(pos));
     pos += 16;
   }
@@ -4881,15 +4896,16 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeHashbang(pos);
 }
 
 function deserializeVecDirective(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 72;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDirective(pos));
     pos += 72;
   }
@@ -4897,10 +4913,11 @@ function deserializeVecDirective(pos) {
 }
 
 function deserializeVecStatement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStatement(pos));
     pos += 16;
   }
@@ -5068,10 +5085,11 @@ function deserializeBoxV8IntrinsicExpression(pos) {
 }
 
 function deserializeVecArrayExpressionElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeArrayExpressionElement(pos));
     pos += 16;
   }
@@ -5083,10 +5101,11 @@ function deserializeBoxSpreadElement(pos) {
 }
 
 function deserializeVecObjectPropertyKind(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeObjectPropertyKind(pos));
     pos += 16;
   }
@@ -5110,10 +5129,11 @@ function deserializeBoxPrivateIdentifier(pos) {
 }
 
 function deserializeVecTemplateElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 48;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTemplateElement(pos));
     pos += 48;
   }
@@ -5121,10 +5141,11 @@ function deserializeVecTemplateElement(pos) {
 }
 
 function deserializeVecExpression(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExpression(pos));
     pos += 16;
   }
@@ -5136,12 +5157,12 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeStr(pos);
 }
 
@@ -5158,10 +5179,11 @@ function deserializeBoxPrivateFieldExpression(pos) {
 }
 
 function deserializeVecArgument(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeArgument(pos));
     pos += 16;
   }
@@ -5182,10 +5204,11 @@ function deserializeOptionAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeOptionAssignmentTargetMaybeDefault(pos));
     pos += 16;
   }
@@ -5197,15 +5220,16 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxAssignmentTargetRest(pos);
 }
 
 function deserializeVecAssignmentTargetProperty(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeAssignmentTargetProperty(pos));
     pos += 16;
   }
@@ -5326,10 +5350,11 @@ function deserializeBoxTSImportEqualsDeclaration(pos) {
 }
 
 function deserializeVecVariableDeclarator(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 64;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeVariableDeclarator(pos));
     pos += 64;
   }
@@ -5347,15 +5372,16 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeLabelIdentifier(pos);
 }
 
 function deserializeVecSwitchCase(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 48;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeSwitchCase(pos));
     pos += 48;
   }
@@ -5367,12 +5393,12 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxBlockStatement(pos);
 }
 
@@ -5386,7 +5412,7 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeAnnotation(pos);
 }
 
@@ -5407,10 +5433,11 @@ function deserializeBoxAssignmentPattern(pos) {
 }
 
 function deserializeVecBindingProperty(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 64;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeBindingProperty(pos));
     pos += 64;
   }
@@ -5422,7 +5449,7 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxBindingRestElement(pos);
 }
 
@@ -5432,10 +5459,11 @@ function deserializeOptionBindingPattern(pos) {
 }
 
 function deserializeVecOptionBindingPattern(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeOptionBindingPattern(pos));
     pos += 32;
   }
@@ -5443,7 +5471,7 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeBindingIdentifier(pos);
 }
 
@@ -5452,7 +5480,7 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
@@ -5461,7 +5489,7 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSThisParameter(pos);
 }
 
@@ -5474,15 +5502,16 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxFunctionBody(pos);
 }
 
 function deserializeVecFormalParameter(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 72;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeFormalParameter(pos));
     pos += 72;
   }
@@ -5490,10 +5519,11 @@ function deserializeVecFormalParameter(pos) {
 }
 
 function deserializeVecDecorator(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 24;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDecorator(pos));
     pos += 24;
   }
@@ -5506,10 +5536,11 @@ function deserializeOptionTSAccessibility(pos) {
 }
 
 function deserializeVecTSClassImplements(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSClassImplements(pos));
     pos += 32;
   }
@@ -5521,10 +5552,11 @@ function deserializeBoxClassBody(pos) {
 }
 
 function deserializeVecClassElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeClassElement(pos));
     pos += 16;
   }
@@ -5581,10 +5613,11 @@ function deserializeOptionImportPhase(pos) {
 }
 
 function deserializeVecImportDeclarationSpecifier(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportDeclarationSpecifier(pos));
     pos += 16;
   }
@@ -5592,7 +5625,7 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeVecImportDeclarationSpecifier(pos);
 }
 
@@ -5601,7 +5634,7 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxWithClause(pos);
 }
 
@@ -5618,10 +5651,11 @@ function deserializeBoxImportNamespaceSpecifier(pos) {
 }
 
 function deserializeVecImportAttribute(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 112;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportAttribute(pos));
     pos += 112;
   }
@@ -5634,10 +5668,11 @@ function deserializeOptionDeclaration(pos) {
 }
 
 function deserializeVecExportSpecifier(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 128;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExportSpecifier(pos));
     pos += 128;
   }
@@ -5663,10 +5698,11 @@ function deserializeBoxJSXOpeningElement(pos) {
 }
 
 function deserializeVecJSXChild(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeJSXChild(pos));
     pos += 16;
   }
@@ -5678,15 +5714,16 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxJSXClosingElement(pos);
 }
 
 function deserializeVecJSXAttributeItem(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeJSXAttributeItem(pos));
     pos += 16;
   }
@@ -5731,10 +5768,11 @@ function deserializeBoxJSXSpreadChild(pos) {
 }
 
 function deserializeVecTSEnumMember(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 40;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSEnumMember(pos));
     pos += 40;
   }
@@ -5890,10 +5928,11 @@ function deserializeBoxJSDocUnknownType(pos) {
 }
 
 function deserializeVecTSType(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSType(pos));
     pos += 16;
   }
@@ -5901,10 +5940,11 @@ function deserializeVecTSType(pos) {
 }
 
 function deserializeVecTSTupleElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSTupleElement(pos));
     pos += 16;
   }
@@ -5929,10 +5969,11 @@ function deserializeOptionTSType(pos) {
 }
 
 function deserializeVecTSTypeParameter(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 80;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSTypeParameter(pos));
     pos += 80;
   }
@@ -5940,10 +5981,11 @@ function deserializeVecTSTypeParameter(pos) {
 }
 
 function deserializeVecTSInterfaceHeritage(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSInterfaceHeritage(pos));
     pos += 32;
   }
@@ -5955,10 +5997,11 @@ function deserializeBoxTSInterfaceBody(pos) {
 }
 
 function deserializeVecTSSignature(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSSignature(pos));
     pos += 16;
   }
@@ -5982,10 +6025,11 @@ function deserializeBoxTSMethodSignature(pos) {
 }
 
 function deserializeVecTSIndexSignatureName(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
     pos += 32;
   }
@@ -6006,7 +6050,7 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxObjectExpression(pos);
 }
 
@@ -6029,15 +6073,16 @@ function deserializeBoxTSExternalModuleReference(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeNameSpan(pos);
 }
 
 function deserializeVecError(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 80;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeError(pos));
     pos += 80;
   }
@@ -6045,10 +6090,11 @@ function deserializeVecError(pos) {
 }
 
 function deserializeVecErrorLabel(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 24;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeErrorLabel(pos));
     pos += 24;
   }
@@ -6056,10 +6102,11 @@ function deserializeVecErrorLabel(pos) {
 }
 
 function deserializeVecStaticImport(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 56;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStaticImport(pos));
     pos += 56;
   }
@@ -6067,10 +6114,11 @@ function deserializeVecStaticImport(pos) {
 }
 
 function deserializeVecStaticExport(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStaticExport(pos));
     pos += 32;
   }
@@ -6078,10 +6126,11 @@ function deserializeVecStaticExport(pos) {
 }
 
 function deserializeVecDynamicImport(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDynamicImport(pos));
     pos += 16;
   }
@@ -6089,10 +6138,11 @@ function deserializeVecDynamicImport(pos) {
 }
 
 function deserializeVecSpan(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 8;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeSpan(pos));
     pos += 8;
   }
@@ -6100,10 +6150,11 @@ function deserializeVecSpan(pos) {
 }
 
 function deserializeVecImportEntry(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 96;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportEntry(pos));
     pos += 96;
   }
@@ -6111,10 +6162,11 @@ function deserializeVecImportEntry(pos) {
 }
 
 function deserializeVecExportEntry(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 144;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExportEntry(pos));
     pos += 144;
   }

--- a/napi/parser/generated/deserialize/ts_parent.js
+++ b/napi/parser/generated/deserialize/ts_parent.js
@@ -1,7 +1,13 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
-let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen, parent = null;
+let uint8,
+  uint32,
+  float64,
+  sourceText,
+  sourceIsAscii,
+  sourceByteLen,
+  parent = null;
 
 const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
@@ -25,16 +31,12 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInpu
 
 export function resetBuffer() {
   // Clear buffer and source text string to allow them to be garbage collected
-  uint8 =
-    uint32 =
-    float64 =
-    sourceText =
-      void 0;
+  uint8 = uint32 = float64 = sourceText = void 0;
 }
 
 function deserializeProgram(pos) {
   let end = deserializeU32(pos + 4),
-    program = parent = {
+    program = (parent = {
       type: 'Program',
       body: null,
       sourceType: deserializeModuleKind(pos + 125),
@@ -42,9 +44,9 @@ function deserializeProgram(pos) {
       start: 0,
       end,
       parent: null,
-    };
+    });
   program.hashbang = deserializeOptionHashbang(pos + 48);
-  let body = program.body = deserializeVecDirective(pos + 72);
+  let body = (program.body = deserializeVecDirective(pos + 72));
   body.push(...deserializeVecStatement(pos + 96));
   {
     let start;
@@ -162,7 +164,7 @@ function deserializeIdentifierName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Identifier',
       decorators: null,
       name: deserializeStr(pos + 8),
@@ -171,7 +173,7 @@ function deserializeIdentifierName(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.decorators = [];
   node.optional = false;
   node.typeAnnotation = null;
@@ -183,7 +185,7 @@ function deserializeIdentifierReference(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Identifier',
       decorators: null,
       name: deserializeStr(pos + 8),
@@ -192,7 +194,7 @@ function deserializeIdentifierReference(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.decorators = [];
   node.optional = false;
   node.typeAnnotation = null;
@@ -204,7 +206,7 @@ function deserializeBindingIdentifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Identifier',
       decorators: null,
       name: deserializeStr(pos + 8),
@@ -213,7 +215,7 @@ function deserializeBindingIdentifier(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.decorators = [];
   node.optional = false;
   node.typeAnnotation = null;
@@ -225,7 +227,7 @@ function deserializeLabelIdentifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Identifier',
       decorators: null,
       name: deserializeStr(pos + 8),
@@ -234,7 +236,7 @@ function deserializeLabelIdentifier(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.decorators = [];
   node.optional = false;
   node.typeAnnotation = null;
@@ -255,13 +257,13 @@ function deserializeArrayExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ArrayExpression',
       elements: null,
       start,
       end,
       parent,
-    };
+    });
   node.elements = deserializeVecArrayExpressionElement(pos + 8);
   parent = previousParent;
   return node;
@@ -372,13 +374,13 @@ function deserializeObjectExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ObjectExpression',
       properties: null,
       start,
       end,
       parent,
-    };
+    });
   node.properties = deserializeVecObjectPropertyKind(pos + 8);
   parent = previousParent;
   return node;
@@ -399,7 +401,7 @@ function deserializeObjectProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Property',
       kind: deserializePropertyKind(pos + 40),
       key: null,
@@ -411,7 +413,7 @@ function deserializeObjectProperty(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.key = deserializePropertyKey(pos + 8);
   node.value = deserializeExpression(pos + 24);
   node.optional = false;
@@ -533,14 +535,14 @@ function deserializeTemplateLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TemplateLiteral',
       quasis: null,
       expressions: null,
       start,
       end,
       parent,
-    };
+    });
   node.quasis = deserializeVecTemplateElement(pos + 8);
   node.expressions = deserializeVecExpression(pos + 32);
   parent = previousParent;
@@ -551,7 +553,7 @@ function deserializeTaggedTemplateExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TaggedTemplateExpression',
       tag: null,
       typeArguments: null,
@@ -559,7 +561,7 @@ function deserializeTaggedTemplateExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.tag = deserializeExpression(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   node.quasi = deserializeTemplateLiteral(pos + 32);
@@ -572,7 +574,8 @@ function deserializeTemplateElement(pos) {
     start = deserializeU32(pos) - 1,
     end = deserializeU32(pos + 4) + 2 - tail,
     value = deserializeTemplateElementValue(pos + 8);
-  value.cooked !== null && deserializeBool(pos + 41) &&
+  value.cooked !== null &&
+    deserializeBool(pos + 41) &&
     (value.cooked = value.cooked.replace(/\uFFFD(.{4})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16))));
   return {
     type: 'TemplateElement',
@@ -595,7 +598,7 @@ function deserializeComputedMemberExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'MemberExpression',
       object: null,
       property: null,
@@ -604,7 +607,7 @@ function deserializeComputedMemberExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.object = deserializeExpression(pos + 8);
   node.property = deserializeExpression(pos + 24);
   node.computed = true;
@@ -616,7 +619,7 @@ function deserializeStaticMemberExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'MemberExpression',
       object: null,
       property: null,
@@ -625,7 +628,7 @@ function deserializeStaticMemberExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.object = deserializeExpression(pos + 8);
   node.property = deserializeIdentifierName(pos + 24);
   node.computed = false;
@@ -637,7 +640,7 @@ function deserializePrivateFieldExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'MemberExpression',
       object: null,
       property: null,
@@ -646,7 +649,7 @@ function deserializePrivateFieldExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.object = deserializeExpression(pos + 8);
   node.property = deserializePrivateIdentifier(pos + 24);
   node.computed = false;
@@ -658,7 +661,7 @@ function deserializeCallExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'CallExpression',
       callee: null,
       typeArguments: null,
@@ -667,7 +670,7 @@ function deserializeCallExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.callee = deserializeExpression(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   node.arguments = deserializeVecArgument(pos + 32);
@@ -679,7 +682,7 @@ function deserializeNewExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'NewExpression',
       callee: null,
       typeArguments: null,
@@ -687,7 +690,7 @@ function deserializeNewExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.callee = deserializeExpression(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   node.arguments = deserializeVecArgument(pos + 32);
@@ -699,14 +702,14 @@ function deserializeMetaProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'MetaProperty',
       meta: null,
       property: null,
       start,
       end,
       parent,
-    };
+    });
   node.meta = deserializeIdentifierName(pos + 8);
   node.property = deserializeIdentifierName(pos + 32);
   parent = previousParent;
@@ -717,13 +720,13 @@ function deserializeSpreadElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'SpreadElement',
       argument: null,
       start,
       end,
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -828,7 +831,7 @@ function deserializeUpdateExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'UpdateExpression',
       operator: deserializeUpdateOperator(pos + 24),
       prefix: deserializeBool(pos + 25),
@@ -836,7 +839,7 @@ function deserializeUpdateExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.argument = deserializeSimpleAssignmentTarget(pos + 8);
   parent = previousParent;
   return node;
@@ -846,7 +849,7 @@ function deserializeUnaryExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'UnaryExpression',
       operator: deserializeUnaryOperator(pos + 24),
       argument: null,
@@ -854,7 +857,7 @@ function deserializeUnaryExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   node.prefix = true;
   parent = previousParent;
@@ -865,7 +868,7 @@ function deserializeBinaryExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'BinaryExpression',
       left: null,
       operator: deserializeBinaryOperator(pos + 40),
@@ -873,7 +876,7 @@ function deserializeBinaryExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.left = deserializeExpression(pos + 8);
   node.right = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -884,7 +887,7 @@ function deserializePrivateInExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'BinaryExpression',
       left: null,
       operator: null,
@@ -892,7 +895,7 @@ function deserializePrivateInExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.left = deserializePrivateIdentifier(pos + 8);
   node.operator = 'in';
   node.right = deserializeExpression(pos + 32);
@@ -904,7 +907,7 @@ function deserializeLogicalExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'LogicalExpression',
       left: null,
       operator: deserializeLogicalOperator(pos + 40),
@@ -912,7 +915,7 @@ function deserializeLogicalExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.left = deserializeExpression(pos + 8);
   node.right = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -923,7 +926,7 @@ function deserializeConditionalExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ConditionalExpression',
       test: null,
       consequent: null,
@@ -931,7 +934,7 @@ function deserializeConditionalExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.test = deserializeExpression(pos + 8);
   node.consequent = deserializeExpression(pos + 24);
   node.alternate = deserializeExpression(pos + 40);
@@ -943,7 +946,7 @@ function deserializeAssignmentExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'AssignmentExpression',
       operator: deserializeAssignmentOperator(pos + 40),
       left: null,
@@ -951,7 +954,7 @@ function deserializeAssignmentExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.left = deserializeAssignmentTarget(pos + 8);
   node.right = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -1012,7 +1015,7 @@ function deserializeArrayAssignmentTarget(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ArrayPattern',
       decorators: null,
       elements: null,
@@ -1021,7 +1024,7 @@ function deserializeArrayAssignmentTarget(pos) {
       start,
       end,
       parent,
-    },
+    }),
     elements = deserializeVecOptionAssignmentTargetMaybeDefault(pos + 8),
     rest = deserializeOptionBoxAssignmentTargetRest(pos + 32);
   rest !== null && elements.push(rest);
@@ -1037,7 +1040,7 @@ function deserializeObjectAssignmentTarget(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ObjectPattern',
       decorators: null,
       properties: null,
@@ -1046,7 +1049,7 @@ function deserializeObjectAssignmentTarget(pos) {
       start,
       end,
       parent,
-    },
+    }),
     properties = deserializeVecAssignmentTargetProperty(pos + 8),
     rest = deserializeOptionBoxAssignmentTargetRest(pos + 32);
   rest !== null && properties.push(rest);
@@ -1062,7 +1065,7 @@ function deserializeAssignmentTargetRest(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'RestElement',
       decorators: null,
       argument: null,
@@ -1072,7 +1075,7 @@ function deserializeAssignmentTargetRest(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.decorators = [];
   node.argument = deserializeAssignmentTarget(pos + 8);
   node.optional = false;
@@ -1115,7 +1118,7 @@ function deserializeAssignmentTargetWithDefault(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'AssignmentPattern',
       decorators: null,
       left: null,
@@ -1125,7 +1128,7 @@ function deserializeAssignmentTargetWithDefault(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.decorators = [];
   node.left = deserializeAssignmentTarget(pos + 8);
   node.right = deserializeExpression(pos + 24);
@@ -1150,7 +1153,7 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Property',
       kind: null,
       key: null,
@@ -1162,12 +1165,13 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
       start,
       end,
       parent,
-    },
+    }),
     key = deserializeIdentifierReference(pos + 8),
     init = deserializeOptionExpression(pos + 40),
     value = { ...key };
   if (init !== null) {
-    let left = value, previousParent = parent;
+    let left = value,
+      previousParent = parent;
     value = parent = {
       type: 'AssignmentPattern',
       decorators: [],
@@ -1198,7 +1202,7 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Property',
       kind: null,
       key: null,
@@ -1210,7 +1214,7 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.kind = 'init';
   node.key = deserializePropertyKey(pos + 8);
   node.value = deserializeAssignmentTargetMaybeDefault(pos + 24);
@@ -1225,13 +1229,13 @@ function deserializeSequenceExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'SequenceExpression',
       expressions: null,
       start,
       end,
       parent,
-    };
+    });
   node.expressions = deserializeVecExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -1250,13 +1254,13 @@ function deserializeAwaitExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'AwaitExpression',
       argument: null,
       start,
       end,
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -1266,13 +1270,13 @@ function deserializeChainExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ChainExpression',
       expression: null,
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeChainElement(pos + 8);
   parent = previousParent;
   return node;
@@ -1387,21 +1391,22 @@ function deserializeDirective(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ExpressionStatement',
       expression: null,
       directive: deserializeStr(pos + 56),
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeStringLiteral(pos + 8);
   parent = previousParent;
   return node;
 }
 
 function deserializeHashbang(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Hashbang',
     value: deserializeStr(pos + 8),
@@ -1415,13 +1420,13 @@ function deserializeBlockStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'BlockStatement',
       body: null,
       start,
       end,
       parent,
-    };
+    });
   node.body = deserializeVecStatement(pos + 8);
   parent = previousParent;
   return node;
@@ -1454,7 +1459,7 @@ function deserializeVariableDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'VariableDeclaration',
       kind: deserializeVariableDeclarationKind(pos + 32),
       declarations: null,
@@ -1462,7 +1467,7 @@ function deserializeVariableDeclaration(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.declarations = deserializeVecVariableDeclarator(pos + 8);
   parent = previousParent;
   return node;
@@ -1489,7 +1494,7 @@ function deserializeVariableDeclarator(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'VariableDeclarator',
       id: null,
       init: null,
@@ -1497,7 +1502,7 @@ function deserializeVariableDeclarator(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.id = deserializeBindingPattern(pos + 8);
   node.init = deserializeOptionExpression(pos + 40);
   parent = previousParent;
@@ -1517,14 +1522,14 @@ function deserializeExpressionStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ExpressionStatement',
       expression: null,
       directive: null,
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   node.directive = null;
   parent = previousParent;
@@ -1535,7 +1540,7 @@ function deserializeIfStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'IfStatement',
       test: null,
       consequent: null,
@@ -1543,7 +1548,7 @@ function deserializeIfStatement(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.test = deserializeExpression(pos + 8);
   node.consequent = deserializeStatement(pos + 24);
   node.alternate = deserializeOptionStatement(pos + 40);
@@ -1555,14 +1560,14 @@ function deserializeDoWhileStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'DoWhileStatement',
       body: null,
       test: null,
       start,
       end,
       parent,
-    };
+    });
   node.body = deserializeStatement(pos + 8);
   node.test = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -1573,14 +1578,14 @@ function deserializeWhileStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'WhileStatement',
       test: null,
       body: null,
       start,
       end,
       parent,
-    };
+    });
   node.test = deserializeExpression(pos + 8);
   node.body = deserializeStatement(pos + 24);
   parent = previousParent;
@@ -1591,7 +1596,7 @@ function deserializeForStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ForStatement',
       init: null,
       test: null,
@@ -1600,7 +1605,7 @@ function deserializeForStatement(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.init = deserializeOptionForStatementInit(pos + 8);
   node.test = deserializeOptionExpression(pos + 24);
   node.update = deserializeOptionExpression(pos + 40);
@@ -1708,7 +1713,7 @@ function deserializeForInStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ForInStatement',
       left: null,
       right: null,
@@ -1716,7 +1721,7 @@ function deserializeForInStatement(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.left = deserializeForStatementLeft(pos + 8);
   node.right = deserializeExpression(pos + 24);
   node.body = deserializeStatement(pos + 40);
@@ -1757,7 +1762,7 @@ function deserializeForOfStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ForOfStatement',
       await: deserializeBool(pos + 60),
       left: null,
@@ -1766,7 +1771,7 @@ function deserializeForOfStatement(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.left = deserializeForStatementLeft(pos + 8);
   node.right = deserializeExpression(pos + 24);
   node.body = deserializeStatement(pos + 40);
@@ -1778,13 +1783,13 @@ function deserializeContinueStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ContinueStatement',
       label: null,
       start,
       end,
       parent,
-    };
+    });
   node.label = deserializeOptionLabelIdentifier(pos + 8);
   parent = previousParent;
   return node;
@@ -1794,13 +1799,13 @@ function deserializeBreakStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'BreakStatement',
       label: null,
       start,
       end,
       parent,
-    };
+    });
   node.label = deserializeOptionLabelIdentifier(pos + 8);
   parent = previousParent;
   return node;
@@ -1810,13 +1815,13 @@ function deserializeReturnStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ReturnStatement',
       argument: null,
       start,
       end,
       parent,
-    };
+    });
   node.argument = deserializeOptionExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -1826,14 +1831,14 @@ function deserializeWithStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'WithStatement',
       object: null,
       body: null,
       start,
       end,
       parent,
-    };
+    });
   node.object = deserializeExpression(pos + 8);
   node.body = deserializeStatement(pos + 24);
   parent = previousParent;
@@ -1844,14 +1849,14 @@ function deserializeSwitchStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'SwitchStatement',
       discriminant: null,
       cases: null,
       start,
       end,
       parent,
-    };
+    });
   node.discriminant = deserializeExpression(pos + 8);
   node.cases = deserializeVecSwitchCase(pos + 24);
   parent = previousParent;
@@ -1862,14 +1867,14 @@ function deserializeSwitchCase(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'SwitchCase',
       test: null,
       consequent: null,
       start,
       end,
       parent,
-    };
+    });
   node.test = deserializeOptionExpression(pos + 8);
   node.consequent = deserializeVecStatement(pos + 24);
   parent = previousParent;
@@ -1880,14 +1885,14 @@ function deserializeLabeledStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'LabeledStatement',
       label: null,
       body: null,
       start,
       end,
       parent,
-    };
+    });
   node.label = deserializeLabelIdentifier(pos + 8);
   node.body = deserializeStatement(pos + 32);
   parent = previousParent;
@@ -1898,13 +1903,13 @@ function deserializeThrowStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ThrowStatement',
       argument: null,
       start,
       end,
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -1914,7 +1919,7 @@ function deserializeTryStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TryStatement',
       block: null,
       handler: null,
@@ -1922,7 +1927,7 @@ function deserializeTryStatement(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.block = deserializeBoxBlockStatement(pos + 8);
   node.handler = deserializeOptionBoxCatchClause(pos + 16);
   node.finalizer = deserializeOptionBoxBlockStatement(pos + 24);
@@ -1934,14 +1939,14 @@ function deserializeCatchClause(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'CatchClause',
       param: null,
       body: null,
       start,
       end,
       parent,
-    };
+    });
   node.param = deserializeOptionCatchParameter(pos + 8);
   node.body = deserializeBoxBlockStatement(pos + 48);
   parent = previousParent;
@@ -1992,7 +1997,7 @@ function deserializeAssignmentPattern(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'AssignmentPattern',
       decorators: null,
       left: null,
@@ -2002,7 +2007,7 @@ function deserializeAssignmentPattern(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.decorators = [];
   node.left = deserializeBindingPattern(pos + 8);
   node.right = deserializeExpression(pos + 40);
@@ -2016,7 +2021,7 @@ function deserializeObjectPattern(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ObjectPattern',
       decorators: null,
       properties: null,
@@ -2025,7 +2030,7 @@ function deserializeObjectPattern(pos) {
       start,
       end,
       parent,
-    },
+    }),
     properties = deserializeVecBindingProperty(pos + 8),
     rest = deserializeOptionBoxBindingRestElement(pos + 32);
   rest !== null && properties.push(rest);
@@ -2041,7 +2046,7 @@ function deserializeBindingProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Property',
       kind: null,
       key: null,
@@ -2053,7 +2058,7 @@ function deserializeBindingProperty(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.kind = 'init';
   node.key = deserializePropertyKey(pos + 8);
   node.value = deserializeBindingPattern(pos + 24);
@@ -2067,7 +2072,7 @@ function deserializeArrayPattern(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ArrayPattern',
       decorators: null,
       elements: null,
@@ -2076,7 +2081,7 @@ function deserializeArrayPattern(pos) {
       start,
       end,
       parent,
-    },
+    }),
     elements = deserializeVecOptionBindingPattern(pos + 8),
     rest = deserializeOptionBoxBindingRestElement(pos + 32);
   rest !== null && elements.push(rest);
@@ -2092,7 +2097,7 @@ function deserializeBindingRestElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'RestElement',
       decorators: null,
       argument: null,
@@ -2102,7 +2107,7 @@ function deserializeBindingRestElement(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.decorators = [];
   node.argument = deserializeBindingPattern(pos + 8);
   node.optional = false;
@@ -2116,7 +2121,7 @@ function deserializeFunction(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: deserializeFunctionType(pos + 84),
       id: null,
       generator: deserializeBool(pos + 85),
@@ -2130,7 +2135,7 @@ function deserializeFunction(pos) {
       start,
       end,
       parent,
-    },
+    }),
     params = deserializeBoxFormalParameters(pos + 56);
   {
     let thisParam = deserializeOptionBoxTSThisParameter(pos + 48);
@@ -2163,10 +2168,10 @@ function deserializeFunctionType(pos) {
 
 function deserializeFormalParameters(pos) {
   let params = deserializeVecFormalParameter(pos + 8);
-  if (uint32[pos + 32 >> 2] !== 0 && uint32[pos + 36 >> 2] !== 0) {
-    pos = uint32[pos + 32 >> 2];
+  if (uint32[(pos + 32) >> 2] !== 0 && uint32[(pos + 36) >> 2] !== 0) {
+    pos = uint32[(pos + 32) >> 2];
     let previousParent = parent,
-      rest = parent = {
+      rest = (parent = {
         type: 'RestElement',
         decorators: [],
         argument: null,
@@ -2176,7 +2181,7 @@ function deserializeFormalParameters(pos) {
         start: deserializeU32(pos),
         end: deserializeU32(pos + 4),
         parent,
-      };
+      });
     rest.argument = deserializeBindingPatternKind(pos + 8);
     rest.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
     params.push(rest);
@@ -2222,13 +2227,13 @@ function deserializeFunctionBody(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'BlockStatement',
       body: null,
       start,
       end,
       parent,
-    },
+    }),
     body = deserializeVecDirective(pos + 8);
   body.push(...deserializeVecStatement(pos + 32));
   node.body = body;
@@ -2241,7 +2246,7 @@ function deserializeArrowFunctionExpression(pos) {
     start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ArrowFunctionExpression',
       expression,
       async: deserializeBool(pos + 45),
@@ -2254,7 +2259,7 @@ function deserializeArrowFunctionExpression(pos) {
       start,
       end,
       parent,
-    },
+    }),
     body = deserializeBoxFunctionBody(pos + 32);
   if (expression === true) {
     body = body.body[0].expression;
@@ -2274,14 +2279,14 @@ function deserializeYieldExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'YieldExpression',
       delegate: deserializeBool(pos + 24),
       argument: null,
       start,
       end,
       parent,
-    };
+    });
   node.argument = deserializeOptionExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -2291,7 +2296,7 @@ function deserializeClass(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: deserializeClassType(pos + 132),
       decorators: null,
       id: null,
@@ -2305,7 +2310,7 @@ function deserializeClass(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.decorators = deserializeVecDecorator(pos + 8);
   node.id = deserializeOptionBindingIdentifier(pos + 32);
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 64);
@@ -2332,13 +2337,13 @@ function deserializeClassBody(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ClassBody',
       body: null,
       start,
       end,
       parent,
-    };
+    });
   node.body = deserializeVecClassElement(pos + 8);
   parent = previousParent;
   return node;
@@ -2365,7 +2370,7 @@ function deserializeMethodDefinition(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: deserializeMethodDefinitionType(pos + 56),
       decorators: null,
       key: null,
@@ -2379,7 +2384,7 @@ function deserializeMethodDefinition(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.decorators = deserializeVecDecorator(pos + 8);
   node.key = deserializePropertyKey(pos + 32);
   node.value = deserializeBoxFunction(pos + 48);
@@ -2402,7 +2407,7 @@ function deserializePropertyDefinition(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: deserializePropertyDefinitionType(pos + 72),
       decorators: null,
       key: null,
@@ -2419,7 +2424,7 @@ function deserializePropertyDefinition(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.decorators = deserializeVecDecorator(pos + 8);
   node.key = deserializePropertyKey(pos + 32);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 48);
@@ -2455,7 +2460,8 @@ function deserializeMethodDefinitionKind(pos) {
 }
 
 function deserializePrivateIdentifier(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'PrivateIdentifier',
     name: deserializeStr(pos + 8),
@@ -2469,13 +2475,13 @@ function deserializeStaticBlock(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'StaticBlock',
       body: null,
       start,
       end,
       parent,
-    };
+    });
   node.body = deserializeVecStatement(pos + 8);
   parent = previousParent;
   return node;
@@ -2496,7 +2502,7 @@ function deserializeAccessorProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: deserializeAccessorPropertyType(pos + 72),
       decorators: null,
       key: null,
@@ -2513,7 +2519,7 @@ function deserializeAccessorProperty(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.decorators = deserializeVecDecorator(pos + 8);
   node.key = deserializePropertyKey(pos + 32);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 48);
@@ -2529,7 +2535,7 @@ function deserializeImportExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ImportExpression',
       source: null,
       options: null,
@@ -2537,7 +2543,7 @@ function deserializeImportExpression(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.source = deserializeExpression(pos + 8);
   node.options = deserializeOptionExpression(pos + 24);
   parent = previousParent;
@@ -2548,7 +2554,7 @@ function deserializeImportDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ImportDeclaration',
       specifiers: null,
       source: null,
@@ -2558,7 +2564,7 @@ function deserializeImportDeclaration(pos) {
       start,
       end,
       parent,
-    },
+    }),
     specifiers = deserializeOptionVecImportDeclarationSpecifier(pos + 8);
   specifiers === null && (specifiers = []);
   let withClause = deserializeOptionBoxWithClause(pos + 80);
@@ -2597,7 +2603,7 @@ function deserializeImportSpecifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ImportSpecifier',
       imported: null,
       local: null,
@@ -2605,7 +2611,7 @@ function deserializeImportSpecifier(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.imported = deserializeModuleExportName(pos + 8);
   node.local = deserializeBindingIdentifier(pos + 64);
   parent = previousParent;
@@ -2616,13 +2622,13 @@ function deserializeImportDefaultSpecifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ImportDefaultSpecifier',
       local: null,
       start,
       end,
       parent,
-    };
+    });
   node.local = deserializeBindingIdentifier(pos + 8);
   parent = previousParent;
   return node;
@@ -2632,13 +2638,13 @@ function deserializeImportNamespaceSpecifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ImportNamespaceSpecifier',
       local: null,
       start,
       end,
       parent,
-    };
+    });
   node.local = deserializeBindingIdentifier(pos + 8);
   parent = previousParent;
   return node;
@@ -2652,14 +2658,14 @@ function deserializeImportAttribute(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ImportAttribute',
       key: null,
       value: null,
       start,
       end,
       parent,
-    };
+    });
   node.key = deserializeImportAttributeKey(pos + 8);
   node.value = deserializeStringLiteral(pos + 64);
   parent = previousParent;
@@ -2681,7 +2687,7 @@ function deserializeExportNamedDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ExportNamedDeclaration',
       declaration: null,
       specifiers: null,
@@ -2691,7 +2697,7 @@ function deserializeExportNamedDeclaration(pos) {
       start,
       end,
       parent,
-    },
+    }),
     withClause = deserializeOptionBoxWithClause(pos + 96);
   node.declaration = deserializeOptionDeclaration(pos + 8);
   node.specifiers = deserializeVecExportSpecifier(pos + 24);
@@ -2705,14 +2711,14 @@ function deserializeExportDefaultDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ExportDefaultDeclaration',
       declaration: null,
       exportKind: null,
       start,
       end,
       parent,
-    };
+    });
   node.declaration = deserializeExportDefaultDeclarationKind(pos + 8);
   node.exportKind = 'value';
   parent = previousParent;
@@ -2723,7 +2729,7 @@ function deserializeExportAllDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ExportAllDeclaration',
       exported: null,
       source: null,
@@ -2732,7 +2738,7 @@ function deserializeExportAllDeclaration(pos) {
       start,
       end,
       parent,
-    },
+    }),
     withClause = deserializeOptionBoxWithClause(pos + 112);
   node.exported = deserializeOptionModuleExportName(pos + 8);
   node.source = deserializeStringLiteral(pos + 64);
@@ -2745,7 +2751,7 @@ function deserializeExportSpecifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ExportSpecifier',
       local: null,
       exported: null,
@@ -2753,7 +2759,7 @@ function deserializeExportSpecifier(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.local = deserializeModuleExportName(pos + 8);
   node.exported = deserializeModuleExportName(pos + 64);
   parent = previousParent;
@@ -2876,14 +2882,14 @@ function deserializeV8IntrinsicExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'V8IntrinsicExpression',
       name: null,
       arguments: null,
       start,
       end,
       parent,
-    };
+    });
   node.name = deserializeIdentifierName(pos + 8);
   node.arguments = deserializeVecArgument(pos + 32);
   parent = previousParent;
@@ -2895,14 +2901,14 @@ function deserializeBooleanLiteral(pos) {
     start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Literal',
       value,
       raw: null,
       start,
       end,
       parent,
-    };
+    });
   node.raw = start === 0 && end === 0 ? null : value + '';
   parent = previousParent;
   return node;
@@ -2912,14 +2918,14 @@ function deserializeNullLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Literal',
       value: null,
       raw: null,
       start,
       end,
       parent,
-    };
+    });
   node.value = null;
   node.raw = start === 0 && end === 0 ? null : 'null';
   parent = previousParent;
@@ -2927,7 +2933,8 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Literal',
     value: deserializeF64(pos + 8),
@@ -2942,14 +2949,14 @@ function deserializeStringLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Literal',
       value: null,
       raw: deserializeOptionStr(pos + 24),
       start,
       end,
       parent,
-    },
+    }),
     value = deserializeStr(pos + 8);
   deserializeBool(pos + 40) &&
     (value = value.replace(/\uFFFD(.{4})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16))));
@@ -2962,7 +2969,7 @@ function deserializeBigIntLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Literal',
       value: null,
       raw: deserializeOptionStr(pos + 24),
@@ -2970,7 +2977,7 @@ function deserializeBigIntLiteral(pos) {
       start,
       end,
       parent,
-    },
+    }),
     bigint = deserializeStr(pos + 8);
   node.value = BigInt(bigint);
   node.bigint = bigint;
@@ -2982,7 +2989,7 @@ function deserializeRegExpLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Literal',
       value: null,
       raw: deserializeOptionStr(pos + 40),
@@ -2990,7 +2997,7 @@ function deserializeRegExpLiteral(pos) {
       start,
       end,
       parent,
-    },
+    }),
     regex = deserializeRegExp(pos + 8),
     value = null;
   try {
@@ -3010,7 +3017,8 @@ function deserializeRegExp(pos) {
 }
 
 function deserializeRegExpFlags(pos) {
-  let flagBits = deserializeU8(pos), flags = '';
+  let flagBits = deserializeU8(pos),
+    flags = '';
   // Alphabetical order
   flagBits & 64 && (flags += 'd');
   flagBits & 1 && (flags += 'g');
@@ -3027,7 +3035,7 @@ function deserializeJSXElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXElement',
       openingElement: null,
       children: null,
@@ -3035,7 +3043,7 @@ function deserializeJSXElement(pos) {
       start,
       end,
       parent,
-    },
+    }),
     closingElement = deserializeOptionBoxJSXClosingElement(pos + 40),
     openingElement = deserializeBoxJSXOpeningElement(pos + 8);
   closingElement === null && (openingElement.selfClosing = true);
@@ -3050,7 +3058,7 @@ function deserializeJSXOpeningElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXOpeningElement',
       name: null,
       typeArguments: null,
@@ -3059,7 +3067,7 @@ function deserializeJSXOpeningElement(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.name = deserializeJSXElementName(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   node.attributes = deserializeVecJSXAttributeItem(pos + 32);
@@ -3072,13 +3080,13 @@ function deserializeJSXClosingElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXClosingElement',
       name: null,
       start,
       end,
       parent,
-    };
+    });
   node.name = deserializeJSXElementName(pos + 8);
   parent = previousParent;
   return node;
@@ -3088,7 +3096,7 @@ function deserializeJSXFragment(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXFragment',
       openingFragment: null,
       children: null,
@@ -3096,7 +3104,7 @@ function deserializeJSXFragment(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.openingFragment = deserializeJSXOpeningFragment(pos + 8);
   node.children = deserializeVecJSXChild(pos + 16);
   node.closingFragment = deserializeJSXClosingFragment(pos + 40);
@@ -3108,12 +3116,12 @@ function deserializeJSXOpeningFragment(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXOpeningFragment',
       start,
       end,
       parent,
-    };
+    });
   parent = previousParent;
   return node;
 }
@@ -3162,14 +3170,14 @@ function deserializeJSXNamespacedName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXNamespacedName',
       namespace: null,
       name: null,
       start,
       end,
       parent,
-    };
+    });
   node.namespace = deserializeJSXIdentifier(pos + 8);
   node.name = deserializeJSXIdentifier(pos + 32);
   parent = previousParent;
@@ -3180,14 +3188,14 @@ function deserializeJSXMemberExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXMemberExpression',
       object: null,
       property: null,
       start,
       end,
       parent,
-    };
+    });
   node.object = deserializeJSXMemberExpressionObject(pos + 8);
   node.property = deserializeJSXIdentifier(pos + 24);
   parent = previousParent;
@@ -3225,13 +3233,13 @@ function deserializeJSXExpressionContainer(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXExpressionContainer',
       expression: null,
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeJSXExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -3356,14 +3364,14 @@ function deserializeJSXAttribute(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXAttribute',
       name: null,
       value: null,
       start,
       end,
       parent,
-    };
+    });
   node.name = deserializeJSXAttributeName(pos + 8);
   node.value = deserializeOptionJSXAttributeValue(pos + 24);
   parent = previousParent;
@@ -3374,13 +3382,13 @@ function deserializeJSXSpreadAttribute(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXSpreadAttribute',
       argument: null,
       start,
       end,
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -3413,7 +3421,8 @@ function deserializeJSXAttributeValue(pos) {
 }
 
 function deserializeJSXIdentifier(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXIdentifier',
     name: deserializeStr(pos + 8),
@@ -3444,20 +3453,21 @@ function deserializeJSXSpreadChild(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXSpreadChild',
       expression: null,
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
 }
 
 function deserializeJSXText(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXText',
     value: deserializeStr(pos + 8),
@@ -3472,7 +3482,7 @@ function deserializeTSThisParameter(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Identifier',
       decorators: null,
       name: null,
@@ -3481,7 +3491,7 @@ function deserializeTSThisParameter(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.decorators = [];
   node.name = 'this';
   node.optional = false;
@@ -3494,7 +3504,7 @@ function deserializeTSEnumDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSEnumDeclaration',
       id: null,
       body: null,
@@ -3503,7 +3513,7 @@ function deserializeTSEnumDeclaration(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.id = deserializeBindingIdentifier(pos + 8);
   node.body = deserializeTSEnumBody(pos + 40);
   parent = previousParent;
@@ -3514,13 +3524,13 @@ function deserializeTSEnumBody(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSEnumBody',
       members: null,
       start,
       end,
       parent,
-    };
+    });
   node.members = deserializeVecTSEnumMember(pos + 8);
   parent = previousParent;
   return node;
@@ -3530,7 +3540,7 @@ function deserializeTSEnumMember(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSEnumMember',
       id: null,
       initializer: null,
@@ -3538,7 +3548,7 @@ function deserializeTSEnumMember(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.id = deserializeTSEnumMemberName(pos + 8);
   node.initializer = deserializeOptionExpression(pos + 24);
   node.computed = deserializeU8(pos + 8) > 1;
@@ -3565,13 +3575,13 @@ function deserializeTSTypeAnnotation(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeAnnotation',
       typeAnnotation: null,
       start,
       end,
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3581,13 +3591,13 @@ function deserializeTSLiteralType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSLiteralType',
       literal: null,
       start,
       end,
       parent,
-    };
+    });
   node.literal = deserializeTSLiteral(pos + 8);
   parent = previousParent;
   return node;
@@ -3697,7 +3707,7 @@ function deserializeTSConditionalType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSConditionalType',
       checkType: null,
       extendsType: null,
@@ -3706,7 +3716,7 @@ function deserializeTSConditionalType(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.checkType = deserializeTSType(pos + 8);
   node.extendsType = deserializeTSType(pos + 24);
   node.trueType = deserializeTSType(pos + 40);
@@ -3719,13 +3729,13 @@ function deserializeTSUnionType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSUnionType',
       types: null,
       start,
       end,
       parent,
-    };
+    });
   node.types = deserializeVecTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3735,13 +3745,13 @@ function deserializeTSIntersectionType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSIntersectionType',
       types: null,
       start,
       end,
       parent,
-    };
+    });
   node.types = deserializeVecTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3768,14 +3778,14 @@ function deserializeTSTypeOperator(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeOperator',
       operator: deserializeTSTypeOperatorOperator(pos + 24),
       typeAnnotation: null,
       start,
       end,
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3798,13 +3808,13 @@ function deserializeTSArrayType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSArrayType',
       elementType: null,
       start,
       end,
       parent,
-    };
+    });
   node.elementType = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3814,14 +3824,14 @@ function deserializeTSIndexedAccessType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSIndexedAccessType',
       objectType: null,
       indexType: null,
       start,
       end,
       parent,
-    };
+    });
   node.objectType = deserializeTSType(pos + 8);
   node.indexType = deserializeTSType(pos + 24);
   parent = previousParent;
@@ -3832,13 +3842,13 @@ function deserializeTSTupleType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTupleType',
       elementTypes: null,
       start,
       end,
       parent,
-    };
+    });
   node.elementTypes = deserializeVecTSTupleElement(pos + 8);
   parent = previousParent;
   return node;
@@ -3848,7 +3858,7 @@ function deserializeTSNamedTupleMember(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSNamedTupleMember',
       label: null,
       elementType: null,
@@ -3856,7 +3866,7 @@ function deserializeTSNamedTupleMember(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.label = deserializeIdentifierName(pos + 8);
   node.elementType = deserializeTSTupleElement(pos + 32);
   parent = previousParent;
@@ -3867,13 +3877,13 @@ function deserializeTSOptionalType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSOptionalType',
       typeAnnotation: null,
       start,
       end,
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3883,13 +3893,13 @@ function deserializeTSRestType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSRestType',
       typeAnnotation: null,
       start,
       end,
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -4110,14 +4120,14 @@ function deserializeTSTypeReference(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeReference',
       typeName: null,
       typeArguments: null,
       start,
       end,
       parent,
-    };
+    });
   node.typeName = deserializeTSTypeName(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   parent = previousParent;
@@ -4141,14 +4151,14 @@ function deserializeTSQualifiedName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSQualifiedName',
       left: null,
       right: null,
       start,
       end,
       parent,
-    };
+    });
   node.left = deserializeTSTypeName(pos + 8);
   node.right = deserializeIdentifierName(pos + 24);
   parent = previousParent;
@@ -4159,13 +4169,13 @@ function deserializeTSTypeParameterInstantiation(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeParameterInstantiation',
       params: null,
       start,
       end,
       parent,
-    };
+    });
   node.params = deserializeVecTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -4175,7 +4185,7 @@ function deserializeTSTypeParameter(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeParameter',
       name: null,
       constraint: null,
@@ -4186,7 +4196,7 @@ function deserializeTSTypeParameter(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.name = deserializeBindingIdentifier(pos + 8);
   node.constraint = deserializeOptionTSType(pos + 40);
   node.default = deserializeOptionTSType(pos + 56);
@@ -4198,13 +4208,13 @@ function deserializeTSTypeParameterDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeParameterDeclaration',
       params: null,
       start,
       end,
       parent,
-    };
+    });
   node.params = deserializeVecTSTypeParameter(pos + 8);
   parent = previousParent;
   return node;
@@ -4214,7 +4224,7 @@ function deserializeTSTypeAliasDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeAliasDeclaration',
       id: null,
       typeParameters: null,
@@ -4223,7 +4233,7 @@ function deserializeTSTypeAliasDeclaration(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.id = deserializeBindingIdentifier(pos + 8);
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 40);
   node.typeAnnotation = deserializeTSType(pos + 48);
@@ -4248,19 +4258,19 @@ function deserializeTSClassImplements(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSClassImplements',
       expression: null,
       typeArguments: null,
       start,
       end,
       parent,
-    },
+    }),
     expression = deserializeTSTypeName(pos + 8);
   if (expression.type === 'TSQualifiedName') {
     let object = expression.left,
       { right } = expression,
-      previous = expression = {
+      previous = (expression = {
         type: 'MemberExpression',
         object,
         property: right,
@@ -4269,7 +4279,7 @@ function deserializeTSClassImplements(pos) {
         start: expression.start,
         end: expression.end,
         parent,
-      };
+      });
     right.parent = previous;
     for (;;) {
       if (object.type !== 'TSQualifiedName') {
@@ -4301,7 +4311,7 @@ function deserializeTSInterfaceDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSInterfaceDeclaration',
       id: null,
       typeParameters: null,
@@ -4311,7 +4321,7 @@ function deserializeTSInterfaceDeclaration(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.id = deserializeBindingIdentifier(pos + 8);
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 40);
   node.extends = deserializeVecTSInterfaceHeritage(pos + 48);
@@ -4324,13 +4334,13 @@ function deserializeTSInterfaceBody(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSInterfaceBody',
       body: null,
       start,
       end,
       parent,
-    };
+    });
   node.body = deserializeVecTSSignature(pos + 8);
   parent = previousParent;
   return node;
@@ -4340,7 +4350,7 @@ function deserializeTSPropertySignature(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSPropertySignature',
       computed: deserializeBool(pos + 32),
       optional: deserializeBool(pos + 33),
@@ -4352,7 +4362,7 @@ function deserializeTSPropertySignature(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.key = deserializePropertyKey(pos + 8);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   node.accessibility = null;
@@ -4382,7 +4392,7 @@ function deserializeTSIndexSignature(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSIndexSignature',
       parameters: null,
       typeAnnotation: null,
@@ -4392,7 +4402,7 @@ function deserializeTSIndexSignature(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.parameters = deserializeVecTSIndexSignatureName(pos + 8);
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
   node.accessibility = null;
@@ -4404,7 +4414,7 @@ function deserializeTSCallSignatureDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSCallSignatureDeclaration',
       typeParameters: null,
       params: null,
@@ -4412,7 +4422,7 @@ function deserializeTSCallSignatureDeclaration(pos) {
       start,
       end,
       parent,
-    },
+    }),
     params = deserializeBoxFormalParameters(pos + 24),
     thisParam = deserializeOptionBoxTSThisParameter(pos + 16);
   thisParam !== null && params.unshift(thisParam);
@@ -4440,7 +4450,7 @@ function deserializeTSMethodSignature(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSMethodSignature',
       key: null,
       computed: deserializeBool(pos + 60),
@@ -4455,7 +4465,7 @@ function deserializeTSMethodSignature(pos) {
       start,
       end,
       parent,
-    },
+    }),
     params = deserializeBoxFormalParameters(pos + 40),
     thisParam = deserializeOptionBoxTSThisParameter(pos + 32);
   thisParam !== null && params.unshift(thisParam);
@@ -4474,7 +4484,7 @@ function deserializeTSConstructSignatureDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSConstructSignatureDeclaration',
       typeParameters: null,
       params: null,
@@ -4482,7 +4492,7 @@ function deserializeTSConstructSignatureDeclaration(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 8);
   node.params = deserializeBoxFormalParameters(pos + 16);
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 24);
@@ -4494,7 +4504,7 @@ function deserializeTSIndexSignatureName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Identifier',
       decorators: null,
       name: deserializeStr(pos + 8),
@@ -4503,7 +4513,7 @@ function deserializeTSIndexSignatureName(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.decorators = [];
   node.optional = false;
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 24);
@@ -4515,14 +4525,14 @@ function deserializeTSInterfaceHeritage(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSInterfaceHeritage',
       expression: null,
       typeArguments: null,
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   parent = previousParent;
@@ -4533,7 +4543,7 @@ function deserializeTSTypePredicate(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypePredicate',
       parameterName: null,
       asserts: deserializeBool(pos + 32),
@@ -4541,7 +4551,7 @@ function deserializeTSTypePredicate(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.parameterName = deserializeTSTypePredicateName(pos + 8);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   parent = previousParent;
@@ -4598,7 +4608,7 @@ function deserializeTSModuleDeclaration(pos) {
       body.parent = node;
     } else {
       let innerId = body.id;
-      if (innerId.type === 'Identifier') {
+      if (innerId.type === 'Identifier')
         id.parent =
           innerId.parent =
           node.id =
@@ -4611,7 +4621,7 @@ function deserializeTSModuleDeclaration(pos) {
               end: innerId.end,
               parent: node,
             };
-      } else {
+      else {
         // Replace `left` of innermost `TSQualifiedName` with a nested `TSQualifiedName` with `id` of
         // this module on left, and previous `left` of innermost `TSQualifiedName` on right
         node.id = innerId;
@@ -4623,14 +4633,17 @@ function deserializeTSModuleDeclaration(pos) {
           innerId = innerId.left;
         }
         let right = innerId.left;
-        id.parent = right.parent = innerId.left = {
-          type: 'TSQualifiedName',
-          left: id,
-          right,
-          start,
-          end: right.end,
-          parent: innerId,
-        };
+        id.parent =
+          right.parent =
+          innerId.left =
+            {
+              type: 'TSQualifiedName',
+              left: id,
+              right,
+              start,
+              end: right.end,
+              parent: innerId,
+            };
       }
       if (Object.hasOwn(body, 'body')) {
         body = body.body;
@@ -4682,13 +4695,13 @@ function deserializeTSModuleBlock(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSModuleBlock',
       body: null,
       start,
       end,
       parent,
-    },
+    }),
     body = deserializeVecDirective(pos + 8);
   body.push(...deserializeVecStatement(pos + 32));
   node.body = body;
@@ -4700,13 +4713,13 @@ function deserializeTSTypeLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeLiteral',
       members: null,
       start,
       end,
       parent,
-    };
+    });
   node.members = deserializeVecTSSignature(pos + 8);
   parent = previousParent;
   return node;
@@ -4716,13 +4729,13 @@ function deserializeTSInferType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSInferType',
       typeParameter: null,
       start,
       end,
       parent,
-    };
+    });
   node.typeParameter = deserializeBoxTSTypeParameter(pos + 8);
   parent = previousParent;
   return node;
@@ -4732,14 +4745,14 @@ function deserializeTSTypeQuery(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeQuery',
       exprName: null,
       typeArguments: null,
       start,
       end,
       parent,
-    };
+    });
   node.exprName = deserializeTSTypeQueryExprName(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   parent = previousParent;
@@ -4765,7 +4778,7 @@ function deserializeTSImportType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSImportType',
       argument: null,
       options: null,
@@ -4774,7 +4787,7 @@ function deserializeTSImportType(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.argument = deserializeTSType(pos + 8);
   node.options = deserializeOptionBoxObjectExpression(pos + 24);
   node.qualifier = deserializeOptionTSImportTypeQualifier(pos + 32);
@@ -4798,14 +4811,14 @@ function deserializeTSImportTypeQualifiedName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSQualifiedName',
       left: null,
       right: null,
       start,
       end,
       parent,
-    };
+    });
   node.left = deserializeTSImportTypeQualifier(pos + 8);
   node.right = deserializeIdentifierName(pos + 24);
   parent = previousParent;
@@ -4816,7 +4829,7 @@ function deserializeTSFunctionType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSFunctionType',
       typeParameters: null,
       params: null,
@@ -4824,7 +4837,7 @@ function deserializeTSFunctionType(pos) {
       start,
       end,
       parent,
-    },
+    }),
     params = deserializeBoxFormalParameters(pos + 24),
     thisParam = deserializeOptionBoxTSThisParameter(pos + 16);
   thisParam !== null && params.unshift(thisParam);
@@ -4839,7 +4852,7 @@ function deserializeTSConstructorType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSConstructorType',
       abstract: deserializeBool(pos + 36),
       typeParameters: null,
@@ -4848,7 +4861,7 @@ function deserializeTSConstructorType(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 8);
   node.params = deserializeBoxFormalParameters(pos + 16);
   node.returnType = deserializeBoxTSTypeAnnotation(pos + 24);
@@ -4860,7 +4873,7 @@ function deserializeTSMappedType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSMappedType',
       key: null,
       constraint: null,
@@ -4871,7 +4884,7 @@ function deserializeTSMappedType(pos) {
       start,
       end,
       parent,
-    },
+    }),
     typeParameter = deserializeBoxTSTypeParameter(pos + 8),
     key = typeParameter.name;
   key.parent = parent;
@@ -4905,14 +4918,14 @@ function deserializeTSTemplateLiteralType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTemplateLiteralType',
       quasis: null,
       types: null,
       start,
       end,
       parent,
-    };
+    });
   node.quasis = deserializeVecTemplateElement(pos + 8);
   node.types = deserializeVecTSType(pos + 32);
   parent = previousParent;
@@ -4923,14 +4936,14 @@ function deserializeTSAsExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSAsExpression',
       expression: null,
       typeAnnotation: null,
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   node.typeAnnotation = deserializeTSType(pos + 24);
   parent = previousParent;
@@ -4941,14 +4954,14 @@ function deserializeTSSatisfiesExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSSatisfiesExpression',
       expression: null,
       typeAnnotation: null,
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   node.typeAnnotation = deserializeTSType(pos + 24);
   parent = previousParent;
@@ -4959,14 +4972,14 @@ function deserializeTSTypeAssertion(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeAssertion',
       typeAnnotation: null,
       expression: null,
       start,
       end,
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   node.expression = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -4977,7 +4990,7 @@ function deserializeTSImportEqualsDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSImportEqualsDeclaration',
       id: null,
       moduleReference: null,
@@ -4985,7 +4998,7 @@ function deserializeTSImportEqualsDeclaration(pos) {
       start,
       end,
       parent,
-    };
+    });
   node.id = deserializeBindingIdentifier(pos + 8);
   node.moduleReference = deserializeTSModuleReference(pos + 40);
   parent = previousParent;
@@ -5011,13 +5024,13 @@ function deserializeTSExternalModuleReference(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSExternalModuleReference',
       expression: null,
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeStringLiteral(pos + 8);
   parent = previousParent;
   return node;
@@ -5027,13 +5040,13 @@ function deserializeTSNonNullExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSNonNullExpression',
       expression: null,
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -5043,13 +5056,13 @@ function deserializeDecorator(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Decorator',
       expression: null,
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -5059,13 +5072,13 @@ function deserializeTSExportAssignment(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSExportAssignment',
       expression: null,
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -5075,13 +5088,13 @@ function deserializeTSNamespaceExportDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSNamespaceExportDeclaration',
       id: null,
       start,
       end,
       parent,
-    };
+    });
   node.id = deserializeIdentifierName(pos + 8);
   parent = previousParent;
   return node;
@@ -5091,14 +5104,14 @@ function deserializeTSInstantiationExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSInstantiationExpression',
       expression: null,
       typeArguments: null,
       start,
       end,
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   node.typeArguments = deserializeBoxTSTypeParameterInstantiation(pos + 24);
   parent = previousParent;
@@ -5120,14 +5133,14 @@ function deserializeJSDocNullableType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSJSDocNullableType',
       typeAnnotation: null,
       postfix: deserializeBool(pos + 24),
       start,
       end,
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -5137,14 +5150,14 @@ function deserializeJSDocNonNullableType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSJSDocNonNullableType',
       typeAnnotation: null,
       postfix: deserializeBool(pos + 24),
       start,
       end,
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -5171,7 +5184,9 @@ function deserializeCommentKind(pos) {
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12), start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let type = deserializeCommentKind(pos + 12),
+    start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type,
     value: sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2)),
@@ -5181,7 +5196,8 @@ function deserializeComment(pos) {
 }
 
 function deserializeNameSpan(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     value: deserializeStr(pos + 8),
     start,
@@ -5228,7 +5244,8 @@ function deserializeImportImportName(pos) {
 }
 
 function deserializeExportEntry(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
@@ -5337,7 +5354,8 @@ function deserializeExportLocalName(pos) {
 }
 
 function deserializeDynamicImport(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeSpan(pos + 8),
     start,
@@ -5531,7 +5549,8 @@ function deserializeErrorSeverity(pos) {
 }
 
 function deserializeErrorLabel(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     message: deserializeOptionStr(pos + 8),
     start,
@@ -5550,7 +5569,8 @@ function deserializeEcmaScriptModule(pos) {
 }
 
 function deserializeStaticImport(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeNameSpan(pos + 8),
     entries: deserializeVecImportEntry(pos + 32),
@@ -5560,7 +5580,8 @@ function deserializeStaticImport(pos) {
 }
 
 function deserializeStaticExport(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     entries: deserializeVecExportEntry(pos + 8),
     start,
@@ -5577,7 +5598,8 @@ function deserializeU8(pos) {
 }
 
 function deserializeStr(pos) {
-  let pos32 = pos >> 2, len = uint32[pos32 + 2];
+  let pos32 = pos >> 2,
+    len = uint32[pos32 + 2];
   if (len === 0) return '';
   pos = uint32[pos32];
   if (sourceIsAscii && pos < sourceByteLen) return sourceText.substr(pos, len);
@@ -5586,7 +5608,8 @@ function deserializeStr(pos) {
   let end = pos + len;
   if (len > 50) return decodeStr(uint8.subarray(pos, end));
   // Shorter strings decode by hand to avoid native call
-  let out = '', c;
+  let out = '',
+    c;
   do {
     c = uint8[pos++];
     if (c < 128) out += fromCodePoint(c);
@@ -5599,10 +5622,11 @@ function deserializeStr(pos) {
 }
 
 function deserializeVecComment(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeComment(pos));
     pos += 16;
   }
@@ -5610,15 +5634,16 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeHashbang(pos);
 }
 
 function deserializeVecDirective(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 72;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDirective(pos));
     pos += 72;
   }
@@ -5626,10 +5651,11 @@ function deserializeVecDirective(pos) {
 }
 
 function deserializeVecStatement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStatement(pos));
     pos += 16;
   }
@@ -5797,10 +5823,11 @@ function deserializeBoxV8IntrinsicExpression(pos) {
 }
 
 function deserializeVecArrayExpressionElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeArrayExpressionElement(pos));
     pos += 16;
   }
@@ -5812,10 +5839,11 @@ function deserializeBoxSpreadElement(pos) {
 }
 
 function deserializeVecObjectPropertyKind(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeObjectPropertyKind(pos));
     pos += 16;
   }
@@ -5839,10 +5867,11 @@ function deserializeBoxPrivateIdentifier(pos) {
 }
 
 function deserializeVecTemplateElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 48;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTemplateElement(pos));
     pos += 48;
   }
@@ -5850,10 +5879,11 @@ function deserializeVecTemplateElement(pos) {
 }
 
 function deserializeVecExpression(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExpression(pos));
     pos += 16;
   }
@@ -5865,12 +5895,12 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeStr(pos);
 }
 
@@ -5887,10 +5917,11 @@ function deserializeBoxPrivateFieldExpression(pos) {
 }
 
 function deserializeVecArgument(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeArgument(pos));
     pos += 16;
   }
@@ -5911,10 +5942,11 @@ function deserializeOptionAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeOptionAssignmentTargetMaybeDefault(pos));
     pos += 16;
   }
@@ -5926,15 +5958,16 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxAssignmentTargetRest(pos);
 }
 
 function deserializeVecAssignmentTargetProperty(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeAssignmentTargetProperty(pos));
     pos += 16;
   }
@@ -6055,10 +6088,11 @@ function deserializeBoxTSImportEqualsDeclaration(pos) {
 }
 
 function deserializeVecVariableDeclarator(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 64;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeVariableDeclarator(pos));
     pos += 64;
   }
@@ -6076,15 +6110,16 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeLabelIdentifier(pos);
 }
 
 function deserializeVecSwitchCase(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 48;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeSwitchCase(pos));
     pos += 48;
   }
@@ -6096,12 +6131,12 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxBlockStatement(pos);
 }
 
@@ -6115,7 +6150,7 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeAnnotation(pos);
 }
 
@@ -6136,10 +6171,11 @@ function deserializeBoxAssignmentPattern(pos) {
 }
 
 function deserializeVecBindingProperty(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 64;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeBindingProperty(pos));
     pos += 64;
   }
@@ -6151,7 +6187,7 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxBindingRestElement(pos);
 }
 
@@ -6161,10 +6197,11 @@ function deserializeOptionBindingPattern(pos) {
 }
 
 function deserializeVecOptionBindingPattern(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeOptionBindingPattern(pos));
     pos += 32;
   }
@@ -6172,7 +6209,7 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeBindingIdentifier(pos);
 }
 
@@ -6181,7 +6218,7 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
@@ -6190,7 +6227,7 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSThisParameter(pos);
 }
 
@@ -6203,15 +6240,16 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxFunctionBody(pos);
 }
 
 function deserializeVecFormalParameter(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 72;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeFormalParameter(pos));
     pos += 72;
   }
@@ -6219,10 +6257,11 @@ function deserializeVecFormalParameter(pos) {
 }
 
 function deserializeVecDecorator(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 24;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDecorator(pos));
     pos += 24;
   }
@@ -6235,10 +6274,11 @@ function deserializeOptionTSAccessibility(pos) {
 }
 
 function deserializeVecTSClassImplements(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSClassImplements(pos));
     pos += 32;
   }
@@ -6250,10 +6290,11 @@ function deserializeBoxClassBody(pos) {
 }
 
 function deserializeVecClassElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeClassElement(pos));
     pos += 16;
   }
@@ -6310,10 +6351,11 @@ function deserializeOptionImportPhase(pos) {
 }
 
 function deserializeVecImportDeclarationSpecifier(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportDeclarationSpecifier(pos));
     pos += 16;
   }
@@ -6321,7 +6363,7 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeVecImportDeclarationSpecifier(pos);
 }
 
@@ -6330,7 +6372,7 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxWithClause(pos);
 }
 
@@ -6347,10 +6389,11 @@ function deserializeBoxImportNamespaceSpecifier(pos) {
 }
 
 function deserializeVecImportAttribute(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 112;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportAttribute(pos));
     pos += 112;
   }
@@ -6363,10 +6406,11 @@ function deserializeOptionDeclaration(pos) {
 }
 
 function deserializeVecExportSpecifier(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 128;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExportSpecifier(pos));
     pos += 128;
   }
@@ -6392,10 +6436,11 @@ function deserializeBoxJSXOpeningElement(pos) {
 }
 
 function deserializeVecJSXChild(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeJSXChild(pos));
     pos += 16;
   }
@@ -6407,15 +6452,16 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxJSXClosingElement(pos);
 }
 
 function deserializeVecJSXAttributeItem(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeJSXAttributeItem(pos));
     pos += 16;
   }
@@ -6460,10 +6506,11 @@ function deserializeBoxJSXSpreadChild(pos) {
 }
 
 function deserializeVecTSEnumMember(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 40;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSEnumMember(pos));
     pos += 40;
   }
@@ -6619,10 +6666,11 @@ function deserializeBoxJSDocUnknownType(pos) {
 }
 
 function deserializeVecTSType(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSType(pos));
     pos += 16;
   }
@@ -6630,10 +6678,11 @@ function deserializeVecTSType(pos) {
 }
 
 function deserializeVecTSTupleElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSTupleElement(pos));
     pos += 16;
   }
@@ -6658,10 +6707,11 @@ function deserializeOptionTSType(pos) {
 }
 
 function deserializeVecTSTypeParameter(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 80;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSTypeParameter(pos));
     pos += 80;
   }
@@ -6669,10 +6719,11 @@ function deserializeVecTSTypeParameter(pos) {
 }
 
 function deserializeVecTSInterfaceHeritage(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSInterfaceHeritage(pos));
     pos += 32;
   }
@@ -6684,10 +6735,11 @@ function deserializeBoxTSInterfaceBody(pos) {
 }
 
 function deserializeVecTSSignature(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSSignature(pos));
     pos += 16;
   }
@@ -6711,10 +6763,11 @@ function deserializeBoxTSMethodSignature(pos) {
 }
 
 function deserializeVecTSIndexSignatureName(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
     pos += 32;
   }
@@ -6735,7 +6788,7 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxObjectExpression(pos);
 }
 
@@ -6758,15 +6811,16 @@ function deserializeBoxTSExternalModuleReference(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeNameSpan(pos);
 }
 
 function deserializeVecError(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 80;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeError(pos));
     pos += 80;
   }
@@ -6774,10 +6828,11 @@ function deserializeVecError(pos) {
 }
 
 function deserializeVecErrorLabel(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 24;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeErrorLabel(pos));
     pos += 24;
   }
@@ -6785,10 +6840,11 @@ function deserializeVecErrorLabel(pos) {
 }
 
 function deserializeVecStaticImport(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 56;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStaticImport(pos));
     pos += 56;
   }
@@ -6796,10 +6852,11 @@ function deserializeVecStaticImport(pos) {
 }
 
 function deserializeVecStaticExport(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStaticExport(pos));
     pos += 32;
   }
@@ -6807,10 +6864,11 @@ function deserializeVecStaticExport(pos) {
 }
 
 function deserializeVecDynamicImport(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDynamicImport(pos));
     pos += 16;
   }
@@ -6818,10 +6876,11 @@ function deserializeVecDynamicImport(pos) {
 }
 
 function deserializeVecSpan(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 8;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeSpan(pos));
     pos += 8;
   }
@@ -6829,10 +6888,11 @@ function deserializeVecSpan(pos) {
 }
 
 function deserializeVecImportEntry(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 96;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportEntry(pos));
     pos += 96;
   }
@@ -6840,10 +6900,11 @@ function deserializeVecImportEntry(pos) {
 }
 
 function deserializeVecExportEntry(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 144;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExportEntry(pos));
     pos += 144;
   }

--- a/napi/parser/generated/deserialize/ts_range.js
+++ b/napi/parser/generated/deserialize/ts_range.js
@@ -25,11 +25,7 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInpu
 
 export function resetBuffer() {
   // Clear buffer and source text string to allow them to be garbage collected
-  uint8 =
-    uint32 =
-    float64 =
-    sourceText =
-      void 0;
+  uint8 = uint32 = float64 = sourceText = void 0;
 }
 
 function deserializeProgram(pos) {
@@ -44,7 +40,7 @@ function deserializeProgram(pos) {
       range: [0, end],
     };
   program.hashbang = deserializeOptionHashbang(pos + 48);
-  let body = program.body = deserializeVecDirective(pos + 72);
+  let body = (program.body = deserializeVecDirective(pos + 72));
   body.push(...deserializeVecStatement(pos + 96));
   {
     let start;
@@ -234,7 +230,8 @@ function deserializeLabelIdentifier(pos) {
 }
 
 function deserializeThisExpression(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'ThisExpression',
     start,
@@ -554,7 +551,8 @@ function deserializeTemplateElement(pos) {
     start = deserializeU32(pos) - 1,
     end = deserializeU32(pos + 4) + 2 - tail,
     value = deserializeTemplateElementValue(pos + 8);
-  value.cooked !== null && deserializeBool(pos + 41) &&
+  value.cooked !== null &&
+    deserializeBool(pos + 41) &&
     (value.cooked = value.cooked.replace(/\uFFFD(.{4})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16))));
   return {
     type: 'TemplateElement',
@@ -1111,17 +1109,18 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     key = deserializeIdentifierReference(pos + 8),
     init = deserializeOptionExpression(pos + 40),
     value = { ...key };
-  init !== null && (value = {
-    type: 'AssignmentPattern',
-    decorators: [],
-    left: value,
-    right: init,
-    optional: false,
-    typeAnnotation: null,
-    start,
-    end,
-    range: [start, end],
-  });
+  init !== null &&
+    (value = {
+      type: 'AssignmentPattern',
+      decorators: [],
+      left: value,
+      right: init,
+      optional: false,
+      typeAnnotation: null,
+      start,
+      end,
+      range: [start, end],
+    });
   node.kind = 'init';
   node.key = key;
   node.value = value;
@@ -1172,7 +1171,8 @@ function deserializeSequenceExpression(pos) {
 }
 
 function deserializeSuper(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Super',
     start,
@@ -1233,8 +1233,8 @@ function deserializeParenthesizedExpression(pos) {
     node = {
       type: 'ParenthesizedExpression',
       expression: null,
-      start: start = deserializeU32(pos),
-      end: end = deserializeU32(pos + 4),
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
     node.expression = deserializeExpression(pos + 8);
@@ -1329,7 +1329,8 @@ function deserializeDirective(pos) {
 }
 
 function deserializeHashbang(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Hashbang',
     value: deserializeStr(pos + 8),
@@ -1427,7 +1428,8 @@ function deserializeVariableDeclarator(pos) {
 }
 
 function deserializeEmptyStatement(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'EmptyStatement',
     start,
@@ -1842,7 +1844,8 @@ function deserializeCatchParameter(pos) {
 }
 
 function deserializeDebuggerStatement(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'DebuggerStatement',
     start,
@@ -2036,8 +2039,8 @@ function deserializeFunctionType(pos) {
 
 function deserializeFormalParameters(pos) {
   let params = deserializeVecFormalParameter(pos + 8);
-  if (uint32[pos + 32 >> 2] !== 0 && uint32[pos + 36 >> 2] !== 0) {
-    pos = uint32[pos + 32 >> 2];
+  if (uint32[(pos + 32) >> 2] !== 0 && uint32[(pos + 36) >> 2] !== 0) {
+    pos = uint32[(pos + 32) >> 2];
     let start,
       end,
       rest = {
@@ -2047,8 +2050,8 @@ function deserializeFormalParameters(pos) {
         optional: deserializeBool(pos + 32),
         typeAnnotation: null,
         value: null,
-        start: start = deserializeU32(pos),
-        end: end = deserializeU32(pos + 4),
+        start: (start = deserializeU32(pos)),
+        end: (end = deserializeU32(pos + 4)),
         range: [start, end],
       };
     rest.argument = deserializeBindingPatternKind(pos + 8);
@@ -2079,8 +2082,8 @@ function deserializeFormalParameter(pos) {
         parameter: null,
         readonly,
         static: false,
-        start: start = deserializeU32(pos),
-        end: end = deserializeU32(pos + 4),
+        start: (start = deserializeU32(pos)),
+        end: (end = deserializeU32(pos + 4)),
         range: [start, end],
       };
       param.decorators = deserializeVecDecorator(pos + 8);
@@ -2310,7 +2313,8 @@ function deserializeMethodDefinitionKind(pos) {
 }
 
 function deserializePrivateIdentifier(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'PrivateIdentifier',
     name: deserializeStr(pos + 8),
@@ -2752,7 +2756,8 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Literal',
     value: deserializeF64(pos + 8),
@@ -2829,7 +2834,8 @@ function deserializeRegExp(pos) {
 }
 
 function deserializeRegExpFlags(pos) {
-  let flagBits = deserializeU8(pos), flags = '';
+  let flagBits = deserializeU8(pos),
+    flags = '';
   // Alphabetical order
   flagBits & 64 && (flags += 'd');
   flagBits & 1 && (flags += 'g');
@@ -2916,7 +2922,8 @@ function deserializeJSXFragment(pos) {
 }
 
 function deserializeJSXOpeningFragment(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXOpeningFragment',
     start,
@@ -2926,7 +2933,8 @@ function deserializeJSXOpeningFragment(pos) {
 }
 
 function deserializeJSXClosingFragment(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXClosingFragment',
     start,
@@ -3135,7 +3143,8 @@ function deserializeJSXExpression(pos) {
 }
 
 function deserializeJSXEmptyExpression(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXEmptyExpression',
     start,
@@ -3212,7 +3221,8 @@ function deserializeJSXAttributeValue(pos) {
 }
 
 function deserializeJSXIdentifier(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXIdentifier',
     name: deserializeStr(pos + 8),
@@ -3254,7 +3264,8 @@ function deserializeJSXSpreadChild(pos) {
 }
 
 function deserializeJSXText(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXText',
     value: deserializeStr(pos + 8),
@@ -3533,8 +3544,8 @@ function deserializeTSParenthesizedType(pos) {
     node = {
       type: 'TSParenthesizedType',
       typeAnnotation: null,
-      start: start = deserializeU32(pos),
-      end: end = deserializeU32(pos + 4),
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
     node.typeAnnotation = deserializeTSType(pos + 8);
@@ -3745,7 +3756,8 @@ function deserializeTSTupleElement(pos) {
 }
 
 function deserializeTSAnyKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSAnyKeyword',
     start,
@@ -3755,7 +3767,8 @@ function deserializeTSAnyKeyword(pos) {
 }
 
 function deserializeTSStringKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSStringKeyword',
     start,
@@ -3765,7 +3778,8 @@ function deserializeTSStringKeyword(pos) {
 }
 
 function deserializeTSBooleanKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSBooleanKeyword',
     start,
@@ -3775,7 +3789,8 @@ function deserializeTSBooleanKeyword(pos) {
 }
 
 function deserializeTSNumberKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSNumberKeyword',
     start,
@@ -3785,7 +3800,8 @@ function deserializeTSNumberKeyword(pos) {
 }
 
 function deserializeTSNeverKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSNeverKeyword',
     start,
@@ -3795,7 +3811,8 @@ function deserializeTSNeverKeyword(pos) {
 }
 
 function deserializeTSIntrinsicKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSIntrinsicKeyword',
     start,
@@ -3805,7 +3822,8 @@ function deserializeTSIntrinsicKeyword(pos) {
 }
 
 function deserializeTSUnknownKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSUnknownKeyword',
     start,
@@ -3815,7 +3833,8 @@ function deserializeTSUnknownKeyword(pos) {
 }
 
 function deserializeTSNullKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSNullKeyword',
     start,
@@ -3825,7 +3844,8 @@ function deserializeTSNullKeyword(pos) {
 }
 
 function deserializeTSUndefinedKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSUndefinedKeyword',
     start,
@@ -3835,7 +3855,8 @@ function deserializeTSUndefinedKeyword(pos) {
 }
 
 function deserializeTSVoidKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSVoidKeyword',
     start,
@@ -3845,7 +3866,8 @@ function deserializeTSVoidKeyword(pos) {
 }
 
 function deserializeTSSymbolKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSSymbolKeyword',
     start,
@@ -3855,7 +3877,8 @@ function deserializeTSSymbolKeyword(pos) {
 }
 
 function deserializeTSThisType(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSThisType',
     start,
@@ -3865,7 +3888,8 @@ function deserializeTSThisType(pos) {
 }
 
 function deserializeTSObjectKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSObjectKeyword',
     start,
@@ -3875,7 +3899,8 @@ function deserializeTSObjectKeyword(pos) {
 }
 
 function deserializeTSBigIntKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSBigIntKeyword',
     start,
@@ -4027,17 +4052,17 @@ function deserializeTSClassImplements(pos) {
       { right } = expression,
       start,
       end,
-      previous = expression = {
+      previous = (expression = {
         type: 'MemberExpression',
         object,
         property: right,
         optional: false,
         computed: false,
-        start: start = expression.start,
-        end: end = expression.end,
+        start: (start = expression.start),
+        end: (end = expression.end),
         range: [start, end],
-      };
-    for (; object.type === 'TSQualifiedName';) {
+      });
+    for (; object.type === 'TSQualifiedName'; ) {
       let { left, right } = object;
       previous = previous.object = {
         type: 'MemberExpression',
@@ -4045,8 +4070,8 @@ function deserializeTSClassImplements(pos) {
         property: right,
         optional: false,
         computed: false,
-        start: start = object.start,
-        end: end = object.end,
+        start: (start = object.start),
+        end: (end = object.end),
         range: [start, end],
       };
       object = left;
@@ -4341,8 +4366,8 @@ function deserializeTSModuleDeclaration(pos) {
           type: 'TSQualifiedName',
           left: id,
           right: innerId,
-          start: start = id.start,
-          end: end = innerId.end,
+          start: (start = id.start),
+          end: (end = innerId.end),
           range: [start, end],
         };
       } else {
@@ -4355,13 +4380,14 @@ function deserializeTSModuleDeclaration(pos) {
           if (innerId.left.type === 'Identifier') break;
           innerId = innerId.left;
         }
-        let end, right = innerId.left;
+        let end,
+          right = innerId.left;
         innerId.left = {
           type: 'TSQualifiedName',
           left: id,
           right,
           start,
-          end: end = right.end,
+          end: (end = right.end),
           range: [start, end],
         };
       }
@@ -4836,7 +4862,8 @@ function deserializeJSDocNonNullableType(pos) {
 }
 
 function deserializeJSDocUnknownType(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSJSDocUnknownType',
     start,
@@ -4857,7 +4884,9 @@ function deserializeCommentKind(pos) {
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12), start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let type = deserializeCommentKind(pos + 12),
+    start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type,
     value: sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2)),
@@ -4868,7 +4897,8 @@ function deserializeComment(pos) {
 }
 
 function deserializeNameSpan(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     value: deserializeStr(pos + 8),
     start,
@@ -4919,7 +4949,8 @@ function deserializeImportImportName(pos) {
 }
 
 function deserializeExportEntry(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
@@ -5039,7 +5070,8 @@ function deserializeExportLocalName(pos) {
 }
 
 function deserializeDynamicImport(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeSpan(pos + 8),
     start,
@@ -5234,7 +5266,8 @@ function deserializeErrorSeverity(pos) {
 }
 
 function deserializeErrorLabel(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     message: deserializeOptionStr(pos + 8),
     start,
@@ -5254,7 +5287,8 @@ function deserializeEcmaScriptModule(pos) {
 }
 
 function deserializeStaticImport(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeNameSpan(pos + 8),
     entries: deserializeVecImportEntry(pos + 32),
@@ -5265,7 +5299,8 @@ function deserializeStaticImport(pos) {
 }
 
 function deserializeStaticExport(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     entries: deserializeVecExportEntry(pos + 8),
     start,
@@ -5283,7 +5318,8 @@ function deserializeU8(pos) {
 }
 
 function deserializeStr(pos) {
-  let pos32 = pos >> 2, len = uint32[pos32 + 2];
+  let pos32 = pos >> 2,
+    len = uint32[pos32 + 2];
   if (len === 0) return '';
   pos = uint32[pos32];
   if (sourceIsAscii && pos < sourceByteLen) return sourceText.substr(pos, len);
@@ -5292,7 +5328,8 @@ function deserializeStr(pos) {
   let end = pos + len;
   if (len > 50) return decodeStr(uint8.subarray(pos, end));
   // Shorter strings decode by hand to avoid native call
-  let out = '', c;
+  let out = '',
+    c;
   do {
     c = uint8[pos++];
     if (c < 128) out += fromCodePoint(c);
@@ -5305,10 +5342,11 @@ function deserializeStr(pos) {
 }
 
 function deserializeVecComment(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeComment(pos));
     pos += 16;
   }
@@ -5316,15 +5354,16 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeHashbang(pos);
 }
 
 function deserializeVecDirective(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 72;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDirective(pos));
     pos += 72;
   }
@@ -5332,10 +5371,11 @@ function deserializeVecDirective(pos) {
 }
 
 function deserializeVecStatement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStatement(pos));
     pos += 16;
   }
@@ -5503,10 +5543,11 @@ function deserializeBoxV8IntrinsicExpression(pos) {
 }
 
 function deserializeVecArrayExpressionElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeArrayExpressionElement(pos));
     pos += 16;
   }
@@ -5518,10 +5559,11 @@ function deserializeBoxSpreadElement(pos) {
 }
 
 function deserializeVecObjectPropertyKind(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeObjectPropertyKind(pos));
     pos += 16;
   }
@@ -5545,10 +5587,11 @@ function deserializeBoxPrivateIdentifier(pos) {
 }
 
 function deserializeVecTemplateElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 48;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTemplateElement(pos));
     pos += 48;
   }
@@ -5556,10 +5599,11 @@ function deserializeVecTemplateElement(pos) {
 }
 
 function deserializeVecExpression(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExpression(pos));
     pos += 16;
   }
@@ -5571,12 +5615,12 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeStr(pos);
 }
 
@@ -5593,10 +5637,11 @@ function deserializeBoxPrivateFieldExpression(pos) {
 }
 
 function deserializeVecArgument(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeArgument(pos));
     pos += 16;
   }
@@ -5617,10 +5662,11 @@ function deserializeOptionAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeOptionAssignmentTargetMaybeDefault(pos));
     pos += 16;
   }
@@ -5632,15 +5678,16 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxAssignmentTargetRest(pos);
 }
 
 function deserializeVecAssignmentTargetProperty(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeAssignmentTargetProperty(pos));
     pos += 16;
   }
@@ -5761,10 +5808,11 @@ function deserializeBoxTSImportEqualsDeclaration(pos) {
 }
 
 function deserializeVecVariableDeclarator(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 64;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeVariableDeclarator(pos));
     pos += 64;
   }
@@ -5782,15 +5830,16 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeLabelIdentifier(pos);
 }
 
 function deserializeVecSwitchCase(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 48;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeSwitchCase(pos));
     pos += 48;
   }
@@ -5802,12 +5851,12 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxBlockStatement(pos);
 }
 
@@ -5821,7 +5870,7 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeAnnotation(pos);
 }
 
@@ -5842,10 +5891,11 @@ function deserializeBoxAssignmentPattern(pos) {
 }
 
 function deserializeVecBindingProperty(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 64;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeBindingProperty(pos));
     pos += 64;
   }
@@ -5857,7 +5907,7 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxBindingRestElement(pos);
 }
 
@@ -5867,10 +5917,11 @@ function deserializeOptionBindingPattern(pos) {
 }
 
 function deserializeVecOptionBindingPattern(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeOptionBindingPattern(pos));
     pos += 32;
   }
@@ -5878,7 +5929,7 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeBindingIdentifier(pos);
 }
 
@@ -5887,7 +5938,7 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
@@ -5896,7 +5947,7 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSThisParameter(pos);
 }
 
@@ -5909,15 +5960,16 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxFunctionBody(pos);
 }
 
 function deserializeVecFormalParameter(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 72;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeFormalParameter(pos));
     pos += 72;
   }
@@ -5925,10 +5977,11 @@ function deserializeVecFormalParameter(pos) {
 }
 
 function deserializeVecDecorator(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 24;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDecorator(pos));
     pos += 24;
   }
@@ -5941,10 +5994,11 @@ function deserializeOptionTSAccessibility(pos) {
 }
 
 function deserializeVecTSClassImplements(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSClassImplements(pos));
     pos += 32;
   }
@@ -5956,10 +6010,11 @@ function deserializeBoxClassBody(pos) {
 }
 
 function deserializeVecClassElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeClassElement(pos));
     pos += 16;
   }
@@ -6016,10 +6071,11 @@ function deserializeOptionImportPhase(pos) {
 }
 
 function deserializeVecImportDeclarationSpecifier(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportDeclarationSpecifier(pos));
     pos += 16;
   }
@@ -6027,7 +6083,7 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeVecImportDeclarationSpecifier(pos);
 }
 
@@ -6036,7 +6092,7 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxWithClause(pos);
 }
 
@@ -6053,10 +6109,11 @@ function deserializeBoxImportNamespaceSpecifier(pos) {
 }
 
 function deserializeVecImportAttribute(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 112;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportAttribute(pos));
     pos += 112;
   }
@@ -6069,10 +6126,11 @@ function deserializeOptionDeclaration(pos) {
 }
 
 function deserializeVecExportSpecifier(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 128;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExportSpecifier(pos));
     pos += 128;
   }
@@ -6098,10 +6156,11 @@ function deserializeBoxJSXOpeningElement(pos) {
 }
 
 function deserializeVecJSXChild(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeJSXChild(pos));
     pos += 16;
   }
@@ -6113,15 +6172,16 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxJSXClosingElement(pos);
 }
 
 function deserializeVecJSXAttributeItem(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeJSXAttributeItem(pos));
     pos += 16;
   }
@@ -6166,10 +6226,11 @@ function deserializeBoxJSXSpreadChild(pos) {
 }
 
 function deserializeVecTSEnumMember(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 40;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSEnumMember(pos));
     pos += 40;
   }
@@ -6325,10 +6386,11 @@ function deserializeBoxJSDocUnknownType(pos) {
 }
 
 function deserializeVecTSType(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSType(pos));
     pos += 16;
   }
@@ -6336,10 +6398,11 @@ function deserializeVecTSType(pos) {
 }
 
 function deserializeVecTSTupleElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSTupleElement(pos));
     pos += 16;
   }
@@ -6364,10 +6427,11 @@ function deserializeOptionTSType(pos) {
 }
 
 function deserializeVecTSTypeParameter(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 80;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSTypeParameter(pos));
     pos += 80;
   }
@@ -6375,10 +6439,11 @@ function deserializeVecTSTypeParameter(pos) {
 }
 
 function deserializeVecTSInterfaceHeritage(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSInterfaceHeritage(pos));
     pos += 32;
   }
@@ -6390,10 +6455,11 @@ function deserializeBoxTSInterfaceBody(pos) {
 }
 
 function deserializeVecTSSignature(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSSignature(pos));
     pos += 16;
   }
@@ -6417,10 +6483,11 @@ function deserializeBoxTSMethodSignature(pos) {
 }
 
 function deserializeVecTSIndexSignatureName(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
     pos += 32;
   }
@@ -6441,7 +6508,7 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxObjectExpression(pos);
 }
 
@@ -6464,15 +6531,16 @@ function deserializeBoxTSExternalModuleReference(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeNameSpan(pos);
 }
 
 function deserializeVecError(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 80;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeError(pos));
     pos += 80;
   }
@@ -6480,10 +6548,11 @@ function deserializeVecError(pos) {
 }
 
 function deserializeVecErrorLabel(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 24;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeErrorLabel(pos));
     pos += 24;
   }
@@ -6491,10 +6560,11 @@ function deserializeVecErrorLabel(pos) {
 }
 
 function deserializeVecStaticImport(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 56;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStaticImport(pos));
     pos += 56;
   }
@@ -6502,10 +6572,11 @@ function deserializeVecStaticImport(pos) {
 }
 
 function deserializeVecStaticExport(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStaticExport(pos));
     pos += 32;
   }
@@ -6513,10 +6584,11 @@ function deserializeVecStaticExport(pos) {
 }
 
 function deserializeVecDynamicImport(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDynamicImport(pos));
     pos += 16;
   }
@@ -6524,10 +6596,11 @@ function deserializeVecDynamicImport(pos) {
 }
 
 function deserializeVecSpan(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 8;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeSpan(pos));
     pos += 8;
   }
@@ -6535,10 +6608,11 @@ function deserializeVecSpan(pos) {
 }
 
 function deserializeVecImportEntry(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 96;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportEntry(pos));
     pos += 96;
   }
@@ -6546,10 +6620,11 @@ function deserializeVecImportEntry(pos) {
 }
 
 function deserializeVecExportEntry(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 144;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExportEntry(pos));
     pos += 144;
   }

--- a/napi/parser/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/generated/deserialize/ts_range_parent.js
@@ -1,7 +1,13 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
-let uint8, uint32, float64, sourceText, sourceIsAscii, sourceByteLen, parent = null;
+let uint8,
+  uint32,
+  float64,
+  sourceText,
+  sourceIsAscii,
+  sourceByteLen,
+  parent = null;
 
 const textDecoder = new TextDecoder('utf-8', { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
@@ -25,16 +31,12 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLenInput, getLocInpu
 
 export function resetBuffer() {
   // Clear buffer and source text string to allow them to be garbage collected
-  uint8 =
-    uint32 =
-    float64 =
-    sourceText =
-      void 0;
+  uint8 = uint32 = float64 = sourceText = void 0;
 }
 
 function deserializeProgram(pos) {
   let end = deserializeU32(pos + 4),
-    program = parent = {
+    program = (parent = {
       type: 'Program',
       body: null,
       sourceType: deserializeModuleKind(pos + 125),
@@ -43,9 +45,9 @@ function deserializeProgram(pos) {
       end,
       range: [0, end],
       parent: null,
-    };
+    });
   program.hashbang = deserializeOptionHashbang(pos + 48);
-  let body = program.body = deserializeVecDirective(pos + 72);
+  let body = (program.body = deserializeVecDirective(pos + 72));
   body.push(...deserializeVecStatement(pos + 96));
   {
     let start;
@@ -163,7 +165,7 @@ function deserializeIdentifierName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Identifier',
       decorators: null,
       name: deserializeStr(pos + 8),
@@ -173,7 +175,7 @@ function deserializeIdentifierName(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = [];
   node.optional = false;
   node.typeAnnotation = null;
@@ -185,7 +187,7 @@ function deserializeIdentifierReference(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Identifier',
       decorators: null,
       name: deserializeStr(pos + 8),
@@ -195,7 +197,7 @@ function deserializeIdentifierReference(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = [];
   node.optional = false;
   node.typeAnnotation = null;
@@ -207,7 +209,7 @@ function deserializeBindingIdentifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Identifier',
       decorators: null,
       name: deserializeStr(pos + 8),
@@ -217,7 +219,7 @@ function deserializeBindingIdentifier(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = [];
   node.optional = false;
   node.typeAnnotation = null;
@@ -229,7 +231,7 @@ function deserializeLabelIdentifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Identifier',
       decorators: null,
       name: deserializeStr(pos + 8),
@@ -239,7 +241,7 @@ function deserializeLabelIdentifier(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = [];
   node.optional = false;
   node.typeAnnotation = null;
@@ -248,7 +250,8 @@ function deserializeLabelIdentifier(pos) {
 }
 
 function deserializeThisExpression(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'ThisExpression',
     start,
@@ -262,14 +265,14 @@ function deserializeArrayExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ArrayExpression',
       elements: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.elements = deserializeVecArrayExpressionElement(pos + 8);
   parent = previousParent;
   return node;
@@ -380,14 +383,14 @@ function deserializeObjectExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ObjectExpression',
       properties: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.properties = deserializeVecObjectPropertyKind(pos + 8);
   parent = previousParent;
   return node;
@@ -408,7 +411,7 @@ function deserializeObjectProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Property',
       kind: deserializePropertyKind(pos + 40),
       key: null,
@@ -421,7 +424,7 @@ function deserializeObjectProperty(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.key = deserializePropertyKey(pos + 8);
   node.value = deserializeExpression(pos + 24);
   node.optional = false;
@@ -543,7 +546,7 @@ function deserializeTemplateLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TemplateLiteral',
       quasis: null,
       expressions: null,
@@ -551,7 +554,7 @@ function deserializeTemplateLiteral(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.quasis = deserializeVecTemplateElement(pos + 8);
   node.expressions = deserializeVecExpression(pos + 32);
   parent = previousParent;
@@ -562,7 +565,7 @@ function deserializeTaggedTemplateExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TaggedTemplateExpression',
       tag: null,
       typeArguments: null,
@@ -571,7 +574,7 @@ function deserializeTaggedTemplateExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.tag = deserializeExpression(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   node.quasi = deserializeTemplateLiteral(pos + 32);
@@ -584,7 +587,8 @@ function deserializeTemplateElement(pos) {
     start = deserializeU32(pos) - 1,
     end = deserializeU32(pos + 4) + 2 - tail,
     value = deserializeTemplateElementValue(pos + 8);
-  value.cooked !== null && deserializeBool(pos + 41) &&
+  value.cooked !== null &&
+    deserializeBool(pos + 41) &&
     (value.cooked = value.cooked.replace(/\uFFFD(.{4})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16))));
   return {
     type: 'TemplateElement',
@@ -608,7 +612,7 @@ function deserializeComputedMemberExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'MemberExpression',
       object: null,
       property: null,
@@ -618,7 +622,7 @@ function deserializeComputedMemberExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.object = deserializeExpression(pos + 8);
   node.property = deserializeExpression(pos + 24);
   node.computed = true;
@@ -630,7 +634,7 @@ function deserializeStaticMemberExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'MemberExpression',
       object: null,
       property: null,
@@ -640,7 +644,7 @@ function deserializeStaticMemberExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.object = deserializeExpression(pos + 8);
   node.property = deserializeIdentifierName(pos + 24);
   node.computed = false;
@@ -652,7 +656,7 @@ function deserializePrivateFieldExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'MemberExpression',
       object: null,
       property: null,
@@ -662,7 +666,7 @@ function deserializePrivateFieldExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.object = deserializeExpression(pos + 8);
   node.property = deserializePrivateIdentifier(pos + 24);
   node.computed = false;
@@ -674,7 +678,7 @@ function deserializeCallExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'CallExpression',
       callee: null,
       typeArguments: null,
@@ -684,7 +688,7 @@ function deserializeCallExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.callee = deserializeExpression(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   node.arguments = deserializeVecArgument(pos + 32);
@@ -696,7 +700,7 @@ function deserializeNewExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'NewExpression',
       callee: null,
       typeArguments: null,
@@ -705,7 +709,7 @@ function deserializeNewExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.callee = deserializeExpression(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   node.arguments = deserializeVecArgument(pos + 32);
@@ -717,7 +721,7 @@ function deserializeMetaProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'MetaProperty',
       meta: null,
       property: null,
@@ -725,7 +729,7 @@ function deserializeMetaProperty(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.meta = deserializeIdentifierName(pos + 8);
   node.property = deserializeIdentifierName(pos + 32);
   parent = previousParent;
@@ -736,14 +740,14 @@ function deserializeSpreadElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'SpreadElement',
       argument: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -848,7 +852,7 @@ function deserializeUpdateExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'UpdateExpression',
       operator: deserializeUpdateOperator(pos + 24),
       prefix: deserializeBool(pos + 25),
@@ -857,7 +861,7 @@ function deserializeUpdateExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeSimpleAssignmentTarget(pos + 8);
   parent = previousParent;
   return node;
@@ -867,7 +871,7 @@ function deserializeUnaryExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'UnaryExpression',
       operator: deserializeUnaryOperator(pos + 24),
       argument: null,
@@ -876,7 +880,7 @@ function deserializeUnaryExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   node.prefix = true;
   parent = previousParent;
@@ -887,7 +891,7 @@ function deserializeBinaryExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'BinaryExpression',
       left: null,
       operator: deserializeBinaryOperator(pos + 40),
@@ -896,7 +900,7 @@ function deserializeBinaryExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializeExpression(pos + 8);
   node.right = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -907,7 +911,7 @@ function deserializePrivateInExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'BinaryExpression',
       left: null,
       operator: null,
@@ -916,7 +920,7 @@ function deserializePrivateInExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializePrivateIdentifier(pos + 8);
   node.operator = 'in';
   node.right = deserializeExpression(pos + 32);
@@ -928,7 +932,7 @@ function deserializeLogicalExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'LogicalExpression',
       left: null,
       operator: deserializeLogicalOperator(pos + 40),
@@ -937,7 +941,7 @@ function deserializeLogicalExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializeExpression(pos + 8);
   node.right = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -948,7 +952,7 @@ function deserializeConditionalExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ConditionalExpression',
       test: null,
       consequent: null,
@@ -957,7 +961,7 @@ function deserializeConditionalExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.test = deserializeExpression(pos + 8);
   node.consequent = deserializeExpression(pos + 24);
   node.alternate = deserializeExpression(pos + 40);
@@ -969,7 +973,7 @@ function deserializeAssignmentExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'AssignmentExpression',
       operator: deserializeAssignmentOperator(pos + 40),
       left: null,
@@ -978,7 +982,7 @@ function deserializeAssignmentExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializeAssignmentTarget(pos + 8);
   node.right = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -1039,7 +1043,7 @@ function deserializeArrayAssignmentTarget(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ArrayPattern',
       decorators: null,
       elements: null,
@@ -1049,7 +1053,7 @@ function deserializeArrayAssignmentTarget(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     elements = deserializeVecOptionAssignmentTargetMaybeDefault(pos + 8),
     rest = deserializeOptionBoxAssignmentTargetRest(pos + 32);
   rest !== null && elements.push(rest);
@@ -1065,7 +1069,7 @@ function deserializeObjectAssignmentTarget(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ObjectPattern',
       decorators: null,
       properties: null,
@@ -1075,7 +1079,7 @@ function deserializeObjectAssignmentTarget(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     properties = deserializeVecAssignmentTargetProperty(pos + 8),
     rest = deserializeOptionBoxAssignmentTargetRest(pos + 32);
   rest !== null && properties.push(rest);
@@ -1091,7 +1095,7 @@ function deserializeAssignmentTargetRest(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'RestElement',
       decorators: null,
       argument: null,
@@ -1102,7 +1106,7 @@ function deserializeAssignmentTargetRest(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = [];
   node.argument = deserializeAssignmentTarget(pos + 8);
   node.optional = false;
@@ -1145,7 +1149,7 @@ function deserializeAssignmentTargetWithDefault(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'AssignmentPattern',
       decorators: null,
       left: null,
@@ -1156,7 +1160,7 @@ function deserializeAssignmentTargetWithDefault(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = [];
   node.left = deserializeAssignmentTarget(pos + 8);
   node.right = deserializeExpression(pos + 24);
@@ -1181,7 +1185,7 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Property',
       kind: null,
       key: null,
@@ -1194,12 +1198,13 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     key = deserializeIdentifierReference(pos + 8),
     init = deserializeOptionExpression(pos + 40),
     value = { ...key };
   if (init !== null) {
-    let left = value, previousParent = parent;
+    let left = value,
+      previousParent = parent;
     value = parent = {
       type: 'AssignmentPattern',
       decorators: [],
@@ -1231,7 +1236,7 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Property',
       kind: null,
       key: null,
@@ -1244,7 +1249,7 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.kind = 'init';
   node.key = deserializePropertyKey(pos + 8);
   node.value = deserializeAssignmentTargetMaybeDefault(pos + 24);
@@ -1259,21 +1264,22 @@ function deserializeSequenceExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'SequenceExpression',
       expressions: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expressions = deserializeVecExpression(pos + 8);
   parent = previousParent;
   return node;
 }
 
 function deserializeSuper(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Super',
     start,
@@ -1287,14 +1293,14 @@ function deserializeAwaitExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'AwaitExpression',
       argument: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -1304,14 +1310,14 @@ function deserializeChainExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ChainExpression',
       expression: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeChainElement(pos + 8);
   parent = previousParent;
   return node;
@@ -1337,12 +1343,14 @@ function deserializeChainElement(pos) {
 function deserializeParenthesizedExpression(pos) {
   let node;
   {
-    let start, end, previousParent = parent;
+    let start,
+      end,
+      previousParent = parent;
     node = parent = {
       type: 'ParenthesizedExpression',
       expression: null,
-      start: start = deserializeU32(pos),
-      end: end = deserializeU32(pos + 4),
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     };
@@ -1427,7 +1435,7 @@ function deserializeDirective(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ExpressionStatement',
       expression: null,
       directive: deserializeStr(pos + 56),
@@ -1435,14 +1443,15 @@ function deserializeDirective(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeStringLiteral(pos + 8);
   parent = previousParent;
   return node;
 }
 
 function deserializeHashbang(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Hashbang',
     value: deserializeStr(pos + 8),
@@ -1457,14 +1466,14 @@ function deserializeBlockStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'BlockStatement',
       body: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.body = deserializeVecStatement(pos + 8);
   parent = previousParent;
   return node;
@@ -1497,7 +1506,7 @@ function deserializeVariableDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'VariableDeclaration',
       kind: deserializeVariableDeclarationKind(pos + 32),
       declarations: null,
@@ -1506,7 +1515,7 @@ function deserializeVariableDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.declarations = deserializeVecVariableDeclarator(pos + 8);
   parent = previousParent;
   return node;
@@ -1533,7 +1542,7 @@ function deserializeVariableDeclarator(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'VariableDeclarator',
       id: null,
       init: null,
@@ -1542,7 +1551,7 @@ function deserializeVariableDeclarator(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.id = deserializeBindingPattern(pos + 8);
   node.init = deserializeOptionExpression(pos + 40);
   parent = previousParent;
@@ -1550,7 +1559,8 @@ function deserializeVariableDeclarator(pos) {
 }
 
 function deserializeEmptyStatement(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'EmptyStatement',
     start,
@@ -1564,7 +1574,7 @@ function deserializeExpressionStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ExpressionStatement',
       expression: null,
       directive: null,
@@ -1572,7 +1582,7 @@ function deserializeExpressionStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   node.directive = null;
   parent = previousParent;
@@ -1583,7 +1593,7 @@ function deserializeIfStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'IfStatement',
       test: null,
       consequent: null,
@@ -1592,7 +1602,7 @@ function deserializeIfStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.test = deserializeExpression(pos + 8);
   node.consequent = deserializeStatement(pos + 24);
   node.alternate = deserializeOptionStatement(pos + 40);
@@ -1604,7 +1614,7 @@ function deserializeDoWhileStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'DoWhileStatement',
       body: null,
       test: null,
@@ -1612,7 +1622,7 @@ function deserializeDoWhileStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.body = deserializeStatement(pos + 8);
   node.test = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -1623,7 +1633,7 @@ function deserializeWhileStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'WhileStatement',
       test: null,
       body: null,
@@ -1631,7 +1641,7 @@ function deserializeWhileStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.test = deserializeExpression(pos + 8);
   node.body = deserializeStatement(pos + 24);
   parent = previousParent;
@@ -1642,7 +1652,7 @@ function deserializeForStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ForStatement',
       init: null,
       test: null,
@@ -1652,7 +1662,7 @@ function deserializeForStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.init = deserializeOptionForStatementInit(pos + 8);
   node.test = deserializeOptionExpression(pos + 24);
   node.update = deserializeOptionExpression(pos + 40);
@@ -1760,7 +1770,7 @@ function deserializeForInStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ForInStatement',
       left: null,
       right: null,
@@ -1769,7 +1779,7 @@ function deserializeForInStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializeForStatementLeft(pos + 8);
   node.right = deserializeExpression(pos + 24);
   node.body = deserializeStatement(pos + 40);
@@ -1810,7 +1820,7 @@ function deserializeForOfStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ForOfStatement',
       await: deserializeBool(pos + 60),
       left: null,
@@ -1820,7 +1830,7 @@ function deserializeForOfStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializeForStatementLeft(pos + 8);
   node.right = deserializeExpression(pos + 24);
   node.body = deserializeStatement(pos + 40);
@@ -1832,14 +1842,14 @@ function deserializeContinueStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ContinueStatement',
       label: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.label = deserializeOptionLabelIdentifier(pos + 8);
   parent = previousParent;
   return node;
@@ -1849,14 +1859,14 @@ function deserializeBreakStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'BreakStatement',
       label: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.label = deserializeOptionLabelIdentifier(pos + 8);
   parent = previousParent;
   return node;
@@ -1866,14 +1876,14 @@ function deserializeReturnStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ReturnStatement',
       argument: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeOptionExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -1883,7 +1893,7 @@ function deserializeWithStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'WithStatement',
       object: null,
       body: null,
@@ -1891,7 +1901,7 @@ function deserializeWithStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.object = deserializeExpression(pos + 8);
   node.body = deserializeStatement(pos + 24);
   parent = previousParent;
@@ -1902,7 +1912,7 @@ function deserializeSwitchStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'SwitchStatement',
       discriminant: null,
       cases: null,
@@ -1910,7 +1920,7 @@ function deserializeSwitchStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.discriminant = deserializeExpression(pos + 8);
   node.cases = deserializeVecSwitchCase(pos + 24);
   parent = previousParent;
@@ -1921,7 +1931,7 @@ function deserializeSwitchCase(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'SwitchCase',
       test: null,
       consequent: null,
@@ -1929,7 +1939,7 @@ function deserializeSwitchCase(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.test = deserializeOptionExpression(pos + 8);
   node.consequent = deserializeVecStatement(pos + 24);
   parent = previousParent;
@@ -1940,7 +1950,7 @@ function deserializeLabeledStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'LabeledStatement',
       label: null,
       body: null,
@@ -1948,7 +1958,7 @@ function deserializeLabeledStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.label = deserializeLabelIdentifier(pos + 8);
   node.body = deserializeStatement(pos + 32);
   parent = previousParent;
@@ -1959,14 +1969,14 @@ function deserializeThrowStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ThrowStatement',
       argument: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -1976,7 +1986,7 @@ function deserializeTryStatement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TryStatement',
       block: null,
       handler: null,
@@ -1985,7 +1995,7 @@ function deserializeTryStatement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.block = deserializeBoxBlockStatement(pos + 8);
   node.handler = deserializeOptionBoxCatchClause(pos + 16);
   node.finalizer = deserializeOptionBoxBlockStatement(pos + 24);
@@ -1997,7 +2007,7 @@ function deserializeCatchClause(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'CatchClause',
       param: null,
       body: null,
@@ -2005,7 +2015,7 @@ function deserializeCatchClause(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.param = deserializeOptionCatchParameter(pos + 8);
   node.body = deserializeBoxBlockStatement(pos + 48);
   parent = previousParent;
@@ -2017,7 +2027,8 @@ function deserializeCatchParameter(pos) {
 }
 
 function deserializeDebuggerStatement(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'DebuggerStatement',
     start,
@@ -2058,7 +2069,7 @@ function deserializeAssignmentPattern(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'AssignmentPattern',
       decorators: null,
       left: null,
@@ -2069,7 +2080,7 @@ function deserializeAssignmentPattern(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = [];
   node.left = deserializeBindingPattern(pos + 8);
   node.right = deserializeExpression(pos + 40);
@@ -2083,7 +2094,7 @@ function deserializeObjectPattern(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ObjectPattern',
       decorators: null,
       properties: null,
@@ -2093,7 +2104,7 @@ function deserializeObjectPattern(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     properties = deserializeVecBindingProperty(pos + 8),
     rest = deserializeOptionBoxBindingRestElement(pos + 32);
   rest !== null && properties.push(rest);
@@ -2109,7 +2120,7 @@ function deserializeBindingProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Property',
       kind: null,
       key: null,
@@ -2122,7 +2133,7 @@ function deserializeBindingProperty(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.kind = 'init';
   node.key = deserializePropertyKey(pos + 8);
   node.value = deserializeBindingPattern(pos + 24);
@@ -2136,7 +2147,7 @@ function deserializeArrayPattern(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ArrayPattern',
       decorators: null,
       elements: null,
@@ -2146,7 +2157,7 @@ function deserializeArrayPattern(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     elements = deserializeVecOptionBindingPattern(pos + 8),
     rest = deserializeOptionBoxBindingRestElement(pos + 32);
   rest !== null && elements.push(rest);
@@ -2162,7 +2173,7 @@ function deserializeBindingRestElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'RestElement',
       decorators: null,
       argument: null,
@@ -2173,7 +2184,7 @@ function deserializeBindingRestElement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = [];
   node.argument = deserializeBindingPattern(pos + 8);
   node.optional = false;
@@ -2187,7 +2198,7 @@ function deserializeFunction(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: deserializeFunctionType(pos + 84),
       id: null,
       generator: deserializeBool(pos + 85),
@@ -2202,7 +2213,7 @@ function deserializeFunction(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     params = deserializeBoxFormalParameters(pos + 56);
   {
     let thisParam = deserializeOptionBoxTSThisParameter(pos + 48);
@@ -2235,23 +2246,23 @@ function deserializeFunctionType(pos) {
 
 function deserializeFormalParameters(pos) {
   let params = deserializeVecFormalParameter(pos + 8);
-  if (uint32[pos + 32 >> 2] !== 0 && uint32[pos + 36 >> 2] !== 0) {
-    pos = uint32[pos + 32 >> 2];
+  if (uint32[(pos + 32) >> 2] !== 0 && uint32[(pos + 36) >> 2] !== 0) {
+    pos = uint32[(pos + 32) >> 2];
     let start,
       end,
       previousParent = parent,
-      rest = parent = {
+      rest = (parent = {
         type: 'RestElement',
         decorators: [],
         argument: null,
         optional: deserializeBool(pos + 32),
         typeAnnotation: null,
         value: null,
-        start: start = deserializeU32(pos),
-        end: end = deserializeU32(pos + 4),
+        start: (start = deserializeU32(pos)),
+        end: (end = deserializeU32(pos + 4)),
         range: [start, end],
         parent,
-      };
+      });
     rest.argument = deserializeBindingPatternKind(pos + 8);
     rest.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
     params.push(rest);
@@ -2282,8 +2293,8 @@ function deserializeFormalParameter(pos) {
         parameter: null,
         readonly,
         static: false,
-        start: start = deserializeU32(pos),
-        end: end = deserializeU32(pos + 4),
+        start: (start = deserializeU32(pos)),
+        end: (end = deserializeU32(pos + 4)),
         range: [start, end],
         parent,
       };
@@ -2299,14 +2310,14 @@ function deserializeFunctionBody(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'BlockStatement',
       body: null,
       start,
       end,
       range: [start, end],
       parent,
-    },
+    }),
     body = deserializeVecDirective(pos + 8);
   body.push(...deserializeVecStatement(pos + 32));
   node.body = body;
@@ -2319,7 +2330,7 @@ function deserializeArrowFunctionExpression(pos) {
     start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ArrowFunctionExpression',
       expression,
       async: deserializeBool(pos + 45),
@@ -2333,7 +2344,7 @@ function deserializeArrowFunctionExpression(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     body = deserializeBoxFunctionBody(pos + 32);
   if (expression === true) {
     body = body.body[0].expression;
@@ -2353,7 +2364,7 @@ function deserializeYieldExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'YieldExpression',
       delegate: deserializeBool(pos + 24),
       argument: null,
@@ -2361,7 +2372,7 @@ function deserializeYieldExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeOptionExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -2371,7 +2382,7 @@ function deserializeClass(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: deserializeClassType(pos + 132),
       decorators: null,
       id: null,
@@ -2386,7 +2397,7 @@ function deserializeClass(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = deserializeVecDecorator(pos + 8);
   node.id = deserializeOptionBindingIdentifier(pos + 32);
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 64);
@@ -2413,14 +2424,14 @@ function deserializeClassBody(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ClassBody',
       body: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.body = deserializeVecClassElement(pos + 8);
   parent = previousParent;
   return node;
@@ -2447,7 +2458,7 @@ function deserializeMethodDefinition(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: deserializeMethodDefinitionType(pos + 56),
       decorators: null,
       key: null,
@@ -2462,7 +2473,7 @@ function deserializeMethodDefinition(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = deserializeVecDecorator(pos + 8);
   node.key = deserializePropertyKey(pos + 32);
   node.value = deserializeBoxFunction(pos + 48);
@@ -2485,7 +2496,7 @@ function deserializePropertyDefinition(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: deserializePropertyDefinitionType(pos + 72),
       decorators: null,
       key: null,
@@ -2503,7 +2514,7 @@ function deserializePropertyDefinition(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = deserializeVecDecorator(pos + 8);
   node.key = deserializePropertyKey(pos + 32);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 48);
@@ -2539,7 +2550,8 @@ function deserializeMethodDefinitionKind(pos) {
 }
 
 function deserializePrivateIdentifier(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'PrivateIdentifier',
     name: deserializeStr(pos + 8),
@@ -2554,14 +2566,14 @@ function deserializeStaticBlock(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'StaticBlock',
       body: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.body = deserializeVecStatement(pos + 8);
   parent = previousParent;
   return node;
@@ -2582,7 +2594,7 @@ function deserializeAccessorProperty(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: deserializeAccessorPropertyType(pos + 72),
       decorators: null,
       key: null,
@@ -2600,7 +2612,7 @@ function deserializeAccessorProperty(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = deserializeVecDecorator(pos + 8);
   node.key = deserializePropertyKey(pos + 32);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 48);
@@ -2616,7 +2628,7 @@ function deserializeImportExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ImportExpression',
       source: null,
       options: null,
@@ -2625,7 +2637,7 @@ function deserializeImportExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.source = deserializeExpression(pos + 8);
   node.options = deserializeOptionExpression(pos + 24);
   parent = previousParent;
@@ -2636,7 +2648,7 @@ function deserializeImportDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ImportDeclaration',
       specifiers: null,
       source: null,
@@ -2647,7 +2659,7 @@ function deserializeImportDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     specifiers = deserializeOptionVecImportDeclarationSpecifier(pos + 8);
   specifiers === null && (specifiers = []);
   let withClause = deserializeOptionBoxWithClause(pos + 80);
@@ -2686,7 +2698,7 @@ function deserializeImportSpecifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ImportSpecifier',
       imported: null,
       local: null,
@@ -2695,7 +2707,7 @@ function deserializeImportSpecifier(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.imported = deserializeModuleExportName(pos + 8);
   node.local = deserializeBindingIdentifier(pos + 64);
   parent = previousParent;
@@ -2706,14 +2718,14 @@ function deserializeImportDefaultSpecifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ImportDefaultSpecifier',
       local: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.local = deserializeBindingIdentifier(pos + 8);
   parent = previousParent;
   return node;
@@ -2723,14 +2735,14 @@ function deserializeImportNamespaceSpecifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ImportNamespaceSpecifier',
       local: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.local = deserializeBindingIdentifier(pos + 8);
   parent = previousParent;
   return node;
@@ -2744,7 +2756,7 @@ function deserializeImportAttribute(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ImportAttribute',
       key: null,
       value: null,
@@ -2752,7 +2764,7 @@ function deserializeImportAttribute(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.key = deserializeImportAttributeKey(pos + 8);
   node.value = deserializeStringLiteral(pos + 64);
   parent = previousParent;
@@ -2774,7 +2786,7 @@ function deserializeExportNamedDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ExportNamedDeclaration',
       declaration: null,
       specifiers: null,
@@ -2785,7 +2797,7 @@ function deserializeExportNamedDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     withClause = deserializeOptionBoxWithClause(pos + 96);
   node.declaration = deserializeOptionDeclaration(pos + 8);
   node.specifiers = deserializeVecExportSpecifier(pos + 24);
@@ -2799,7 +2811,7 @@ function deserializeExportDefaultDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ExportDefaultDeclaration',
       declaration: null,
       exportKind: null,
@@ -2807,7 +2819,7 @@ function deserializeExportDefaultDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.declaration = deserializeExportDefaultDeclarationKind(pos + 8);
   node.exportKind = 'value';
   parent = previousParent;
@@ -2818,7 +2830,7 @@ function deserializeExportAllDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ExportAllDeclaration',
       exported: null,
       source: null,
@@ -2828,7 +2840,7 @@ function deserializeExportAllDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     withClause = deserializeOptionBoxWithClause(pos + 112);
   node.exported = deserializeOptionModuleExportName(pos + 8);
   node.source = deserializeStringLiteral(pos + 64);
@@ -2841,7 +2853,7 @@ function deserializeExportSpecifier(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'ExportSpecifier',
       local: null,
       exported: null,
@@ -2850,7 +2862,7 @@ function deserializeExportSpecifier(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.local = deserializeModuleExportName(pos + 8);
   node.exported = deserializeModuleExportName(pos + 64);
   parent = previousParent;
@@ -2973,7 +2985,7 @@ function deserializeV8IntrinsicExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'V8IntrinsicExpression',
       name: null,
       arguments: null,
@@ -2981,7 +2993,7 @@ function deserializeV8IntrinsicExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.name = deserializeIdentifierName(pos + 8);
   node.arguments = deserializeVecArgument(pos + 32);
   parent = previousParent;
@@ -2993,7 +3005,7 @@ function deserializeBooleanLiteral(pos) {
     start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Literal',
       value,
       raw: null,
@@ -3001,7 +3013,7 @@ function deserializeBooleanLiteral(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.raw = start === 0 && end === 0 ? null : value + '';
   parent = previousParent;
   return node;
@@ -3011,7 +3023,7 @@ function deserializeNullLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Literal',
       value: null,
       raw: null,
@@ -3019,7 +3031,7 @@ function deserializeNullLiteral(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.value = null;
   node.raw = start === 0 && end === 0 ? null : 'null';
   parent = previousParent;
@@ -3027,7 +3039,8 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'Literal',
     value: deserializeF64(pos + 8),
@@ -3043,7 +3056,7 @@ function deserializeStringLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Literal',
       value: null,
       raw: deserializeOptionStr(pos + 24),
@@ -3051,7 +3064,7 @@ function deserializeStringLiteral(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     value = deserializeStr(pos + 8);
   deserializeBool(pos + 40) &&
     (value = value.replace(/\uFFFD(.{4})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16))));
@@ -3064,7 +3077,7 @@ function deserializeBigIntLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Literal',
       value: null,
       raw: deserializeOptionStr(pos + 24),
@@ -3073,7 +3086,7 @@ function deserializeBigIntLiteral(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     bigint = deserializeStr(pos + 8);
   node.value = BigInt(bigint);
   node.bigint = bigint;
@@ -3085,7 +3098,7 @@ function deserializeRegExpLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Literal',
       value: null,
       raw: deserializeOptionStr(pos + 40),
@@ -3094,7 +3107,7 @@ function deserializeRegExpLiteral(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     regex = deserializeRegExp(pos + 8),
     value = null;
   try {
@@ -3114,7 +3127,8 @@ function deserializeRegExp(pos) {
 }
 
 function deserializeRegExpFlags(pos) {
-  let flagBits = deserializeU8(pos), flags = '';
+  let flagBits = deserializeU8(pos),
+    flags = '';
   // Alphabetical order
   flagBits & 64 && (flags += 'd');
   flagBits & 1 && (flags += 'g');
@@ -3131,7 +3145,7 @@ function deserializeJSXElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXElement',
       openingElement: null,
       children: null,
@@ -3140,7 +3154,7 @@ function deserializeJSXElement(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     closingElement = deserializeOptionBoxJSXClosingElement(pos + 40),
     openingElement = deserializeBoxJSXOpeningElement(pos + 8);
   closingElement === null && (openingElement.selfClosing = true);
@@ -3155,7 +3169,7 @@ function deserializeJSXOpeningElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXOpeningElement',
       name: null,
       typeArguments: null,
@@ -3165,7 +3179,7 @@ function deserializeJSXOpeningElement(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.name = deserializeJSXElementName(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   node.attributes = deserializeVecJSXAttributeItem(pos + 32);
@@ -3178,14 +3192,14 @@ function deserializeJSXClosingElement(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXClosingElement',
       name: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.name = deserializeJSXElementName(pos + 8);
   parent = previousParent;
   return node;
@@ -3195,7 +3209,7 @@ function deserializeJSXFragment(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXFragment',
       openingFragment: null,
       children: null,
@@ -3204,7 +3218,7 @@ function deserializeJSXFragment(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.openingFragment = deserializeJSXOpeningFragment(pos + 8);
   node.children = deserializeVecJSXChild(pos + 16);
   node.closingFragment = deserializeJSXClosingFragment(pos + 40);
@@ -3216,19 +3230,20 @@ function deserializeJSXOpeningFragment(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXOpeningFragment',
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   parent = previousParent;
   return node;
 }
 
 function deserializeJSXClosingFragment(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXClosingFragment',
     start,
@@ -3275,7 +3290,7 @@ function deserializeJSXNamespacedName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXNamespacedName',
       namespace: null,
       name: null,
@@ -3283,7 +3298,7 @@ function deserializeJSXNamespacedName(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.namespace = deserializeJSXIdentifier(pos + 8);
   node.name = deserializeJSXIdentifier(pos + 32);
   parent = previousParent;
@@ -3294,7 +3309,7 @@ function deserializeJSXMemberExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXMemberExpression',
       object: null,
       property: null,
@@ -3302,7 +3317,7 @@ function deserializeJSXMemberExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.object = deserializeJSXMemberExpressionObject(pos + 8);
   node.property = deserializeJSXIdentifier(pos + 24);
   parent = previousParent;
@@ -3342,14 +3357,14 @@ function deserializeJSXExpressionContainer(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXExpressionContainer',
       expression: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeJSXExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -3451,7 +3466,8 @@ function deserializeJSXExpression(pos) {
 }
 
 function deserializeJSXEmptyExpression(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXEmptyExpression',
     start,
@@ -3476,7 +3492,7 @@ function deserializeJSXAttribute(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXAttribute',
       name: null,
       value: null,
@@ -3484,7 +3500,7 @@ function deserializeJSXAttribute(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.name = deserializeJSXAttributeName(pos + 8);
   node.value = deserializeOptionJSXAttributeValue(pos + 24);
   parent = previousParent;
@@ -3495,14 +3511,14 @@ function deserializeJSXSpreadAttribute(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXSpreadAttribute',
       argument: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -3535,7 +3551,8 @@ function deserializeJSXAttributeValue(pos) {
 }
 
 function deserializeJSXIdentifier(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXIdentifier',
     name: deserializeStr(pos + 8),
@@ -3567,21 +3584,22 @@ function deserializeJSXSpreadChild(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'JSXSpreadChild',
       expression: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
 }
 
 function deserializeJSXText(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'JSXText',
     value: deserializeStr(pos + 8),
@@ -3597,7 +3615,7 @@ function deserializeTSThisParameter(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Identifier',
       decorators: null,
       name: null,
@@ -3607,7 +3625,7 @@ function deserializeTSThisParameter(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = [];
   node.name = 'this';
   node.optional = false;
@@ -3620,7 +3638,7 @@ function deserializeTSEnumDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSEnumDeclaration',
       id: null,
       body: null,
@@ -3630,7 +3648,7 @@ function deserializeTSEnumDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.id = deserializeBindingIdentifier(pos + 8);
   node.body = deserializeTSEnumBody(pos + 40);
   parent = previousParent;
@@ -3641,14 +3659,14 @@ function deserializeTSEnumBody(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSEnumBody',
       members: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.members = deserializeVecTSEnumMember(pos + 8);
   parent = previousParent;
   return node;
@@ -3658,7 +3676,7 @@ function deserializeTSEnumMember(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSEnumMember',
       id: null,
       initializer: null,
@@ -3667,7 +3685,7 @@ function deserializeTSEnumMember(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.id = deserializeTSEnumMemberName(pos + 8);
   node.initializer = deserializeOptionExpression(pos + 24);
   node.computed = deserializeU8(pos + 8) > 1;
@@ -3694,14 +3712,14 @@ function deserializeTSTypeAnnotation(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeAnnotation',
       typeAnnotation: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3711,14 +3729,14 @@ function deserializeTSLiteralType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSLiteralType',
       literal: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.literal = deserializeTSLiteral(pos + 8);
   parent = previousParent;
   return node;
@@ -3828,7 +3846,7 @@ function deserializeTSConditionalType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSConditionalType',
       checkType: null,
       extendsType: null,
@@ -3838,7 +3856,7 @@ function deserializeTSConditionalType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.checkType = deserializeTSType(pos + 8);
   node.extendsType = deserializeTSType(pos + 24);
   node.trueType = deserializeTSType(pos + 40);
@@ -3851,14 +3869,14 @@ function deserializeTSUnionType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSUnionType',
       types: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.types = deserializeVecTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3868,14 +3886,14 @@ function deserializeTSIntersectionType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSIntersectionType',
       types: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.types = deserializeVecTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3884,12 +3902,14 @@ function deserializeTSIntersectionType(pos) {
 function deserializeTSParenthesizedType(pos) {
   let node;
   {
-    let start, end, previousParent = parent;
+    let start,
+      end,
+      previousParent = parent;
     node = parent = {
       type: 'TSParenthesizedType',
       typeAnnotation: null,
-      start: start = deserializeU32(pos),
-      end: end = deserializeU32(pos + 4),
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     };
@@ -3903,7 +3923,7 @@ function deserializeTSTypeOperator(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeOperator',
       operator: deserializeTSTypeOperatorOperator(pos + 24),
       typeAnnotation: null,
@@ -3911,7 +3931,7 @@ function deserializeTSTypeOperator(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3934,14 +3954,14 @@ function deserializeTSArrayType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSArrayType',
       elementType: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.elementType = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -3951,7 +3971,7 @@ function deserializeTSIndexedAccessType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSIndexedAccessType',
       objectType: null,
       indexType: null,
@@ -3959,7 +3979,7 @@ function deserializeTSIndexedAccessType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.objectType = deserializeTSType(pos + 8);
   node.indexType = deserializeTSType(pos + 24);
   parent = previousParent;
@@ -3970,14 +3990,14 @@ function deserializeTSTupleType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTupleType',
       elementTypes: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.elementTypes = deserializeVecTSTupleElement(pos + 8);
   parent = previousParent;
   return node;
@@ -3987,7 +4007,7 @@ function deserializeTSNamedTupleMember(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSNamedTupleMember',
       label: null,
       elementType: null,
@@ -3996,7 +4016,7 @@ function deserializeTSNamedTupleMember(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.label = deserializeIdentifierName(pos + 8);
   node.elementType = deserializeTSTupleElement(pos + 32);
   parent = previousParent;
@@ -4007,14 +4027,14 @@ function deserializeTSOptionalType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSOptionalType',
       typeAnnotation: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -4024,14 +4044,14 @@ function deserializeTSRestType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSRestType',
       typeAnnotation: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -4123,7 +4143,8 @@ function deserializeTSTupleElement(pos) {
 }
 
 function deserializeTSAnyKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSAnyKeyword',
     start,
@@ -4134,7 +4155,8 @@ function deserializeTSAnyKeyword(pos) {
 }
 
 function deserializeTSStringKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSStringKeyword',
     start,
@@ -4145,7 +4167,8 @@ function deserializeTSStringKeyword(pos) {
 }
 
 function deserializeTSBooleanKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSBooleanKeyword',
     start,
@@ -4156,7 +4179,8 @@ function deserializeTSBooleanKeyword(pos) {
 }
 
 function deserializeTSNumberKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSNumberKeyword',
     start,
@@ -4167,7 +4191,8 @@ function deserializeTSNumberKeyword(pos) {
 }
 
 function deserializeTSNeverKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSNeverKeyword',
     start,
@@ -4178,7 +4203,8 @@ function deserializeTSNeverKeyword(pos) {
 }
 
 function deserializeTSIntrinsicKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSIntrinsicKeyword',
     start,
@@ -4189,7 +4215,8 @@ function deserializeTSIntrinsicKeyword(pos) {
 }
 
 function deserializeTSUnknownKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSUnknownKeyword',
     start,
@@ -4200,7 +4227,8 @@ function deserializeTSUnknownKeyword(pos) {
 }
 
 function deserializeTSNullKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSNullKeyword',
     start,
@@ -4211,7 +4239,8 @@ function deserializeTSNullKeyword(pos) {
 }
 
 function deserializeTSUndefinedKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSUndefinedKeyword',
     start,
@@ -4222,7 +4251,8 @@ function deserializeTSUndefinedKeyword(pos) {
 }
 
 function deserializeTSVoidKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSVoidKeyword',
     start,
@@ -4233,7 +4263,8 @@ function deserializeTSVoidKeyword(pos) {
 }
 
 function deserializeTSSymbolKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSSymbolKeyword',
     start,
@@ -4244,7 +4275,8 @@ function deserializeTSSymbolKeyword(pos) {
 }
 
 function deserializeTSThisType(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSThisType',
     start,
@@ -4255,7 +4287,8 @@ function deserializeTSThisType(pos) {
 }
 
 function deserializeTSObjectKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSObjectKeyword',
     start,
@@ -4266,7 +4299,8 @@ function deserializeTSObjectKeyword(pos) {
 }
 
 function deserializeTSBigIntKeyword(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSBigIntKeyword',
     start,
@@ -4280,7 +4314,7 @@ function deserializeTSTypeReference(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeReference',
       typeName: null,
       typeArguments: null,
@@ -4288,7 +4322,7 @@ function deserializeTSTypeReference(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeName = deserializeTSTypeName(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   parent = previousParent;
@@ -4312,7 +4346,7 @@ function deserializeTSQualifiedName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSQualifiedName',
       left: null,
       right: null,
@@ -4320,7 +4354,7 @@ function deserializeTSQualifiedName(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializeTSTypeName(pos + 8);
   node.right = deserializeIdentifierName(pos + 24);
   parent = previousParent;
@@ -4331,14 +4365,14 @@ function deserializeTSTypeParameterInstantiation(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeParameterInstantiation',
       params: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.params = deserializeVecTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -4348,7 +4382,7 @@ function deserializeTSTypeParameter(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeParameter',
       name: null,
       constraint: null,
@@ -4360,7 +4394,7 @@ function deserializeTSTypeParameter(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.name = deserializeBindingIdentifier(pos + 8);
   node.constraint = deserializeOptionTSType(pos + 40);
   node.default = deserializeOptionTSType(pos + 56);
@@ -4372,14 +4406,14 @@ function deserializeTSTypeParameterDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeParameterDeclaration',
       params: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.params = deserializeVecTSTypeParameter(pos + 8);
   parent = previousParent;
   return node;
@@ -4389,7 +4423,7 @@ function deserializeTSTypeAliasDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeAliasDeclaration',
       id: null,
       typeParameters: null,
@@ -4399,7 +4433,7 @@ function deserializeTSTypeAliasDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.id = deserializeBindingIdentifier(pos + 8);
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 40);
   node.typeAnnotation = deserializeTSType(pos + 48);
@@ -4424,7 +4458,7 @@ function deserializeTSClassImplements(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSClassImplements',
       expression: null,
       typeArguments: null,
@@ -4432,24 +4466,24 @@ function deserializeTSClassImplements(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     expression = deserializeTSTypeName(pos + 8);
   if (expression.type === 'TSQualifiedName') {
     let object = expression.left,
       { right } = expression,
       start,
       end,
-      previous = expression = {
+      previous = (expression = {
         type: 'MemberExpression',
         object,
         property: right,
         optional: false,
         computed: false,
-        start: start = expression.start,
-        end: end = expression.end,
+        start: (start = expression.start),
+        end: (end = expression.end),
         range: [start, end],
         parent,
-      };
+      });
     right.parent = previous;
     for (;;) {
       if (object.type !== 'TSQualifiedName') {
@@ -4463,8 +4497,8 @@ function deserializeTSClassImplements(pos) {
         property: right,
         optional: false,
         computed: false,
-        start: start = object.start,
-        end: end = object.end,
+        start: (start = object.start),
+        end: (end = object.end),
         range: [start, end],
         parent: previous,
       };
@@ -4482,7 +4516,7 @@ function deserializeTSInterfaceDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSInterfaceDeclaration',
       id: null,
       typeParameters: null,
@@ -4493,7 +4527,7 @@ function deserializeTSInterfaceDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.id = deserializeBindingIdentifier(pos + 8);
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 40);
   node.extends = deserializeVecTSInterfaceHeritage(pos + 48);
@@ -4506,14 +4540,14 @@ function deserializeTSInterfaceBody(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSInterfaceBody',
       body: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.body = deserializeVecTSSignature(pos + 8);
   parent = previousParent;
   return node;
@@ -4523,7 +4557,7 @@ function deserializeTSPropertySignature(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSPropertySignature',
       computed: deserializeBool(pos + 32),
       optional: deserializeBool(pos + 33),
@@ -4536,7 +4570,7 @@ function deserializeTSPropertySignature(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.key = deserializePropertyKey(pos + 8);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   node.accessibility = null;
@@ -4566,7 +4600,7 @@ function deserializeTSIndexSignature(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSIndexSignature',
       parameters: null,
       typeAnnotation: null,
@@ -4577,7 +4611,7 @@ function deserializeTSIndexSignature(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.parameters = deserializeVecTSIndexSignatureName(pos + 8);
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
   node.accessibility = null;
@@ -4589,7 +4623,7 @@ function deserializeTSCallSignatureDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSCallSignatureDeclaration',
       typeParameters: null,
       params: null,
@@ -4598,7 +4632,7 @@ function deserializeTSCallSignatureDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     params = deserializeBoxFormalParameters(pos + 24),
     thisParam = deserializeOptionBoxTSThisParameter(pos + 16);
   thisParam !== null && params.unshift(thisParam);
@@ -4626,7 +4660,7 @@ function deserializeTSMethodSignature(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSMethodSignature',
       key: null,
       computed: deserializeBool(pos + 60),
@@ -4642,7 +4676,7 @@ function deserializeTSMethodSignature(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     params = deserializeBoxFormalParameters(pos + 40),
     thisParam = deserializeOptionBoxTSThisParameter(pos + 32);
   thisParam !== null && params.unshift(thisParam);
@@ -4661,7 +4695,7 @@ function deserializeTSConstructSignatureDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSConstructSignatureDeclaration',
       typeParameters: null,
       params: null,
@@ -4670,7 +4704,7 @@ function deserializeTSConstructSignatureDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 8);
   node.params = deserializeBoxFormalParameters(pos + 16);
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 24);
@@ -4682,7 +4716,7 @@ function deserializeTSIndexSignatureName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Identifier',
       decorators: null,
       name: deserializeStr(pos + 8),
@@ -4692,7 +4726,7 @@ function deserializeTSIndexSignatureName(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.decorators = [];
   node.optional = false;
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 24);
@@ -4704,7 +4738,7 @@ function deserializeTSInterfaceHeritage(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSInterfaceHeritage',
       expression: null,
       typeArguments: null,
@@ -4712,7 +4746,7 @@ function deserializeTSInterfaceHeritage(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   parent = previousParent;
@@ -4723,7 +4757,7 @@ function deserializeTSTypePredicate(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypePredicate',
       parameterName: null,
       asserts: deserializeBool(pos + 32),
@@ -4732,7 +4766,7 @@ function deserializeTSTypePredicate(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.parameterName = deserializeTSTypePredicateName(pos + 8);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   parent = previousParent;
@@ -4801,8 +4835,8 @@ function deserializeTSModuleDeclaration(pos) {
               type: 'TSQualifiedName',
               left: id,
               right: innerId,
-              start: start = id.start,
-              end: end = innerId.end,
+              start: (start = id.start),
+              end: (end = innerId.end),
               range: [start, end],
               parent: node,
             };
@@ -4817,16 +4851,20 @@ function deserializeTSModuleDeclaration(pos) {
           if (innerId.left.type === 'Identifier') break;
           innerId = innerId.left;
         }
-        let end, right = innerId.left;
-        id.parent = right.parent = innerId.left = {
-          type: 'TSQualifiedName',
-          left: id,
-          right,
-          start,
-          end: end = right.end,
-          range: [start, end],
-          parent: innerId,
-        };
+        let end,
+          right = innerId.left;
+        id.parent =
+          right.parent =
+          innerId.left =
+            {
+              type: 'TSQualifiedName',
+              left: id,
+              right,
+              start,
+              end: (end = right.end),
+              range: [start, end],
+              parent: innerId,
+            };
       }
       if (Object.hasOwn(body, 'body')) {
         body = body.body;
@@ -4878,14 +4916,14 @@ function deserializeTSModuleBlock(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSModuleBlock',
       body: null,
       start,
       end,
       range: [start, end],
       parent,
-    },
+    }),
     body = deserializeVecDirective(pos + 8);
   body.push(...deserializeVecStatement(pos + 32));
   node.body = body;
@@ -4897,14 +4935,14 @@ function deserializeTSTypeLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeLiteral',
       members: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.members = deserializeVecTSSignature(pos + 8);
   parent = previousParent;
   return node;
@@ -4914,14 +4952,14 @@ function deserializeTSInferType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSInferType',
       typeParameter: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeParameter = deserializeBoxTSTypeParameter(pos + 8);
   parent = previousParent;
   return node;
@@ -4931,7 +4969,7 @@ function deserializeTSTypeQuery(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeQuery',
       exprName: null,
       typeArguments: null,
@@ -4939,7 +4977,7 @@ function deserializeTSTypeQuery(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.exprName = deserializeTSTypeQueryExprName(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   parent = previousParent;
@@ -4965,7 +5003,7 @@ function deserializeTSImportType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSImportType',
       argument: null,
       options: null,
@@ -4975,7 +5013,7 @@ function deserializeTSImportType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.argument = deserializeTSType(pos + 8);
   node.options = deserializeOptionBoxObjectExpression(pos + 24);
   node.qualifier = deserializeOptionTSImportTypeQualifier(pos + 32);
@@ -4999,7 +5037,7 @@ function deserializeTSImportTypeQualifiedName(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSQualifiedName',
       left: null,
       right: null,
@@ -5007,7 +5045,7 @@ function deserializeTSImportTypeQualifiedName(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.left = deserializeTSImportTypeQualifier(pos + 8);
   node.right = deserializeIdentifierName(pos + 24);
   parent = previousParent;
@@ -5018,7 +5056,7 @@ function deserializeTSFunctionType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSFunctionType',
       typeParameters: null,
       params: null,
@@ -5027,7 +5065,7 @@ function deserializeTSFunctionType(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     params = deserializeBoxFormalParameters(pos + 24),
     thisParam = deserializeOptionBoxTSThisParameter(pos + 16);
   thisParam !== null && params.unshift(thisParam);
@@ -5042,7 +5080,7 @@ function deserializeTSConstructorType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSConstructorType',
       abstract: deserializeBool(pos + 36),
       typeParameters: null,
@@ -5052,7 +5090,7 @@ function deserializeTSConstructorType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 8);
   node.params = deserializeBoxFormalParameters(pos + 16);
   node.returnType = deserializeBoxTSTypeAnnotation(pos + 24);
@@ -5064,7 +5102,7 @@ function deserializeTSMappedType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSMappedType',
       key: null,
       constraint: null,
@@ -5076,7 +5114,7 @@ function deserializeTSMappedType(pos) {
       end,
       range: [start, end],
       parent,
-    },
+    }),
     typeParameter = deserializeBoxTSTypeParameter(pos + 8),
     key = typeParameter.name;
   key.parent = parent;
@@ -5110,7 +5148,7 @@ function deserializeTSTemplateLiteralType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTemplateLiteralType',
       quasis: null,
       types: null,
@@ -5118,7 +5156,7 @@ function deserializeTSTemplateLiteralType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.quasis = deserializeVecTemplateElement(pos + 8);
   node.types = deserializeVecTSType(pos + 32);
   parent = previousParent;
@@ -5129,7 +5167,7 @@ function deserializeTSAsExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSAsExpression',
       expression: null,
       typeAnnotation: null,
@@ -5137,7 +5175,7 @@ function deserializeTSAsExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   node.typeAnnotation = deserializeTSType(pos + 24);
   parent = previousParent;
@@ -5148,7 +5186,7 @@ function deserializeTSSatisfiesExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSSatisfiesExpression',
       expression: null,
       typeAnnotation: null,
@@ -5156,7 +5194,7 @@ function deserializeTSSatisfiesExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   node.typeAnnotation = deserializeTSType(pos + 24);
   parent = previousParent;
@@ -5167,7 +5205,7 @@ function deserializeTSTypeAssertion(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSTypeAssertion',
       typeAnnotation: null,
       expression: null,
@@ -5175,7 +5213,7 @@ function deserializeTSTypeAssertion(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   node.expression = deserializeExpression(pos + 24);
   parent = previousParent;
@@ -5186,7 +5224,7 @@ function deserializeTSImportEqualsDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSImportEqualsDeclaration',
       id: null,
       moduleReference: null,
@@ -5195,7 +5233,7 @@ function deserializeTSImportEqualsDeclaration(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.id = deserializeBindingIdentifier(pos + 8);
   node.moduleReference = deserializeTSModuleReference(pos + 40);
   parent = previousParent;
@@ -5221,14 +5259,14 @@ function deserializeTSExternalModuleReference(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSExternalModuleReference',
       expression: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeStringLiteral(pos + 8);
   parent = previousParent;
   return node;
@@ -5238,14 +5276,14 @@ function deserializeTSNonNullExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSNonNullExpression',
       expression: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -5255,14 +5293,14 @@ function deserializeDecorator(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'Decorator',
       expression: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -5272,14 +5310,14 @@ function deserializeTSExportAssignment(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSExportAssignment',
       expression: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   parent = previousParent;
   return node;
@@ -5289,14 +5327,14 @@ function deserializeTSNamespaceExportDeclaration(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSNamespaceExportDeclaration',
       id: null,
       start,
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.id = deserializeIdentifierName(pos + 8);
   parent = previousParent;
   return node;
@@ -5306,7 +5344,7 @@ function deserializeTSInstantiationExpression(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSInstantiationExpression',
       expression: null,
       typeArguments: null,
@@ -5314,7 +5352,7 @@ function deserializeTSInstantiationExpression(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.expression = deserializeExpression(pos + 8);
   node.typeArguments = deserializeBoxTSTypeParameterInstantiation(pos + 24);
   parent = previousParent;
@@ -5336,7 +5374,7 @@ function deserializeJSDocNullableType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSJSDocNullableType',
       typeAnnotation: null,
       postfix: deserializeBool(pos + 24),
@@ -5344,7 +5382,7 @@ function deserializeJSDocNullableType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
@@ -5354,7 +5392,7 @@ function deserializeJSDocNonNullableType(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
     previousParent = parent,
-    node = parent = {
+    node = (parent = {
       type: 'TSJSDocNonNullableType',
       typeAnnotation: null,
       postfix: deserializeBool(pos + 24),
@@ -5362,14 +5400,15 @@ function deserializeJSDocNonNullableType(pos) {
       end,
       range: [start, end],
       parent,
-    };
+    });
   node.typeAnnotation = deserializeTSType(pos + 8);
   parent = previousParent;
   return node;
 }
 
 function deserializeJSDocUnknownType(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: 'TSJSDocUnknownType',
     start,
@@ -5391,7 +5430,9 @@ function deserializeCommentKind(pos) {
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12), start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let type = deserializeCommentKind(pos + 12),
+    start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type,
     value: sourceText.slice(start + 2, end - (type === 'Line' ? 0 : 2)),
@@ -5402,7 +5443,8 @@ function deserializeComment(pos) {
 }
 
 function deserializeNameSpan(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     value: deserializeStr(pos + 8),
     start,
@@ -5453,7 +5495,8 @@ function deserializeImportImportName(pos) {
 }
 
 function deserializeExportEntry(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
@@ -5573,7 +5616,8 @@ function deserializeExportLocalName(pos) {
 }
 
 function deserializeDynamicImport(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeSpan(pos + 8),
     start,
@@ -5768,7 +5812,8 @@ function deserializeErrorSeverity(pos) {
 }
 
 function deserializeErrorLabel(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     message: deserializeOptionStr(pos + 8),
     start,
@@ -5788,7 +5833,8 @@ function deserializeEcmaScriptModule(pos) {
 }
 
 function deserializeStaticImport(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeNameSpan(pos + 8),
     entries: deserializeVecImportEntry(pos + 32),
@@ -5799,7 +5845,8 @@ function deserializeStaticImport(pos) {
 }
 
 function deserializeStaticExport(pos) {
-  let start = deserializeU32(pos), end = deserializeU32(pos + 4);
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     entries: deserializeVecExportEntry(pos + 8),
     start,
@@ -5817,7 +5864,8 @@ function deserializeU8(pos) {
 }
 
 function deserializeStr(pos) {
-  let pos32 = pos >> 2, len = uint32[pos32 + 2];
+  let pos32 = pos >> 2,
+    len = uint32[pos32 + 2];
   if (len === 0) return '';
   pos = uint32[pos32];
   if (sourceIsAscii && pos < sourceByteLen) return sourceText.substr(pos, len);
@@ -5826,7 +5874,8 @@ function deserializeStr(pos) {
   let end = pos + len;
   if (len > 50) return decodeStr(uint8.subarray(pos, end));
   // Shorter strings decode by hand to avoid native call
-  let out = '', c;
+  let out = '',
+    c;
   do {
     c = uint8[pos++];
     if (c < 128) out += fromCodePoint(c);
@@ -5839,10 +5888,11 @@ function deserializeStr(pos) {
 }
 
 function deserializeVecComment(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeComment(pos));
     pos += 16;
   }
@@ -5850,15 +5900,16 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeHashbang(pos);
 }
 
 function deserializeVecDirective(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 72;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDirective(pos));
     pos += 72;
   }
@@ -5866,10 +5917,11 @@ function deserializeVecDirective(pos) {
 }
 
 function deserializeVecStatement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStatement(pos));
     pos += 16;
   }
@@ -6037,10 +6089,11 @@ function deserializeBoxV8IntrinsicExpression(pos) {
 }
 
 function deserializeVecArrayExpressionElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeArrayExpressionElement(pos));
     pos += 16;
   }
@@ -6052,10 +6105,11 @@ function deserializeBoxSpreadElement(pos) {
 }
 
 function deserializeVecObjectPropertyKind(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeObjectPropertyKind(pos));
     pos += 16;
   }
@@ -6079,10 +6133,11 @@ function deserializeBoxPrivateIdentifier(pos) {
 }
 
 function deserializeVecTemplateElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 48;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTemplateElement(pos));
     pos += 48;
   }
@@ -6090,10 +6145,11 @@ function deserializeVecTemplateElement(pos) {
 }
 
 function deserializeVecExpression(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExpression(pos));
     pos += 16;
   }
@@ -6105,12 +6161,12 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeStr(pos);
 }
 
@@ -6127,10 +6183,11 @@ function deserializeBoxPrivateFieldExpression(pos) {
 }
 
 function deserializeVecArgument(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeArgument(pos));
     pos += 16;
   }
@@ -6151,10 +6208,11 @@ function deserializeOptionAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeOptionAssignmentTargetMaybeDefault(pos));
     pos += 16;
   }
@@ -6166,15 +6224,16 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxAssignmentTargetRest(pos);
 }
 
 function deserializeVecAssignmentTargetProperty(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeAssignmentTargetProperty(pos));
     pos += 16;
   }
@@ -6295,10 +6354,11 @@ function deserializeBoxTSImportEqualsDeclaration(pos) {
 }
 
 function deserializeVecVariableDeclarator(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 64;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeVariableDeclarator(pos));
     pos += 64;
   }
@@ -6316,15 +6376,16 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeLabelIdentifier(pos);
 }
 
 function deserializeVecSwitchCase(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 48;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeSwitchCase(pos));
     pos += 48;
   }
@@ -6336,12 +6397,12 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxBlockStatement(pos);
 }
 
@@ -6355,7 +6416,7 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeAnnotation(pos);
 }
 
@@ -6376,10 +6437,11 @@ function deserializeBoxAssignmentPattern(pos) {
 }
 
 function deserializeVecBindingProperty(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 64;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeBindingProperty(pos));
     pos += 64;
   }
@@ -6391,7 +6453,7 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxBindingRestElement(pos);
 }
 
@@ -6401,10 +6463,11 @@ function deserializeOptionBindingPattern(pos) {
 }
 
 function deserializeVecOptionBindingPattern(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeOptionBindingPattern(pos));
     pos += 32;
   }
@@ -6412,7 +6475,7 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeBindingIdentifier(pos);
 }
 
@@ -6421,7 +6484,7 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
@@ -6430,7 +6493,7 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxTSThisParameter(pos);
 }
 
@@ -6443,15 +6506,16 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxFunctionBody(pos);
 }
 
 function deserializeVecFormalParameter(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 72;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeFormalParameter(pos));
     pos += 72;
   }
@@ -6459,10 +6523,11 @@ function deserializeVecFormalParameter(pos) {
 }
 
 function deserializeVecDecorator(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 24;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDecorator(pos));
     pos += 24;
   }
@@ -6475,10 +6540,11 @@ function deserializeOptionTSAccessibility(pos) {
 }
 
 function deserializeVecTSClassImplements(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSClassImplements(pos));
     pos += 32;
   }
@@ -6490,10 +6556,11 @@ function deserializeBoxClassBody(pos) {
 }
 
 function deserializeVecClassElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeClassElement(pos));
     pos += 16;
   }
@@ -6550,10 +6617,11 @@ function deserializeOptionImportPhase(pos) {
 }
 
 function deserializeVecImportDeclarationSpecifier(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportDeclarationSpecifier(pos));
     pos += 16;
   }
@@ -6561,7 +6629,7 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeVecImportDeclarationSpecifier(pos);
 }
 
@@ -6570,7 +6638,7 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxWithClause(pos);
 }
 
@@ -6587,10 +6655,11 @@ function deserializeBoxImportNamespaceSpecifier(pos) {
 }
 
 function deserializeVecImportAttribute(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 112;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportAttribute(pos));
     pos += 112;
   }
@@ -6603,10 +6672,11 @@ function deserializeOptionDeclaration(pos) {
 }
 
 function deserializeVecExportSpecifier(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 128;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExportSpecifier(pos));
     pos += 128;
   }
@@ -6632,10 +6702,11 @@ function deserializeBoxJSXOpeningElement(pos) {
 }
 
 function deserializeVecJSXChild(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeJSXChild(pos));
     pos += 16;
   }
@@ -6647,15 +6718,16 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxJSXClosingElement(pos);
 }
 
 function deserializeVecJSXAttributeItem(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeJSXAttributeItem(pos));
     pos += 16;
   }
@@ -6700,10 +6772,11 @@ function deserializeBoxJSXSpreadChild(pos) {
 }
 
 function deserializeVecTSEnumMember(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 40;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSEnumMember(pos));
     pos += 40;
   }
@@ -6859,10 +6932,11 @@ function deserializeBoxJSDocUnknownType(pos) {
 }
 
 function deserializeVecTSType(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSType(pos));
     pos += 16;
   }
@@ -6870,10 +6944,11 @@ function deserializeVecTSType(pos) {
 }
 
 function deserializeVecTSTupleElement(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSTupleElement(pos));
     pos += 16;
   }
@@ -6898,10 +6973,11 @@ function deserializeOptionTSType(pos) {
 }
 
 function deserializeVecTSTypeParameter(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 80;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSTypeParameter(pos));
     pos += 80;
   }
@@ -6909,10 +6985,11 @@ function deserializeVecTSTypeParameter(pos) {
 }
 
 function deserializeVecTSInterfaceHeritage(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSInterfaceHeritage(pos));
     pos += 32;
   }
@@ -6924,10 +7001,11 @@ function deserializeBoxTSInterfaceBody(pos) {
 }
 
 function deserializeVecTSSignature(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSSignature(pos));
     pos += 16;
   }
@@ -6951,10 +7029,11 @@ function deserializeBoxTSMethodSignature(pos) {
 }
 
 function deserializeVecTSIndexSignatureName(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
     pos += 32;
   }
@@ -6975,7 +7054,7 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[pos + 4 >> 2] === 0) return null;
+  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
   return deserializeBoxObjectExpression(pos);
 }
 
@@ -6998,15 +7077,16 @@ function deserializeBoxTSExternalModuleReference(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  if (uint32[pos + 8 >> 2] === 0 && uint32[pos + 12 >> 2] === 0) return null;
+  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
   return deserializeNameSpan(pos);
 }
 
 function deserializeVecError(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 80;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeError(pos));
     pos += 80;
   }
@@ -7014,10 +7094,11 @@ function deserializeVecError(pos) {
 }
 
 function deserializeVecErrorLabel(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 24;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeErrorLabel(pos));
     pos += 24;
   }
@@ -7025,10 +7106,11 @@ function deserializeVecErrorLabel(pos) {
 }
 
 function deserializeVecStaticImport(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 56;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStaticImport(pos));
     pos += 56;
   }
@@ -7036,10 +7118,11 @@ function deserializeVecStaticImport(pos) {
 }
 
 function deserializeVecStaticExport(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 32;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeStaticExport(pos));
     pos += 32;
   }
@@ -7047,10 +7130,11 @@ function deserializeVecStaticExport(pos) {
 }
 
 function deserializeVecDynamicImport(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 16;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeDynamicImport(pos));
     pos += 16;
   }
@@ -7058,10 +7142,11 @@ function deserializeVecDynamicImport(pos) {
 }
 
 function deserializeVecSpan(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 8;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeSpan(pos));
     pos += 8;
   }
@@ -7069,10 +7154,11 @@ function deserializeVecSpan(pos) {
 }
 
 function deserializeVecImportEntry(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 96;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeImportEntry(pos));
     pos += 96;
   }
@@ -7080,10 +7166,11 @@ function deserializeVecImportEntry(pos) {
 }
 
 function deserializeVecExportEntry(pos) {
-  let arr = [], pos32 = pos >> 2;
+  let arr = [],
+    pos32 = pos >> 2;
   pos = uint32[pos32];
   let endPos = pos + uint32[pos32 + 2] * 144;
-  for (; pos !== endPos;) {
+  for (; pos !== endPos; ) {
     arr.push(deserializeExportEntry(pos));
     pos += 144;
   }

--- a/napi/parser/generated/lazy/constructors.js
+++ b/napi/parser/generated/lazy/constructors.js
@@ -48,7 +48,7 @@ export class Program {
     const internal = this.#internal,
       cached = internal.$body;
     if (cached !== void 0) return cached;
-    return internal.$body = constructVecStatement(internal.pos + 96, internal.ast);
+    return (internal.$body = constructVecStatement(internal.pos + 96, internal.ast));
   }
 
   toJSON() {
@@ -191,7 +191,7 @@ export class IdentifierName {
     const internal = this.#internal,
       cached = internal.$name;
     if (cached !== void 0) return cached;
-    return internal.$name = constructStr(internal.pos + 8, internal.ast);
+    return (internal.$name = constructStr(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -239,7 +239,7 @@ export class IdentifierReference {
     const internal = this.#internal,
       cached = internal.$name;
     if (cached !== void 0) return cached;
-    return internal.$name = constructStr(internal.pos + 8, internal.ast);
+    return (internal.$name = constructStr(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -287,7 +287,7 @@ export class BindingIdentifier {
     const internal = this.#internal,
       cached = internal.$name;
     if (cached !== void 0) return cached;
-    return internal.$name = constructStr(internal.pos + 8, internal.ast);
+    return (internal.$name = constructStr(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -335,7 +335,7 @@ export class LabelIdentifier {
     const internal = this.#internal,
       cached = internal.$name;
     if (cached !== void 0) return cached;
-    return internal.$name = constructStr(internal.pos + 8, internal.ast);
+    return (internal.$name = constructStr(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -423,7 +423,7 @@ export class ArrayExpression {
     const internal = this.#internal,
       cached = internal.$elements;
     if (cached !== void 0) return cached;
-    return internal.$elements = constructVecArrayExpressionElement(internal.pos + 8, internal.ast);
+    return (internal.$elements = constructVecArrayExpressionElement(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -608,7 +608,7 @@ export class ObjectExpression {
     const internal = this.#internal,
       cached = internal.$properties;
     if (cached !== void 0) return cached;
-    return internal.$properties = constructVecObjectPropertyKind(internal.pos + 8, internal.ast);
+    return (internal.$properties = constructVecObjectPropertyKind(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -853,14 +853,14 @@ export class TemplateLiteral {
     const internal = this.#internal,
       cached = internal.$quasis;
     if (cached !== void 0) return cached;
-    return internal.$quasis = constructVecTemplateElement(internal.pos + 8, internal.ast);
+    return (internal.$quasis = constructVecTemplateElement(internal.pos + 8, internal.ast));
   }
 
   get expressions() {
     const internal = this.#internal,
       cached = internal.$expressions;
     if (cached !== void 0) return cached;
-    return internal.$expressions = constructVecExpression(internal.pos + 32, internal.ast);
+    return (internal.$expressions = constructVecExpression(internal.pos + 32, internal.ast));
   }
 
   toJSON() {
@@ -1008,14 +1008,14 @@ export class TemplateElementValue {
     const internal = this.#internal,
       cached = internal.$raw;
     if (cached !== void 0) return cached;
-    return internal.$raw = constructStr(internal.pos, internal.ast);
+    return (internal.$raw = constructStr(internal.pos, internal.ast));
   }
 
   get cooked() {
     const internal = this.#internal,
       cached = internal.$cooked;
     if (cached !== void 0) return cached;
-    return internal.$cooked = constructOptionStr(internal.pos + 16, internal.ast);
+    return (internal.$cooked = constructOptionStr(internal.pos + 16, internal.ast));
   }
 
   toJSON() {
@@ -1258,7 +1258,7 @@ export class CallExpression {
     const internal = this.#internal,
       cached = internal.$arguments;
     if (cached !== void 0) return cached;
-    return internal.$arguments = constructVecArgument(internal.pos + 32, internal.ast);
+    return (internal.$arguments = constructVecArgument(internal.pos + 32, internal.ast));
   }
 
   get optional() {
@@ -1324,7 +1324,7 @@ export class NewExpression {
     const internal = this.#internal,
       cached = internal.$arguments;
     if (cached !== void 0) return cached;
-    return internal.$arguments = constructVecArgument(internal.pos + 32, internal.ast);
+    return (internal.$arguments = constructVecArgument(internal.pos + 32, internal.ast));
   }
 
   toJSON() {
@@ -2022,7 +2022,7 @@ export class ArrayAssignmentTarget {
     const internal = this.#internal,
       cached = internal.$elements;
     if (cached !== void 0) return cached;
-    return internal.$elements = constructVecOptionAssignmentTargetMaybeDefault(internal.pos + 8, internal.ast);
+    return (internal.$elements = constructVecOptionAssignmentTargetMaybeDefault(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -2070,7 +2070,7 @@ export class ObjectAssignmentTarget {
     const internal = this.#internal,
       cached = internal.$properties;
     if (cached !== void 0) return cached;
-    return internal.$properties = constructVecAssignmentTargetProperty(internal.pos + 8, internal.ast);
+    return (internal.$properties = constructVecAssignmentTargetProperty(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -2366,7 +2366,7 @@ export class SequenceExpression {
     const internal = this.#internal,
       cached = internal.$expressions;
     if (cached !== void 0) return cached;
-    return internal.$expressions = constructVecExpression(internal.pos + 8, internal.ast);
+    return (internal.$expressions = constructVecExpression(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -2685,7 +2685,7 @@ export class Directive {
     const internal = this.#internal,
       cached = internal.$directive;
     if (cached !== void 0) return cached;
-    return internal.$directive = constructStr(internal.pos + 56, internal.ast);
+    return (internal.$directive = constructStr(internal.pos + 56, internal.ast));
   }
 
   toJSON() {
@@ -2734,7 +2734,7 @@ export class Hashbang {
     const internal = this.#internal,
       cached = internal.$value;
     if (cached !== void 0) return cached;
-    return internal.$value = constructStr(internal.pos + 8, internal.ast);
+    return (internal.$value = constructStr(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -2782,7 +2782,7 @@ export class BlockStatement {
     const internal = this.#internal,
       cached = internal.$body;
     if (cached !== void 0) return cached;
-    return internal.$body = constructVecStatement(internal.pos + 8, internal.ast);
+    return (internal.$body = constructVecStatement(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -2858,7 +2858,7 @@ export class VariableDeclaration {
     const internal = this.#internal,
       cached = internal.$declarations;
     if (cached !== void 0) return cached;
-    return internal.$declarations = constructVecVariableDeclarator(internal.pos + 8, internal.ast);
+    return (internal.$declarations = constructVecVariableDeclarator(internal.pos + 8, internal.ast));
   }
 
   get declare() {
@@ -3741,7 +3741,7 @@ export class SwitchStatement {
     const internal = this.#internal,
       cached = internal.$cases;
     if (cached !== void 0) return cached;
-    return internal.$cases = constructVecSwitchCase(internal.pos + 24, internal.ast);
+    return (internal.$cases = constructVecSwitchCase(internal.pos + 24, internal.ast));
   }
 
   toJSON() {
@@ -3795,7 +3795,7 @@ export class SwitchCase {
     const internal = this.#internal,
       cached = internal.$consequent;
     if (cached !== void 0) return cached;
-    return internal.$consequent = constructVecStatement(internal.pos + 24, internal.ast);
+    return (internal.$consequent = constructVecStatement(internal.pos + 24, internal.ast));
   }
 
   toJSON() {
@@ -4235,7 +4235,7 @@ export class ObjectPattern {
     const internal = this.#internal,
       cached = internal.$properties;
     if (cached !== void 0) return cached;
-    return internal.$properties = constructVecBindingProperty(internal.pos + 8, internal.ast);
+    return (internal.$properties = constructVecBindingProperty(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -4347,7 +4347,7 @@ export class ArrayPattern {
     const internal = this.#internal,
       cached = internal.$elements;
     if (cached !== void 0) return cached;
-    return internal.$elements = constructVecOptionBindingPattern(internal.pos + 8, internal.ast);
+    return (internal.$elements = constructVecOptionBindingPattern(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -4553,7 +4553,7 @@ export class FormalParameters {
     const internal = this.#internal,
       cached = internal.$items;
     if (cached !== void 0) return cached;
-    return internal.$items = constructVecFormalParameter(internal.pos + 8, internal.ast);
+    return (internal.$items = constructVecFormalParameter(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -4591,7 +4591,7 @@ export class FormalParameter {
     const internal = this.#internal,
       cached = internal.$decorators;
     if (cached !== void 0) return cached;
-    return internal.$decorators = constructVecDecorator(internal.pos + 8, internal.ast);
+    return (internal.$decorators = constructVecDecorator(internal.pos + 8, internal.ast));
   }
 
   get pattern() {
@@ -4657,7 +4657,7 @@ export class FunctionBody {
     const internal = this.#internal,
       cached = internal.$body;
     if (cached !== void 0) return cached;
-    return internal.$body = constructVecStatement(internal.pos + 32, internal.ast);
+    return (internal.$body = constructVecStatement(internal.pos + 32, internal.ast));
   }
 
   toJSON() {
@@ -4837,7 +4837,7 @@ export class Class {
     const internal = this.#internal,
       cached = internal.$decorators;
     if (cached !== void 0) return cached;
-    return internal.$decorators = constructVecDecorator(internal.pos + 8, internal.ast);
+    return (internal.$decorators = constructVecDecorator(internal.pos + 8, internal.ast));
   }
 
   get id() {
@@ -4864,7 +4864,7 @@ export class Class {
     const internal = this.#internal,
       cached = internal.$implements;
     if (cached !== void 0) return cached;
-    return internal.$implements = constructVecTSClassImplements(internal.pos + 96, internal.ast);
+    return (internal.$implements = constructVecTSClassImplements(internal.pos + 96, internal.ast));
   }
 
   get body() {
@@ -4946,7 +4946,7 @@ export class ClassBody {
     const internal = this.#internal,
       cached = internal.$body;
     if (cached !== void 0) return cached;
-    return internal.$body = constructVecClassElement(internal.pos + 8, internal.ast);
+    return (internal.$body = constructVecClassElement(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -5015,7 +5015,7 @@ export class MethodDefinition {
     const internal = this.#internal,
       cached = internal.$decorators;
     if (cached !== void 0) return cached;
-    return internal.$decorators = constructVecDecorator(internal.pos + 8, internal.ast);
+    return (internal.$decorators = constructVecDecorator(internal.pos + 8, internal.ast));
   }
 
   get key() {
@@ -5126,7 +5126,7 @@ export class PropertyDefinition {
     const internal = this.#internal,
       cached = internal.$decorators;
     if (cached !== void 0) return cached;
-    return internal.$decorators = constructVecDecorator(internal.pos + 8, internal.ast);
+    return (internal.$decorators = constructVecDecorator(internal.pos + 8, internal.ast));
   }
 
   get key() {
@@ -5266,7 +5266,7 @@ export class PrivateIdentifier {
     const internal = this.#internal,
       cached = internal.$name;
     if (cached !== void 0) return cached;
-    return internal.$name = constructStr(internal.pos + 8, internal.ast);
+    return (internal.$name = constructStr(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -5314,7 +5314,7 @@ export class StaticBlock {
     const internal = this.#internal,
       cached = internal.$body;
     if (cached !== void 0) return cached;
-    return internal.$body = constructVecStatement(internal.pos + 8, internal.ast);
+    return (internal.$body = constructVecStatement(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -5396,7 +5396,7 @@ export class AccessorProperty {
     const internal = this.#internal,
       cached = internal.$decorators;
     if (cached !== void 0) return cached;
-    return internal.$decorators = constructVecDecorator(internal.pos + 8, internal.ast);
+    return (internal.$decorators = constructVecDecorator(internal.pos + 8, internal.ast));
   }
 
   get key() {
@@ -5550,7 +5550,7 @@ export class ImportDeclaration {
     const internal = this.#internal,
       cached = internal.$specifiers;
     if (cached !== void 0) return cached;
-    return internal.$specifiers = constructOptionVecImportDeclarationSpecifier(internal.pos + 8, internal.ast);
+    return (internal.$specifiers = constructOptionVecImportDeclarationSpecifier(internal.pos + 8, internal.ast));
   }
 
   get source() {
@@ -5785,7 +5785,7 @@ export class WithClause {
     const internal = this.#internal,
       cached = internal.$attributes;
     if (cached !== void 0) return cached;
-    return internal.$attributes = constructVecImportAttribute(internal.pos + 8, internal.ast);
+    return (internal.$attributes = constructVecImportAttribute(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -5898,7 +5898,7 @@ export class ExportNamedDeclaration {
     const internal = this.#internal,
       cached = internal.$specifiers;
     if (cached !== void 0) return cached;
-    return internal.$specifiers = constructVecExportSpecifier(internal.pos + 24, internal.ast);
+    return (internal.$specifiers = constructVecExportSpecifier(internal.pos + 24, internal.ast));
   }
 
   get source() {
@@ -6250,7 +6250,7 @@ export class V8IntrinsicExpression {
     const internal = this.#internal,
       cached = internal.$arguments;
     if (cached !== void 0) return cached;
-    return internal.$arguments = constructVecArgument(internal.pos + 32, internal.ast);
+    return (internal.$arguments = constructVecArgument(internal.pos + 32, internal.ast));
   }
 
   toJSON() {
@@ -6390,7 +6390,7 @@ export class NumericLiteral {
     const internal = this.#internal,
       cached = internal.$raw;
     if (cached !== void 0) return cached;
-    return internal.$raw = constructOptionStr(internal.pos + 16, internal.ast);
+    return (internal.$raw = constructOptionStr(internal.pos + 16, internal.ast));
   }
 
   toJSON() {
@@ -6439,14 +6439,14 @@ export class StringLiteral {
     const internal = this.#internal,
       cached = internal.$value;
     if (cached !== void 0) return cached;
-    return internal.$value = constructStr(internal.pos + 8, internal.ast);
+    return (internal.$value = constructStr(internal.pos + 8, internal.ast));
   }
 
   get raw() {
     const internal = this.#internal,
       cached = internal.$raw;
     if (cached !== void 0) return cached;
-    return internal.$raw = constructOptionStr(internal.pos + 24, internal.ast);
+    return (internal.$raw = constructOptionStr(internal.pos + 24, internal.ast));
   }
 
   toJSON() {
@@ -6495,14 +6495,14 @@ export class BigIntLiteral {
     const internal = this.#internal,
       cached = internal.$value;
     if (cached !== void 0) return cached;
-    return internal.$value = constructStr(internal.pos + 8, internal.ast);
+    return (internal.$value = constructStr(internal.pos + 8, internal.ast));
   }
 
   get raw() {
     const internal = this.#internal,
       cached = internal.$raw;
     if (cached !== void 0) return cached;
-    return internal.$raw = constructOptionStr(internal.pos + 24, internal.ast);
+    return (internal.$raw = constructOptionStr(internal.pos + 24, internal.ast));
   }
 
   toJSON() {
@@ -6556,7 +6556,7 @@ export class RegExpLiteral {
     const internal = this.#internal,
       cached = internal.$raw;
     if (cached !== void 0) return cached;
-    return internal.$raw = constructOptionStr(internal.pos + 40, internal.ast);
+    return (internal.$raw = constructOptionStr(internal.pos + 40, internal.ast));
   }
 
   toJSON() {
@@ -6633,7 +6633,7 @@ export class RegExpPattern {
     const internal = this.#internal,
       cached = internal.$pattern;
     if (cached !== void 0) return cached;
-    return internal.$pattern = constructStr(internal.pos, internal.ast);
+    return (internal.$pattern = constructStr(internal.pos, internal.ast));
   }
 
   toJSON() {
@@ -6708,7 +6708,7 @@ export class JSXElement {
     const internal = this.#internal,
       cached = internal.$children;
     if (cached !== void 0) return cached;
-    return internal.$children = constructVecJSXChild(internal.pos + 16, internal.ast);
+    return (internal.$children = constructVecJSXChild(internal.pos + 16, internal.ast));
   }
 
   get closingElement() {
@@ -6773,7 +6773,7 @@ export class JSXOpeningElement {
     const internal = this.#internal,
       cached = internal.$attributes;
     if (cached !== void 0) return cached;
-    return internal.$attributes = constructVecJSXAttributeItem(internal.pos + 32, internal.ast);
+    return (internal.$attributes = constructVecJSXAttributeItem(internal.pos + 32, internal.ast));
   }
 
   toJSON() {
@@ -6874,7 +6874,7 @@ export class JSXFragment {
     const internal = this.#internal,
       cached = internal.$children;
     if (cached !== void 0) return cached;
-    return internal.$children = constructVecJSXChild(internal.pos + 16, internal.ast);
+    return (internal.$children = constructVecJSXChild(internal.pos + 16, internal.ast));
   }
 
   get closingFragment() {
@@ -7459,7 +7459,7 @@ export class JSXIdentifier {
     const internal = this.#internal,
       cached = internal.$name;
     if (cached !== void 0) return cached;
-    return internal.$name = constructStr(internal.pos + 8, internal.ast);
+    return (internal.$name = constructStr(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -7570,14 +7570,14 @@ export class JSXText {
     const internal = this.#internal,
       cached = internal.$value;
     if (cached !== void 0) return cached;
-    return internal.$value = constructStr(internal.pos + 8, internal.ast);
+    return (internal.$value = constructStr(internal.pos + 8, internal.ast));
   }
 
   get raw() {
     const internal = this.#internal,
       cached = internal.$raw;
     if (cached !== void 0) return cached;
-    return internal.$raw = constructOptionStr(internal.pos + 24, internal.ast);
+    return (internal.$raw = constructOptionStr(internal.pos + 24, internal.ast));
   }
 
   toJSON() {
@@ -7736,7 +7736,7 @@ export class TSEnumBody {
     const internal = this.#internal,
       cached = internal.$members;
     if (cached !== void 0) return cached;
-    return internal.$members = constructVecTSEnumMember(internal.pos + 8, internal.ast);
+    return (internal.$members = constructVecTSEnumMember(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -8107,7 +8107,7 @@ export class TSUnionType {
     const internal = this.#internal,
       cached = internal.$types;
     if (cached !== void 0) return cached;
-    return internal.$types = constructVecTSType(internal.pos + 8, internal.ast);
+    return (internal.$types = constructVecTSType(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -8155,7 +8155,7 @@ export class TSIntersectionType {
     const internal = this.#internal,
       cached = internal.$types;
     if (cached !== void 0) return cached;
-    return internal.$types = constructVecTSType(internal.pos + 8, internal.ast);
+    return (internal.$types = constructVecTSType(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -8412,7 +8412,7 @@ export class TSTupleType {
     const internal = this.#internal,
       cached = internal.$elementTypes;
     if (cached !== void 0) return cached;
-    return internal.$elementTypes = constructVecTSTupleElement(internal.pos + 8, internal.ast);
+    return (internal.$elementTypes = constructVecTSTupleElement(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -9372,7 +9372,7 @@ export class TSTypeParameterInstantiation {
     const internal = this.#internal,
       cached = internal.$params;
     if (cached !== void 0) return cached;
-    return internal.$params = constructVecTSType(internal.pos + 8, internal.ast);
+    return (internal.$params = constructVecTSType(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -9496,7 +9496,7 @@ export class TSTypeParameterDeclaration {
     const internal = this.#internal,
       cached = internal.$params;
     if (cached !== void 0) return cached;
-    return internal.$params = constructVecTSTypeParameter(internal.pos + 8, internal.ast);
+    return (internal.$params = constructVecTSTypeParameter(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -9683,7 +9683,7 @@ export class TSInterfaceDeclaration {
     const internal = this.#internal,
       cached = internal.$extends;
     if (cached !== void 0) return cached;
-    return internal.$extends = constructVecTSInterfaceHeritage(internal.pos + 48, internal.ast);
+    return (internal.$extends = constructVecTSInterfaceHeritage(internal.pos + 48, internal.ast));
   }
 
   get body() {
@@ -9745,7 +9745,7 @@ export class TSInterfaceBody {
     const internal = this.#internal,
       cached = internal.$body;
     if (cached !== void 0) return cached;
-    return internal.$body = constructVecTSSignature(internal.pos + 8, internal.ast);
+    return (internal.$body = constructVecTSSignature(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -9880,7 +9880,7 @@ export class TSIndexSignature {
     const internal = this.#internal,
       cached = internal.$parameters;
     if (cached !== void 0) return cached;
-    return internal.$parameters = constructVecTSIndexSignatureName(internal.pos + 8, internal.ast);
+    return (internal.$parameters = constructVecTSIndexSignatureName(internal.pos + 8, internal.ast));
   }
 
   get typeAnnotation() {
@@ -10157,7 +10157,7 @@ export class TSIndexSignatureName {
     const internal = this.#internal,
       cached = internal.$name;
     if (cached !== void 0) return cached;
-    return internal.$name = constructStr(internal.pos + 8, internal.ast);
+    return (internal.$name = constructStr(internal.pos + 8, internal.ast));
   }
 
   get typeAnnotation() {
@@ -10431,7 +10431,7 @@ export class TSModuleBlock {
     const internal = this.#internal,
       cached = internal.$body;
     if (cached !== void 0) return cached;
-    return internal.$body = constructVecStatement(internal.pos + 32, internal.ast);
+    return (internal.$body = constructVecStatement(internal.pos + 32, internal.ast));
   }
 
   toJSON() {
@@ -10479,7 +10479,7 @@ export class TSTypeLiteral {
     const internal = this.#internal,
       cached = internal.$members;
     if (cached !== void 0) return cached;
-    return internal.$members = constructVecTSSignature(internal.pos + 8, internal.ast);
+    return (internal.$members = constructVecTSSignature(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -10966,14 +10966,14 @@ export class TSTemplateLiteralType {
     const internal = this.#internal,
       cached = internal.$quasis;
     if (cached !== void 0) return cached;
-    return internal.$quasis = constructVecTemplateElement(internal.pos + 8, internal.ast);
+    return (internal.$quasis = constructVecTemplateElement(internal.pos + 8, internal.ast));
   }
 
   get types() {
     const internal = this.#internal,
       cached = internal.$types;
     if (cached !== void 0) return cached;
-    return internal.$types = constructVecTSType(internal.pos + 32, internal.ast);
+    return (internal.$types = constructVecTSType(internal.pos + 32, internal.ast));
   }
 
   toJSON() {
@@ -11732,7 +11732,7 @@ export class NameSpan {
     const internal = this.#internal,
       cached = internal.$value;
     if (cached !== void 0) return cached;
-    return internal.$value = constructStr(internal.pos + 8, internal.ast);
+    return (internal.$value = constructStr(internal.pos + 8, internal.ast));
   }
 
   get start() {
@@ -12210,7 +12210,7 @@ export class RawTransferData {
     const internal = this.#internal,
       cached = internal.$comments;
     if (cached !== void 0) return cached;
-    return internal.$comments = constructVecComment(internal.pos + 128, internal.ast);
+    return (internal.$comments = constructVecComment(internal.pos + 128, internal.ast));
   }
 
   get module() {
@@ -12222,7 +12222,7 @@ export class RawTransferData {
     const internal = this.#internal,
       cached = internal.$errors;
     if (cached !== void 0) return cached;
-    return internal.$errors = constructVecError(internal.pos + 256, internal.ast);
+    return (internal.$errors = constructVecError(internal.pos + 256, internal.ast));
   }
 
   toJSON() {
@@ -12264,28 +12264,28 @@ export class Error {
     const internal = this.#internal,
       cached = internal.$message;
     if (cached !== void 0) return cached;
-    return internal.$message = constructStr(internal.pos, internal.ast);
+    return (internal.$message = constructStr(internal.pos, internal.ast));
   }
 
   get labels() {
     const internal = this.#internal,
       cached = internal.$labels;
     if (cached !== void 0) return cached;
-    return internal.$labels = constructVecErrorLabel(internal.pos + 16, internal.ast);
+    return (internal.$labels = constructVecErrorLabel(internal.pos + 16, internal.ast));
   }
 
   get helpMessage() {
     const internal = this.#internal,
       cached = internal.$helpMessage;
     if (cached !== void 0) return cached;
-    return internal.$helpMessage = constructOptionStr(internal.pos + 40, internal.ast);
+    return (internal.$helpMessage = constructOptionStr(internal.pos + 40, internal.ast));
   }
 
   get codeframe() {
     const internal = this.#internal,
       cached = internal.$codeframe;
     if (cached !== void 0) return cached;
-    return internal.$codeframe = constructStr(internal.pos + 56, internal.ast);
+    return (internal.$codeframe = constructStr(internal.pos + 56, internal.ast));
   }
 
   toJSON() {
@@ -12336,7 +12336,7 @@ export class ErrorLabel {
     const internal = this.#internal,
       cached = internal.$message;
     if (cached !== void 0) return cached;
-    return internal.$message = constructOptionStr(internal.pos + 8, internal.ast);
+    return (internal.$message = constructOptionStr(internal.pos + 8, internal.ast));
   }
 
   get start() {
@@ -12394,28 +12394,28 @@ export class EcmaScriptModule {
     const internal = this.#internal,
       cached = internal.$staticImports;
     if (cached !== void 0) return cached;
-    return internal.$staticImports = constructVecStaticImport(internal.pos, internal.ast);
+    return (internal.$staticImports = constructVecStaticImport(internal.pos, internal.ast));
   }
 
   get staticExports() {
     const internal = this.#internal,
       cached = internal.$staticExports;
     if (cached !== void 0) return cached;
-    return internal.$staticExports = constructVecStaticExport(internal.pos + 24, internal.ast);
+    return (internal.$staticExports = constructVecStaticExport(internal.pos + 24, internal.ast));
   }
 
   get dynamicImports() {
     const internal = this.#internal,
       cached = internal.$dynamicImports;
     if (cached !== void 0) return cached;
-    return internal.$dynamicImports = constructVecDynamicImport(internal.pos + 48, internal.ast);
+    return (internal.$dynamicImports = constructVecDynamicImport(internal.pos + 48, internal.ast));
   }
 
   get importMetas() {
     const internal = this.#internal,
       cached = internal.$importMetas;
     if (cached !== void 0) return cached;
-    return internal.$importMetas = constructVecSpan(internal.pos + 72, internal.ast);
+    return (internal.$importMetas = constructVecSpan(internal.pos + 72, internal.ast));
   }
 
   toJSON() {
@@ -12468,7 +12468,7 @@ export class StaticImport {
     const internal = this.#internal,
       cached = internal.$entries;
     if (cached !== void 0) return cached;
-    return internal.$entries = constructVecImportEntry(internal.pos + 32, internal.ast);
+    return (internal.$entries = constructVecImportEntry(internal.pos + 32, internal.ast));
   }
 
   toJSON() {
@@ -12515,7 +12515,7 @@ export class StaticExport {
     const internal = this.#internal,
       cached = internal.$entries;
     if (cached !== void 0) return cached;
-    return internal.$entries = constructVecExportEntry(internal.pos + 8, internal.ast);
+    return (internal.$entries = constructVecExportEntry(internal.pos + 8, internal.ast));
   }
 
   toJSON() {
@@ -12575,13 +12575,7 @@ function constructStr(pos, ast) {
 function constructVecComment(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    16,
-    constructComment,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 16, constructComment, ast);
 }
 
 function constructComment(pos, ast) {
@@ -12596,13 +12590,7 @@ function constructOptionHashbang(pos, ast) {
 function constructVecDirective(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    72,
-    constructDirective,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 72, constructDirective, ast);
 }
 
 function constructDirective(pos, ast) {
@@ -12612,13 +12600,7 @@ function constructDirective(pos, ast) {
 function constructVecStatement(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    16,
-    constructStatement,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 16, constructStatement, ast);
 }
 
 function constructBoxBooleanLiteral(pos, ast) {
@@ -12784,13 +12766,7 @@ function constructBoxV8IntrinsicExpression(pos, ast) {
 function constructVecArrayExpressionElement(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    16,
-    constructArrayExpressionElement,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 16, constructArrayExpressionElement, ast);
 }
 
 function constructBoxSpreadElement(pos, ast) {
@@ -12800,13 +12776,7 @@ function constructBoxSpreadElement(pos, ast) {
 function constructVecObjectPropertyKind(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    16,
-    constructObjectPropertyKind,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 16, constructObjectPropertyKind, ast);
 }
 
 function constructBoxObjectProperty(pos, ast) {
@@ -12828,13 +12798,7 @@ function constructBoxPrivateIdentifier(pos, ast) {
 function constructVecTemplateElement(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    48,
-    constructTemplateElement,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 48, constructTemplateElement, ast);
 }
 
 function constructTemplateElement(pos, ast) {
@@ -12844,13 +12808,7 @@ function constructTemplateElement(pos, ast) {
 function constructVecExpression(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    16,
-    constructExpression,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 16, constructExpression, ast);
 }
 
 function constructBoxTSTypeParameterInstantiation(pos, ast) {
@@ -12882,13 +12840,7 @@ function constructBoxPrivateFieldExpression(pos, ast) {
 function constructVecArgument(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    16,
-    constructArgument,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 16, constructArgument, ast);
 }
 
 function constructBoxArrayAssignmentTarget(pos, ast) {
@@ -12907,13 +12859,7 @@ function constructOptionAssignmentTargetMaybeDefault(pos, ast) {
 function constructVecOptionAssignmentTargetMaybeDefault(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    16,
-    constructOptionAssignmentTargetMaybeDefault,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 16, constructOptionAssignmentTargetMaybeDefault, ast);
 }
 
 function constructBoxAssignmentTargetRest(pos, ast) {
@@ -12928,13 +12874,7 @@ function constructOptionBoxAssignmentTargetRest(pos, ast) {
 function constructVecAssignmentTargetProperty(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    16,
-    constructAssignmentTargetProperty,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 16, constructAssignmentTargetProperty, ast);
 }
 
 function constructBoxAssignmentTargetWithDefault(pos, ast) {
@@ -13053,13 +12993,7 @@ function constructBoxTSImportEqualsDeclaration(pos, ast) {
 function constructVecVariableDeclarator(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    64,
-    constructVariableDeclarator,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 64, constructVariableDeclarator, ast);
 }
 
 function constructVariableDeclarator(pos, ast) {
@@ -13084,13 +13018,7 @@ function constructOptionLabelIdentifier(pos, ast) {
 function constructVecSwitchCase(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    48,
-    constructSwitchCase,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 48, constructSwitchCase, ast);
 }
 
 function constructSwitchCase(pos, ast) {
@@ -13144,13 +13072,7 @@ function constructBoxAssignmentPattern(pos, ast) {
 function constructVecBindingProperty(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    64,
-    constructBindingProperty,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 64, constructBindingProperty, ast);
 }
 
 function constructBindingProperty(pos, ast) {
@@ -13174,13 +13096,7 @@ function constructOptionBindingPattern(pos, ast) {
 function constructVecOptionBindingPattern(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    32,
-    constructOptionBindingPattern,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 32, constructOptionBindingPattern, ast);
 }
 
 function constructOptionBindingIdentifier(pos, ast) {
@@ -13222,13 +13138,7 @@ function constructOptionBoxFunctionBody(pos, ast) {
 function constructVecFormalParameter(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    72,
-    constructFormalParameter,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 72, constructFormalParameter, ast);
 }
 
 function constructFormalParameter(pos, ast) {
@@ -13238,13 +13148,7 @@ function constructFormalParameter(pos, ast) {
 function constructVecDecorator(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    24,
-    constructDecorator,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 24, constructDecorator, ast);
 }
 
 function constructDecorator(pos, ast) {
@@ -13259,13 +13163,7 @@ function constructOptionTSAccessibility(pos, ast) {
 function constructVecTSClassImplements(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    32,
-    constructTSClassImplements,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 32, constructTSClassImplements, ast);
 }
 
 function constructTSClassImplements(pos, ast) {
@@ -13279,13 +13177,7 @@ function constructBoxClassBody(pos, ast) {
 function constructVecClassElement(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    16,
-    constructClassElement,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 16, constructClassElement, ast);
 }
 
 function constructBoxStaticBlock(pos, ast) {
@@ -13340,13 +13232,7 @@ function constructOptionImportPhase(pos, ast) {
 function constructVecImportDeclarationSpecifier(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    16,
-    constructImportDeclarationSpecifier,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 16, constructImportDeclarationSpecifier, ast);
 }
 
 function constructOptionVecImportDeclarationSpecifier(pos, ast) {
@@ -13378,13 +13264,7 @@ function constructBoxImportNamespaceSpecifier(pos, ast) {
 function constructVecImportAttribute(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    112,
-    constructImportAttribute,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 112, constructImportAttribute, ast);
 }
 
 function constructImportAttribute(pos, ast) {
@@ -13399,13 +13279,7 @@ function constructOptionDeclaration(pos, ast) {
 function constructVecExportSpecifier(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    128,
-    constructExportSpecifier,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 128, constructExportSpecifier, ast);
 }
 
 function constructExportSpecifier(pos, ast) {
@@ -13433,13 +13307,7 @@ function constructBoxJSXOpeningElement(pos, ast) {
 function constructVecJSXChild(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    16,
-    constructJSXChild,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 16, constructJSXChild, ast);
 }
 
 function constructBoxJSXClosingElement(pos, ast) {
@@ -13454,13 +13322,7 @@ function constructOptionBoxJSXClosingElement(pos, ast) {
 function constructVecJSXAttributeItem(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    16,
-    constructJSXAttributeItem,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 16, constructJSXAttributeItem, ast);
 }
 
 function constructBoxJSXIdentifier(pos, ast) {
@@ -13503,13 +13365,7 @@ function constructBoxJSXSpreadChild(pos, ast) {
 function constructVecTSEnumMember(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    40,
-    constructTSEnumMember,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 40, constructTSEnumMember, ast);
 }
 
 function constructTSEnumMember(pos, ast) {
@@ -13667,25 +13523,13 @@ function constructBoxJSDocUnknownType(pos, ast) {
 function constructVecTSType(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    16,
-    constructTSType,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 16, constructTSType, ast);
 }
 
 function constructVecTSTupleElement(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    16,
-    constructTSTupleElement,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 16, constructTSTupleElement, ast);
 }
 
 function constructBoxTSOptionalType(pos, ast) {
@@ -13708,13 +13552,7 @@ function constructOptionTSType(pos, ast) {
 function constructVecTSTypeParameter(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    80,
-    constructTSTypeParameter,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 80, constructTSTypeParameter, ast);
 }
 
 function constructTSTypeParameter(pos, ast) {
@@ -13724,13 +13562,7 @@ function constructTSTypeParameter(pos, ast) {
 function constructVecTSInterfaceHeritage(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    32,
-    constructTSInterfaceHeritage,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 32, constructTSInterfaceHeritage, ast);
 }
 
 function constructTSInterfaceHeritage(pos, ast) {
@@ -13744,13 +13576,7 @@ function constructBoxTSInterfaceBody(pos, ast) {
 function constructVecTSSignature(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    16,
-    constructTSSignature,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 16, constructTSSignature, ast);
 }
 
 function constructBoxTSPropertySignature(pos, ast) {
@@ -13772,13 +13598,7 @@ function constructBoxTSMethodSignature(pos, ast) {
 function constructVecTSIndexSignatureName(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    32,
-    constructTSIndexSignatureName,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 32, constructTSIndexSignatureName, ast);
 }
 
 function constructTSIndexSignatureName(pos, ast) {
@@ -13840,13 +13660,7 @@ function constructOptionU64(pos, ast) {
 function constructVecError(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    80,
-    constructError,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 80, constructError, ast);
 }
 
 function constructError(pos, ast) {
@@ -13856,13 +13670,7 @@ function constructError(pos, ast) {
 function constructVecErrorLabel(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    24,
-    constructErrorLabel,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 24, constructErrorLabel, ast);
 }
 
 function constructErrorLabel(pos, ast) {
@@ -13872,13 +13680,7 @@ function constructErrorLabel(pos, ast) {
 function constructVecStaticImport(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    56,
-    constructStaticImport,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 56, constructStaticImport, ast);
 }
 
 function constructStaticImport(pos, ast) {
@@ -13888,13 +13690,7 @@ function constructStaticImport(pos, ast) {
 function constructVecStaticExport(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    32,
-    constructStaticExport,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 32, constructStaticExport, ast);
 }
 
 function constructStaticExport(pos, ast) {
@@ -13904,13 +13700,7 @@ function constructStaticExport(pos, ast) {
 function constructVecDynamicImport(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    16,
-    constructDynamicImport,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 16, constructDynamicImport, ast);
 }
 
 function constructDynamicImport(pos, ast) {
@@ -13920,13 +13710,7 @@ function constructDynamicImport(pos, ast) {
 function constructVecSpan(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    8,
-    constructSpan,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 8, constructSpan, ast);
 }
 
 function constructSpan(pos, ast) {
@@ -13936,13 +13720,7 @@ function constructSpan(pos, ast) {
 function constructVecImportEntry(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    96,
-    constructImportEntry,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 96, constructImportEntry, ast);
 }
 
 function constructImportEntry(pos, ast) {
@@ -13952,13 +13730,7 @@ function constructImportEntry(pos, ast) {
 function constructVecExportEntry(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(
-    uint32[pos32],
-    uint32[pos32 + 2],
-    144,
-    constructExportEntry,
-    ast,
-  );
+  return new NodeArray(uint32[pos32], uint32[pos32 + 2], 144, constructExportEntry, ast);
 }
 
 function constructExportEntry(pos, ast) {

--- a/napi/parser/generated/lazy/walk.js
+++ b/napi/parser/generated/lazy/walk.js
@@ -2,192 +2,194 @@
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer_lazy.rs`.
 
 import {
-  AccessorProperty,
-  ArrayAssignmentTarget,
-  ArrayExpression,
-  ArrayPattern,
-  ArrowFunctionExpression,
-  AssignmentExpression,
-  AssignmentPattern,
-  AssignmentTargetPropertyIdentifier,
-  AssignmentTargetPropertyProperty,
-  AssignmentTargetWithDefault,
-  AwaitExpression,
-  BigIntLiteral,
-  BinaryExpression,
-  BindingIdentifier,
-  BindingProperty,
-  BlockStatement,
-  BooleanLiteral,
-  BreakStatement,
-  CallExpression,
-  CatchClause,
-  ChainExpression,
-  Class,
-  ClassBody,
-  ComputedMemberExpression,
-  ConditionalExpression,
-  ContinueStatement,
-  DebuggerStatement,
-  Decorator,
-  DoWhileStatement,
-  Elision,
-  EmptyStatement,
-  ExportAllDeclaration,
-  ExportDefaultDeclaration,
-  ExportNamedDeclaration,
-  ExportSpecifier,
-  ExpressionStatement,
-  ForInStatement,
-  FormalParameters,
-  ForOfStatement,
-  ForStatement,
-  Function,
-  FunctionBody,
-  Hashbang,
+  Program,
   IdentifierName,
   IdentifierReference,
-  IfStatement,
-  ImportAttribute,
-  ImportDeclaration,
-  ImportDefaultSpecifier,
-  ImportExpression,
-  ImportNamespaceSpecifier,
-  ImportSpecifier,
-  JSDocNonNullableType,
-  JSDocNullableType,
-  JSDocUnknownType,
-  JSXAttribute,
-  JSXClosingElement,
-  JSXClosingFragment,
-  JSXElement,
-  JSXEmptyExpression,
-  JSXExpressionContainer,
-  JSXFragment,
-  JSXIdentifier,
-  JSXMemberExpression,
-  JSXNamespacedName,
-  JSXOpeningElement,
-  JSXOpeningFragment,
-  JSXSpreadAttribute,
-  JSXSpreadChild,
-  JSXText,
-  LabeledStatement,
+  BindingIdentifier,
   LabelIdentifier,
-  LogicalExpression,
-  MetaProperty,
-  MethodDefinition,
-  NewExpression,
-  NullLiteral,
-  NumericLiteral,
-  ObjectAssignmentTarget,
+  ThisExpression,
+  ArrayExpression,
+  Elision,
   ObjectExpression,
-  ObjectPattern,
   ObjectProperty,
-  ParenthesizedExpression,
-  PrivateFieldExpression,
-  PrivateIdentifier,
-  PrivateInExpression,
-  Program,
-  PropertyDefinition,
-  RegExpLiteral,
-  ReturnStatement,
-  SequenceExpression,
-  SpreadElement,
-  StaticBlock,
-  StaticMemberExpression,
-  StringLiteral,
-  Super,
-  SwitchCase,
-  SwitchStatement,
+  TemplateLiteral,
   TaggedTemplateExpression,
   TemplateElement,
-  TemplateLiteral,
-  ThisExpression,
-  ThrowStatement,
-  TryStatement,
-  TSAnyKeyword,
-  TSArrayType,
-  TSAsExpression,
-  TSBigIntKeyword,
-  TSBooleanKeyword,
-  TSCallSignatureDeclaration,
-  TSClassImplements,
-  TSConditionalType,
-  TSConstructorType,
-  TSConstructSignatureDeclaration,
-  TSEnumBody,
-  TSEnumDeclaration,
-  TSEnumMember,
-  TSExportAssignment,
-  TSExternalModuleReference,
-  TSFunctionType,
-  TSImportEqualsDeclaration,
-  TSImportType,
-  TSImportTypeQualifiedName,
-  TSIndexedAccessType,
-  TSIndexSignature,
-  TSIndexSignatureName,
-  TSInferType,
-  TSInstantiationExpression,
-  TSInterfaceBody,
-  TSInterfaceDeclaration,
-  TSInterfaceHeritage,
-  TSIntersectionType,
-  TSIntrinsicKeyword,
-  TSLiteralType,
-  TSMappedType,
-  TSMethodSignature,
-  TSModuleBlock,
-  TSModuleDeclaration,
-  TSNamedTupleMember,
-  TSNamespaceExportDeclaration,
-  TSNeverKeyword,
-  TSNonNullExpression,
-  TSNullKeyword,
-  TSNumberKeyword,
-  TSObjectKeyword,
-  TSOptionalType,
-  TSParenthesizedType,
-  TSPropertySignature,
-  TSQualifiedName,
-  TSRestType,
-  TSSatisfiesExpression,
-  TSStringKeyword,
-  TSSymbolKeyword,
-  TSTemplateLiteralType,
-  TSThisType,
-  TSTupleType,
-  TSTypeAliasDeclaration,
-  TSTypeAnnotation,
-  TSTypeAssertion,
-  TSTypeLiteral,
-  TSTypeOperator,
-  TSTypeParameter,
-  TSTypeParameterDeclaration,
-  TSTypeParameterInstantiation,
-  TSTypePredicate,
-  TSTypeQuery,
-  TSTypeReference,
-  TSUndefinedKeyword,
-  TSUnionType,
-  TSUnknownKeyword,
-  TSVoidKeyword,
-  UnaryExpression,
+  ComputedMemberExpression,
+  StaticMemberExpression,
+  PrivateFieldExpression,
+  CallExpression,
+  NewExpression,
+  MetaProperty,
+  SpreadElement,
   UpdateExpression,
-  V8IntrinsicExpression,
+  UnaryExpression,
+  BinaryExpression,
+  PrivateInExpression,
+  LogicalExpression,
+  ConditionalExpression,
+  AssignmentExpression,
+  ArrayAssignmentTarget,
+  ObjectAssignmentTarget,
+  AssignmentTargetWithDefault,
+  AssignmentTargetPropertyIdentifier,
+  AssignmentTargetPropertyProperty,
+  SequenceExpression,
+  Super,
+  AwaitExpression,
+  ChainExpression,
+  ParenthesizedExpression,
+  Hashbang,
+  BlockStatement,
   VariableDeclaration,
   VariableDeclarator,
+  EmptyStatement,
+  ExpressionStatement,
+  IfStatement,
+  DoWhileStatement,
   WhileStatement,
+  ForStatement,
+  ForInStatement,
+  ForOfStatement,
+  ContinueStatement,
+  BreakStatement,
+  ReturnStatement,
   WithStatement,
+  SwitchStatement,
+  SwitchCase,
+  LabeledStatement,
+  ThrowStatement,
+  TryStatement,
+  CatchClause,
+  DebuggerStatement,
+  AssignmentPattern,
+  ObjectPattern,
+  BindingProperty,
+  ArrayPattern,
+  Function,
+  FormalParameters,
+  FunctionBody,
+  ArrowFunctionExpression,
   YieldExpression,
+  Class,
+  ClassBody,
+  MethodDefinition,
+  PropertyDefinition,
+  PrivateIdentifier,
+  StaticBlock,
+  AccessorProperty,
+  ImportExpression,
+  ImportDeclaration,
+  ImportSpecifier,
+  ImportDefaultSpecifier,
+  ImportNamespaceSpecifier,
+  ImportAttribute,
+  ExportNamedDeclaration,
+  ExportDefaultDeclaration,
+  ExportAllDeclaration,
+  ExportSpecifier,
+  V8IntrinsicExpression,
+  BooleanLiteral,
+  NullLiteral,
+  NumericLiteral,
+  StringLiteral,
+  BigIntLiteral,
+  RegExpLiteral,
+  JSXElement,
+  JSXOpeningElement,
+  JSXClosingElement,
+  JSXFragment,
+  JSXOpeningFragment,
+  JSXClosingFragment,
+  JSXNamespacedName,
+  JSXMemberExpression,
+  JSXExpressionContainer,
+  JSXEmptyExpression,
+  JSXAttribute,
+  JSXSpreadAttribute,
+  JSXIdentifier,
+  JSXSpreadChild,
+  JSXText,
+  TSEnumDeclaration,
+  TSEnumBody,
+  TSEnumMember,
+  TSTypeAnnotation,
+  TSLiteralType,
+  TSConditionalType,
+  TSUnionType,
+  TSIntersectionType,
+  TSParenthesizedType,
+  TSTypeOperator,
+  TSArrayType,
+  TSIndexedAccessType,
+  TSTupleType,
+  TSNamedTupleMember,
+  TSOptionalType,
+  TSRestType,
+  TSAnyKeyword,
+  TSStringKeyword,
+  TSBooleanKeyword,
+  TSNumberKeyword,
+  TSNeverKeyword,
+  TSIntrinsicKeyword,
+  TSUnknownKeyword,
+  TSNullKeyword,
+  TSUndefinedKeyword,
+  TSVoidKeyword,
+  TSSymbolKeyword,
+  TSThisType,
+  TSObjectKeyword,
+  TSBigIntKeyword,
+  TSTypeReference,
+  TSQualifiedName,
+  TSTypeParameterInstantiation,
+  TSTypeParameter,
+  TSTypeParameterDeclaration,
+  TSTypeAliasDeclaration,
+  TSClassImplements,
+  TSInterfaceDeclaration,
+  TSInterfaceBody,
+  TSPropertySignature,
+  TSIndexSignature,
+  TSCallSignatureDeclaration,
+  TSMethodSignature,
+  TSConstructSignatureDeclaration,
+  TSIndexSignatureName,
+  TSInterfaceHeritage,
+  TSTypePredicate,
+  TSModuleDeclaration,
+  TSModuleBlock,
+  TSTypeLiteral,
+  TSInferType,
+  TSTypeQuery,
+  TSImportType,
+  TSImportTypeQualifiedName,
+  TSFunctionType,
+  TSConstructorType,
+  TSMappedType,
+  TSTemplateLiteralType,
+  TSAsExpression,
+  TSSatisfiesExpression,
+  TSTypeAssertion,
+  TSImportEqualsDeclaration,
+  TSExternalModuleReference,
+  TSNonNullExpression,
+  Decorator,
+  TSExportAssignment,
+  TSNamespaceExportDeclaration,
+  TSInstantiationExpression,
+  JSDocNullableType,
+  JSDocNonNullableType,
+  JSDocUnknownType,
 } from './constructors.js';
 
 export { walkProgram };
 
 function walkProgram(pos, ast, visitors) {
   const enterExit = visitors[38];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new Program(pos, ast);
@@ -363,7 +365,9 @@ function walkThisExpression(pos, ast, visitors) {
 
 function walkArrayExpression(pos, ast, visitors) {
   const enterExit = visitors[39];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ArrayExpression(pos, ast);
@@ -524,7 +528,9 @@ function walkElision(pos, ast, visitors) {
 
 function walkObjectExpression(pos, ast, visitors) {
   const enterExit = visitors[40];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ObjectExpression(pos, ast);
@@ -551,7 +557,9 @@ function walkObjectPropertyKind(pos, ast, visitors) {
 
 function walkObjectProperty(pos, ast, visitors) {
   const enterExit = visitors[41];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ObjectProperty(pos, ast);
@@ -708,7 +716,9 @@ function walkPropertyKey(pos, ast, visitors) {
 
 function walkTemplateLiteral(pos, ast, visitors) {
   const enterExit = visitors[42];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TemplateLiteral(pos, ast);
@@ -723,7 +733,9 @@ function walkTemplateLiteral(pos, ast, visitors) {
 
 function walkTaggedTemplateExpression(pos, ast, visitors) {
   const enterExit = visitors[43];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TaggedTemplateExpression(pos, ast);
@@ -744,7 +756,9 @@ function walkTemplateElement(pos, ast, visitors) {
 
 function walkComputedMemberExpression(pos, ast, visitors) {
   const enterExit = visitors[44];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ComputedMemberExpression(pos, ast);
@@ -759,7 +773,9 @@ function walkComputedMemberExpression(pos, ast, visitors) {
 
 function walkStaticMemberExpression(pos, ast, visitors) {
   const enterExit = visitors[45];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new StaticMemberExpression(pos, ast);
@@ -774,7 +790,9 @@ function walkStaticMemberExpression(pos, ast, visitors) {
 
 function walkPrivateFieldExpression(pos, ast, visitors) {
   const enterExit = visitors[46];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new PrivateFieldExpression(pos, ast);
@@ -789,7 +807,9 @@ function walkPrivateFieldExpression(pos, ast, visitors) {
 
 function walkCallExpression(pos, ast, visitors) {
   const enterExit = visitors[47];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new CallExpression(pos, ast);
@@ -805,7 +825,9 @@ function walkCallExpression(pos, ast, visitors) {
 
 function walkNewExpression(pos, ast, visitors) {
   const enterExit = visitors[48];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new NewExpression(pos, ast);
@@ -821,7 +843,9 @@ function walkNewExpression(pos, ast, visitors) {
 
 function walkMetaProperty(pos, ast, visitors) {
   const enterExit = visitors[49];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new MetaProperty(pos, ast);
@@ -836,7 +860,9 @@ function walkMetaProperty(pos, ast, visitors) {
 
 function walkSpreadElement(pos, ast, visitors) {
   const enterExit = visitors[50];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new SpreadElement(pos, ast);
@@ -989,7 +1015,9 @@ function walkArgument(pos, ast, visitors) {
 
 function walkUpdateExpression(pos, ast, visitors) {
   const enterExit = visitors[51];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new UpdateExpression(pos, ast);
@@ -1003,7 +1031,9 @@ function walkUpdateExpression(pos, ast, visitors) {
 
 function walkUnaryExpression(pos, ast, visitors) {
   const enterExit = visitors[52];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new UnaryExpression(pos, ast);
@@ -1017,7 +1047,9 @@ function walkUnaryExpression(pos, ast, visitors) {
 
 function walkBinaryExpression(pos, ast, visitors) {
   const enterExit = visitors[53];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new BinaryExpression(pos, ast);
@@ -1032,7 +1064,9 @@ function walkBinaryExpression(pos, ast, visitors) {
 
 function walkPrivateInExpression(pos, ast, visitors) {
   const enterExit = visitors[54];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new PrivateInExpression(pos, ast);
@@ -1047,7 +1081,9 @@ function walkPrivateInExpression(pos, ast, visitors) {
 
 function walkLogicalExpression(pos, ast, visitors) {
   const enterExit = visitors[55];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new LogicalExpression(pos, ast);
@@ -1062,7 +1098,9 @@ function walkLogicalExpression(pos, ast, visitors) {
 
 function walkConditionalExpression(pos, ast, visitors) {
   const enterExit = visitors[56];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ConditionalExpression(pos, ast);
@@ -1078,7 +1116,9 @@ function walkConditionalExpression(pos, ast, visitors) {
 
 function walkAssignmentExpression(pos, ast, visitors) {
   const enterExit = visitors[57];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new AssignmentExpression(pos, ast);
@@ -1161,7 +1201,9 @@ function walkSimpleAssignmentTarget(pos, ast, visitors) {
 
 function walkArrayAssignmentTarget(pos, ast, visitors) {
   const enterExit = visitors[58];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ArrayAssignmentTarget(pos, ast);
@@ -1175,7 +1217,9 @@ function walkArrayAssignmentTarget(pos, ast, visitors) {
 
 function walkObjectAssignmentTarget(pos, ast, visitors) {
   const enterExit = visitors[59];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ObjectAssignmentTarget(pos, ast);
@@ -1229,7 +1273,9 @@ function walkAssignmentTargetMaybeDefault(pos, ast, visitors) {
 
 function walkAssignmentTargetWithDefault(pos, ast, visitors) {
   const enterExit = visitors[60];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new AssignmentTargetWithDefault(pos, ast);
@@ -1257,7 +1303,9 @@ function walkAssignmentTargetProperty(pos, ast, visitors) {
 
 function walkAssignmentTargetPropertyIdentifier(pos, ast, visitors) {
   const enterExit = visitors[61];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new AssignmentTargetPropertyIdentifier(pos, ast);
@@ -1272,7 +1320,9 @@ function walkAssignmentTargetPropertyIdentifier(pos, ast, visitors) {
 
 function walkAssignmentTargetPropertyProperty(pos, ast, visitors) {
   const enterExit = visitors[62];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new AssignmentTargetPropertyProperty(pos, ast);
@@ -1287,7 +1337,9 @@ function walkAssignmentTargetPropertyProperty(pos, ast, visitors) {
 
 function walkSequenceExpression(pos, ast, visitors) {
   const enterExit = visitors[63];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new SequenceExpression(pos, ast);
@@ -1306,7 +1358,9 @@ function walkSuper(pos, ast, visitors) {
 
 function walkAwaitExpression(pos, ast, visitors) {
   const enterExit = visitors[64];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new AwaitExpression(pos, ast);
@@ -1320,7 +1374,9 @@ function walkAwaitExpression(pos, ast, visitors) {
 
 function walkChainExpression(pos, ast, visitors) {
   const enterExit = visitors[65];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ChainExpression(pos, ast);
@@ -1356,7 +1412,9 @@ function walkChainElement(pos, ast, visitors) {
 
 function walkParenthesizedExpression(pos, ast, visitors) {
   const enterExit = visitors[66];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ParenthesizedExpression(pos, ast);
@@ -1478,7 +1536,9 @@ function walkHashbang(pos, ast, visitors) {
 
 function walkBlockStatement(pos, ast, visitors) {
   const enterExit = visitors[67];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new BlockStatement(pos, ast);
@@ -1523,7 +1583,9 @@ function walkDeclaration(pos, ast, visitors) {
 
 function walkVariableDeclaration(pos, ast, visitors) {
   const enterExit = visitors[68];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new VariableDeclaration(pos, ast);
@@ -1537,7 +1599,9 @@ function walkVariableDeclaration(pos, ast, visitors) {
 
 function walkVariableDeclarator(pos, ast, visitors) {
   const enterExit = visitors[69];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new VariableDeclarator(pos, ast);
@@ -1557,7 +1621,9 @@ function walkEmptyStatement(pos, ast, visitors) {
 
 function walkExpressionStatement(pos, ast, visitors) {
   const enterExit = visitors[70];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ExpressionStatement(pos, ast);
@@ -1571,7 +1637,9 @@ function walkExpressionStatement(pos, ast, visitors) {
 
 function walkIfStatement(pos, ast, visitors) {
   const enterExit = visitors[71];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new IfStatement(pos, ast);
@@ -1587,7 +1655,9 @@ function walkIfStatement(pos, ast, visitors) {
 
 function walkDoWhileStatement(pos, ast, visitors) {
   const enterExit = visitors[72];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new DoWhileStatement(pos, ast);
@@ -1602,7 +1672,9 @@ function walkDoWhileStatement(pos, ast, visitors) {
 
 function walkWhileStatement(pos, ast, visitors) {
   const enterExit = visitors[73];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new WhileStatement(pos, ast);
@@ -1617,7 +1689,9 @@ function walkWhileStatement(pos, ast, visitors) {
 
 function walkForStatement(pos, ast, visitors) {
   const enterExit = visitors[74];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ForStatement(pos, ast);
@@ -1773,7 +1847,9 @@ function walkForStatementInit(pos, ast, visitors) {
 
 function walkForInStatement(pos, ast, visitors) {
   const enterExit = visitors[75];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ForInStatement(pos, ast);
@@ -1829,7 +1905,9 @@ function walkForStatementLeft(pos, ast, visitors) {
 
 function walkForOfStatement(pos, ast, visitors) {
   const enterExit = visitors[76];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ForOfStatement(pos, ast);
@@ -1845,7 +1923,9 @@ function walkForOfStatement(pos, ast, visitors) {
 
 function walkContinueStatement(pos, ast, visitors) {
   const enterExit = visitors[77];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ContinueStatement(pos, ast);
@@ -1859,7 +1939,9 @@ function walkContinueStatement(pos, ast, visitors) {
 
 function walkBreakStatement(pos, ast, visitors) {
   const enterExit = visitors[78];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new BreakStatement(pos, ast);
@@ -1873,7 +1955,9 @@ function walkBreakStatement(pos, ast, visitors) {
 
 function walkReturnStatement(pos, ast, visitors) {
   const enterExit = visitors[79];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ReturnStatement(pos, ast);
@@ -1887,7 +1971,9 @@ function walkReturnStatement(pos, ast, visitors) {
 
 function walkWithStatement(pos, ast, visitors) {
   const enterExit = visitors[80];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new WithStatement(pos, ast);
@@ -1902,7 +1988,9 @@ function walkWithStatement(pos, ast, visitors) {
 
 function walkSwitchStatement(pos, ast, visitors) {
   const enterExit = visitors[81];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new SwitchStatement(pos, ast);
@@ -1917,7 +2005,9 @@ function walkSwitchStatement(pos, ast, visitors) {
 
 function walkSwitchCase(pos, ast, visitors) {
   const enterExit = visitors[82];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new SwitchCase(pos, ast);
@@ -1932,7 +2022,9 @@ function walkSwitchCase(pos, ast, visitors) {
 
 function walkLabeledStatement(pos, ast, visitors) {
   const enterExit = visitors[83];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new LabeledStatement(pos, ast);
@@ -1947,7 +2039,9 @@ function walkLabeledStatement(pos, ast, visitors) {
 
 function walkThrowStatement(pos, ast, visitors) {
   const enterExit = visitors[84];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ThrowStatement(pos, ast);
@@ -1961,7 +2055,9 @@ function walkThrowStatement(pos, ast, visitors) {
 
 function walkTryStatement(pos, ast, visitors) {
   const enterExit = visitors[85];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TryStatement(pos, ast);
@@ -1977,7 +2073,9 @@ function walkTryStatement(pos, ast, visitors) {
 
 function walkCatchClause(pos, ast, visitors) {
   const enterExit = visitors[86];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new CatchClause(pos, ast);
@@ -2025,7 +2123,9 @@ function walkBindingPatternKind(pos, ast, visitors) {
 
 function walkAssignmentPattern(pos, ast, visitors) {
   const enterExit = visitors[87];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new AssignmentPattern(pos, ast);
@@ -2040,7 +2140,9 @@ function walkAssignmentPattern(pos, ast, visitors) {
 
 function walkObjectPattern(pos, ast, visitors) {
   const enterExit = visitors[88];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ObjectPattern(pos, ast);
@@ -2054,7 +2156,9 @@ function walkObjectPattern(pos, ast, visitors) {
 
 function walkBindingProperty(pos, ast, visitors) {
   const enterExit = visitors[89];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new BindingProperty(pos, ast);
@@ -2069,7 +2173,9 @@ function walkBindingProperty(pos, ast, visitors) {
 
 function walkArrayPattern(pos, ast, visitors) {
   const enterExit = visitors[90];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ArrayPattern(pos, ast);
@@ -2083,7 +2189,9 @@ function walkArrayPattern(pos, ast, visitors) {
 
 function walkFunction(pos, ast, visitors) {
   const enterExit = visitors[91];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new Function(pos, ast);
@@ -2101,7 +2209,9 @@ function walkFunction(pos, ast, visitors) {
 
 function walkFormalParameters(pos, ast, visitors) {
   const enterExit = visitors[92];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new FormalParameters(pos, ast);
@@ -2120,7 +2230,9 @@ function walkFormalParameter(pos, ast, visitors) {
 
 function walkFunctionBody(pos, ast, visitors) {
   const enterExit = visitors[93];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new FunctionBody(pos, ast);
@@ -2134,7 +2246,9 @@ function walkFunctionBody(pos, ast, visitors) {
 
 function walkArrowFunctionExpression(pos, ast, visitors) {
   const enterExit = visitors[94];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ArrowFunctionExpression(pos, ast);
@@ -2151,7 +2265,9 @@ function walkArrowFunctionExpression(pos, ast, visitors) {
 
 function walkYieldExpression(pos, ast, visitors) {
   const enterExit = visitors[95];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new YieldExpression(pos, ast);
@@ -2165,7 +2281,9 @@ function walkYieldExpression(pos, ast, visitors) {
 
 function walkClass(pos, ast, visitors) {
   const enterExit = visitors[96];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new Class(pos, ast);
@@ -2185,7 +2303,9 @@ function walkClass(pos, ast, visitors) {
 
 function walkClassBody(pos, ast, visitors) {
   const enterExit = visitors[97];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ClassBody(pos, ast);
@@ -2221,7 +2341,9 @@ function walkClassElement(pos, ast, visitors) {
 
 function walkMethodDefinition(pos, ast, visitors) {
   const enterExit = visitors[98];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new MethodDefinition(pos, ast);
@@ -2237,7 +2359,9 @@ function walkMethodDefinition(pos, ast, visitors) {
 
 function walkPropertyDefinition(pos, ast, visitors) {
   const enterExit = visitors[99];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new PropertyDefinition(pos, ast);
@@ -2259,7 +2383,9 @@ function walkPrivateIdentifier(pos, ast, visitors) {
 
 function walkStaticBlock(pos, ast, visitors) {
   const enterExit = visitors[100];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new StaticBlock(pos, ast);
@@ -2273,7 +2399,9 @@ function walkStaticBlock(pos, ast, visitors) {
 
 function walkAccessorProperty(pos, ast, visitors) {
   const enterExit = visitors[101];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new AccessorProperty(pos, ast);
@@ -2290,7 +2418,9 @@ function walkAccessorProperty(pos, ast, visitors) {
 
 function walkImportExpression(pos, ast, visitors) {
   const enterExit = visitors[102];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ImportExpression(pos, ast);
@@ -2305,7 +2435,9 @@ function walkImportExpression(pos, ast, visitors) {
 
 function walkImportDeclaration(pos, ast, visitors) {
   const enterExit = visitors[103];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ImportDeclaration(pos, ast);
@@ -2337,7 +2469,9 @@ function walkImportDeclarationSpecifier(pos, ast, visitors) {
 
 function walkImportSpecifier(pos, ast, visitors) {
   const enterExit = visitors[104];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ImportSpecifier(pos, ast);
@@ -2352,7 +2486,9 @@ function walkImportSpecifier(pos, ast, visitors) {
 
 function walkImportDefaultSpecifier(pos, ast, visitors) {
   const enterExit = visitors[105];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ImportDefaultSpecifier(pos, ast);
@@ -2366,7 +2502,9 @@ function walkImportDefaultSpecifier(pos, ast, visitors) {
 
 function walkImportNamespaceSpecifier(pos, ast, visitors) {
   const enterExit = visitors[106];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ImportNamespaceSpecifier(pos, ast);
@@ -2384,7 +2522,9 @@ function walkWithClause(pos, ast, visitors) {
 
 function walkImportAttribute(pos, ast, visitors) {
   const enterExit = visitors[107];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ImportAttribute(pos, ast);
@@ -2412,7 +2552,9 @@ function walkImportAttributeKey(pos, ast, visitors) {
 
 function walkExportNamedDeclaration(pos, ast, visitors) {
   const enterExit = visitors[108];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ExportNamedDeclaration(pos, ast);
@@ -2429,7 +2571,9 @@ function walkExportNamedDeclaration(pos, ast, visitors) {
 
 function walkExportDefaultDeclaration(pos, ast, visitors) {
   const enterExit = visitors[109];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ExportDefaultDeclaration(pos, ast);
@@ -2443,7 +2587,9 @@ function walkExportDefaultDeclaration(pos, ast, visitors) {
 
 function walkExportAllDeclaration(pos, ast, visitors) {
   const enterExit = visitors[110];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ExportAllDeclaration(pos, ast);
@@ -2459,7 +2605,9 @@ function walkExportAllDeclaration(pos, ast, visitors) {
 
 function walkExportSpecifier(pos, ast, visitors) {
   const enterExit = visitors[111];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new ExportSpecifier(pos, ast);
@@ -2635,7 +2783,9 @@ function walkModuleExportName(pos, ast, visitors) {
 
 function walkV8IntrinsicExpression(pos, ast, visitors) {
   const enterExit = visitors[112];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new V8IntrinsicExpression(pos, ast);
@@ -2680,7 +2830,9 @@ function walkRegExpLiteral(pos, ast, visitors) {
 
 function walkJSXElement(pos, ast, visitors) {
   const enterExit = visitors[113];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new JSXElement(pos, ast);
@@ -2696,7 +2848,9 @@ function walkJSXElement(pos, ast, visitors) {
 
 function walkJSXOpeningElement(pos, ast, visitors) {
   const enterExit = visitors[114];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new JSXOpeningElement(pos, ast);
@@ -2712,7 +2866,9 @@ function walkJSXOpeningElement(pos, ast, visitors) {
 
 function walkJSXClosingElement(pos, ast, visitors) {
   const enterExit = visitors[115];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new JSXClosingElement(pos, ast);
@@ -2726,7 +2882,9 @@ function walkJSXClosingElement(pos, ast, visitors) {
 
 function walkJSXFragment(pos, ast, visitors) {
   const enterExit = visitors[116];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new JSXFragment(pos, ast);
@@ -2774,7 +2932,9 @@ function walkJSXElementName(pos, ast, visitors) {
 
 function walkJSXNamespacedName(pos, ast, visitors) {
   const enterExit = visitors[117];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new JSXNamespacedName(pos, ast);
@@ -2789,7 +2949,9 @@ function walkJSXNamespacedName(pos, ast, visitors) {
 
 function walkJSXMemberExpression(pos, ast, visitors) {
   const enterExit = visitors[118];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new JSXMemberExpression(pos, ast);
@@ -2820,7 +2982,9 @@ function walkJSXMemberExpressionObject(pos, ast, visitors) {
 
 function walkJSXExpressionContainer(pos, ast, visitors) {
   const enterExit = visitors[119];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new JSXExpressionContainer(pos, ast);
@@ -2991,7 +3155,9 @@ function walkJSXAttributeItem(pos, ast, visitors) {
 
 function walkJSXAttribute(pos, ast, visitors) {
   const enterExit = visitors[120];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new JSXAttribute(pos, ast);
@@ -3006,7 +3172,9 @@ function walkJSXAttribute(pos, ast, visitors) {
 
 function walkJSXSpreadAttribute(pos, ast, visitors) {
   const enterExit = visitors[121];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new JSXSpreadAttribute(pos, ast);
@@ -3079,7 +3247,9 @@ function walkJSXChild(pos, ast, visitors) {
 
 function walkJSXSpreadChild(pos, ast, visitors) {
   const enterExit = visitors[122];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new JSXSpreadChild(pos, ast);
@@ -3098,7 +3268,9 @@ function walkJSXText(pos, ast, visitors) {
 
 function walkTSEnumDeclaration(pos, ast, visitors) {
   const enterExit = visitors[123];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSEnumDeclaration(pos, ast);
@@ -3113,7 +3285,9 @@ function walkTSEnumDeclaration(pos, ast, visitors) {
 
 function walkTSEnumBody(pos, ast, visitors) {
   const enterExit = visitors[124];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSEnumBody(pos, ast);
@@ -3127,7 +3301,9 @@ function walkTSEnumBody(pos, ast, visitors) {
 
 function walkTSEnumMember(pos, ast, visitors) {
   const enterExit = visitors[125];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSEnumMember(pos, ast);
@@ -3161,7 +3337,9 @@ function walkTSEnumMemberName(pos, ast, visitors) {
 
 function walkTSTypeAnnotation(pos, ast, visitors) {
   const enterExit = visitors[126];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSTypeAnnotation(pos, ast);
@@ -3175,7 +3353,9 @@ function walkTSTypeAnnotation(pos, ast, visitors) {
 
 function walkTSLiteralType(pos, ast, visitors) {
   const enterExit = visitors[127];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSLiteralType(pos, ast);
@@ -3332,7 +3512,9 @@ function walkTSType(pos, ast, visitors) {
 
 function walkTSConditionalType(pos, ast, visitors) {
   const enterExit = visitors[128];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSConditionalType(pos, ast);
@@ -3349,7 +3531,9 @@ function walkTSConditionalType(pos, ast, visitors) {
 
 function walkTSUnionType(pos, ast, visitors) {
   const enterExit = visitors[129];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSUnionType(pos, ast);
@@ -3363,7 +3547,9 @@ function walkTSUnionType(pos, ast, visitors) {
 
 function walkTSIntersectionType(pos, ast, visitors) {
   const enterExit = visitors[130];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSIntersectionType(pos, ast);
@@ -3377,7 +3563,9 @@ function walkTSIntersectionType(pos, ast, visitors) {
 
 function walkTSParenthesizedType(pos, ast, visitors) {
   const enterExit = visitors[131];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSParenthesizedType(pos, ast);
@@ -3391,7 +3579,9 @@ function walkTSParenthesizedType(pos, ast, visitors) {
 
 function walkTSTypeOperator(pos, ast, visitors) {
   const enterExit = visitors[132];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSTypeOperator(pos, ast);
@@ -3405,7 +3595,9 @@ function walkTSTypeOperator(pos, ast, visitors) {
 
 function walkTSArrayType(pos, ast, visitors) {
   const enterExit = visitors[133];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSArrayType(pos, ast);
@@ -3419,7 +3611,9 @@ function walkTSArrayType(pos, ast, visitors) {
 
 function walkTSIndexedAccessType(pos, ast, visitors) {
   const enterExit = visitors[134];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSIndexedAccessType(pos, ast);
@@ -3434,7 +3628,9 @@ function walkTSIndexedAccessType(pos, ast, visitors) {
 
 function walkTSTupleType(pos, ast, visitors) {
   const enterExit = visitors[135];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSTupleType(pos, ast);
@@ -3448,7 +3644,9 @@ function walkTSTupleType(pos, ast, visitors) {
 
 function walkTSNamedTupleMember(pos, ast, visitors) {
   const enterExit = visitors[136];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSNamedTupleMember(pos, ast);
@@ -3463,7 +3661,9 @@ function walkTSNamedTupleMember(pos, ast, visitors) {
 
 function walkTSOptionalType(pos, ast, visitors) {
   const enterExit = visitors[137];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSOptionalType(pos, ast);
@@ -3477,7 +3677,9 @@ function walkTSOptionalType(pos, ast, visitors) {
 
 function walkTSRestType(pos, ast, visitors) {
   const enterExit = visitors[138];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSRestType(pos, ast);
@@ -3685,7 +3887,9 @@ function walkTSBigIntKeyword(pos, ast, visitors) {
 
 function walkTSTypeReference(pos, ast, visitors) {
   const enterExit = visitors[139];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSTypeReference(pos, ast);
@@ -3716,7 +3920,9 @@ function walkTSTypeName(pos, ast, visitors) {
 
 function walkTSQualifiedName(pos, ast, visitors) {
   const enterExit = visitors[140];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSQualifiedName(pos, ast);
@@ -3731,7 +3937,9 @@ function walkTSQualifiedName(pos, ast, visitors) {
 
 function walkTSTypeParameterInstantiation(pos, ast, visitors) {
   const enterExit = visitors[141];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSTypeParameterInstantiation(pos, ast);
@@ -3745,7 +3953,9 @@ function walkTSTypeParameterInstantiation(pos, ast, visitors) {
 
 function walkTSTypeParameter(pos, ast, visitors) {
   const enterExit = visitors[142];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSTypeParameter(pos, ast);
@@ -3761,7 +3971,9 @@ function walkTSTypeParameter(pos, ast, visitors) {
 
 function walkTSTypeParameterDeclaration(pos, ast, visitors) {
   const enterExit = visitors[143];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSTypeParameterDeclaration(pos, ast);
@@ -3775,7 +3987,9 @@ function walkTSTypeParameterDeclaration(pos, ast, visitors) {
 
 function walkTSTypeAliasDeclaration(pos, ast, visitors) {
   const enterExit = visitors[144];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSTypeAliasDeclaration(pos, ast);
@@ -3791,7 +4005,9 @@ function walkTSTypeAliasDeclaration(pos, ast, visitors) {
 
 function walkTSClassImplements(pos, ast, visitors) {
   const enterExit = visitors[145];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSClassImplements(pos, ast);
@@ -3806,7 +4022,9 @@ function walkTSClassImplements(pos, ast, visitors) {
 
 function walkTSInterfaceDeclaration(pos, ast, visitors) {
   const enterExit = visitors[146];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSInterfaceDeclaration(pos, ast);
@@ -3823,7 +4041,9 @@ function walkTSInterfaceDeclaration(pos, ast, visitors) {
 
 function walkTSInterfaceBody(pos, ast, visitors) {
   const enterExit = visitors[147];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSInterfaceBody(pos, ast);
@@ -3837,7 +4057,9 @@ function walkTSInterfaceBody(pos, ast, visitors) {
 
 function walkTSPropertySignature(pos, ast, visitors) {
   const enterExit = visitors[148];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSPropertySignature(pos, ast);
@@ -3874,7 +4096,9 @@ function walkTSSignature(pos, ast, visitors) {
 
 function walkTSIndexSignature(pos, ast, visitors) {
   const enterExit = visitors[149];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSIndexSignature(pos, ast);
@@ -3889,7 +4113,9 @@ function walkTSIndexSignature(pos, ast, visitors) {
 
 function walkTSCallSignatureDeclaration(pos, ast, visitors) {
   const enterExit = visitors[150];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSCallSignatureDeclaration(pos, ast);
@@ -3905,7 +4131,9 @@ function walkTSCallSignatureDeclaration(pos, ast, visitors) {
 
 function walkTSMethodSignature(pos, ast, visitors) {
   const enterExit = visitors[151];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSMethodSignature(pos, ast);
@@ -3922,7 +4150,9 @@ function walkTSMethodSignature(pos, ast, visitors) {
 
 function walkTSConstructSignatureDeclaration(pos, ast, visitors) {
   const enterExit = visitors[152];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSConstructSignatureDeclaration(pos, ast);
@@ -3938,7 +4168,9 @@ function walkTSConstructSignatureDeclaration(pos, ast, visitors) {
 
 function walkTSIndexSignatureName(pos, ast, visitors) {
   const enterExit = visitors[153];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSIndexSignatureName(pos, ast);
@@ -3952,7 +4184,9 @@ function walkTSIndexSignatureName(pos, ast, visitors) {
 
 function walkTSInterfaceHeritage(pos, ast, visitors) {
   const enterExit = visitors[154];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSInterfaceHeritage(pos, ast);
@@ -3967,7 +4201,9 @@ function walkTSInterfaceHeritage(pos, ast, visitors) {
 
 function walkTSTypePredicate(pos, ast, visitors) {
   const enterExit = visitors[155];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSTypePredicate(pos, ast);
@@ -3995,7 +4231,9 @@ function walkTSTypePredicateName(pos, ast, visitors) {
 
 function walkTSModuleDeclaration(pos, ast, visitors) {
   const enterExit = visitors[156];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSModuleDeclaration(pos, ast);
@@ -4036,7 +4274,9 @@ function walkTSModuleDeclarationBody(pos, ast, visitors) {
 
 function walkTSModuleBlock(pos, ast, visitors) {
   const enterExit = visitors[157];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSModuleBlock(pos, ast);
@@ -4050,7 +4290,9 @@ function walkTSModuleBlock(pos, ast, visitors) {
 
 function walkTSTypeLiteral(pos, ast, visitors) {
   const enterExit = visitors[158];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSTypeLiteral(pos, ast);
@@ -4064,7 +4306,9 @@ function walkTSTypeLiteral(pos, ast, visitors) {
 
 function walkTSInferType(pos, ast, visitors) {
   const enterExit = visitors[159];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSInferType(pos, ast);
@@ -4078,7 +4322,9 @@ function walkTSInferType(pos, ast, visitors) {
 
 function walkTSTypeQuery(pos, ast, visitors) {
   const enterExit = visitors[160];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSTypeQuery(pos, ast);
@@ -4112,7 +4358,9 @@ function walkTSTypeQueryExprName(pos, ast, visitors) {
 
 function walkTSImportType(pos, ast, visitors) {
   const enterExit = visitors[161];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSImportType(pos, ast);
@@ -4142,7 +4390,9 @@ function walkTSImportTypeQualifier(pos, ast, visitors) {
 
 function walkTSImportTypeQualifiedName(pos, ast, visitors) {
   const enterExit = visitors[162];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSImportTypeQualifiedName(pos, ast);
@@ -4157,7 +4407,9 @@ function walkTSImportTypeQualifiedName(pos, ast, visitors) {
 
 function walkTSFunctionType(pos, ast, visitors) {
   const enterExit = visitors[163];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSFunctionType(pos, ast);
@@ -4173,7 +4425,9 @@ function walkTSFunctionType(pos, ast, visitors) {
 
 function walkTSConstructorType(pos, ast, visitors) {
   const enterExit = visitors[164];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSConstructorType(pos, ast);
@@ -4189,7 +4443,9 @@ function walkTSConstructorType(pos, ast, visitors) {
 
 function walkTSMappedType(pos, ast, visitors) {
   const enterExit = visitors[165];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSMappedType(pos, ast);
@@ -4204,7 +4460,9 @@ function walkTSMappedType(pos, ast, visitors) {
 
 function walkTSTemplateLiteralType(pos, ast, visitors) {
   const enterExit = visitors[166];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSTemplateLiteralType(pos, ast);
@@ -4219,7 +4477,9 @@ function walkTSTemplateLiteralType(pos, ast, visitors) {
 
 function walkTSAsExpression(pos, ast, visitors) {
   const enterExit = visitors[167];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSAsExpression(pos, ast);
@@ -4234,7 +4494,9 @@ function walkTSAsExpression(pos, ast, visitors) {
 
 function walkTSSatisfiesExpression(pos, ast, visitors) {
   const enterExit = visitors[168];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSSatisfiesExpression(pos, ast);
@@ -4249,7 +4511,9 @@ function walkTSSatisfiesExpression(pos, ast, visitors) {
 
 function walkTSTypeAssertion(pos, ast, visitors) {
   const enterExit = visitors[169];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSTypeAssertion(pos, ast);
@@ -4264,7 +4528,9 @@ function walkTSTypeAssertion(pos, ast, visitors) {
 
 function walkTSImportEqualsDeclaration(pos, ast, visitors) {
   const enterExit = visitors[170];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSImportEqualsDeclaration(pos, ast);
@@ -4298,7 +4564,9 @@ function walkTSModuleReference(pos, ast, visitors) {
 
 function walkTSExternalModuleReference(pos, ast, visitors) {
   const enterExit = visitors[171];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSExternalModuleReference(pos, ast);
@@ -4312,7 +4580,9 @@ function walkTSExternalModuleReference(pos, ast, visitors) {
 
 function walkTSNonNullExpression(pos, ast, visitors) {
   const enterExit = visitors[172];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSNonNullExpression(pos, ast);
@@ -4326,7 +4596,9 @@ function walkTSNonNullExpression(pos, ast, visitors) {
 
 function walkDecorator(pos, ast, visitors) {
   const enterExit = visitors[173];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new Decorator(pos, ast);
@@ -4340,7 +4612,9 @@ function walkDecorator(pos, ast, visitors) {
 
 function walkTSExportAssignment(pos, ast, visitors) {
   const enterExit = visitors[174];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSExportAssignment(pos, ast);
@@ -4354,7 +4628,9 @@ function walkTSExportAssignment(pos, ast, visitors) {
 
 function walkTSNamespaceExportDeclaration(pos, ast, visitors) {
   const enterExit = visitors[175];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSNamespaceExportDeclaration(pos, ast);
@@ -4368,7 +4644,9 @@ function walkTSNamespaceExportDeclaration(pos, ast, visitors) {
 
 function walkTSInstantiationExpression(pos, ast, visitors) {
   const enterExit = visitors[176];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new TSInstantiationExpression(pos, ast);
@@ -4383,7 +4661,9 @@ function walkTSInstantiationExpression(pos, ast, visitors) {
 
 function walkJSDocNullableType(pos, ast, visitors) {
   const enterExit = visitors[177];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new JSDocNullableType(pos, ast);
@@ -4397,7 +4677,9 @@ function walkJSDocNullableType(pos, ast, visitors) {
 
 function walkJSDocNonNullableType(pos, ast, visitors) {
   const enterExit = visitors[178];
-  let node, enter, exit = null;
+  let node,
+    enter,
+    exit = null;
   if (enterExit !== null) {
     ({ enter, exit } = enterExit);
     node = new JSDocNonNullableType(pos, ast);
@@ -4415,9 +4697,8 @@ function walkJSDocUnknownType(pos, ast, visitors) {
 }
 
 function walkOptionHashbang(pos, ast, visitors) {
-  if (!(ast.buffer.uint32[(pos + 8) >> 2] === 0 && ast.buffer.uint32[(pos + 12) >> 2] === 0)) {
+  if (!(ast.buffer.uint32[(pos + 8) >> 2] === 0 && ast.buffer.uint32[(pos + 12) >> 2] === 0))
     walkHashbang(pos, ast, visitors);
-  }
 }
 
 function walkVecStatement(pos, ast, visitors) {
@@ -4656,9 +4937,8 @@ function walkBoxTSTypeParameterInstantiation(pos, ast, visitors) {
 }
 
 function walkOptionBoxTSTypeParameterInstantiation(pos, ast, visitors) {
-  if (!(ast.buffer.uint32[pos >> 2] === 0 && ast.buffer.uint32[(pos + 4) >> 2] === 0)) {
+  if (!(ast.buffer.uint32[pos >> 2] === 0 && ast.buffer.uint32[(pos + 4) >> 2] === 0))
     walkBoxTSTypeParameterInstantiation(pos, ast, visitors);
-  }
 }
 
 function walkBoxComputedMemberExpression(pos, ast, visitors) {
@@ -4850,9 +5130,8 @@ function walkOptionForStatementInit(pos, ast, visitors) {
 }
 
 function walkOptionLabelIdentifier(pos, ast, visitors) {
-  if (!(ast.buffer.uint32[(pos + 8) >> 2] === 0 && ast.buffer.uint32[(pos + 12) >> 2] === 0)) {
+  if (!(ast.buffer.uint32[(pos + 8) >> 2] === 0 && ast.buffer.uint32[(pos + 12) >> 2] === 0))
     walkLabelIdentifier(pos, ast, visitors);
-  }
 }
 
 function walkVecSwitchCase(pos, ast, visitors) {
@@ -4871,15 +5150,13 @@ function walkBoxCatchClause(pos, ast, visitors) {
 }
 
 function walkOptionBoxCatchClause(pos, ast, visitors) {
-  if (!(ast.buffer.uint32[pos >> 2] === 0 && ast.buffer.uint32[(pos + 4) >> 2] === 0)) {
+  if (!(ast.buffer.uint32[pos >> 2] === 0 && ast.buffer.uint32[(pos + 4) >> 2] === 0))
     walkBoxCatchClause(pos, ast, visitors);
-  }
 }
 
 function walkOptionBoxBlockStatement(pos, ast, visitors) {
-  if (!(ast.buffer.uint32[pos >> 2] === 0 && ast.buffer.uint32[(pos + 4) >> 2] === 0)) {
+  if (!(ast.buffer.uint32[pos >> 2] === 0 && ast.buffer.uint32[(pos + 4) >> 2] === 0))
     walkBoxBlockStatement(pos, ast, visitors);
-  }
 }
 
 function walkOptionCatchParameter(pos, ast, visitors) {
@@ -4891,9 +5168,8 @@ function walkBoxTSTypeAnnotation(pos, ast, visitors) {
 }
 
 function walkOptionBoxTSTypeAnnotation(pos, ast, visitors) {
-  if (!(ast.buffer.uint32[pos >> 2] === 0 && ast.buffer.uint32[(pos + 4) >> 2] === 0)) {
+  if (!(ast.buffer.uint32[pos >> 2] === 0 && ast.buffer.uint32[(pos + 4) >> 2] === 0))
     walkBoxTSTypeAnnotation(pos, ast, visitors);
-  }
 }
 
 function walkBoxBindingIdentifier(pos, ast, visitors) {
@@ -4939,9 +5215,8 @@ function walkVecOptionBindingPattern(pos, ast, visitors) {
 }
 
 function walkOptionBindingIdentifier(pos, ast, visitors) {
-  if (!(ast.buffer.uint32[(pos + 8) >> 2] === 0 && ast.buffer.uint32[(pos + 12) >> 2] === 0)) {
+  if (!(ast.buffer.uint32[(pos + 8) >> 2] === 0 && ast.buffer.uint32[(pos + 12) >> 2] === 0))
     walkBindingIdentifier(pos, ast, visitors);
-  }
 }
 
 function walkBoxTSTypeParameterDeclaration(pos, ast, visitors) {
@@ -4949,9 +5224,8 @@ function walkBoxTSTypeParameterDeclaration(pos, ast, visitors) {
 }
 
 function walkOptionBoxTSTypeParameterDeclaration(pos, ast, visitors) {
-  if (!(ast.buffer.uint32[pos >> 2] === 0 && ast.buffer.uint32[(pos + 4) >> 2] === 0)) {
+  if (!(ast.buffer.uint32[pos >> 2] === 0 && ast.buffer.uint32[(pos + 4) >> 2] === 0))
     walkBoxTSTypeParameterDeclaration(pos, ast, visitors);
-  }
 }
 
 function walkBoxFormalParameters(pos, ast, visitors) {
@@ -4963,9 +5237,8 @@ function walkBoxFunctionBody(pos, ast, visitors) {
 }
 
 function walkOptionBoxFunctionBody(pos, ast, visitors) {
-  if (!(ast.buffer.uint32[pos >> 2] === 0 && ast.buffer.uint32[(pos + 4) >> 2] === 0)) {
+  if (!(ast.buffer.uint32[pos >> 2] === 0 && ast.buffer.uint32[(pos + 4) >> 2] === 0))
     walkBoxFunctionBody(pos, ast, visitors);
-  }
 }
 
 function walkVecFormalParameter(pos, ast, visitors) {
@@ -5072,9 +5345,8 @@ function walkVecImportDeclarationSpecifier(pos, ast, visitors) {
 }
 
 function walkOptionVecImportDeclarationSpecifier(pos, ast, visitors) {
-  if (!(ast.buffer.uint32[pos >> 2] === 0 && ast.buffer.uint32[(pos + 4) >> 2] === 0)) {
+  if (!(ast.buffer.uint32[pos >> 2] === 0 && ast.buffer.uint32[(pos + 4) >> 2] === 0))
     walkVecImportDeclarationSpecifier(pos, ast, visitors);
-  }
 }
 
 function walkBoxWithClause(pos, ast, visitors) {
@@ -5082,9 +5354,8 @@ function walkBoxWithClause(pos, ast, visitors) {
 }
 
 function walkOptionBoxWithClause(pos, ast, visitors) {
-  if (!(ast.buffer.uint32[pos >> 2] === 0 && ast.buffer.uint32[(pos + 4) >> 2] === 0)) {
+  if (!(ast.buffer.uint32[pos >> 2] === 0 && ast.buffer.uint32[(pos + 4) >> 2] === 0))
     walkBoxWithClause(pos, ast, visitors);
-  }
 }
 
 function walkBoxImportSpecifier(pos, ast, visitors) {
@@ -5153,9 +5424,8 @@ function walkBoxJSXClosingElement(pos, ast, visitors) {
 }
 
 function walkOptionBoxJSXClosingElement(pos, ast, visitors) {
-  if (!(ast.buffer.uint32[pos >> 2] === 0 && ast.buffer.uint32[(pos + 4) >> 2] === 0)) {
+  if (!(ast.buffer.uint32[pos >> 2] === 0 && ast.buffer.uint32[(pos + 4) >> 2] === 0))
     walkBoxJSXClosingElement(pos, ast, visitors);
-  }
 }
 
 function walkVecJSXAttributeItem(pos, ast, visitors) {
@@ -5479,9 +5749,8 @@ function walkBoxTSTypeParameter(pos, ast, visitors) {
 }
 
 function walkOptionBoxObjectExpression(pos, ast, visitors) {
-  if (!(ast.buffer.uint32[pos >> 2] === 0 && ast.buffer.uint32[(pos + 4) >> 2] === 0)) {
+  if (!(ast.buffer.uint32[pos >> 2] === 0 && ast.buffer.uint32[(pos + 4) >> 2] === 0))
     walkBoxObjectExpression(pos, ast, visitors);
-  }
 }
 
 function walkOptionTSImportTypeQualifier(pos, ast, visitors) {

--- a/napi/parser/generated/visit/walk.js
+++ b/napi/parser/generated/visit/walk.js
@@ -10,7 +10,8 @@ function walkNode(node, visitors) {
   if (isArray(node)) {
     let len = node.length;
     for (let i = 0; i < len; i++) walkNode(node[i], visitors);
-  } else {switch (node.type) {
+  } else
+    switch (node.type) {
       case 'DebuggerStatement':
         walkDebuggerStatement(node, visitors);
         break;
@@ -506,7 +507,7 @@ function walkNode(node, visitors) {
       case 'TSUnionType':
         walkTSUnionType(node, visitors);
         break;
-    }}
+    }
 }
 
 function walkDebuggerStatement(node, visitors) {
@@ -645,7 +646,8 @@ function walkTSVoidKeyword(node, visitors) {
 }
 
 function walkAccessorProperty(node, visitors) {
-  let enterExit = visitors[27], exit = null;
+  let enterExit = visitors[27],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -659,7 +661,8 @@ function walkAccessorProperty(node, visitors) {
 }
 
 function walkArrayExpression(node, visitors) {
-  let enterExit = visitors[28], exit = null;
+  let enterExit = visitors[28],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -670,7 +673,8 @@ function walkArrayExpression(node, visitors) {
 }
 
 function walkArrayPattern(node, visitors) {
-  let enterExit = visitors[29], exit = null;
+  let enterExit = visitors[29],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -683,7 +687,8 @@ function walkArrayPattern(node, visitors) {
 }
 
 function walkArrowFunctionExpression(node, visitors) {
-  let enterExit = visitors[30], exit = null;
+  let enterExit = visitors[30],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -697,7 +702,8 @@ function walkArrowFunctionExpression(node, visitors) {
 }
 
 function walkAssignmentExpression(node, visitors) {
-  let enterExit = visitors[31], exit = null;
+  let enterExit = visitors[31],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -709,7 +715,8 @@ function walkAssignmentExpression(node, visitors) {
 }
 
 function walkAssignmentPattern(node, visitors) {
-  let enterExit = visitors[32], exit = null;
+  let enterExit = visitors[32],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -723,7 +730,8 @@ function walkAssignmentPattern(node, visitors) {
 }
 
 function walkAwaitExpression(node, visitors) {
-  let enterExit = visitors[33], exit = null;
+  let enterExit = visitors[33],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -734,7 +742,8 @@ function walkAwaitExpression(node, visitors) {
 }
 
 function walkBinaryExpression(node, visitors) {
-  let enterExit = visitors[34], exit = null;
+  let enterExit = visitors[34],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -746,7 +755,8 @@ function walkBinaryExpression(node, visitors) {
 }
 
 function walkBlockStatement(node, visitors) {
-  let enterExit = visitors[35], exit = null;
+  let enterExit = visitors[35],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -757,7 +767,8 @@ function walkBlockStatement(node, visitors) {
 }
 
 function walkBreakStatement(node, visitors) {
-  let enterExit = visitors[36], exit = null;
+  let enterExit = visitors[36],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -768,7 +779,8 @@ function walkBreakStatement(node, visitors) {
 }
 
 function walkCallExpression(node, visitors) {
-  let enterExit = visitors[37], exit = null;
+  let enterExit = visitors[37],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -781,7 +793,8 @@ function walkCallExpression(node, visitors) {
 }
 
 function walkCatchClause(node, visitors) {
-  let enterExit = visitors[38], exit = null;
+  let enterExit = visitors[38],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -793,7 +806,8 @@ function walkCatchClause(node, visitors) {
 }
 
 function walkChainExpression(node, visitors) {
-  let enterExit = visitors[39], exit = null;
+  let enterExit = visitors[39],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -804,7 +818,8 @@ function walkChainExpression(node, visitors) {
 }
 
 function walkClassBody(node, visitors) {
-  let enterExit = visitors[40], exit = null;
+  let enterExit = visitors[40],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -815,7 +830,8 @@ function walkClassBody(node, visitors) {
 }
 
 function walkClassDeclaration(node, visitors) {
-  let enterExit = visitors[41], exit = null;
+  let enterExit = visitors[41],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -832,7 +848,8 @@ function walkClassDeclaration(node, visitors) {
 }
 
 function walkClassExpression(node, visitors) {
-  let enterExit = visitors[42], exit = null;
+  let enterExit = visitors[42],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -849,7 +866,8 @@ function walkClassExpression(node, visitors) {
 }
 
 function walkConditionalExpression(node, visitors) {
-  let enterExit = visitors[43], exit = null;
+  let enterExit = visitors[43],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -862,7 +880,8 @@ function walkConditionalExpression(node, visitors) {
 }
 
 function walkContinueStatement(node, visitors) {
-  let enterExit = visitors[44], exit = null;
+  let enterExit = visitors[44],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -873,7 +892,8 @@ function walkContinueStatement(node, visitors) {
 }
 
 function walkDecorator(node, visitors) {
-  let enterExit = visitors[45], exit = null;
+  let enterExit = visitors[45],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -884,7 +904,8 @@ function walkDecorator(node, visitors) {
 }
 
 function walkDoWhileStatement(node, visitors) {
-  let enterExit = visitors[46], exit = null;
+  let enterExit = visitors[46],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -896,7 +917,8 @@ function walkDoWhileStatement(node, visitors) {
 }
 
 function walkExportAllDeclaration(node, visitors) {
-  let enterExit = visitors[47], exit = null;
+  let enterExit = visitors[47],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -909,7 +931,8 @@ function walkExportAllDeclaration(node, visitors) {
 }
 
 function walkExportDefaultDeclaration(node, visitors) {
-  let enterExit = visitors[48], exit = null;
+  let enterExit = visitors[48],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -920,7 +943,8 @@ function walkExportDefaultDeclaration(node, visitors) {
 }
 
 function walkExportNamedDeclaration(node, visitors) {
-  let enterExit = visitors[49], exit = null;
+  let enterExit = visitors[49],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -934,7 +958,8 @@ function walkExportNamedDeclaration(node, visitors) {
 }
 
 function walkExportSpecifier(node, visitors) {
-  let enterExit = visitors[50], exit = null;
+  let enterExit = visitors[50],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -946,7 +971,8 @@ function walkExportSpecifier(node, visitors) {
 }
 
 function walkExpressionStatement(node, visitors) {
-  let enterExit = visitors[51], exit = null;
+  let enterExit = visitors[51],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -957,7 +983,8 @@ function walkExpressionStatement(node, visitors) {
 }
 
 function walkForInStatement(node, visitors) {
-  let enterExit = visitors[52], exit = null;
+  let enterExit = visitors[52],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -970,7 +997,8 @@ function walkForInStatement(node, visitors) {
 }
 
 function walkForOfStatement(node, visitors) {
-  let enterExit = visitors[53], exit = null;
+  let enterExit = visitors[53],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -983,7 +1011,8 @@ function walkForOfStatement(node, visitors) {
 }
 
 function walkForStatement(node, visitors) {
-  let enterExit = visitors[54], exit = null;
+  let enterExit = visitors[54],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -997,7 +1026,8 @@ function walkForStatement(node, visitors) {
 }
 
 function walkFunctionDeclaration(node, visitors) {
-  let enterExit = visitors[55], exit = null;
+  let enterExit = visitors[55],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1012,7 +1042,8 @@ function walkFunctionDeclaration(node, visitors) {
 }
 
 function walkFunctionExpression(node, visitors) {
-  let enterExit = visitors[56], exit = null;
+  let enterExit = visitors[56],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1027,7 +1058,8 @@ function walkFunctionExpression(node, visitors) {
 }
 
 function walkIdentifier(node, visitors) {
-  let enterExit = visitors[57], exit = null;
+  let enterExit = visitors[57],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1039,7 +1071,8 @@ function walkIdentifier(node, visitors) {
 }
 
 function walkIfStatement(node, visitors) {
-  let enterExit = visitors[58], exit = null;
+  let enterExit = visitors[58],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1052,7 +1085,8 @@ function walkIfStatement(node, visitors) {
 }
 
 function walkImportAttribute(node, visitors) {
-  let enterExit = visitors[59], exit = null;
+  let enterExit = visitors[59],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1064,7 +1098,8 @@ function walkImportAttribute(node, visitors) {
 }
 
 function walkImportDeclaration(node, visitors) {
-  let enterExit = visitors[60], exit = null;
+  let enterExit = visitors[60],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1077,7 +1112,8 @@ function walkImportDeclaration(node, visitors) {
 }
 
 function walkImportDefaultSpecifier(node, visitors) {
-  let enterExit = visitors[61], exit = null;
+  let enterExit = visitors[61],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1088,7 +1124,8 @@ function walkImportDefaultSpecifier(node, visitors) {
 }
 
 function walkImportExpression(node, visitors) {
-  let enterExit = visitors[62], exit = null;
+  let enterExit = visitors[62],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1100,7 +1137,8 @@ function walkImportExpression(node, visitors) {
 }
 
 function walkImportNamespaceSpecifier(node, visitors) {
-  let enterExit = visitors[63], exit = null;
+  let enterExit = visitors[63],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1111,7 +1149,8 @@ function walkImportNamespaceSpecifier(node, visitors) {
 }
 
 function walkImportSpecifier(node, visitors) {
-  let enterExit = visitors[64], exit = null;
+  let enterExit = visitors[64],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1123,7 +1162,8 @@ function walkImportSpecifier(node, visitors) {
 }
 
 function walkLabeledStatement(node, visitors) {
-  let enterExit = visitors[65], exit = null;
+  let enterExit = visitors[65],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1135,7 +1175,8 @@ function walkLabeledStatement(node, visitors) {
 }
 
 function walkLogicalExpression(node, visitors) {
-  let enterExit = visitors[66], exit = null;
+  let enterExit = visitors[66],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1147,7 +1188,8 @@ function walkLogicalExpression(node, visitors) {
 }
 
 function walkMemberExpression(node, visitors) {
-  let enterExit = visitors[67], exit = null;
+  let enterExit = visitors[67],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1159,7 +1201,8 @@ function walkMemberExpression(node, visitors) {
 }
 
 function walkMetaProperty(node, visitors) {
-  let enterExit = visitors[68], exit = null;
+  let enterExit = visitors[68],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1171,7 +1214,8 @@ function walkMetaProperty(node, visitors) {
 }
 
 function walkMethodDefinition(node, visitors) {
-  let enterExit = visitors[69], exit = null;
+  let enterExit = visitors[69],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1184,7 +1228,8 @@ function walkMethodDefinition(node, visitors) {
 }
 
 function walkNewExpression(node, visitors) {
-  let enterExit = visitors[70], exit = null;
+  let enterExit = visitors[70],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1197,7 +1242,8 @@ function walkNewExpression(node, visitors) {
 }
 
 function walkObjectExpression(node, visitors) {
-  let enterExit = visitors[71], exit = null;
+  let enterExit = visitors[71],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1208,7 +1254,8 @@ function walkObjectExpression(node, visitors) {
 }
 
 function walkObjectPattern(node, visitors) {
-  let enterExit = visitors[72], exit = null;
+  let enterExit = visitors[72],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1221,7 +1268,8 @@ function walkObjectPattern(node, visitors) {
 }
 
 function walkParenthesizedExpression(node, visitors) {
-  let enterExit = visitors[73], exit = null;
+  let enterExit = visitors[73],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1232,7 +1280,8 @@ function walkParenthesizedExpression(node, visitors) {
 }
 
 function walkProgram(node, visitors) {
-  let enterExit = visitors[74], exit = null;
+  let enterExit = visitors[74],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1243,7 +1292,8 @@ function walkProgram(node, visitors) {
 }
 
 function walkProperty(node, visitors) {
-  let enterExit = visitors[75], exit = null;
+  let enterExit = visitors[75],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1255,7 +1305,8 @@ function walkProperty(node, visitors) {
 }
 
 function walkPropertyDefinition(node, visitors) {
-  let enterExit = visitors[76], exit = null;
+  let enterExit = visitors[76],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1269,7 +1320,8 @@ function walkPropertyDefinition(node, visitors) {
 }
 
 function walkRestElement(node, visitors) {
-  let enterExit = visitors[77], exit = null;
+  let enterExit = visitors[77],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1282,7 +1334,8 @@ function walkRestElement(node, visitors) {
 }
 
 function walkReturnStatement(node, visitors) {
-  let enterExit = visitors[78], exit = null;
+  let enterExit = visitors[78],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1293,7 +1346,8 @@ function walkReturnStatement(node, visitors) {
 }
 
 function walkSequenceExpression(node, visitors) {
-  let enterExit = visitors[79], exit = null;
+  let enterExit = visitors[79],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1304,7 +1358,8 @@ function walkSequenceExpression(node, visitors) {
 }
 
 function walkSpreadElement(node, visitors) {
-  let enterExit = visitors[80], exit = null;
+  let enterExit = visitors[80],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1315,7 +1370,8 @@ function walkSpreadElement(node, visitors) {
 }
 
 function walkStaticBlock(node, visitors) {
-  let enterExit = visitors[81], exit = null;
+  let enterExit = visitors[81],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1326,7 +1382,8 @@ function walkStaticBlock(node, visitors) {
 }
 
 function walkSwitchCase(node, visitors) {
-  let enterExit = visitors[82], exit = null;
+  let enterExit = visitors[82],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1338,7 +1395,8 @@ function walkSwitchCase(node, visitors) {
 }
 
 function walkSwitchStatement(node, visitors) {
-  let enterExit = visitors[83], exit = null;
+  let enterExit = visitors[83],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1350,7 +1408,8 @@ function walkSwitchStatement(node, visitors) {
 }
 
 function walkTaggedTemplateExpression(node, visitors) {
-  let enterExit = visitors[84], exit = null;
+  let enterExit = visitors[84],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1363,7 +1422,8 @@ function walkTaggedTemplateExpression(node, visitors) {
 }
 
 function walkTemplateLiteral(node, visitors) {
-  let enterExit = visitors[85], exit = null;
+  let enterExit = visitors[85],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1375,7 +1435,8 @@ function walkTemplateLiteral(node, visitors) {
 }
 
 function walkThrowStatement(node, visitors) {
-  let enterExit = visitors[86], exit = null;
+  let enterExit = visitors[86],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1386,7 +1447,8 @@ function walkThrowStatement(node, visitors) {
 }
 
 function walkTryStatement(node, visitors) {
-  let enterExit = visitors[87], exit = null;
+  let enterExit = visitors[87],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1399,7 +1461,8 @@ function walkTryStatement(node, visitors) {
 }
 
 function walkUnaryExpression(node, visitors) {
-  let enterExit = visitors[88], exit = null;
+  let enterExit = visitors[88],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1410,7 +1473,8 @@ function walkUnaryExpression(node, visitors) {
 }
 
 function walkUpdateExpression(node, visitors) {
-  let enterExit = visitors[89], exit = null;
+  let enterExit = visitors[89],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1421,7 +1485,8 @@ function walkUpdateExpression(node, visitors) {
 }
 
 function walkV8IntrinsicExpression(node, visitors) {
-  let enterExit = visitors[90], exit = null;
+  let enterExit = visitors[90],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1433,7 +1498,8 @@ function walkV8IntrinsicExpression(node, visitors) {
 }
 
 function walkVariableDeclaration(node, visitors) {
-  let enterExit = visitors[91], exit = null;
+  let enterExit = visitors[91],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1444,7 +1510,8 @@ function walkVariableDeclaration(node, visitors) {
 }
 
 function walkVariableDeclarator(node, visitors) {
-  let enterExit = visitors[92], exit = null;
+  let enterExit = visitors[92],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1456,7 +1523,8 @@ function walkVariableDeclarator(node, visitors) {
 }
 
 function walkWhileStatement(node, visitors) {
-  let enterExit = visitors[93], exit = null;
+  let enterExit = visitors[93],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1468,7 +1536,8 @@ function walkWhileStatement(node, visitors) {
 }
 
 function walkWithStatement(node, visitors) {
-  let enterExit = visitors[94], exit = null;
+  let enterExit = visitors[94],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1480,7 +1549,8 @@ function walkWithStatement(node, visitors) {
 }
 
 function walkYieldExpression(node, visitors) {
-  let enterExit = visitors[95], exit = null;
+  let enterExit = visitors[95],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1491,7 +1561,8 @@ function walkYieldExpression(node, visitors) {
 }
 
 function walkJSXAttribute(node, visitors) {
-  let enterExit = visitors[96], exit = null;
+  let enterExit = visitors[96],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1503,7 +1574,8 @@ function walkJSXAttribute(node, visitors) {
 }
 
 function walkJSXClosingElement(node, visitors) {
-  let enterExit = visitors[97], exit = null;
+  let enterExit = visitors[97],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1514,7 +1586,8 @@ function walkJSXClosingElement(node, visitors) {
 }
 
 function walkJSXElement(node, visitors) {
-  let enterExit = visitors[98], exit = null;
+  let enterExit = visitors[98],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1527,7 +1600,8 @@ function walkJSXElement(node, visitors) {
 }
 
 function walkJSXExpressionContainer(node, visitors) {
-  let enterExit = visitors[99], exit = null;
+  let enterExit = visitors[99],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1538,7 +1612,8 @@ function walkJSXExpressionContainer(node, visitors) {
 }
 
 function walkJSXFragment(node, visitors) {
-  let enterExit = visitors[100], exit = null;
+  let enterExit = visitors[100],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1551,7 +1626,8 @@ function walkJSXFragment(node, visitors) {
 }
 
 function walkJSXMemberExpression(node, visitors) {
-  let enterExit = visitors[101], exit = null;
+  let enterExit = visitors[101],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1563,7 +1639,8 @@ function walkJSXMemberExpression(node, visitors) {
 }
 
 function walkJSXNamespacedName(node, visitors) {
-  let enterExit = visitors[102], exit = null;
+  let enterExit = visitors[102],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1575,7 +1652,8 @@ function walkJSXNamespacedName(node, visitors) {
 }
 
 function walkJSXOpeningElement(node, visitors) {
-  let enterExit = visitors[103], exit = null;
+  let enterExit = visitors[103],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1588,7 +1666,8 @@ function walkJSXOpeningElement(node, visitors) {
 }
 
 function walkJSXSpreadAttribute(node, visitors) {
-  let enterExit = visitors[104], exit = null;
+  let enterExit = visitors[104],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1599,7 +1678,8 @@ function walkJSXSpreadAttribute(node, visitors) {
 }
 
 function walkJSXSpreadChild(node, visitors) {
-  let enterExit = visitors[105], exit = null;
+  let enterExit = visitors[105],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1610,7 +1690,8 @@ function walkJSXSpreadChild(node, visitors) {
 }
 
 function walkTSAbstractAccessorProperty(node, visitors) {
-  let enterExit = visitors[106], exit = null;
+  let enterExit = visitors[106],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1623,7 +1704,8 @@ function walkTSAbstractAccessorProperty(node, visitors) {
 }
 
 function walkTSAbstractMethodDefinition(node, visitors) {
-  let enterExit = visitors[107], exit = null;
+  let enterExit = visitors[107],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1635,7 +1717,8 @@ function walkTSAbstractMethodDefinition(node, visitors) {
 }
 
 function walkTSAbstractPropertyDefinition(node, visitors) {
-  let enterExit = visitors[108], exit = null;
+  let enterExit = visitors[108],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1648,7 +1731,8 @@ function walkTSAbstractPropertyDefinition(node, visitors) {
 }
 
 function walkTSArrayType(node, visitors) {
-  let enterExit = visitors[109], exit = null;
+  let enterExit = visitors[109],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1659,7 +1743,8 @@ function walkTSArrayType(node, visitors) {
 }
 
 function walkTSAsExpression(node, visitors) {
-  let enterExit = visitors[110], exit = null;
+  let enterExit = visitors[110],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1671,7 +1756,8 @@ function walkTSAsExpression(node, visitors) {
 }
 
 function walkTSCallSignatureDeclaration(node, visitors) {
-  let enterExit = visitors[111], exit = null;
+  let enterExit = visitors[111],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1684,7 +1770,8 @@ function walkTSCallSignatureDeclaration(node, visitors) {
 }
 
 function walkTSClassImplements(node, visitors) {
-  let enterExit = visitors[112], exit = null;
+  let enterExit = visitors[112],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1696,7 +1783,8 @@ function walkTSClassImplements(node, visitors) {
 }
 
 function walkTSConditionalType(node, visitors) {
-  let enterExit = visitors[113], exit = null;
+  let enterExit = visitors[113],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1710,7 +1798,8 @@ function walkTSConditionalType(node, visitors) {
 }
 
 function walkTSConstructSignatureDeclaration(node, visitors) {
-  let enterExit = visitors[114], exit = null;
+  let enterExit = visitors[114],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1723,7 +1812,8 @@ function walkTSConstructSignatureDeclaration(node, visitors) {
 }
 
 function walkTSConstructorType(node, visitors) {
-  let enterExit = visitors[115], exit = null;
+  let enterExit = visitors[115],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1736,7 +1826,8 @@ function walkTSConstructorType(node, visitors) {
 }
 
 function walkTSDeclareFunction(node, visitors) {
-  let enterExit = visitors[116], exit = null;
+  let enterExit = visitors[116],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1751,7 +1842,8 @@ function walkTSDeclareFunction(node, visitors) {
 }
 
 function walkTSEmptyBodyFunctionExpression(node, visitors) {
-  let enterExit = visitors[117], exit = null;
+  let enterExit = visitors[117],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1765,7 +1857,8 @@ function walkTSEmptyBodyFunctionExpression(node, visitors) {
 }
 
 function walkTSEnumBody(node, visitors) {
-  let enterExit = visitors[118], exit = null;
+  let enterExit = visitors[118],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1776,7 +1869,8 @@ function walkTSEnumBody(node, visitors) {
 }
 
 function walkTSEnumDeclaration(node, visitors) {
-  let enterExit = visitors[119], exit = null;
+  let enterExit = visitors[119],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1788,7 +1882,8 @@ function walkTSEnumDeclaration(node, visitors) {
 }
 
 function walkTSEnumMember(node, visitors) {
-  let enterExit = visitors[120], exit = null;
+  let enterExit = visitors[120],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1800,7 +1895,8 @@ function walkTSEnumMember(node, visitors) {
 }
 
 function walkTSExportAssignment(node, visitors) {
-  let enterExit = visitors[121], exit = null;
+  let enterExit = visitors[121],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1811,7 +1907,8 @@ function walkTSExportAssignment(node, visitors) {
 }
 
 function walkTSExternalModuleReference(node, visitors) {
-  let enterExit = visitors[122], exit = null;
+  let enterExit = visitors[122],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1822,7 +1919,8 @@ function walkTSExternalModuleReference(node, visitors) {
 }
 
 function walkTSFunctionType(node, visitors) {
-  let enterExit = visitors[123], exit = null;
+  let enterExit = visitors[123],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1835,7 +1933,8 @@ function walkTSFunctionType(node, visitors) {
 }
 
 function walkTSImportEqualsDeclaration(node, visitors) {
-  let enterExit = visitors[124], exit = null;
+  let enterExit = visitors[124],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1847,7 +1946,8 @@ function walkTSImportEqualsDeclaration(node, visitors) {
 }
 
 function walkTSImportType(node, visitors) {
-  let enterExit = visitors[125], exit = null;
+  let enterExit = visitors[125],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1861,7 +1961,8 @@ function walkTSImportType(node, visitors) {
 }
 
 function walkTSIndexSignature(node, visitors) {
-  let enterExit = visitors[126], exit = null;
+  let enterExit = visitors[126],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1873,7 +1974,8 @@ function walkTSIndexSignature(node, visitors) {
 }
 
 function walkTSIndexedAccessType(node, visitors) {
-  let enterExit = visitors[127], exit = null;
+  let enterExit = visitors[127],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1885,7 +1987,8 @@ function walkTSIndexedAccessType(node, visitors) {
 }
 
 function walkTSInferType(node, visitors) {
-  let enterExit = visitors[128], exit = null;
+  let enterExit = visitors[128],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1896,7 +1999,8 @@ function walkTSInferType(node, visitors) {
 }
 
 function walkTSInstantiationExpression(node, visitors) {
-  let enterExit = visitors[129], exit = null;
+  let enterExit = visitors[129],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1908,7 +2012,8 @@ function walkTSInstantiationExpression(node, visitors) {
 }
 
 function walkTSInterfaceBody(node, visitors) {
-  let enterExit = visitors[130], exit = null;
+  let enterExit = visitors[130],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1919,7 +2024,8 @@ function walkTSInterfaceBody(node, visitors) {
 }
 
 function walkTSInterfaceDeclaration(node, visitors) {
-  let enterExit = visitors[131], exit = null;
+  let enterExit = visitors[131],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1933,7 +2039,8 @@ function walkTSInterfaceDeclaration(node, visitors) {
 }
 
 function walkTSInterfaceHeritage(node, visitors) {
-  let enterExit = visitors[132], exit = null;
+  let enterExit = visitors[132],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1945,7 +2052,8 @@ function walkTSInterfaceHeritage(node, visitors) {
 }
 
 function walkTSIntersectionType(node, visitors) {
-  let enterExit = visitors[133], exit = null;
+  let enterExit = visitors[133],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1956,7 +2064,8 @@ function walkTSIntersectionType(node, visitors) {
 }
 
 function walkTSJSDocNonNullableType(node, visitors) {
-  let enterExit = visitors[134], exit = null;
+  let enterExit = visitors[134],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1967,7 +2076,8 @@ function walkTSJSDocNonNullableType(node, visitors) {
 }
 
 function walkTSJSDocNullableType(node, visitors) {
-  let enterExit = visitors[135], exit = null;
+  let enterExit = visitors[135],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1978,7 +2088,8 @@ function walkTSJSDocNullableType(node, visitors) {
 }
 
 function walkTSLiteralType(node, visitors) {
-  let enterExit = visitors[136], exit = null;
+  let enterExit = visitors[136],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -1989,7 +2100,8 @@ function walkTSLiteralType(node, visitors) {
 }
 
 function walkTSMappedType(node, visitors) {
-  let enterExit = visitors[137], exit = null;
+  let enterExit = visitors[137],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2003,7 +2115,8 @@ function walkTSMappedType(node, visitors) {
 }
 
 function walkTSMethodSignature(node, visitors) {
-  let enterExit = visitors[138], exit = null;
+  let enterExit = visitors[138],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2017,7 +2130,8 @@ function walkTSMethodSignature(node, visitors) {
 }
 
 function walkTSModuleBlock(node, visitors) {
-  let enterExit = visitors[139], exit = null;
+  let enterExit = visitors[139],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2028,7 +2142,8 @@ function walkTSModuleBlock(node, visitors) {
 }
 
 function walkTSModuleDeclaration(node, visitors) {
-  let enterExit = visitors[140], exit = null;
+  let enterExit = visitors[140],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2040,7 +2155,8 @@ function walkTSModuleDeclaration(node, visitors) {
 }
 
 function walkTSNamedTupleMember(node, visitors) {
-  let enterExit = visitors[141], exit = null;
+  let enterExit = visitors[141],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2052,7 +2168,8 @@ function walkTSNamedTupleMember(node, visitors) {
 }
 
 function walkTSNamespaceExportDeclaration(node, visitors) {
-  let enterExit = visitors[142], exit = null;
+  let enterExit = visitors[142],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2063,7 +2180,8 @@ function walkTSNamespaceExportDeclaration(node, visitors) {
 }
 
 function walkTSNonNullExpression(node, visitors) {
-  let enterExit = visitors[143], exit = null;
+  let enterExit = visitors[143],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2074,7 +2192,8 @@ function walkTSNonNullExpression(node, visitors) {
 }
 
 function walkTSOptionalType(node, visitors) {
-  let enterExit = visitors[144], exit = null;
+  let enterExit = visitors[144],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2085,7 +2204,8 @@ function walkTSOptionalType(node, visitors) {
 }
 
 function walkTSParameterProperty(node, visitors) {
-  let enterExit = visitors[145], exit = null;
+  let enterExit = visitors[145],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2097,7 +2217,8 @@ function walkTSParameterProperty(node, visitors) {
 }
 
 function walkTSParenthesizedType(node, visitors) {
-  let enterExit = visitors[146], exit = null;
+  let enterExit = visitors[146],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2108,7 +2229,8 @@ function walkTSParenthesizedType(node, visitors) {
 }
 
 function walkTSPropertySignature(node, visitors) {
-  let enterExit = visitors[147], exit = null;
+  let enterExit = visitors[147],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2120,7 +2242,8 @@ function walkTSPropertySignature(node, visitors) {
 }
 
 function walkTSQualifiedName(node, visitors) {
-  let enterExit = visitors[148], exit = null;
+  let enterExit = visitors[148],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2132,7 +2255,8 @@ function walkTSQualifiedName(node, visitors) {
 }
 
 function walkTSRestType(node, visitors) {
-  let enterExit = visitors[149], exit = null;
+  let enterExit = visitors[149],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2143,7 +2267,8 @@ function walkTSRestType(node, visitors) {
 }
 
 function walkTSSatisfiesExpression(node, visitors) {
-  let enterExit = visitors[150], exit = null;
+  let enterExit = visitors[150],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2155,7 +2280,8 @@ function walkTSSatisfiesExpression(node, visitors) {
 }
 
 function walkTSTemplateLiteralType(node, visitors) {
-  let enterExit = visitors[151], exit = null;
+  let enterExit = visitors[151],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2167,7 +2293,8 @@ function walkTSTemplateLiteralType(node, visitors) {
 }
 
 function walkTSTupleType(node, visitors) {
-  let enterExit = visitors[152], exit = null;
+  let enterExit = visitors[152],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2178,7 +2305,8 @@ function walkTSTupleType(node, visitors) {
 }
 
 function walkTSTypeAliasDeclaration(node, visitors) {
-  let enterExit = visitors[153], exit = null;
+  let enterExit = visitors[153],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2191,7 +2319,8 @@ function walkTSTypeAliasDeclaration(node, visitors) {
 }
 
 function walkTSTypeAnnotation(node, visitors) {
-  let enterExit = visitors[154], exit = null;
+  let enterExit = visitors[154],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2202,7 +2331,8 @@ function walkTSTypeAnnotation(node, visitors) {
 }
 
 function walkTSTypeAssertion(node, visitors) {
-  let enterExit = visitors[155], exit = null;
+  let enterExit = visitors[155],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2214,7 +2344,8 @@ function walkTSTypeAssertion(node, visitors) {
 }
 
 function walkTSTypeLiteral(node, visitors) {
-  let enterExit = visitors[156], exit = null;
+  let enterExit = visitors[156],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2225,7 +2356,8 @@ function walkTSTypeLiteral(node, visitors) {
 }
 
 function walkTSTypeOperator(node, visitors) {
-  let enterExit = visitors[157], exit = null;
+  let enterExit = visitors[157],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2236,7 +2368,8 @@ function walkTSTypeOperator(node, visitors) {
 }
 
 function walkTSTypeParameter(node, visitors) {
-  let enterExit = visitors[158], exit = null;
+  let enterExit = visitors[158],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2249,7 +2382,8 @@ function walkTSTypeParameter(node, visitors) {
 }
 
 function walkTSTypeParameterDeclaration(node, visitors) {
-  let enterExit = visitors[159], exit = null;
+  let enterExit = visitors[159],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2260,7 +2394,8 @@ function walkTSTypeParameterDeclaration(node, visitors) {
 }
 
 function walkTSTypeParameterInstantiation(node, visitors) {
-  let enterExit = visitors[160], exit = null;
+  let enterExit = visitors[160],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2271,7 +2406,8 @@ function walkTSTypeParameterInstantiation(node, visitors) {
 }
 
 function walkTSTypePredicate(node, visitors) {
-  let enterExit = visitors[161], exit = null;
+  let enterExit = visitors[161],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2283,7 +2419,8 @@ function walkTSTypePredicate(node, visitors) {
 }
 
 function walkTSTypeQuery(node, visitors) {
-  let enterExit = visitors[162], exit = null;
+  let enterExit = visitors[162],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2295,7 +2432,8 @@ function walkTSTypeQuery(node, visitors) {
 }
 
 function walkTSTypeReference(node, visitors) {
-  let enterExit = visitors[163], exit = null;
+  let enterExit = visitors[163],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);
@@ -2307,7 +2445,8 @@ function walkTSTypeReference(node, visitors) {
 }
 
 function walkTSUnionType(node, visitors) {
-  let enterExit = visitors[164], exit = null;
+  let enterExit = visitors[164],
+    exit = null;
   if (enterExit !== null) {
     let enter;
     ({ enter, exit } = enterExit);

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -583,12 +583,10 @@ export interface DebuggerStatement extends Span {
   parent?: Node;
 }
 
-export type BindingPattern =
-  & ({
-    optional?: boolean;
-    typeAnnotation?: TSTypeAnnotation | null;
-  })
-  & (BindingIdentifier | ObjectPattern | ArrayPattern | AssignmentPattern);
+export type BindingPattern = {
+  optional?: boolean;
+  typeAnnotation?: TSTypeAnnotation | null;
+} & (BindingIdentifier | ObjectPattern | ArrayPattern | AssignmentPattern);
 
 export type BindingPatternKind = BindingIdentifier | ObjectPattern | ArrayPattern | AssignmentPattern;
 
@@ -673,11 +671,9 @@ export interface FormalParameterRest extends Span {
   value?: null;
 }
 
-export type FormalParameter =
-  & ({
-    decorators?: Array<Decorator>;
-  })
-  & BindingPattern;
+export type FormalParameter = {
+  decorators?: Array<Decorator>;
+} & BindingPattern;
 
 export interface TSParameterProperty extends Span {
   type: 'TSParameterProperty';


### PR DESCRIPTION
https://github.com/oxc-project/oxc/commit/a8e5181ab73e3cee5904af3acc6c5927def9d500#diff-dc1a48ba0d3878494d547c7c5fb975720dddac4966c510f9babec50161110538 broke ast tools generation.

This PR uses oxfmt to format the generated ast files