### PR TITLE
docs(linter): Add configuration option docs for promise/no-callback-in-promise rule.

### DIFF
--- a/crates/oxc_linter/src/rules/promise/no_callback_in_promise.rs
+++ b/crates/oxc_linter/src/rules/promise/no_callback_in_promise.rs
@@ -5,6 +5,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, GetSpan, Span};
+use schemars::JsonSchema;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -17,14 +18,16 @@ fn no_callback_in_promise_diagnostic(span: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct NoCallbackInPromise(Box<NoCallbackInPromiseConfig>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct NoCallbackInPromiseConfig {
-    callbacks: Vec<CompactStr>,
+    /// An array of callback names to allow in promises.
+    exceptions: Vec<CompactStr>,
 }
 
 impl Default for NoCallbackInPromiseConfig {
     fn default() -> Self {
-        Self { callbacks: vec!["callback".into(), "cb".into(), "done".into(), "next".into()] }
+        Self { exceptions: vec!["callback".into(), "cb".into(), "done".into(), "next".into()] }
     }
 }
 
@@ -72,6 +75,7 @@ declare_oxc_lint!(
     NoCallbackInPromise,
     promise,
     correctness,
+    config = NoCallbackInPromiseConfig,
 );
 
 impl Rule for NoCallbackInPromise {
@@ -87,7 +91,7 @@ impl Rule for NoCallbackInPromise {
             })
             .unwrap_or_default();
 
-        default_config.callbacks.retain(|item| !exceptions.contains(&item.to_string()));
+        default_config.exceptions.retain(|item| !exceptions.contains(&item.to_string()));
 
         Self(Box::new(default_config))
     }
@@ -100,7 +104,7 @@ impl Rule for NoCallbackInPromise {
         let is_not_callback = call_expr
             .callee
             .get_identifier_reference()
-            .is_none_or(|id| self.callbacks.binary_search(&id.name.as_str().into()).is_err());
+            .is_none_or(|id| self.exceptions.binary_search(&id.name.as_str().into()).is_err());
 
         if is_not_callback {
             if Self::has_promise_callback(call_expr) {
@@ -111,7 +115,7 @@ impl Rule for NoCallbackInPromise {
                 };
 
                 let name = id.name.as_str();
-                if self.callbacks.binary_search(&name.into()).is_ok() {
+                if self.exceptions.binary_search(&name.into()).is_ok() {
                     ctx.diagnostic(no_callback_in_promise_diagnostic(id.span));
                 }
             }

--- a/crates/oxc_linter/src/rules/promise/no_callback_in_promise.rs
+++ b/crates/oxc_linter/src/rules/promise/no_callback_in_promise.rs
@@ -27,7 +27,10 @@ pub struct NoCallbackInPromiseConfig {
 
 impl Default for NoCallbackInPromiseConfig {
     fn default() -> Self {
-        Self { callbacks: vec!["callback".into(), "cb".into(), "done".into(), "next".into()], exceptions: Vec::new() }
+        Self {
+            callbacks: vec!["callback".into(), "cb".into(), "done".into(), "next".into()],
+            exceptions: Vec::new(),
+        }
     }
 }
 

--- a/crates/oxc_linter/src/rules/promise/no_callback_in_promise.rs
+++ b/crates/oxc_linter/src/rules/promise/no_callback_in_promise.rs
@@ -21,7 +21,9 @@ pub struct NoCallbackInPromise(Box<NoCallbackInPromiseConfig>);
 #[derive(Debug, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase", default)]
 pub struct NoCallbackInPromiseConfig {
+    /// List of callback function names to check for within Promise `then` and `catch` methods.
     callbacks: Vec<CompactStr>,
+    /// List of callback function names to allow within Promise `then` and `catch` methods.
     exceptions: Vec<CompactStr>,
 }
 


### PR DESCRIPTION
Part of #14743.

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### callbacks

type: `string[]`

default: `["callback", "cb", "done", "next"]`

List of callback function names to check for within Promise `then` and `catch` methods.


### exceptions

type: `string[]`

default: `[]`

List of callback function names to allow within Promise `then` and `catch` methods.
```