### PR TITLE
perf(linter/no-unwanted-polyfillio): should run when source type is jsx

### DIFF
--- a/crates/oxc_linter/src/rules/nextjs/no_unwanted_polyfillio.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_unwanted_polyfillio.rs
@@ -9,7 +9,7 @@ use oxc_semantic::AstNode;
 use oxc_span::Span;
 
 use crate::{
-    context::LintContext,
+    context::{ContextHost, LintContext},
     rule::Rule,
     utils::{NEXT_POLYFILLED_FEATURES, find_url_query_value, get_next_script_import_local_name},
 };
@@ -48,6 +48,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnwantedPolyfillio {
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        ctx.source_type().is_jsx()
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;


### PR DESCRIPTION
I believe some of the rules under Next.js should only run when the source type variant is `jsx`. If that’s correct, I’ll gradually refine those rules across the next few PRs.