### PR TITLE
feat(oxlint): add maxWarnings config option

### DIFF
--- a/apps/oxlint/fixtures/max_warnings_config/.oxlintrc.json
+++ b/apps/oxlint/fixtures/max_warnings_config/.oxlintrc.json
@@ -1,0 +1,7 @@
+{
+  "maxWarnings": 0,
+  "rules": {
+    "no-debugger": "warn",
+    "no-console": "warn"
+  }
+}

--- a/apps/oxlint/fixtures/max_warnings_config/many-warnings.js
+++ b/apps/oxlint/fixtures/max_warnings_config/many-warnings.js
@@ -1,0 +1,7 @@
+// This file has 6 warnings
+debugger;
+console.log("1");
+debugger;
+console.log("2");
+debugger;
+console.log("3");

--- a/apps/oxlint/fixtures/max_warnings_config/oxlintrc-5-warnings.json
+++ b/apps/oxlint/fixtures/max_warnings_config/oxlintrc-5-warnings.json
@@ -1,0 +1,7 @@
+{
+  "maxWarnings": 5,
+  "rules": {
+    "no-debugger": "warn",
+    "no-console": "warn"
+  }
+}

--- a/apps/oxlint/fixtures/max_warnings_config/test.js
+++ b/apps/oxlint/fixtures/max_warnings_config/test.js
@@ -1,0 +1,3 @@
+// This file has 2 warnings
+debugger;
+console.log("test");

--- a/apps/oxlint/fixtures/max_warnings_nested_error/.oxlintrc.json
+++ b/apps/oxlint/fixtures/max_warnings_nested_error/.oxlintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-debugger": "warn"
+  }
+}

--- a/apps/oxlint/fixtures/max_warnings_nested_error/subdir/.oxlintrc.json
+++ b/apps/oxlint/fixtures/max_warnings_nested_error/subdir/.oxlintrc.json
@@ -1,0 +1,6 @@
+{
+  "maxWarnings": 5,
+  "rules": {
+    "no-console": "warn"
+  }
+}

--- a/apps/oxlint/fixtures/max_warnings_nested_error/subdir/test.js
+++ b/apps/oxlint/fixtures/max_warnings_nested_error/subdir/test.js
@@ -1,0 +1,1 @@
+console.log("test");

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -428,7 +428,7 @@ impl CliRunner {
     ) -> (DiagnosticService, DiagnosticSender) {
         // CLI flag takes precedence over config file
         let max_warnings = warning_options.max_warnings.or(config_max_warnings);
-        
+
         let (service, sender) = DiagnosticService::new(reporter.get_diagnostic_reporter());
         (
             service
@@ -538,7 +538,7 @@ impl CliRunner {
                 );
                 return Err(CliRunResult::InvalidOptionConfig);
             }
-            
+
             // Collect ignore patterns and their root
             nested_ignore_patterns.push((
                 oxlintrc.ignore_patterns.clone(),

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1350,4 +1350,41 @@ mod test {
         let args = &["--type-aware"];
         Tester::new().with_cwd("fixtures/tsgolint_config_error".into()).test_and_snapshot(args);
     }
+
+    #[test]
+    fn test_max_warnings_config_zero() {
+        // maxWarnings: 0 should fail when there are warnings
+        let args = &["-c", ".oxlintrc.json", "test.js"];
+        Tester::new().with_cwd("fixtures/max_warnings_config".into()).test_and_snapshot(args);
+    }
+
+    #[test]
+    fn test_max_warnings_config_threshold_exceeded() {
+        // maxWarnings: 5 should fail when there are 6 warnings
+        let args = &["-c", "oxlintrc-5-warnings.json", "many-warnings.js"];
+        Tester::new().with_cwd("fixtures/max_warnings_config".into()).test_and_snapshot(args);
+    }
+
+    #[test]
+    fn test_max_warnings_config_threshold_not_exceeded() {
+        // maxWarnings: 5 should pass when there are 2 warnings
+        let args = &["-c", "oxlintrc-5-warnings.json", "test.js"];
+        Tester::new().with_cwd("fixtures/max_warnings_config".into()).test_and_snapshot(args);
+    }
+
+    #[test]
+    fn test_max_warnings_cli_override() {
+        // CLI --max-warnings should override config file
+        let args = &["-c", ".oxlintrc.json", "--max-warnings", "10", "test.js"];
+        Tester::new().with_cwd("fixtures/max_warnings_config".into()).test_and_snapshot(args);
+    }
+
+    #[test]
+    fn test_max_warnings_nested_config_error() {
+        // maxWarnings in nested config should produce an error
+        let args = &["subdir/test.js"];
+        Tester::new()
+            .with_cwd("fixtures/max_warnings_nested_error".into())
+            .test_and_snapshot(args);
+    }
 }

--- a/apps/oxlint/src/snapshots/fixtures__max_warnings_config_-c .oxlintrc.json --max-warnings 10 test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__max_warnings_config_-c .oxlintrc.json --max-warnings 10 test.js@oxlint.snap
@@ -1,0 +1,30 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: -c .oxlintrc.json --max-warnings 10 test.js
+working directory: fixtures/max_warnings_config
+----------
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[test.js:2:1]
+ 1 | // This file has 2 warnings
+ 2 | debugger;
+   : ^^^^^^^^^
+ 3 | console.log("test");
+   `----
+  help: Remove the debugger statement
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: Unexpected console statement.
+   ,-[test.js:3:1]
+ 2 | debugger;
+ 3 | console.log("test");
+   : ^^^^^^^^^^^
+   `----
+  help: Delete this console statement.
+
+Found 2 warnings and 0 errors.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__max_warnings_config_-c .oxlintrc.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__max_warnings_config_-c .oxlintrc.json test.js@oxlint.snap
@@ -1,0 +1,31 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: -c .oxlintrc.json test.js
+working directory: fixtures/max_warnings_config
+----------
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[test.js:2:1]
+ 1 | // This file has 2 warnings
+ 2 | debugger;
+   : ^^^^^^^^^
+ 3 | console.log("test");
+   `----
+  help: Remove the debugger statement
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: Unexpected console statement.
+   ,-[test.js:3:1]
+ 2 | debugger;
+ 3 | console.log("test");
+   : ^^^^^^^^^^^
+   `----
+  help: Delete this console statement.
+
+Found 2 warnings and 0 errors.
+Exceeded maximum number of warnings. Found 2.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+----------
+CLI result: LintMaxWarningsExceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__max_warnings_config_-c oxlintrc-5-warnings.json many-warnings.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__max_warnings_config_-c oxlintrc-5-warnings.json many-warnings.js@oxlint.snap
@@ -1,0 +1,67 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: -c oxlintrc-5-warnings.json many-warnings.js
+working directory: fixtures/max_warnings_config
+----------
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[many-warnings.js:2:1]
+ 1 | // This file has 6 warnings
+ 2 | debugger;
+   : ^^^^^^^^^
+ 3 | console.log("1");
+   `----
+  help: Remove the debugger statement
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: Unexpected console statement.
+   ,-[many-warnings.js:3:1]
+ 2 | debugger;
+ 3 | console.log("1");
+   : ^^^^^^^^^^^
+ 4 | debugger;
+   `----
+  help: Delete this console statement.
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[many-warnings.js:4:1]
+ 3 | console.log("1");
+ 4 | debugger;
+   : ^^^^^^^^^
+ 5 | console.log("2");
+   `----
+  help: Remove the debugger statement
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: Unexpected console statement.
+   ,-[many-warnings.js:5:1]
+ 4 | debugger;
+ 5 | console.log("2");
+   : ^^^^^^^^^^^
+ 6 | debugger;
+   `----
+  help: Delete this console statement.
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[many-warnings.js:6:1]
+ 5 | console.log("2");
+ 6 | debugger;
+   : ^^^^^^^^^
+ 7 | console.log("3");
+   `----
+  help: Remove the debugger statement
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: Unexpected console statement.
+   ,-[many-warnings.js:7:1]
+ 6 | debugger;
+ 7 | console.log("3");
+   : ^^^^^^^^^^^
+   `----
+  help: Delete this console statement.
+
+Found 6 warnings and 0 errors.
+Exceeded maximum number of warnings. Found 6.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+----------
+CLI result: LintMaxWarningsExceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__max_warnings_config_-c oxlintrc-5-warnings.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__max_warnings_config_-c oxlintrc-5-warnings.json test.js@oxlint.snap
@@ -1,0 +1,30 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: -c oxlintrc-5-warnings.json test.js
+working directory: fixtures/max_warnings_config
+----------
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[test.js:2:1]
+ 1 | // This file has 2 warnings
+ 2 | debugger;
+   : ^^^^^^^^^
+ 3 | console.log("test");
+   `----
+  help: Remove the debugger statement
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: Unexpected console statement.
+   ,-[test.js:3:1]
+ 2 | debugger;
+ 3 | console.log("test");
+   : ^^^^^^^^^^^
+   `----
+  help: Delete this console statement.
+
+Found 2 warnings and 0 errors.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__max_warnings_nested_error_subdir__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__max_warnings_nested_error_subdir__test.js@oxlint.snap
@@ -1,0 +1,12 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: subdir/test.js
+working directory: fixtures/max_warnings_nested_error
+----------
+Error: 'maxWarnings' option is only valid in the root configuration file.
+Found in nested config: <cwd>/fixtures/max_warnings_nested_error/subdir/.oxlintrc.json
+----------
+CLI result: InvalidOptionConfig
+----------


### PR DESCRIPTION
## Summary

This PR adds support for the `maxWarnings` configuration option in `.oxlintrc.json` files, allowing users to specify a warning threshold that will cause the linter to exit with a non-zero code.

## Changes

- Added `max_warnings` field to `Oxlintrc` struct in `crates/oxc_linter/src/config/oxlintrc.rs`
- Wired `max_warnings` through the config system to `DiagnosticService`
- CLI `--max-warnings` flag takes precedence over config file value
- Added validation to prevent `maxWarnings` in nested config files (raises error as specified)
- Added unit tests for parsing and merging behavior

## Example Usage

```json
{
  "maxWarnings": 0
}
```

## Testing

- ✅ All new unit tests pass
- ✅ Existing tests pass (except unrelated tsgolint tests)
- ✅ Config parsing works correctly
- ✅ Merge behavior works as expected
- ✅ Nested config validation works

Closes #15020