### PR TITLE
docs(linter): Avoid linebreaks for markdown links and update plugins docs in the configuration schema.

### DIFF
--- a/crates/oxc_linter/src/config/env.rs
+++ b/crates/oxc_linter/src/config/env.rs
@@ -6,9 +6,8 @@ use serde::{Deserialize, Serialize};
 
 /// Predefine global variables.
 ///
-/// Environments specify what global variables are predefined. See [ESLint's
-/// list of
-/// environments](https://eslint.org/docs/v8.x/use/configure/language-options#specifying-environments)
+/// Environments specify what global variables are predefined.
+/// See [ESLint's list of environments](https://eslint.org/docs/v8.x/use/configure/language-options#specifying-environments)
 /// for what environments are available and what each one provides.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 pub struct OxlintEnv(FxHashMap<String, bool>);

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -63,6 +63,12 @@ use super::{
 #[serde(default)]
 #[non_exhaustive]
 pub struct Oxlintrc {
+    /// Enabled built-in plugins for Oxlint.
+    /// You can view the list of available plugins on
+    /// [the website](https://oxc.rs/docs/guide/usage/linter/plugins.html#supported-plugins).
+    ///
+    /// NOTE: Setting the `plugins` field will overwrite the base set of plugins.
+    /// The `plugins` array should reflect all of the plugins you want to use.
     pub plugins: Option<LintPlugins>,
     /// JS plugins.
     ///

--- a/crates/oxc_linter/src/snapshots/schema_json.snap
+++ b/crates/oxc_linter/src/snapshots/schema_json.snap
@@ -71,6 +71,7 @@ expression: json
       ]
     },
     "plugins": {
+      "description": "Enabled built-in plugins for Oxlint.\nYou can view the list of available plugins on\n[the website](https://oxc.rs/docs/guide/usage/linter/plugins.html#supported-plugins).\n\nNOTE: Setting the `plugins` field will overwrite the base set of plugins.\nThe `plugins` array should reflect all of the plugins you want to use.",
       "default": null,
       "anyOf": [
         {

--- a/crates/oxc_linter/src/snapshots/schema_json.snap
+++ b/crates/oxc_linter/src/snapshots/schema_json.snap
@@ -396,7 +396,7 @@ expression: json
       }
     },
     "OxlintEnv": {
-      "description": "Predefine global variables.\n\nEnvironments specify what global variables are predefined. See [ESLint's\nlist of\nenvironments](https://eslint.org/docs/v8.x/use/configure/language-options#specifying-environments)\nfor what environments are available and what each one provides.",
+      "description": "Predefine global variables.\n\nEnvironments specify what global variables are predefined.\nSee [ESLint's list of environments](https://eslint.org/docs/v8.x/use/configure/language-options#specifying-environments)\nfor what environments are available and what each one provides.",
       "type": "object",
       "additionalProperties": {
         "type": "boolean"

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -67,6 +67,7 @@
       ]
     },
     "plugins": {
+      "description": "Enabled built-in plugins for Oxlint.\nYou can view the list of available plugins on\n[the website](https://oxc.rs/docs/guide/usage/linter/plugins.html#supported-plugins).\n\nNOTE: Setting the `plugins` field will overwrite the base set of plugins.\nThe `plugins` array should reflect all of the plugins you want to use.",
       "default": null,
       "anyOf": [
         {

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -392,7 +392,7 @@
       }
     },
     "OxlintEnv": {
-      "description": "Predefine global variables.\n\nEnvironments specify what global variables are predefined. See [ESLint's\nlist of\nenvironments](https://eslint.org/docs/v8.x/use/configure/language-options#specifying-environments)\nfor what environments are available and what each one provides.",
+      "description": "Predefine global variables.\n\nEnvironments specify what global variables are predefined.\nSee [ESLint's list of environments](https://eslint.org/docs/v8.x/use/configure/language-options#specifying-environments)\nfor what environments are available and what each one provides.",
       "type": "object",
       "additionalProperties": {
         "type": "boolean"

--- a/tasks/website/src/linter/snapshots/schema_markdown.snap
+++ b/tasks/website/src/linter/snapshots/schema_markdown.snap
@@ -137,9 +137,8 @@ type: `Record<string, boolean>`
 
 Predefine global variables.
 
-Environments specify what global variables are predefined. See [ESLint's
-list of
-environments](https://eslint.org/docs/v8.x/use/configure/language-options#specifying-environments)
+Environments specify what global variables are predefined.
+See [ESLint's list of environments](https://eslint.org/docs/v8.x/use/configure/language-options#specifying-environments)
 for what environments are available and what each one provides.
 
 


### PR DESCRIPTION
This bothered me: <img width="795" height="245" alt="Screenshot 2025-11-03 at 5 27 07 PM" src="https://github.com/user-attachments/assets/071a1800-b5dd-427d-ad11-310081d116ae" />


Although I think this may not fix the problem anyway because we aren't serializing the values in the configuration_schema.json file as `markdownDescription`? So VS Code may not render it as markdown anyway.

Also updated the docs for the `plugins` field, which previously had no docs:

<img width="683" height="213" alt="Screenshot 2025-11-03 at 7 28 25 PM" src="https://github.com/user-attachments/assets/47ea2465-878b-440a-a9b0-de68a43fcb8c" />