### PR TITLE
refactor(ast/estree): shorten raw transfer deserializer for `AssignmentTargetPropertyIdentifier`

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -1254,9 +1254,8 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     init = deserializeOptionExpression(pos + 40),
     value = { ...key };
   if (init !== null) {
-    let left = value,
-      previousParent = parent;
-    value = parent = {
+    let left = value;
+    value = {
       __proto__: NodeProto,
       type: 'AssignmentPattern',
       decorators: [],
@@ -1271,7 +1270,6 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     };
     left.parent = value;
     init.parent = value;
-    parent = previousParent;
   }
   node.kind = 'init';
   node.key = key;

--- a/crates/oxc_ast/src/serialize/js.rs
+++ b/crates/oxc_ast/src/serialize/js.rs
@@ -430,8 +430,7 @@ impl ESTree for ArrowFunctionExpressionBody<'_> {
         let value = { ...THIS.key };
         if (init !== null) {
             const left = value;
-            const previousParent = parent;
-            value = parent = {
+            value = {
                 type: 'AssignmentPattern',
                 ...(IS_TS && { decorators: [] }),
                 left,
@@ -448,7 +447,6 @@ impl ESTree for ArrowFunctionExpressionBody<'_> {
             if (PARENT) {
                 left.parent = value;
                 init.parent = value;
-                parent = previousParent;
             }
         }
         value

--- a/napi/parser/generated/deserialize/js_parent.js
+++ b/napi/parser/generated/deserialize/js_parent.js
@@ -1096,9 +1096,8 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     init = deserializeOptionExpression(pos + 40),
     value = { ...key };
   if (init !== null) {
-    let left = value,
-      previousParent = parent;
-    value = parent = {
+    let left = value;
+    value = {
       type: 'AssignmentPattern',
       left,
       right: init,
@@ -1108,7 +1107,6 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     };
     left.parent = value;
     init.parent = value;
-    parent = previousParent;
   }
   node.kind = 'init';
   node.key = key;

--- a/napi/parser/generated/deserialize/js_range_parent.js
+++ b/napi/parser/generated/deserialize/js_range_parent.js
@@ -1129,9 +1129,8 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     init = deserializeOptionExpression(pos + 40),
     value = { ...key };
   if (init !== null) {
-    let left = value,
-      previousParent = parent;
-    value = parent = {
+    let left = value;
+    value = {
       type: 'AssignmentPattern',
       left,
       right: init,
@@ -1142,7 +1141,6 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     };
     left.parent = value;
     init.parent = value;
-    parent = previousParent;
   }
   node.kind = 'init';
   node.key = key;

--- a/napi/parser/generated/deserialize/ts_parent.js
+++ b/napi/parser/generated/deserialize/ts_parent.js
@@ -1170,9 +1170,8 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     init = deserializeOptionExpression(pos + 40),
     value = { ...key };
   if (init !== null) {
-    let left = value,
-      previousParent = parent;
-    value = parent = {
+    let left = value;
+    value = {
       type: 'AssignmentPattern',
       decorators: [],
       left,
@@ -1185,7 +1184,6 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     };
     left.parent = value;
     init.parent = value;
-    parent = previousParent;
   }
   node.kind = 'init';
   node.key = key;

--- a/napi/parser/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/generated/deserialize/ts_range_parent.js
@@ -1203,9 +1203,8 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     init = deserializeOptionExpression(pos + 40),
     value = { ...key };
   if (init !== null) {
-    let left = value,
-      previousParent = parent;
-    value = parent = {
+    let left = value;
+    value = {
       type: 'AssignmentPattern',
       decorators: [],
       left,
@@ -1219,7 +1218,6 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     };
     left.parent = value;
     init.parent = value;
-    parent = previousParent;
   }
   node.kind = 'init';
   node.key = key;


### PR DESCRIPTION
There are no `deserialize` calls while constructing `value` here, so it's pointless to assign to `parent` and then set it back again. Remove this pointless code, and shorten the deserializer a little.