### PR TITLE
docs(linter): Add configuration option docs for 4 rules.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/max_lines.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_lines.rs
@@ -1,6 +1,7 @@
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
+use schemars::JsonSchema;
 use serde_json::Value;
 
 use crate::{context::LintContext, rule::Rule, utils::count_comment_lines};
@@ -14,10 +15,14 @@ fn max_lines_diagnostic(count: usize, max: usize, span: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct MaxLines(Box<MaxLinesConfig>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct MaxLinesConfig {
+    /// Maximum number of lines allowed per file.
     max: usize,
+    /// Whether to ignore blank lines when counting.
     skip_blank_lines: bool,
+    /// Whether to ignore comments when counting.
     skip_comments: bool,
 }
 
@@ -49,7 +54,8 @@ declare_oxc_lint!(
     /// Recommendations usually range from 100 to 500 lines.
     MaxLines,
     eslint,
-    pedantic
+    pedantic,
+    config = MaxLinesConfig,
 );
 
 impl Rule for MaxLines {


### PR DESCRIPTION
Part of #14743.

- eslint/grouped-accessor-pairs
- eslint/class-methods-use-this
- typescript/no-require-imports
- eslint/max-lines

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### max

type: `integer`

default: `300`

Maximum number of lines allowed per file.


### skipBlankLines

type: `boolean`

default: `false`

Whether to ignore blank lines when counting.


### skipComments

type: `boolean`

default: `false`

Whether to ignore comments when counting.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### allow

type: `string[]`

default: `[]`

These strings will be compiled into regular expressions with the u flag and be used to test against the imported path.
A common use case is to allow importing `package.json`. This is because `package.json` commonly lives outside of the TS root directory,
so statically importing it would lead to root directory conflicts, especially with `resolveJsonModule` enabled.
You can also use it to allow importing any JSON if your environment doesn't support JSON modules, or use it for other cases where `import` statements cannot work.

With `{ allow: ['/package\\.json$'] }`:

Examples of **correct** code for this rule:
\```ts
console.log(require('../package.json').version);
\```


### allowAsImport

type: `boolean`

default: `false`

When set to `true`, `import ... = require(...)` declarations won't be reported.
This is useful if you use certain module options that require strict CommonJS interop semantics.

When set to `true`:

Examples of **incorrect** code for this rule:
\```ts
var foo = require('foo');
const foo = require('foo');
let foo = require('foo');
\```
Examples of **correct** code for this rule:
\```ts
import foo = require('foo');
import foo from 'foo';
\```
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### enforceForClassFields

type: `boolean`

default: `true`

Enforce this rule for class fields that are functions.


### exceptMethods

type: `array`

default: `[]`

List of method names to exempt from this rule.


#### exceptMethods[n]

type: `object`





##### exceptMethods[n].name

type: `string`





##### exceptMethods[n].private

type: `boolean`





### ignoreClassesWithImplements

type: `"all" | "public-fields"`

default: `null`

Whether to ignore classes that implement interfaces.


### ignoreOverrideMethods

type: `boolean`

default: `false`

Whether to ignore methods that are overridden.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### enforceForTSTypes

type: `boolean`

default: `false`

When `enforceForTSTypes` is enabled, this rule also applies to TypeScript interfaces and type aliases:

Examples of **incorrect** TypeScript code:
\```ts
interface Foo {
get a(): string;
someProperty: string;
set a(value: string);
}

type Bar = {
get b(): string;
someProperty: string;
set b(value: string);
};
\```

Examples of **correct** TypeScript code:
\```ts
interface Foo {
get a(): string;
set a(value: string);
someProperty: string;
}

type Bar = {
get b(): string;
set b(value: string);
someProperty: string;
};
\```


### pairOrder

type: `"anyOrder" | "getBeforeSet" | "setBeforeGet"`

default: `"anyOrder"`

A string value to control the order of the getter/setter pairs:
- `"anyOrder"`: Accessors can be in any order
- `"getBeforeSet"`: Getters must come before setters
- `"setBeforeGet"`: Setters must come before getters
```