### PR TITLE
docs(linter): Add configuration docs for 6 react rules.

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
@@ -18,6 +18,8 @@ use oxc_diagnostics::{Error, LabeledSpan, OxcDiagnostic};
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::NodeId;
 use oxc_span::{GetSpan as _, Span};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 fn jsx_curly_brace_presence_unnecessary_diagnostic(span: Span) -> OxcDiagnostic {
@@ -32,7 +34,8 @@ fn jsx_curly_brace_presence_necessary_diagnostic(span: Span) -> OxcDiagnostic {
         )])
 }
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
 enum Allowed {
     Always,
     Never,
@@ -64,7 +67,8 @@ impl Allowed {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", default)]
 pub struct JsxCurlyBracePresence {
     props: Allowed,
     children: Allowed,
@@ -82,11 +86,9 @@ impl Default for JsxCurlyBracePresence {
 }
 
 declare_oxc_lint!(
-    /// # Disallow unnecessary JSX expressions when literals alone are
+    /// Disallow unnecessary JSX expressions when literals alone are
     /// sufficient or enforce JSX expressions on literals in JSX children or
     /// attributes (`react/jsx-curly-brace-presence`)
-    ///
-    /// 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://oxc-project.github.io/docs/guide/usage/linter/cli.html#fix-problems).
     ///
     /// This rule allows you to enforce curly braces or disallow unnecessary
     /// curly braces in JSX props and/or children.
@@ -300,7 +302,8 @@ declare_oxc_lint!(
     JsxCurlyBracePresence,
     react,
     style,
-    fix
+    fix,
+    config = JsxCurlyBracePresence,
 );
 
 impl Rule for JsxCurlyBracePresence {

--- a/crates/oxc_linter/src/rules/react/jsx_no_script_url.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_script_url.rs
@@ -1,5 +1,6 @@
 use lazy_regex::{Lazy, Regex, lazy_regex};
 use rustc_hash::FxHashMap;
+use schemars::JsonSchema;
 use serde_json::Value;
 
 use oxc_ast::{AstKind, ast::JSXAttributeItem};
@@ -14,7 +15,6 @@ use crate::{
 };
 
 fn jsx_no_script_url_diagnostic(span: Span) -> OxcDiagnostic {
-    // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
     OxcDiagnostic::warn("A future version of React will block javascript: URLs as a security precaution.")
         .with_help("Use event handlers instead if you can. If you need to generate unsafe HTML, try using dangerouslySetInnerHTML instead.")
         .with_label(span)
@@ -27,9 +27,12 @@ static JS_SCRIPT_REGEX: Lazy<Regex> = lazy_regex!(
 #[derive(Debug, Default, Clone)]
 pub struct JsxNoScriptUrl(Box<JsxNoScriptUrlConfig>);
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct JsxNoScriptUrlConfig {
+    /// Whether to include components from settings.
     include_from_settings: bool,
+    /// Additional components to check.
     components: FxHashMap<String, Vec<String>>,
 }
 
@@ -66,7 +69,8 @@ declare_oxc_lint!(
     JsxNoScriptUrl,
     react,
     suspicious,
-    pending
+    pending,
+    config = JsxNoScriptUrlConfig,
 );
 
 fn is_link_attribute(tag_name: &str, prop_value_literal: String, ctx: &LintContext) -> bool {

--- a/crates/oxc_linter/src/rules/react/jsx_pascal_case.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_pascal_case.rs
@@ -3,6 +3,7 @@ use oxc_ast::{AstKind, ast::JSXElementName};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, Span};
+use schemars::JsonSchema;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -23,11 +24,16 @@ fn jsx_pascal_case_diagnostic(
 #[derive(Debug, Default, Clone)]
 pub struct JsxPascalCase(Box<JsxPascalCaseConfig>);
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct JsxPascalCaseConfig {
+    /// Whether to allow all-caps component names.
     pub allow_all_caps: bool,
+    /// Whether to allow namespaced component names.
     pub allow_namespace: bool,
+    /// Whether to allow leading underscores in component names.
     pub allow_leading_underscore: bool,
+    /// List of component names to ignore.
     pub ignore: Vec<CompactStr>,
 }
 
@@ -92,36 +98,10 @@ declare_oxc_lint!(
     ///     <div />
     /// </_AllowedComponent>
     /// ```
-    ///
-    /// ### Options
-    ///
-    /// #### allowAllCaps
-    ///
-    /// `{ type: boolean, default: false }`
-    ///
-    /// Optional boolean set to true to allow components name in all caps
-    ///
-    /// #### allowLeadingUnderscore
-    ///
-    /// `{ type: boolean, default: false }`
-    ///
-    /// Optional boolean set to true to allow components name with that starts with an underscore
-    ///
-    /// #### allowNamespace
-    ///
-    /// `{ type: boolean, default: false }`
-    ///
-    /// Optional boolean set to true to ignore namespaced components
-    ///
-    /// #### ignore
-    ///
-    /// `{ type: Array<string | RegExp>, default: [] }`
-    ///
-    /// Optional string-array of component names to ignore during validation
-    ///
     JsxPascalCase,
     react,
-    style
+    style,
+    config = JsxPascalCaseConfig,
 );
 
 impl Rule for JsxPascalCase {

--- a/crates/oxc_linter/src/rules/react/style_prop_object.rs
+++ b/crates/oxc_linter/src/rules/react/style_prop_object.rs
@@ -8,6 +8,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, GetSpan, Span};
+use schemars::JsonSchema;
 
 use crate::{
     AstNode,
@@ -24,8 +25,10 @@ fn style_prop_object_diagnostic(span: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct StylePropObject(Box<StylePropObjectConfig>);
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct StylePropObjectConfig {
+    /// List of component names on which to allow style prop values of any type.
     allow: Vec<CompactStr>,
 }
 
@@ -77,7 +80,8 @@ declare_oxc_lint!(
     /// ```
     StylePropObject,
     react,
-    suspicious
+    suspicious,
+    config = StylePropObjectConfig,
 );
 
 fn is_invalid_type(ty: &TSType) -> bool {


### PR DESCRIPTION
Part of #14743.

- react/jsx-fragments
- react/jsx-filename-extension
- react/style-prop-object
- react/jsx-curly-brace-presence
- react/jsx-no-script-url
- react/jsx-pascal-case

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### allow

type: `"always" | "as-needed"`

default: `"always"`

When to allow a JSX filename extension. By default all files may have a JSX extension.
Set this to `as-needed` to only allow JSX file extensions in files that contain JSX syntax.


### extensions

type: `string[]`

default: `["jsx"]`

The set of allowed file extensions.


### ignoreFilesWithoutCode

type: `boolean`

default: `false`

If enabled, files that do not contain code (i.e. are empty, contain only whitespaces or comments) will not be rejected.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### children

type: `"always" | "never" | "ignore"`

default: `"never"`




### propElementValues

type: `"always" | "never" | "ignore"`

default: `"ignore"`




### props

type: `"always" | "never" | "ignore"`

default: `"never"`
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### components

type: `Record<string, array>`

default: `{}`

Additional components to check.


### includeFromSettings

type: `boolean`

default: `false`

Whether to include components from settings.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### allowAllCaps

type: `boolean`

default: `false`

Whether to allow all-caps component names.


### allowLeadingUnderscore

type: `boolean`

default: `false`

Whether to allow leading underscores in component names.


### allowNamespace

type: `boolean`

default: `false`

Whether to allow namespaced component names.


### ignore

type: `string[]`

default: `[]`

List of component names to ignore.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### mode

type: `"syntax" | "element"`

default: `"syntax"`

`syntax` mode:

This is the default mode. It will enforce the shorthand syntax for React fragments, with one exception.
Keys or attributes are not supported by the shorthand syntax, so the rule will not warn on standard-form fragments that use those.

Examples of **incorrect** code for this rule:
\```jsx
<React.Fragment><Foo /></React.Fragment>
\```

Examples of **correct** code for this rule:
\```jsx
<><Foo /></>
\```

\```jsx
<React.Fragment key="key"><Foo /></React.Fragment>
\```

`element` mode:
This mode enforces the standard form for React fragments.

Examples of **incorrect** code for this rule:
\```jsx
<><Foo /></>
\```

Examples of **correct** code for this rule:
\```jsx
<React.Fragment><Foo /></React.Fragment>
\```

\```jsx
<React.Fragment key="key"><Foo /></React.Fragment>
\```
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### allow

type: `string[]`

default: `[]`

List of component names on which to allow style prop values of any type.
```