### PR TITLE
chore(tasks/coverage): exclude some parser babel test cases that are not relevant

### DIFF
--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -3,23 +3,7 @@ commit: 4cc3d888
 parser_babel Summary:
 AST Parsed     : 2422/2440 (99.26%)
 Positive Passed: 2395/2440 (98.16%)
-Negative Passed: 1670/1760 (94.89%)
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/invalid-startindex-and-startline-specified-without-startcolumn/input.js
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/startline-and-startcolumn-specified/input.js
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/startline-specified/input.js
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/sourcetype-commonjs/invalid-allowAwaitOutsideFunction-false/input.js
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/sourcetype-commonjs/invalid-allowNewTargetOutsideFunction-false/input.js
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/sourcetype-commonjs/invalid-allowNewTargetOutsideFunction-true/input.js
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/sourcetype-commonjs/invalid-allowReturnOutsideFunction-false/input.js
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/sourcetype-commonjs/invalid-allowReturnOutsideFunction-true/input.js
-
+Negative Passed: 1670/1752 (95.32%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/destructuring/error-operator-for-default/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/for-of/invalid-let-as-identifier/input.js

--- a/tasks/coverage/src/babel/mod.rs
+++ b/tasks/coverage/src/babel/mod.rs
@@ -46,8 +46,22 @@ impl<T: Case> Suite<T> for BabelSuite<T> {
         ]
         .iter()
         .any(|p| path.to_string_lossy().replace('\\', "/").contains(p));
+        let not_interesting_files = [
+            // tests for babel options (`startIndex`, `startLine`)
+            "core/categorized/invalid-startindex-and-startline-specified-without-startcolumn",
+            "core/categorized/startline-and-startcolumn-specified",
+            "core/categorized/startline-specified",
+            // tests for babel options (`sourceType: 'commonjs'` + other options)
+            "core/sourcetype-commonjs/invalid-allowAwaitOutsideFunction-false",
+            "core/sourcetype-commonjs/invalid-allowNewTargetOutsideFunction-false",
+            "core/sourcetype-commonjs/invalid-allowNewTargetOutsideFunction-true",
+            "core/sourcetype-commonjs/invalid-allowReturnOutsideFunction-false",
+            "core/sourcetype-commonjs/invalid-allowReturnOutsideFunction-true",
+        ]
+        .iter()
+        .any(|p| path.to_string_lossy().replace('\\', "/").ends_with(&format!("{p}/input.js")));
         let incorrect_extension = path.extension().is_none_or(|ext| ext == "json" || ext == "md");
-        not_supported_directory || incorrect_extension
+        not_supported_directory || not_interesting_files || incorrect_extension
     }
 
     fn save_test_cases(&mut self, tests: Vec<T>) {


### PR DESCRIPTION
Skipped some parser babel test cases because these are not relevant. It tests option combination validations, but for us, these should be done in simple unit tests.