### PR TITLE
docs(linter): Add configuration option docs for typescript/triple-slash-reference rule.

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
+++ b/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
@@ -3,6 +3,8 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use rustc_hash::FxHashMap;
+use schemars::JsonSchema;
+use serde::{Deserialize,Serialize};
 
 use crate::{
     context::{ContextHost, LintContext},
@@ -18,25 +20,35 @@ fn triple_slash_reference_diagnostic(ref_kind: &str, span: Span) -> OxcDiagnosti
 #[derive(Debug, Default, Clone)]
 pub struct TripleSlashReference(Box<TripleSlashReferenceConfig>);
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct TripleSlashReferenceConfig {
+    /// What to enforce for `/// <reference lib="..." />` references.
     lib: LibOption,
+    /// What to enforce for `/// <reference path="..." />` references.
     path: PathOption,
+    /// What to enforce for `/// <reference types="..." />` references.
     types: TypesOption,
 }
-#[derive(Debug, Default, Clone, PartialEq)]
+
+#[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
 enum LibOption {
     #[default]
     Always,
     Never,
 }
-#[derive(Debug, Default, Clone, PartialEq)]
+
+#[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
 enum PathOption {
     Always,
     #[default]
     Never,
 }
-#[derive(Debug, Default, Clone, PartialEq)]
+
+#[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
 enum TypesOption {
     Always,
     Never,
@@ -70,7 +82,8 @@ declare_oxc_lint!(
     /// ```
     TripleSlashReference,
     typescript,
-    correctness
+    correctness,
+    config = TripleSlashReferenceConfig,
 );
 
 impl Rule for TripleSlashReference {

--- a/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
+++ b/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use rustc_hash::FxHashMap;
 use schemars::JsonSchema;
-use serde::{Deserialize,Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::{
     context::{ContextHost, LintContext},


### PR DESCRIPTION
Part of #14743.

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### lib

type: `"always" | "never"`

default: `"always"`

What to enforce for `/// <reference lib="..." />` references.


### path

type: `"always" | "never"`

default: `"never"`

What to enforce for `/// <reference path="..." />` references.


### types

type: `"always" | "never" | "prefer-import"`

default: `"prefer-import"`

What to enforce for `/// <reference types="..." />` references.
```