### PR TITLE
docs(linter): Add config option docs for 7 rules.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
@@ -10,6 +10,8 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::AssignmentOperator;
+use schemars::JsonSchema;
+use serde::Deserialize;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -17,9 +19,18 @@ fn no_self_assign_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("this expression is assigned to itself").with_label(span)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct NoSelfAssign {
-    /// if this is true, no-self-assign rule warns self-assignments of properties. Default is true.
+    /// The `props` option when set to `false`, disables the checking of properties.
+    ///
+    /// With `props` set to `false` the following are examples of correct code:
+    /// ```javascript
+    /// obj.a = obj.a;
+    /// obj.a.b = obj.a.b;
+    /// obj["a"] = obj["a"];
+    /// obj[a] = obj[a];
+    /// ```
     props: bool,
 }
 
@@ -81,25 +92,10 @@ declare_oxc_lint!(
     /// foo &= foo;
     /// foo |= foo;
     /// ```
-    ///
-    /// ### Options
-    ///
-    /// #### props
-    ///
-    /// `{ type: boolean, default: true }`
-    ///
-    /// The `props` option when set to `false`, disables the checking of properties.
-    ///
-    /// With `props` set to `false` the following are examples of correct code:
-    /// ```javascript
-    /// obj.a = obj.a;
-    /// obj.a.b = obj.a.b;
-    /// obj["a"] = obj["a"];
-    /// obj[a] = obj[a];
-    /// ```
     NoSelfAssign,
     eslint,
-    correctness
+    correctness,
+    config = NoSelfAssign
 );
 
 impl Rule for NoSelfAssign {

--- a/crates/oxc_linter/src/rules/jest/prefer_lowercase_title/mod.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_lowercase_title/mod.rs
@@ -2,6 +2,8 @@ use oxc_ast::{AstKind, ast::Argument};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, Span};
+use schemars::JsonSchema;
+use serde::Deserialize;
 
 #[cfg(test)]
 mod tests;
@@ -20,11 +22,88 @@ fn prefer_lowercase_title_diagnostic(title: &str, span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct PreferLowercaseTitleConfig {
+    /// This array option allows specifying prefixes, which contain capitals that titles
+    /// can start with. This can be useful when writing tests for API endpoints, where
+    /// you'd like to prefix with the HTTP method.
+    /// By default, nothing is allowed (the equivalent of `{ "allowedPrefixes": [] }`).
+    ///
+    /// Example of **correct** code for the `{ "allowedPrefixes": ["GET"] }` option:
+    /// ```js
+    /// /* eslint jest/prefer-lowercase-title: ["error", { "allowedPrefixes": ["GET"] }] */
+    /// describe('GET /live');
+    /// ```
     allowed_prefixes: Vec<CompactStr>,
+    /// This array option controls which Jest or Vitest functions are checked by this rule. There
+    /// are four possible values:
+    /// - `"describe"`
+    /// - `"test"`
+    /// - `"it"`
+    /// - `"bench"`
+    ///
+    /// By default, none of these options are enabled (the equivalent of
+    /// `{ "ignore": [] }`).
+    ///
+    /// Example of **correct** code for the `{ "ignore": ["describe"] }` option:
+    /// ```js
+    /// /* eslint jest/prefer-lowercase-title: ["error", { "ignore": ["describe"] }] */
+    /// describe('Uppercase description');
+    /// ```
+    ///
+    /// Example of **correct** code for the `{ "ignore": ["test"] }` option:
+    /// ```js
+    /// /* eslint jest/prefer-lowercase-title: ["error", { "ignore": ["test"] }] */
+    /// test('Uppercase description');
+    /// ```
+    ///
+    /// Example of **correct** code for the `{ "ignore": ["it"] }` option:
+    /// ```js
+    /// /* eslint jest/prefer-lowercase-title: ["error", { "ignore": ["it"] }] */
+    /// it('Uppercase description');
+    /// ```
     ignore: Vec<CompactStr>,
+    /// This option can be set to allow only the top-level `describe` blocks to have a
+    /// title starting with an upper-case letter.
+    ///
+    /// Example of **correct** code for the `{ "ignoreTopLevelDescribe": true }` option:
+    /// ```js
+    /// /* eslint jest/prefer-lowercase-title: ["error", { "ignoreTopLevelDescribe": true }] */
+    /// describe('MyClass', () => {
+    ///     describe('#myMethod', () => {
+    ///         it('does things', () => {
+    ///             //
+    ///         });
+    ///     });
+    /// });
+    /// ```
     ignore_top_level_describe: bool,
+    /// This option can be set to only validate that the first character of a test name is lowercased.
+    ///
+    /// Example of **correct** code for the `{ "lowercaseFirstCharacterOnly": true }` option:
+    /// ```js
+    /// /* eslint vitest/prefer-lowercase-title: ["error", { "lowercaseFirstCharacterOnly": true }] */
+    /// describe('myClass', () => {
+    ///     describe('myMethod', () => {
+    ///         it('does things', () => {
+    ///             //
+    ///         });
+    ///     });
+    /// });
+    /// ```
+    ///
+    /// Example of **incorrect** code for the `{ "lowercaseFirstCharacterOnly": true }` option:
+    /// ```js
+    /// /* eslint vitest/prefer-lowercase-title: ["error", { "lowercaseFirstCharacterOnly": true }] */
+    /// describe('MyClass', () => {
+    ///     describe('MyMethod', () => {
+    ///         it('does things', () => {
+    ///             //
+    ///         });
+    ///     });
+    /// });
+    /// ```
     lowercase_first_character_only: bool,
 }
 
@@ -72,110 +151,11 @@ declare_oxc_lint!(
     ///     expect(sum(1, 2)).toBe(3);
     /// });
     /// ```
-    ///
-    /// ### Options
-    /// ```json
-    /// {
-    ///     "jest/prefer-lowercase-title": [
-    ///         "error",
-    ///         {
-    ///             "ignore": ["describe", "test"]
-    ///         }
-    ///     ]
-    /// }
-    /// ```
-    ///
-    /// #### `ignore`
-    ///
-    /// This array option controls which Jest or Vitest functions are checked by this rule. There
-    /// are four possible values:
-    /// - `"describe"`
-    /// - `"test"`
-    /// - `"it"`
-    /// - `"bench"`
-    ///
-    /// By default, none of these options are enabled (the equivalent of
-    /// `{ "ignore": [] }`).
-    ///
-    /// Example of **correct** code for the `{ "ignore": ["describe"] }` option:
-    /// ```js
-    /// /* eslint jest/prefer-lowercase-title: ["error", { "ignore": ["describe"] }] */
-    /// describe('Uppercase description');
-    /// ```
-    ///
-    /// Example of **correct** code for the `{ "ignore": ["test"] }` option:
-    /// ```js
-    /// /* eslint jest/prefer-lowercase-title: ["error", { "ignore": ["test"] }] */
-    /// test('Uppercase description');
-    /// ```
-    ///
-    /// Example of **correct** code for the `{ "ignore": ["it"] }` option:
-    /// ```js
-    /// /* eslint jest/prefer-lowercase-title: ["error", { "ignore": ["it"] }] */
-    /// it('Uppercase description');
-    /// ```
-    ///
-    /// #### `allowedPrefixes`
-    ///
-    /// This array option allows specifying prefixes, which contain capitals that titles
-    /// can start with. This can be useful when writing tests for API endpoints, where
-    /// you'd like to prefix with the HTTP method.
-    /// By default, nothing is allowed (the equivalent of `{ "allowedPrefixes": [] }`).
-    ///
-    /// Example of **correct** code for the `{ "allowedPrefixes": ["GET"] }` option:
-    /// ```js
-    /// /* eslint jest/prefer-lowercase-title: ["error", { "allowedPrefixes": ["GET"] }] */
-    /// describe('GET /live');
-    /// ```
-    ///
-    /// #### `ignoreTopLevelDescribe`
-    ///
-    /// This option can be set to allow only the top-level `describe` blocks to have a
-    /// title starting with an upper-case letter.
-    ///
-    /// Example of **correct** code for the `{ "ignoreTopLevelDescribe": true }` option:
-    /// ```js
-    /// /* eslint jest/prefer-lowercase-title: ["error", { "ignoreTopLevelDescribe": true }] */
-    /// describe('MyClass', () => {
-    ///     describe('#myMethod', () => {
-    ///         it('does things', () => {
-    ///             //
-    ///         });
-    ///     });
-    /// });
-    /// ```
-    ///
-    /// #### `lowercaseFirstCharacterOnly`
-    ///
-    /// This option can be set to only validate that the first character of a test name is lowercased.
-    ///
-    /// Example of **correct** code for the `{ "lowercaseFirstCharacterOnly": true }` option:
-    /// ```js
-    /// /* eslint vitest/prefer-lowercase-title: ["error", { "lowercaseFirstCharacterOnly": true }] */
-    /// describe('myClass', () => {
-    ///     describe('myMethod', () => {
-    ///         it('does things', () => {
-    ///             //
-    ///         });
-    ///     });
-    /// });
-    /// ```
-    ///
-    /// Example of **incorrect** code for the `{ "lowercaseFirstCharacterOnly": true }` option:
-    /// ```js
-    /// /* eslint vitest/prefer-lowercase-title: ["error", { "lowercaseFirstCharacterOnly": true }] */
-    /// describe('MyClass', () => {
-    ///     describe('MyMethod', () => {
-    ///         it('does things', () => {
-    ///             //
-    ///         });
-    ///     });
-    /// });
-    /// ```
     PreferLowercaseTitle,
     jest,
     style,
-    fix
+    fix,
+    config = PreferLowercaseTitleConfig
 );
 
 impl Rule for PreferLowercaseTitle {

--- a/crates/oxc_linter/src/rules/jsx_a11y/label_has_associated_control.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/label_has_associated_control.rs
@@ -7,6 +7,8 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, Span};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     AstNode,
@@ -33,20 +35,28 @@ pub struct LabelHasAssociatedControl(Box<LabelHasAssociatedControlConfig>);
 const DEFAULT_CONTROL_COMPONENTS: [&str; 6] =
     ["input", "meter", "output", "progress", "select", "textarea"];
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct LabelHasAssociatedControlConfig {
+    /// Maximum depth to search for a nested control.
     depth: u8,
+    /// The type of association required between the label and the control.
     assert: Assert,
+    /// Custom JSX components to be treated as labels.
     label_components: Vec<CompactStr>,
+    /// Attributes to check for accessible label text.
     label_attributes: Vec<CompactStr>,
+    /// Custom JSX components to be treated as form controls.
     control_components: Vec<CompactStr>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
 enum Assert {
     HtmlFor,
     Nesting,
     Both,
+    #[default]
     Either,
 }
 
@@ -110,6 +120,7 @@ declare_oxc_lint!(
     LabelHasAssociatedControl,
     jsx_a11y,
     correctness,
+    config = LabelHasAssociatedControlConfig
 );
 
 impl Rule for LabelHasAssociatedControl {

--- a/crates/oxc_linter/src/rules/jsx_a11y/media_has_caption.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/media_has_caption.rs
@@ -7,6 +7,8 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{AstNode, context::LintContext, rule::Rule, utils::get_element_type};
@@ -20,10 +22,14 @@ fn media_has_caption_diagnostic(span: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct MediaHasCaption(Box<MediaHasCaptionConfig>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct MediaHasCaptionConfig {
+    /// Element names to treat as `<audio>` elements
     audio: Vec<Cow<'static, str>>,
+    /// Element names to treat as `<video>` elements
     video: Vec<Cow<'static, str>>,
+    /// Element names to treat as `<track>` elements
     track: Vec<Cow<'static, str>>,
 }
 
@@ -63,7 +69,8 @@ declare_oxc_lint!(
     /// ```
     MediaHasCaption,
     jsx_a11y,
-    correctness
+    correctness,
+    config = MediaHasCaptionConfig,
 );
 
 impl Rule for MediaHasCaption {

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
@@ -5,6 +5,8 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, Span};
+use schemars::JsonSchema;
+use serde::Deserialize;
 
 use crate::{
     AstNode,
@@ -22,20 +24,30 @@ fn no_noninteractive_tabindex_diagnostic(span: Span) -> OxcDiagnostic {
 #[derive(Debug, Clone)]
 pub struct NoNoninteractiveTabindex(Box<NoNoninteractiveTabindexConfig>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 struct NoNoninteractiveTabindexConfig {
+    /// An array of custom HTML elements that should be considered interactive.
     tags: Vec<CompactStr>,
+    /// An array of ARIA roles that should be considered interactive.
     roles: Vec<CompactStr>,
+    /// If `true`, allows tabIndex values to be expression values (e.g., variables, ternaries). If `false`, only string literal values are allowed.
     allow_expression_values: bool,
+}
+
+impl Default for NoNoninteractiveTabindexConfig {
+    fn default() -> Self {
+        Self {
+            roles: vec![CompactStr::new("tabpanel")],
+            allow_expression_values: true,
+            tags: vec![],
+        }
+    }
 }
 
 impl Default for NoNoninteractiveTabindex {
     fn default() -> Self {
-        Self(Box::new(NoNoninteractiveTabindexConfig {
-            roles: vec![CompactStr::new("tabpanel")],
-            allow_expression_values: true,
-            tags: vec![],
-        }))
+        Self(Box::new(NoNoninteractiveTabindexConfig::default()))
     }
 }
 
@@ -79,6 +91,7 @@ declare_oxc_lint!(
     NoNoninteractiveTabindex,
     jsx_a11y,
     correctness,
+    config = NoNoninteractiveTabindexConfig,
 );
 
 // https://html.spec.whatwg.org/multipage/dom.html#interactive-content

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
@@ -21,7 +21,7 @@ fn no_noninteractive_tabindex_diagnostic(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct NoNoninteractiveTabindex(Box<NoNoninteractiveTabindexConfig>);
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
@@ -42,12 +42,6 @@ impl Default for NoNoninteractiveTabindexConfig {
             allow_expression_values: true,
             tags: vec![],
         }
-    }
-}
-
-impl Default for NoNoninteractiveTabindex {
-    fn default() -> Self {
-        Self(Box::default())
     }
 }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
@@ -47,7 +47,7 @@ impl Default for NoNoninteractiveTabindexConfig {
 
 impl Default for NoNoninteractiveTabindex {
     fn default() -> Self {
-        Self(Box::new(NoNoninteractiveTabindexConfig::default()))
+        Self(Box::default())
     }
 }
 

--- a/crates/oxc_linter/src/rules/promise/spec_only.rs
+++ b/crates/oxc_linter/src/rules/promise/spec_only.rs
@@ -2,6 +2,8 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, GetSpan, Span};
 use rustc_hash::FxHashSet;
+use schemars::JsonSchema;
+use serde::Deserialize;
 
 use crate::{AstNode, context::LintContext, rule::Rule, utils::PROMISE_STATIC_METHODS};
 
@@ -13,8 +15,10 @@ fn spec_only(prop_name: &str, member_span: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct SpecOnly(Box<SpecOnlyConfig>);
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct SpecOnlyConfig {
+    /// List of Promise static methods that are allowed to be used.
     allowed_methods: Option<FxHashSet<CompactStr>>,
 }
 
@@ -49,6 +53,7 @@ declare_oxc_lint!(
     SpecOnly,
     promise,
     restriction,
+    config = SpecOnlyConfig,
 );
 
 impl Rule for SpecOnly {

--- a/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
@@ -34,7 +34,7 @@ pub struct ConsistentGenericConstructorsConfig {
     /// Specifies where the generic type should be specified.
     ///
     /// Possible values:
-    /// - `"constructor"` (default):Type arguments that only appear on the type annotation are disallowed.
+    /// - `"constructor"` (default): Type arguments that only appear on the type annotation are disallowed.
     /// - `"type-annotation"`: Type arguments that only appear on the constructor are disallowed.
     option: PreferGenericType,
 }

--- a/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
@@ -5,6 +5,8 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -26,15 +28,24 @@ fn consistent_generic_constructors_diagnostic_prefer_constructor(span: Span) -> 
 #[derive(Debug, Default, Clone)]
 pub struct ConsistentGenericConstructors(Box<ConsistentGenericConstructorsConfig>);
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct ConsistentGenericConstructorsConfig {
+    /// Specifies where the generic type should be specified.
+    ///
+    /// Possible values:
+    /// - `"constructor"` (default):Type arguments that only appear on the type annotation are disallowed.
+    /// - `"type-annotation"`: Type arguments that only appear on the constructor are disallowed.
     option: PreferGenericType,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
 enum PreferGenericType {
+    /// Type arguments that only appear on the type annotation are disallowed.
     #[default]
     Constructor,
+    /// Type arguments that only appear on the constructor are disallowed.
     TypeAnnotation,
 }
 
@@ -77,7 +88,8 @@ declare_oxc_lint!(
     ConsistentGenericConstructors,
     typescript,
     style,
-    pending
+    pending,
+    config = ConsistentGenericConstructorsConfig
 );
 
 impl Rule for ConsistentGenericConstructors {


### PR DESCRIPTION
Part of #14743.

- eslint/no-self-assign
- jest/prefer-lowercase-title
- jsx-a11y/label-has-associated-control
- jsx-a11y/media-has-caption
- jsx-a11y/no-noninteractive-tabindex
- promise/spec-only
- typescript/consistent-generic-constructors

For `jsx-a11y/no-noninteractive-tabindex`, this required changing the way this is implemented slightly so we properly derive the default value, otherwise the JsonSchema derivation complained.

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### props

type: `boolean`

default: `true`

The `props` option when set to `false`, disables the checking of properties.

With `props` set to `false` the following are examples of correct code:
\```javascript
obj.a = obj.a;
obj.a.b = obj.a.b;
obj["a"] = obj["a"];
obj[a] = obj[a];
\```
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### option


default: `"constructor"`

Specifies where the generic type should be specified.

Possible values:
- `"constructor"` (default):Type arguments that only appear on the type annotation are disallowed.
- `"type-annotation"`: Type arguments that only appear on the constructor are disallowed.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### allowedPrefixes

type: `string[]`

default: `[]`

This array option allows specifying prefixes, which contain capitals that titles
can start with. This can be useful when writing tests for API endpoints, where
you'd like to prefix with the HTTP method.
By default, nothing is allowed (the equivalent of `{ "allowedPrefixes": [] }`).

Example of **correct** code for the `{ "allowedPrefixes": ["GET"] }` option:
\```js
/* eslint jest/prefer-lowercase-title: ["error", { "allowedPrefixes": ["GET"] }] */
describe('GET /live');
\```


### ignore

type: `string[]`

default: `[]`

This array option controls which Jest or Vitest functions are checked by this rule. There
are four possible values:
- `"describe"`
- `"test"`
- `"it"`
- `"bench"`

By default, none of these options are enabled (the equivalent of
`{ "ignore": [] }`).

Example of **correct** code for the `{ "ignore": ["describe"] }` option:
\```js
/* eslint jest/prefer-lowercase-title: ["error", { "ignore": ["describe"] }] */
describe('Uppercase description');
\```

Example of **correct** code for the `{ "ignore": ["test"] }` option:
\```js
/* eslint jest/prefer-lowercase-title: ["error", { "ignore": ["test"] }] */
test('Uppercase description');
\```

Example of **correct** code for the `{ "ignore": ["it"] }` option:
\```js
/* eslint jest/prefer-lowercase-title: ["error", { "ignore": ["it"] }] */
it('Uppercase description');
\```


### ignoreTopLevelDescribe

type: `boolean`

default: `false`

This option can be set to allow only the top-level `describe` blocks to have a
title starting with an upper-case letter.

Example of **correct** code for the `{ "ignoreTopLevelDescribe": true }` option:
\```js
/* eslint jest/prefer-lowercase-title: ["error", { "ignoreTopLevelDescribe": true }] */
describe('MyClass', () => {
describe('#myMethod', () => {
it('does things', () => {
//
});
});
});
\```


### lowercaseFirstCharacterOnly

type: `boolean`

default: `true`

This option can be set to only validate that the first character of a test name is lowercased.

Example of **correct** code for the `{ "lowercaseFirstCharacterOnly": true }` option:
\```js
/* eslint vitest/prefer-lowercase-title: ["error", { "lowercaseFirstCharacterOnly": true }] */
describe('myClass', () => {
describe('myMethod', () => {
it('does things', () => {
//
});
});
});
\```

Example of **incorrect** code for the `{ "lowercaseFirstCharacterOnly": true }` option:
\```js
/* eslint vitest/prefer-lowercase-title: ["error", { "lowercaseFirstCharacterOnly": true }] */
describe('MyClass', () => {
describe('MyMethod', () => {
it('does things', () => {
//
});
});
});
\```
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### audio

type: `string[]`

default: `["audio"]`

Element names to treat as `<audio>` elements


### track

type: `string[]`

default: `["track"]`

Element names to treat as `<track>` elements


### video

type: `string[]`

default: `["video"]`

Element names to treat as `<video>` elements
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### assert

type: `"html-for" | "nesting" | "both" | "either"`

default: `"either"`

The type of association required between the label and the control.


### controlComponents

type: `string[]`

default: `[]`

Custom JSX components to be treated as form controls.


### depth

type: `integer`

default: `2`

Maximum depth to search for a nested control.


### labelAttributes

type: `string[]`

default: `["alt", "aria-label", "aria-labelledby"]`

Attributes to check for accessible label text.


### labelComponents

type: `string[]`

default: `["label"]`

Custom JSX components to be treated as labels.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### allowExpressionValues

type: `boolean`

default: `true`

If `true`, allows tabIndex values to be expression values (e.g., variables, ternaries). If `false`, only string literal values are allowed.


### roles

type: `string[]`

default: `["tabpanel"]`

An array of ARIA roles that should be considered interactive.


### tags

type: `string[]`

default: `[]`

An array of custom HTML elements that should be considered interactive.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### allowedMethods

type: `string[]`

default: `null`

List of Promise static methods that are allowed to be used.
```