### PR TITLE
docs(linter): Remove unnecessary link comments.

### DIFF
--- a/crates/oxc_linter/src/rules/import/no_named_export.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_export.rs
@@ -14,7 +14,6 @@ fn no_named_export_diagnostic(span: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct NoNamedExport;
 
-// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
 declare_oxc_lint!(
     /// ### What it does
     ///

--- a/crates/oxc_linter/src/rules/promise/always_return.rs
+++ b/crates/oxc_linter/src/rules/promise/always_return.rs
@@ -53,7 +53,6 @@ impl std::ops::Deref for AlwaysReturn {
     }
 }
 
-// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
 declare_oxc_lint!(
     /// ### What it does
     ///

--- a/crates/oxc_linter/src/rules/react/jsx_fragments.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_fragments.rs
@@ -38,7 +38,6 @@ impl From<&str> for FragmentMode {
     }
 }
 
-// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
 declare_oxc_lint!(
     /// ### What it does
     ///

--- a/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
@@ -76,7 +76,6 @@ impl std::ops::Deref for JsxHandlerNames {
     }
 }
 
-// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
 declare_oxc_lint!(
     /// ### What it does
     ///

--- a/crates/oxc_linter/src/rules/unicorn/no_array_method_this_argument.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_method_this_argument.rs
@@ -20,7 +20,6 @@ fn no_array_method_this_argument_diagnostic(span: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct NoArrayMethodThisArgument;
 
-// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
 declare_oxc_lint!(
     /// ### What it does
     ///

--- a/crates/oxc_linter/src/rules/unicorn/no_unnecessary_array_splice_count.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unnecessary_array_splice_count.rs
@@ -24,7 +24,6 @@ fn no_unnecessary_array_splice_count_diagnostic(span: Span, arg_str: &str) -> Ox
 #[derive(Debug, Default, Clone)]
 pub struct NoUnnecessaryArraySpliceCount;
 
-// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
 declare_oxc_lint!(
     /// ### What it does
     ///

--- a/crates/oxc_linter/src/rules/unicorn/prefer_classlist_toggle.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_classlist_toggle.rs
@@ -25,7 +25,6 @@ fn prefer_classlist_toggle_diagnostic(span: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct PreferClasslistToggle;
 
-// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
 declare_oxc_lint!(
     /// ### What it does
     ///


### PR DESCRIPTION
This cleans up some leftover comments in various lint rule files that referenced a GitHub issue for documentation details, this is because of the link being in the template file and not being cleaned up when creating these rules.