### PR TITLE
docs(linter): Add configuration option docs for react/check-requires-onchange-or-readonly rule.

### DIFF
--- a/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
+++ b/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
@@ -5,6 +5,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
+use schemars::JsonSchema;
 
 use crate::{
     AstNode,
@@ -25,9 +26,12 @@ fn exclusive_checked_attribute(checked_span: Span, default_checked_span: Span) -
         .with_labels([checked_span, default_checked_span])
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct CheckedRequiresOnchangeOrReadonly {
+    /// Ignore the requirement to provide either `onChange` or `readOnly` when the `checked` prop is present.
     ignore_missing_properties: bool,
+    /// Ignore the restriction that `checked` and `defaultChecked` should not be used together.
     ignore_exclusive_checked_attribute: bool,
 }
 
@@ -64,7 +68,8 @@ declare_oxc_lint!(
     /// ```
     CheckedRequiresOnchangeOrReadonly,
     react,
-    pedantic
+    pedantic,
+    config = CheckedRequiresOnchangeOrReadonly,
 );
 
 impl Rule for CheckedRequiresOnchangeOrReadonly {


### PR DESCRIPTION


Part of #14743.

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### ignoreExclusiveCheckedAttribute

type: `boolean`

default: `false`

Ignore the restriction that `checked` and `defaultChecked` should not be used together.


### ignoreMissingProperties

type: `boolean`

default: `false`

Ignore the requirement to provide either `onChange` or `readOnly` when the `checked` prop is present.
```