### PR TITLE
docs(README): update architecture link to point to parser documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For more information, check out our website at [oxc.rs](https://oxc.rs).
 - **Developer Experience**: Clear APIs, comprehensive documentation, and sensible configuration.
 - **Modular composability**: Use individual components independently or compose them into complete toolchains.
 
-Read more about our [architecture](https://oxc.rs/docs/contribute/parser.html) and [performance philosophy](https://oxc.rs/docs/learn/performance).
+Read more about our [architecture](https://oxc.rs/docs/learn/architecture/parser.html) and [performance philosophy](https://oxc.rs/docs/learn/performance).
 
 ## 📦 Tools & Packages
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For more information, check out our website at [oxc.rs](https://oxc.rs).
 - **Developer Experience**: Clear APIs, comprehensive documentation, and sensible configuration.
 - **Modular composability**: Use individual components independently or compose them into complete toolchains.
 
-Read more about our [architecture](https://oxc.rs/docs/learn/architecture) and [performance philosophy](https://oxc.rs/docs/learn/performance).
+Read more about our [architecture](https://oxc.rs/docs/learn/architecture/parser.html) and [performance philosophy](https://oxc.rs/docs/learn/performance).
 
 ## 📦 Tools & Packages
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For more information, check out our website at [oxc.rs](https://oxc.rs).
 - **Developer Experience**: Clear APIs, comprehensive documentation, and sensible configuration.
 - **Modular composability**: Use individual components independently or compose them into complete toolchains.
 
-Read more about our [architecture](https://oxc.rs/docs/learn/architecture/parser.html) and [performance philosophy](https://oxc.rs/docs/learn/performance).
+Read more about our [architecture](https://oxc.rs/docs/contribute/parser.html) and [performance philosophy](https://oxc.rs/docs/learn/performance).
 
 ## 📦 Tools & Packages
 


### PR DESCRIPTION
The `https://oxc.rs/docs/learn/architecture` is missing, should replace with `https://oxc.rs/docs/contribute/parser.html`.