### PR TITLE
fix(ci): Correct boolean comparison in check-version action

### DIFF
--- a/.github/actions/check-version/action.yml
+++ b/.github/actions/check-version/action.yml
@@ -15,9 +15,8 @@ inputs:
 
   diff-search:
     required: false
-    type: boolean
-    default: false
-    description: Use git diff to check for version changes instead of comparing with external URL
+    default: "false"
+    description: Use git diff to check for version changes instead of comparing with external URL (pass 'true' or 'false' as string)
 
 outputs:
   version:
@@ -34,7 +33,7 @@ runs:
       uses: EndBug/version-check@5102328418c0130d66ca712d755c303e93368ce2 # v2.1.7
       id: version
       with:
-        static-checking: ${{ inputs.diff-search == false && 'localIsNew' || '' }}
+        static-checking: ${{ inputs.diff-search != 'true' && 'localIsNew' || '' }}
         diff-search: ${{ inputs.diff-search }}
         file-url: ${{ inputs.file-url }}
         file-name: ${{ inputs.file-name }}


### PR DESCRIPTION
The `inputs.diff-search == false` comparison always evaluated to `false` because composite action inputs are strings, not booleans.

> https://github.com/actions/runner/issues/2238

This caused `static-checking` to be set to an empty string instead of `'localIsNew'`, making version-check fall back to commit history search mode and fail to detect version changes.