### PR TITLE
perf(codegen): reduce branches printing `ObjectPattern`

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2818,10 +2818,12 @@ impl Gen for BindingPatternKind<'_> {
 impl Gen for ObjectPattern<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
-        p.print_ascii_byte(b'{');
-        if !self.is_empty() {
-            p.print_soft_space();
+        if self.is_empty() {
+            p.print_str("{}");
+            return;
         }
+        p.print_ascii_byte(b'{');
+        p.print_soft_space();
         p.print_list(&self.properties, ctx);
         if let Some(rest) = &self.rest {
             if !self.properties.is_empty() {
@@ -2830,9 +2832,7 @@ impl Gen for ObjectPattern<'_> {
             }
             rest.print(p, ctx);
         }
-        if !self.is_empty() {
-            p.print_soft_space();
-        }
+        p.print_soft_space();
         p.print_ascii_byte(b'}');
     }
 }


### PR DESCRIPTION
Small perf optimization. Make a fast path for printing an empty object literal.

Previously we branched twice on `self.is_empty()` (unpredicable branches), and did an unnecessary call to `print_list` for empty objects. This change should speed up printing both empty objects, and objects which do have properties.