### PR TITLE
docs(linter): Add configuration option docs for 6 rules

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_return_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_return_assign.rs
@@ -2,8 +2,8 @@ use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
-use serde_json::Value;
 use schemars::JsonSchema;
+use serde_json::Value;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 

--- a/crates/oxc_linter/src/rules/eslint/no_return_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_return_assign.rs
@@ -3,6 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use serde_json::Value;
+use schemars::JsonSchema;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -12,8 +13,10 @@ fn no_return_assign_diagnostic(span: Span, message: &'static str) -> OxcDiagnost
         .with_help("Did you mean to use `==` instead of `=`?")
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct NoReturnAssign {
+    /// Whether to always disallow assignment in return statements.
     always_disallow_assignment_in_return: bool,
 }
 
@@ -44,7 +47,8 @@ declare_oxc_lint!(
     NoReturnAssign,
     eslint,
     style,
-    pending // TODO: add a suggestion
+    pending, // TODO: add a suggestion
+    config = NoReturnAssign,
 );
 
 fn is_sentinel_node(ast_kind: AstKind) -> bool {

--- a/crates/oxc_linter/src/rules/eslint/radix.rs
+++ b/crates/oxc_linter/src/rules/eslint/radix.rs
@@ -5,6 +5,8 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -27,8 +29,10 @@ fn invalid_radix(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", default)]
 pub struct Radix {
+    /// Configuration option to specify when to require the radix parameter.
     radix_type: RadixType,
 }
 
@@ -59,7 +63,8 @@ declare_oxc_lint!(
     Radix,
     eslint,
     pedantic,
-    conditional_fix_dangerous
+    conditional_fix_dangerous,
+    config = Radix,
 );
 
 impl Rule for Radix {
@@ -146,7 +151,8 @@ impl Radix {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
 enum RadixType {
     #[default]
     Always,

--- a/crates/oxc_linter/src/rules/react/jsx_boolean_value.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_boolean_value.rs
@@ -6,6 +6,8 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, Span};
 use rustc_hash::FxHashSet;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     AstNode,
@@ -32,17 +34,22 @@ fn boolean_value_undefined_false_diagnostic(attr: &str, span: Span) -> OxcDiagno
 #[derive(Debug, Default, Clone)]
 pub struct JsxBooleanValue(Box<JsxBooleanValueConfig>);
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum EnforceBooleanAttribute {
     Always,
     #[default]
     Never,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", default)]
 pub struct JsxBooleanValueConfig {
+    /// Enforce boolean attributes to always or never have a value.
     pub enforce_boolean_attribute: EnforceBooleanAttribute,
+    /// List of attribute names to exclude from the rule.
     pub exceptions: FxHashSet<CompactStr>,
+    /// If true, treats `prop={false}` as equivalent to the prop being undefined
     pub assume_undefined_is_false: bool,
 }
 
@@ -78,6 +85,7 @@ declare_oxc_lint!(
     react,
     style,
     fix,
+    config = JsxBooleanValueConfig,
 );
 
 impl Rule for JsxBooleanValue {

--- a/crates/oxc_linter/src/rules/react/no_unknown_property.rs
+++ b/crates/oxc_linter/src/rules/react/no_unknown_property.rs
@@ -11,6 +11,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use phf::{Map, Set, phf_map, phf_set};
 use rustc_hash::{FxHashMap, FxHashSet};
+use schemars::JsonSchema;
 use serde::Deserialize;
 
 use crate::{
@@ -50,19 +51,19 @@ fn unknown_prop(span: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct NoUnknownProperty(Box<NoUnknownPropertyConfig>);
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct NoUnknownPropertyConfig {
-    #[serde(default)]
+    /// List of properties to ignore.
     ignore: FxHashSet<Cow<'static, str>>,
-    #[serde(default)]
+    /// Require `data-*` attributes to be lowercase, e.g. `data-foobar` instead of `data-fooBar`.
     require_data_lowercase: bool,
 }
 
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow usage of unknown DOM property.
+    /// Disallow usage of unknown DOM properties.
     ///
     /// ### Why is this bad?
     ///
@@ -92,7 +93,8 @@ declare_oxc_lint!(
     NoUnknownProperty,
     react,
     restriction,
-    pending
+    pending,
+    config = NoUnknownPropertyConfig,
 );
 
 const ATTRIBUTE_TAGS_MAP: Map<&'static str, Set<&'static str>> = phf_map! {

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
@@ -7,6 +7,8 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     AstNode,
@@ -24,12 +26,29 @@ fn consistent_type_definitions_diagnostic(
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", default)]
 pub struct ConsistentTypeDefinitions {
+    /// Configuration option to enforce either 'interface' or 'type' for object type definitions.
+    ///
+    /// Setting to `type` enforces the use of types for object type definitions.
+    ///
+    /// Examples of **incorrect** code for this option:
+    /// ```typescript
+    /// interface T {
+    ///   x: number;
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this option:
+    /// ```typescript
+    /// type T = { x: number };
+    /// ```
     config: ConsistentTypeDefinitionsConfig,
 }
 
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
 enum ConsistentTypeDefinitionsConfig {
     #[default]
     Interface,
@@ -65,36 +84,11 @@ declare_oxc_lint!(
     ///   x: number;
     /// }
     /// ```
-    ///
-    /// ### Options
-    ///
-    /// This rule has a single string option:
-    ///
-    /// `{ type: string, default: "interface" }`
-    ///
-    /// ### interface
-    ///
-    /// This is the default option.
-    ///
-    /// ### type
-    ///
-    /// Enforces the use of types for object type definitions.
-    ///
-    /// Examples of **incorrect** code for this option:
-    /// ```typescript
-    /// interface T {
-    ///   x: number;
-    /// }
-    /// ```
-    ///
-    /// Examples of **correct** code for this option:
-    /// ```typescript
-    /// type T = { x: number };
-    /// ```
     ConsistentTypeDefinitions,
     typescript,
     style,
-    fix
+    fix,
+    config = ConsistentTypeDefinitions,
 );
 
 impl Rule for ConsistentTypeDefinitions {


### PR DESCRIPTION
Part of #14743.

- eslint/no-return-assign
- eslint/no-constant-condition
- typescript/consistent-type-definitions
- react/jsx-boolean-value
- eslint/radix
- react/no-unknown-property

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### assumeUndefinedIsFalse

type: `boolean`

default: `false`

If true, treats `prop={false}` as equivalent to the prop being undefined


### enforceBooleanAttribute

type: `"always" | "never"`

default: `"never"`

Enforce boolean attributes to always or never have a value.


### exceptions

type: `string[]`

default: `[]`

List of attribute names to exclude from the rule.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### config

type: `"interface" | "type"`

default: `"interface"`

Configuration option to enforce either 'interface' or 'type' for object type definitions.

Setting to `type` enforces the use of types for object type definitions.

Examples of **incorrect** code for this option:
\```typescript
interface T {
x: number;
}
\```

Examples of **correct** code for this option:
\```typescript
type T = { x: number };
\```
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### ignore

type: `string[]`

default: `[]`

List of properties to ignore.


### requireDataLowercase

type: `boolean`

default: `false`

Require `data-*` attributes to be lowercase, e.g. `data-foobar` instead of `data-fooBar`.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### radixType

type: `"always" | "as-needed"`

default: `"always"`

Configuration option to specify when to require the radix parameter.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### checkLoops

type: `"all" | "allExceptWhileTrue" | "none"`

default: `"allExceptWhileTrue"`

Configuration option to specify whether to check for constant conditions in loops.

- `"all"` or `true` disallows constant expressions in loops
- `"allExceptWhileTrue"` disallows constant expressions in loops except while loops with expression `true`
- `"none"` or `false` allows constant expressions in loops
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### alwaysDisallowAssignmentInReturn

type: `boolean`

default: `false`

Whether to always disallow assignment in return statements.
```