### PR TITLE
fix(codegen): print space before `BindingRestElement` in `ObjectPattern`

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2826,6 +2826,7 @@ impl Gen for ObjectPattern<'_> {
         if let Some(rest) = &self.rest {
             if !self.properties.is_empty() {
                 p.print_comma();
+                p.print_soft_space();
             }
             rest.print(p, ctx);
         }

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -12,6 +12,8 @@ fn cases() {
 
 #[test]
 fn decl() {
+    test_same("const [foo, ...bar] = qux;\n");
+    test_same("const { foo, ...bar } = qux;\n");
     test_minify("const [foo] = bar", "const[foo]=bar;");
     test_minify("const {foo} = bar", "const{foo}=bar;");
     test_minify("const foo = bar", "const foo=bar;");


### PR DESCRIPTION
Previously we didn't print a space before `...` in object destructuring. e.g.:

```js
const o = { x,...rest };
```

Fix that (noticed in output of raw transfer codegen).
