### PR TITLE
fix(parser): reject `using` / `await using` in single statement contexts

### DIFF
--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -53,10 +53,14 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    pub(crate) fn parse_using_statement(&mut self) -> Statement<'a> {
-        let mut decl = self.parse_using_declaration(StatementContext::StatementList);
+    pub(crate) fn parse_using_statement(&mut self, stmt_ctx: StatementContext) -> Statement<'a> {
+        let mut decl = self.parse_using_declaration(stmt_ctx);
         self.asi();
         decl.span = self.end_span(decl.span.start);
+        debug_assert!(decl.kind.is_lexical());
+        if stmt_ctx.is_single_statement() {
+            self.error(diagnostics::lexical_declaration_single_statement(decl.span));
+        }
         Statement::VariableDeclaration(self.alloc(decl))
     }
 

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -123,8 +123,8 @@ impl<'a> ParserImpl<'a> {
             Kind::Async => self.parse_async_statement(self.start_span(), stmt_ctx),
             Kind::Import => self.parse_import_statement(stmt_ctx),
             Kind::Const => self.parse_const_statement(stmt_ctx),
-            Kind::Using if self.is_using_declaration() => self.parse_using_statement(),
-            Kind::Await if self.is_using_statement() => self.parse_using_statement(),
+            Kind::Using if self.is_using_declaration() => self.parse_using_statement(stmt_ctx),
+            Kind::Await if self.is_using_statement() => self.parse_using_statement(stmt_ctx),
             Kind::Interface
             | Kind::Type
             | Kind::Module

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -3,30 +3,18 @@ commit: 4cc3d888
 parser_babel Summary:
 AST Parsed     : 2422/2440 (99.26%)
 Positive Passed: 2395/2440 (98.16%)
-Negative Passed: 1679/1752 (95.83%)
+Negative Passed: 1685/1752 (96.18%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/private-in/invalid-private-followed-by-in-2/input.js
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-in-single-statement-context-async/input.js
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-in-single-statement-context-sync/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-module-bare-case-await-using-binding/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-script-bare-case-await-using-binding/input.js
 
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-script-top-level-labeled-using-binding/input.js
-
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-script-top-level-using-binding/input.js
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-in-single-statement-context/input.js
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-labeled-using-binding/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-module-bare-case-using-binding/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-script-bare-case-using-binding/input.js
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-script-top-level-labeled-using-binding/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-script-top-level-using-binding/input.js
 
@@ -9103,6 +9091,121 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  4 │ }
    ╰────
 
+  × Lexical declaration cannot appear in a single-statement context
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-in-single-statement-context-async/input.js:2:13]
+ 1 │ async function f() {
+ 2 │   while (1) await using a = foo;
+   ·             ────────────────────
+ 3 │   for (;;) await using b = foo;
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Lexical declaration cannot appear in a single-statement context
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-in-single-statement-context-async/input.js:3:12]
+ 2 │   while (1) await using a = foo;
+ 3 │   for (;;) await using b = foo;
+   ·            ────────────────────
+ 4 │   do await using c = foo; while (1);
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Lexical declaration cannot appear in a single-statement context
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-in-single-statement-context-async/input.js:4:6]
+ 3 │   for (;;) await using b = foo;
+ 4 │   do await using c = foo; while (1);
+   ·      ────────────────────
+ 5 │   if (1) await using d = foo;
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Lexical declaration cannot appear in a single-statement context
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-in-single-statement-context-async/input.js:5:10]
+ 4 │   do await using c = foo; while (1);
+ 5 │   if (1) await using d = foo;
+   ·          ────────────────────
+ 6 │   with (1) await using e = foo;
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Lexical declaration cannot appear in a single-statement context
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-in-single-statement-context-async/input.js:6:12]
+ 5 │   if (1) await using d = foo;
+ 6 │   with (1) await using e = foo;
+   ·            ────────────────────
+ 7 │   label: await using f = foo;
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Lexical declaration cannot appear in a single-statement context
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-in-single-statement-context-async/input.js:7:10]
+ 6 │   with (1) await using e = foo;
+ 7 │   label: await using f = foo;
+   ·          ────────────────────
+ 8 │ }
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Lexical declaration cannot appear in a single-statement context
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-in-single-statement-context-sync/input.js:2:13]
+ 1 │ {
+ 2 │   while (1) await using a = foo;
+   ·             ────────────────────
+ 3 │   for (;0;) await using b = foo;
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Lexical declaration cannot appear in a single-statement context
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-in-single-statement-context-sync/input.js:3:13]
+ 2 │   while (1) await using a = foo;
+ 3 │   for (;0;) await using b = foo;
+   ·             ────────────────────
+ 4 │   do await using c = foo; while (1);
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Lexical declaration cannot appear in a single-statement context
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-in-single-statement-context-sync/input.js:4:6]
+ 3 │   for (;0;) await using b = foo;
+ 4 │   do await using c = foo; while (1);
+   ·      ────────────────────
+ 5 │   if (1) await using d = foo;
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Lexical declaration cannot appear in a single-statement context
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-in-single-statement-context-sync/input.js:5:10]
+ 4 │   do await using c = foo; while (1);
+ 5 │   if (1) await using d = foo;
+   ·          ────────────────────
+ 6 │   with (1) await using e = foo;
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Lexical declaration cannot appear in a single-statement context
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-in-single-statement-context-sync/input.js:6:12]
+ 5 │   if (1) await using d = foo;
+ 6 │   with (1) await using e = foo;
+   ·            ────────────────────
+ 7 │   label: await using f = foo;
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Lexical declaration cannot appear in a single-statement context
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-in-single-statement-context-sync/input.js:7:10]
+ 6 │   with (1) await using e = foo;
+ 7 │   label: await using f = foo;
+   ·          ────────────────────
+ 8 │ }
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Lexical declaration cannot appear in a single-statement context
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-script-top-level-labeled-using-binding/input.js:1:8]
+ 1 │ label: await using x = bar();
+   ·        ──────────────────────
+   ╰────
+  help: Wrap this declaration in a block statement
+
   × Cannot assign to this expression
    ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-using-array-pattern/input.js:2:3]
  1 │ async function f() {
@@ -9337,6 +9440,76 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ for (using of;of.isValid;);
    ·              ─
    ╰────
+
+  × Lexical declaration cannot appear in a single-statement context
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-in-single-statement-context/input.js:2:13]
+ 1 │ {
+ 2 │   while (1) using a = foo;
+   ·             ──────────────
+ 3 │   for (;;) using b = foo;
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Lexical declaration cannot appear in a single-statement context
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-in-single-statement-context/input.js:3:12]
+ 2 │   while (1) using a = foo;
+ 3 │   for (;;) using b = foo;
+   ·            ──────────────
+ 4 │   do using c = foo; while (1);
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Lexical declaration cannot appear in a single-statement context
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-in-single-statement-context/input.js:4:6]
+ 3 │   for (;;) using b = foo;
+ 4 │   do using c = foo; while (1);
+   ·      ──────────────
+ 5 │   if (1) using d = foo;
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Lexical declaration cannot appear in a single-statement context
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-in-single-statement-context/input.js:5:10]
+ 4 │   do using c = foo; while (1);
+ 5 │   if (1) using d = foo;
+   ·          ──────────────
+ 6 │   with (1) using e = foo;
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Lexical declaration cannot appear in a single-statement context
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-in-single-statement-context/input.js:6:12]
+ 5 │   if (1) using d = foo;
+ 6 │   with (1) using e = foo;
+   ·            ──────────────
+ 7 │   label: using f = foo;
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Lexical declaration cannot appear in a single-statement context
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-in-single-statement-context/input.js:7:10]
+ 6 │   with (1) using e = foo;
+ 7 │   label: using f = foo;
+   ·          ──────────────
+ 8 │ }
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Lexical declaration cannot appear in a single-statement context
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-labeled-using-binding/input.js:2:10]
+ 1 │ {
+ 2 │   label: using x = bar();
+   ·          ────────────────
+ 3 │ }
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Lexical declaration cannot appear in a single-statement context
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-script-top-level-labeled-using-binding/input.js:1:8]
+ 1 │ label: using x = bar();
+   ·        ────────────────
+   ╰────
+  help: Wrap this declaration in a block statement
 
   × Cannot use `await` as an identifier in an async context
    ╭─[babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-using-binding-await-module/input.js:2:9]

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: 8ea03f88
 parser_typescript Summary:
 AST Parsed     : 8825/8827 (99.98%)
 Positive Passed: 8814/8827 (99.85%)
-Negative Passed: 1451/3530 (41.10%)
+Negative Passed: 1453/3530 (41.16%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment8.ts
@@ -3796,8 +3796,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statement
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.10.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.12.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.13.ts
@@ -3813,8 +3811,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statement
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsWithAsyncIteratorObject.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsWithIteratorObject.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.10.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.14.ts
 
@@ -25570,6 +25566,15 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  7 │ function *gen() {
    ╰────
 
+  × Lexical declaration cannot appear in a single-statement context
+   ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.10.ts:5:12]
+ 4 │ async function f() {
+ 5 │     if (x) await using a = null;
+   ·            ─────────────────────
+ 6 │ }
+   ╰────
+  help: Wrap this declaration in a block statement
+
   × Unexpected token
    ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.11.ts:1:8]
  1 │ export await using x = null;
@@ -25725,6 +25730,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·                     ╰── `;` expected
  6 │ 
    ╰────
+
+  × Lexical declaration cannot appear in a single-statement context
+   ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.10.ts:2:8]
+ 1 │ declare var x: any;
+ 2 │ if (x) using a = null;
+   ·        ───────────────
+   ╰────
+  help: Wrap this declaration in a block statement
 
   × Unexpected token
    ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.13.ts:1:8]


### PR DESCRIPTION
Reject codes like `while (1) using foo = {}` similar to `while (1) let foo = {}`.