### PR TITLE
docs(linter): Add configuration option docs for jsdoc/no-defaults rule.

### DIFF
--- a/crates/oxc_linter/src/rules/jsdoc/no_defaults.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/no_defaults.rs
@@ -2,6 +2,7 @@ use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
+use schemars::JsonSchema;
 use serde::Deserialize;
 
 use crate::{
@@ -47,12 +48,14 @@ declare_oxc_lint!(
     /// ```
     NoDefaults,
     jsdoc,
-    correctness
+    correctness,
+    config = NoDefaultsConfig,
 );
 
-#[derive(Debug, Default, Clone, Deserialize)]
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 struct NoDefaultsConfig {
-    #[serde(default, rename = "noOptionalParamNames")]
+    /// If true, report the presence of optional param names (square brackets) on `@param` tags.
     no_optional_param_names: bool,
 }
 


### PR DESCRIPTION
Part of #14743.

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### noOptionalParamNames

type: `boolean`

default: `false`

If true, report the presence of optional param names (square brackets) on `@param` tags.
```