### PR TITLE
chore(oxlint): remove semblance of a published package from `apps/oxlint/package.json`

### DIFF
--- a/apps/oxfmt/package.json
+++ b/apps/oxfmt/package.json
@@ -1,11 +1,11 @@
 {
-  "private": true,
   "name": "oxfmt",
   "version": "0.9.0",
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
-  "bin": "dist/cli.js",
-  "types": "dist/index.d.ts",
+  "description": "Internal development package for oxfmt. For the published package.json template, see `npm/oxfmt/package.json`.",
+  "license": "MIT",
   "scripts": {
     "build": "pnpm run build-napi-release && pnpm run build-js",
     "build-dev": "pnpm run build-napi && pnpm run build-js",
@@ -19,16 +19,6 @@
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   },
-  "author": "Boshen and oxc contributors",
-  "license": "MIT",
-  "homepage": "https://oxc.rs",
-  "bugs": "https://github.com/oxc-project/oxc/issues",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/oxc-project/oxc.git",
-    "directory": "apps/oxfmt"
-  },
-  "description": "Local project to build and publish `npm/oxfmt`. Be sure to sync dependencies!",
   "dependencies": {
     "prettier": "3.6.2",
     "@prettier/sync": "0.6.1"

--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -1,10 +1,11 @@
 {
   "name": "oxlint",
   "version": "1.26.0",
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
-  "bin": "dist/cli.js",
-  "types": "dist/index.d.ts",
+  "description": "Internal development package for oxlint. For the published package.json template, see `npm/oxlint/package.json`.",
+  "license": "MIT",
   "scripts": {
     "build": "pnpm run build-napi-release && pnpm run build-js",
     "build-dev": "pnpm run build-napi && pnpm run build-js",
@@ -18,23 +19,6 @@
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   },
-  "description": "Linter for the JavaScript Oxidation Compiler",
-  "author": "Boshen and oxc contributors",
-  "license": "MIT",
-  "homepage": "https://oxc.rs",
-  "bugs": "https://github.com/oxc-project/oxc/issues",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/oxc-project/oxc.git",
-    "directory": "apps/oxlint"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public"
-  },
-  "files": [
-    "dist"
-  ],
   "devDependencies": {
     "@typescript-eslint/scope-manager": "^8.46.2",
     "@types/esquery": "^1.5.4",

--- a/npm/oxlint/scripts/generate-packages.js
+++ b/npm/oxlint/scripts/generate-packages.js
@@ -6,13 +6,19 @@ import { fileURLToPath } from 'node:url';
 
 const OXLINT_BIN_NAME = 'oxlint';
 const OXLS_BIN_NAME = 'oxc_language_server';
-const OXLINT_ROOT = resolve(fileURLToPath(import.meta.url), '../..'); // <REPO ROOT>/npm/oxlint
-const PACKAGES_ROOT = resolve(OXLINT_ROOT, '..'); // <REPO ROOT>/npm
+/** <REPO ROOT>/npm/oxlint` */
+const OXLINT_ROOT = resolve(fileURLToPath(import.meta.url), '../..');
+/** `<REPO ROOT>/npm` */
+const PACKAGES_ROOT = resolve(OXLINT_ROOT, '..');
 const REPO_ROOT = resolve(PACKAGES_ROOT, '..');
-const MANIFEST_PATH = resolve(OXLINT_ROOT, 'package.json'); // <REPO ROOT>/npm/oxlint/package.json
-const OXLINT_DIST_SRC = resolve(REPO_ROOT, 'apps/oxlint/dist'); // <REPO ROOT>/apps/oxlint/dist
-const OXLINT_DIST_DEST = resolve(OXLINT_ROOT, 'dist'); // <REPO ROOT>/npm/oxlint/dist
+/** `<REPO ROOT>/npm/oxlint/package.json` */
+const MANIFEST_PATH = resolve(OXLINT_ROOT, 'package.json');
+/** `<REPO ROOT>/apps/oxlint/dist` */
+const OXLINT_DIST_SRC = resolve(REPO_ROOT, 'apps/oxlint/dist');
+/** `<REPO ROOT>/npm/oxlint/dist` */
+const OXLINT_DIST_DEST = resolve(OXLINT_ROOT, 'dist');
 
+/** Parsed `<REPO ROOT>/npm/oxlint/package.json` */
 const rootManifest = JSON.parse(fs.readFileSync(MANIFEST_PATH).toString('utf-8'));
 
 const LIBC_MAPPING = {
@@ -78,6 +84,7 @@ function generateNativePackage(target) {
 }
 
 function writeManifest() {
+  /** `<REPO ROOT>/npm/oxlint/package.json` */
   const manifestPath = resolve(PACKAGES_ROOT, OXLINT_BIN_NAME, 'package.json');
 
   const manifestData = JSON.parse(fs.readFileSync(manifestPath).toString('utf-8'));


### PR DESCRIPTION
- Follow up to https://github.com/oxc-project/oxc/pull/15210
- `apps/oxlint/dist` is referred to by `npm/oxlint/package.json` which is used as the template for `oxlint` CLI and each NAPI triplet package manifest created in [scripts/generate-packages.js](https://github.com/oxc-project/oxc/blob/377e90450fad74f0c5c8548a754e5fd3e3efff2c/npm/oxlint/scripts/generate-packages.js#L4).
- `apps/oxlint/package.json` is effectively a manifest for a private, internal-only package.
- Removes fields which are only relevant to public packages, and explicitly adds `"private": true` to avoid confusion.
- No user facing changes.