### PR TITLE
fix(linter/plugins): resolve JS plugins only with conditions Node.js supports

### DIFF
--- a/apps/oxlint/test/fixtures/load_paths/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/load_paths/.oxlintrc.json
@@ -13,7 +13,9 @@
     "plugin11",
     "plugin12",
     "plugin13",
-    "plugin14"
+    "plugin14",
+    "plugin15",
+    "plugin16"
   ],
   "rules": {
     "plugin1/no-debugger": "error",
@@ -29,6 +31,8 @@
     "plugin11/no-debugger": "error",
     "plugin12/no-debugger": "error",
     "plugin13/no-debugger": "error",
-    "plugin14/no-debugger": "error"
+    "plugin14/no-debugger": "error",
+    "plugin15/no-debugger": "error",
+    "plugin16/no-debugger": "error"
   }
 }

--- a/apps/oxlint/test/fixtures/load_paths/node_modules/plugin15/index.esm.js
+++ b/apps/oxlint/test/fixtures/load_paths/node_modules/plugin15/index.esm.js
@@ -1,0 +1,20 @@
+// should not use "module" condition
+export default {
+  meta: {
+    name: "plugin15",
+  },
+  rules: {
+    "no-debugger": {
+      create(context) {
+        return {
+          DebuggerStatement(debuggerStatement) {
+            context.report({
+              message: "Unexpected Debugger Statement",
+              node: debuggerStatement,
+            });
+          },
+        };
+      },
+    },
+  },
+};

--- a/apps/oxlint/test/fixtures/load_paths/node_modules/plugin15/index.mjs
+++ b/apps/oxlint/test/fixtures/load_paths/node_modules/plugin15/index.mjs
@@ -1,0 +1,20 @@
+// should not use "module" condition
+export default {
+  meta: {
+    name: "plugin15",
+  },
+  rules: {
+    "no-debugger": {
+      create(context) {
+        return {
+          DebuggerStatement(debuggerStatement) {
+            context.report({
+              message: "Unexpected Debugger Statement",
+              node: debuggerStatement,
+            });
+          },
+        };
+      },
+    },
+  },
+};

--- a/apps/oxlint/test/fixtures/load_paths/node_modules/plugin15/package.json
+++ b/apps/oxlint/test/fixtures/load_paths/node_modules/plugin15/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "plugin15",
+  "exports": {
+    ".": {
+      "module": "./index.esm.js",
+      "default": "./index.mjs"
+    }
+  }
+}

--- a/apps/oxlint/test/fixtures/load_paths/node_modules/plugin16/index.js
+++ b/apps/oxlint/test/fixtures/load_paths/node_modules/plugin16/index.js
@@ -1,0 +1,20 @@
+// should use "module-sync" condition
+export default {
+  meta: {
+    name: "plugin16",
+  },
+  rules: {
+    "no-debugger": {
+      create(context) {
+        return {
+          DebuggerStatement(debuggerStatement) {
+            context.report({
+              message: "Unexpected Debugger Statement",
+              node: debuggerStatement,
+            });
+          },
+        };
+      },
+    },
+  },
+};

--- a/apps/oxlint/test/fixtures/load_paths/node_modules/plugin16/package.json
+++ b/apps/oxlint/test/fixtures/load_paths/node_modules/plugin16/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "plugin16",
+  "type": "module",
+  "exports": {
+    ".": {
+      "module-sync": "./index.js"
+    }
+  }
+}

--- a/apps/oxlint/test/fixtures/load_paths/output.snap.md
+++ b/apps/oxlint/test/fixtures/load_paths/output.snap.md
@@ -46,6 +46,18 @@
    : ^^^^^^^^^
    `----
 
+  x plugin15(no-debugger): Unexpected Debugger Statement
+   ,-[files/index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+
+  x plugin16(no-debugger): Unexpected Debugger Statement
+   ,-[files/index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+
   x plugin2(no-debugger): Unexpected Debugger Statement
    ,-[files/index.js:1:1]
  1 | debugger;
@@ -94,7 +106,7 @@
    : ^^^^^^^^^
    `----
 
-Found 1 warning and 14 errors.
+Found 1 warning and 16 errors.
 Finished in Xms on 1 file using X threads.
 ```
 

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -173,8 +173,7 @@ impl ConfigStoreBuilder {
             };
 
             let resolver = Resolver::new(ResolveOptions {
-                main_fields: vec!["module".into(), "main".into()],
-                condition_names: vec!["module".into(), "import".into()],
+                condition_names: vec!["module-sync".into(), "node".into(), "import".into()],
                 ..Default::default()
             });
 


### PR DESCRIPTION
Fixes the `require` related error described in https://github.com/oxc-project/oxc/discussions/14862#discussioncomment-14861678.
This was happening because Node.js does not use `module` condition but the plugin resolver used that. I aligned the conditions to what Node.js uses (I didn't include `node-addon` because it's not popular and requires detecting `--no-addons` to do it properly).
https://nodejs.org/docs/v24.11.0/api/packages.html#conditional-exports

I'm not sure why, but the test snapshot doesn't seem stable on my machine.

cc @TheAlexLichter 

refs #14541
