### PR TITLE
perf(ast/estree): remove pointless assignments from raw transfer deserializers

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -200,7 +200,6 @@ function deserializeIdentifierName(pos) {
     });
   node.decorators = [];
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -223,7 +222,6 @@ function deserializeIdentifierReference(pos) {
     });
   node.decorators = [];
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -246,7 +244,6 @@ function deserializeBindingIdentifier(pos) {
     });
   node.decorators = [];
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -269,7 +266,6 @@ function deserializeLabelIdentifier(pos) {
     });
   node.decorators = [];
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -1107,7 +1103,6 @@ function deserializeArrayAssignmentTarget(pos) {
   node.decorators = [];
   node.elements = elements;
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -1134,7 +1129,6 @@ function deserializeObjectAssignmentTarget(pos) {
   node.decorators = [];
   node.properties = properties;
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -1159,8 +1153,6 @@ function deserializeAssignmentTargetRest(pos) {
   node.decorators = [];
   node.argument = deserializeAssignmentTarget(pos + 8);
   node.optional = false;
-  node.typeAnnotation = null;
-  node.value = null;
   parent = previousParent;
   return node;
 }
@@ -1215,7 +1207,6 @@ function deserializeAssignmentTargetWithDefault(pos) {
   node.left = deserializeAssignmentTarget(pos + 8);
   node.right = deserializeExpression(pos + 24);
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -1645,7 +1636,6 @@ function deserializeExpressionStatement(pos) {
       parent,
     });
   node.expression = deserializeExpression(pos + 8);
-  node.directive = null;
   parent = previousParent;
   return node;
 }
@@ -2164,7 +2154,6 @@ function deserializeAssignmentPattern(pos) {
   node.left = deserializeBindingPattern(pos + 8);
   node.right = deserializeExpression(pos + 40);
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -2191,7 +2180,6 @@ function deserializeObjectPattern(pos) {
   node.decorators = [];
   node.properties = properties;
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -2246,7 +2234,6 @@ function deserializeArrayPattern(pos) {
   node.decorators = [];
   node.elements = elements;
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -2271,8 +2258,6 @@ function deserializeBindingRestElement(pos) {
   node.decorators = [];
   node.argument = deserializeBindingPattern(pos + 8);
   node.optional = false;
-  node.typeAnnotation = null;
-  node.value = null;
   parent = previousParent;
   return node;
 }
@@ -2442,7 +2427,6 @@ function deserializeArrowFunctionExpression(pos) {
   node.params = deserializeBoxFormalParameters(pos + 16);
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   node.body = body;
-  node.id = null;
   node.generator = false;
   parent = previousParent;
   return node;
@@ -3141,7 +3125,6 @@ function deserializeNullLiteral(pos) {
       range: [start, end],
       parent,
     });
-  node.value = null;
   node.raw = start === 0 && end === 0 ? null : 'null';
   parent = previousParent;
   return node;
@@ -4733,7 +4716,6 @@ function deserializeTSPropertySignature(pos) {
     });
   node.key = deserializePropertyKey(pos + 8);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
-  node.accessibility = null;
   node.static = false;
   parent = previousParent;
   return node;
@@ -4775,7 +4757,6 @@ function deserializeTSIndexSignature(pos) {
     });
   node.parameters = deserializeVecTSIndexSignatureName(pos + 8);
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
-  node.accessibility = null;
   parent = previousParent;
   return node;
 }
@@ -4847,7 +4828,6 @@ function deserializeTSMethodSignature(pos) {
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 24);
   node.params = params;
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 48);
-  node.accessibility = null;
   node.readonly = false;
   node.static = false;
   parent = previousParent;

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -1813,7 +1813,6 @@ function deserializeArrowFunctionExpression(pos) {
   expression === true && (body = body.body[0].expression);
   node.params = deserializeBoxFormalParameters(pos + 16);
   node.body = body;
-  node.id = null;
   node.generator = false;
   return node;
 }
@@ -2350,7 +2349,6 @@ function deserializeNullLiteral(pos) {
       start,
       end,
     };
-  node.value = null;
   node.raw = start === 0 && end === 0 ? null : 'null';
   return node;
 }
@@ -3522,7 +3520,6 @@ function deserializeTSPropertySignature(pos) {
     };
   node.key = deserializePropertyKey(pos + 8);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
-  node.accessibility = null;
   node.static = false;
   return node;
 }
@@ -3559,7 +3556,6 @@ function deserializeTSIndexSignature(pos) {
     };
   node.parameters = deserializeVecTSIndexSignatureName(pos + 8);
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
-  node.accessibility = null;
   return node;
 }
 
@@ -3619,7 +3615,6 @@ function deserializeTSMethodSignature(pos) {
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 24);
   node.params = params;
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 48);
-  node.accessibility = null;
   node.readonly = false;
   node.static = false;
   return node;

--- a/napi/parser/generated/deserialize/js_parent.js
+++ b/napi/parser/generated/deserialize/js_parent.js
@@ -2108,7 +2108,6 @@ function deserializeArrowFunctionExpression(pos) {
   }
   node.params = deserializeBoxFormalParameters(pos + 16);
   node.body = body;
-  node.id = null;
   node.generator = false;
   parent = previousParent;
   return node;
@@ -2728,7 +2727,6 @@ function deserializeNullLiteral(pos) {
       end,
       parent,
     });
-  node.value = null;
   node.raw = start === 0 && end === 0 ? null : 'null';
   parent = previousParent;
   return node;
@@ -4103,7 +4101,6 @@ function deserializeTSPropertySignature(pos) {
     });
   node.key = deserializePropertyKey(pos + 8);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
-  node.accessibility = null;
   node.static = false;
   parent = previousParent;
   return node;
@@ -4143,7 +4140,6 @@ function deserializeTSIndexSignature(pos) {
     });
   node.parameters = deserializeVecTSIndexSignatureName(pos + 8);
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
-  node.accessibility = null;
   parent = previousParent;
   return node;
 }
@@ -4211,7 +4207,6 @@ function deserializeTSMethodSignature(pos) {
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 24);
   node.params = params;
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 48);
-  node.accessibility = null;
   node.readonly = false;
   node.static = false;
   parent = previousParent;

--- a/napi/parser/generated/deserialize/js_range.js
+++ b/napi/parser/generated/deserialize/js_range.js
@@ -1978,7 +1978,6 @@ function deserializeArrowFunctionExpression(pos) {
   expression === true && (body = body.body[0].expression);
   node.params = deserializeBoxFormalParameters(pos + 16);
   node.body = body;
-  node.id = null;
   node.generator = false;
   return node;
 }
@@ -2558,7 +2557,6 @@ function deserializeNullLiteral(pos) {
       end,
       range: [start, end],
     };
-  node.value = null;
   node.raw = start === 0 && end === 0 ? null : 'null';
   return node;
 }
@@ -3886,7 +3884,6 @@ function deserializeTSPropertySignature(pos) {
     };
   node.key = deserializePropertyKey(pos + 8);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
-  node.accessibility = null;
   node.static = false;
   return node;
 }
@@ -3924,7 +3921,6 @@ function deserializeTSIndexSignature(pos) {
     };
   node.parameters = deserializeVecTSIndexSignatureName(pos + 8);
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
-  node.accessibility = null;
   return node;
 }
 
@@ -3988,7 +3984,6 @@ function deserializeTSMethodSignature(pos) {
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 24);
   node.params = params;
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 48);
-  node.accessibility = null;
   node.readonly = false;
   node.static = false;
   return node;

--- a/napi/parser/generated/deserialize/js_range_parent.js
+++ b/napi/parser/generated/deserialize/js_range_parent.js
@@ -2194,7 +2194,6 @@ function deserializeArrowFunctionExpression(pos) {
   }
   node.params = deserializeBoxFormalParameters(pos + 16);
   node.body = body;
-  node.id = null;
   node.generator = false;
   parent = previousParent;
   return node;
@@ -2835,7 +2834,6 @@ function deserializeNullLiteral(pos) {
       range: [start, end],
       parent,
     });
-  node.value = null;
   node.raw = start === 0 && end === 0 ? null : 'null';
   parent = previousParent;
   return node;
@@ -4307,7 +4305,6 @@ function deserializeTSPropertySignature(pos) {
     });
   node.key = deserializePropertyKey(pos + 8);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
-  node.accessibility = null;
   node.static = false;
   parent = previousParent;
   return node;
@@ -4348,7 +4345,6 @@ function deserializeTSIndexSignature(pos) {
     });
   node.parameters = deserializeVecTSIndexSignatureName(pos + 8);
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
-  node.accessibility = null;
   parent = previousParent;
   return node;
 }
@@ -4418,7 +4414,6 @@ function deserializeTSMethodSignature(pos) {
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 24);
   node.params = params;
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 48);
-  node.accessibility = null;
   node.readonly = false;
   node.static = false;
   parent = previousParent;

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -166,7 +166,6 @@ function deserializeIdentifierName(pos) {
     };
   node.decorators = [];
   node.optional = false;
-  node.typeAnnotation = null;
   return node;
 }
 
@@ -184,7 +183,6 @@ function deserializeIdentifierReference(pos) {
     };
   node.decorators = [];
   node.optional = false;
-  node.typeAnnotation = null;
   return node;
 }
 
@@ -202,7 +200,6 @@ function deserializeBindingIdentifier(pos) {
     };
   node.decorators = [];
   node.optional = false;
-  node.typeAnnotation = null;
   return node;
 }
 
@@ -220,7 +217,6 @@ function deserializeLabelIdentifier(pos) {
     };
   node.decorators = [];
   node.optional = false;
-  node.typeAnnotation = null;
   return node;
 }
 
@@ -930,7 +926,6 @@ function deserializeArrayAssignmentTarget(pos) {
   node.decorators = [];
   node.elements = elements;
   node.optional = false;
-  node.typeAnnotation = null;
   return node;
 }
 
@@ -950,7 +945,6 @@ function deserializeObjectAssignmentTarget(pos) {
   node.decorators = [];
   node.properties = properties;
   node.optional = false;
-  node.typeAnnotation = null;
   return node;
 }
 
@@ -968,8 +962,6 @@ function deserializeAssignmentTargetRest(pos) {
   node.decorators = [];
   node.argument = deserializeAssignmentTarget(pos + 8);
   node.optional = false;
-  node.typeAnnotation = null;
-  node.value = null;
   return node;
 }
 
@@ -1017,7 +1009,6 @@ function deserializeAssignmentTargetWithDefault(pos) {
   node.left = deserializeAssignmentTarget(pos + 8);
   node.right = deserializeExpression(pos + 24);
   node.optional = false;
-  node.typeAnnotation = null;
   return node;
 }
 
@@ -1368,7 +1359,6 @@ function deserializeExpressionStatement(pos) {
     end: deserializeU32(pos + 4),
   };
   node.expression = deserializeExpression(pos + 8);
-  node.directive = null;
   return node;
 }
 
@@ -1760,7 +1750,6 @@ function deserializeAssignmentPattern(pos) {
   node.left = deserializeBindingPattern(pos + 8);
   node.right = deserializeExpression(pos + 40);
   node.optional = false;
-  node.typeAnnotation = null;
   return node;
 }
 
@@ -1780,7 +1769,6 @@ function deserializeObjectPattern(pos) {
   node.decorators = [];
   node.properties = properties;
   node.optional = false;
-  node.typeAnnotation = null;
   return node;
 }
 
@@ -1823,7 +1811,6 @@ function deserializeArrayPattern(pos) {
   node.decorators = [];
   node.elements = elements;
   node.optional = false;
-  node.typeAnnotation = null;
   return node;
 }
 
@@ -1841,8 +1828,6 @@ function deserializeBindingRestElement(pos) {
   node.decorators = [];
   node.argument = deserializeBindingPattern(pos + 8);
   node.optional = false;
-  node.typeAnnotation = null;
-  node.value = null;
   return node;
 }
 
@@ -1979,7 +1964,6 @@ function deserializeArrowFunctionExpression(pos) {
   node.params = deserializeBoxFormalParameters(pos + 16);
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   node.body = body;
-  node.id = null;
   node.generator = false;
   return node;
 }
@@ -2561,7 +2545,6 @@ function deserializeNullLiteral(pos) {
       start,
       end,
     };
-  node.value = null;
   node.raw = start === 0 && end === 0 ? null : 'null';
   return node;
 }
@@ -3783,7 +3766,6 @@ function deserializeTSPropertySignature(pos) {
     };
   node.key = deserializePropertyKey(pos + 8);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
-  node.accessibility = null;
   node.static = false;
   return node;
 }
@@ -3820,7 +3802,6 @@ function deserializeTSIndexSignature(pos) {
     };
   node.parameters = deserializeVecTSIndexSignatureName(pos + 8);
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
-  node.accessibility = null;
   return node;
 }
 
@@ -3880,7 +3861,6 @@ function deserializeTSMethodSignature(pos) {
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 24);
   node.params = params;
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 48);
-  node.accessibility = null;
   node.readonly = false;
   node.static = false;
   return node;

--- a/napi/parser/generated/deserialize/ts_parent.js
+++ b/napi/parser/generated/deserialize/ts_parent.js
@@ -176,7 +176,6 @@ function deserializeIdentifierName(pos) {
     });
   node.decorators = [];
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -197,7 +196,6 @@ function deserializeIdentifierReference(pos) {
     });
   node.decorators = [];
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -218,7 +216,6 @@ function deserializeBindingIdentifier(pos) {
     });
   node.decorators = [];
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -239,7 +236,6 @@ function deserializeLabelIdentifier(pos) {
     });
   node.decorators = [];
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -1031,7 +1027,6 @@ function deserializeArrayAssignmentTarget(pos) {
   node.decorators = [];
   node.elements = elements;
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -1056,7 +1051,6 @@ function deserializeObjectAssignmentTarget(pos) {
   node.decorators = [];
   node.properties = properties;
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -1079,8 +1073,6 @@ function deserializeAssignmentTargetRest(pos) {
   node.decorators = [];
   node.argument = deserializeAssignmentTarget(pos + 8);
   node.optional = false;
-  node.typeAnnotation = null;
-  node.value = null;
   parent = previousParent;
   return node;
 }
@@ -1133,7 +1125,6 @@ function deserializeAssignmentTargetWithDefault(pos) {
   node.left = deserializeAssignmentTarget(pos + 8);
   node.right = deserializeExpression(pos + 24);
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -1538,7 +1529,6 @@ function deserializeExpressionStatement(pos) {
       parent,
     });
   node.expression = deserializeExpression(pos + 8);
-  node.directive = null;
   parent = previousParent;
   return node;
 }
@@ -2019,7 +2009,6 @@ function deserializeAssignmentPattern(pos) {
   node.left = deserializeBindingPattern(pos + 8);
   node.right = deserializeExpression(pos + 40);
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -2044,7 +2033,6 @@ function deserializeObjectPattern(pos) {
   node.decorators = [];
   node.properties = properties;
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -2095,7 +2083,6 @@ function deserializeArrayPattern(pos) {
   node.decorators = [];
   node.elements = elements;
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -2118,8 +2105,6 @@ function deserializeBindingRestElement(pos) {
   node.decorators = [];
   node.argument = deserializeBindingPattern(pos + 8);
   node.optional = false;
-  node.typeAnnotation = null;
-  node.value = null;
   parent = previousParent;
   return node;
 }
@@ -2276,7 +2261,6 @@ function deserializeArrowFunctionExpression(pos) {
   node.params = deserializeBoxFormalParameters(pos + 16);
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   node.body = body;
-  node.id = null;
   node.generator = false;
   parent = previousParent;
   return node;
@@ -2933,7 +2917,6 @@ function deserializeNullLiteral(pos) {
       end,
       parent,
     });
-  node.value = null;
   node.raw = start === 0 && end === 0 ? null : 'null';
   parent = previousParent;
   return node;
@@ -4372,7 +4355,6 @@ function deserializeTSPropertySignature(pos) {
     });
   node.key = deserializePropertyKey(pos + 8);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
-  node.accessibility = null;
   node.static = false;
   parent = previousParent;
   return node;
@@ -4412,7 +4394,6 @@ function deserializeTSIndexSignature(pos) {
     });
   node.parameters = deserializeVecTSIndexSignatureName(pos + 8);
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
-  node.accessibility = null;
   parent = previousParent;
   return node;
 }
@@ -4480,7 +4461,6 @@ function deserializeTSMethodSignature(pos) {
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 24);
   node.params = params;
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 48);
-  node.accessibility = null;
   node.readonly = false;
   node.static = false;
   parent = previousParent;

--- a/napi/parser/generated/deserialize/ts_range.js
+++ b/napi/parser/generated/deserialize/ts_range.js
@@ -168,7 +168,6 @@ function deserializeIdentifierName(pos) {
     };
   node.decorators = [];
   node.optional = false;
-  node.typeAnnotation = null;
   return node;
 }
 
@@ -187,7 +186,6 @@ function deserializeIdentifierReference(pos) {
     };
   node.decorators = [];
   node.optional = false;
-  node.typeAnnotation = null;
   return node;
 }
 
@@ -206,7 +204,6 @@ function deserializeBindingIdentifier(pos) {
     };
   node.decorators = [];
   node.optional = false;
-  node.typeAnnotation = null;
   return node;
 }
 
@@ -225,7 +222,6 @@ function deserializeLabelIdentifier(pos) {
     };
   node.decorators = [];
   node.optional = false;
-  node.typeAnnotation = null;
   return node;
 }
 
@@ -979,7 +975,6 @@ function deserializeArrayAssignmentTarget(pos) {
   node.decorators = [];
   node.elements = elements;
   node.optional = false;
-  node.typeAnnotation = null;
   return node;
 }
 
@@ -1002,7 +997,6 @@ function deserializeObjectAssignmentTarget(pos) {
   node.decorators = [];
   node.properties = properties;
   node.optional = false;
-  node.typeAnnotation = null;
   return node;
 }
 
@@ -1023,8 +1017,6 @@ function deserializeAssignmentTargetRest(pos) {
   node.decorators = [];
   node.argument = deserializeAssignmentTarget(pos + 8);
   node.optional = false;
-  node.typeAnnotation = null;
-  node.value = null;
   return node;
 }
 
@@ -1075,7 +1067,6 @@ function deserializeAssignmentTargetWithDefault(pos) {
   node.left = deserializeAssignmentTarget(pos + 8);
   node.right = deserializeExpression(pos + 24);
   node.optional = false;
-  node.typeAnnotation = null;
   return node;
 }
 
@@ -1461,7 +1452,6 @@ function deserializeExpressionStatement(pos) {
       range: [start, end],
     };
   node.expression = deserializeExpression(pos + 8);
-  node.directive = null;
   return node;
 }
 
@@ -1905,7 +1895,6 @@ function deserializeAssignmentPattern(pos) {
   node.left = deserializeBindingPattern(pos + 8);
   node.right = deserializeExpression(pos + 40);
   node.optional = false;
-  node.typeAnnotation = null;
   return node;
 }
 
@@ -1928,7 +1917,6 @@ function deserializeObjectPattern(pos) {
   node.decorators = [];
   node.properties = properties;
   node.optional = false;
-  node.typeAnnotation = null;
   return node;
 }
 
@@ -1975,7 +1963,6 @@ function deserializeArrayPattern(pos) {
   node.decorators = [];
   node.elements = elements;
   node.optional = false;
-  node.typeAnnotation = null;
   return node;
 }
 
@@ -1996,8 +1983,6 @@ function deserializeBindingRestElement(pos) {
   node.decorators = [];
   node.argument = deserializeBindingPattern(pos + 8);
   node.optional = false;
-  node.typeAnnotation = null;
-  node.value = null;
   return node;
 }
 
@@ -2144,7 +2129,6 @@ function deserializeArrowFunctionExpression(pos) {
   node.params = deserializeBoxFormalParameters(pos + 16);
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   node.body = body;
-  node.id = null;
   node.generator = false;
   return node;
 }
@@ -2761,7 +2745,6 @@ function deserializeNullLiteral(pos) {
       end,
       range: [start, end],
     };
-  node.value = null;
   node.raw = start === 0 && end === 0 ? null : 'null';
   return node;
 }
@@ -4146,7 +4129,6 @@ function deserializeTSPropertySignature(pos) {
     };
   node.key = deserializePropertyKey(pos + 8);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
-  node.accessibility = null;
   node.static = false;
   return node;
 }
@@ -4184,7 +4166,6 @@ function deserializeTSIndexSignature(pos) {
     };
   node.parameters = deserializeVecTSIndexSignatureName(pos + 8);
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
-  node.accessibility = null;
   return node;
 }
 
@@ -4248,7 +4229,6 @@ function deserializeTSMethodSignature(pos) {
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 24);
   node.params = params;
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 48);
-  node.accessibility = null;
   node.readonly = false;
   node.static = false;
   return node;

--- a/napi/parser/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/generated/deserialize/ts_range_parent.js
@@ -178,7 +178,6 @@ function deserializeIdentifierName(pos) {
     });
   node.decorators = [];
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -200,7 +199,6 @@ function deserializeIdentifierReference(pos) {
     });
   node.decorators = [];
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -222,7 +220,6 @@ function deserializeBindingIdentifier(pos) {
     });
   node.decorators = [];
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -244,7 +241,6 @@ function deserializeLabelIdentifier(pos) {
     });
   node.decorators = [];
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -1060,7 +1056,6 @@ function deserializeArrayAssignmentTarget(pos) {
   node.decorators = [];
   node.elements = elements;
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -1086,7 +1081,6 @@ function deserializeObjectAssignmentTarget(pos) {
   node.decorators = [];
   node.properties = properties;
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -1110,8 +1104,6 @@ function deserializeAssignmentTargetRest(pos) {
   node.decorators = [];
   node.argument = deserializeAssignmentTarget(pos + 8);
   node.optional = false;
-  node.typeAnnotation = null;
-  node.value = null;
   parent = previousParent;
   return node;
 }
@@ -1165,7 +1157,6 @@ function deserializeAssignmentTargetWithDefault(pos) {
   node.left = deserializeAssignmentTarget(pos + 8);
   node.right = deserializeExpression(pos + 24);
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -1594,7 +1585,6 @@ function deserializeExpressionStatement(pos) {
       parent,
     });
   node.expression = deserializeExpression(pos + 8);
-  node.directive = null;
   parent = previousParent;
   return node;
 }
@@ -2095,7 +2085,6 @@ function deserializeAssignmentPattern(pos) {
   node.left = deserializeBindingPattern(pos + 8);
   node.right = deserializeExpression(pos + 40);
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -2121,7 +2110,6 @@ function deserializeObjectPattern(pos) {
   node.decorators = [];
   node.properties = properties;
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -2174,7 +2162,6 @@ function deserializeArrayPattern(pos) {
   node.decorators = [];
   node.elements = elements;
   node.optional = false;
-  node.typeAnnotation = null;
   parent = previousParent;
   return node;
 }
@@ -2198,8 +2185,6 @@ function deserializeBindingRestElement(pos) {
   node.decorators = [];
   node.argument = deserializeBindingPattern(pos + 8);
   node.optional = false;
-  node.typeAnnotation = null;
-  node.value = null;
   parent = previousParent;
   return node;
 }
@@ -2364,7 +2349,6 @@ function deserializeArrowFunctionExpression(pos) {
   node.params = deserializeBoxFormalParameters(pos + 16);
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   node.body = body;
-  node.id = null;
   node.generator = false;
   parent = previousParent;
   return node;
@@ -3042,7 +3026,6 @@ function deserializeNullLiteral(pos) {
       range: [start, end],
       parent,
     });
-  node.value = null;
   node.raw = start === 0 && end === 0 ? null : 'null';
   parent = previousParent;
   return node;
@@ -4583,7 +4566,6 @@ function deserializeTSPropertySignature(pos) {
     });
   node.key = deserializePropertyKey(pos + 8);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
-  node.accessibility = null;
   node.static = false;
   parent = previousParent;
   return node;
@@ -4624,7 +4606,6 @@ function deserializeTSIndexSignature(pos) {
     });
   node.parameters = deserializeVecTSIndexSignatureName(pos + 8);
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
-  node.accessibility = null;
   parent = previousParent;
   return node;
 }
@@ -4694,7 +4675,6 @@ function deserializeTSMethodSignature(pos) {
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 24);
   node.params = params;
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 48);
-  node.accessibility = null;
   node.readonly = false;
   node.static = false;
   parent = previousParent;

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -376,7 +376,9 @@ fn generate_struct(
 
                 if deser_type == DeserializerType::Both {
                     write_it!(fields_str, "{field_name}: null,");
-                    write_it!(assignments_str, "node.{field_name} = {value};");
+                    if value != "null" {
+                        write_it!(assignments_str, "node.{field_name} = {value};");
+                    }
                 } else {
                     let condition = match deser_type {
                         DeserializerType::JsOnly => "!IS_TS",
@@ -384,7 +386,9 @@ fn generate_struct(
                         DeserializerType::Both => unreachable!(),
                     };
                     write_it!(fields_str, "...({condition} && {{ {field_name}: null }}),");
-                    write_it!(assignments_str, "if ({condition}) node.{field_name} = {value};");
+                    if value != "null" {
+                        write_it!(assignments_str, "if ({condition}) node.{field_name} = {value};");
+                    }
                 }
             }
         }


### PR DESCRIPTION
Small perf optimization to raw transfer. Shorten deserializers by not assigning `null` to fields which were already initialized as `null`.