### PR TITLE
docs(linter): Add config docs for 4 more rules.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/prefer_destructuring.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_destructuring.rs
@@ -5,9 +5,9 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use schemars::JsonSchema;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/mouse_events_have_key_events.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/mouse_events_have_key_events.rs
@@ -2,6 +2,7 @@ use oxc_ast::{AstKind, ast::JSXAttributeValue};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, GetSpan, Span};
+use schemars::JsonSchema;
 
 use crate::{
     AstNode,
@@ -26,9 +27,12 @@ fn miss_on_blur(span: Span, attr_name: &str) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct MouseEventsHaveKeyEvents(Box<MouseEventsHaveKeyEventsConfig>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct MouseEventsHaveKeyEventsConfig {
+    /// List of hover-in mouse event handlers that require corresponding keyboard event handlers.
     hover_in_handlers: Vec<CompactStr>,
+    /// List of hover-out mouse event handlers that require corresponding keyboard event handlers.
     hover_out_handlers: Vec<CompactStr>,
 }
 
@@ -44,12 +48,12 @@ impl Default for MouseEventsHaveKeyEventsConfig {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Enforce onmouseover/onmouseout are accompanied by onfocus/onblur.
+    /// Enforce onMouseOver/onMouseOut are accompanied by onFocus/onBlur.
     ///
     /// ### Why is this bad?
     ///
     /// Coding for the keyboard is important for users with physical disabilities who cannot use a mouse,
-    /// AT compatibility, and screenreader users.
+    /// AT compatibility, and screen reader users.
     ///
     /// ### Examples
     ///
@@ -64,7 +68,8 @@ declare_oxc_lint!(
     /// ```
     MouseEventsHaveKeyEvents,
     jsx_a11y,
-    correctness
+    correctness,
+    config = MouseEventsHaveKeyEventsConfig,
 );
 
 impl Rule for MouseEventsHaveKeyEvents {

--- a/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
@@ -10,6 +10,8 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, GetSpan, Span};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     AstNode,
@@ -35,17 +37,25 @@ fn explicit_props_in_spread_attributes(span: Span) -> OxcDiagnostic {
 .with_label(span)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", default)]
 pub struct JsxNoTargetBlank {
+    /// Whether to enforce dynamic links or enforce static links.
     enforce_dynamic_links: EnforceDynamicLinksEnum,
+    /// Whether to warn when spread attributes are used.
     warn_on_spread_attributes: bool,
+    /// Whether to allow referrers.
     allow_referrer: bool,
+    /// Whether to check link elements.
     links: bool,
+    /// Whether to check form elements.
     forms: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
 enum EnforceDynamicLinksEnum {
+    #[default]
     Always,
     Never,
 }
@@ -129,7 +139,8 @@ declare_oxc_lint!(
     /// [`noopener` docs]: https://html.spec.whatwg.org/multipage/links.html#link-type-noopener
     JsxNoTargetBlank,
     react,
-    correctness
+    correctness,
+    config = JsxNoTargetBlank,
 );
 
 impl Rule for JsxNoTargetBlank {


### PR DESCRIPTION
Part of #14743.

- react/only-export-components
- react/jsx-no-target-blank
- jsx-a11y/mouse-events-have-key-events
- eslint/prefer-destructuring

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### AssignmentExpression

type: `object`

default: `{"array":true, "object":true}`

Configuration for destructuring in assignment expressions, configured for arrays and objects independently.


#### AssignmentExpression.array

type: `boolean`

default: `true`




#### AssignmentExpression.object

type: `boolean`

default: `true`




### VariableDeclarator

type: `object`

default: `{"array":true, "object":true}`

Configuration for destructuring in variable declarations, configured for arrays and objects independently.


#### VariableDeclarator.array

type: `boolean`

default: `true`




#### VariableDeclarator.object

type: `boolean`

default: `true`




### enforceForRenamedProperties

type: `boolean`

default: `false`

Determines whether the object destructuring rule applies to renamed variables.
```

```md

## Configuration

This rule accepts a configuration object with the following properties:

### hoverInHandlers

type: `string[]`

default: `["onMouseOver"]`

List of hover-in mouse event handlers that require corresponding keyboard event handlers.


### hoverOutHandlers

type: `string[]`

default: `["onMouseOut"]`

List of hover-out mouse event handlers that require corresponding keyboard event handlers.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### allowReferrer

type: `boolean`

default: `false`

Whether to allow referrers.


### enforceDynamicLinks

type: `"always" | "never"`

default: `"always"`

Whether to enforce dynamic links or enforce static links.


### forms

type: `boolean`

default: `false`

Whether to check form elements.


### links

type: `boolean`

default: `true`

Whether to check link elements.


### warnOnSpreadAttributes

type: `boolean`

default: `false`

Whether to warn when spread attributes are used.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### allowConstantExport

type: `[
  boolean,
  null
]`

default: `null`

Allow exporting primitive constants (string/number/boolean/template literal)
alongside component exports without triggering a violation. Recommended when your
bundler’s Fast Refresh integration supports this (enabled by the plugin’s `vite`
preset).

\```jsx
// Allowed when allowConstantExport: true
export const VERSION = "3";
export const Foo = () => null;
\```


### allowExportNames

type: `string[]`

default: `null`

Treat specific named exports as HMR-safe (useful for frameworks that hot-replace
certain exports). For example, in Remix:
`{ "allowExportNames": ["meta", "links", "headers", "loader", "action"] }`


### checkJS

type: `[
  boolean,
  null
]`

default: `null`

Check `.js` files that contain JSX (in addition to `.tsx`/`.jsx`). To reduce
false positives, only files that import React are checked when this is enabled.


### customHOCs

type: `string[]`

default: `null`

If you export components wrapped in custom higher-order components, list their
identifiers here to avoid false positives.
```