### PR TITLE
fix(parser): reject invalid assignment operator in assignment targets

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -881,6 +881,13 @@ pub fn variable_declarator_definite_type_assertion(span: Span) -> OxcDiagnostic 
 }
 
 #[cold]
+pub fn invalid_assignment_target_default_value_operator(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Only '=' operator can be used for specifying default value.")
+        .with_label(span)
+        .with_help("Replace this operator with `=`.")
+}
+
+#[cold]
 pub fn invalid_rest_assignment_target(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Invalid rest operator's argument.").with_label(span)
 }

--- a/crates/oxc_parser/src/js/grammar.rs
+++ b/crates/oxc_parser/src/js/grammar.rs
@@ -140,6 +140,11 @@ impl<'a> CoverGrammar<'a, Expression<'a>> for AssignmentTargetMaybeDefault<'a> {
     fn cover(expr: Expression<'a>, p: &mut ParserImpl<'a>) -> Self {
         match expr {
             Expression::AssignmentExpression(assignment_expr) => {
+                if assignment_expr.operator != AssignmentOperator::Assign {
+                    p.error(diagnostics::invalid_assignment_target_default_value_operator(
+                        assignment_expr.span,
+                    ));
+                }
                 let target = AssignmentTargetWithDefault::cover(assignment_expr.unbox(), p);
                 AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(p.alloc(target))
             }

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -3,9 +3,7 @@ commit: 4cc3d888
 parser_babel Summary:
 AST Parsed     : 2422/2440 (99.26%)
 Positive Passed: 2395/2440 (98.16%)
-Negative Passed: 1670/1752 (95.32%)
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/destructuring/error-operator-for-default/input.js
-
+Negative Passed: 1671/1752 (95.38%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/for-of/invalid-let-as-identifier/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/uncategorised/335/input.js
@@ -3195,6 +3193,13 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·            ┬
    ·            ╰── `:` expected
    ╰────
+
+  × Only '=' operator can be used for specifying default value.
+   ╭─[babel/packages/babel-parser/test/fixtures/es2015/destructuring/error-operator-for-default/input.js:1:3]
+ 1 │ ([a += a] = a)
+   ·   ──────
+   ╰────
+  help: Replace this operator with `=`.
 
   × Expected `,` but found `(`
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/destructuring/invalid-object-method/input.js:1:12]


### PR DESCRIPTION
Reject cases like `([a += a] = a)`.