### PR TITLE
docs(linter): Add configuration option docs for various jsx-a11y rules

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/alt_text.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/alt_text.rs
@@ -5,6 +5,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, Span};
+use schemars::JsonSchema;
 
 use crate::{
     AstNode,
@@ -69,11 +70,17 @@ fn input_type_image(span: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct AltText(Box<AltTextConfig>);
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct AltTextConfig {
+    /// Custom components to check for alt text on `img` elements.
     img: Option<Vec<CompactStr>>,
+    /// Custom components to check for alt text on `object` elements.
     object: Option<Vec<CompactStr>>,
+    /// Custom components to check for alt text on `area` elements.
     area: Option<Vec<CompactStr>>,
+    /// Custom components to check for alt text on `input[type="image"]` elements.
+    #[serde(rename = "input[type=\"image\"]")]
     input_type_image: Option<Vec<CompactStr>>,
 }
 
@@ -128,7 +135,8 @@ declare_oxc_lint!(
     /// ```
     AltText,
     jsx_a11y,
-    correctness
+    correctness,
+    config = AltTextConfig,
 );
 
 impl Rule for AltText {

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_ambiguous_text.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_ambiguous_text.rs
@@ -7,6 +7,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, Span};
+use schemars::JsonSchema;
 
 use crate::{
     AstNode,
@@ -29,8 +30,10 @@ fn anchor_has_ambiguous_text(span: Span, text: &CompactStr) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct AnchorAmbiguousText(Box<AnchorAmbiguousTextConfig>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct AnchorAmbiguousTextConfig {
+    /// List of ambiguous words or phrases that should be flagged in anchor text.
     words: Vec<CompactStr>,
 }
 
@@ -88,6 +91,7 @@ declare_oxc_lint!(
     AnchorAmbiguousText,
     jsx_a11y,
     restriction,
+    config = AnchorAmbiguousTextConfig,
 );
 
 impl Rule for AnchorAmbiguousText {

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
@@ -7,6 +7,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, GetSpan, Span};
+use schemars::JsonSchema;
 use serde_json::Value;
 
 use crate::{
@@ -37,9 +38,10 @@ fn cant_be_anchor(span: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct AnchorIsValid(Box<AnchorIsValidConfig>);
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct AnchorIsValidConfig {
-    /// Unique and sorted list of valid hrefs
+    /// List of strings that are valid href values.
     valid_hrefs: Vec<CompactStr>,
 }
 
@@ -85,14 +87,14 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// There are **many reasons** why an anchor should not have a logic and have a correct `href` attribute:
+    /// There are **many reasons** why an anchor should not have logic and have a correct `href` attribute:
     /// - it can disrupt the correct flow of the user navigation e.g. a user that wants to open the link
     /// in another tab, but the default "click" behaviour is prevented
     /// - it can source of invalid links, and crawlers can't navigate the website, risking to penalise SEO ranking
     ///
-    /// ### Example
+    /// ### Examples
     ///
-    /// #### Valid
+    /// Examples of **valid** code for this rule:
     ///
     /// ```jsx
     /// <>
@@ -102,7 +104,7 @@ declare_oxc_lint!(
     /// </>
     /// ```
     ///
-    /// #### Invalid
+    /// Examples of **invalid** code for this rule:
     ///
     /// ```jsx
     /// <>
@@ -119,7 +121,8 @@ declare_oxc_lint!(
     /// - [WCAG 2.1.1](https://www.w3.org/WAI/WCAG21/Understanding/keyboard)
     AnchorIsValid,
     jsx_a11y,
-    correctness
+    correctness,
+    config = AnchorIsValidConfig
 );
 
 impl Rule for AnchorIsValid {

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
@@ -5,6 +5,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
+use schemars::JsonSchema;
 
 use crate::{
     AstNode,
@@ -25,9 +26,12 @@ fn aria_role_diagnostic(span: Span, help_suffix: &str) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct AriaRole(Box<AriaRoleConfig>);
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct AriaRoleConfig {
+    /// Determines if developer-created components are checked.
     ignore_non_dom: bool,
+    /// Custom roles that should be allowed in addition to the ARIA spec.
     allowed_invalid_roles: Vec<String>,
 }
 
@@ -45,7 +49,6 @@ declare_oxc_lint!(
     /// Elements with ARIA roles must use a valid, non-abstract ARIA role. A
     /// reference to role definitions can be found at
     /// [WAI-ARIA](https://www.w3.org/TR/wai-aria/#role_definitions) site.
-    ///
     ///
     /// ### Why is this bad?
     ///
@@ -72,25 +75,6 @@ declare_oxc_lint!(
     /// selected, or whether or not a collapsible tree or list node is expanded
     /// or collapsed.
     ///
-    /// ### Rule options
-    /// This rule takes one optional object argument of type object:
-    /// ```json
-    /// {
-    ///     "rules": {
-    ///         "jsx-a11y/aria-role": [ 2, {
-    ///             "allowedInvalidRoles": ["text"],
-    ///             "ignoreNonDOM": true
-    ///         }],
-    ///     }
-    ///  }
-    /// ```
-    /// `allowedInvalidRules` is an optional string array of custom roles that
-    /// should be allowed in addition to the ARIA spec, such as for cases when
-    /// you need to use a non-standard role.
-    ///
-    /// For the `ignoreNonDOM` option, this determines if developer created
-    /// components are checked.
-    ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
@@ -111,7 +95,8 @@ declare_oxc_lint!(
     /// ```
     AriaRole,
     jsx_a11y,
-    correctness
+    correctness,
+    config = AriaRoleConfig
 );
 
 impl Rule for AriaRole {

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
@@ -30,6 +30,7 @@ pub struct AriaRole(Box<AriaRoleConfig>);
 #[serde(rename_all = "camelCase", default)]
 pub struct AriaRoleConfig {
     /// Determines if developer-created components are checked.
+    #[serde(rename = "ignoreNonDOM")]
     ignore_non_dom: bool,
     /// Custom roles that should be allowed in addition to the ARIA spec.
     allowed_invalid_roles: Vec<String>,

--- a/crates/oxc_linter/src/rules/jsx_a11y/autocomplete_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/autocomplete_valid.rs
@@ -6,6 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, Span};
 use rustc_hash::FxHashSet;
+use schemars::JsonSchema;
 use serde_json::Value;
 
 use crate::{
@@ -23,6 +24,7 @@ fn autocomplete_valid_diagnostic(span: Span, autocomplete: &str) -> OxcDiagnosti
 
 #[derive(Debug, Default, Clone)]
 pub struct AutocompleteValid(Box<AutocompleteValidConfig>);
+
 declare_oxc_lint!(
     /// ### What it does
     ///
@@ -45,11 +47,14 @@ declare_oxc_lint!(
     /// ```
     AutocompleteValid,
     jsx_a11y,
-    correctness
+    correctness,
+    config = AutocompleteValidConfig
 );
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct AutocompleteValidConfig {
+    /// List of custom component names that should be treated as input elements.
     input_components: FxHashSet<CompactStr>,
 }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/heading_has_content.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/heading_has_content.rs
@@ -2,6 +2,7 @@ use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, Span};
+use schemars::JsonSchema;
 
 use crate::{
     AstNode,
@@ -21,8 +22,11 @@ fn heading_has_content_diagnostic(span: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct HeadingHasContent(Box<HeadingHasContentConfig>);
 
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct HeadingHasContentConfig {
+    /// Additional custom component names to treat as heading elements.
+    /// These will be validated in addition to the standard h1-h6 elements.
     components: Option<Vec<CompactStr>>,
 }
 
@@ -61,7 +65,8 @@ declare_oxc_lint!(
     /// ```
     HeadingHasContent,
     jsx_a11y,
-    correctness
+    correctness,
+    config = HeadingHasContentConfig,
 );
 
 // always including <h1> thru <h6>

--- a/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
@@ -8,6 +8,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, Span};
+use schemars::JsonSchema;
 use serde_json::Value;
 
 use crate::{
@@ -27,9 +28,13 @@ fn img_redundant_alt_diagnostic(span: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct ImgRedundantAlt(Box<ImgRedundantAltConfig>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct ImgRedundantAltConfig {
+    /// JSX element types to validate (component names) where the rule applies.
+    /// For example, `["img", "Image"]`.
     types_to_validate: Vec<CompactStr>,
+    /// Words considered redundant in alt text that should trigger a warning.
     redundant_words: Vec<Cow<'static, str>>,
 }
 
@@ -93,7 +98,8 @@ declare_oxc_lint!(
     /// ```
     ImgRedundantAlt,
     jsx_a11y,
-    correctness
+    correctness,
+    config = ImgRedundantAltConfig,
 );
 
 impl Rule for ImgRedundantAlt {

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
@@ -2,6 +2,7 @@ use oxc_ast::{AstKind, ast::JSXAttributeItem};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
+use schemars::JsonSchema;
 
 use crate::{
     AstNode,
@@ -17,8 +18,11 @@ fn no_autofocus_diagnostic(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(default)]
 pub struct NoAutofocus {
+    /// Determines if developer-created components are checked.
+    #[serde(rename = "ignoreNonDOM")]
     ignore_non_dom: bool,
 }
 
@@ -33,23 +37,6 @@ declare_oxc_lint!(
     /// non-sighted users alike. It can be disorienting when focus is shifted
     /// without user input and can interfere with assistive technologies.
     /// Users should control when and where focus moves on a page.
-    ///
-    /// ### Rule Option
-    ///
-    /// This rule takes one optional object argument of type object:
-    ///
-    /// ```json
-    /// {
-    ///     "rules": {
-    ///         "jsx-a11y/no-autofocus": [ 2, {
-    ///             "ignoreNonDOM": true
-    ///         }],
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// For the `ignoreNonDOM` option, this determines if developer created
-    /// components are checked.
     ///
     /// ### Examples
     ///
@@ -68,7 +55,8 @@ declare_oxc_lint!(
     NoAutofocus,
     jsx_a11y,
     correctness,
-    fix
+    fix,
+    config = NoAutofocus,
 );
 
 impl NoAutofocus {


### PR DESCRIPTION
Part of #14743.

- jsx-a11y/no-autofocus
- jsx-a11y/anchor-ambiguous-text
- jsx-a11y/alt-text
- jsx-a11y/autocomplete-valid
- jsx-a11y/anchor-is-valid
- jsx-a11y/aria-role
- jsx-a11y/heading-has-content
- jsx-a11y/img-redundant-alt

Generated docs (not in order, sorry):

```md
## Configuration

This rule accepts a configuration object with the following properties:

### area

type: `string[]`

default: `[]`

Custom components to check for alt text on `area` elements.


### img

type: `string[]`

default: `[]`

Custom components to check for alt text on `img` elements.


### input[type="image"]

type: `string[]`

default: `[]`

Custom components to check for alt text on `input[type="image"]` elements.


### object

type: `string[]`

default: `[]`

Custom components to check for alt text on `object` elements.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### words

type: `string[]`

default: `["click here", "here", "link", "a link", "learn more"]`

List of ambiguous words or phrases that should be flagged in anchor text.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### redundantWords

type: `string[]`

default: `["image", "photo", "picture"]`

Words considered redundant in alt text that should trigger a warning.


### typesToValidate

type: `string[]`

default: `["img"]`

JSX element types to validate (component names) where the rule applies.
For example, `["img", "Image"]`.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### ignoreNonDOM

type: `boolean`

default: `false`

Determines if developer-created components are checked.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### validHrefs

type: `string[]`

default: `[]`

List of strings that are valid href values.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### inputComponents

type: `string[]`

default: `["input"]`

List of custom component names that should be treated as input elements.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### components

type: `string[]`

default: `null`

Additional custom component names to treat as heading elements.
These will be validated in addition to the standard h1-h6 elements.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### allowedInvalidRoles

type: `string[]`

default: `[]`

Custom roles that should be allowed in addition to the ARIA spec.


### ignoreNonDOM

type: `boolean`

default: `false`

Determines if developer-created components are checked.
```