### PR TITLE
fix(linter): Fix JSON schema to deny additional properties for plugins enum.

### DIFF
--- a/crates/oxc_linter/src/config/plugins.rs
+++ b/crates/oxc_linter/src/config/plugins.rs
@@ -249,16 +249,9 @@ impl JsonSchema for LintPlugins {
 
         let enum_schema = r#gen.subschema_for::<LintPluginOptionsSchema>();
 
-        let string_schema = Schema::Object(schemars::schema::SchemaObject {
-            instance_type: Some(schemars::schema::SingleOrVec::Single(Box::new(
-                schemars::schema::InstanceType::String,
-            ))),
-            ..Default::default()
-        });
-
         let item_schema = Schema::Object(schemars::schema::SchemaObject {
             subschemas: Some(Box::new(schemars::schema::SubschemaValidation {
-                any_of: Some(vec![enum_schema, string_schema]),
+                any_of: Some(vec![enum_schema]),
                 ..Default::default()
             })),
             ..Default::default()

--- a/crates/oxc_linter/src/snapshots/schema_json.snap
+++ b/crates/oxc_linter/src/snapshots/schema_json.snap
@@ -327,9 +327,6 @@ expression: json
         "anyOf": [
           {
             "$ref": "#/definitions/LintPluginOptionsSchema"
-          },
-          {
-            "type": "string"
           }
         ]
       }

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -323,9 +323,6 @@
         "anyOf": [
           {
             "$ref": "#/definitions/LintPluginOptionsSchema"
-          },
-          {
-            "type": "string"
           }
         ]
       }


### PR DESCRIPTION
This ensures that VS Code and other editors will not accept unknown values for the plugins field.

I believe `string` was allowed initially because of the way jsPlugins were going to be implemented (see #12117), but then the jsPlugins plans changed to use a separate config field? I'm not 100% sure, but that appears to be the case. Anyway, the schema was never updated after that pivot, and so this fixes the problem. We could probably remove the `any_of` to simplify things, but eh I just want to fix this for now.

With this change, jsPlugins still allows arbitrary values, while `plugins` only allows known values:

<img width="222" height="280" alt="Screenshot 2025-11-03 at 11 16 41 PM" src="https://github.com/user-attachments/assets/7f7c8756-f9c3-4dad-8642-189197cfa1cc" />

In the future, it'd probably be good to add tests to do basic schema validation (e.g. here are 10 JSON blobs that should pass, here are 10 JSON blobs that should fail) so we can ensure regressions don't occur for this kind of developer experience nice-to-have.

Part of #15247.