### PR TITLE
fix(linter): Fix JSON schema to deny additional properties for categories enum.

### DIFF
--- a/crates/oxc_linter/src/config/categories.rs
+++ b/crates/oxc_linter/src/config/categories.rs
@@ -48,7 +48,7 @@ impl JsonSchema for OxlintCategories {
             r#gen.subschema_for::<FxHashMap<RuleCategory, AllowWarnDeny>>().into_object();
 
         {
-            schema.object().additional_properties = None;
+            schema.object().additional_properties = Some(Box::new(false.into()));
             let properties = &mut schema.object().properties;
 
             properties.insert(RuleCategory::Correctness.as_str().to_string(), severity.clone());

--- a/crates/oxc_linter/src/snapshots/schema_json.snap
+++ b/crates/oxc_linter/src/snapshots/schema_json.snap
@@ -393,7 +393,8 @@ expression: json
         "suspicious": {
           "$ref": "#/definitions/AllowWarnDeny"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "OxlintEnv": {
       "description": "Predefine global variables.\n\nEnvironments specify what global variables are predefined. See [ESLint's\nlist of\nenvironments](https://eslint.org/docs/v8.x/use/configure/language-options#specifying-environments)\nfor what environments are available and what each one provides.",

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -389,7 +389,8 @@
         "suspicious": {
           "$ref": "#/definitions/AllowWarnDeny"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "OxlintEnv": {
       "description": "Predefine global variables.\n\nEnvironments specify what global variables are predefined. See [ESLint's\nlist of\nenvironments](https://eslint.org/docs/v8.x/use/configure/language-options#specifying-environments)\nfor what environments are available and what each one provides.",


### PR DESCRIPTION
This ensures that VS Code and other editors will not accept unknown values for the categories field. Apparently, `None` doesn't work as expected here 🤷 

And now I correctly get a warning in the editor, to match the one I get when running oxlint with a config like this:

<img width="356" height="120" alt="Screenshot 2025-11-03 at 10 49 01 PM" src="https://github.com/user-attachments/assets/499e2cdb-39f1-435b-8ab2-91adf9892b31" />

Part of https://github.com/oxc-project/oxc/issues/15247.