### PR TITLE
refactor(cfg, tasks): remove unnecessary `#[expect]`

### DIFF
--- a/crates/oxc_cfg/src/builder/context.rs
+++ b/crates/oxc_cfg/src/builder/context.rs
@@ -89,7 +89,6 @@ impl<'a, 'c> QueryCtx<'a, 'c> {
     #[inline]
     #[expect(clippy::wrong_self_convention, clippy::new_ret_no_self)]
     pub fn new(self, flags: CtxFlags) -> RefCtxCursor<'a, 'c> {
-        #![expect(unsafe_code)]
         self.0.ctx_stack.push(Ctx::new(self.1, flags));
         // SAFETY: we just pushed this `Ctx` into the stack.
         let ctx = unsafe { self.0.ctx_stack.last_mut().unwrap_unchecked() };

--- a/tasks/benchmark/src/lib.rs
+++ b/tasks/benchmark/src/lib.rs
@@ -27,7 +27,7 @@ static GLOBAL: NeverGrowInPlaceAllocator = NeverGrowInPlaceAllocator;
 struct NeverGrowInPlaceAllocator;
 
 // SAFETY: Methods simply delegate to `System` allocator
-#[expect(unsafe_code, clippy::undocumented_unsafe_blocks)]
+#[expect(clippy::undocumented_unsafe_blocks)]
 unsafe impl GlobalAlloc for NeverGrowInPlaceAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         unsafe { System.alloc(layout) }

--- a/tasks/track_memory_allocations/src/lib.rs
+++ b/tasks/track_memory_allocations/src/lib.rs
@@ -65,7 +65,7 @@ fn reset_global_allocs() {
 
 // SAFETY: Methods simply delegate to `MiMalloc` allocator to ensure that the allocator
 // is the same across different platforms for the purposes of tracking allocations.
-#[expect(unsafe_code, clippy::undocumented_unsafe_blocks)]
+#[expect(clippy::undocumented_unsafe_blocks)]
 unsafe impl GlobalAlloc for TrackedAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let ret = unsafe { MiMalloc.alloc(layout) };


### PR DESCRIPTION
Tiny refactor. Remove unnecessary `#[expect(unsafe_code)]` attributes. We don't enable this lint rule anyway.