### PR TITLE
fix(parser): reject `using` / `await using` in a switch `case` / `default` clause

### DIFF
--- a/crates/oxc_linter/src/snapshots/eslint_no_case_declarations.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_case_declarations.snap
@@ -49,14 +49,16 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────
    ╰────
 
-  ⚠ eslint(no-case-declarations): Unexpected lexical declaration in case block.
+  × Using declaration cannot appear in the bare case statement.
    ╭─[no_case_declarations.tsx:1:23]
  1 │ switch (a) { default: using x = {}; break; }
-   ·                       ─────
+   ·                       ─────────────
    ╰────
+  help: Wrap this declaration in a block statement
 
-  ⚠ eslint(no-case-declarations): Unexpected lexical declaration in case block.
+  × Using declaration cannot appear in the bare case statement.
    ╭─[no_case_declarations.tsx:1:23]
  1 │ switch (a) { default: await using x = {}; break; }
-   ·                       ───────────
+   ·                       ───────────────────
    ╰────
+  help: Wrap this declaration in a block statement

--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -640,6 +640,13 @@ pub fn using_declaration_cannot_be_exported(identifier: &str, span: Span) -> Oxc
 }
 
 #[cold]
+pub fn using_declaration_not_allowed_in_switch_bare_case(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Using declaration cannot appear in the bare case statement.")
+        .with_label(span)
+        .with_help("Wrap this declaration in a block statement")
+}
+
+#[cold]
 pub fn jsx_element_no_match(span: Span, span1: Span, name: &str) -> OxcDiagnostic {
     OxcDiagnostic::error(format!("Expected corresponding JSX closing tag for '{name}'."))
         .with_labels([

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -658,6 +658,15 @@ impl<'a> ParserImpl<'a> {
                 break;
             }
             let stmt = self.parse_statement_list_item(StatementContext::StatementList);
+            if let Statement::VariableDeclaration(var_decl) = &stmt
+                && var_decl.kind.is_using()
+            {
+                // It is a Syntax Error if UsingDeclaration is contained directly within the StatementList of either a CaseClause or DefaultClause.
+                // It is a Syntax Error if AwaitUsingDeclaration is contained directly within the StatementList of either a CaseClause or DefaultClause.
+                self.error(diagnostics::using_declaration_not_allowed_in_switch_bare_case(
+                    stmt.span(),
+                ));
+            }
             consequent.push(stmt);
         }
         self.ast.switch_case(self.end_span(span), test, consequent)

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -2,7 +2,7 @@ commit: 8ea03f88
 
 estree_typescript Summary:
 AST Parsed     : 8767/8767 (100.00%)
-Positive Passed: 8762/8767 (99.94%)
+Positive Passed: 8761/8767 (99.93%)
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/importDefer/importDeferComments.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/importDefer/importDeferDeclaration.ts
@@ -12,4 +12,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuit
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitEntities.tsx
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitNesting.tsx
+
+Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.1.ts
+Using declaration cannot appear in the bare case statement.
 

--- a/tasks/coverage/snapshots/formatter_typescript.snap
+++ b/tasks/coverage/snapshots/formatter_typescript.snap
@@ -2,7 +2,7 @@ commit: 8ea03f88
 
 formatter_typescript Summary:
 AST Parsed     : 8827/8827 (100.00%)
-Positive Passed: 8818/8827 (99.90%)
+Positive Passed: 8817/8827 (99.89%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdLikeInputDeclarationEmit.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/arrayFromAsync.ts
@@ -19,5 +19,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/e
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/yieldStatementNoAsiAfterTransform.ts
 
+Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.1.ts
+Using declaration cannot appear in the bare case statement.Using declaration cannot appear in the bare case statement.Using declaration cannot appear in the bare case statement.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/returnStatements/returnStatementNoAsiAfterTransform.ts
 

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -3,18 +3,10 @@ commit: 4cc3d888
 parser_babel Summary:
 AST Parsed     : 2422/2440 (99.26%)
 Positive Passed: 2396/2440 (98.20%)
-Negative Passed: 1685/1752 (96.18%)
+Negative Passed: 1689/1752 (96.40%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/private-in/invalid-private-followed-by-in-2/input.js
 
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-module-bare-case-await-using-binding/input.js
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-script-bare-case-await-using-binding/input.js
-
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-script-top-level-using-binding/input.js
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-module-bare-case-using-binding/input.js
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-script-bare-case-using-binding/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-script-top-level-using-binding/input.js
 
@@ -9214,6 +9206,42 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Wrap this declaration in a block statement
 
+  × Using declaration cannot appear in the bare case statement.
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-module-bare-case-await-using-binding/input.js:5:7]
+ 4 │       {}
+ 5 │       await using x = bar();
+   ·       ──────────────────────
+ 6 │     default:
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Using declaration cannot appear in the bare case statement.
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-module-bare-case-await-using-binding/input.js:8:7]
+ 7 │       {}
+ 8 │       await using y = bar();
+   ·       ──────────────────────
+ 9 │   }
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Using declaration cannot appear in the bare case statement.
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-script-bare-case-await-using-binding/input.js:5:7]
+ 4 │       {}
+ 5 │       await using x = bar();
+   ·       ──────────────────────
+ 6 │     default:
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Using declaration cannot appear in the bare case statement.
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-script-bare-case-await-using-binding/input.js:8:7]
+ 7 │       {}
+ 8 │       await using y = bar();
+   ·       ──────────────────────
+ 9 │   }
+   ╰────
+  help: Wrap this declaration in a block statement
+
   × Lexical declaration cannot appear in a single-statement context
    ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-script-top-level-labeled-using-binding/input.js:1:8]
  1 │ label: await using x = bar();
@@ -9519,6 +9547,42 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  2 │   label: using x = bar();
    ·          ────────────────
  3 │ }
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Using declaration cannot appear in the bare case statement.
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-module-bare-case-using-binding/input.js:5:7]
+ 4 │       {}
+ 5 │       using x = bar();
+   ·       ────────────────
+ 6 │     default:
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Using declaration cannot appear in the bare case statement.
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-module-bare-case-using-binding/input.js:8:7]
+ 7 │       {}
+ 8 │       using y = bar();
+   ·       ────────────────
+ 9 │   }
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Using declaration cannot appear in the bare case statement.
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-script-bare-case-using-binding/input.js:5:7]
+ 4 │       {}
+ 5 │       using x = bar();
+   ·       ────────────────
+ 6 │     default:
+   ╰────
+  help: Wrap this declaration in a block statement
+
+  × Using declaration cannot appear in the bare case statement.
+   ╭─[babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-script-bare-case-using-binding/input.js:8:7]
+ 7 │       {}
+ 8 │       using y = bar();
+   ·       ────────────────
+ 9 │   }
    ╰────
   help: Wrap this declaration in a block statement
 

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -2,8 +2,8 @@ commit: 8ea03f88
 
 parser_typescript Summary:
 AST Parsed     : 8825/8827 (99.98%)
-Positive Passed: 8814/8827 (99.85%)
-Negative Passed: 1453/3530 (41.16%)
+Positive Passed: 8813/8827 (99.84%)
+Negative Passed: 1454/3530 (41.19%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment8.ts
@@ -3794,8 +3794,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/scanner/e
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInvalidInitializer.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.12.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.13.ts
@@ -4434,6 +4432,35 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ─
  3 │ }
    ╰────
+
+Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.1.ts
+
+  × Using declaration cannot appear in the bare case statement.
+    ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.1.ts:95:9]
+ 94 │     case 0:
+ 95 │         using d20 = { [Symbol.dispose]() {} };
+    ·         ──────────────────────────────────────
+ 96 │         break;
+    ╰────
+  help: Wrap this declaration in a block statement
+
+  × Using declaration cannot appear in the bare case statement.
+     ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.1.ts:99:9]
+  98 │     case 1:
+  99 │         using d21 = { [Symbol.dispose]() {} };
+     ·         ──────────────────────────────────────
+ 100 │         break;
+     ╰────
+  help: Wrap this declaration in a block statement
+
+  × Using declaration cannot appear in the bare case statement.
+     ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.1.ts:106:13]
+ 105 │         case 0:
+ 106 │             using d22 = { [Symbol.dispose]() {} };
+     ·             ──────────────────────────────────────
+ 107 │             break;
+     ╰────
+  help: Wrap this declaration in a block statement
 
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
@@ -25930,6 +25957,33 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ──────────
  7 │ function *gen() {
    ╰────
+
+  × Using declaration cannot appear in the bare case statement.
+    ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.1.ts:41:9]
+ 40 │     case 0:
+ 41 │         await using d20 = { async [Symbol.asyncDispose]() {} };
+    ·         ───────────────────────────────────────────────────────
+ 42 │         break;
+    ╰────
+  help: Wrap this declaration in a block statement
+
+  × Using declaration cannot appear in the bare case statement.
+    ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.1.ts:45:9]
+ 44 │     case 1:
+ 45 │         await using d21 = { async [Symbol.asyncDispose]() {} };
+    ·         ───────────────────────────────────────────────────────
+ 46 │         break;
+    ╰────
+  help: Wrap this declaration in a block statement
+
+  × Using declaration cannot appear in the bare case statement.
+    ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.1.ts:52:13]
+ 51 │         case 0:
+ 52 │             await using d22 = { async [Symbol.asyncDispose]() {} };
+    ·             ───────────────────────────────────────────────────────
+ 53 │             break;
+    ╰────
+  help: Wrap this declaration in a block statement
 
   × Lexical declaration cannot appear in a single-statement context
    ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.10.ts:5:12]

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -46161,6 +46161,9 @@ after transform: ScopeId(2): [ScopeId(4)]
 rebuilt        : ScopeId(9): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.1.ts
+Using declaration cannot appear in the bare case statement.
+Using declaration cannot appear in the bare case statement.
+Using declaration cannot appear in the bare case statement.
 Bindings mismatch:
 after transform: ScopeId(0): ["C1", "C2", "C3", "N", "_af", "_ag", "_asyncToGenerator", "_awaitAsyncGenerator", "_defineProperty", "_usingCtx2", "_usingCtx20", "_usingCtx23", "_usingCtx24", "_usingCtx25", "_usingCtx26", "_usingCtx27", "_usingCtx28", "_usingCtx29", "_usingCtx30", "_usingCtx6", "_wrapAsyncGenerator", "a", "af", "ag", "d1", "f", "g"]
 rebuilt        : ScopeId(0): ["C1", "C2", "C3", "N", "_af", "_ag", "_asyncToGenerator", "_awaitAsyncGenerator", "_defineProperty", "_usingCtx2", "_usingCtx20", "_usingCtx21", "_usingCtx22", "_usingCtx23", "_usingCtx24", "_usingCtx25", "_usingCtx26", "_usingCtx27", "_usingCtx28", "_usingCtx29", "_usingCtx30", "_usingCtx6", "_wrapAsyncGenerator", "a", "af", "ag", "d1", "f", "g"]

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 4cc3d888
 
-Passed: 712/1217
+Passed: 711/1217
 
 # All Passed:
 * babel-plugin-transform-logical-assignment-operators
@@ -268,7 +268,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-explicit-resource-management (21/29)
+# babel-plugin-transform-explicit-resource-management (20/29)
 * integration/commonjs-transform/input.js
 x Output mismatch
 
@@ -285,6 +285,28 @@ rebuilt        : ScopeId(2): ["x"]
 Symbol scope ID mismatch for "x":
 after transform: SymbolId(1): ScopeId(1)
 rebuilt        : SymbolId(2): ScopeId(2)
+
+* transform-sync/invalid-switch-bare-case/input.js
+
+  x Using declaration cannot appear in the bare case statement.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-explicit-resource-management/test/fixtures/transform-sync/invalid-switch-bare-case/input.js:4:7]
+ 3 |     case 0:
+ 4 |       using x = 0;
+   :       ^^^^^^^^^^^^
+ 5 |       break;
+   `----
+  help: Wrap this declaration in a block statement
+
+
+  x Using declaration cannot appear in the bare case statement.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-explicit-resource-management/test/fixtures/transform-sync/invalid-switch-bare-case/input.js:7:7]
+ 6 |     default:
+ 7 |       using y = 1;
+   :       ^^^^^^^^^^^^
+ 8 |       break;
+   `----
+  help: Wrap this declaration in a block statement
+
 
 * transform-sync/multiple-nested/input.js
 Bindings mismatch:


### PR DESCRIPTION
`using` / `await using` directly nested within a `case` or `default` clause are now disallowed (https://github.com/rbuckton/ecma262/pull/14). This PR implements this change.

Note that TypeScript does not disallow them yet (https://github.com/microsoft/TypeScript/issues/62708) and the test failing in `tasks/coverage/snapshots/parser_typescript.snap` is caused by that.

