### PR TITLE
fix(semantic): allow `arguments` in the class field keys

### DIFF
--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -2,7 +2,7 @@ commit: 4cc3d888
 
 parser_babel Summary:
 AST Parsed     : 2422/2440 (99.26%)
-Positive Passed: 2395/2440 (98.16%)
+Positive Passed: 2396/2440 (98.20%)
 Negative Passed: 1685/1752 (96.18%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/private-in/invalid-private-followed-by-in-2/input.js
 
@@ -265,17 +265,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/s
    · ──────
  2 │ {}
    ╰────
-
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-properties/arguments-in-key/input.js
-
-  × 'arguments' is not allowed in class field initializer
-   ╭─[babel/packages/babel-parser/test/fixtures/es2022/class-properties/arguments-in-key/input.js:3:6]
- 2 │   class A {
- 3 │     [arguments] = 2;
-   ·      ─────────
- 4 │   }
-   ╰────
-  help: Assign the 'arguments' variable to a temporary variable outside
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-properties/new-target/input.js
 

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -2,7 +2,7 @@ commit: 4cc3d888
 
 semantic_babel Summary:
 AST Parsed     : 2440/2440 (100.00%)
-Positive Passed: 2006/2440 (82.21%)
+Positive Passed: 2007/2440 (82.25%)
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/annex-b/enabled/valid-assignment-target-type/input.js
 Cannot assign to this expression
 
@@ -100,9 +100,6 @@ rebuilt        : ScopeId(1): ["x"]
 Symbol scope ID mismatch for "_x":
 after transform: SymbolId(1): ScopeId(1)
 rebuilt        : SymbolId(2): ScopeId(0)
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-properties/arguments-in-key/input.js
-'arguments' is not allowed in class field initializer
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-properties/await-identifier-in-computed-property-inside-params-of-function-inside-params-of-async-function/input.js
 Bindings mismatch:


### PR DESCRIPTION
Allow codes like `function foo() { class Bar { [arguments]: 1 } }`.