### PR TITLE
release(oxlint): v1.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_language_server"
-version = "1.24.0"
+version = "1.25.0"
 dependencies = [
  "env_logger",
  "futures",
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_linter"
-version = "1.24.0"
+version = "1.25.0"
 dependencies = [
  "bitflags 2.10.0",
  "constcat",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "oxlint"
-version = "1.24.0"
+version = "1.25.0"
 dependencies = [
  "bpaf",
  "cow-utils",

--- a/apps/oxlint/CHANGELOG.md
+++ b/apps/oxlint/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.25.0] - 2025-10-30
+
+### 💥 BREAKING CHANGES
+
+- 659fd37 linter: [**BREAKING**] `tsgolint`: request fixes when necessary (#15048) (camchenry)
+
+### 🚀 Features
+
+- ed24d60 linter: Expose tsgolint program diagnostics (#15080) (camc314)
+- f7bef73 linter/plugins: Scope manager API (#14890) (Arsh)
+- 3e15cdd linter/strict-boolean-expression: Add rule (#14930) (camc314)
+- bd74603 linter: Add support for vitest/valid-title rule (#12085) (Tyler Earls)
+
+### 🐛 Bug Fixes
+
+- 597340e ast-tools: Use oxfmt to format generated code (#15064) (camc314)
+- 2de9f39 linter/plugins: Fall back to package name if meta.name is missing (#14938) (Peter Wagenet)
+
+### 🧪 Testing
+
+- bf898e5 linter: Increase stability of tsgolint test cases (#15063) (camc314)
+
+
 ## [1.24.0] - 2025-10-22
 
 ### 🚀 Features

--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxlint"
-version = "1.24.0"
+version = "1.25.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "type": "module",
   "main": "dist/index.js",
   "bin": "dist/cli.js",

--- a/apps/oxlint/src-js/bindings.js
+++ b/apps/oxlint/src-js/bindings.js
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/android-arm64')
         const bindingPackageVersion = require('@oxlint/android-arm64/package.json').version
-        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/android-arm-eabi')
         const bindingPackageVersion = require('@oxlint/android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -118,8 +118,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/win32-x64-gnu')
         const bindingPackageVersion = require('@oxlint/win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -134,8 +134,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/win32-x64')
         const bindingPackageVersion = require('@oxlint/win32-x64/package.json').version
-        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -151,8 +151,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/win32-ia32')
         const bindingPackageVersion = require('@oxlint/win32-ia32/package.json').version
-        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -167,8 +167,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/win32-arm64')
         const bindingPackageVersion = require('@oxlint/win32-arm64/package.json').version
-        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -186,8 +186,8 @@ function requireNative() {
     try {
       const binding = require('@oxlint/darwin-universal')
       const bindingPackageVersion = require('@oxlint/darwin-universal/package.json').version
-      if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -202,8 +202,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/darwin-x64')
         const bindingPackageVersion = require('@oxlint/darwin-x64/package.json').version
-        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -218,8 +218,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/darwin-arm64')
         const bindingPackageVersion = require('@oxlint/darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -238,8 +238,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/freebsd-x64')
         const bindingPackageVersion = require('@oxlint/freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -254,8 +254,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/freebsd-arm64')
         const bindingPackageVersion = require('@oxlint/freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -275,8 +275,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-x64-musl')
           const bindingPackageVersion = require('@oxlint/linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-x64-gnu')
           const bindingPackageVersion = require('@oxlint/linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -309,8 +309,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-arm64-musl')
           const bindingPackageVersion = require('@oxlint/linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-arm64-gnu')
           const bindingPackageVersion = require('@oxlint/linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -343,8 +343,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-arm-musleabihf')
           const bindingPackageVersion = require('@oxlint/linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-arm-gnueabihf')
           const bindingPackageVersion = require('@oxlint/linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -377,8 +377,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-loong64-musl')
           const bindingPackageVersion = require('@oxlint/linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-loong64-gnu')
           const bindingPackageVersion = require('@oxlint/linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -411,8 +411,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-riscv64-musl')
           const bindingPackageVersion = require('@oxlint/linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -427,8 +427,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-riscv64-gnu')
           const bindingPackageVersion = require('@oxlint/linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -444,8 +444,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/linux-ppc64-gnu')
         const bindingPackageVersion = require('@oxlint/linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -460,8 +460,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/linux-s390x-gnu')
         const bindingPackageVersion = require('@oxlint/linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -480,8 +480,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/openharmony-arm64')
         const bindingPackageVersion = require('@oxlint/openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -496,8 +496,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/openharmony-x64')
         const bindingPackageVersion = require('@oxlint/openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -512,8 +512,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/openharmony-arm')
         const bindingPackageVersion = require('@oxlint/openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '1.24.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.24.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.25.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.25.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/crates/oxc_language_server/CHANGELOG.md
+++ b/crates/oxc_language_server/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.25.0] - 2025-10-30
+
+### 💥 BREAKING CHANGES
+
+- 659fd37 linter: [**BREAKING**] `tsgolint`: request fixes when necessary (#15048) (camchenry)
+
+### 🚜 Refactor
+
+- b1e1531 language_server: Extract library interface from main.rs (#15036) (Boshen)
+- 5de99c2 formatter: Export unified way to get_parse_options (#15027) (leaysgur)
+- b55df7f language_server: Move sub option for `flags` to the root + deprecate flags (#14933) (Sysix)
+
+
 ## [1.24.0] - 2025-10-22
 
 ### 🚀 Features

--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_language_server"
-version = "1.24.0"
+version = "1.25.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_linter/CHANGELOG.md
+++ b/crates/oxc_linter/CHANGELOG.md
@@ -4,6 +4,93 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.25.0] - 2025-10-30
+
+### 💥 BREAKING CHANGES
+
+- 659fd37 linter: [**BREAKING**] `tsgolint`: request fixes when necessary (#15048) (camchenry)
+
+### 🚀 Features
+
+- ed24d60 linter: Expose tsgolint program diagnostics (#15080) (camc314)
+- 23660c9 linter: `tsgolint`: handle omitted fixes and suggestions (#15047) (camchenry)
+- 3e15cdd linter/strict-boolean-expression: Add rule (#14930) (camc314)
+- bd74603 linter: Add support for vitest/valid-title rule (#12085) (Tyler Earls)
+
+### 🐛 Bug Fixes
+
+- e41dee5 linter/consistent-type-definition: Skip comments when looking for token (#14909) (camc314)
+- 806f9ba linter: Search system PATH for tsgolint executable (#14861) (magic-akari)
+- ee68089 linter: Normalize JS plugin names (#15010) (Peter Wagenet)
+- 5eaaa8e linter: Prevent underflow in count_comment_lines for JSX files (#15026) (ityuany)
+- 88577a8 import/no-namespace: Remove dot special case (#15032) (Arsh)
+- 55ee962 linter/vars-on-top: False positive with typescript declare block (#14952) (Hamir Mahal)
+- 2de9f39 linter/plugins: Fall back to package name if meta.name is missing (#14938) (Peter Wagenet)
+- 5ace84b linter/no-empty-object-type: Parse `"allowWithName"` as regular expressions (#14943) (Arsh)
+- 3e29d23 linter: Use aliases when parsing cli rules (#14912) (Arsh)
+- b94b6aa linter/explicit-module-boundary-types: False negative with export default function (#14905) (camc314)
+- 7060863 linter/no-standaline-expect: False positive with expect in callback (#14902) (camc314)
+- dc5a71b linter/no-accumulating-spread: False positive in nested callbacks within reduce (#14898) (camc314)
+
+### 📚 Documentation
+
+- e15c91c linter: Add configuration option docs for eslint/init-declarations rule. (#15085) (Connor Shea)
+- f4505bc linter: Add configuration option docs for eslint/id-length rule. (#15083) (Connor Shea)
+- dd4c9d2 linter: Add configuration option docs for eslint/getter-return rule. (#15081) (Connor Shea)
+- 008e67a linter: Add configuration option docs for jest/no-large-snapshots rule. (#15079) (Connor Shea)
+- 31daf79 linter: Add configuration option docs for import/no-commonjs rule. (#15077) (Connor Shea)
+- 9bf8ebe linter: Add configuration option docs for jsdoc/check-tag-names rule. (#15076) (Connor Shea)
+- 491ab5e linter: Add configuration option docs for jsdoc/no-defaults rule. (#15074) (Connor Shea)
+- 2602d7e linter: Add configuration option docs for jsdoc/empty-tags rule. (#15072) (Connor Shea)
+- c3a92e0 linter: Add configuration option docs for oxc/no-rest-spread-properties rule. (#15070) (Connor Shea)
+- c7c9213 linter: Add configuration option docs for oxc/no-optional-chaining rule. (#15071) (Connor Shea)
+- 47a616f linter: Add configuration option docs for typescript/no-empty-object-type rule. (#14968) (Connor Shea)
+- fcc1e25 linter: Add configuration option docs for typescript/no-explicit-any rule. (#15051) (Connor Shea)
+- 1b88934 linter: Add configuration option docs for eslint/no-multi-assign rule. (#15052) (Connor Shea)
+- 909d4b9 linter: Add configuration option docs for eslint/no-unsafe-negation rule. (#15053) (Connor Shea)
+- f60763b linter: Add configuration option docs for eslint/no-useless-computed-key rule. (#15054) (Connor Shea)
+- c8911d4 linter: Add configuration option docs for eslint/no-unneeded-ternary rule. (#15056) (Connor Shea)
+- 9fc6374 linter: Add configuration option docs for eslint/no-misleading-character-class rule. (#15058) (Connor Shea)
+- 7656e2b linter: Add configuration option docs for eslint/sort-imports rule. (#15013) (Connor Shea)
+- bb06039 linter: Add configuration option docs for unicorn/no-instanceof-builtins rule. (#14999) (Connor Shea)
+- a4af5ff linter: Add configuration option docs for unicorn/no-typeof-undefined rule. (#15001) (Connor Shea)
+- ac2ed39 linter: Add configuration option docs for unicorn/numeric-separators-style rule. (#15002) (Connor Shea)
+- 5ce3e33 linter: Add configuration option docs for unicorn/prefer-object-from-entries rule. (#15003) (Connor Shea)
+- 07aea72 linter: Add configuration option docs for eslint/sort-keys rule. (#15014) (Connor Shea)
+- 35b36e0 linter: Add configuration option docs for eslint/no-eval rule. (#15015) (Connor Shea)
+- d222b85 linter: Add configuration option docs for eslint/no-empty rule. (#15017) (Connor Shea)
+- 83bbc37 linter: Add configuration option docs for eslint/no-extend-native rule. (#15018) (Connor Shea)
+- aade2fe linter: Add configuration option docs for eslint/no-extra-boolean-cast rule. (#15019) (Connor Shea)
+- bae0c09 linter: Add configuration option docs for jsdoc/require-yields rule. (#15024) (Connor Shea)
+- 06c77b6 linter: Add configuration option docs for unicorn/prefer-at rule. (#15023) (Connor Shea)
+- 54b2cb4 linter: Add configuration option docs for eslint/max-classes-per-file rule. (#15022) (Connor Shea)
+- b5acda7 linter: Add configuration option docs for typescript/explicit-module-boundary-types rule. (#15021) (Connor Shea)
+- a0c6162 linter: Add configuration option docs for vue/max-props rule. (#14966) (Connor Shea)
+- 3ec59c0 linter: Add configuration option docs for no-async-endpoint-handlers rule. (#14965) (Connor Shea)
+- 7a275fd linter: Add configuration option docs for no-map-spread rule. (#14964) (Connor Shea)
+- 0002b7c linter: Add configuration option docs for no-barrel-file rule. (#14963) (Connor Shea)
+- fd4b7ab linter: Add configuration option docs for unicorn/consistent-function-scoping rule. (#14969) (Connor Shea)
+- aa339b3 linter: Add configuration option docs for eslint/no-void rule. (#14970) (Connor Shea)
+- af8bdae linter: Add configuration option docs for import/no-anonymous-default-export rule. (#14971) (Connor Shea)
+- 5a81953 linter: Add configuration option docs for jest/require-hook rule. (#14972) (Connor Shea)
+- 1be268d linter: Add configuration option docs for jest/require-top-level-describe rule. (#14973) (Connor Shea)
+- 860a58c linter: Add configuration option docs for jest/no-hooks rule. (#14974) (Connor Shea)
+- b69b586 linter: Add configuration option docs for jest/max-expects rule. (#14975) (Connor Shea)
+- 2e02fe0 linter: Add configuration option docs for jest/no-deprecated-functions rule (#14976) (Connor Shea)
+- cdc6c4f linter: Add configuration option docs for unicorn/no-array-sort rule. (#14977) (Connor Shea)
+- 40eb394 linter/no-unassigned-import-config: Add auto generated config docs (#14918) (camc314)
+
+### ⚡ Performance
+
+- a9f68b2 linter: Move up rule retainment into initial collection to reduce allocation size (#14822) (camchenry)
+- b27c5b9 linter: Add codegen support for regex nodes (#14874) (camchenry)
+
+### 🧪 Testing
+
+- bf898e5 linter: Increase stability of tsgolint test cases (#15063) (camc314)
+- 49da411 linter/no-standalone-expect: Fix tests (#14901) (camc314)
+
+
 ## [1.24.0] - 2025-10-22
 
 ### 🚀 Features

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_linter"
-version = "1.24.0"
+version = "1.25.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.25.0] - 2025-10-30
+
+### 💥 BREAKING CHANGES
+
+- 659fd37 linter: [**BREAKING**] `tsgolint`: request fixes when necessary (#15048) (camchenry)
+
+### 🐛 Bug Fixes
+
+- 5a2832d editor: Stop client when delete .oxlintrc.json with `oxc.requireConfig` (#14897) (Liang Mi)
+
+### 🚜 Refactor
+
+- 8d8d508 editor: Flatten `flags` options (#15006) (Sysix)
+
+
 ## [1.24.0] - 2025-10-22
 
 ### 🚀 Features

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "oxc-vscode",
   "description": "oxc vscode extension",
   "license": "MIT",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "icon": "icon.png",
   "publisher": "oxc",
   "displayName": "Oxc",

--- a/npm/oxlint/CHANGELOG.md
+++ b/npm/oxlint/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.25.0] - 2025-10-30
+
+### 🚀 Features
+
+- bd74603 linter: Add support for vitest/valid-title rule (#12085) (Tyler Earls)
+
+
 ## [1.24.0] - 2025-10-22
 
 ### 🐛 Bug Fixes

--- a/npm/oxlint/package.json
+++ b/npm/oxlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "type": "module",
   "description": "Linter for the JavaScript Oxidation Compiler",
   "keywords": [],


### PR DESCRIPTION
## [1.25.0] - 2025-10-30

### 💥 BREAKING CHANGES

- 659fd37 linter: [**BREAKING**] `tsgolint`: request fixes when necessary (#15048) (camchenry)

### 🚀 Features

- ed24d60 linter: Expose tsgolint program diagnostics (#15080) (camc314)
- 23660c9 linter: `tsgolint`: handle omitted fixes and suggestions (#15047) (camchenry)
- f7bef73 linter/plugins: Scope manager API (#14890) (Arsh)
- 3e15cdd linter/strict-boolean-expression: Add rule (#14930) (camc314)
- bd74603 linter: Add support for vitest/valid-title rule (#12085) (Tyler Earls)

### 🐛 Bug Fixes

- e41dee5 linter/consistent-type-definition: Skip comments when looking for token (#14909) (camc314)
- 806f9ba linter: Search system PATH for tsgolint executable (#14861) (magic-akari)
- ee68089 linter: Normalize JS plugin names (#15010) (Peter Wagenet)
- 597340e ast-tools: Use oxfmt to format generated code (#15064) (camc314)
- 5eaaa8e linter: Prevent underflow in count_comment_lines for JSX files (#15026) (ityuany)
- 88577a8 import/no-namespace: Remove dot special case (#15032) (Arsh)
- 55ee962 linter/vars-on-top: False positive with typescript declare block (#14952) (Hamir Mahal)
- 2de9f39 linter/plugins: Fall back to package name if meta.name is missing (#14938) (Peter Wagenet)
- 5ace84b linter/no-empty-object-type: Parse `"allowWithName"` as regular expressions (#14943) (Arsh)
- 5a2832d editor: Stop client when delete .oxlintrc.json with `oxc.requireConfig` (#14897) (Liang Mi)
- 3e29d23 linter: Use aliases when parsing cli rules (#14912) (Arsh)
- b94b6aa linter/explicit-module-boundary-types: False negative with export default function (#14905) (camc314)
- 7060863 linter/no-standaline-expect: False positive with expect in callback (#14902) (camc314)
- dc5a71b linter/no-accumulating-spread: False positive in nested callbacks within reduce (#14898) (camc314)

### 🚜 Refactor

- 8d8d508 editor: Flatten `flags` options (#15006) (Sysix)
- b1e1531 language_server: Extract library interface from main.rs (#15036) (Boshen)
- 5de99c2 formatter: Export unified way to get_parse_options (#15027) (leaysgur)
- b55df7f language_server: Move sub option for `flags` to the root + deprecate flags (#14933) (Sysix)

### 📚 Documentation

- e15c91c linter: Add configuration option docs for eslint/init-declarations rule. (#15085) (Connor Shea)
- f4505bc linter: Add configuration option docs for eslint/id-length rule. (#15083) (Connor Shea)
- dd4c9d2 linter: Add configuration option docs for eslint/getter-return rule. (#15081) (Connor Shea)
- 008e67a linter: Add configuration option docs for jest/no-large-snapshots rule. (#15079) (Connor Shea)
- 31daf79 linter: Add configuration option docs for import/no-commonjs rule. (#15077) (Connor Shea)
- 9bf8ebe linter: Add configuration option docs for jsdoc/check-tag-names rule. (#15076) (Connor Shea)
- 491ab5e linter: Add configuration option docs for jsdoc/no-defaults rule. (#15074) (Connor Shea)
- 2602d7e linter: Add configuration option docs for jsdoc/empty-tags rule. (#15072) (Connor Shea)
- c3a92e0 linter: Add configuration option docs for oxc/no-rest-spread-properties rule. (#15070) (Connor Shea)
- c7c9213 linter: Add configuration option docs for oxc/no-optional-chaining rule. (#15071) (Connor Shea)
- 47a616f linter: Add configuration option docs for typescript/no-empty-object-type rule. (#14968) (Connor Shea)
- fcc1e25 linter: Add configuration option docs for typescript/no-explicit-any rule. (#15051) (Connor Shea)
- 1b88934 linter: Add configuration option docs for eslint/no-multi-assign rule. (#15052) (Connor Shea)
- 909d4b9 linter: Add configuration option docs for eslint/no-unsafe-negation rule. (#15053) (Connor Shea)
- f60763b linter: Add configuration option docs for eslint/no-useless-computed-key rule. (#15054) (Connor Shea)
- c8911d4 linter: Add configuration option docs for eslint/no-unneeded-ternary rule. (#15056) (Connor Shea)
- 9fc6374 linter: Add configuration option docs for eslint/no-misleading-character-class rule. (#15058) (Connor Shea)
- 7656e2b linter: Add configuration option docs for eslint/sort-imports rule. (#15013) (Connor Shea)
- bb06039 linter: Add configuration option docs for unicorn/no-instanceof-builtins rule. (#14999) (Connor Shea)
- a4af5ff linter: Add configuration option docs for unicorn/no-typeof-undefined rule. (#15001) (Connor Shea)
- ac2ed39 linter: Add configuration option docs for unicorn/numeric-separators-style rule. (#15002) (Connor Shea)
- 5ce3e33 linter: Add configuration option docs for unicorn/prefer-object-from-entries rule. (#15003) (Connor Shea)
- 07aea72 linter: Add configuration option docs for eslint/sort-keys rule. (#15014) (Connor Shea)
- 35b36e0 linter: Add configuration option docs for eslint/no-eval rule. (#15015) (Connor Shea)
- d222b85 linter: Add configuration option docs for eslint/no-empty rule. (#15017) (Connor Shea)
- 83bbc37 linter: Add configuration option docs for eslint/no-extend-native rule. (#15018) (Connor Shea)
- aade2fe linter: Add configuration option docs for eslint/no-extra-boolean-cast rule. (#15019) (Connor Shea)
- bae0c09 linter: Add configuration option docs for jsdoc/require-yields rule. (#15024) (Connor Shea)
- 06c77b6 linter: Add configuration option docs for unicorn/prefer-at rule. (#15023) (Connor Shea)
- 54b2cb4 linter: Add configuration option docs for eslint/max-classes-per-file rule. (#15022) (Connor Shea)
- b5acda7 linter: Add configuration option docs for typescript/explicit-module-boundary-types rule. (#15021) (Connor Shea)
- a0c6162 linter: Add configuration option docs for vue/max-props rule. (#14966) (Connor Shea)
- 3ec59c0 linter: Add configuration option docs for no-async-endpoint-handlers rule. (#14965) (Connor Shea)
- 7a275fd linter: Add configuration option docs for no-map-spread rule. (#14964) (Connor Shea)
- 0002b7c linter: Add configuration option docs for no-barrel-file rule. (#14963) (Connor Shea)
- fd4b7ab linter: Add configuration option docs for unicorn/consistent-function-scoping rule. (#14969) (Connor Shea)
- aa339b3 linter: Add configuration option docs for eslint/no-void rule. (#14970) (Connor Shea)
- af8bdae linter: Add configuration option docs for import/no-anonymous-default-export rule. (#14971) (Connor Shea)
- 5a81953 linter: Add configuration option docs for jest/require-hook rule. (#14972) (Connor Shea)
- 1be268d linter: Add configuration option docs for jest/require-top-level-describe rule. (#14973) (Connor Shea)
- 860a58c linter: Add configuration option docs for jest/no-hooks rule. (#14974) (Connor Shea)
- b69b586 linter: Add configuration option docs for jest/max-expects rule. (#14975) (Connor Shea)
- 2e02fe0 linter: Add configuration option docs for jest/no-deprecated-functions rule (#14976) (Connor Shea)
- cdc6c4f linter: Add configuration option docs for unicorn/no-array-sort rule. (#14977) (Connor Shea)
- 40eb394 linter/no-unassigned-import-config: Add auto generated config docs (#14918) (camc314)

### ⚡ Performance

- a9f68b2 linter: Move up rule retainment into initial collection to reduce allocation size (#14822) (camchenry)
- b27c5b9 linter: Add codegen support for regex nodes (#14874) (camchenry)

### 🧪 Testing

- bf898e5 linter: Increase stability of tsgolint test cases (#15063) (camc314)
- 49da411 linter/no-standalone-expect: Fix tests (#14901) (camc314)