### PR TITLE
docs(linter): Add configuration option docs for 4 jest rules

### DIFF
--- a/crates/oxc_linter/src/rules/jest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/expect_expect.rs
@@ -36,7 +36,7 @@ pub struct ExpectExpect(Box<ExpectExpectConfig>);
 pub struct ExpectExpectConfig {
     /// A list of function names that should be treated as assertion functions.
     assert_function_names_jest: Vec<CompactStr>,
-    /// A list of function names that should be treated as assertion functions.
+    /// A list of function names that should be treated as assertion functions for Vitest.
     assert_function_names_vitest: Vec<CompactStr>,
     /// An array of function names that should also be treated as test blocks.
     additional_test_block_functions: Vec<CompactStr>,

--- a/crates/oxc_linter/src/rules/jest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/expect_expect.rs
@@ -11,6 +11,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, GetSpan, Span};
 use oxc_syntax::scope::ScopeFlags;
+use schemars::JsonSchema;
 
 use crate::{
     ast_util::get_declaration_of_variable,
@@ -30,10 +31,14 @@ fn expect_expect_diagnostic(span: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct ExpectExpect(Box<ExpectExpectConfig>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct ExpectExpectConfig {
+    /// A list of function names that should be treated as assertion functions.
     assert_function_names_jest: Vec<CompactStr>,
+    /// A list of function names that should be treated as assertion functions.
     assert_function_names_vitest: Vec<CompactStr>,
+    /// An array of function names that should also be treated as test blocks.
     additional_test_block_functions: Vec<CompactStr>,
 }
 
@@ -67,7 +72,7 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    ///  People may forget to add assertions.
+    /// People may forget to add assertions.
     ///
     /// ### Examples
     ///
@@ -91,7 +96,8 @@ declare_oxc_lint!(
     /// ```
     ExpectExpect,
     jest,
-    correctness
+    correctness,
+    config = ExpectExpectConfig,
 );
 
 impl Rule for ExpectExpect {

--- a/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
@@ -3,6 +3,8 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use rustc_hash::FxHashMap;
+use schemars::JsonSchema;
+use serde::Deserialize;
 
 use crate::{
     context::LintContext,
@@ -21,8 +23,10 @@ fn restricted_jest_method_with_message(x0: &str, span1: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct NoRestrictedJestMethods(Box<NoRestrictedJestMethodsConfig>);
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
 pub struct NoRestrictedJestMethodsConfig {
+    /// A mapping of restricted Jest method names to custom messages.
     restricted_jest_methods: FxHashMap<String, String>,
 }
 
@@ -67,6 +71,7 @@ declare_oxc_lint!(
     NoRestrictedJestMethods,
     jest,
     style,
+    config = NoRestrictedJestMethodsConfig,
 );
 
 impl Rule for NoRestrictedJestMethods {

--- a/crates/oxc_linter/src/rules/jest/no_restricted_matchers.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_matchers.rs
@@ -5,6 +5,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use rustc_hash::FxHashMap;
+use schemars::JsonSchema;
 
 use crate::{
     context::LintContext,
@@ -28,8 +29,12 @@ fn restricted_chain_with_message(chain_call: &str, message: &str, span: Span) ->
 #[derive(Debug, Default, Clone)]
 pub struct NoRestrictedMatchers(Box<NoRestrictedMatchersConfig>);
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct NoRestrictedMatchersConfig {
+    /// A map of restricted matchers/modifiers to custom messages.
+    /// The key is the matcher/modifier name (e.g., "toBeFalsy", "resolves", "not.toHaveBeenCalledWith").
+    /// The value is an optional custom message to display when the matcher/modifier is used.
     restricted_matchers: FxHashMap<String, String>,
 }
 
@@ -103,6 +108,7 @@ declare_oxc_lint!(
     NoRestrictedMatchers,
     jest,
     style,
+    config = NoRestrictedMatchersConfig,
 );
 
 const MODIFIER_NAME: [&str; 3] = ["not", "rejects", "resolves"];

--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect/mod.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect/mod.rs
@@ -4,6 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::NodeId;
 use oxc_span::{CompactStr, Span};
 use rustc_hash::FxHashMap;
+use schemars::JsonSchema;
 
 #[cfg(test)]
 mod tests;
@@ -29,8 +30,10 @@ fn no_standalone_expect_diagnostic(span: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct NoStandaloneExpect(Box<NoStandaloneExpectConfig>);
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct NoStandaloneExpectConfig {
+    /// An array of function names that should also be treated as test blocks.
     additional_test_block_functions: Vec<CompactStr>,
 }
 
@@ -69,7 +72,8 @@ declare_oxc_lint!(
     /// ```
     NoStandaloneExpect,
     jest,
-    correctness
+    correctness,
+    config = NoStandaloneExpectConfig,
 );
 
 impl Rule for NoStandaloneExpect {


### PR DESCRIPTION
Part of #14743.

- jest/no-restricted-matchers
- jest/expect-expect
- jest/no-standalone-expect
- jest/no-restricted-jest-methods

Note for no-restricted-matchers that this is technically incorrect in that the configuration options do not actually accept a key, it's just a direct object passed as the first argument. But there's not any way to represent that right now in the auto-gen system

Generated docs:

```md

## Configuration

This rule accepts a configuration object with the following properties:

### restrictedMatchers

type: `Record<string, string>`

default: `{}`

A map of restricted matchers/modifiers to custom messages.
The key is the matcher/modifier name (e.g., "toBeFalsy", "resolves", "not.toHaveBeenCalledWith").
The value is an optional custom message to display when the matcher/modifier is used.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### additionalTestBlockFunctions

type: `string[]`

default: `[]`

An array of function names that should also be treated as test blocks.


### assertFunctionNamesJest

type: `string[]`

default: `["expect"]`

A list of function names that should be treated as assertion functions.


### assertFunctionNamesVitest

type: `string[]`

default: `["expect", "expectTypeOf", "assert", "assertType"]`

A list of function names that should be treated as assertion functions.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### restrictedJestMethods

type: `Record<string, string>`

default: `{}`

A mapping of restricted Jest method names to custom messages.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### additionalTestBlockFunctions

type: `string[]`

default: `[]`

An array of function names that should also be treated as test blocks.
```