### PR TITLE
fix(linter): ignore script tag in code comment

### DIFF
--- a/crates/oxc_linter/src/loader/partial_loader/astro.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/astro.rs
@@ -2,12 +2,9 @@ use memchr::memmem::{Finder, FinderRev};
 
 use oxc_span::{SourceType, Span};
 
-use crate::loader::{
-    JavaScriptSource,
-    partial_loader::{COMMENT_END, COMMENT_START, SCRIPT_START, find_script_start},
-};
+use crate::loader::JavaScriptSource;
 
-use super::SCRIPT_END;
+use super::{COMMENT_END, COMMENT_START, SCRIPT_END, SCRIPT_START, find_script_start};
 
 const ASTRO_SPLIT: &str = "---";
 

--- a/crates/oxc_linter/src/loader/partial_loader/astro.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/astro.rs
@@ -2,9 +2,9 @@ use memchr::memmem::Finder;
 
 use oxc_span::{SourceType, Span};
 
-use crate::loader::JavaScriptSource;
+use crate::loader::{JavaScriptSource, partial_loader::find_script_start};
 
-use super::{SCRIPT_END, SCRIPT_START};
+use super::SCRIPT_END;
 
 const ASTRO_SPLIT: &str = "---";
 
@@ -53,7 +53,6 @@ impl<'a> AstroPartialLoader<'a> {
     /// In .astro files, you can add client-side JavaScript by adding one (or more) `<script>` tags.
     /// <https://docs.astro.build/en/guides/client-side-scripts/#using-script-in-astro>
     fn parse_scripts(&self, start: usize) -> Vec<JavaScriptSource<'a>> {
-        let script_start_finder = Finder::new(SCRIPT_START);
         let script_end_finder = Finder::new(SCRIPT_END);
 
         let mut results = vec![];
@@ -63,9 +62,8 @@ impl<'a> AstroPartialLoader<'a> {
             let js_start;
             let js_end;
             // find opening "<script"
-            if let Some(offset) = script_start_finder.find(&self.source_text.as_bytes()[pointer..])
-            {
-                pointer += offset + SCRIPT_START.len();
+            if let Some(offset) = find_script_start(self.source_text, &pointer) {
+                pointer += offset;
             } else {
                 break;
             }

--- a/crates/oxc_linter/src/loader/partial_loader/mod.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/mod.rs
@@ -1,3 +1,4 @@
+use memchr::memmem::Finder;
 use oxc_span::VALID_EXTENSIONS;
 
 use crate::loader::JavaScriptSource;
@@ -68,4 +69,11 @@ fn find_script_closing_angle(source_text: &str, pointer: usize) -> Option<usize>
     }
 
     None
+}
+
+fn find_script_start(source_text: &str, pointer: &usize) -> Option<usize> {
+    let script_start_finder = Finder::new(SCRIPT_START);
+    let offset = script_start_finder.find(&source_text.as_bytes()[*pointer..])?;
+
+    Some(offset + SCRIPT_START.len())
 }

--- a/crates/oxc_linter/src/loader/partial_loader/mod.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/mod.rs
@@ -73,11 +73,14 @@ fn find_script_closing_angle(source_text: &str, pointer: usize) -> Option<usize>
     None
 }
 
-fn find_script_start(source_text: &str, pointer: &usize) -> Option<usize> {
-    let mut new_pointer = *pointer;
-    let script_start_finder = Finder::new(SCRIPT_START);
-    let comment_start_finder = FinderRev::new(COMMENT_START);
-    let comment_end_finder = Finder::new(COMMENT_END);
+fn find_script_start(
+    source_text: &str,
+    pointer: usize,
+    script_start_finder: &Finder<'_>,
+    comment_start_finder: &FinderRev<'_>,
+    comment_end_finder: &Finder<'_>,
+) -> Option<usize> {
+    let mut new_pointer = pointer;
 
     loop {
         new_pointer +=
@@ -95,5 +98,5 @@ fn find_script_start(source_text: &str, pointer: &usize) -> Option<usize> {
         }
     }
 
-    Some(new_pointer - *pointer)
+    Some(new_pointer - pointer)
 }

--- a/crates/oxc_linter/src/loader/partial_loader/svelte.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/svelte.rs
@@ -2,9 +2,9 @@ use memchr::memmem::Finder;
 
 use oxc_span::SourceType;
 
-use crate::loader::JavaScriptSource;
+use crate::loader::{JavaScriptSource, partial_loader::find_script_start};
 
-use super::{SCRIPT_END, SCRIPT_START, find_script_closing_angle};
+use super::{SCRIPT_END, find_script_closing_angle};
 
 pub struct SveltePartialLoader<'a> {
     source_text: &'a str,
@@ -35,12 +35,10 @@ impl<'a> SveltePartialLoader<'a> {
     }
 
     fn parse_script(&self, pointer: &mut usize) -> Option<JavaScriptSource<'a>> {
-        let script_start_finder = Finder::new(SCRIPT_START);
         let script_end_finder = Finder::new(SCRIPT_END);
 
         // find opening "<script"
-        let offset = script_start_finder.find(&self.source_text.as_bytes()[*pointer..])?;
-        *pointer += offset + SCRIPT_START.len();
+        *pointer += find_script_start(self.source_text, pointer)?;
 
         // find closing ">"
         let offset = find_script_closing_angle(self.source_text, *pointer)?;

--- a/crates/oxc_linter/src/loader/partial_loader/svelte.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/svelte.rs
@@ -2,9 +2,12 @@ use memchr::memmem::{Finder, FinderRev};
 
 use oxc_span::SourceType;
 
-use crate::loader::{JavaScriptSource, partial_loader::find_script_start};
+use crate::loader::JavaScriptSource;
 
-use super::{COMMENT_END, COMMENT_START, SCRIPT_END, SCRIPT_START, find_script_closing_angle};
+use super::{
+    COMMENT_END, COMMENT_START, SCRIPT_END, SCRIPT_START, find_script_closing_angle,
+    find_script_start,
+};
 
 pub struct SveltePartialLoader<'a> {
     source_text: &'a str,

--- a/crates/oxc_linter/src/loader/partial_loader/vue.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/vue.rs
@@ -287,6 +287,18 @@ mod test {
     }
 
     #[test]
+    fn test_script_inside_code_comment() {
+        let source_text = r"
+        <!-- <script>a</script> -->
+        <script>b</script>
+        ";
+
+        let result: JavaScriptSource<'_> = parse_vue(source_text);
+        assert_eq!(result.source_text, "b");
+        assert_eq!(result.start, 53);
+    }
+
+    #[test]
     fn lang() {
         let cases = [
             ("<script>debugger</script>", Some(SourceType::mjs())),

--- a/crates/oxc_linter/src/loader/partial_loader/vue.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/vue.rs
@@ -2,12 +2,12 @@ use memchr::memmem::{Finder, FinderRev};
 
 use oxc_span::SourceType;
 
-use crate::{
-    frameworks::FrameworkOptions,
-    loader::partial_loader::{SCRIPT_START, find_script_start},
-};
+use crate::frameworks::FrameworkOptions;
 
-use super::{COMMENT_END, COMMENT_START, JavaScriptSource, SCRIPT_END, find_script_closing_angle};
+use super::{
+    COMMENT_END, COMMENT_START, JavaScriptSource, SCRIPT_END, SCRIPT_START,
+    find_script_closing_angle, find_script_start,
+};
 
 pub struct VuePartialLoader<'a> {
     source_text: &'a str,

--- a/crates/oxc_linter/src/loader/partial_loader/vue.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/vue.rs
@@ -302,12 +302,13 @@ mod test {
     fn test_script_inside_code_comment() {
         let source_text = r"
         <!-- <script>a</script> -->
+        <!-- <script> -->
         <script>b</script>
         ";
 
         let result: JavaScriptSource<'_> = parse_vue(source_text);
         assert_eq!(result.source_text, "b");
-        assert_eq!(result.start, 53);
+        assert_eq!(result.start, 79);
     }
 
     #[test]


### PR DESCRIPTION
Partial loader tries parsing the `<script>` tag in the code comment incorrectly

For example, we have a `.vue` file

```vue
<!-- <script setup lang="tsx"> -->
<script setup lang="ts">
const count = ref(0)
</script>
```

And the loader will regard these as script part

```
 -->
<script setup lang="ts">
const count = ref(0)
```

So this PR added some `Finder`s for code comment to ignore the `<script>` in code comment, also works on `.svelte` and `.astro` files

