### PR TITLE
docs(linter): Add configuration option docs for 5 rules.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/curly.rs
+++ b/crates/oxc_linter/src/rules/eslint/curly.rs
@@ -1877,7 +1877,7 @@ fn test() {
 			doSomething()
 			;
 			} while (foo)",
-            "do 
+            "do  
 			doSomething()
 			;
 			 while (foo)",

--- a/crates/oxc_linter/src/rules/eslint/curly.rs
+++ b/crates/oxc_linter/src/rules/eslint/curly.rs
@@ -1624,7 +1624,7 @@ fn test() {
             "if (foo) {
 			 quz = true;
 			 }",
-            "if (foo)
+            "if (foo) 
 			 quz = true;
 			 ",
             Some(serde_json::json!(["multi-or-nest"])),
@@ -1648,7 +1648,7 @@ fn test() {
             "if (foo) {
 			 var bar = 'baz';
 			 }",
-            "if (foo)
+            "if (foo) 
 			 var bar = 'baz';
 			 ",
             Some(serde_json::json!(["multi-or-nest"])),
@@ -1657,7 +1657,7 @@ fn test() {
             "while (true) {
 			 doSomething();
 			 }",
-            "while (true)
+            "while (true) 
 			 doSomething();
 			 ",
             Some(serde_json::json!(["multi-or-nest"])),
@@ -1666,7 +1666,7 @@ fn test() {
             "for (var i = 0; foo; i++) {
 			 doSomething();
 			 }",
-            "for (var i = 0; foo; i++)
+            "for (var i = 0; foo; i++) 
 			 doSomething();
 			 ",
             Some(serde_json::json!(["multi-or-nest"])),
@@ -1766,14 +1766,14 @@ fn test() {
         (
             "if (foo) { bar; }
 			++baz;",
-            "if (foo)  bar;
+            "if (foo)  bar; 
 			++baz;",
             Some(serde_json::json!(["multi"])),
         ),
         (
             "if (foo) { bar }
 			Baz();",
-            "if (foo)  bar
+            "if (foo)  bar 
 			Baz();",
             Some(serde_json::json!(["multi"])),
         ),
@@ -1796,7 +1796,7 @@ fn test() {
 			doSomething()
 			;
 			}",
-            "if (foo)
+            "if (foo) 
 			doSomething()
 			;
 			",
@@ -1809,7 +1809,7 @@ fn test() {
 			;
 			}",
             "if (foo) doSomething();
-			else if (bar)
+			else if (bar) 
 			doSomethingElse()
 			;
 			",
@@ -1822,7 +1822,7 @@ fn test() {
 			;
 			}",
             "if (foo) doSomething();
-			else
+			else 
 			doSomethingElse()
 			;
 			",
@@ -1833,7 +1833,7 @@ fn test() {
 			doSomething()
 			;
 			}",
-            "for (var i = 0; foo; i++)
+            "for (var i = 0; foo; i++) 
 			doSomething()
 			;
 			",
@@ -1844,7 +1844,7 @@ fn test() {
 			doSomething()
 			;
 			}",
-            "for (var foo in bar)
+            "for (var foo in bar) 
 			doSomething()
 			;
 			",
@@ -1855,7 +1855,7 @@ fn test() {
 			doSomething()
 			;
 			}",
-            "for (var foo of bar)
+            "for (var foo of bar) 
 			doSomething()
 			;
 			",
@@ -1866,7 +1866,7 @@ fn test() {
 			doSomething()
 			;
 			}",
-            "while (foo)
+            "while (foo) 
 			doSomething()
 			;
 			",
@@ -1877,7 +1877,7 @@ fn test() {
 			doSomething()
 			;
 			} while (foo)",
-            "do
+            "do 
 			doSomething()
 			;
 			 while (foo)",

--- a/crates/oxc_linter/src/rules/promise/always_return.rs
+++ b/crates/oxc_linter/src/rules/promise/always_return.rs
@@ -16,8 +16,8 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::NodeId;
 use oxc_span::{GetSpan, Span};
 use rustc_hash::FxHashSet;
-use serde::Deserialize;
 use schemars::JsonSchema;
+use serde::Deserialize;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 

--- a/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
@@ -3,6 +3,7 @@ use std::{borrow::Cow, hash::Hash};
 use itertools::Itertools;
 use lazy_regex::Regex;
 use rustc_hash::FxHashSet;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use oxc_ast::{
@@ -207,9 +208,10 @@ pub struct ExhaustiveDepsConfig {
     additional_hooks: Option<Regex>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 struct ExhaustiveDepsConfigJson {
-    #[serde(rename = "additionalHooks")]
+    /// Optionally provide a regex of additional hooks to check.
     additional_hooks: Option<String>,
 }
 
@@ -244,24 +246,11 @@ declare_oxc_lint!(
     ///     return <div />;
     /// }
     /// ```
-    ///
-    /// ### Options
-    ///
-    /// #### additionalHooks
-    ///
-    /// `{ type: string }`
-    ///
-    /// Optionally provide a regex of additional hooks to check.
-    ///
-    /// Example:
-    ///
-    /// ```json
-    /// { "react/exhaustive-deps": ["error", { "additionalHooks": "useSpecialEffect" }] }
-    /// ```
     ExhaustiveDeps,
     react,
     correctness,
-    safe_fixes_and_dangerous_suggestions
+    safe_fixes_and_dangerous_suggestions,
+    config = ExhaustiveDepsConfigJson,
 );
 
 const HOOKS_USELESS_WITHOUT_DEPENDENCIES: [&str; 2] = ["useCallback", "useMemo"];

--- a/crates/oxc_linter/src/rules/typescript/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_namespace.rs
@@ -5,6 +5,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
+use schemars::JsonSchema;
 
 use crate::{
     AstNode,
@@ -18,49 +19,9 @@ fn no_namespace_diagnostic(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct NoNamespace {
-    allow_declarations: bool,
-    allow_definition_files: bool,
-}
-
-impl Default for NoNamespace {
-    fn default() -> Self {
-        Self { allow_declarations: false, allow_definition_files: true }
-    }
-}
-
-declare_oxc_lint!(
-    /// ### What it does
-    ///
-    /// Disallow TypeScript namespaces.
-    ///
-    /// ### Why is this bad?
-    ///
-    /// TypeScript historically allowed a form of code organization called "custom modules" (module Example {}),
-    /// later renamed to "namespaces" (namespace Example). Namespaces are an outdated way to organize TypeScript code.
-    /// ES2015 module syntax is now preferred (import/export).
-    ///
-    /// ### Examples
-    ///
-    /// Examples of **incorrect** code for this rule:
-    /// ```typescript
-    /// module foo {}
-    /// namespace foo {}
-    /// declare module foo {}
-    /// declare namespace foo {}
-    /// ```
-    ///
-    /// Examples of **correct** code for this rule:
-    /// ```typescript
-    /// declare module 'foo' {}
-    /// // anything inside a d.ts file
-    /// ```
-    ///
-    /// #### allowDeclarations
-    ///
-    /// `{ type: boolean, allowDeclarations: false }`
-    ///
     /// Whether to allow declare with custom TypeScript namespaces.
     ///
     /// Examples of **incorrect** code for this rule when `{ "allowDeclarations": true }`
@@ -96,11 +57,7 @@ declare_oxc_lint!(
     /// ```typescript
     /// declare module 'foo' {}
     /// ```
-    ///
-    /// #### allowDefinitionFiles
-    ///
-    /// `{ type: boolean, allowDefinitionFiles: true }`
-    ///
+    allow_declarations: bool,
     /// Examples of **incorrect** code for this rule when `{ "allowDefinitionFiles": true }`
     /// ```typescript
     /// // if outside a d.ts file
@@ -119,9 +76,45 @@ declare_oxc_lint!(
     /// declare module 'foo' {}
     /// // anything inside a d.ts file
     /// ```
+    allow_definition_files: bool,
+}
+
+impl Default for NoNamespace {
+    fn default() -> Self {
+        Self { allow_declarations: false, allow_definition_files: true }
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow TypeScript namespaces.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// TypeScript historically allowed a form of code organization called "custom modules" (module Example {}),
+    /// later renamed to "namespaces" (namespace Example). Namespaces are an outdated way to organize TypeScript code.
+    /// ES2015 module syntax is now preferred (import/export).
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// module foo {}
+    /// namespace foo {}
+    /// declare module foo {}
+    /// declare namespace foo {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// declare module 'foo' {}
+    /// // anything inside a d.ts file
+    /// ```
     NoNamespace,
     typescript,
-    restriction
+    restriction,
+    config = NoNamespace,
 );
 
 impl Rule for NoNamespace {


### PR DESCRIPTION
Part of #14743.

- typescript/no-namespace
- react/exhaustive-deps
- typescript/array-type
- promise/always-return
- eslint/curly

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### consistent

type: `boolean`

default: `false`

Whether to enforce consistent use of curly braces in if-else chains.


### curlyType

type: `"all" | "multi" | "multi-line" | "multi-or-nest"`

default: `"all"`

Which type of curly brace enforcement to use.

- `"all"`: require braces in all cases
- `"multi"`: require braces only for multi-statement blocks
- `"multi-line"`: require braces only for multi-line blocks
- `"multi-or-nest"`: require braces for multi-line blocks or when nested
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### default

type: `"array" | "array-simple" | "generic"`

default: `"array"`

The array type expected for mutable cases.


### readonly

type: `"array" | "array-simple" | "generic"`

default: `null`

The array type expected for readonly cases. If omitted, the value for `default` will be used.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### ignoreAssignmentVariable

type: `string[]`

default: `["globalThis"]`

You can pass an `{ ignoreAssignmentVariable: [] }` as an option to this rule
with a list of variable names so that the last `then()` callback in a promise
chain does not warn if it does an assignment to a global variable. Default is
`["globalThis"]`.

\```javascript
/* eslint promise/always-return: ["error", { ignoreAssignmentVariable: ["globalThis"] }] */

// OK
promise.then((x) => {
globalThis = x
})

promise.then((x) => {
globalThis.x = x
})

// OK
promise.then((x) => {
globalThis.x.y = x
})

// NG
promise.then((x) => {
anyOtherVariable = x
})

// NG
promise.then((x) => {
anyOtherVariable.x = x
})

// NG
promise.then((x) => {
x()
})
\```


### ignoreLastCallback

type: `boolean`

default: `false`

You can pass an `{ ignoreLastCallback: true }` as an option to this rule so that
the last `then()` callback in a promise chain does not warn if it does not have
a `return`. Default is `false`.

\```javascript
// OK
promise.then((x) => {
console.log(x)
})
// OK
void promise.then((x) => {
console.log(x)
})
// OK
await promise.then((x) => {
console.log(x)
})

promise
// NG
.then((x) => {
console.log(x)
})
// OK
.then((x) => {
console.log(x)
})

// NG
const v = promise.then((x) => {
console.log(x)
})
// NG
const v = await promise.then((x) => {
console.log(x)
})
function foo() {
// NG
return promise.then((x) => {
console.log(x)
})
}
\```
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### additionalHooks

type: `[
  string,
  null
]`

default: `null`

Optionally provide a regex of additional hooks to check.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### allowDeclarations

type: `boolean`

default: `false`

Whether to allow declare with custom TypeScript namespaces.

Examples of **incorrect** code for this rule when `{ "allowDeclarations": true }`
\```typescript
module foo {}
namespace foo {}
\```

Examples of **correct** code for this rule when `{ "allowDeclarations": true }`
\```typescript
declare module 'foo' {}
declare module foo {}
declare namespace foo {}

declare global {
namespace foo {}
}

declare module foo {
namespace foo {}
}
\```

Examples of **incorrect** code for this rule when `{ "allowDeclarations": false }`
\```typescript
module foo {}
namespace foo {}
declare module foo {}
declare namespace foo {}
\```

Examples of **correct** code for this rule when `{ "allowDeclarations": false }`
\```typescript
declare module 'foo' {}
\```


### allowDefinitionFiles

type: `boolean`

default: `true`

Examples of **incorrect** code for this rule when `{ "allowDefinitionFiles": true }`
\```typescript
// if outside a d.ts file
module foo {}
namespace foo {}

// if outside a d.ts file
module foo {}
namespace foo {}
declare module foo {}
declare namespace foo {}
\```

Examples of **correct** code for this rule when `{ "allowDefinitionFiles": true }`
\```typescript
declare module 'foo' {}
// anything inside a d.ts file
\```
```