### PR TITLE
docs(linter): Add configuration option docs for eslint/id-length rule.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/id_length.rs
+++ b/crates/oxc_linter/src/rules/eslint/id_length.rs
@@ -39,7 +39,7 @@ impl PropertyKind {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct IdLength(Box<IdLengthConfig>);
 
 impl Deref for IdLength {
@@ -79,12 +79,6 @@ impl Default for IdLengthConfig {
             min: DEFAULT_MIN_LENGTH,
             properties: PropertyKind::default(),
         }
-    }
-}
-
-impl Default for IdLength {
-    fn default() -> Self {
-        Self(Box::new(IdLengthConfig::default()))
     }
 }
 


### PR DESCRIPTION
Part of #14743.

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### exceptionPatterns

type: `string[]`


An array of regex patterns for identifiers to exclude from the rule.
For example, `["^x.*"]` would exclude all identifiers starting with "x".


### exceptions

type: `string[]`

default: `[]`

An array of identifier names that are excluded from the rule.
For example, `["x", "y", "z"]` would allow single-letter identifiers "x", "y", and "z".


### max

type: `integer`

default: `18446744073709551615`

The maximum number of graphemes allowed in an identifier.
Defaults to no maximum (effectively unlimited).


### min

type: `integer`

default: `2`

The minimum number of graphemes required in an identifier.


### properties

type: `"always" | "never"`


When set to `"never"`, property names are not checked for length.
When set to `"always"` (default), property names are checked just like other identifiers.
```