### PR TITLE
feat(linter): implement react/state-in-constructor rule

### DIFF
--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -924,7 +924,8 @@ pub fn get_outer_member_expression<'a, 'b>(
                     return Some(node);
                 }
 
-                if let Some(object) = node.object.as_member_expression()
+                if let Some(MemberExpression::StaticMemberExpression(object)) =
+                    node.object.as_member_expression()
                     && !object.property.name.is_empty()
                 {
                     node = object;

--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -924,7 +924,7 @@ pub fn get_outer_member_expression<'a, 'b>(
                     return Some(node);
                 }
 
-                if let Some(object) = get_static_member_expression_obj(&node.object)
+                if let Some(object) = node.object.as_member_expression()
                     && !object.property.name.is_empty()
                 {
                     node = object;
@@ -935,17 +935,6 @@ pub fn get_outer_member_expression<'a, 'b>(
                 return Some(node);
             }
         }
-        _ => None,
-    }
-}
-
-// Because node.object is of type &Expression<'_>
-// We need a function to get static_member_expression
-fn get_static_member_expression_obj<'a, 'b>(
-    expression: &'b Expression<'a>,
-) -> Option<&'b StaticMemberExpression<'a>> {
-    match expression {
-        Expression::StaticMemberExpression(expr) => Some(expr),
         _ => None,
     }
 }

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2397,6 +2397,11 @@ impl RuleRunner for crate::rules::react::self_closing_comp::SelfClosingComp {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::react::state_in_constructor::StateInConstructor {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::react::style_prop_object::StylePropObject {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::JSXElement]));

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2398,7 +2398,10 @@ impl RuleRunner for crate::rules::react::self_closing_comp::SelfClosingComp {
 }
 
 impl RuleRunner for crate::rules::react::state_in_constructor::StateInConstructor {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::AssignmentExpression,
+        AstType::PropertyDefinition,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -380,6 +380,7 @@ pub(crate) mod react {
     pub mod require_render_return;
     pub mod rules_of_hooks;
     pub mod self_closing_comp;
+    pub mod state_in_constructor;
     pub mod style_prop_object;
     pub mod void_dom_elements_no_children;
 }
@@ -1053,6 +1054,7 @@ oxc_macros::declare_all_lint_rules! {
     react::require_render_return,
     react::rules_of_hooks,
     react::self_closing_comp,
+    react::state_in_constructor,
     react::style_prop_object,
     react::void_dom_elements_no_children,
     react_perf::jsx_no_jsx_as_prop,

--- a/crates/oxc_linter/src/rules/react/state_in_constructor.rs
+++ b/crates/oxc_linter/src/rules/react/state_in_constructor.rs
@@ -157,7 +157,7 @@ impl Rule for StateInConstructor {
                     ctx.diagnostic(state_in_constructor_diagnostic(assign_expr.span, false));
                 }
             }
-            _ => return,
+            _ => (),
         }
     }
 }
@@ -169,11 +169,8 @@ fn has_parent_es6_component<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bo
 /// Checks if a node is inside a constructor method.
 pub fn is_in_constructor(ctx: &LintContext, node_id: NodeId) -> bool {
     for ancestor_id in ctx.nodes().ancestor_ids(node_id) {
-        match ctx.nodes().kind(ancestor_id) {
-            AstKind::MethodDefinition(method) => {
-                return method.kind.is_constructor();
-            }
-            _ => {}
+        if let AstKind::MethodDefinition(method) = ctx.nodes().kind(ancestor_id) {
+            return method.kind.is_constructor();
         }
     }
     false

--- a/crates/oxc_linter/src/rules/react/state_in_constructor.rs
+++ b/crates/oxc_linter/src/rules/react/state_in_constructor.rs
@@ -1,0 +1,580 @@
+use oxc_ast::{
+    AstKind,
+    ast::{Expression, SimpleAssignmentTarget, StaticMemberExpression},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_semantic::NodeId;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule, utils::is_es6_component};
+
+fn state_in_constructor_diagnostic(span: Span, is_state_init_constructor: bool) -> OxcDiagnostic {
+    let message = if is_state_init_constructor {
+        "State initialization should be in a constructor"
+    } else {
+        "State initialization should be in a class property"
+    };
+    OxcDiagnostic::warn(message).with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub enum StateInConstructorConfig {
+    #[default]
+    Always,
+    Never,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct StateInConstructor(Box<StateInConstructorConfig>);
+
+impl std::ops::Deref for StateInConstructor {
+    type Target = StateInConstructorConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces the state initialization style to be either in a constructor or with a class property.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Inconsistent state initialization styles can make the codebase harder to maintain and understand.
+    /// This rule enforces a consistent pattern across React class components.
+    ///
+    /// ### Examples
+    ///
+    /// This rule has two modes: `"always"` and `"never"`.
+    ///
+    /// #### `"always"` mode
+    ///
+    /// Will enforce the state initialization style to be in a constructor. This is the default mode.
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// class Foo extends React.Component {
+    ///   state = { bar: 0 }
+    ///   render() {
+    ///     return <div>Foo</div>
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// class Foo extends React.Component {
+    ///   constructor(props) {
+    ///     super(props)
+    ///     this.state = { bar: 0 }
+    ///   }
+    ///   render() {
+    ///     return <div>Foo</div>
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// #### `"never"` mode
+    ///
+    /// Will enforce the state initialization style to be with a class property.
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// class Foo extends React.Component {
+    ///   constructor(props) {
+    ///     super(props)
+    ///     this.state = { bar: 0 }
+    ///   }
+    ///   render() {
+    ///     return <div>Foo</div>
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// class Foo extends React.Component {
+    ///   state = { bar: 0 }
+    ///   render() {
+    ///     return <div>Foo</div>
+    ///   }
+    /// }
+    /// ```
+    StateInConstructor,
+    react,
+    style,
+);
+
+impl Rule for StateInConstructor {
+    fn from_configuration(value: serde_json::Value) -> Self {
+        let config = value
+            .get(0)
+            .and_then(serde_json::Value::as_str)
+            .map(|mode| match mode {
+                "never" => StateInConstructorConfig::Never,
+                _ => StateInConstructorConfig::Always,
+            })
+            .unwrap_or_default();
+
+        Self(Box::new(config))
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::PropertyDefinition(prop_def) => {
+                let is_always = matches!(*self.0, StateInConstructorConfig::Always);
+
+                if is_always
+                    && !prop_def.r#static
+                    && prop_def.key.name().is_some_and(|name| name == "state")
+                    && has_parent_es6_component(node, ctx)
+                {
+                    ctx.diagnostic(state_in_constructor_diagnostic(prop_def.span, true));
+                }
+            }
+            AstKind::AssignmentExpression(assign_expr) => {
+                let is_never = matches!(*self.0, StateInConstructorConfig::Never);
+
+                if is_never
+                    && let Some(assignment) = assign_expr.left.as_simple_assignment_target()
+                    && let Some(outer_member_expression) = get_outer_member_expression(assignment)
+                    && is_state_member_expression(outer_member_expression)
+                    && is_in_constructor(ctx, node.id())
+                    && has_parent_es6_component(node, ctx)
+                {
+                    ctx.diagnostic(state_in_constructor_diagnostic(assign_expr.span, false));
+                }
+            }
+            _ => return,
+        }
+    }
+}
+
+fn has_parent_es6_component<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
+    ctx.nodes().ancestors(node.id()).any(|node| is_es6_component(node))
+}
+
+fn is_state_member_expression(expression: &StaticMemberExpression<'_>) -> bool {
+    if let Expression::ThisExpression(_) = &expression.object {
+        return expression.property.name == "state";
+    }
+
+    false
+}
+
+fn get_outer_member_expression<'a, 'b>(
+    assignment: &'b SimpleAssignmentTarget<'a>,
+) -> Option<&'b StaticMemberExpression<'a>> {
+    match assignment {
+        SimpleAssignmentTarget::StaticMemberExpression(expr) => {
+            let mut node = &**expr;
+            loop {
+                if node.object.is_null() {
+                    return Some(node);
+                }
+
+                if let Some(object) = get_static_member_expression_obj(&node.object)
+                    && !object.property.name.is_empty()
+                {
+                    node = object;
+
+                    continue;
+                }
+
+                return Some(node);
+            }
+        }
+        _ => None,
+    }
+}
+
+fn get_static_member_expression_obj<'a, 'b>(
+    expression: &'b Expression<'a>,
+) -> Option<&'b StaticMemberExpression<'a>> {
+    match expression {
+        Expression::StaticMemberExpression(expr) => Some(expr),
+        _ => None,
+    }
+}
+
+/// Checks if a node is inside a constructor method.
+pub fn is_in_constructor(ctx: &LintContext, node_id: NodeId) -> bool {
+    for ancestor_id in ctx.nodes().ancestor_ids(node_id) {
+        match ctx.nodes().kind(ancestor_id) {
+            AstKind::MethodDefinition(method) => {
+                return method.kind.is_constructor();
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (
+            "
+			        class Foo extends React.Component {
+			          render() {
+			            return <div>Foo</div>
+			          }
+			        }
+			      ",
+            None,
+        ),
+        (
+            "
+			        class Foo extends React.Component {
+			          render() {
+			            return <div>Foo</div>
+			          }
+			        }
+			      ",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "
+			        class Foo extends React.Component {
+			          constructor(props) {
+			            super(props)
+			            this.state = { bar: 0 }
+			          }
+			          render() {
+			            return <div>Foo</div>
+			          }
+			        }
+			      ",
+            None,
+        ),
+        (
+            "
+			        class Foo extends React.Component {
+			          constructor(props) {
+			            super(props)
+			            this.state = { bar: 0 }
+			          }
+			          render() {
+			            return <div>Foo</div>
+			          }
+			        }
+			      ",
+            Some(serde_json::json!(["always"])),
+        ),
+        (
+            "
+			        class Foo extends React.Component {
+			          constructor(props) {
+			            super(props)
+			            this.state = { bar: 0 }
+			          }
+			          baz = { bar: 0 }
+			          render() {
+			            return <div>Foo</div>
+			          }
+			        }
+			      ",
+            None,
+        ),
+        (
+            "
+			        class Foo extends React.Component {
+			          constructor(props) {
+			            super(props)
+			            this.baz = { bar: 0 }
+			          }
+			          render() {
+			            return <div>Foo</div>
+			          }
+			        }
+			      ",
+            None,
+        ),
+        (
+            "
+			        class Foo extends React.Component {
+			          constructor(props) {
+			            super(props)
+			            this.baz = { bar: 0 }
+			          }
+			          render() {
+			            return <div>Foo</div>
+			          }
+			        }
+			      ",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "
+			        class Foo extends React.Component {
+			          baz = { bar: 0 }
+			          render() {
+			            return <div>Foo</div>
+			          }
+			        }
+			      ",
+            None,
+        ),
+        (
+            "
+			        class Foo extends React.Component {
+			          baz = { bar: 0 }
+			          render() {
+			            return <div>Foo</div>
+			          }
+			        }
+			      ",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "
+			        const Foo = () => <div>Foo</div>
+			      ",
+            None,
+        ),
+        (
+            "
+			        const Foo = () => <div>Foo</div>
+			      ",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "
+			        function Foo () {
+			          return <div>Foo</div>
+			        }
+			      ",
+            None,
+        ),
+        (
+            "
+			        function Foo () {
+			          return <div>Foo</div>
+			        }
+			      ",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "
+			        class Foo extends React.Component {
+			          state = { bar: 0 }
+			          render() {
+			            return <div>Foo</div>
+			          }
+			        }
+			      ",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "
+			        class Foo extends React.Component {
+			          state = { bar: 0 }
+			          baz = { bar: 0 }
+			          render() {
+			            return <div>Foo</div>
+			          }
+			        }
+			      ",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "
+			        class Foo extends React.Component {
+			          constructor(props) {
+			            super(props)
+			            this.baz = { bar: 0 }
+			          }
+			          state = { baz: 0 }
+			          render() {
+			            return <div>Foo</div>
+			          }
+			        }
+			      ",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "
+			        class Foo extends React.Component {
+			          constructor(props) {
+			            super(props)
+			            if (foobar) {
+			              this.state = { bar: 0 }
+			            }
+			          }
+			          render() {
+			            return <div>Foo</div>
+			          }
+			        }
+			      ",
+            None,
+        ),
+        (
+            "
+			        class Foo extends React.Component {
+			          constructor(props) {
+			            super(props)
+			            foobar = { bar: 0 }
+			          }
+			          render() {
+			            return <div>Foo</div>
+			          }
+			        }
+			      ",
+            None,
+        ),
+        (
+            "
+			        class Foo extends React.Component {
+			          constructor(props) {
+			            super(props)
+			            foobar = { bar: 0 }
+			          }
+			          render() {
+			            return <div>Foo</div>
+			          }
+			        }
+			      ",
+            Some(serde_json::json!(["never"])),
+        ),
+    ];
+
+    let fail = vec![
+        (
+            "
+			        class Foo extends React.Component {
+			          constructor(props) {
+			            super(props)
+			            this.state = { bar: 0 }
+			          }
+			          render() {
+			            return <div>Foo</div>
+			          }
+			        }
+			      ",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "
+			        class Foo extends React.Component {
+			          constructor(props) {
+			            super(props)
+			            this.state = { bar: 0 }
+			          }
+			          baz = { bar: 0 }
+			          render() {
+			            return <div>Foo</div>
+			          }
+			        }
+			      ",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "
+			        class Foo extends React.Component {
+			          state = { bar: 0 }
+			          render() {
+			            return <div>Foo</div>
+			          }
+			        }
+			      ",
+            None,
+        ),
+        (
+            "
+			        class Foo extends React.Component {
+			          state = { bar: 0 }
+			          baz = { bar: 0 }
+			          render() {
+			            return <div>Foo</div>
+			          }
+			        }
+			      ",
+            None,
+        ),
+        (
+            "
+			        class Foo extends React.Component {
+			          constructor(props) {
+			            super(props)
+			            this.baz = { bar: 0 }
+			          }
+			          state = { baz: 0 }
+			          render() {
+			            return <div>Foo</div>
+			          }
+			        }
+			      ",
+            None,
+        ),
+        (
+            "
+			        class Foo extends React.Component {
+			          constructor(props) {
+			            super(props)
+			            this.state = { bar: 0 }
+			          }
+			          state = { baz: 0 }
+			          render() {
+			            return <div>Foo</div>
+			          }
+			        }
+			      ",
+            None,
+        ),
+        (
+            "
+			        class Foo extends React.Component {
+			          constructor(props) {
+			            super(props)
+			            this.state = { bar: 0 }
+			          }
+			          state = { baz: 0 }
+			          render() {
+			            return <div>Foo</div>
+			          }
+			        }
+			      ",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "
+			        class Foo extends React.Component {
+			          constructor(props) {
+			            super(props)
+			            if (foobar) {
+			              this.state = { bar: 0 }
+			            }
+			          }
+			          render() {
+			            return <div>Foo</div>
+			          }
+			        }
+			      ",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "
+              class Foo extends React.Component {
+                  constructor(props) {
+                      super(props);
+
+                      function helper() {
+                          this.state = {bar: 0};
+                      }
+
+                      helper();
+                  }
+              }
+			      ",
+            Some(serde_json::json!(["never"])),
+        ),
+    ];
+
+    Tester::new(StateInConstructor::NAME, StateInConstructor::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/react_state_in_constructor.snap
+++ b/crates/oxc_linter/src/snapshots/react_state_in_constructor.snap
@@ -1,0 +1,74 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint-plugin-react(state-in-constructor): State initialization should be in a class property
+   ╭─[state_in_constructor.tsx:5:16]
+ 4 │                         super(props)
+ 5 │                         this.state = { bar: 0 }
+   ·                         ───────────────────────
+ 6 │                       }
+   ╰────
+
+  ⚠ eslint-plugin-react(state-in-constructor): State initialization should be in a class property
+   ╭─[state_in_constructor.tsx:5:16]
+ 4 │                         super(props)
+ 5 │                         this.state = { bar: 0 }
+   ·                         ───────────────────────
+ 6 │                       }
+   ╰────
+
+  ⚠ eslint-plugin-react(state-in-constructor): State initialization should be in a constructor
+   ╭─[state_in_constructor.tsx:3:14]
+ 2 │                     class Foo extends React.Component {
+ 3 │                       state = { bar: 0 }
+   ·                       ──────────────────
+ 4 │                       render() {
+   ╰────
+
+  ⚠ eslint-plugin-react(state-in-constructor): State initialization should be in a constructor
+   ╭─[state_in_constructor.tsx:3:14]
+ 2 │                     class Foo extends React.Component {
+ 3 │                       state = { bar: 0 }
+   ·                       ──────────────────
+ 4 │                       baz = { bar: 0 }
+   ╰────
+
+  ⚠ eslint-plugin-react(state-in-constructor): State initialization should be in a constructor
+   ╭─[state_in_constructor.tsx:7:14]
+ 6 │                       }
+ 7 │                       state = { baz: 0 }
+   ·                       ──────────────────
+ 8 │                       render() {
+   ╰────
+
+  ⚠ eslint-plugin-react(state-in-constructor): State initialization should be in a constructor
+   ╭─[state_in_constructor.tsx:7:14]
+ 6 │                       }
+ 7 │                       state = { baz: 0 }
+   ·                       ──────────────────
+ 8 │                       render() {
+   ╰────
+
+  ⚠ eslint-plugin-react(state-in-constructor): State initialization should be in a class property
+   ╭─[state_in_constructor.tsx:5:16]
+ 4 │                         super(props)
+ 5 │                         this.state = { bar: 0 }
+   ·                         ───────────────────────
+ 6 │                       }
+   ╰────
+
+  ⚠ eslint-plugin-react(state-in-constructor): State initialization should be in a class property
+   ╭─[state_in_constructor.tsx:6:18]
+ 5 │                         if (foobar) {
+ 6 │                           this.state = { bar: 0 }
+   ·                           ───────────────────────
+ 7 │                         }
+   ╰────
+
+  ⚠ eslint-plugin-react(state-in-constructor): State initialization should be in a class property
+   ╭─[state_in_constructor.tsx:7:27]
+ 6 │                       function helper() {
+ 7 │                           this.state = {bar: 0};
+   ·                           ─────────────────────
+ 8 │                       }
+   ╰────

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
     ast::{
         CallExpression, Expression, JSXAttributeItem, JSXAttributeName, JSXAttributeValue,
         JSXChild, JSXElement, JSXElementName, JSXExpression, JSXMemberExpression,
-        JSXMemberExpressionObject, JSXOpeningElement,
+        JSXMemberExpressionObject, JSXOpeningElement, StaticMemberExpression,
     },
 };
 use oxc_ecmascript::{ToBoolean, WithoutGlobalReferenceInformation};
@@ -341,4 +341,13 @@ pub fn is_jsx_fragment(elem: &JSXOpeningElement) -> bool {
         | JSXElementName::Identifier(_)
         | JSXElementName::ThisExpression(_) => false,
     }
+}
+
+// check current node is this.state.xx
+pub fn is_state_member_expression(expression: &StaticMemberExpression<'_>) -> bool {
+    if let Expression::ThisExpression(_) = &expression.object {
+        return expression.property.name == "state";
+    }
+
+    false
 }


### PR DESCRIPTION
This PR adds react/state-in-constructor rule, issue #1022, also moved some methods to ast/react utils to reuse in this rule

[rule doc](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/state-in-constructor.md)
[rule source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/state-in-constructor.js)