### PR TITLE
chore(vscode): Improve the command title for oxc.toggleEnable.

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -46,7 +46,7 @@
       },
       {
         "command": "oxc.toggleEnable",
-        "title": "toggle enable",
+        "title": "Toggle whether oxc is enabled",
         "category": "Oxc"
       },
       {
@@ -78,7 +78,7 @@
           "type": "boolean",
           "default": true,
           "scope": "window",
-          "description": "enable oxc language server"
+          "description": "Enable oxc language server"
         },
         "oxc.requireConfig": {
           "scope": "resource",


### PR DESCRIPTION
I noticed this looked a bit out-of-place:

<img width="739" height="264" alt="Screenshot 2025-11-03 at 10 21 30 PM" src="https://github.com/user-attachments/assets/f1cbfb47-f6d3-4fa6-93ab-a280500335f8" />