### PR TITLE
release(oxfmt): v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_formatter"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "cow-utils",
  "insta",
@@ -2794,7 +2794,7 @@ dependencies = [
 
 [[package]]
 name = "oxfmt"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bpaf",
  "cow-utils",

--- a/apps/oxfmt/CHANGELOG.md
+++ b/apps/oxfmt/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.10.0] - 2025-11-04
+
+### 🚀 Features
+
+- b77f254 oxfmt,formatter: Support `embeddedLanguageFormatting` option (#15216) (leaysgur)
+- 898d6fe oxfmt: Add embedded language formatting with Prettier integration (#14820) (Boshen)
+
+### 🐛 Bug Fixes
+
+- daacf85 oxfmt: Release build fails (#15262) (Dunqing)
+- f5d0348 oxfmt: Sync `dependencies` with `npm/oxfmt` and `apps/oxfmt` (#15261) (leaysgur)
+
+### 🚜 Refactor
+
+- 27b4f36 diagnostic: Remove `path` from sender (#15130) (camc314)
+
+
 ## [0.9.0] - 2025-10-30
 
 ### 🚜 Refactor

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxfmt"
-version = "0.9.0"
+version = "0.10.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_formatter/CHANGELOG.md
+++ b/crates/oxc_formatter/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.10.0] - 2025-11-04
+
+### 🚀 Features
+
+- 505252c formatter: Wrap parenthesis for AssignmentExpression that is a key of `PropertyDefinition` (#15243) (Dunqing)
+- 880b259 formatter: Align import-like formatting the same as Prettier (#15238) (Dunqing)
+- b77f254 oxfmt,formatter: Support `embeddedLanguageFormatting` option (#15216) (leaysgur)
+- 898d6fe oxfmt: Add embedded language formatting with Prettier integration (#14820) (Boshen)
+- e77a48e formatter: Detect code removal feature (#15059) (leaysgur)
+
+### 🐛 Bug Fixes
+
+- 46793d7 formatter: Correct printing comments for `LabeledStatement` (#15260) (Dunqing)
+- 831ae99 formatter: Multiple comments in `LogicalExpression` and `TSIntersectionType` (#15253) (Dunqing)
+- 5fa9b1e formatter: Should not indent `BinaryLikeExpression` when it is an argument of `Boolean` (#15250) (Dunqing)
+- 99e520f formatter: Handle chain expression for `JSXExpressionContainer` (#15242) (Dunqing)
+- a600bf5 formatter: Correct printing comments for `TaggedTemplateExpression` (#15241) (Dunqing)
+- a7289e7 formatter: Handle member chain for the call's parent is a chain expression (#15237) (Dunqing)
+
+### 🚜 Refactor
+
+- 36ae721 formatter: Simplify the use of `indent` with `soft_line_break_or_space` (#15254) (Dunqing)
+- cdd8e2f formatter/sort-imports: Split sort_imports modules (#15189) (leaysgur)
+- 85fb8e8 formatter/sort-imports: Pass options to is_ignored() (#15181) (leaysgur)
+
+### 🧪 Testing
+
+- 9d5b34b formatter/sort-imports: Refactor sort_imports tests (#15188) (leaysgur)
+
+
 ## [0.9.0] - 2025-10-30
 
 ### 🚀 Features

--- a/crates/oxc_formatter/Cargo.toml
+++ b/crates/oxc_formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_formatter"
-version = "0.9.0"
+version = "0.10.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/npm/oxfmt/CHANGELOG.md
+++ b/npm/oxfmt/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.10.0] - 2025-11-04
+
+### 🚀 Features
+
+- b77f254 oxfmt,formatter: Support `embeddedLanguageFormatting` option (#15216) (leaysgur)
+
+### 🐛 Bug Fixes
+
+- f5d0348 oxfmt: Sync `dependencies` with `npm/oxfmt` and `apps/oxfmt` (#15261) (leaysgur)
+
+
 ## [0.9.0] - 2025-10-30
 
 ### 💼 Other

--- a/npm/oxfmt/package.json
+++ b/npm/oxfmt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxfmt",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "type": "module",
   "description": "Formatter for the JavaScript Oxidation Compiler",
   "keywords": [],


### PR DESCRIPTION
## [0.10.0] - 2025-11-04

### 🚀 Features

- 505252c formatter: Wrap parenthesis for AssignmentExpression that is a key of `PropertyDefinition` (#15243) (Dunqing)
- 880b259 formatter: Align import-like formatting the same as Prettier (#15238) (Dunqing)
- b77f254 oxfmt,formatter: Support `embeddedLanguageFormatting` option (#15216) (leaysgur)
- 898d6fe oxfmt: Add embedded language formatting with Prettier integration (#14820) (Boshen)
- e77a48e formatter: Detect code removal feature (#15059) (leaysgur)

### 🐛 Bug Fixes

- daacf85 oxfmt: Release build fails (#15262) (Dunqing)
- f5d0348 oxfmt: Sync `dependencies` with `npm/oxfmt` and `apps/oxfmt` (#15261) (leaysgur)
- 46793d7 formatter: Correct printing comments for `LabeledStatement` (#15260) (Dunqing)
- 831ae99 formatter: Multiple comments in `LogicalExpression` and `TSIntersectionType` (#15253) (Dunqing)
- 5fa9b1e formatter: Should not indent `BinaryLikeExpression` when it is an argument of `Boolean` (#15250) (Dunqing)
- 99e520f formatter: Handle chain expression for `JSXExpressionContainer` (#15242) (Dunqing)
- a600bf5 formatter: Correct printing comments for `TaggedTemplateExpression` (#15241) (Dunqing)
- a7289e7 formatter: Handle member chain for the call's parent is a chain expression (#15237) (Dunqing)

### 🚜 Refactor

- 36ae721 formatter: Simplify the use of `indent` with `soft_line_break_or_space` (#15254) (Dunqing)
- cdd8e2f formatter/sort-imports: Split sort_imports modules (#15189) (leaysgur)
- 27b4f36 diagnostic: Remove `path` from sender (#15130) (camc314)
- 85fb8e8 formatter/sort-imports: Pass options to is_ignored() (#15181) (leaysgur)

### 🧪 Testing

- 9d5b34b formatter/sort-imports: Refactor sort_imports tests (#15188) (leaysgur)