### PR TITLE
docs(linter): Add configuration option docs for unicorn/prefer-number-properties rule.

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
@@ -5,6 +5,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
 use serde_json::Value;
 
 use crate::{
@@ -28,11 +29,12 @@ impl std::ops::Deref for PreferNumberProperties {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct PreferNumberPropertiesConfig {
-    // default is true
+    /// If set to `true`, checks for usage of `Infinity` and `-Infinity` as global variables.
     check_infinity: bool,
-    // default is true
+    /// If set to `true`, checks for usage of `NaN` as a global variable.
     check_nan: bool,
 }
 
@@ -75,7 +77,8 @@ declare_oxc_lint!(
     PreferNumberProperties,
     unicorn,
     restriction,
-    dangerous_fix
+    dangerous_fix,
+    config = PreferNumberPropertiesConfig,
 );
 
 impl Rule for PreferNumberProperties {


### PR DESCRIPTION
Part of #14743.

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### checkInfinity

type: `boolean`

default: `false`

If set to `true`, checks for usage of `Infinity` and `-Infinity` as global variables.


### checkNan

type: `boolean`

default: `true`

If set to `true`, checks for usage of `NaN` as a global variable.
```