### PR TITLE
feat(formatter): wrap parenthesis for AssignmentExpression that is a key of `PropertyDefinition`

### DIFF
--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,12 +1,10 @@
-js compatibility: 696/749 (92.92%)
+js compatibility: 698/749 (93.19%)
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
 | js/arrows/comment.js | 💥💥 | 88.89% |
-| js/assignment-expression/property-key.js | 💥 | 88.89% |
-| js/assignment-expression/property-value.js | 💥 | 88.89% |
 | js/call/boolean/boolean.js | 💥 | 77.88% |
 | js/class-comment/misc.js | 💥 | 72.73% |
 | js/class-comment/superclass.js | 💥 | 95.35% |

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 544/598 (90.97%)
+ts compatibility: 545/598 (91.14%)
 
 # Failed
 
@@ -25,7 +25,6 @@ ts compatibility: 544/598 (90.97%)
 | typescript/comments/16121.ts | 💥 | 72.46% |
 | typescript/comments/mapped_types.ts | 💥 | 96.77% |
 | typescript/comments/method_types.ts | 💥 | 82.05% |
-| typescript/compiler/indexSignatureWithInitializer.ts | 💥 | 87.50% |
 | typescript/conditional-types/comments.ts | 💥✨ | 31.51% |
 | typescript/conditional-types/conditional-types.ts | 💥✨ | 34.48% |
 | typescript/conditional-types/infer-type.ts | 💥✨ | 4.76% |


### PR DESCRIPTION
Align the latest Prettier behavior, which hasn't been released yet.