### PR TITLE
perf(linter/plugins): faster check for `cwd`

### DIFF
--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -86,7 +86,7 @@ export interface InternalContext {
 }
 
 // Cached current working directory.
-let cachedCwd: string | null = null;
+let cwd: string | null = null;
 
 /**
  * Context class.
@@ -133,8 +133,9 @@ export class Context {
 
   // Getter for current working directory.
   get cwd() {
-    getInternal(this, 'access `context.cwd`');
-    return (cachedCwd ??= process.cwd());
+    // Note: We can allow accessing `cwd` in `createOnce`, as it's global. So skip `getInternal` call.
+    if (cwd === null) cwd = process.cwd();
+    return cwd;
   }
 
   // Getter for options for file being linted.


### PR DESCRIPTION
Follow-on after #14814. Small perf optimization. `cwd` is either `null` or a string, so use cheaper `=== null` check instead of `??` (which is equivalent to `cwd === null || cwd === undefined`).

Also rename the var, just for brevity.