### PR TITLE
test(editor): wait longer for "detects diagnostics on run" fixture

### DIFF
--- a/editors/vscode/tests/e2e_server.spec.ts
+++ b/editors/vscode/tests/e2e_server.spec.ts
@@ -74,7 +74,7 @@ suite('E2E Diagnostics', () => {
   testSingleFolderMode('detects diagnostics on run', async () =>
   {
     await loadFixture('lint_on_run');
-    await sleep(250);
+    await sleep(500);
     const diagnostics = await getDiagnosticsWithoutClose(`onType.ts`);
     strictEqual(diagnostics.length, 0);
 
@@ -274,7 +274,7 @@ suite('E2E Diagnostics', () => {
     await waitForDiagnosticChange();
 
     const secondDiagnostics = await getDiagnostics('index.ts');
-    assert(secondDiagnostics.length != 0);
+    strictEqual(secondDiagnostics.length, 1);
   });
 
   test('formats code with `oxc.fmt.experimental`', async () => {


### PR DESCRIPTION
Another task is flaky `changing oxc.typeAware will revalidate the tsgolint diagnostics `, but not sure if this is related with https://github.com/oxc-project/tsgolint/issues/349 