### PR TITLE
fix(linter/no-unused-vars): false positive with member expressions in sequence expressions

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -988,6 +988,24 @@ fn test_arguments() {
         ",
             None,
         ),
+        // https://github.com/oxc-project/oxc/issues/15174
+        // Sequence expressions with member expressions in operations with side effects
+
+        // UpdateExpression cases
+        ("items.reduce((acc, item) => (acc[item.action]++, acc), {})", None),
+        ("items.reduce((acc, item) => (acc[item.action]--, acc), {})", None),
+        ("items.reduce((acc, item) => (++acc[item.action], acc), {})", None),
+        ("items.reduce((acc, item) => (--acc[item.action], acc), {})", None),
+        // AssignmentExpression cases
+        ("items.reduce((acc, item) => (acc[item.action] = 1, acc), {})", None),
+        ("items.reduce((acc, item) => (acc.x[item.action] = 1, acc), {})", None),
+        ("items.reduce((acc, item) => (acc[item.action] += 1, acc), {})", None),
+        ("items.reduce((acc, item) => (acc[item.action] ||= 1, acc), {})", None),
+        // Nested member expressions
+        ("foo.bar((a, b, c) => (a[b.x][c.y]++, a))", None),
+        ("foo.bar((a, b) => (a.foo[b.bar].baz++, a))", None),
+        // Multiple parameters used in sequence
+        ("foo.bar((a, b, c) => (b[c.x]++, a[b.y]++, a))", None),
     ];
     let fail = vec![
         ("function foo(a) {} foo()", None),

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
@@ -643,7 +643,18 @@ impl<'a> Symbol<'_, 'a> {
                     }
                     break;
                 }
-                (_, AstKind::CallExpression(_) | AstKind::NewExpression(_)) => break,
+                (_, AstKind::CallExpression(_) | AstKind::NewExpression(_))
+                | (
+                    // in `(acc[item.action]++, acc)`, reference to `item` should still be considered
+                    // used, even though it's not in the last position of the sequence.
+                    // However, in `(a++, 0)`, `a` should be considered discarded.
+                    // We detect this by checking if there's a MemberExpression in the parent chain.
+                    AstKind::ComputedMemberExpression(_)
+                    | AstKind::StaticMemberExpression(_)
+                    | AstKind::PrivateFieldExpression(_),
+                    // Note: AssignmentExpression is NOT needed here because we already handles it.
+                    AstKind::UpdateExpression(_),
+                ) => break,
                 // (AstKind::FunctionBody(_), _) => return true,
                 // in `(x = a, 0)`, reference to `a` should still be considered
                 // used. Note that this branch must come before the sequence

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
@@ -652,7 +652,7 @@ impl<'a> Symbol<'_, 'a> {
                     AstKind::ComputedMemberExpression(_)
                     | AstKind::StaticMemberExpression(_)
                     | AstKind::PrivateFieldExpression(_),
-                    // Note: AssignmentExpression is NOT needed here because we already handles it.
+                    // Note: AssignmentExpression is NOT needed here because we already handle it.
                     AstKind::UpdateExpression(_),
                 ) => break,
                 // (AstKind::FunctionBody(_), _) => return true,


### PR DESCRIPTION
- Closes: #15174 