### PR TITLE
feat(language_server): respect disable directives for type-aware rules

### DIFF
--- a/crates/oxc_language_server/fixtures/linter/tsgolint/unused_disabled_directives/.oxlintrc.json
+++ b/crates/oxc_language_server/fixtures/linter/tsgolint/unused_disabled_directives/.oxlintrc.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "no-unused-expressions": "off",
+    "@typescript-eslint/no-floating-promises": "error"
+  }
+}

--- a/crates/oxc_language_server/fixtures/linter/tsgolint/unused_disabled_directives/test.ts
+++ b/crates/oxc_language_server/fixtures/linter/tsgolint/unused_disabled_directives/test.ts
@@ -1,0 +1,39 @@
+// Test file for disable directives with type-aware rules
+const myPromise = new Promise(() => {})
+
+// Test oxlint-disable-next-line
+// oxlint-disable-next-line typescript/no-floating-promises
+myPromise
+
+// Test eslint-disable-next-line with @typescript-eslint prefix
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+myPromise
+
+// Test oxlint-disable/enable block
+/* oxlint-disable typescript/no-floating-promises */
+myPromise
+myPromise
+/* oxlint-enable typescript/no-floating-promises */
+
+// This should still report an error (no disable directive)
+myPromise
+
+// Test with different rule name formats
+// oxlint-disable-next-line no-floating-promises
+myPromise
+
+// eslint-disable-next-line typescript-eslint/no-floating-promises
+myPromise
+
+// Test disable-line variant
+myPromise // oxlint-disable-line typescript/no-floating-promises
+
+// Multiple promises in one block
+/* eslint-disable @typescript-eslint/no-floating-promises */
+Promise.resolve(1)
+Promise.resolve(2)
+Promise.resolve(3)
+/* eslint-enable @typescript-eslint/no-floating-promises */
+
+// Should report error
+Promise.resolve(4)

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -461,6 +461,19 @@ mod test {
     }
 
     #[test]
+    fn test_report_tsgolint_unused_directives() {
+        Tester::new(
+            "fixtures/linter/tsgolint/unused_disabled_directives",
+            Some(LintOptions {
+                unused_disable_directives: UnusedDisableDirectives::Deny,
+                type_aware: true,
+                ..Default::default()
+            }),
+        )
+        .test_and_snapshot_single_file("test.ts");
+    }
+
+    #[test]
     fn test_root_ignore_patterns() {
         let tester = Tester::new("fixtures/linter/ignore_patterns", None);
         tester.test_and_snapshot_multiple_file(&[

--- a/crates/oxc_language_server/src/snapshots/fixtures_linter_tsgolint_unused_disabled_directives@test.ts.snap
+++ b/crates/oxc_language_server/src/snapshots/fixtures_linter_tsgolint_unused_disabled_directives@test.ts.snap
@@ -1,0 +1,101 @@
+---
+source: crates/oxc_language_server/src/tester.rs
+---
+########## 
+file: fixtures/linter/tsgolint/unused_disabled_directives/test.ts
+----------
+
+code: "typescript-eslint(no-floating-promises)"
+code_description.href: "None"
+message: "Promises must be awaited.\nhelp: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator."
+range: Range { start: Position { line: 18, character: 0 }, end: Position { line: 18, character: 9 } }
+related_information[0].message: ""
+related_information[0].location.uri: "file://<variable>/fixtures/linter/tsgolint/unused_disabled_directives/test.ts"
+related_information[0].location.range: Range { start: Position { line: 18, character: 0 }, end: Position { line: 18, character: 9 } }
+severity: Some(Error)
+source: Some("oxc")
+tags: None
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Disable no-floating-promises for this line",
+            ),
+            code: "// oxlint-disable-next-line no-floating-promises\n",
+            range: Range {
+                start: Position {
+                    line: 18,
+                    character: 0,
+                },
+                end: Position {
+                    line: 18,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-floating-promises for this file",
+            ),
+            code: "// oxlint-disable no-floating-promises\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)
+
+
+code: "typescript-eslint(no-floating-promises)"
+code_description.href: "None"
+message: "Promises must be awaited.\nhelp: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator."
+range: Range { start: Position { line: 38, character: 0 }, end: Position { line: 38, character: 18 } }
+related_information[0].message: ""
+related_information[0].location.uri: "file://<variable>/fixtures/linter/tsgolint/unused_disabled_directives/test.ts"
+related_information[0].location.range: Range { start: Position { line: 38, character: 0 }, end: Position { line: 38, character: 18 } }
+severity: Some(Error)
+source: Some("oxc")
+tags: None
+fixed: Multiple(
+    [
+        FixedContent {
+            message: Some(
+                "Disable no-floating-promises for this line",
+            ),
+            code: "// oxlint-disable-next-line no-floating-promises\n",
+            range: Range {
+                start: Position {
+                    line: 38,
+                    character: 0,
+                },
+                end: Position {
+                    line: 38,
+                    character: 0,
+                },
+            },
+        },
+        FixedContent {
+            message: Some(
+                "Disable no-floating-promises for this file",
+            ),
+            code: "// oxlint-disable no-floating-promises\n",
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+        },
+    ],
+)

--- a/crates/oxc_linter/src/lint_runner.rs
+++ b/crates/oxc_linter/src/lint_runner.rs
@@ -244,7 +244,8 @@ impl LintRunner {
         let mut messages = self.lint_service.run_source();
 
         if let Some(type_aware_linter) = &self.type_aware_linter
-            && let Ok(tso_messages) = type_aware_linter.lint_source(file, source_text)
+            && let Ok(tso_messages) =
+                type_aware_linter.lint_source(file, source_text, self.directives_store.map())
         {
             messages.extend(tso_messages);
         }


### PR DESCRIPTION
Aligning with `oxlint` CLI tool.

> This PR adds support for disable directives (e.g., oxlint-disable-next-line, eslint-disable) in type-aware linting with tsgolint. Previously, disable directives were only handled by the regular oxc linter, but now they also apply to type-aware rules.