### PR TITLE
docs(linter): Add configuration option docs for import/no-namespace rule.

### DIFF
--- a/crates/oxc_linter/src/rules/import/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/import/no_namespace.rs
@@ -3,6 +3,7 @@ use fast_glob::glob_match;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, Span};
+use schemars::JsonSchema;
 
 use crate::{context::LintContext, module_record::ImportImportName, rule::Rule};
 
@@ -15,8 +16,11 @@ fn no_namespace_diagnostic(span: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct NoNamespace(Box<NoNamespaceConfig>);
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct NoNamespaceConfig {
+    /// An array of glob strings for modules that should be ignored by the rule.
+    /// For example, `["*.json"]` will ignore all JSON imports.
     ignore: Vec<CompactStr>,
 }
 
@@ -49,16 +53,6 @@ declare_oxc_lint!(
     /// * **Explicit Imports**: Modern JavaScript practices encourage explicit imports for specific components. This enhances code readability and maintainability.
     /// * **Tree-Shaking**: Tools like Webpack and Rollup use tree-shaking to remove unused code from your bundles. Namespaced imports can prevent efficient tree-shaking, leading to larger bundle sizes.
     ///
-    /// ### Options
-    ///
-    /// `ignore` : array of glob strings for modules that should be ignored by the rule.
-    ///
-    /// ```json
-    /// {
-    ///     "ignore": ["*.json"]
-    /// }
-    /// ```
-    ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
@@ -78,7 +72,8 @@ declare_oxc_lint!(
     NoNamespace,
     import,
     style,
-    pending  // TODO: fixer
+    pending,  // TODO: fixer
+    config = NoNamespaceConfig,
 );
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-namespace.md>


### PR DESCRIPTION
Part of #14743.

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### ignore

type: `string[]`

default: `[]`

An array of glob strings for modules that should be ignored by the rule.
For example, `["*.json"]` will ignore all JSON imports.
```