### PR TITLE
docs(linter/no-useless-constructor): clarify caveat regarding visibility changes in constructors

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
@@ -52,6 +52,10 @@ declare_oxc_lint!(
     /// such, it is unnecessary to provide an empty constructor or one that
     /// simply delegates into its parent class.
     ///
+    /// # Caveat
+    /// This lint rule will report on constructors whose sole purpose is to change visibility of a parent constructor.
+    /// This is because the rule does not have type information to determine if the parent constructor is public, protected, or private.
+    ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:


### PR DESCRIPTION
Ref: https://github.com/typescript-eslint/typescript-eslint/issues/3820#issuecomment-917821240

closes https://github.com/oxc-project/oxc/issues/15215