### PR TITLE
refactor(language_server): pass `serde_json::Value` to `WorkspaceWorker` configuration changes

### DIFF
--- a/crates/oxc_language_server/src/formatter/server_formatter.rs
+++ b/crates/oxc_language_server/src/formatter/server_formatter.rs
@@ -181,8 +181,10 @@ fn compute_minimal_text_edit<'a>(
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::compute_minimal_text_edit;
-    use crate::formatter::{options::FormatOptions, tester::Tester};
+    use crate::formatter::tester::Tester;
 
     #[test]
     #[should_panic(expected = "assertion failed")]
@@ -269,7 +271,9 @@ mod tests {
     fn test_formatter() {
         Tester::new(
             "fixtures/formatter/basic",
-            Some(FormatOptions { experimental: true, ..Default::default() }),
+            json!({
+                "fmt.experimental": true
+            }),
         )
         .format_and_snapshot_single_file("basic.ts");
     }
@@ -278,7 +282,9 @@ mod tests {
     fn test_root_config_detection() {
         Tester::new(
             "fixtures/formatter/root_config",
-            Some(FormatOptions { experimental: true, ..Default::default() }),
+            json!({
+                "fmt.experimental": true
+            }),
         )
         .format_and_snapshot_single_file("semicolons-as-needed.ts");
     }
@@ -287,9 +293,9 @@ mod tests {
     fn test_custom_config_path() {
         Tester::new(
             "fixtures/formatter/custom_config_path",
-            Some(FormatOptions {
-                experimental: true,
-                config_path: Some("./format.json".to_string()),
+            json!({
+                "fmt.experimental": true,
+                "fmt.configPath": "./format.json",
             }),
         )
         .format_and_snapshot_single_file("semicolons-as-needed.ts");

--- a/crates/oxc_language_server/src/formatter/tester.rs
+++ b/crates/oxc_language_server/src/formatter/tester.rs
@@ -5,7 +5,7 @@ use tower_lsp_server::{
     lsp_types::{TextEdit, Uri},
 };
 
-use crate::{formatter::options::FormatOptions, options::Options, worker::WorkspaceWorker};
+use crate::worker::WorkspaceWorker;
 
 /// Given a file path relative to the crate root directory, return the absolute path of the file.
 pub fn get_file_path(relative_file_path: &str) -> PathBuf {
@@ -45,11 +45,11 @@ fn get_snapshot_from_text_edits(edits: &[TextEdit]) -> String {
 /// Testing struct for the [formatter server][crate::formatter::server_formatter::ServerFormatter].
 pub struct Tester<'t> {
     relative_root_dir: &'t str,
-    options: Option<FormatOptions>,
+    options: serde_json::Value,
 }
 
 impl Tester<'_> {
-    pub fn new(relative_root_dir: &'static str, options: Option<FormatOptions>) -> Self {
+    pub fn new(relative_root_dir: &'static str, options: serde_json::Value) -> Self {
         Self { relative_root_dir, options }
     }
 
@@ -59,9 +59,7 @@ impl Tester<'_> {
             .join(self.relative_root_dir);
         let uri = Uri::from_file_path(absolute_path).expect("could not convert current dir to uri");
         let worker = WorkspaceWorker::new(uri);
-        let option =
-            &Options { format: self.options.clone().unwrap_or_default(), ..Default::default() };
-        worker.start_worker(option).await;
+        worker.start_worker(&self.options).await;
 
         worker
     }

--- a/crates/oxc_language_server/src/linter/options.rs
+++ b/crates/oxc_language_server/src/linter/options.rs
@@ -25,7 +25,9 @@ pub enum Run {
 #[serde(rename_all = "camelCase")]
 pub struct LintOptions {
     pub run: Run, // TODO: the client wants maybe only the formatter, make it optional
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub config_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ts_config_path: Option<String>,
     pub unused_disable_directives: UnusedDisableDirectives,
     pub type_aware: bool,

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -333,11 +333,10 @@ impl ServerLinter {
 mod test {
     use std::path::{Path, PathBuf};
 
+    use serde_json::json;
+
     use crate::{
-        linter::{
-            options::{LintFixKindFlag, LintOptions, Run, UnusedDisableDirectives},
-            server_linter::ServerLinter,
-        },
+        linter::{options::LintOptions, server_linter::ServerLinter},
         tester::{Tester, get_file_path},
     };
 
@@ -374,34 +373,36 @@ mod test {
 
     #[test]
     fn test_no_errors() {
-        Tester::new("fixtures/linter/no_errors", None)
+        Tester::new("fixtures/linter/no_errors", json!({}))
             .test_and_snapshot_single_file("hello_world.js");
     }
 
     #[test]
     fn test_no_console() {
-        Tester::new("fixtures/linter/deny_no_console", None)
+        Tester::new("fixtures/linter/deny_no_console", json!({}))
             .test_and_snapshot_single_file("hello_world.js");
     }
 
     // Test case for https://github.com/oxc-project/oxc/issues/9958
     #[test]
     fn test_issue_9958() {
-        Tester::new("fixtures/linter/issue_9958", None).test_and_snapshot_single_file("issue.ts");
+        Tester::new("fixtures/linter/issue_9958", json!({}))
+            .test_and_snapshot_single_file("issue.ts");
     }
 
     // Test case for https://github.com/oxc-project/oxc/issues/9957
     #[test]
     fn test_regexp() {
-        Tester::new("fixtures/linter/regexp_feature", None)
+        Tester::new("fixtures/linter/regexp_feature", json!({}))
             .test_and_snapshot_single_file("index.ts");
     }
 
     #[test]
     fn test_frameworks() {
-        Tester::new("fixtures/linter/astro", None).test_and_snapshot_single_file("debugger.astro");
-        Tester::new("fixtures/linter/vue", None).test_and_snapshot_single_file("debugger.vue");
-        Tester::new("fixtures/linter/svelte", None)
+        Tester::new("fixtures/linter/astro", json!({}))
+            .test_and_snapshot_single_file("debugger.astro");
+        Tester::new("fixtures/linter/vue", json!({})).test_and_snapshot_single_file("debugger.vue");
+        Tester::new("fixtures/linter/svelte", json!({}))
             .test_and_snapshot_single_file("debugger.svelte");
         // ToDo: fix Tester to work only with Uris and do not access the file system
         // Tester::new("fixtures/linter/nextjs").test_and_snapshot_single_file("%5B%5B..rest%5D%5D/debugger.ts");
@@ -409,30 +410,31 @@ mod test {
 
     #[test]
     fn test_invalid_syntax_file() {
-        Tester::new("fixtures/linter/invalid_syntax", None)
+        Tester::new("fixtures/linter/invalid_syntax", json!({}))
             .test_and_snapshot_multiple_file(&["debugger.ts", "invalid.vue"]);
     }
 
     #[test]
     fn test_cross_module_debugger() {
-        Tester::new("fixtures/linter/cross_module", None)
+        Tester::new("fixtures/linter/cross_module", json!({}))
             .test_and_snapshot_single_file("debugger.ts");
     }
 
     #[test]
     fn test_cross_module_no_cycle() {
-        Tester::new("fixtures/linter/cross_module", None).test_and_snapshot_single_file("dep-a.ts");
+        Tester::new("fixtures/linter/cross_module", json!({}))
+            .test_and_snapshot_single_file("dep-a.ts");
     }
 
     #[test]
     fn test_cross_module_no_cycle_nested_config() {
-        Tester::new("fixtures/linter/cross_module_nested_config", None)
+        Tester::new("fixtures/linter/cross_module_nested_config", json!({}))
             .test_and_snapshot_multiple_file(&["dep-a.ts", "folder/folder-dep-a.ts"]);
     }
 
     #[test]
     fn test_cross_module_no_cycle_extended_config() {
-        Tester::new("fixtures/linter/cross_module_extended_config", None)
+        Tester::new("fixtures/linter/cross_module_extended_config", json!({}))
             .test_and_snapshot_single_file("dep-a.ts");
     }
 
@@ -440,9 +442,8 @@ mod test {
     fn test_multiple_suggestions() {
         Tester::new(
             "fixtures/linter/multiple_suggestions",
-            Some(LintOptions {
-                fix_kind: LintFixKindFlag::SafeFixOrSuggestion,
-                ..Default::default()
+            json!({
+                "fixKind": "safe_fix_or_suggestion"
             }),
         )
         .test_and_snapshot_single_file("forward_ref.ts");
@@ -452,9 +453,8 @@ mod test {
     fn test_report_unused_directives() {
         Tester::new(
             "fixtures/linter/unused_disabled_directives",
-            Some(LintOptions {
-                unused_disable_directives: UnusedDisableDirectives::Deny,
-                ..Default::default()
+            json!({
+                "unusedDisableDirectives": "deny"
             }),
         )
         .test_and_snapshot_single_file("test.js");
@@ -465,10 +465,9 @@ mod test {
     fn test_report_tsgolint_unused_directives() {
         Tester::new(
             "fixtures/linter/tsgolint/unused_disabled_directives",
-            Some(LintOptions {
-                unused_disable_directives: UnusedDisableDirectives::Deny,
-                type_aware: true,
-                ..Default::default()
+            json!({
+                "unusedDisableDirectives": "deny",
+                "typeAware": true
             }),
         )
         .test_and_snapshot_single_file("test.ts");
@@ -476,7 +475,7 @@ mod test {
 
     #[test]
     fn test_root_ignore_patterns() {
-        let tester = Tester::new("fixtures/linter/ignore_patterns", None);
+        let tester = Tester::new("fixtures/linter/ignore_patterns", json!({}));
         tester.test_and_snapshot_multiple_file(&[
             "ignored-file.ts",
             "another_config/not-ignored-file.ts",
@@ -487,9 +486,8 @@ mod test {
     fn test_ts_alias() {
         Tester::new(
             "fixtures/linter/ts_path_alias",
-            Some(LintOptions {
-                ts_config_path: Some("./deep/tsconfig.json".to_string()),
-                ..Default::default()
+            json!({
+                "tsConfigPath": "./deep/tsconfig.json"
             }),
         )
         .test_and_snapshot_single_file("deep/src/dep-a.ts");
@@ -500,10 +498,9 @@ mod test {
     fn test_tsgo_lint() {
         let tester = Tester::new(
             "fixtures/linter/tsgolint",
-            Some(LintOptions {
-                type_aware: true,
-                fix_kind: LintFixKindFlag::All,
-                ..Default::default()
+            json!({
+                "typeAware": true,
+                "fixKind": "all"
             }),
         );
         tester.test_and_snapshot_single_file("no-floating-promises/index.ts");
@@ -511,7 +508,7 @@ mod test {
 
     #[test]
     fn test_ignore_js_plugins() {
-        let tester = Tester::new("fixtures/linter/js_plugins", Some(LintOptions::default()));
+        let tester = Tester::new("fixtures/linter/js_plugins", json!({}));
         tester.test_and_snapshot_single_file("index.js");
     }
 
@@ -520,7 +517,9 @@ mod test {
     fn test_issue_14565() {
         let tester = Tester::new(
             "fixtures/linter/issue_14565",
-            Some(LintOptions { run: Run::OnSave, ..Default::default() }),
+            json!({
+                "run": "onSave"
+            }),
         );
         tester.test_and_snapshot_single_file("foo-bar.astro");
     }

--- a/crates/oxc_language_server/src/options.rs
+++ b/crates/oxc_language_server/src/options.rs
@@ -16,19 +16,17 @@ pub struct Options {
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceOption {
     pub workspace_uri: Uri,
-    pub options: Options,
+    pub options: serde_json::Value,
 }
 
 #[cfg(test)]
 mod test {
     use serde_json::json;
 
-    use crate::linter::options::{LintFixKindFlag, Run};
-
     use super::WorkspaceOption;
 
     #[test]
-    fn test_invalid_workspace_options_json() {
+    fn test_workspace_options_json() {
         let json = json!([{
             "workspaceUri": "file:///root/",
             "options": {
@@ -44,13 +42,6 @@ mod test {
         assert_eq!(workspace[0].workspace_uri.path().as_str(), "/root/");
 
         let options = &workspace[0].options;
-        assert_eq!(options.lint.run, Run::OnType); // fallback
-        assert_eq!(options.lint.config_path, Some("./custom.json".into()));
-        assert_eq!(options.lint.ts_config_path, None);
-        assert!(!options.lint.type_aware);
-        assert!(!options.lint.disable_nested_config);
-        assert_eq!(options.lint.fix_kind, LintFixKindFlag::SafeFix);
-        assert!(options.format.experimental);
-        assert_eq!(options.format.config_path, None);
+        assert_eq!(options["run"], true);
     }
 }

--- a/crates/oxc_language_server/src/tester.rs
+++ b/crates/oxc_language_server/src/tester.rs
@@ -5,7 +5,7 @@ use tower_lsp_server::{
     lsp_types::{CodeDescription, NumberOrString, Uri},
 };
 
-use crate::{linter::options::LintOptions, options::Options, worker::WorkspaceWorker};
+use crate::worker::WorkspaceWorker;
 
 use super::linter::error_with_position::DiagnosticReport;
 
@@ -92,11 +92,11 @@ fixed: {fixed:#?}
 /// Testing struct for the [linter server][crate::linter::server_linter::ServerLinter].
 pub struct Tester<'t> {
     relative_root_dir: &'t str,
-    options: Option<LintOptions>,
+    options: serde_json::Value,
 }
 
 impl Tester<'_> {
-    pub fn new(relative_root_dir: &'static str, options: Option<LintOptions>) -> Self {
+    pub fn new(relative_root_dir: &'static str, options: serde_json::Value) -> Self {
         Self { relative_root_dir, options }
     }
 
@@ -106,9 +106,7 @@ impl Tester<'_> {
             .join(self.relative_root_dir);
         let uri = Uri::from_file_path(absolute_path).expect("could not convert current dir to uri");
         let worker = WorkspaceWorker::new(uri);
-        let option =
-            &Options { lint: self.options.clone().unwrap_or_default(), ..Default::default() };
-        worker.start_worker(option).await;
+        worker.start_worker(&self.options).await;
 
         worker
     }


### PR DESCRIPTION
This PR split the logic for `WorkspaceOption` and his `Options`. 
`WorkspaceOption.option` can now be any `serde_json::Value`. ATM, the `WorkspaceWorker` is still holding the `Option`.
The goal is, that both `ServerLinter` and `ServerFormatter` gets an on `new` a `serde_json::Value` and handles its own options parsing.

That is the first step for splitting the tools and move them to `--lsp` flag for CLI.

Goal of this PR Stack:
- `WorkspaceWorker` should not care about different tool options
- Every tool (currently `ServerFormatter` & `ServerLinter`) should consume `serde_json::Value`
- Building a unified pattern for creating tools beside the current (experimental) ones