### PR TITLE
fix(linter): bundle `@typescript-eslint/scope-manager`

### DIFF
--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -61,7 +61,6 @@
     ]
   },
   "dependencies": {
-    "@typescript-eslint/scope-manager": "^8.46.2",
-    "@typescript-eslint/types": "^8.46.2"
+    "@typescript-eslint/scope-manager": "^8.46.2"
   }
 }

--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -36,6 +36,7 @@
     "dist"
   ],
   "devDependencies": {
+    "@typescript-eslint/scope-manager": "^8.46.2",
     "@types/esquery": "^1.5.4",
     "@types/estree": "^1.0.8",
     "eslint": "^9.36.0",
@@ -59,8 +60,5 @@
       "darwin-x64",
       "darwin-arm64"
     ]
-  },
-  "dependencies": {
-    "@typescript-eslint/scope-manager": "^8.46.2"
   }
 }

--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -15,6 +15,9 @@ const commonConfig: UserConfig = {
     // Not bundled, to avoid needing sourcemaps when debugging.
     /^\.\.?\/.*\/dist\//,
   ],
+  noExternal: [
+    '@typescript-eslint/scope-manager'
+  ],
   // At present only compress syntax.
   // Don't mangle identifiers or remove whitespace, so `dist` code remains somewhat readable.
   minify: { compress: true, mangle: false, codegen: { removeWhitespace: false } },

--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -15,9 +15,7 @@ const commonConfig: UserConfig = {
     // Not bundled, to avoid needing sourcemaps when debugging.
     /^\.\.?\/.*\/dist\//,
   ],
-  noExternal: [
-    '@typescript-eslint/scope-manager'
-  ],
+  noExternal: ['@typescript-eslint/scope-manager'],
   // At present only compress syntax.
   // Don't mangle identifiers or remove whitespace, so `dist` code remains somewhat readable.
   minify: { compress: true, mangle: false, codegen: { removeWhitespace: false } },

--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -18,7 +18,11 @@ const commonConfig: UserConfig = {
   noExternal: ['@typescript-eslint/scope-manager'],
   // At present only compress syntax.
   // Don't mangle identifiers or remove whitespace, so `dist` code remains somewhat readable.
-  minify: { compress: true, mangle: false, codegen: { removeWhitespace: false } },
+  minify: {
+    compress: { keepNames: { function: true, class: true } },
+    mangle: false,
+    codegen: { removeWhitespace: false },
+  },
 };
 
 // Only generate `.d.ts` file for main export, not for CLI

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,13 +58,6 @@ importers:
         version: 4.0.3(@types/node@24.9.1)(@vitest/browser-playwright@4.0.3)(jiti@2.6.1)
 
   apps/oxlint:
-    dependencies:
-      '@typescript-eslint/scope-manager':
-        specifier: ^8.46.2
-        version: 8.46.2
-      '@typescript-eslint/types':
-        specifier: ^8.46.2
-        version: 8.46.2
     devDependencies:
       '@types/esquery':
         specifier: ^1.5.4
@@ -72,6 +65,9 @@ importers:
       '@types/estree':
         specifier: ^1.0.8
         version: 1.0.8
+      '@typescript-eslint/scope-manager':
+        specifier: ^8.46.2
+        version: 8.46.2
       eslint:
         specifier: ^9.36.0
         version: 9.38.0(jiti@2.6.1)


### PR DESCRIPTION
- Closes #15187
- I think there should be an indication that the package at `apps/oxlint` is a private, development only package. I'll work on that in a follow up PR.
- I decided against automatically reflecting `apps/oxlint` dependencies in the generated package's dependencies in favor of the above idea.