### PR TITLE
release(crates): v0.96.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,22 +1625,22 @@ checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "oxc"
-version = "0.95.0"
+version = "0.96.0"
 dependencies = [
- "oxc_allocator 0.95.0",
- "oxc_ast 0.95.0",
- "oxc_ast_visit 0.95.0",
+ "oxc_allocator 0.96.0",
+ "oxc_ast 0.96.0",
+ "oxc_ast_visit 0.96.0",
  "oxc_cfg",
- "oxc_codegen 0.95.0",
- "oxc_diagnostics 0.95.0",
+ "oxc_codegen 0.96.0",
+ "oxc_diagnostics 0.96.0",
  "oxc_isolated_declarations",
- "oxc_mangler 0.95.0",
- "oxc_minifier 0.95.0",
- "oxc_parser 0.95.0",
- "oxc_regular_expression 0.95.0",
- "oxc_semantic 0.95.0",
- "oxc_span 0.95.0",
- "oxc_syntax 0.95.0",
+ "oxc_mangler 0.96.0",
+ "oxc_minifier 0.96.0",
+ "oxc_parser 0.96.0",
+ "oxc_regular_expression 0.96.0",
+ "oxc_semantic 0.96.0",
+ "oxc_span 0.96.0",
+ "oxc_syntax 0.96.0",
  "oxc_transformer",
  "oxc_transformer_plugins",
 ]
@@ -1703,34 +1703,36 @@ dependencies = [
 [[package]]
 name = "oxc_allocator"
 version = "0.95.0"
-dependencies = [
- "allocator-api2",
- "bumpalo",
- "hashbrown 0.16.0",
- "oxc_ast_macros 0.95.0",
- "oxc_data_structures 0.95.0",
- "oxc_estree 0.95.0",
- "rustc-hash",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "oxc_allocator"
-version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "433214c659b860685d987ca25a523a544d35ebf87ee3658a942fd1c664cfa49b"
 dependencies = [
  "allocator-api2",
  "bumpalo",
  "hashbrown 0.16.0",
- "oxc_data_structures 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_data_structures 0.95.0",
  "rustc-hash",
+]
+
+[[package]]
+name = "oxc_allocator"
+version = "0.96.0"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.16.0",
+ "oxc_ast_macros 0.96.0",
+ "oxc_data_structures 0.96.0",
+ "oxc_estree 0.96.0",
+ "rustc-hash",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "oxc_ast"
 version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e78ea25d23521092edcd509198635dd0bd96df7fb71349bcd8087bb8f6a615d"
 dependencies = [
  "bitflags 2.10.0",
  "oxc_allocator 0.95.0",
@@ -1745,24 +1747,24 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.95.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e78ea25d23521092edcd509198635dd0bd96df7fb71349bcd8087bb8f6a615d"
+version = "0.96.0"
 dependencies = [
  "bitflags 2.10.0",
- "oxc_allocator 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast_macros 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_diagnostics 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_estree 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_regular_expression 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.96.0",
+ "oxc_ast_macros 0.96.0",
+ "oxc_data_structures 0.96.0",
+ "oxc_diagnostics 0.96.0",
+ "oxc_estree 0.96.0",
+ "oxc_regular_expression 0.96.0",
+ "oxc_span 0.96.0",
+ "oxc_syntax 0.96.0",
 ]
 
 [[package]]
 name = "oxc_ast_macros"
 version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3f29bf83925451a7ebbd30d3ff449414cc230c9b63aba70487c2ca74ea1e3ed"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1772,9 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.95.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3f29bf83925451a7ebbd30d3ff449414cc230c9b63aba70487c2ca74ea1e3ed"
+version = "0.96.0"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1793,16 +1793,16 @@ dependencies = [
  "indexmap",
  "itertools",
  "lazy-regex",
- "oxc_allocator 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast_visit 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_codegen 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.95.0",
+ "oxc_allocator 0.95.0",
+ "oxc_ast 0.95.0",
+ "oxc_ast_visit 0.95.0",
+ "oxc_codegen 0.95.0",
+ "oxc_data_structures 0.96.0",
  "oxc_index",
- "oxc_minifier 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_parser 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_minifier 0.95.0",
+ "oxc_parser 0.95.0",
+ "oxc_span 0.95.0",
+ "oxc_syntax 0.95.0",
  "phf",
  "phf_codegen",
  "prettyplease",
@@ -1818,6 +1818,8 @@ dependencies = [
 [[package]]
 name = "oxc_ast_visit"
 version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808862f42c9331954cf187261d6a48dbf471ccbe60b6a35f6b1056c11f32e95b"
 dependencies = [
  "oxc_allocator 0.95.0",
  "oxc_ast 0.95.0",
@@ -1827,14 +1829,12 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.95.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808862f42c9331954cf187261d6a48dbf471ccbe60b6a35f6b1056c11f32e95b"
+version = "0.96.0"
 dependencies = [
- "oxc_allocator 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.96.0",
+ "oxc_ast 0.96.0",
+ "oxc_span 0.96.0",
+ "oxc_syntax 0.96.0",
 ]
 
 [[package]]
@@ -1842,18 +1842,18 @@ name = "oxc_benchmark"
 version = "0.0.0"
 dependencies = [
  "criterion2",
- "oxc_allocator 0.95.0",
- "oxc_ast 0.95.0",
- "oxc_ast_visit 0.95.0",
- "oxc_codegen 0.95.0",
+ "oxc_allocator 0.96.0",
+ "oxc_ast 0.96.0",
+ "oxc_ast_visit 0.96.0",
+ "oxc_codegen 0.96.0",
  "oxc_formatter",
  "oxc_isolated_declarations",
  "oxc_linter",
- "oxc_mangler 0.95.0",
- "oxc_minifier 0.95.0",
- "oxc_parser 0.95.0",
- "oxc_semantic 0.95.0",
- "oxc_span 0.95.0",
+ "oxc_mangler 0.96.0",
+ "oxc_minifier 0.96.0",
+ "oxc_parser 0.96.0",
+ "oxc_semantic 0.96.0",
+ "oxc_span 0.96.0",
  "oxc_tasks_common",
  "oxc_transformer",
  "rustc-hash",
@@ -1863,35 +1863,13 @@ dependencies = [
 
 [[package]]
 name = "oxc_cfg"
-version = "0.95.0"
+version = "0.96.0"
 dependencies = [
  "bitflags 2.10.0",
  "itertools",
  "oxc_index",
- "oxc_syntax 0.95.0",
+ "oxc_syntax 0.96.0",
  "petgraph",
- "rustc-hash",
-]
-
-[[package]]
-name = "oxc_codegen"
-version = "0.95.0"
-dependencies = [
- "bitflags 2.10.0",
- "cow-utils",
- "dragonbox_ecma",
- "insta",
- "itoa",
- "oxc_allocator 0.95.0",
- "oxc_ast 0.95.0",
- "oxc_data_structures 0.95.0",
- "oxc_index",
- "oxc_parser 0.95.0",
- "oxc_semantic 0.95.0",
- "oxc_sourcemap",
- "oxc_span 0.95.0",
- "oxc_syntax 0.95.0",
- "pico-args",
  "rustc-hash",
 ]
 
@@ -1905,26 +1883,37 @@ dependencies = [
  "cow-utils",
  "dragonbox_ecma",
  "itoa",
- "oxc_allocator 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.95.0",
+ "oxc_ast 0.95.0",
+ "oxc_data_structures 0.95.0",
  "oxc_index",
- "oxc_semantic 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_semantic 0.95.0",
  "oxc_sourcemap",
- "oxc_span 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_span 0.95.0",
+ "oxc_syntax 0.95.0",
  "rustc-hash",
 ]
 
 [[package]]
-name = "oxc_compat"
-version = "0.95.0"
+name = "oxc_codegen"
+version = "0.96.0"
 dependencies = [
+ "bitflags 2.10.0",
  "cow-utils",
- "oxc-browserslist",
- "oxc_syntax 0.95.0",
+ "dragonbox_ecma",
+ "insta",
+ "itoa",
+ "oxc_allocator 0.96.0",
+ "oxc_ast 0.96.0",
+ "oxc_data_structures 0.96.0",
+ "oxc_index",
+ "oxc_parser 0.96.0",
+ "oxc_semantic 0.96.0",
+ "oxc_sourcemap",
+ "oxc_span 0.96.0",
+ "oxc_syntax 0.96.0",
+ "pico-args",
  "rustc-hash",
- "serde",
 ]
 
 [[package]]
@@ -1935,7 +1924,18 @@ checksum = "bd06b5cb59ece933be410adc6f811108a10c567fa2d105321f8d0f01cc4ab0c6"
 dependencies = [
  "cow-utils",
  "oxc-browserslist",
- "oxc_syntax 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_syntax 0.95.0",
+ "rustc-hash",
+ "serde",
+]
+
+[[package]]
+name = "oxc_compat"
+version = "0.96.0"
+dependencies = [
+ "cow-utils",
+ "oxc-browserslist",
+ "oxc_syntax 0.96.0",
  "rustc-hash",
  "serde",
 ]
@@ -1984,23 +1984,14 @@ dependencies = [
 [[package]]
 name = "oxc_data_structures"
 version = "0.95.0"
-dependencies = [
- "ropey",
-]
-
-[[package]]
-name = "oxc_data_structures"
-version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd090988aa69c1e394f424289abb9bb1281448a072419ca556a07228ad36b854"
 
 [[package]]
-name = "oxc_diagnostics"
-version = "0.95.0"
+name = "oxc_data_structures"
+version = "0.96.0"
 dependencies = [
- "cow-utils",
- "oxc-miette",
- "percent-encoding",
+ "ropey",
 ]
 
 [[package]]
@@ -2015,16 +2006,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "oxc_ecmascript"
-version = "0.95.0"
+name = "oxc_diagnostics"
+version = "0.96.0"
 dependencies = [
  "cow-utils",
- "num-bigint",
- "num-traits",
- "oxc_allocator 0.95.0",
- "oxc_ast 0.95.0",
- "oxc_span 0.95.0",
- "oxc_syntax 0.95.0",
+ "oxc-miette",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -2036,19 +2023,23 @@ dependencies = [
  "cow-utils",
  "num-bigint",
  "num-traits",
- "oxc_allocator 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.95.0",
+ "oxc_ast 0.95.0",
+ "oxc_span 0.95.0",
+ "oxc_syntax 0.95.0",
 ]
 
 [[package]]
-name = "oxc_estree"
-version = "0.95.0"
+name = "oxc_ecmascript"
+version = "0.96.0"
 dependencies = [
- "dragonbox_ecma",
- "itoa",
- "oxc_data_structures 0.95.0",
+ "cow-utils",
+ "num-bigint",
+ "num-traits",
+ "oxc_allocator 0.96.0",
+ "oxc_ast 0.96.0",
+ "oxc_span 0.96.0",
+ "oxc_syntax 0.96.0",
 ]
 
 [[package]]
@@ -2059,7 +2050,16 @@ checksum = "af85b24b7e10bf0ccb252f16d38492f51236c1ba146f62013993667cbf7fa649"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
- "oxc_data_structures 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_data_structures 0.95.0",
+]
+
+[[package]]
+name = "oxc_estree"
+version = "0.96.0"
+dependencies = [
+ "dragonbox_ecma",
+ "itoa",
+ "oxc_data_structures 0.96.0",
 ]
 
 [[package]]
@@ -2070,12 +2070,12 @@ dependencies = [
  "insta",
  "json-strip-comments",
  "oxc-schemars",
- "oxc_allocator 0.95.0",
- "oxc_ast 0.95.0",
- "oxc_data_structures 0.95.0",
- "oxc_parser 0.95.0",
- "oxc_span 0.95.0",
- "oxc_syntax 0.95.0",
+ "oxc_allocator 0.96.0",
+ "oxc_ast 0.96.0",
+ "oxc_data_structures 0.96.0",
+ "oxc_parser 0.96.0",
+ "oxc_span 0.96.0",
+ "oxc_syntax 0.96.0",
  "pico-args",
  "project-root",
  "rustc-hash",
@@ -2096,19 +2096,19 @@ dependencies = [
 
 [[package]]
 name = "oxc_isolated_declarations"
-version = "0.95.0"
+version = "0.96.0"
 dependencies = [
  "bitflags 2.10.0",
  "insta",
- "oxc_allocator 0.95.0",
- "oxc_ast 0.95.0",
- "oxc_ast_visit 0.95.0",
- "oxc_codegen 0.95.0",
- "oxc_diagnostics 0.95.0",
- "oxc_ecmascript 0.95.0",
- "oxc_parser 0.95.0",
- "oxc_span 0.95.0",
- "oxc_syntax 0.95.0",
+ "oxc_allocator 0.96.0",
+ "oxc_ast 0.96.0",
+ "oxc_ast_visit 0.96.0",
+ "oxc_codegen 0.96.0",
+ "oxc_diagnostics 0.96.0",
+ "oxc_ecmascript 0.96.0",
+ "oxc_parser 0.96.0",
+ "oxc_span 0.96.0",
+ "oxc_syntax 0.96.0",
  "rustc-hash",
 ]
 
@@ -2121,12 +2121,12 @@ dependencies = [
  "ignore",
  "insta",
  "log",
- "oxc_allocator 0.95.0",
- "oxc_data_structures 0.95.0",
- "oxc_diagnostics 0.95.0",
+ "oxc_allocator 0.96.0",
+ "oxc_data_structures 0.96.0",
+ "oxc_diagnostics 0.96.0",
  "oxc_formatter",
  "oxc_linter",
- "oxc_parser 0.95.0",
+ "oxc_parser 0.96.0",
  "papaya",
  "rustc-hash",
  "serde",
@@ -2156,23 +2156,23 @@ dependencies = [
  "markdown",
  "memchr",
  "oxc-schemars",
- "oxc_allocator 0.95.0",
- "oxc_ast 0.95.0",
- "oxc_ast_macros 0.95.0",
- "oxc_ast_visit 0.95.0",
+ "oxc_allocator 0.96.0",
+ "oxc_ast 0.96.0",
+ "oxc_ast_macros 0.96.0",
+ "oxc_ast_visit 0.96.0",
  "oxc_cfg",
- "oxc_codegen 0.95.0",
- "oxc_data_structures 0.95.0",
- "oxc_diagnostics 0.95.0",
- "oxc_ecmascript 0.95.0",
+ "oxc_codegen 0.96.0",
+ "oxc_data_structures 0.96.0",
+ "oxc_diagnostics 0.96.0",
+ "oxc_ecmascript 0.96.0",
  "oxc_index",
  "oxc_macros",
- "oxc_parser 0.95.0",
- "oxc_regular_expression 0.95.0",
+ "oxc_parser 0.96.0",
+ "oxc_regular_expression 0.96.0",
  "oxc_resolver",
- "oxc_semantic 0.95.0",
- "oxc_span 0.95.0",
- "oxc_syntax 0.95.0",
+ "oxc_semantic 0.96.0",
+ "oxc_span 0.96.0",
+ "oxc_syntax 0.96.0",
  "papaya",
  "phf",
  "project-root",
@@ -2210,13 +2210,14 @@ dependencies = [
 [[package]]
 name = "oxc_mangler"
 version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb751e1971f0809547347edfebe3755d5bed354aacf3ca7fe7216b901a11dd1d"
 dependencies = [
  "itertools",
  "oxc_allocator 0.95.0",
  "oxc_ast 0.95.0",
  "oxc_data_structures 0.95.0",
  "oxc_index",
- "oxc_parser 0.95.0",
  "oxc_semantic 0.95.0",
  "oxc_span 0.95.0",
  "oxc_syntax 0.95.0",
@@ -2225,28 +2226,27 @@ dependencies = [
 
 [[package]]
 name = "oxc_mangler"
-version = "0.95.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb751e1971f0809547347edfebe3755d5bed354aacf3ca7fe7216b901a11dd1d"
+version = "0.96.0"
 dependencies = [
  "itertools",
- "oxc_allocator 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.96.0",
+ "oxc_ast 0.96.0",
+ "oxc_data_structures 0.96.0",
  "oxc_index",
- "oxc_semantic 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_parser 0.96.0",
+ "oxc_semantic 0.96.0",
+ "oxc_span 0.96.0",
+ "oxc_syntax 0.96.0",
  "rustc-hash",
 ]
 
 [[package]]
 name = "oxc_minifier"
 version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e836caa36befa6f9603eebf56b0c08d1e164ae31160c8e99ab3f535203065a4c"
 dependencies = [
  "cow-utils",
- "insta",
- "javascript-globals",
  "oxc_allocator 0.95.0",
  "oxc_ast 0.95.0",
  "oxc_ast_visit 0.95.0",
@@ -2259,56 +2259,56 @@ dependencies = [
  "oxc_parser 0.95.0",
  "oxc_regular_expression 0.95.0",
  "oxc_semantic 0.95.0",
- "oxc_sourcemap",
  "oxc_span 0.95.0",
  "oxc_syntax 0.95.0",
  "oxc_traverse 0.95.0",
- "pico-args",
  "rustc-hash",
 ]
 
 [[package]]
 name = "oxc_minifier"
-version = "0.95.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e836caa36befa6f9603eebf56b0c08d1e164ae31160c8e99ab3f535203065a4c"
+version = "0.96.0"
 dependencies = [
  "cow-utils",
- "oxc_allocator 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast_visit 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_codegen 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_compat 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ecmascript 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "insta",
+ "javascript-globals",
+ "oxc_allocator 0.96.0",
+ "oxc_ast 0.96.0",
+ "oxc_ast_visit 0.96.0",
+ "oxc_codegen 0.96.0",
+ "oxc_compat 0.96.0",
+ "oxc_data_structures 0.96.0",
+ "oxc_ecmascript 0.96.0",
  "oxc_index",
- "oxc_mangler 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_parser 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_regular_expression 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_semantic 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_traverse 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_mangler 0.96.0",
+ "oxc_parser 0.96.0",
+ "oxc_regular_expression 0.96.0",
+ "oxc_semantic 0.96.0",
+ "oxc_sourcemap",
+ "oxc_span 0.96.0",
+ "oxc_syntax 0.96.0",
+ "oxc_traverse 0.96.0",
+ "pico-args",
  "rustc-hash",
 ]
 
 [[package]]
 name = "oxc_minify_napi"
-version = "0.95.0"
+version = "0.96.0"
 dependencies = [
  "mimalloc-safe",
  "napi",
  "napi-build",
  "napi-derive",
- "oxc_allocator 0.95.0",
- "oxc_codegen 0.95.0",
- "oxc_compat 0.95.0",
- "oxc_diagnostics 0.95.0",
- "oxc_minifier 0.95.0",
+ "oxc_allocator 0.96.0",
+ "oxc_codegen 0.96.0",
+ "oxc_compat 0.96.0",
+ "oxc_diagnostics 0.96.0",
+ "oxc_minifier 0.96.0",
  "oxc_napi",
- "oxc_parser 0.95.0",
+ "oxc_parser 0.96.0",
  "oxc_sourcemap",
- "oxc_span 0.95.0",
+ "oxc_span 0.96.0",
 ]
 
 [[package]]
@@ -2318,12 +2318,12 @@ dependencies = [
  "cow-utils",
  "flate2",
  "humansize",
- "oxc_allocator 0.95.0",
- "oxc_codegen 0.95.0",
- "oxc_minifier 0.95.0",
- "oxc_parser 0.95.0",
- "oxc_semantic 0.95.0",
- "oxc_span 0.95.0",
+ "oxc_allocator 0.96.0",
+ "oxc_codegen 0.96.0",
+ "oxc_minifier 0.96.0",
+ "oxc_parser 0.96.0",
+ "oxc_semantic 0.96.0",
+ "oxc_span 0.96.0",
  "oxc_tasks_common",
  "oxc_transformer_plugins",
  "pico-args",
@@ -2333,39 +2333,16 @@ dependencies = [
 
 [[package]]
 name = "oxc_napi"
-version = "0.95.0"
+version = "0.96.0"
 dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
- "oxc_ast 0.95.0",
- "oxc_ast_visit 0.95.0",
- "oxc_diagnostics 0.95.0",
- "oxc_span 0.95.0",
- "oxc_syntax 0.95.0",
-]
-
-[[package]]
-name = "oxc_parser"
-version = "0.95.0"
-dependencies = [
- "bitflags 2.10.0",
- "cow-utils",
- "memchr",
- "num-bigint",
- "num-traits",
- "oxc_allocator 0.95.0",
- "oxc_ast 0.95.0",
- "oxc_ast_visit 0.95.0",
- "oxc_data_structures 0.95.0",
- "oxc_diagnostics 0.95.0",
- "oxc_ecmascript 0.95.0",
- "oxc_regular_expression 0.95.0",
- "oxc_span 0.95.0",
- "oxc_syntax 0.95.0",
- "pico-args",
- "rustc-hash",
- "seq-macro",
+ "oxc_ast 0.96.0",
+ "oxc_ast_visit 0.96.0",
+ "oxc_diagnostics 0.96.0",
+ "oxc_span 0.96.0",
+ "oxc_syntax 0.96.0",
 ]
 
 [[package]]
@@ -2379,29 +2356,52 @@ dependencies = [
  "memchr",
  "num-bigint",
  "num-traits",
- "oxc_allocator 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_diagnostics 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ecmascript 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_regular_expression 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.95.0",
+ "oxc_ast 0.95.0",
+ "oxc_data_structures 0.95.0",
+ "oxc_diagnostics 0.95.0",
+ "oxc_ecmascript 0.95.0",
+ "oxc_regular_expression 0.95.0",
+ "oxc_span 0.95.0",
+ "oxc_syntax 0.95.0",
+ "rustc-hash",
+ "seq-macro",
+]
+
+[[package]]
+name = "oxc_parser"
+version = "0.96.0"
+dependencies = [
+ "bitflags 2.10.0",
+ "cow-utils",
+ "memchr",
+ "num-bigint",
+ "num-traits",
+ "oxc_allocator 0.96.0",
+ "oxc_ast 0.96.0",
+ "oxc_ast_visit 0.96.0",
+ "oxc_data_structures 0.96.0",
+ "oxc_diagnostics 0.96.0",
+ "oxc_ecmascript 0.96.0",
+ "oxc_regular_expression 0.96.0",
+ "oxc_span 0.96.0",
+ "oxc_syntax 0.96.0",
+ "pico-args",
  "rustc-hash",
  "seq-macro",
 ]
 
 [[package]]
 name = "oxc_parser_napi"
-version = "0.95.0"
+version = "0.96.0"
 dependencies = [
  "mimalloc-safe",
  "napi",
  "napi-build",
  "napi-derive",
  "oxc",
- "oxc_ast_macros 0.95.0",
- "oxc_estree 0.95.0",
+ "oxc_ast_macros 0.96.0",
+ "oxc_estree 0.96.0",
  "oxc_napi",
  "rustc-hash",
 ]
@@ -2428,12 +2428,12 @@ name = "oxc_prettier_conformance"
 version = "0.0.0"
 dependencies = [
  "cow-utils",
- "oxc_allocator 0.95.0",
- "oxc_ast 0.95.0",
- "oxc_ast_visit 0.95.0",
+ "oxc_allocator 0.96.0",
+ "oxc_ast 0.96.0",
+ "oxc_ast_visit 0.96.0",
  "oxc_formatter",
- "oxc_parser 0.95.0",
- "oxc_span 0.95.0",
+ "oxc_parser 0.96.0",
+ "oxc_span 0.96.0",
  "oxc_tasks_common",
  "pico-args",
  "rustc-hash",
@@ -2444,6 +2444,8 @@ dependencies = [
 [[package]]
 name = "oxc_regular_expression"
 version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bafc3035e3b0fe555ae56f7bbc108a7ee520b0858250ba16d197e44ca83746"
 dependencies = [
  "bitflags 2.10.0",
  "oxc_allocator 0.95.0",
@@ -2457,15 +2459,13 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.95.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27bafc3035e3b0fe555ae56f7bbc108a7ee520b0858250ba16d197e44ca83746"
+version = "0.96.0"
 dependencies = [
  "bitflags 2.10.0",
- "oxc_allocator 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast_macros 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_diagnostics 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.96.0",
+ "oxc_ast_macros 0.96.0",
+ "oxc_diagnostics 0.96.0",
+ "oxc_span 0.96.0",
  "phf",
  "rustc-hash",
  "unicode-id-start",
@@ -2510,45 +2510,45 @@ dependencies = [
 [[package]]
 name = "oxc_semantic"
 version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578e5fa0b975a28e1d1ffa6c81c8df094545fe3c3225956d4e93ffe1ade3dae0"
 dependencies = [
- "insta",
  "itertools",
  "oxc_allocator 0.95.0",
  "oxc_ast 0.95.0",
  "oxc_ast_visit 0.95.0",
- "oxc_cfg",
  "oxc_data_structures 0.95.0",
  "oxc_diagnostics 0.95.0",
  "oxc_ecmascript 0.95.0",
  "oxc_index",
- "oxc_parser 0.95.0",
  "oxc_span 0.95.0",
  "oxc_syntax 0.95.0",
  "phf",
  "rustc-hash",
  "self_cell",
- "serde_json",
 ]
 
 [[package]]
 name = "oxc_semantic"
-version = "0.95.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578e5fa0b975a28e1d1ffa6c81c8df094545fe3c3225956d4e93ffe1ade3dae0"
+version = "0.96.0"
 dependencies = [
+ "insta",
  "itertools",
- "oxc_allocator 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast_visit 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_diagnostics 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ecmascript 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.96.0",
+ "oxc_ast 0.96.0",
+ "oxc_ast_visit 0.96.0",
+ "oxc_cfg",
+ "oxc_data_structures 0.96.0",
+ "oxc_diagnostics 0.96.0",
+ "oxc_ecmascript 0.96.0",
  "oxc_index",
- "oxc_span 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_parser 0.96.0",
+ "oxc_span 0.96.0",
+ "oxc_syntax 0.96.0",
  "phf",
  "rustc-hash",
  "self_cell",
+ "serde_json",
 ]
 
 [[package]]
@@ -2570,10 +2570,11 @@ dependencies = [
 [[package]]
 name = "oxc_span"
 version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71243fe1ece27f71a6be5e2ab11d051792eeb578f3b056d7c9bbe82ec8043bf3"
 dependencies = [
  "compact_str",
  "oxc-miette",
- "oxc-schemars",
  "oxc_allocator 0.95.0",
  "oxc_ast_macros 0.95.0",
  "oxc_estree 0.95.0",
@@ -2582,21 +2583,22 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.95.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71243fe1ece27f71a6be5e2ab11d051792eeb578f3b056d7c9bbe82ec8043bf3"
+version = "0.96.0"
 dependencies = [
  "compact_str",
  "oxc-miette",
- "oxc_allocator 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast_macros 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_estree 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc-schemars",
+ "oxc_allocator 0.96.0",
+ "oxc_ast_macros 0.96.0",
+ "oxc_estree 0.96.0",
  "serde",
 ]
 
 [[package]]
 name = "oxc_syntax"
 version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93c99e555ed497111004a71fb2aa6f8fb90b0d3e2733aceeb035e24701d69634"
 dependencies = [
  "bitflags 2.10.0",
  "cow-utils",
@@ -2615,20 +2617,18 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.95.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93c99e555ed497111004a71fb2aa6f8fb90b0d3e2733aceeb035e24701d69634"
+version = "0.96.0"
 dependencies = [
  "bitflags 2.10.0",
  "cow-utils",
  "dragonbox_ecma",
  "nonmax",
- "oxc_allocator 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast_macros 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_estree 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.96.0",
+ "oxc_ast_macros 0.96.0",
+ "oxc_data_structures 0.96.0",
+ "oxc_estree 0.96.0",
  "oxc_index",
- "oxc_span 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_span 0.96.0",
  "phf",
  "serde",
  "unicode-id-start",
@@ -2639,7 +2639,7 @@ name = "oxc_tasks_common"
 version = "0.0.0"
 dependencies = [
  "console 0.16.1",
- "oxc_span 0.95.0",
+ "oxc_span 0.96.0",
  "project-root",
  "similar",
  "ureq",
@@ -2650,13 +2650,13 @@ name = "oxc_tasks_transform_checker"
 version = "0.0.0"
 dependencies = [
  "indexmap",
- "oxc_allocator 0.95.0",
- "oxc_ast 0.95.0",
- "oxc_ast_visit 0.95.0",
- "oxc_diagnostics 0.95.0",
- "oxc_semantic 0.95.0",
- "oxc_span 0.95.0",
- "oxc_syntax 0.95.0",
+ "oxc_allocator 0.96.0",
+ "oxc_ast 0.96.0",
+ "oxc_ast_visit 0.96.0",
+ "oxc_diagnostics 0.96.0",
+ "oxc_semantic 0.96.0",
+ "oxc_span 0.96.0",
+ "oxc_syntax 0.96.0",
  "rustc-hash",
 ]
 
@@ -2666,10 +2666,10 @@ version = "0.0.0"
 dependencies = [
  "humansize",
  "mimalloc-safe",
- "oxc_allocator 0.95.0",
- "oxc_minifier 0.95.0",
- "oxc_parser 0.95.0",
- "oxc_semantic 0.95.0",
+ "oxc_allocator 0.96.0",
+ "oxc_minifier 0.96.0",
+ "oxc_parser 0.96.0",
+ "oxc_semantic 0.96.0",
  "oxc_tasks_common",
  "oxc_transformer",
 ]
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_transform_napi"
-version = "0.95.0"
+version = "0.96.0"
 dependencies = [
  "mimalloc-safe",
  "napi",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer"
-version = "0.95.0"
+version = "0.96.0"
 dependencies = [
  "base64",
  "compact_str",
@@ -2712,20 +2712,20 @@ dependencies = [
  "insta",
  "itoa",
  "memchr",
- "oxc_allocator 0.95.0",
- "oxc_ast 0.95.0",
- "oxc_ast_visit 0.95.0",
- "oxc_codegen 0.95.0",
- "oxc_compat 0.95.0",
- "oxc_data_structures 0.95.0",
- "oxc_diagnostics 0.95.0",
- "oxc_ecmascript 0.95.0",
- "oxc_parser 0.95.0",
- "oxc_regular_expression 0.95.0",
- "oxc_semantic 0.95.0",
- "oxc_span 0.95.0",
- "oxc_syntax 0.95.0",
- "oxc_traverse 0.95.0",
+ "oxc_allocator 0.96.0",
+ "oxc_ast 0.96.0",
+ "oxc_ast_visit 0.96.0",
+ "oxc_codegen 0.96.0",
+ "oxc_compat 0.96.0",
+ "oxc_data_structures 0.96.0",
+ "oxc_diagnostics 0.96.0",
+ "oxc_ecmascript 0.96.0",
+ "oxc_parser 0.96.0",
+ "oxc_regular_expression 0.96.0",
+ "oxc_semantic 0.96.0",
+ "oxc_span 0.96.0",
+ "oxc_syntax 0.96.0",
+ "oxc_traverse 0.96.0",
  "pico-args",
  "rustc-hash",
  "serde",
@@ -2735,26 +2735,26 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer_plugins"
-version = "0.95.0"
+version = "0.96.0"
 dependencies = [
  "cow-utils",
  "insta",
  "itoa",
- "oxc_allocator 0.95.0",
- "oxc_ast 0.95.0",
- "oxc_ast_visit 0.95.0",
- "oxc_codegen 0.95.0",
- "oxc_diagnostics 0.95.0",
- "oxc_ecmascript 0.95.0",
- "oxc_minifier 0.95.0",
- "oxc_parser 0.95.0",
- "oxc_semantic 0.95.0",
+ "oxc_allocator 0.96.0",
+ "oxc_ast 0.96.0",
+ "oxc_ast_visit 0.96.0",
+ "oxc_codegen 0.96.0",
+ "oxc_diagnostics 0.96.0",
+ "oxc_ecmascript 0.96.0",
+ "oxc_minifier 0.96.0",
+ "oxc_parser 0.96.0",
+ "oxc_semantic 0.96.0",
  "oxc_sourcemap",
- "oxc_span 0.95.0",
- "oxc_syntax 0.95.0",
+ "oxc_span 0.96.0",
+ "oxc_syntax 0.96.0",
  "oxc_tasks_common",
  "oxc_transformer",
- "oxc_traverse 0.95.0",
+ "oxc_traverse 0.96.0",
  "pico-args",
  "rustc-hash",
  "similar",
@@ -2763,6 +2763,8 @@ dependencies = [
 [[package]]
 name = "oxc_traverse"
 version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68d00264248ef474988ea02bfa44ccacd9a1d8716f0efb33a9cd6f992cf07b7b"
 dependencies = [
  "itoa",
  "oxc_allocator 0.95.0",
@@ -2778,19 +2780,17 @@ dependencies = [
 
 [[package]]
 name = "oxc_traverse"
-version = "0.95.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d00264248ef474988ea02bfa44ccacd9a1d8716f0efb33a9cd6f992cf07b7b"
+version = "0.96.0"
 dependencies = [
  "itoa",
- "oxc_allocator 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast_visit 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ecmascript 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_semantic 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.95.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.96.0",
+ "oxc_ast 0.96.0",
+ "oxc_ast_visit 0.96.0",
+ "oxc_data_structures 0.96.0",
+ "oxc_ecmascript 0.96.0",
+ "oxc_semantic 0.96.0",
+ "oxc_span 0.96.0",
+ "oxc_syntax 0.96.0",
  "rustc-hash",
 ]
 
@@ -2805,11 +2805,11 @@ dependencies = [
  "lazy-regex",
  "mimalloc-safe",
  "oxc-miette",
- "oxc_allocator 0.95.0",
- "oxc_diagnostics 0.95.0",
+ "oxc_allocator 0.96.0",
+ "oxc_diagnostics 0.96.0",
  "oxc_formatter",
- "oxc_parser 0.95.0",
- "oxc_span 0.95.0",
+ "oxc_parser 0.96.0",
+ "oxc_span 0.96.0",
  "rayon",
  "tracing-subscriber",
 ]
@@ -2828,10 +2828,10 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "oxc-miette",
- "oxc_allocator 0.95.0",
- "oxc_diagnostics 0.95.0",
+ "oxc_allocator 0.96.0",
+ "oxc_diagnostics 0.96.0",
  "oxc_linter",
- "oxc_span 0.95.0",
+ "oxc_span 0.96.0",
  "rayon",
  "rustc-hash",
  "serde",
@@ -3177,11 +3177,11 @@ dependencies = [
  "convert_case",
  "handlebars",
  "lazy-regex",
- "oxc_allocator 0.95.0",
- "oxc_ast 0.95.0",
- "oxc_ast_visit 0.95.0",
- "oxc_parser 0.95.0",
- "oxc_span 0.95.0",
+ "oxc_allocator 0.96.0",
+ "oxc_ast 0.96.0",
+ "oxc_ast_visit 0.96.0",
+ "oxc_parser 0.96.0",
+ "oxc_span 0.96.0",
  "oxc_tasks_common",
  "rustc-hash",
  "serde",
@@ -4083,11 +4083,11 @@ dependencies = [
  "itertools",
  "markdown",
  "oxc-schemars",
- "oxc_allocator 0.95.0",
- "oxc_diagnostics 0.95.0",
+ "oxc_allocator 0.96.0",
+ "oxc_diagnostics 0.96.0",
  "oxc_linter",
- "oxc_parser 0.95.0",
- "oxc_span 0.95.0",
+ "oxc_parser 0.96.0",
+ "oxc_span 0.96.0",
  "oxlint",
  "pico-args",
  "project-root",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,33 +103,33 @@ multiple_crate_versions = "allow"
 
 [workspace.dependencies]
 # publish = true
-oxc = { version = "0.95.0", path = "crates/oxc" } # Main entry point
-oxc_allocator = { version = "0.95.0", path = "crates/oxc_allocator" } # Memory management
-oxc_ast = { version = "0.95.0", path = "crates/oxc_ast" } # AST definitions
-oxc_ast_macros = { version = "0.95.0", path = "crates/oxc_ast_macros" } # AST proc macros
-oxc_ast_visit = { version = "0.95.0", path = "crates/oxc_ast_visit" } # AST visitor pattern
-oxc_cfg = { version = "0.95.0", path = "crates/oxc_cfg" } # Control flow graph
-oxc_codegen = { version = "0.95.0", path = "crates/oxc_codegen" } # Code generation
-oxc_compat = { version = "0.95.0", path = "crates/oxc_compat" } # Browser compatibility
-oxc_data_structures = { version = "0.95.0", path = "crates/oxc_data_structures" } # Shared data structures
-oxc_diagnostics = { version = "0.95.0", path = "crates/oxc_diagnostics" } # Error reporting
-oxc_ecmascript = { version = "0.95.0", path = "crates/oxc_ecmascript" } # ECMAScript operations
-oxc_estree = { version = "0.95.0", path = "crates/oxc_estree" } # ESTree format
-oxc_isolated_declarations = { version = "0.95.0", path = "crates/oxc_isolated_declarations" } # TS declaration generation
-oxc_mangler = { version = "0.95.0", path = "crates/oxc_mangler" } # Name mangling
-oxc_minifier = { version = "0.95.0", path = "crates/oxc_minifier" } # Code minification
-oxc_minify_napi = { version = "0.95.0", path = "napi/minify" } # Node.js minifier binding
-oxc_napi = { version = "0.95.0", path = "crates/oxc_napi" } # NAPI utilities
-oxc_parser = { version = "0.95.0", path = "crates/oxc_parser", features = ["regular_expression"] } # JS/TS parser
-oxc_parser_napi = { version = "0.95.0", path = "napi/parser" } # Node.js parser binding
-oxc_regular_expression = { version = "0.95.0", path = "crates/oxc_regular_expression" } # Regex parser
-oxc_semantic = { version = "0.95.0", path = "crates/oxc_semantic" } # Semantic analysis
-oxc_span = { version = "0.95.0", path = "crates/oxc_span" } # Source positions
-oxc_syntax = { version = "0.95.0", path = "crates/oxc_syntax" } # Syntax utilities
-oxc_transform_napi = { version = "0.95.0", path = "napi/transform" } # Node.js transformer binding
-oxc_transformer = { version = "0.95.0", path = "crates/oxc_transformer" } # Code transformation
-oxc_transformer_plugins = { version = "0.95.0", path = "crates/oxc_transformer_plugins" } # Transformer plugins
-oxc_traverse = { version = "0.95.0", path = "crates/oxc_traverse" } # AST traversal
+oxc = { version = "0.96.0", path = "crates/oxc" } # Main entry point
+oxc_allocator = { version = "0.96.0", path = "crates/oxc_allocator" } # Memory management
+oxc_ast = { version = "0.96.0", path = "crates/oxc_ast" } # AST definitions
+oxc_ast_macros = { version = "0.96.0", path = "crates/oxc_ast_macros" } # AST proc macros
+oxc_ast_visit = { version = "0.96.0", path = "crates/oxc_ast_visit" } # AST visitor pattern
+oxc_cfg = { version = "0.96.0", path = "crates/oxc_cfg" } # Control flow graph
+oxc_codegen = { version = "0.96.0", path = "crates/oxc_codegen" } # Code generation
+oxc_compat = { version = "0.96.0", path = "crates/oxc_compat" } # Browser compatibility
+oxc_data_structures = { version = "0.96.0", path = "crates/oxc_data_structures" } # Shared data structures
+oxc_diagnostics = { version = "0.96.0", path = "crates/oxc_diagnostics" } # Error reporting
+oxc_ecmascript = { version = "0.96.0", path = "crates/oxc_ecmascript" } # ECMAScript operations
+oxc_estree = { version = "0.96.0", path = "crates/oxc_estree" } # ESTree format
+oxc_isolated_declarations = { version = "0.96.0", path = "crates/oxc_isolated_declarations" } # TS declaration generation
+oxc_mangler = { version = "0.96.0", path = "crates/oxc_mangler" } # Name mangling
+oxc_minifier = { version = "0.96.0", path = "crates/oxc_minifier" } # Code minification
+oxc_minify_napi = { version = "0.96.0", path = "napi/minify" } # Node.js minifier binding
+oxc_napi = { version = "0.96.0", path = "crates/oxc_napi" } # NAPI utilities
+oxc_parser = { version = "0.96.0", path = "crates/oxc_parser", features = ["regular_expression"] } # JS/TS parser
+oxc_parser_napi = { version = "0.96.0", path = "napi/parser" } # Node.js parser binding
+oxc_regular_expression = { version = "0.96.0", path = "crates/oxc_regular_expression" } # Regex parser
+oxc_semantic = { version = "0.96.0", path = "crates/oxc_semantic" } # Semantic analysis
+oxc_span = { version = "0.96.0", path = "crates/oxc_span" } # Source positions
+oxc_syntax = { version = "0.96.0", path = "crates/oxc_syntax" } # Syntax utilities
+oxc_transform_napi = { version = "0.96.0", path = "napi/transform" } # Node.js transformer binding
+oxc_transformer = { version = "0.96.0", path = "crates/oxc_transformer" } # Code transformation
+oxc_transformer_plugins = { version = "0.96.0", path = "crates/oxc_transformer_plugins" } # Transformer plugins
+oxc_traverse = { version = "0.96.0", path = "crates/oxc_traverse" } # AST traversal
 
 # publish = false
 oxc_formatter = { path = "crates/oxc_formatter" } # Code formatting

--- a/crates/oxc/CHANGELOG.md
+++ b/crates/oxc/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.95.0] - 2025-10-15
 
 ### 🐛 Bug Fixes

--- a/crates/oxc/Cargo.toml
+++ b/crates/oxc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_allocator/CHANGELOG.md
+++ b/crates/oxc_allocator/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
+
 ## [0.94.0] - 2025-10-06
 
 ### 🚀 Features

--- a/crates/oxc_allocator/Cargo.toml
+++ b/crates/oxc_allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_allocator"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ast/CHANGELOG.md
+++ b/crates/oxc_ast/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.96.0] - 2025-10-30
+
+### 🚀 Features
+
+- b063e0e ast: Add `is_inside_comment` method (#14907) (camc314)
+- bec7a7d semantic: Add scope to `TSConstructorType` (#14676) (camc314)
+- f45d2f0 semantic: Add scope to `TSCallSignatureDeclaration` (#14672) (camc314)
+
+### 🐛 Bug Fixes
+
+- 47d8db1 linter/plugins: Prevent `comments` being accessed after file is linted (#14727) (overlookmotel)
+- be94bfd semantic: Add scope tracking for `with` statements (#14652) (Boshen)
+- 84b2605 linter/plugins: Remove `parent` property from comments (#14624) (overlookmotel)
+
+### 🚜 Refactor
+
+- 14de671 linter/plugins: Simplify `comments` getter (#14728) (overlookmotel)
+- 2b14abc napi/parser: Shorten raw transfer deserializer for `Comment` (#14623) (overlookmotel)
+
+### ⚡ Performance
+
+- 58ba6d6 linter/plugins: Lazy deserialize comments array (#14637) (Arsh)
+
+### 🎨 Styling
+
+- 3029dfb linter/plugins: Reorder code (#14725) (overlookmotel)
+
+
 ## [0.95.0] - 2025-10-15
 
 ### 🚀 Features

--- a/crates/oxc_ast/Cargo.toml
+++ b/crates/oxc_ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ast"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ast_macros/CHANGELOG.md
+++ b/crates/oxc_ast_macros/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.96.0] - 2025-10-30
+
+### 🚀 Features
+
+- bec7a7d semantic: Add scope to `TSConstructorType` (#14676) (camc314)
+
+
 
 
 

--- a/crates/oxc_ast_macros/Cargo.toml
+++ b/crates/oxc_ast_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ast_macros"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ast_visit/CHANGELOG.md
+++ b/crates/oxc_ast_visit/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.96.0] - 2025-10-30
+
+### 🚀 Features
+
+- bec7a7d semantic: Add scope to `TSConstructorType` (#14676) (camc314)
+- f45d2f0 semantic: Add scope to `TSCallSignatureDeclaration` (#14672) (camc314)
+
+### 🐛 Bug Fixes
+
+- be94bfd semantic: Add scope tracking for `with` statements (#14652) (Boshen)
+
+
 
 
 

--- a/crates/oxc_ast_visit/Cargo.toml
+++ b/crates/oxc_ast_visit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ast_visit"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_cfg/CHANGELOG.md
+++ b/crates/oxc_cfg/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.96.0] - 2025-10-30
+
+### 📚 Documentation
+
+- a1cda35 semantic/cfg: Add documentation for `EdgeType` (#14859) (camc314)
+
+
 
 ## [0.94.0] - 2025-10-06
 

--- a/crates/oxc_cfg/Cargo.toml
+++ b/crates/oxc_cfg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_cfg"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_codegen/CHANGELOG.md
+++ b/crates/oxc_codegen/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.96.0] - 2025-10-30
+
+### 🐛 Bug Fixes
+
+- 3fbb307 codegen: Avoid invalid sourcemap tokens for positions beyond source bounds (#15069) (copilot-swe-agent)
+- 4904710 codegen: Print legal comments above directives (#14993) (Boshen)
+
+
 ## [0.95.0] - 2025-10-15
 
 ### ⚡ Performance

--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_codegen"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_compat/CHANGELOG.md
+++ b/crates/oxc_compat/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.95.0] - 2025-10-15
 
 ### 🚀 Features

--- a/crates/oxc_compat/Cargo.toml
+++ b/crates/oxc_compat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_compat"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_data_structures/CHANGELOG.md
+++ b/crates/oxc_data_structures/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.93.0] - 2025-09-28
 
 ### 🚀 Features

--- a/crates/oxc_data_structures/Cargo.toml
+++ b/crates/oxc_data_structures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_data_structures"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_diagnostics/CHANGELOG.md
+++ b/crates/oxc_diagnostics/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.93.0] - 2025-09-28
 
 ### ⚡ Performance

--- a/crates/oxc_diagnostics/Cargo.toml
+++ b/crates/oxc_diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_diagnostics"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ecmascript/CHANGELOG.md
+++ b/crates/oxc_ecmascript/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.91.0] - 2025-09-22
 
 ### 💼 Other

--- a/crates/oxc_ecmascript/Cargo.toml
+++ b/crates/oxc_ecmascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ecmascript"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_estree/CHANGELOG.md
+++ b/crates/oxc_estree/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.91.0] - 2025-09-22
 
 ### 💼 Other

--- a/crates/oxc_estree/Cargo.toml
+++ b/crates/oxc_estree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_estree"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_isolated_declarations/CHANGELOG.md
+++ b/crates/oxc_isolated_declarations/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.91.0] - 2025-09-22
 
 ### 💼 Other

--- a/crates/oxc_isolated_declarations/Cargo.toml
+++ b/crates/oxc_isolated_declarations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_isolated_declarations"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_mangler/CHANGELOG.md
+++ b/crates/oxc_mangler/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.95.0] - 2025-10-15
 
 ### 🚀 Features

--- a/crates/oxc_mangler/Cargo.toml
+++ b/crates/oxc_mangler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_mangler"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_minifier/CHANGELOG.md
+++ b/crates/oxc_minifier/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.96.0] - 2025-10-30
+
+### 🚀 Features
+
+- c51c036 minifier: Handle direct eval calls (#15067) (sapphi-red)
+- d09c7ee minifier: Add `drop_labels` feature (#14634) (sapphi-red)
+
+
 ## [0.95.0] - 2025-10-15
 
 ### 🚀 Features

--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_minifier"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_napi/CHANGELOG.md
+++ b/crates/oxc_napi/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.91.0] - 2025-09-22
 
 ### 💼 Other

--- a/crates/oxc_napi/Cargo.toml
+++ b/crates/oxc_napi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_napi"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_parser/CHANGELOG.md
+++ b/crates/oxc_parser/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.96.0] - 2025-10-30
+
+### 🐛 Bug Fixes
+
+- 384ea3c parser: Report err on missing function body in expression (#14946) (camc314)
+
+
 ## [0.95.0] - 2025-10-15
 
 ### 🚜 Refactor

--- a/crates/oxc_parser/Cargo.toml
+++ b/crates/oxc_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_parser"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_regular_expression/CHANGELOG.md
+++ b/crates/oxc_regular_expression/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.96.0] - 2025-10-30
+
+### 🚜 Refactor
+
+- 561b743 regular_expression: Improve initizalizing state (#15045) (leaysgur)
+
+
 
 
 

--- a/crates/oxc_regular_expression/Cargo.toml
+++ b/crates/oxc_regular_expression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_regular_expression"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_semantic/CHANGELOG.md
+++ b/crates/oxc_semantic/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.96.0] - 2025-10-30
+
+### 🚀 Features
+
+- 1611b4f semantic: Add `is_inside_comment` method (#14908) (camc314)
+- ae2003c semantic: Add `symbol_id` to ts function type binding idents (#14673) (camc314)
+- bec7a7d semantic: Add scope to `TSConstructorType` (#14676) (camc314)
+- f45d2f0 semantic: Add scope to `TSCallSignatureDeclaration` (#14672) (camc314)
+
+### 🐛 Bug Fixes
+
+- 7e888d2 cfg: Append switch case condition to correct block (#14810) (camc314)
+- aec04f2 semantic/cfg: Update example docs + code (#14809) (camc314)
+- cdf2d07 semantic: Add condition basic blocks to CFG for logical expressions (#14671) (camc314)
+- be94bfd semantic: Add scope tracking for `with` statements (#14652) (Boshen)
+
+### 🚜 Refactor
+
+- 109f452 semantic: Eliminate manual current_node_ix manipulation in try statements (#14858) (camc314)
+
+
 ## [0.95.0] - 2025-10-15
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_semantic"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_span/CHANGELOG.md
+++ b/crates/oxc_span/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.91.0] - 2025-09-22
 
 ### 💼 Other

--- a/crates/oxc_span/Cargo.toml
+++ b/crates/oxc_span/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_span"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_syntax/CHANGELOG.md
+++ b/crates/oxc_syntax/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
+
 ## [0.94.0] - 2025-10-06
 
 ### 🚀 Features

--- a/crates/oxc_syntax/Cargo.toml
+++ b/crates/oxc_syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_syntax"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_transformer/CHANGELOG.md
+++ b/crates/oxc_transformer/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.96.0] - 2025-10-30
+
+### 🐛 Bug Fixes
+
+- 2bc1978 transformer/legacy-decorator: Correct generating metadata for getter/setter methods (#14495) (Dunqing)
+
+
 ## [0.95.0] - 2025-10-15
 
 ### 🚀 Features

--- a/crates/oxc_transformer/Cargo.toml
+++ b/crates/oxc_transformer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_transformer"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_transformer_plugins/CHANGELOG.md
+++ b/crates/oxc_transformer_plugins/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+
 ## [0.95.0] - 2025-10-15
 
 ### 🚀 Features

--- a/crates/oxc_transformer_plugins/Cargo.toml
+++ b/crates/oxc_transformer_plugins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_transformer_plugins"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_traverse/CHANGELOG.md
+++ b/crates/oxc_traverse/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.96.0] - 2025-10-30
+
+### 🚀 Features
+
+- bec7a7d semantic: Add scope to `TSConstructorType` (#14676) (camc314)
+- f45d2f0 semantic: Add scope to `TSCallSignatureDeclaration` (#14672) (camc314)
+
+### 🐛 Bug Fixes
+
+- be94bfd semantic: Add scope tracking for `with` statements (#14652) (Boshen)
+
+
 ## [0.95.0] - 2025-10-15
 
 ### 🚀 Features

--- a/crates/oxc_traverse/Cargo.toml
+++ b/crates/oxc_traverse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_traverse"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/minify/CHANGELOG.md
+++ b/napi/minify/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.96.0] - 2025-10-30
+
+### 🚀 Features
+
+- 9e36186 napi/minify: Expose `drop_labels` option (#14635) (sapphi-red)
+- d09c7ee minifier: Add `drop_labels` feature (#14634) (sapphi-red)
+
+
 ## [0.95.0] - 2025-10-15
 
 ### 🚀 Features

--- a/napi/minify/Cargo.toml
+++ b/napi/minify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_minify_napi"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/minify/index.js
+++ b/napi/minify/index.js
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-android-arm64')
         const bindingPackageVersion = require('@oxc-minify/binding-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-android-arm-eabi')
         const bindingPackageVersion = require('@oxc-minify/binding-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -118,8 +118,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-win32-x64-gnu')
         const bindingPackageVersion = require('@oxc-minify/binding-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -134,8 +134,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-win32-x64-msvc')
         const bindingPackageVersion = require('@oxc-minify/binding-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -151,8 +151,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-win32-ia32-msvc')
         const bindingPackageVersion = require('@oxc-minify/binding-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -167,8 +167,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-win32-arm64-msvc')
         const bindingPackageVersion = require('@oxc-minify/binding-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -186,8 +186,8 @@ function requireNative() {
     try {
       const binding = require('@oxc-minify/binding-darwin-universal')
       const bindingPackageVersion = require('@oxc-minify/binding-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -202,8 +202,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-darwin-x64')
         const bindingPackageVersion = require('@oxc-minify/binding-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -218,8 +218,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-darwin-arm64')
         const bindingPackageVersion = require('@oxc-minify/binding-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -238,8 +238,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-freebsd-x64')
         const bindingPackageVersion = require('@oxc-minify/binding-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -254,8 +254,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-freebsd-arm64')
         const bindingPackageVersion = require('@oxc-minify/binding-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -275,8 +275,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-x64-musl')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-x64-gnu')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -309,8 +309,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-arm64-musl')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-arm64-gnu')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -343,8 +343,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-arm-musleabihf')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -377,8 +377,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-loong64-musl')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-loong64-gnu')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -411,8 +411,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-riscv64-musl')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -427,8 +427,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-riscv64-gnu')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -444,8 +444,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-linux-ppc64-gnu')
         const bindingPackageVersion = require('@oxc-minify/binding-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -460,8 +460,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-linux-s390x-gnu')
         const bindingPackageVersion = require('@oxc-minify/binding-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -480,8 +480,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-openharmony-arm64')
         const bindingPackageVersion = require('@oxc-minify/binding-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -496,8 +496,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-openharmony-x64')
         const bindingPackageVersion = require('@oxc-minify/binding-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -512,8 +512,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-openharmony-arm')
         const bindingPackageVersion = require('@oxc-minify/binding-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/napi/minify/package.json
+++ b/napi/minify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-minify",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "type": "module",
   "main": "index.js",
   "browser": "browser.js",

--- a/napi/parser/CHANGELOG.md
+++ b/napi/parser/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.96.0] - 2025-10-30
+
+### 🚀 Features
+
+- bec7a7d semantic: Add scope to `TSConstructorType` (#14676) (camc314)
+
+### 🐛 Bug Fixes
+
+- 597340e ast-tools: Use oxfmt to format generated code (#15064) (camc314)
+- 84b2605 linter/plugins: Remove `parent` property from comments (#14624) (overlookmotel)
+
+### 🚜 Refactor
+
+- 14de671 linter/plugins: Simplify `comments` getter (#14728) (overlookmotel)
+- 85a2743 linter/plugins, napi/parser: Remove extraneous code from raw transfer deserializers (#14683) (overlookmotel)
+- 2b14abc napi/parser: Shorten raw transfer deserializer for `Comment` (#14623) (overlookmotel)
+
+
 ## [0.95.0] - 2025-10-15
 
 ### 🚀 Features

--- a/napi/parser/Cargo.toml
+++ b/napi/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_parser_napi"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-parser",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "type": "module",
   "main": "src-js/index.js",
   "browser": "src-js/wasm.js",

--- a/napi/parser/src-js/bindings.js
+++ b/napi/parser/src-js/bindings.js
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-android-arm64')
         const bindingPackageVersion = require('@oxc-parser/binding-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-android-arm-eabi')
         const bindingPackageVersion = require('@oxc-parser/binding-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -118,8 +118,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-win32-x64-gnu')
         const bindingPackageVersion = require('@oxc-parser/binding-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -134,8 +134,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-win32-x64-msvc')
         const bindingPackageVersion = require('@oxc-parser/binding-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -151,8 +151,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-win32-ia32-msvc')
         const bindingPackageVersion = require('@oxc-parser/binding-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -167,8 +167,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-win32-arm64-msvc')
         const bindingPackageVersion = require('@oxc-parser/binding-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -186,8 +186,8 @@ function requireNative() {
     try {
       const binding = require('@oxc-parser/binding-darwin-universal')
       const bindingPackageVersion = require('@oxc-parser/binding-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -202,8 +202,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-darwin-x64')
         const bindingPackageVersion = require('@oxc-parser/binding-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -218,8 +218,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-darwin-arm64')
         const bindingPackageVersion = require('@oxc-parser/binding-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -238,8 +238,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-freebsd-x64')
         const bindingPackageVersion = require('@oxc-parser/binding-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -254,8 +254,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-freebsd-arm64')
         const bindingPackageVersion = require('@oxc-parser/binding-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -275,8 +275,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-x64-musl')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-x64-gnu')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -309,8 +309,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-arm64-musl')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-arm64-gnu')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -343,8 +343,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-arm-musleabihf')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -377,8 +377,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-loong64-musl')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-loong64-gnu')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -411,8 +411,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-riscv64-musl')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -427,8 +427,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-riscv64-gnu')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -444,8 +444,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-linux-ppc64-gnu')
         const bindingPackageVersion = require('@oxc-parser/binding-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -460,8 +460,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-linux-s390x-gnu')
         const bindingPackageVersion = require('@oxc-parser/binding-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -480,8 +480,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-openharmony-arm64')
         const bindingPackageVersion = require('@oxc-parser/binding-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -496,8 +496,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-openharmony-x64')
         const bindingPackageVersion = require('@oxc-parser/binding-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -512,8 +512,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-openharmony-arm')
         const bindingPackageVersion = require('@oxc-parser/binding-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/napi/transform/CHANGELOG.md
+++ b/napi/transform/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
+
 ## [0.94.0] - 2025-10-06
 
 ### 🚀 Features

--- a/napi/transform/Cargo.toml
+++ b/napi/transform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_transform_napi"
-version = "0.95.0"
+version = "0.96.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/transform/index.js
+++ b/napi/transform/index.js
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-android-arm64')
         const bindingPackageVersion = require('@oxc-transform/binding-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-android-arm-eabi')
         const bindingPackageVersion = require('@oxc-transform/binding-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -118,8 +118,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-win32-x64-gnu')
         const bindingPackageVersion = require('@oxc-transform/binding-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -134,8 +134,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-win32-x64-msvc')
         const bindingPackageVersion = require('@oxc-transform/binding-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -151,8 +151,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-win32-ia32-msvc')
         const bindingPackageVersion = require('@oxc-transform/binding-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -167,8 +167,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-win32-arm64-msvc')
         const bindingPackageVersion = require('@oxc-transform/binding-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -186,8 +186,8 @@ function requireNative() {
     try {
       const binding = require('@oxc-transform/binding-darwin-universal')
       const bindingPackageVersion = require('@oxc-transform/binding-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -202,8 +202,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-darwin-x64')
         const bindingPackageVersion = require('@oxc-transform/binding-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -218,8 +218,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-darwin-arm64')
         const bindingPackageVersion = require('@oxc-transform/binding-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -238,8 +238,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-freebsd-x64')
         const bindingPackageVersion = require('@oxc-transform/binding-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -254,8 +254,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-freebsd-arm64')
         const bindingPackageVersion = require('@oxc-transform/binding-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -275,8 +275,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-x64-musl')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-x64-gnu')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -309,8 +309,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-arm64-musl')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-arm64-gnu')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -343,8 +343,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-arm-musleabihf')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -377,8 +377,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-loong64-musl')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-loong64-gnu')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -411,8 +411,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-riscv64-musl')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -427,8 +427,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-riscv64-gnu')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -444,8 +444,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-linux-ppc64-gnu')
         const bindingPackageVersion = require('@oxc-transform/binding-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -460,8 +460,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-linux-s390x-gnu')
         const bindingPackageVersion = require('@oxc-transform/binding-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -480,8 +480,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-openharmony-arm64')
         const bindingPackageVersion = require('@oxc-transform/binding-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -496,8 +496,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-openharmony-x64')
         const bindingPackageVersion = require('@oxc-transform/binding-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -512,8 +512,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-openharmony-arm')
         const bindingPackageVersion = require('@oxc-transform/binding-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.95.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.95.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/napi/transform/package.json
+++ b/napi/transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-transform",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "type": "module",
   "main": "index.js",
   "browser": "browser.js",

--- a/npm/oxc-types/CHANGELOG.md
+++ b/npm/oxc-types/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.96.0] - 2025-10-30
+
+### 🐛 Bug Fixes
+
+- 597340e ast-tools: Use oxfmt to format generated code (#15064) (camc314)
+
+
 
 ## [0.94.0] - 2025-10-06
 

--- a/npm/oxc-types/package.json
+++ b/npm/oxc-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxc-project/types",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "description": "Types for Oxc AST nodes",
   "type": "module",
   "keywords": [

--- a/npm/runtime/CHANGELOG.md
+++ b/npm/runtime/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 
 
+
 ## [0.91.0] - 2025-09-22
 
 ### 🚀 Features

--- a/npm/runtime/package.json
+++ b/npm/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxc-project/runtime",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "description": "Oxc's modular runtime helpers",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## [0.96.0] - 2025-10-30

### 🚀 Features

- c51c036 minifier: Handle direct eval calls (#15067) (sapphi-red)
- 1611b4f semantic: Add `is_inside_comment` method (#14908) (camc314)
- b063e0e ast: Add `is_inside_comment` method (#14907) (camc314)
- ae2003c semantic: Add `symbol_id` to ts function type binding idents (#14673) (camc314)
- bec7a7d semantic: Add scope to `TSConstructorType` (#14676) (camc314)
- f45d2f0 semantic: Add scope to `TSCallSignatureDeclaration` (#14672) (camc314)
- 9e36186 napi/minify: Expose `drop_labels` option (#14635) (sapphi-red)
- d09c7ee minifier: Add `drop_labels` feature (#14634) (sapphi-red)

### 🐛 Bug Fixes

- 3fbb307 codegen: Avoid invalid sourcemap tokens for positions beyond source bounds (#15069) (copilot-swe-agent)
- 597340e ast-tools: Use oxfmt to format generated code (#15064) (camc314)
- 4904710 codegen: Print legal comments above directives (#14993) (Boshen)
- 384ea3c parser: Report err on missing function body in expression (#14946) (camc314)
- 2bc1978 transformer/legacy-decorator: Correct generating metadata for getter/setter methods (#14495) (Dunqing)
- 7e888d2 cfg: Append switch case condition to correct block (#14810) (camc314)
- aec04f2 semantic/cfg: Update example docs + code (#14809) (camc314)
- 47d8db1 linter/plugins: Prevent `comments` being accessed after file is linted (#14727) (overlookmotel)
- cdf2d07 semantic: Add condition basic blocks to CFG for logical expressions (#14671) (camc314)
- be94bfd semantic: Add scope tracking for `with` statements (#14652) (Boshen)
- 84b2605 linter/plugins: Remove `parent` property from comments (#14624) (overlookmotel)

### 🚜 Refactor

- 561b743 regular_expression: Improve initizalizing state (#15045) (leaysgur)
- 109f452 semantic: Eliminate manual current_node_ix manipulation in try statements (#14858) (camc314)
- 14de671 linter/plugins: Simplify `comments` getter (#14728) (overlookmotel)
- 85a2743 linter/plugins, napi/parser: Remove extraneous code from raw transfer deserializers (#14683) (overlookmotel)
- 2b14abc napi/parser: Shorten raw transfer deserializer for `Comment` (#14623) (overlookmotel)

### 📚 Documentation

- a1cda35 semantic/cfg: Add documentation for `EdgeType` (#14859) (camc314)

### ⚡ Performance

- 58ba6d6 linter/plugins: Lazy deserialize comments array (#14637) (Arsh)

### 🎨 Styling

- 3029dfb linter/plugins: Reorder code (#14725) (overlookmotel)