### PR TITLE
feat(parser): improve error message for using declarations with `export`

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -522,6 +522,13 @@ pub fn using_declarations_must_be_initialized(span: Span) -> OxcDiagnostic {
 }
 
 #[cold]
+pub fn using_declaration_cannot_be_exported(identifier: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Using declarations cannot be exported directly.")
+        .with_label(span)
+        .with_help(format!("Remove the `export` here and add `export {{ {identifier} }}` as a separate statement to export the declaration"))
+}
+
+#[cold]
 pub fn jsx_element_no_match(span: Span, span1: Span, name: &str) -> OxcDiagnostic {
     OxcDiagnostic::error(format!("Expected corresponding JSX closing tag for '{name}'."))
         .with_labels([span, span1])

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -428,7 +428,7 @@ impl<'a> ParserImpl<'a> {
         self.parse_any_for_loop(span, init_declaration, r#await)
     }
 
-    fn is_using_declaration(&mut self) -> bool {
+    pub(crate) fn is_using_declaration(&mut self) -> bool {
         let token = self.lexer.peek_token();
         let kind = token.kind();
         (kind.is_binding_identifier() || kind == Kind::LCurly) && !token.is_on_new_line()

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -445,6 +445,23 @@ impl<'a> ParserImpl<'a> {
                 );
                 Declaration::VariableDeclaration(decl)
             }
+            Kind::Using if self.is_using_declaration() => {
+                self.expect(Kind::Using);
+                let identifier = self.parse_identifier_kind(self.cur_kind()).1.as_str();
+                self.fatal_error(diagnostics::using_declaration_cannot_be_exported(
+                    identifier,
+                    self.end_span(start_span),
+                ))
+            }
+            Kind::Await if self.is_using_statement() => {
+                self.expect(Kind::Await);
+                self.expect(Kind::Using);
+                let identifier = self.parse_identifier_kind(self.cur_kind()).1.as_str();
+                self.fatal_error(diagnostics::using_declaration_cannot_be_exported(
+                    identifier,
+                    self.end_span(start_span),
+                ))
+            }
             Kind::Class => {
                 let decl = self.parse_class_declaration(start_span, modifiers, decorators);
                 Declaration::ClassDeclaration(decl)

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -9049,11 +9049,12 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  8 │   }
    ╰────
 
-  × Unexpected token
+  × Using declarations cannot be exported directly.
    ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-export-await-using/input.js:1:8]
  1 │ export await using basic = reader();
-   ·        ─────
+   ·        ─────────────────
    ╰────
+  help: Remove the `export` here and add `export { basic }` as a separate statement to export the declaration
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-export-default-await-using/input.js:1:27]
@@ -9385,11 +9386,12 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Try inserting a semicolon here
 
-  × Unexpected token
+  × Using declarations cannot be exported directly.
    ╭─[babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-export-using/input.js:1:8]
  1 │ export using basic = reader();
-   ·        ─────
+   ·        ───────────
    ╰────
+  help: Remove the `export` here and add `export { basic }` as a separate statement to export the declaration
 
   × Expected `)` but found `of`
    ╭─[babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-for-await-using-binding-of-of/input.mjs:1:24]

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -25575,12 +25575,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ╰────
   help: Wrap this declaration in a block statement
 
-  × Unexpected token
+  × Using declarations cannot be exported directly.
    ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.11.ts:1:8]
  1 │ export await using x = null;
-   ·        ─────
+   ·        ─────────────
  2 │ declare await using y: null;
    ╰────
+  help: Remove the `export` here and add `export { x }` as a separate statement to export the declaration
 
   × Using declarations must have an initializer.
    ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.16.ts:2:17]
@@ -25739,12 +25740,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ╰────
   help: Wrap this declaration in a block statement
 
-  × Unexpected token
+  × Using declarations cannot be exported directly.
    ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.13.ts:1:8]
  1 │ export using x = null;
-   ·        ─────
+   ·        ───────
  2 │ declare using y: null;
    ╰────
+  help: Remove the `export` here and add `export { x }` as a separate statement to export the declaration
 
   × Using declarations must have an initializer.
    ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.16.ts:2:11]


### PR DESCRIPTION
Add a better error message for `export using x = something` and `export await using x = something`.