### PR TITLE
fix(parser): reject `for (let.something of ...)`

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -292,6 +292,11 @@ pub fn for_loop_async_of(span: Span) -> OxcDiagnostic {
         .with_help("Did you mean to use a for await...of statement?")
 }
 
+pub fn for_loop_let_reserved_word(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("The left-hand side of a `for...of` statement may not start with `let`")
+        .with_label(span)
+}
+
 #[cold]
 pub fn for_await(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("await can only be used in conjunction with `for...of` statements")

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -393,15 +393,13 @@ impl<'a> ParserImpl<'a> {
                 self.parse_for_in_loop(span, r#await, for_stmt_left)
             }
             Kind::Of => {
-                if init_expression.is_identifier_reference() {
-                    if !r#await && is_async {
-                        // `for (async of ...)` is not allowed
-                        self.error(diagnostics::for_loop_async_of(self.end_span(expr_span)));
-                    }
-                    if is_let {
-                        // `for (let of ...)` is not allowed
-                        self.error(diagnostics::unexpected_token(self.end_span(expr_span)));
-                    }
+                if !r#await && is_async && init_expression.is_identifier_reference() {
+                    // `for (async of ...)` is not allowed
+                    self.error(diagnostics::for_loop_async_of(self.end_span(expr_span)));
+                }
+                if is_let {
+                    // `for (let of ...)`, `for (let.something of ...)` is not allowed
+                    self.error(diagnostics::for_loop_let_reserved_word(self.end_span(expr_span)));
                 }
                 let target = AssignmentTarget::cover(init_expression, self);
                 let for_stmt_left = ForStatementLeft::from(target);

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -3,9 +3,7 @@ commit: 4cc3d888
 parser_babel Summary:
 AST Parsed     : 2422/2440 (99.26%)
 Positive Passed: 2395/2440 (98.16%)
-Negative Passed: 1671/1752 (95.38%)
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/for-of/invalid-let-as-identifier/input.js
-
+Negative Passed: 1672/1752 (95.43%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/uncategorised/335/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2017/async-functions/async-await-as-arrow-binding-identifier/input.js
@@ -3308,6 +3306,28 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ for (let x of y, z) {}
    ·                ┬
    ·                ╰── `)` expected
+   ╰────
+
+  × The left-hand side of a `for...of` statement may not start with `let`
+   ╭─[babel/packages/babel-parser/test/fixtures/es2015/for-of/invalid-let-as-identifier/input.js:1:6]
+ 1 │ for (let.foo of []);
+   ·      ───────
+ 2 │ for (let().bar of []);
+   ╰────
+
+  × The left-hand side of a `for...of` statement may not start with `let`
+   ╭─[babel/packages/babel-parser/test/fixtures/es2015/for-of/invalid-let-as-identifier/input.js:2:6]
+ 1 │ for (let.foo of []);
+ 2 │ for (let().bar of []);
+   ·      ─────────
+ 3 │ for (let``.bar of []);
+   ╰────
+
+  × The left-hand side of a `for...of` statement may not start with `let`
+   ╭─[babel/packages/babel-parser/test/fixtures/es2015/for-of/invalid-let-as-identifier/input.js:3:6]
+ 2 │ for (let().bar of []);
+ 3 │ for (let``.bar of []);
+   ·      ─────────
    ╰────
 
   × Keywords cannot contain escape characters


### PR DESCRIPTION
Reject cases like `for (let.something of ...)`. TIL that this is not allowed.
`for (let of ...)` was already rejected but these cases were not handled.


