### PR TITLE
fix(oxfmt): Sync `dependencies` with `npm/oxfmt` and `apps/oxfmt`

### DIFF
--- a/apps/oxfmt/package.json
+++ b/apps/oxfmt/package.json
@@ -19,7 +19,6 @@
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   },
-  "description": "Formatter for the JavaScript Oxidation Compiler",
   "author": "Boshen and oxc contributors",
   "license": "MIT",
   "homepage": "https://oxc.rs",
@@ -29,13 +28,7 @@
     "url": "https://github.com/oxc-project/oxc.git",
     "directory": "apps/oxfmt"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public"
-  },
-  "files": [
-    "dist"
-  ],
+  "description": "Local project to build and publish `npm/oxfmt`. Be sure to sync dependencies!",
   "dependencies": {
     "prettier": "3.6.2",
     "@prettier/sync": "0.6.1"

--- a/npm/oxfmt/package.json
+++ b/npm/oxfmt/package.json
@@ -22,6 +22,10 @@
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   },
+  "dependencies": {
+    "prettier": "3.6.2",
+    "@prettier/sync": "0.6.1"
+  },
   "files": [
     "bin/oxfmt",
     "configuration_schema.json",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,7 +227,14 @@ importers:
 
   npm/oxc-types: {}
 
-  npm/oxfmt: {}
+  npm/oxfmt:
+    dependencies:
+      '@prettier/sync':
+        specifier: 0.6.1
+        version: 0.6.1(prettier@3.6.2)
+      prettier:
+        specifier: 3.6.2
+        version: 3.6.2
 
   npm/oxlint: {}
 


### PR DESCRIPTION
Fixes #15256 for now.