### PR TITLE
feat(linter): permit comments in `.oxlintrc.json` via json schema file

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -571,7 +571,8 @@ mod test {
     #[test]
     fn test_schema_json() {
         let path = get_project_root().unwrap().join("npm/oxlint/configuration_schema.json");
-        let schema = schemars::schema_for!(Oxlintrc);
+        let mut schema = schemars::schema_for!(Oxlintrc);
+        schema.schema.extensions.insert("allowComments".to_string(), serde_json::Value::Bool(true));
         let json = serde_json::to_string_pretty(&schema).unwrap();
         let existing_json = fs::read_to_string(&path).unwrap_or_default();
         if existing_json.trim() != json.trim() {

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -572,6 +572,8 @@ mod test {
     fn test_schema_json() {
         let path = get_project_root().unwrap().join("npm/oxlint/configuration_schema.json");
         let mut schema = schemars::schema_for!(Oxlintrc);
+        // setting `allowComments` to true to allow comments in JSON schema files
+        // https://github.com/microsoft/vscode-json-languageservice/blob/356d5dd980d49c6ac09ec8446614a6f94016dcea/src/jsonLanguageTypes.ts#L127-L131
         schema.schema.extensions.insert("allowComments".to_string(), serde_json::Value::Bool(true));
         let json = serde_json::to_string_pretty(&schema).unwrap();
         let existing_json = fs::read_to_string(&path).unwrap_or_default();

--- a/crates/oxc_linter/src/snapshots/schema_json.snap
+++ b/crates/oxc_linter/src/snapshots/schema_json.snap
@@ -125,6 +125,7 @@ expression: json
       ]
     }
   },
+  "allowComments": true,
   "definitions": {
     "AllowWarnDeny": {
       "oneOf": [

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -121,6 +121,7 @@
       ]
     }
   },
+  "allowComments": true,
   "definitions": {
     "AllowWarnDeny": {
       "oneOf": [


### PR DESCRIPTION
With this small change, VS Code will stop complaining about comments in oxlint configuration files.
Similar usages: https://github.com/search?q=path%3A*schema*.json+%2F%5E%5B+%5D%7B0%2C4%7D%22allowcomments%22%3A+true%2F&type=code