### PR TITLE
fix(ast/estree): fix raw transfer deserializer for `AssignmentTargetPropertyIdentifier`

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -1251,8 +1251,21 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
       parent,
     }),
     key = deserializeIdentifierReference(pos + 8),
-    init = deserializeOptionExpression(pos + 40),
-    value = { ...key };
+    keyStart,
+    keyEnd,
+    value = {
+      __proto__: NodeProto,
+      type: 'Identifier',
+      decorators: [],
+      name: key.name,
+      optional: false,
+      typeAnnotation: null,
+      start: (keyStart = key.start),
+      end: (keyEnd = key.end),
+      range: [keyStart, keyEnd],
+      parent,
+    },
+    init = deserializeOptionExpression(pos + 40);
   if (init !== null) {
     let left = value;
     value = {

--- a/crates/oxc_ast/src/serialize/js.rs
+++ b/crates/oxc_ast/src/serialize/js.rs
@@ -426,8 +426,22 @@ impl ESTree for ArrowFunctionExpressionBody<'_> {
 #[estree(
     ts_type = "IdentifierReference | AssignmentTargetWithDefault",
     raw_deser = "
+        // Clone `key`
+        let keyStart, keyEnd;
+        let value = {
+            type: 'Identifier',
+            ...(IS_TS && { decorators: [] }),
+            name: THIS.key.name,
+            ...(IS_TS && {
+                optional: false,
+                typeAnnotation: null,
+            }),
+            start: keyStart = THIS.key.start,
+            end: keyEnd = THIS.key.end,
+            ...(RANGE && { range: [keyStart, keyEnd] }),
+            ...(PARENT && { parent }),
+        };
         const init = DESER[Option<Expression>](POS_OFFSET.init);
-        let value = { ...THIS.key };
         if (init !== null) {
             const left = value;
             value = {

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -970,8 +970,13 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
       end,
     },
     key = deserializeIdentifierReference(pos + 8),
-    init = deserializeOptionExpression(pos + 40),
-    value = { ...key };
+    value = {
+      type: 'Identifier',
+      name: key.name,
+      start: key.start,
+      end: key.end,
+    },
+    init = deserializeOptionExpression(pos + 40);
   init !== null &&
     (value = {
       type: 'AssignmentPattern',

--- a/napi/parser/generated/deserialize/js_parent.js
+++ b/napi/parser/generated/deserialize/js_parent.js
@@ -1093,8 +1093,14 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
       parent,
     }),
     key = deserializeIdentifierReference(pos + 8),
-    init = deserializeOptionExpression(pos + 40),
-    value = { ...key };
+    value = {
+      type: 'Identifier',
+      name: key.name,
+      start: key.start,
+      end: key.end,
+      parent,
+    },
+    init = deserializeOptionExpression(pos + 40);
   if (init !== null) {
     let left = value;
     value = {

--- a/napi/parser/generated/deserialize/js_range.js
+++ b/napi/parser/generated/deserialize/js_range.js
@@ -1029,8 +1029,16 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
       range: [start, end],
     },
     key = deserializeIdentifierReference(pos + 8),
-    init = deserializeOptionExpression(pos + 40),
-    value = { ...key };
+    keyStart,
+    keyEnd,
+    value = {
+      type: 'Identifier',
+      name: key.name,
+      start: (keyStart = key.start),
+      end: (keyEnd = key.end),
+      range: [keyStart, keyEnd],
+    },
+    init = deserializeOptionExpression(pos + 40);
   init !== null &&
     (value = {
       type: 'AssignmentPattern',

--- a/napi/parser/generated/deserialize/js_range_parent.js
+++ b/napi/parser/generated/deserialize/js_range_parent.js
@@ -1126,8 +1126,17 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
       parent,
     }),
     key = deserializeIdentifierReference(pos + 8),
-    init = deserializeOptionExpression(pos + 40),
-    value = { ...key };
+    keyStart,
+    keyEnd,
+    value = {
+      type: 'Identifier',
+      name: key.name,
+      start: (keyStart = key.start),
+      end: (keyEnd = key.end),
+      range: [keyStart, keyEnd],
+      parent,
+    },
+    init = deserializeOptionExpression(pos + 40);
   if (init !== null) {
     let left = value;
     value = {

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -1048,8 +1048,16 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
       end,
     },
     key = deserializeIdentifierReference(pos + 8),
-    init = deserializeOptionExpression(pos + 40),
-    value = { ...key };
+    value = {
+      type: 'Identifier',
+      decorators: [],
+      name: key.name,
+      optional: false,
+      typeAnnotation: null,
+      start: key.start,
+      end: key.end,
+    },
+    init = deserializeOptionExpression(pos + 40);
   init !== null &&
     (value = {
       type: 'AssignmentPattern',

--- a/napi/parser/generated/deserialize/ts_parent.js
+++ b/napi/parser/generated/deserialize/ts_parent.js
@@ -1167,8 +1167,17 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
       parent,
     }),
     key = deserializeIdentifierReference(pos + 8),
-    init = deserializeOptionExpression(pos + 40),
-    value = { ...key };
+    value = {
+      type: 'Identifier',
+      decorators: [],
+      name: key.name,
+      optional: false,
+      typeAnnotation: null,
+      start: key.start,
+      end: key.end,
+      parent,
+    },
+    init = deserializeOptionExpression(pos + 40);
   if (init !== null) {
     let left = value;
     value = {

--- a/napi/parser/generated/deserialize/ts_range.js
+++ b/napi/parser/generated/deserialize/ts_range.js
@@ -1107,8 +1107,19 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
       range: [start, end],
     },
     key = deserializeIdentifierReference(pos + 8),
-    init = deserializeOptionExpression(pos + 40),
-    value = { ...key };
+    keyStart,
+    keyEnd,
+    value = {
+      type: 'Identifier',
+      decorators: [],
+      name: key.name,
+      optional: false,
+      typeAnnotation: null,
+      start: (keyStart = key.start),
+      end: (keyEnd = key.end),
+      range: [keyStart, keyEnd],
+    },
+    init = deserializeOptionExpression(pos + 40);
   init !== null &&
     (value = {
       type: 'AssignmentPattern',

--- a/napi/parser/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/generated/deserialize/ts_range_parent.js
@@ -1200,8 +1200,20 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
       parent,
     }),
     key = deserializeIdentifierReference(pos + 8),
-    init = deserializeOptionExpression(pos + 40),
-    value = { ...key };
+    keyStart,
+    keyEnd,
+    value = {
+      type: 'Identifier',
+      decorators: [],
+      name: key.name,
+      optional: false,
+      typeAnnotation: null,
+      start: (keyStart = key.start),
+      end: (keyEnd = key.end),
+      range: [keyStart, keyEnd],
+      parent,
+    },
+    init = deserializeOptionExpression(pos + 40);
   if (init !== null) {
     let left = value;
     value = {


### PR DESCRIPTION
1. Tiny bug fix - make sure `range` arrays for `key` and `value` are independent objects, so mutating one doesn't mutate the other.
2. Perf optimization - remove usage of `...` spread, which is expensive.