### PR TITLE
[DRAFT] Example docs auto-generation problem for Regex in config structs.

### DIFF
--- a/crates/oxc_linter/src/rules/promise/param_names.rs
+++ b/crates/oxc_linter/src/rules/promise/param_names.rs
@@ -6,6 +6,8 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -19,9 +21,14 @@ fn param_names_diagnostic(span: Span, pattern: &str) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct ParamNames(Box<ParamNamesConfig>);
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Deserialize, Clone, Serialize, JsonSchema, Default)]
+#[serde(rename_all = "camelCase", default)]
 pub struct ParamNamesConfig {
+    /// Regex pattern used to validate the `resolve` parameter name. If provided, this pattern
+    /// is used instead of the default `^_?resolve$` check.
     resolve_pattern: Option<Regex>,
+    /// Regex pattern used to validate the `reject` parameter name. If provided, this pattern
+    /// is used instead of the default `^_?reject$` check.
     reject_pattern: Option<Regex>,
 }
 
@@ -65,6 +72,7 @@ declare_oxc_lint!(
     ParamNames,
     promise,
     style,
+    config = ParamNamesConfig,
 );
 
 impl Rule for ParamNames {


### PR DESCRIPTION
This has compile errors, unfortunately.

<img width="752" height="338" alt="Screenshot 2025-10-30 at 1 31 35 PM" src="https://github.com/user-attachments/assets/4f099cd4-5da6-4758-a4e7-5ab30e07fbf2" />

I can get around this problem somewhat by using `#[schemars(with = "Option<String>")]`, but it requires that I remove the Serialize/Deserialize derivations, which results in losing the ability to get the `default` value automatically:

```rs
#[derive(Debug, Clone, JsonSchema, Default)]
#[serde(rename_all = "camelCase", default)]
pub struct ParamNamesConfig {
    /// Regex pattern used to validate the `resolve` parameter name. If provided, this pattern
    /// is used instead of the default `^_?resolve$` check.
    #[schemars(with = "Option<String>")]
    resolve_pattern: Option<Regex>,
    /// Regex pattern used to validate the `reject` parameter name. If provided, this pattern
    /// is used instead of the default `^_?reject$` check.
    #[schemars(with = "Option<String>")]
    reject_pattern: Option<Regex>,
}
```

Generated docs for the above:

```
## Configuration

This rule accepts a configuration object with the following properties:

### rejectPattern

type: `[
  string,
  null
]`


Regex pattern used to validate the `reject` parameter name. If provided, this pattern
is used instead of the default `^_?reject$` check.


### resolvePattern

type: `[
  string,
  null
]`


Regex pattern used to validate the `resolve` parameter name. If provided, this pattern
is used instead of the default `^_?resolve$` check.
```

Is there a good way to resolve this? Should I create a separate config struct for representing the json schema that explicitly uses `Option<String>`, or is there a way to fix the lazy regex class to serialize properly?