### PR TITLE
fix(ast/estree): correct raw transfer deserializer for `FormalParameter`

### DIFF
--- a/crates/oxc_ast/src/serialize/js.rs
+++ b/crates/oxc_ast/src/serialize/js.rs
@@ -216,8 +216,8 @@ impl ESTree for FormalParametersRest<'_, '_> {
                     parameter: null,
                     readonly,
                     static: false,
-                    start: start = DESER[u32]( POS_OFFSET<BindingRestElement>.span.start ),
-                    end: end = DESER[u32]( POS_OFFSET<BindingRestElement>.span.end ),
+                    start: start = DESER[u32]( POS_OFFSET.span.start ),
+                    end: end = DESER[u32]( POS_OFFSET.span.end ),
                     ...(RANGE && { range: [start, end] }),
                     ...(PARENT && { parent }),
                 };


### PR DESCRIPTION
Correct the custom deserializer for `FormalParameter`. Was using the span offsets from `BindingRestElement`, when should be `FormalParameter`. `span` is the 1st field in both structs, so this fix makes no difference to the generated deserializer code, but it makes sure it'll remain correct if `span` field in either struct moves position later on.