### PR TITLE
docs(linter): Add configuration option docs for 6 rules

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/max_lines_per_function.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_lines_per_function.rs
@@ -5,6 +5,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::Semantic;
 use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
 use serde_json::Value;
 
 use crate::{
@@ -28,11 +29,18 @@ fn max_lines_per_function_diagnostic(
     .with_label(span)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct MaxLinesPerFunctionConfig {
+    /// Maximum number of lines allowed in a function.
     max: usize,
+    /// Skip lines containing just comments.
     skip_comments: bool,
+    /// Skip lines made up purely of whitespace.
     skip_blank_lines: bool,
+    /// The `IIFEs` option controls whether IIFEs are included in the line count.
+    /// By default, IIFEs are not considered, but when set to `true`, they will
+    /// be included in the line count for the function.
     iifes: bool,
 }
 
@@ -105,50 +113,10 @@ declare_oxc_lint!(
     ///     const x = 0;
     /// }
     /// ```
-    ///
-    /// ### Options
-    ///
-    /// #### max
-    ///
-    /// { type: number, default: 50 }
-    ///
-    /// The `max` enforces a maximum number of lines in a function.
-    ///
-    /// #### skipBlankLines
-    ///
-    /// { type: boolean, default: false }
-    ///
-    /// The `skipBlankLines` ignore lines made up purely of whitespace.
-    ///
-    /// #### skipComments
-    ///
-    /// { type: boolean, default: false }
-    ///
-    /// The `skipComments` ignore lines containing just comments.
-    ///
-    /// #### IIFEs
-    ///
-    /// { type: boolean, default: false }
-    ///
-    /// The `IIFEs` option controls whether IIFEs are included in the line count.
-    /// By default, IIFEs are not considered, but when set to `true`, they will
-    /// be included in the line count for the function.
-    ///
-    /// Example:
-    /// ```json
-    /// "eslint/max-lines-per-function": [
-    ///   "error",
-    ///   {
-    ///     "max": 50,
-    ///     "skipBlankLines": false,
-    ///     "skipComments": false,
-    ///     "IIFEs": false
-    ///   }
-    /// ]
-    /// ```
     MaxLinesPerFunction,
     eslint,
-    pedantic
+    pedantic,
+    config = MaxLinesPerFunctionConfig,
 );
 
 impl Rule for MaxLinesPerFunction {

--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -2,6 +2,7 @@ use oxc_ast::{AstKind, ast::TSType};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
+use schemars::JsonSchema;
 use serde_json::Value;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
@@ -17,9 +18,15 @@ fn max_params_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct MaxParams(Box<MaxParamsConfig>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct MaxParamsConfig {
+    /// Maximum number of parameters allowed in function definitions.
     max: usize,
+    /// This option is for counting the `this` parameter if it is of type `void`.
+    ///
+    /// For example `{ "countVoidThis": true }` would mean that having a function
+    /// take a `this` parameter of type `void` is counted towards the maximum number of parameters.
     count_void_this: bool,
 }
 
@@ -78,29 +85,10 @@ declare_oxc_lint!(
     ///     doSomething();
     /// };
     /// ```
-    ///
-    /// ### Options
-    ///
-    /// #### max
-    ///
-    /// `{ "max": number }`
-    ///
-    /// This option is for changing the maximum allowed number of function parameters.
-    ///
-    /// For example `{ "max": 4 }` would mean that having a function take four
-    /// parameters is allowed which overrides the default of three.
-    ///
-    /// #### countVoidThis
-    ///
-    /// `{ "countVoidThis": boolean }`
-    ///
-    /// This option is for counting the `this` parameter if it is of type `void`.
-    ///
-    /// For example `{ "countVoidThis": true }` would mean that having a function
-    /// take a `this` parameter of type `void` is counted towards the maximum number of parameters.
     MaxParams,
     eslint,
-    style
+    style,
+    config = MaxParamsConfig,
 );
 
 impl Rule for MaxParams {

--- a/crates/oxc_linter/src/rules/eslint/operator_assignment.rs
+++ b/crates/oxc_linter/src/rules/eslint/operator_assignment.rs
@@ -47,8 +47,8 @@ pub struct OperatorAssignment {
     ///
     /// Example:
     /// ```json
-    /// "eslint/max-nested-callbacks": ["error", "always"]
-    /// "eslint/max-nested-callbacks": ["error", "never"]
+    /// "eslint/operator-assignment": ["error", "always"]
+    /// "eslint/operator-assignment": ["error", "never"]
     /// ```
     mode: Mode,
 }

--- a/crates/oxc_linter/src/rules/eslint/sort_vars.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_vars.rs
@@ -8,6 +8,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
+use schemars::JsonSchema;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -15,8 +16,10 @@ fn sort_vars_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Variable declarations should be sorted").with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct SortVars {
+    /// When `true`, the rule ignores case-sensitivity when sorting variables.
     ignore_case: bool,
 }
 
@@ -46,7 +49,8 @@ declare_oxc_lint!(
     SortVars,
     eslint,
     pedantic,
-    pending
+    pending,
+    config = SortVars,
 );
 
 impl Rule for SortVars {

--- a/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
+++ b/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
@@ -2,7 +2,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{SPAN, Span};
 use schemars::JsonSchema;
-use serde::{Deserialize};
+use serde::Deserialize;
 
 use crate::{context::LintContext, rule::Rule};
 

--- a/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
+++ b/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
@@ -1,6 +1,8 @@
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{SPAN, Span};
+use schemars::JsonSchema;
+use serde::{Deserialize};
 
 use crate::{context::LintContext, rule::Rule};
 
@@ -16,8 +18,10 @@ fn expected_unicode_bom_diagnostic(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct UnicodeBom {
+    /// Configuration option to specify whether to require or disallow Unicode BOM.
     bom_option: BomOptionType,
 }
 
@@ -43,7 +47,8 @@ declare_oxc_lint!(
     UnicodeBom,
     eslint,
     restriction,
-    fix
+    fix,
+    config = UnicodeBom,
 );
 
 impl Rule for UnicodeBom {
@@ -76,7 +81,8 @@ impl Rule for UnicodeBom {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
 enum BomOptionType {
     Always,
     #[default]


### PR DESCRIPTION
Part of #14743.

- eslint/operator-assignment
- eslint/max-lines-per-function
- eslint/max-params
- eslint/unicode-bom
- eslint/no-global-assign
- eslint/sort-vars

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### mode

type: `"always" | "never"`

default: `"always"`

This rule has a single string option:
* `always` requires assignment operator shorthand where possible
* `never` disallows assignment operator shorthand

Example:
\```json
"eslint/operator-assignment": ["error", "always"]
"eslint/operator-assignment": ["error", "never"]
\```
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### iifes

type: `boolean`

default: `false`

The `IIFEs` option controls whether IIFEs are included in the line count.
By default, IIFEs are not considered, but when set to `true`, they will
be included in the line count for the function.


### max

type: `integer`

default: `50`

Maximum number of lines allowed in a function.


### skipBlankLines

type: `boolean`

default: `false`

Skip lines made up purely of whitespace.


### skipComments

type: `boolean`

default: `false`

Skip lines containing just comments.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### bomOption

type: `"always" | "never"`


Configuration option to specify whether to require or disallow Unicode BOM.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### ignoreCase

type: `boolean`

default: `false`

When `true`, the rule ignores case-sensitivity when sorting variables.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### countVoidThis

type: `boolean`

default: `false`

This option is for counting the `this` parameter if it is of type `void`.

For example `{ "countVoidThis": true }` would mean that having a function
take a `this` parameter of type `void` is counted towards the maximum number of parameters.


### max

type: `integer`

default: `3`

Maximum number of parameters allowed in function definitions.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### exceptions

type: `string[]`

default: `[]`

List of global variable names to exclude from this rule.
Globals listed here can be assigned to without triggering warnings.
```

Most notable non-documentation change is changing the no-global-assign rule's struct to use "exceptions" instead of "excludes".