### PR TITLE
fix(allocator): avoid dereferencing `Box` when obtaining its `Address`

### DIFF
--- a/crates/oxc_allocator/src/address.rs
+++ b/crates/oxc_allocator/src/address.rs
@@ -1,4 +1,4 @@
-use std::ptr::{NonNull, addr_of};
+use std::ptr::NonNull;
 
 use crate::Box;
 
@@ -160,7 +160,8 @@ impl<T> GetAddress for Box<'_, T> {
     /// so this address acts as a unique identifier for the duration of the arena's existence.
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(addr_of!(**self))
+        let ptr = Box::as_non_null(self).as_ptr().cast_const();
+        Address::from_ptr(ptr)
     }
 }
 


### PR DESCRIPTION
Use `Box::as_non_null` method (added in #15321) to ensure that creating an `Address` from a `Box`, no intermediate reference to the contents of the `Box` is created. This is important in `Traverse` which has tight aliasing constraints.

Possibly `addr_of!` macro we used previously already ensured this, but I'm not 100% sure due to the double deref (`**`). Using `Box::as_non_null` is unambiguously safe.