### PR TITLE
perf(allocator/address): add `#[repr(transparent)]` to `Address`

### DIFF
--- a/crates/oxc_allocator/src/address.rs
+++ b/crates/oxc_allocator/src/address.rs
@@ -4,6 +4,7 @@ use crate::Box;
 
 /// Memory address of an AST node in arena.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
 pub struct Address(usize);
 
 impl Address {


### PR DESCRIPTION
`Address` just wraps a `usize`, so make it `#[repr(transparent)]`. This may improve perf in some cases (or maybe not, but still it's good practice).