### PR TITLE
fix(linter): Improve diagnostic for react/button-has-type.

### DIFF
--- a/crates/oxc_linter/src/rules/react/button_has_type.rs
+++ b/crates/oxc_linter/src/rules/react/button_has_type.rs
@@ -277,6 +277,10 @@ fn test() {
             Some(serde_json::json!([{ "reset": false }])),
         ),
         (
+            r#"React.createElement("button", {type: "button"})"#,
+            Some(serde_json::json!([{ "reset": false, "submit": false }])),
+        ),
+        (
             r#"
 			        function MyComponent(): ReactElement {
 			          const buttonProps: (Required<Attributes> & ButtonHTMLAttributes<HTMLButtonElement>)[] = [
@@ -344,6 +348,10 @@ fn test() {
         (
             r#"React.createElement("button", {type: condition ? "reset" : "button"})"#,
             Some(serde_json::json!([{ "reset": false }])),
+        ),
+        (
+            r#"React.createElement("button", {type: condition ? "reset" : "button"})"#,
+            Some(serde_json::json!([{ "reset": false, "submit": false }])),
         ),
         (r#"Foo.createElement("button")"#, None),
         (

--- a/crates/oxc_linter/src/snapshots/react_button_has_type.snap
+++ b/crates/oxc_linter/src/snapshots/react_button_has_type.snap
@@ -183,6 +183,13 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Change the `type` attribute to one of the allowed values: `button` or `submit`.
 
+  ⚠ eslint-plugin-react(button-has-type): `button` elements must have a valid `type` attribute.
+   ╭─[button_has_type.tsx:1:32]
+ 1 │ React.createElement("button", {type: condition ? "reset" : "button"})
+   ·                                ────────────────────────────────────
+   ╰────
+  help: Change the `type` attribute to one of the allowed values: `button`.
+
   ⚠ eslint-plugin-react(button-has-type): `button` elements must have an explicit `type` attribute.
    ╭─[button_has_type.tsx:1:1]
  1 │ Foo.createElement("button")

--- a/crates/oxc_linter/src/snapshots/react_button_has_type.snap
+++ b/crates/oxc_linter/src/snapshots/react_button_has_type.snap
@@ -55,7 +55,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <button type="reset"/>
    ·         ────────────
    ╰────
-  help: Change the `type` attribute to one of the allowed values: `button`, `submit`, or `reset`.
+  help: Change the `type` attribute to one of the allowed values: `button` or `submit`.
 
   ⚠ eslint-plugin-react(button-has-type): `button` elements must have a valid `type` attribute.
    ╭─[button_has_type.tsx:1:9]
@@ -76,7 +76,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <button type={condition ? "button" : "reset"}/>
    ·         ─────────────────────────────────────
    ╰────
-  help: Change the `type` attribute to one of the allowed values: `button`, `submit`, or `reset`.
+  help: Change the `type` attribute to one of the allowed values: `button` or `submit`.
 
   ⚠ eslint-plugin-react(button-has-type): `button` elements must have a valid `type` attribute.
    ╭─[button_has_type.tsx:1:9]
@@ -104,7 +104,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <button type={condition ? "reset" : "button"}/>
    ·         ─────────────────────────────────────
    ╰────
-  help: Change the `type` attribute to one of the allowed values: `button`, `submit`, or `reset`.
+  help: Change the `type` attribute to one of the allowed values: `button` or `submit`.
 
   ⚠ eslint-plugin-react(button-has-type): `button` elements must have an explicit `type` attribute.
    ╭─[button_has_type.tsx:1:1]
@@ -139,7 +139,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ React.createElement("button", {type: "reset"})
    ·                                ─────────────
    ╰────
-  help: Change the `type` attribute to one of the allowed values: `button`, `submit`, or `reset`.
+  help: Change the `type` attribute to one of the allowed values: `button` or `submit`.
 
   ⚠ eslint-plugin-react(button-has-type): `button` elements must have a valid `type` attribute.
    ╭─[button_has_type.tsx:1:32]
@@ -160,7 +160,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ React.createElement("button", {type: condition ? "button" : "reset"})
    ·                                ────────────────────────────────────
    ╰────
-  help: Change the `type` attribute to one of the allowed values: `button`, `submit`, or `reset`.
+  help: Change the `type` attribute to one of the allowed values: `button` or `submit`.
 
   ⚠ eslint-plugin-react(button-has-type): `button` elements must have a valid `type` attribute.
    ╭─[button_has_type.tsx:1:32]
@@ -181,7 +181,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ React.createElement("button", {type: condition ? "reset" : "button"})
    ·                                ────────────────────────────────────
    ╰────
-  help: Change the `type` attribute to one of the allowed values: `button`, `submit`, or `reset`.
+  help: Change the `type` attribute to one of the allowed values: `button` or `submit`.
 
   ⚠ eslint-plugin-react(button-has-type): `button` elements must have an explicit `type` attribute.
    ╭─[button_has_type.tsx:1:1]


### PR DESCRIPTION
Fixes #15147. Previously, the diagnostic message did not change based on the options configured for the rule.

**Disclaimer:** Fully written by GitHub Copilot w/ Claude Sonnet 4.5. I only made minor edits and followed its work to make sure it made sense and tested the changes briefly. I also added the basic additional test cases. But I do not really know much Rust, so please review accordingly.