### PR TITLE
docs(linter): Add config option docs for 3 rules.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
@@ -3,6 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, Span};
 use oxc_syntax::operator::BinaryOperator;
+use schemars::JsonSchema;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -15,9 +16,27 @@ fn no_bitwise_diagnostic(operator: &str, span: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct NoBitwise(Box<NoBitwiseConfig>);
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct NoBitwiseConfig {
+    /// The `allow` option permits the given list of bitwise operators to be used
+    /// as exceptions to this rule.
+    ///
+    /// For example `{ "allow": ["~"] }` would allow the use of the bitwise operator
+    /// `~` without restriction. Such as in the following:
+    ///
+    /// ```javascript
+    /// ~[1,2,3].indexOf(1) === -1;
+    /// ```
     allow: Vec<CompactStr>,
+    /// When set to true the `int32Hint` option allows the use of bitwise OR in |0
+    /// pattern for type casting.
+    ///
+    /// For example with `{ "int32Hint": true }` the following is permitted:
+    ///
+    /// ```javascript
+    /// const b = a|0;
+    /// ```
     int32_hint: bool,
 }
 
@@ -66,38 +85,10 @@ declare_oxc_lint!(
     /// ```javascript
     /// var x = y > z;
     /// ```
-    ///
-    /// ### Options
-    ///
-    /// #### allow
-    ///
-    /// `{ type: string[], default: [] }`
-    ///
-    /// The `allow` option permits the given list of bitwise operators to be used
-    /// as exceptions to this rule.
-    ///
-    /// For example `{ "allow": ["~"] }` would allow the use of the bitwise operator
-    /// `~` without restriction. Such as in the following:
-    ///
-    /// ```javascript
-    /// ~[1,2,3].indexOf(1) === -1;
-    /// ```
-    ///
-    /// #### int32Hint
-    ///
-    /// `{ type: boolean, default: false }`
-    ///
-    /// When set to true the `int32Hint` option allows the use of bitwise OR in |0
-    /// pattern for type casting.
-    ///
-    /// For example with `{ "int32Hint": true }` the following is permitted:
-    ///
-    /// ```javascript
-    /// const b = a|0;
-    /// ```
     NoBitwise,
     eslint,
-    restriction
+    restriction,
+    config = NoBitwiseConfig,
 );
 
 impl Rule for NoBitwise {

--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -2,6 +2,8 @@ use oxc_ast::{AstKind, ast::Expression};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, GetSpan, Span};
+use schemars::JsonSchema;
+use serde::Deserialize;
 
 use crate::{
     AstNode,
@@ -23,8 +25,24 @@ fn no_console_diagnostic(span: Span, allow: &[CompactStr]) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct NoConsole(Box<NoConsoleConfig>);
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct NoConsoleConfig {
+    /// The `allow` option permits the given list of console methods to be used as exceptions to
+    /// this rule.
+    ///
+    /// Say the option was configured as `{ "allow": ["info"] }` then the rule would behave as
+    /// follows:
+    ///
+    /// Example of **incorrect** code for this option:
+    /// ```javascript
+    /// console.log('foo');
+    /// ```
+    ///
+    /// Example of **correct** code for this option:
+    /// ```javascript
+    /// console.info('foo');
+    /// ```
     pub allow: Vec<CompactStr>,
 }
 
@@ -63,32 +81,11 @@ declare_oxc_lint!(
     /// // custom console
     /// Console.log("Hello world!");
     /// ```
-    ///
-    /// ### Options
-    ///
-    /// #### allow
-    ///
-    /// `{ type: string[], default: [] }`
-    ///
-    /// The `allow` option permits the given list of console methods to be used as exceptions to
-    /// this rule.
-    ///
-    /// Say the option was configured as `{ "allow": ["info"] }` then the rule would behave as
-    /// follows:
-    ///
-    /// Example of **incorrect** code for this option:
-    /// ```javascript
-    /// console.log('foo');
-    /// ```
-    ///
-    /// Example of **correct** code for this option:
-    /// ```javascript
-    /// console.info('foo');
-    /// ```
     NoConsole,
     eslint,
     restriction,
-    conditional_suggestion
+    conditional_suggestion,
+    config = NoConsoleConfig,
 );
 
 impl Rule for NoConsole {

--- a/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
@@ -2,6 +2,8 @@ use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -11,27 +13,33 @@ fn no_inner_declarations_diagnostic(decl_type: &str, body: &str, span: Span) -> 
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct NoInnerDeclarations {
+    /// Determines what type of declarations to check.
     config: NoInnerDeclarationsConfig,
+    /// Controls whether function declarations in nested blocks are allowed in strict mode (ES6+ behavior).
+    #[schemars(with = "BlockScopedFunctions")]
     block_scoped_functions: Option<BlockScopedFunctions>,
 }
 
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
 enum NoInnerDeclarationsConfig {
-    /// Disallows function declarations in nested blocks
+    /// Disallows function declarations in nested blocks.
     #[default]
     Functions,
-    /// Disallows function and var declarations in nested blocks
+    /// Disallows function and var declarations in nested blocks.
     Both,
 }
 
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
 enum BlockScopedFunctions {
-    /// Allow function declarations in nested blocks in strict mode (ES6+ behavior)
+    /// Allow function declarations in nested blocks in strict mode (ES6+ behavior).
     #[default]
     Allow,
-    /// Disallow function declarations in nested blocks regardless of strict mode
+    /// Disallow function declarations in nested blocks regardless of strict mode.
     Disallow,
 }
 
@@ -64,7 +72,8 @@ declare_oxc_lint!(
     /// ```
     NoInnerDeclarations,
     eslint,
-    pedantic
+    pedantic,
+    config = NoInnerDeclarations,
 );
 
 impl Rule for NoInnerDeclarations {


### PR DESCRIPTION
Part of #14743.

- eslint/no-bitwise
- eslint/no-console
- eslint/no-inner-declarations

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### allow

type: `string[]`

default: `[]`

The `allow` option permits the given list of console methods to be used as exceptions to
this rule.

Say the option was configured as `{ "allow": ["info"] }` then the rule would behave as
follows:

Example of **incorrect** code for this option:
\```javascript
console.log('foo');
\```

Example of **correct** code for this option:
\```javascript
console.info('foo');
\```
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### blockScopedFunctions


default: `null`

Controls whether function declarations in nested blocks are allowed in strict mode (ES6+ behavior).


### config


default: `"functions"`

Determines what type of declarations to check.
```

```md
## Configuration

This rule accepts a configuration object with the following properties:

### allow

type: `string[]`

default: `[]`

The `allow` option permits the given list of bitwise operators to be used
as exceptions to this rule.

For example `{ "allow": ["~"] }` would allow the use of the bitwise operator
`~` without restriction. Such as in the following:

\```javascript
~[1,2,3].indexOf(1) === -1;
\```


### int32Hint

type: `boolean`

default: `false`

When set to true the `int32Hint` option allows the use of bitwise OR in |0
pattern for type casting.

For example with `{ "int32Hint": true }` the following is permitted:

\```javascript
const b = a|0;
\```
```