### PR TITLE
feat(parser): improve error message for missing conditional alternative

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -189,6 +189,20 @@ impl<'a> ParserImpl<'a> {
         self.advance(kind);
     }
 
+    #[inline]
+    pub(crate) fn expect_conditional_alternative(&mut self, question_span: Span) {
+        if !self.at(Kind::Colon) {
+            let range = self.cur_token().span();
+            let error = diagnostics::expect_conditional_alternative(
+                self.cur_kind().to_str(),
+                range,
+                question_span,
+            );
+            self.set_fatal_error(error);
+        }
+        self.bump_any(); // bump `:`
+    }
+
     /// Expect the next next token to be a `JsxChild`, i.e. `<` or `{` or `JSXText`
     /// # Errors
     pub(crate) fn expect_jsx_child(&mut self, kind: Kind) {

--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -45,6 +45,14 @@ pub fn expect_token(x0: &str, x1: &str, span: Span) -> OxcDiagnostic {
 }
 
 #[cold]
+pub fn expect_conditional_alternative(x: &str, span: Span, question_span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("Expected `:` but found `{x}`")).with_labels([
+        span.primary_label("`:` expected"),
+        question_span.label("Conditional starts here"),
+    ])
+}
+
+#[cold]
 pub fn unexpected_trailing_comma(name: &'static str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error(format!("{name} may not have a trailing comma."))
         .with_label(span)

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -1216,6 +1216,7 @@ impl<'a> ParserImpl<'a> {
         lhs: Expression<'a>,
         allow_return_type_in_arrow_function: bool,
     ) -> Expression<'a> {
+        let question_span = self.token.span();
         if !self.eat(Kind::Question) {
             return lhs;
         }
@@ -1224,7 +1225,7 @@ impl<'a> ParserImpl<'a> {
                 /* allow_return_type_in_arrow_function */ false,
             )
         });
-        self.expect(Kind::Colon);
+        self.expect_conditional_alternative(question_span);
         let alternate =
             self.parse_assignment_expression_or_higher_impl(allow_return_type_in_arrow_function);
         self.ast.expression_conditional(self.end_span(lhs_span), lhs, consequent, alternate)

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -24,10 +24,11 @@ impl<'a> ParserImpl<'a> {
         {
             let extends_type =
                 self.context_add(Context::DisallowConditionalTypes, Self::parse_ts_type);
+            let question_span = self.token.span();
             self.expect(Kind::Question);
             let true_type =
                 self.context_remove(Context::DisallowConditionalTypes, Self::parse_ts_type);
-            self.expect(Kind::Colon);
+            self.expect_conditional_alternative(question_span);
             let false_type =
                 self.context_remove(Context::DisallowConditionalTypes, Self::parse_ts_type);
             return self.ast.ts_type_conditional_type(

--- a/tasks/coverage/misc/fail/missing-conditional-alternative-type.ts
+++ b/tasks/coverage/misc/fail/missing-conditional-alternative-type.ts
@@ -1,0 +1,1 @@
+type A = 1 extends 2 ? 3

--- a/tasks/coverage/misc/fail/missing-conditional-alternative.js
+++ b/tasks/coverage/misc/fail/missing-conditional-alternative.js
@@ -1,0 +1,1 @@
+const foo = 1 ? 2

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 48/48 (100.00%)
 Positive Passed: 48/48 (100.00%)
-Negative Passed: 94/94 (100.00%)
+Negative Passed: 96/96 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -48,6 +48,20 @@ Negative Passed: 94/94 (100.00%)
  7 │ function foo4([eval]) {}
    ·                ────
  8 │ 
+   ╰────
+
+  × Expected `:` but found `EOF`
+   ╭─[misc/fail/missing-conditional-alternative-type.ts:2:1]
+ 1 │ type A = 1 extends 2 ? 3
+   ·                      ┬
+   ·                      ╰── Conditional starts here
+   ╰────
+
+  × Expected `:` but found `EOF`
+   ╭─[misc/fail/missing-conditional-alternative.js:2:1]
+ 1 │ const foo = 1 ? 2
+   ·               ┬
+   ·               ╰── Conditional starts here
    ╰────
 
   × Identifier `b` has already been declared


### PR DESCRIPTION
Improve error message for missing alternative for conditional expressions.
```
 × Expected `:` but found `EOF`
   ╭─[misc/fail/missing-conditional-alternative-type.ts:2:1]
 1 │ type A = 1 extends 2 ? 3
   ·                      ┬
   ·                      ╰── Conditional starts here
   ╰────

  × Expected `:` but found `EOF`
   ╭─[misc/fail/missing-conditional-alternative.js:2:1]
 1 │ const foo = 1 ? 2
   ·               ┬
   ·               ╰── Conditional starts here
   ╰────
```
Without this PR, the error mesage is a simple ``Expected `:` but found `EOF` `` only.
