### PR TITLE
fix(parser): reject `yield` and `await` in object destructing shorthand property parameters

### DIFF
--- a/crates/oxc_parser/src/js/binding.rs
+++ b/crates/oxc_parser/src/js/binding.rs
@@ -130,6 +130,7 @@ impl<'a> ParserImpl<'a> {
 
         let mut shorthand = false;
         let is_binding_identifier = self.cur_kind().is_binding_identifier();
+        let key_cur_kind = self.cur_kind();
         let (key, computed) = self.parse_property_name();
 
         let value = if is_binding_identifier && !self.at(Kind::Colon) {
@@ -138,6 +139,7 @@ impl<'a> ParserImpl<'a> {
             //       ^ BindingIdentifier
             if let PropertyKey::StaticIdentifier(ident) = &key {
                 shorthand = true;
+                self.check_identifier_with_span(key_cur_kind, self.ctx, ident.span);
                 let identifier =
                     self.ast.binding_pattern_kind_binding_identifier(ident.span, ident.name);
                 let left = self.ast.binding_pattern(identifier, NONE, false);

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -120,13 +120,17 @@ impl<'a> ParserImpl<'a> {
     }
 
     pub(crate) fn check_identifier(&mut self, kind: Kind, ctx: Context) {
+        self.check_identifier_with_span(kind, ctx, self.cur_token().span());
+    }
+
+    pub(crate) fn check_identifier_with_span(&mut self, kind: Kind, ctx: Context, span: Span) {
         // It is a Syntax Error if this production has an [Await] parameter.
         if ctx.has_await() && kind == Kind::Await {
-            self.error(diagnostics::identifier_async("await", self.cur_token().span()));
+            self.error(diagnostics::identifier_async("await", span));
         }
         // It is a Syntax Error if this production has a [Yield] parameter.
         if ctx.has_yield() && kind == Kind::Yield {
-            self.error(diagnostics::identifier_generator("yield", self.cur_token().span()));
+            self.error(diagnostics::identifier_generator("yield", span));
         }
     }
 

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -3,12 +3,8 @@ commit: 4cc3d888
 parser_babel Summary:
 AST Parsed     : 2422/2440 (99.26%)
 Positive Passed: 2395/2440 (98.16%)
-Negative Passed: 1672/1752 (95.43%)
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/uncategorised/335/input.js
-
+Negative Passed: 1675/1752 (95.61%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2017/async-functions/async-await-as-arrow-binding-identifier/input.js
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2017/async-functions/await-binding-inside-arrow-params-inside-async-arrow-params/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2018/object-rest-spread/comma-after-rest/input.js
 
@@ -41,8 +37,6 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-script-top-level-labeled-using-binding/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-script-top-level-using-binding/input.js
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/es2015-generator/generator-parameter-binding-property-reserved/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-private-property/typescript-invalid-abstract/input.ts
 
@@ -4828,6 +4822,12 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·     ────
    ╰────
 
+  × Cannot use `yield` as an identifier in a generator context
+   ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/335/input.js:1:14]
+ 1 │ function* y({yield}) {}
+   ·              ─────
+   ╰────
+
   × Bad escape sequence in untagged template literal
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/339/input.js:1:2]
  1 │ `\07`
@@ -4910,6 +4910,12 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/359/input.js:1:7]
  1 │ const await = foo();
    ·       ─────
+   ╰────
+
+  × Cannot use `await` as an identifier in an async context
+   ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/361/input.js:1:9]
+ 1 │ const { await } = foo();
+   ·         ─────
    ╰────
 
   × The keyword 'await' is reserved
@@ -5637,6 +5643,12 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╭─[babel/packages/babel-parser/test/fixtures/es2017/async-functions/await-async-function-expression-name/input.js:1:17]
  1 │ (async function await() {});
    ·                 ─────
+   ╰────
+
+  × Cannot use `await` as an identifier in an async context
+   ╭─[babel/packages/babel-parser/test/fixtures/es2017/async-functions/await-binding-inside-arrow-params-inside-async-arrow-params/input.js:1:15]
+ 1 │ async (a = ({ await }) => {}) => {};
+   ·               ─────
    ╰────
 
   × Cannot use `await` as an identifier in an async context
@@ -9730,6 +9742,12 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·                      ───┬───
    ·                         ╰── yield expression not allowed in formal parameter
  3 │ })
+   ╰────
+
+  × Cannot use `yield` as an identifier in a generator context
+   ╭─[babel/packages/babel-parser/test/fixtures/esprima/es2015-generator/generator-parameter-binding-property-reserved/input.js:1:13]
+ 1 │ (function*({yield}) {})
+   ·             ─────
    ╰────
 
   × Expected function name

--- a/tasks/coverage/snapshots/parser_test262.snap
+++ b/tasks/coverage/snapshots/parser_test262.snap
@@ -38948,6 +38948,14 @@ Expect to Parse: tasks/coverage/test262/test/annexB/language/expressions/assignm
  31 │ 
     ╰────
 
+  × Cannot use `await` as an identifier in an async context
+    ╭─[test262/test/language/statements/variable/dstr/obj-ptrn-elem-id-static-init-await-invalid.js:25:10]
+ 24 │   static {
+ 25 │     var {await} = {};
+    ·          ─────
+ 26 │   }
+    ╰────
+
   × Cannot use await in class static initialization block
     ╭─[test262/test/language/statements/variable/dstr/obj-ptrn-elem-id-static-init-await-invalid.js:25:10]
  24 │   static {

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -14979,6 +14979,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ╰────
 
   × Cannot use `await` as an identifier in an async context
+   ╭─[typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock22.ts:7:11]
+ 6 │   static {
+ 7 │     let { await } = {} as any; // illegal, cannot declare a new binding for await
+   ·           ─────
+ 8 │   }
+   ╰────
+
+  × Cannot use `await` as an identifier in an async context
     ╭─[typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock22.ts:13:9]
  12 │   static {
  13 │     let await; // illegal, cannot declare a new binding for await


### PR DESCRIPTION
Reject cases like `function* y({yield}) {}` and `async function y({await}) {}` in scripts (in modules, these were already rejected as `yield` and `await` are reserved keywords).