### PR TITLE
docs(linter): Add configuration option docs for eslint/no-undef rule.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -12,9 +12,10 @@ fn no_undef_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(default)]
 pub struct NoUndef {
-    /// The `typeOf` option allows the rule to ignore undefined variables used in a `typeof` expression.
+    /// When set to `true`, warns on undefined variables used in a `typeof` expression.
+    #[serde(rename = "typeof")] // This field can't be called typeof directly, as that's a keyword in Rust.
     type_of: bool,
 }
 
@@ -241,11 +242,11 @@ fn test() {
 
     Tester::new(NoUndef::NAME, NoUndef::PLUGIN, pass, fail).test_and_snapshot();
 
-    let pass = vec![(
+    let pass = vec![];
+    let fail = vec![(
         "if (typeof anUndefinedVar === 'string') {}",
-        Some(serde_json::json!([{ "typeOf": true }])),
+        Some(serde_json::json!([{ "typeof": true }])),
     )];
-    let fail = vec![];
 
     Tester::new(NoUndef::NAME, NoUndef::PLUGIN, pass, fail).test();
 

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -243,7 +243,10 @@ fn test() {
 
     Tester::new(NoUndef::NAME, NoUndef::PLUGIN, pass, fail).test_and_snapshot();
 
-    let pass = vec![];
+    let pass = vec![(
+        "if (typeof anUndefinedVar === 'string') {}",
+        Some(serde_json::json!([{ "typeof": false }])),
+    )];
     let fail = vec![(
         "if (typeof anUndefinedVar === 'string') {}",
         Some(serde_json::json!([{ "typeof": true }])),

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -241,11 +241,11 @@ fn test() {
 
     Tester::new(NoUndef::NAME, NoUndef::PLUGIN, pass, fail).test_and_snapshot();
 
-    let pass = vec![];
-    let fail = vec![(
+    let pass = vec![(
         "if (typeof anUndefinedVar === 'string') {}",
-        Some(serde_json::json!([{ "typeof": true }])),
+        Some(serde_json::json!([{ "typeOf": true }])),
     )];
+    let fail = vec![];
 
     Tester::new(NoUndef::NAME, NoUndef::PLUGIN, pass, fail).test();
 

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -3,6 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::UnaryOperator;
+use schemars::JsonSchema;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -10,8 +11,10 @@ fn no_undef_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("'{name}' is not defined.")).with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct NoUndef {
+    /// The `typeOf` option allows the rule to ignore undefined variables used in a `typeof` expression.
     type_of: bool,
 }
 
@@ -33,7 +36,8 @@ declare_oxc_lint!(
     /// ```
     NoUndef,
     eslint,
-    nursery
+    nursery,
+    config = NoUndef,
 );
 
 impl Rule for NoUndef {

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -15,7 +15,8 @@ fn no_undef_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
 #[serde(default)]
 pub struct NoUndef {
     /// When set to `true`, warns on undefined variables used in a `typeof` expression.
-    #[serde(rename = "typeof")] // This field can't be called typeof directly, as that's a keyword in Rust.
+    #[serde(rename = "typeof")]
+    // This field can't be called typeof directly, as that's a keyword in Rust.
     type_of: bool,
 }
 


### PR DESCRIPTION
Part of #14743.

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### typeof

type: `boolean`

default: `false`

When set to `true`, warns on undefined variables used in a `typeof` expression.
```

The `type_of` field needs to be force-renamed to match what's used in `from_configuration`.