### PR TITLE
fix(formatter): handle member chain for the call's parent is a chain expression

### DIFF
--- a/crates/oxc_formatter/src/ast_nodes/impls/ast_nodes.rs
+++ b/crates/oxc_formatter/src/ast_nodes/impls/ast_nodes.rs
@@ -23,4 +23,15 @@ impl<'a> AstNodes<'a> {
             if matches!(node, AstNodes::Program(_)) { None } else { Some(node.parent()) }
         })
     }
+
+    /// If the node is a ChainExpression, recursively skip to its parent until a non-ChainExpression node is found.
+    /// This is useful for analyses that want to ignore the presence of ChainExpressions in the AST.
+    pub fn without_chain_expression(&self) -> &AstNodes<'a> {
+        match self {
+            AstNodes::ChainExpression(chain_expression) => {
+                chain_expression.parent.without_chain_expression()
+            }
+            _ => self,
+        }
+    }
 }

--- a/crates/oxc_formatter/src/utils/member_chain/mod.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/mod.rs
@@ -37,7 +37,6 @@ impl<'a, 'b> MemberChain<'a, 'b> {
         call_expression: &'b AstNode<'a, CallExpression<'a>>,
         f: &Formatter<'_, 'a>,
     ) -> Self {
-        let parent = &call_expression.parent;
         let mut chain_members = chain_members_iter(call_expression, f).collect::<Vec<_>>();
         chain_members.reverse();
 
@@ -54,7 +53,7 @@ impl<'a, 'b> MemberChain<'a, 'b> {
 
         // Here we check if the first element of Groups::groups can be moved inside the head.
         // If so, then we extract it and concatenate it together with the head.
-        member_chain.maybe_merge_with_first_group(parent, f);
+        member_chain.maybe_merge_with_first_group(call_expression.parent, f);
 
         member_chain
     }
@@ -93,14 +92,16 @@ impl<'a, 'b> MemberChain<'a, 'b> {
         if self.head.members().len() == 1
             && let ChainMember::Node(node) = self.head.members()[0]
         {
-            if let Expression::Identifier(identifier) = node.as_ref() {
-                has_computed_property ||
-                is_factory(&identifier.name) ||
-                // If an identifier has a name that is shorter than the tab with, then we join it with the "head"
-                (matches!(parent, AstNodes::ExpressionStatement(stmt) if !stmt.is_arrow_function_body())
-                    && has_short_name(&identifier.name, f.options().indent_width.value()))
-            } else {
-                matches!(node.as_ref(), Expression::ThisExpression(_))
+            match node.as_ref() {
+                Expression::Identifier(identifier) => {
+                    has_computed_property ||
+                    is_factory(&identifier.name) ||
+                    // If an identifier has a name that is shorter than the tab width, then we join it with the "head"
+                    (matches!(parent.without_chain_expression(), AstNodes::ExpressionStatement(stmt) if !stmt.is_arrow_function_body())
+                        && has_short_name(&identifier.name, f.options().indent_width.value()))
+                }
+                Expression::ThisExpression(_) => true,
+                _ => false,
             }
         } else if let Some(ChainMember::StaticMember(expression)) = self.head.members().last() {
             has_computed_property || is_factory(&expression.property().name)

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 684/749 (91.32%)
+js compatibility: 685/749 (91.46%)
 
 # Failed
 
@@ -42,7 +42,6 @@ js compatibility: 684/749 (91.32%)
 | js/label/empty_label.js | 💥 | 66.67% |
 | js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 22.22% |
 | js/logical-expressions/multiple-comments/17192.js | 💥 | 60.00% |
-| js/method-chain/issue-17457.js | 💥 | 0.00% |
 | js/object-multiline/multiline.js | 💥✨ | 22.22% |
 | js/quote-props/classes.js | 💥💥✨✨ | 47.06% |
 | js/quote-props/objects.js | 💥💥✨✨ | 45.10% |


### PR DESCRIPTION
This is an error-prone situation because Biome didn't have a ChainExpression. However, we have to handle it on a case-by-case basis.